### PR TITLE
Move faster in lighter armors and slower in heavier armors

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
@@ -103,9 +103,7 @@
   - type: CMArmor
     armor: 25
     explosionArmor: 20
-  - type: ClothingSpeedModifier
-    walkModifier: 1
-    sprintModifier: 1
+  
 
 - type: entity
   parent: CMArmorM3Medium
@@ -193,6 +191,9 @@
   - type: CMArmor
     armor: 15
     explosionArmor: 20
+  - type: ClothingSpeedModifier
+    walkModifier: 1
+    sprintModifier: 1
   - type: Storage
     grid:
     - 0,0,3,1 # 2 slots

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
@@ -78,8 +78,8 @@
       enum.StorageUiKey.Key:
         type: StorageBoundUserInterface
   - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.9
+    walkModifier: 0.85
+    sprintModifier: 0.85
   - type: CMHardArmor
   - type: FixedItemSizeStorage
   - type: IgnoreContentsSize
@@ -103,6 +103,9 @@
   - type: CMArmor
     armor: 25
     explosionArmor: 20
+  - type: ClothingSpeedModifier
+    walkModifier: 1
+    sprintModifier: 1
 
 - type: entity
   parent: CMArmorM3Medium
@@ -118,8 +121,8 @@
     armor: 25
     explosionArmor: 35
   - type: ClothingSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.8
+    walkModifier: 0.75
+    sprintModifier: 0.75
   - type: Storage
     grid:
     - 0,0,3,1 # 2 slots


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Change speed values for Light, Medium, and Heavy marine armors.

## Why / Balance
The purpose is to increase the speed difference to be more noticeable. I think, armor selection should have trade-offs such that heavy armors have better armor values but move more slowly. While this was already implemented, in game the difference in speed felt negligible. As a result, I propose increasing the difference in speed multipliers in armor.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Yaml edits on the speed modifiers, I also explicitly added the speed modifier on the light armor to be 1. I assume if absent it would take the speed multiplier from the parent.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
I cannot run SS13 to check what the speed differences are in CM13, in addition the local server does not seem to work for me. Although, the latter is probably just a skill issue on my part. I think a video comparison should be shown of the speed of the character whilst wearing armor that changes speed.

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
I think this change should require a showcase, I am unable to produce one at this time.

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
This only changes one yaml file, I do not think anything should break.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- tweak: Parent marine armor (the medium one) speed mult .9 -> .85
- tweak: EOD armor (the heavy one) speed mult .8 -> .75
- add: Explicit speed value on M3-L (the light one) speed multiplier as 1

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
While, I like the idea behind this I am not certain about it. I would like for this to be used as a way for us to debate this topic of armor movement speed. In addition, I realize this is super low priority, but given my busy schedule "I'm doing my part!" as they say.