### PR TITLE
Fix marines not being able to move after being unnested and having incorrect standing states

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Medical/doctor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Medical/doctor.yml
@@ -29,7 +29,7 @@
     back: CMSatchelMarine
     shoes: ClothingShoesColorWhite
     id: CMIDCardDoctor
-    ears: CMHeadsetMedical # TODO CM14 Medical Vender
+    ears: CMHeadsetMedical # TODO RMC14 Medical Vender
 
 - type: startingGear
   id: CMGearDoctorEquipped

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Medical/nurse.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Medical/nurse.yml
@@ -29,7 +29,7 @@
     back: CMSatchelMarine
     shoes: ClothingShoesColorWhite
     id: CMIDCardNurse
-    ears: CMHeadsetMedical # TODO CM14 Medical Vender
+    ears: CMHeadsetMedical # TODO RMC14 Medical Vender
 
 - type: startingGear
   id: CMGearNurseEquipped


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed marines not being able to move after being un-nested.
- fix: Fixed marines falling down if they die while nested, and not falling down once un-nested after being killed..
