### PR TITLE
Change raffle duration 30 > 10, no extending, 0 delay to clicking button

### DIFF
--- a/Content.Client/UserInterface/Systems/Ghost/Controls/Roles/GhostRoleRulesWindow.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/Controls/Roles/GhostRoleRulesWindow.xaml.cs
@@ -27,6 +27,10 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls.Roles
                 TopBanner.SetMessage(FormattedMessage.FromMarkupPermissive(rules + "\n" + Loc.GetString("ghost-roles-window-rules-footer", ("time", ghostRoleTime))));
                 RequestButton.Disabled = true;
             }
+            else
+            {
+                TopBanner.SetMessage(FormattedMessage.FromMarkupPermissive(rules));
+            }
 
             RequestButton.OnPressed += requestAction;
         }

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1960,7 +1960,7 @@ namespace Content.Shared.CCVar
         /// The time you must spend reading the rules, before the "Request" button is enabled
         /// </summary>
         public static readonly CVarDef<float> GhostRoleTime =
-            CVarDef.Create("ghost.role_time", 3f, CVar.REPLICATED | CVar.SERVER);
+            CVarDef.Create("ghost.role_time", 0f, CVar.REPLICATED | CVar.SERVER);
 
         /// <summary>
         /// Whether or not to kill the player's mob on ghosting, when it is in a critical health state.

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1960,7 +1960,7 @@ namespace Content.Shared.CCVar
         /// The time you must spend reading the rules, before the "Request" button is enabled
         /// </summary>
         public static readonly CVarDef<float> GhostRoleTime =
-            CVarDef.Create("ghost.role_time", 0f, CVar.REPLICATED | CVar.SERVER);
+            CVarDef.Create("ghost.role_time", 0.2f, CVar.REPLICATED | CVar.SERVER);
 
         /// <summary>
         /// Whether or not to kill the player's mob on ghosting, when it is in a critical health state.

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1960,7 +1960,7 @@ namespace Content.Shared.CCVar
         /// The time you must spend reading the rules, before the "Request" button is enabled
         /// </summary>
         public static readonly CVarDef<float> GhostRoleTime =
-            CVarDef.Create("ghost.role_time", 0.2f, CVar.REPLICATED | CVar.SERVER);
+            CVarDef.Create("ghost.role_time", 0f, CVar.REPLICATED | CVar.SERVER);
 
         /// <summary>
         /// Whether or not to kill the player's mob on ghosting, when it is in a critical health state.

--- a/Resources/Prototypes/GhostRoleRaffles/settings.yml
+++ b/Resources/Prototypes/GhostRoleRaffles/settings.yml
@@ -11,5 +11,5 @@
   id: short
   settings:
     initialDuration: 10
-    joinExtendsDurationBy: 5
-    maxDuration: 30
+    joinExtendsDurationBy: 0
+    maxDuration: 10


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Raffle durations are now 10 seconds, down from 30, and don't extend when more people join the raffle
- tweak: There is no longer a 3 second delay to clicking the join raffle button.