### PR TITLE
Fix warrior punch action description

### DIFF
--- a/Content.Shared/_RMC14/Tackle/TackleSystem.cs
+++ b/Content.Shared/_RMC14/Tackle/TackleSystem.cs
@@ -34,6 +34,7 @@ public sealed class TackleSystem : EntitySystem
         var time = _timing.CurTime;
         var recently = EnsureComp<TackledRecentlyComponent>(target);
         recently.LastTackled = time;
+        recently.LastTackledDuration = tackle.Stun > recently.LastTackledDuration ? tackle.Stun : recently.LastTackledDuration;
         recently.Current += tackle.Strength;
 
         Dirty(target, recently);
@@ -88,9 +89,9 @@ public sealed class TackleSystem : EntitySystem
 
         var time = _timing.CurTime;
         var query = EntityQueryEnumerator<TackledRecentlyComponent, TackleableComponent>();
-        while (query.MoveNext(out var uid, out var recently, out var able))
+        while (query.MoveNext(out var uid, out var recently, out _))
         {
-            if (time > recently.LastTackled + able.Expires)
+            if (time > recently.LastTackled + recently.LastTackledDuration)
                 RemCompDeferred<TackledRecentlyComponent>(uid);
         }
     }

--- a/Content.Shared/_RMC14/Tackle/TackleableComponent.cs
+++ b/Content.Shared/_RMC14/Tackle/TackleableComponent.cs
@@ -2,9 +2,5 @@
 
 namespace Content.Shared._RMC14.Tackle;
 
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-public sealed partial class TackleableComponent : Component
-{
-    [DataField, AutoNetworkedField]
-    public TimeSpan Expires = TimeSpan.FromSeconds(4);
-}
+[RegisterComponent, NetworkedComponent]
+public sealed partial class TackleableComponent : Component;

--- a/Content.Shared/_RMC14/Tackle/TackledRecentlyComponent.cs
+++ b/Content.Shared/_RMC14/Tackle/TackledRecentlyComponent.cs
@@ -11,4 +11,7 @@ public sealed partial class TackledRecentlyComponent : Component
 
     [DataField, AutoNetworkedField]
     public TimeSpan LastTackled;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan LastTackledDuration;
 }

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
@@ -247,7 +247,7 @@
   id: ActionXenoPunch
   parent: ActionXenoBase
   name: Punch
-  description: Punches the targeted marine dealing a hefty amount of damage as well as slowing the target for seconds.
+  description: Punches the targeted marine dealing a hefty amount of damage as well as slowing the target.
   components:
   - type: EntityTargetAction
     itemIconStyle: NoItem


### PR DESCRIPTION
## About the PR
Also includes changelog from other commits.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: Enabled the Warrior > Crusher evolution.
- fix: Fixed the spitter's xeno spit being able to hurt other xenos.
- fix: Fixed the M54C's AP and Extended mags not being able to fit into some storages.
- tweak: Tackle stacks no longer expire while downed, making it easier to keep a tackled target down.
- tweak: Fog walls now occlude vision.