### PR TITLE
Lower marines per xeno from 4 to 3, move it to a CVar

### DIFF
--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleComponent.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleComponent.cs
@@ -11,9 +11,6 @@ namespace Content.Server._RMC14.Rules;
 public sealed partial class CMDistressSignalRuleComponent : Component
 {
     [DataField]
-    public int PlayersPerXeno = 4;
-
-    [DataField]
     public List<EntProtoId> SquadIds = ["SquadAlpha", "SquadBravo", "SquadCharlie", "SquadDelta"];
 
     [DataField]

--- a/Content.Shared/_RMC14/CCVar/CMCVars.cs
+++ b/Content.Shared/_RMC14/CCVar/CMCVars.cs
@@ -29,4 +29,7 @@ public sealed class CMCVars : CVars
 
     public static readonly CVarDef<float> CMBleedTimeMultiplier =
         CVarDef.Create("cm.bleed_time_multiplier", 1f, CVar.REPLICATED | CVar.SERVER);
+
+    public static readonly CVarDef<float> CMMarinesPerXeno =
+        CVarDef.Create("cm.marines_per_xeno", 3f, CVar.REPLICATED | CVar.SERVER);
 }


### PR DESCRIPTION
## About the PR
No burrowed larva yet but this should help bridge the gap until then.
Also we can now modify it live instead.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: The amount of marines per xeno has been lowered from 4 to 3. With 200 players this means that 67 xenos will spawn round-start, instead of 50.