### PR TITLE
Fix the Queen not detaching from the ovipositor on crit or death, add popups

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
@@ -70,17 +70,22 @@ public sealed class XenoEggSystem : EntitySystem
 
         var ev = new XenoGrowOvipositorDoAfterEvent { PlasmaCost = args.AttachPlasmaCost };
         var delay = args.AttachDoAfter;
+        var popup = new LocId("cm-xeno-ovipositor-attach");
+        var popupType = PopupType.Medium;
         if (hasOvipositor)
         {
             ev.PlasmaCost = FixedPoint2.Zero;
             delay = args.DetachDoAfter;
+            popup = "cm-xeno-ovipositor-detach";
+            popupType = PopupType.MediumCaution;
         }
 
         var doAfterArgs = new DoAfterArgs(EntityManager, xeno, delay, ev, xeno)
         {
-            BreakOnMove = true
+            BreakOnMove = true,
         };
-        _doAfter.TryStartDoAfter(doAfterArgs);
+        if (_doAfter.TryStartDoAfter(doAfterArgs))
+            _popup.PopupClient(Loc.GetString(popup), xeno, xeno, PopupType.Medium);
     }
 
     private void OnXenoGrowOvipositorDoAfter(Entity<XenoComponent> xeno, ref XenoGrowOvipositorDoAfterEvent args)
@@ -299,8 +304,6 @@ public sealed class XenoEggSystem : EntitySystem
                 _actions.SetToggled(actionId, true);
             }
         }
-
-        _popup.PopupClient(Loc.GetString("cm-xeno-ovipositor-attach"), xeno, xeno);
     }
 
     private void DetachOvipositor(Entity<XenoAttachedOvipositorComponent> xeno)

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
@@ -93,3 +93,7 @@ cm-xeno-charge-spit-expire = Our spits are back to normal.
 # Turn Invisible
 cm-xeno-invisibility-already-invisible = We are already invisible!
 cm-xeno-invisibility-expire = We feel our invisibility end!
+
+# Ovipositor
+cm-xeno-ovipositor-attach = We start attaching to the ovipositor.
+cm-xeno-ovipositor-detach = We start detaching from the ovipositor.


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed the Queen not detaching from the ovipositor on crit or death.
- tweak: Added popups to the Queen when starting to attach to or detach from the ovipositor.