### PR TITLE
feat(CMArmorHelmetM10Medic): Add medhud components to corpsman helmet.

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Head/Helmets/marine_helmets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Head/Helmets/marine_helmets.yml
@@ -72,6 +72,13 @@
     sprite: _RMC14/Objects/Clothing/Head/Helmets/m10/med.rsi
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/Head/Helmets/m10/med.rsi
+  - type: ShowHealthBars # TODO RMC14 Hack
+    damageContainers:
+    - Biological
+  - type: HolocardScanner # TODO RMC14 Hack
+  - type: ShowHealthIcons # TODO RMC14 Hack
+    damageContainers:
+    - Biological
 
 - type: entity
   parent: ArmorHelmetM10


### PR DESCRIPTION
## About the PR
Corpsmen now have a medical hud within their helmet. Talked about in Discord for this one.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

![Screenshot from 2024-06-24 18-58-33](https://github.com/RMC-14/RMC-14/assets/87243814/9fb0a1f8-c3ec-4071-94e2-72d0b1da67c7)

- [ x ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- add: Add medical hud to corpsman helmets.