### PR TITLE
Revert "add a new valid license"

### DIFF
--- a/.github/rsi-schema.json
+++ b/.github/rsi-schema.json
@@ -1,7 +1,7 @@
 {
    "$schema":"http://json-schema.org/draft-07/schema",
    "default":{
-
+      
    },
    "description":"JSON Schema for SS14 RSI validation.",
    "examples":[
@@ -83,8 +83,7 @@
             "CC-BY-NC-4.0",
             "CC-BY-NC-SA-3.0",
             "CC-BY-NC-SA-4.0",
-            "CC0-1.0",
-            "CC-SAMPLING+-1.0"
+            "CC0-1.0"
          ],
          "examples":[
             "CC-BY-SA-3.0"
@@ -105,7 +104,7 @@
       "size":{
          "$id":"#/properties/size",
          "default":{
-
+            
          },
          "description":"The dimensions of the sprites inside the RSI.  This is not the size of the PNG files that store the sprite sheet.",
          "examples":[
@@ -146,7 +145,7 @@
          "title":"Icon States",
          "description":"Metadata for icon states. Includes name, directions, delays, etc.",
          "default":[
-
+            
          ],
          "examples":[
             [


### PR DESCRIPTION
Reverts RMC-14/RMC-14#2634

It wasn't actually a valid license after all 