### PR TITLE
Make xenonids accumulate evolution points past the max for the first 15 minutes of the round

### DIFF
--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -617,11 +617,6 @@ namespace Content.Server.GameTicking
             }
         }
 
-        public TimeSpan RoundDuration()
-        {
-            return _gameTiming.CurTime.Subtract(RoundStartTimeSpan);
-        }
-
         private void AnnounceRound()
         {
             if (CurrentPreset == null) return;

--- a/Content.Server/_RMC14/Xenonids/Hive/XenoHiveSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Hive/XenoHiveSystem.cs
@@ -12,7 +12,6 @@ public sealed class XenoHiveSystem : SharedXenoHiveSystem
     [Dependency] private readonly XenoAnnounceSystem _xenoAnnounce = default!;
     [Dependency] private readonly GameTicker _gameTicker = default!;
     [Dependency] private readonly IPrototypeManager _prototypes = default!;
-    [Dependency] private readonly IGameTiming _timing = default!;
 
     private readonly List<string> _announce = [];
 
@@ -21,7 +20,7 @@ public sealed class XenoHiveSystem : SharedXenoHiveSystem
         if (_gameTicker.RunLevel != GameRunLevel.InRound)
             return;
 
-        var roundTime = _timing.CurTime - _gameTicker.RoundStartTimeSpan;
+        var roundTime = _gameTicker.RoundDuration();
         var hives = EntityQueryEnumerator<HiveComponent>();
         while (hives.MoveNext(out var hiveId, out var hive))
         {

--- a/Content.Shared/GameTicking/SharedGameTicker.cs
+++ b/Content.Shared/GameTicking/SharedGameTicker.cs
@@ -5,12 +5,14 @@ using Robust.Shared.Replays;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.Markdown.Mapping;
 using Robust.Shared.Serialization.Markdown.Value;
+using Robust.Shared.Timing;
 
 namespace Content.Shared.GameTicking
 {
     public abstract class SharedGameTicker : EntitySystem
     {
         [Dependency] private readonly IReplayRecordingManager _replay = default!;
+        [Dependency] private readonly IGameTiming _gameTiming = default!;
 
         // See ideally these would be pulled from the job definition or something.
         // But this is easier, and at least it isn't hardcoded.
@@ -40,6 +42,11 @@ namespace Content.Shared.GameTicking
         private void OnRecordingStart(MappingDataNode metadata, List<object> events)
         {
             metadata["roundId"] = new ValueDataNode(RoundId.ToString());
+        }
+
+        public TimeSpan RoundDuration()
+        {
+            return _gameTiming.CurTime.Subtract(RoundStartTimeSpan);
         }
     }
 

--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionComponent.cs
@@ -43,4 +43,7 @@ public sealed partial class XenoEvolutionComponent : Component
 
     [DataField, AutoNetworkedField]
     public SoundSpecifier EvolutionReadySound = new SoundPathSpecifier("/Audio/_RMC14/Xeno/xeno_evolveready.ogg", AudioParams.Default.WithVolume(-6));
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan AccumulatePointsBefore = TimeSpan.FromMinutes(15);
 }


### PR DESCRIPTION
## About the PR
No devolving yet tbd, same as 13 otherwise

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Xenonids now accumulate evolution points past their max in the first 15 minutes of the round, making it easier for round-start xenonids to choose their evolution as soon as the castes are unlocked.