### PR TITLE
Make the hf2 health analyzer automatically update every second, add use delay and unskilled doafter

### DIFF
--- a/Content.Client/_CM14/Medical/Scanner/HealthScannerBoundUserInterface.cs
+++ b/Content.Client/_CM14/Medical/Scanner/HealthScannerBoundUserInterface.cs
@@ -113,7 +113,7 @@ public sealed class HealthScannerBoundUserInterface : BoundUserInterface
             _window.BloodTypeLabel.Text = "Blood:";
             var bloodMsg = new FormattedMessage();
             bloodMsg.PushColor(Color.FromHex("#25B732"));
-            bloodMsg.AddText($"{uiState.BloodPercentage}%");
+            bloodMsg.AddText($"{uiState.BloodPercentage:F2}%");
             bloodMsg.Pop();
             _window.BloodAmountLabel.SetMessage(bloodMsg);
 

--- a/Content.Server/_CM14/Medical/Scanner/HealthScannerSystem.cs
+++ b/Content.Server/_CM14/Medical/Scanner/HealthScannerSystem.cs
@@ -1,16 +1,20 @@
 ﻿using Content.Server.Body.Components;
 using Content.Server.Body.Systems;
 using Content.Server.Chemistry.Containers.EntitySystems;
+using Content.Server.DoAfter;
 using Content.Server.Popups;
 using Content.Server.Temperature.Components;
+using Content.Shared._CM14.Marines.Skills;
 using Content.Shared._CM14.Medical.Scanner;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Damage;
+using Content.Shared.DoAfter;
 using Content.Shared.Interaction;
 using Content.Shared.Mobs.Components;
+using Content.Shared.Timing;
 using Robust.Server.Audio;
 using Robust.Server.GameObjects;
-using Robust.Shared.Network;
+using Robust.Shared.Timing;
 
 namespace Content.Server._CM14.Medical.Scanner;
 
@@ -18,52 +22,135 @@ public sealed class HealthScannerSystem : EntitySystem
 {
     [Dependency] private readonly AudioSystem _audio = default!;
     [Dependency] private readonly BloodstreamSystem _bloodstream = default!;
-    [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly DoAfterSystem _doAfter = default!;
     [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly SolutionContainerSystem _solution = default!;
+    [Dependency] private readonly SkillsSystem _skills = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly TransformSystem _transform = default!;
     [Dependency] private readonly UserInterfaceSystem _ui = default!;
+    [Dependency] private readonly UseDelaySystem _useDelay = default!;
 
     public override void Initialize()
     {
         SubscribeLocalEvent<HealthScannerComponent, AfterInteractEvent>(OnAfterInteract);
+        SubscribeLocalEvent<HealthScannerComponent, DoAfterAttemptEvent<HealthScannerDoAfterEvent>>(OnDoAfterAttempt);
+        SubscribeLocalEvent<HealthScannerComponent, HealthScannerDoAfterEvent>(OnDoAfter);
     }
 
     private void OnAfterInteract(Entity<HealthScannerComponent> scanner, ref AfterInteractEvent args)
     {
-        var target = args.Target;
-        if (!args.CanReach ||
-            !HasComp<DamageableComponent>(target) ||
-            !HasComp<MobStateComponent>(target) ||
-            !HasComp<MobThresholdsComponent>(target))
+        if (args.Target is not { } target ||
+            !CanUseHealthScannerPopup(scanner, args.User, target))
         {
             return;
         }
 
-        if (_net.IsClient)
-            return;
-
-        var ev = new HealthScannerAttemptTargetEvent();
-        RaiseLocalEvent(target.Value, ref ev);
-        if (ev.Cancelled)
+        var delay = _skills.GetDelay(args.User, scanner);
+        var ev = new HealthScannerDoAfterEvent(GetNetEntity(target));
+        var doAfter = new DoAfterArgs(EntityManager, args.User, delay, ev, scanner, null, scanner)
         {
-            if (ev.Popup != null)
-                _popup.PopupEntity(ev.Popup, target.Value, args.User);
+            BreakOnMove = true,
+            AttemptFrequency = AttemptFrequency.EveryTick
+        };
 
+        if (delay > TimeSpan.Zero)
+        {
+            var name = Loc.GetString("zzzz-the", ("ent", target));
+            _popup.PopupEntity($"You start fumbling around with {name}...", target, args.User);
+        }
+
+        _doAfter.TryStartDoAfter(doAfter);
+    }
+
+    private void OnDoAfterAttempt(Entity<HealthScannerComponent> ent, ref DoAfterAttemptEvent<HealthScannerDoAfterEvent> args)
+    {
+        var doAfter = args.DoAfter.Args;
+        if (!CanUseHealthScannerPopup(ent, doAfter.User, GetEntity(args.Event.Scanned)))
+        {
+            args.Cancel();
             return;
         }
+
+        if (!Transform(doAfter.User).Coordinates.InRange(EntityManager, _transform, args.DoAfter.UserPosition, doAfter.MovementThreshold))
+            args.Cancel();
+    }
+
+    private void OnDoAfter(Entity<HealthScannerComponent> scanner, ref HealthScannerDoAfterEvent args)
+    {
+        if (args.Cancelled || args.Handled)
+            return;
+
+        args.Handled = true;
+
+        if (TryComp(scanner, out UseDelayComponent? useDelay))
+            _useDelay.TryResetDelay((scanner, useDelay));
+
+        scanner.Comp.Target = GetEntity(args.Scanned);
 
         _audio.PlayPvs(scanner.Comp.Sound, scanner);
         _ui.OpenUi(scanner.Owner, HealthScannerUIKey.Key, args.User);
 
-        var blood = _bloodstream.GetBloodLevelPercentage(target.Value) * 100;
+        UpdateUI(scanner);
+    }
+
+    private bool CanUseHealthScannerPopup(Entity<HealthScannerComponent> scanner, EntityUid user, EntityUid target)
+    {
+        if (!HasComp<DamageableComponent>(target) ||
+            !HasComp<MobStateComponent>(target) ||
+            !HasComp<MobThresholdsComponent>(target))
+        {
+            _popup.PopupEntity("You can't analyze that!", target, user);
+            return false;
+        }
+
+        if (TryComp(scanner, out UseDelayComponent? useDelay) &&
+            _useDelay.IsDelayed((scanner, useDelay)))
+        {
+            return false;
+        }
+
+        var ev = new HealthScannerAttemptTargetEvent();
+        RaiseLocalEvent(target, ref ev);
+        if (ev.Cancelled)
+        {
+            if (ev.Popup != null)
+                _popup.PopupEntity(ev.Popup, target, user);
+
+            return false;
+        }
+
+        return true;
+    }
+
+    private void UpdateUI(Entity<HealthScannerComponent> scanner)
+    {
+        if (scanner.Comp.Target is not { } target)
+            return;
+
+        var blood = _bloodstream.GetBloodLevelPercentage(target) * 100;
         var temperature = CompOrNull<TemperatureComponent>(target)?.CurrentTemperature;
 
         Solution? chemicals = null;
-        if (TryComp(target.Value, out BloodstreamComponent? bloodstream))
+        if (TryComp(target, out BloodstreamComponent? bloodstream))
         {
-            _solution.TryGetSolution(target.Value, bloodstream.ChemicalSolutionName, out _, out chemicals);
+            _solution.TryGetSolution(target, bloodstream.ChemicalSolutionName, out _, out chemicals);
         }
 
-        _ui.SetUiState(scanner.Owner, HealthScannerUIKey.Key, new HealthScannerBuiState(GetNetEntity(target.Value), blood, temperature, chemicals));
+        _ui.SetUiState(scanner.Owner, HealthScannerUIKey.Key, new HealthScannerBuiState(GetNetEntity(target), blood, temperature, chemicals));
+    }
+
+    public override void Update(float frameTime)
+    {
+        var time = _timing.CurTime;
+        var scanners = EntityQueryEnumerator<HealthScannerComponent>();
+        while (scanners.MoveNext(out var uid, out var active))
+        {
+            if (time < active.UpdateAt)
+                continue;
+
+            active.UpdateAt = time + active.UpdateCooldown;
+            UpdateUI((uid, active));
+        }
     }
 }

--- a/Content.Shared/_CM14/Marines/Skills/SkillsSystem.cs
+++ b/Content.Shared/_CM14/Marines/Skills/SkillsSystem.cs
@@ -15,4 +15,21 @@ public sealed class SkillsSystem : EntitySystem
             args.MaxDoAfter(ent.Comp.DoAfter);
         }
     }
