### PR TITLE
Fixed wrong localization strings

### DIFF
--- a/Content.Shared/_RMC14/Anchor/DeployableItemSystem.cs
+++ b/Content.Shared/_RMC14/Anchor/DeployableItemSystem.cs
@@ -95,7 +95,7 @@ public sealed class DeployableItemSystem : EntitySystem
                 else if (filled < total * ent.Comp.HalfFullThreshold)
                     args.PushMarkup(Loc.GetString("cm-magazine-box-examine-half-full"));
                 else
-                    args.PushMarkup(Loc.GetString("cm-magazine-examine-almost-full"));
+                    args.PushMarkup(Loc.GetString("cm-magazine-box-examine-almost-full"));
             }
             else
             {

--- a/Resources/Locale/en-US/_RMC14/changelog.ftl
+++ b/Resources/Locale/en-US/_RMC14/changelog.ftl
@@ -1,1 +1,1 @@
-﻿changelog-tab-title-CM = CM
+﻿changelog-tab-title-RMC14 = RMC14


### PR DESCRIPTION
## About the PR

for magazine box
- `cm-magazine-examine-almost-full` -> `cm-magazine-box-examine-almost-full`

for changelog
- `changelog-tab-title-CM` -> `changelog-tab-title-RMC14`

fixes #2573