+
+    public TimeSpan GetDelay(EntityUid user, EntityUid tool)
+    {
+        if (!TryComp(tool, out MedicallyUnskilledDoAfterComponent? doAfter) ||
+            doAfter.Min <= 0)
+        {
+            return default;
+        }
+
+        if (!TryComp(user, out SkillsComponent? skills) ||
+            skills.Medical < doAfter.Min)
+        {
+            return doAfter.DoAfter;
+        }
+
+        return default;
+    }
 }

--- a/Content.Shared/_CM14/Medical/Scanner/HealthScannerComponent.cs
+++ b/Content.Shared/_CM14/Medical/Scanner/HealthScannerComponent.cs
@@ -3,9 +3,18 @@ using Robust.Shared.GameStates;
 
 namespace Content.Shared._CM14.Medical.Scanner;
 
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
 public sealed partial class HealthScannerComponent : Component
 {
     [DataField, AutoNetworkedField]
     public SoundSpecifier? Sound;
+
+    [DataField, AutoNetworkedField]
+    public EntityUid? Target;
+
+    [DataField, AutoNetworkedField, AutoPausedField]
+    public TimeSpan UpdateAt;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan UpdateCooldown = TimeSpan.FromSeconds(1);
 }

--- a/Content.Shared/_CM14/Medical/Scanner/HealthScannerDoAfterEvent.cs
+++ b/Content.Shared/_CM14/Medical/Scanner/HealthScannerDoAfterEvent.cs
@@ -1,0 +1,16 @@
+﻿using Content.Shared.DoAfter;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._CM14.Medical.Scanner;
+
+[Serializable, NetSerializable]
+public sealed partial class HealthScannerDoAfterEvent : SimpleDoAfterEvent
+{
+    [DataField]
+    public NetEntity Scanned;
+
+    public HealthScannerDoAfterEvent(NetEntity scanned)
+    {
+        Scanned = scanned;
+    }
+}

--- a/Resources/Prototypes/_CM14/Entities/Objects/Medical/health_analyzer.yml
+++ b/Resources/Prototypes/_CM14/Entities/Objects/Medical/health_analyzer.yml
@@ -28,3 +28,6 @@
   - type: GuideHelp
     guides:
     - Medical Doctor
+  - type: UseDelay
+    delay: 1
+  - type: MedicallyUnskilledDoAfter


### PR DESCRIPTION
## About the PR
Fixes #2073
Fixes #2074

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: The hf2 health analyzer now automatically updates every second.
- tweak: Added a delay to using the hf2 health analyzer for medically unskilled marines.