### PR TITLE
Adds melee attacks to guns.

### DIFF
--- a/Content.Client/_RMC14/Weapons/Melee/CMMeleeWeaponSystem.cs
+++ b/Content.Client/_RMC14/Weapons/Melee/CMMeleeWeaponSystem.cs
@@ -1,24 +1,38 @@
-﻿using Content.Client.Weapons.Melee;
+﻿using Content.Client.Gameplay;
+using Content.Client.Weapons.Melee;
 using Content.Shared._RMC14.Input;
 using Content.Shared._RMC14.Weapons.Melee;
+using Content.Shared.ActionBlocker;
+using Content.Shared.CombatMode;
+using Content.Shared.Hands.Components;
+using Content.Shared.Weapons.Melee;
+using Content.Shared.Weapons.Melee.Events;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.Input;
 using Robust.Client.Player;
+using Robust.Client.State;
+using Robust.Shared.Input;
 using Robust.Shared.Input.Binding;
 using Robust.Shared.Map;
+using Robust.Shared.Timing;
 
 namespace Content.Client._RMC14.Weapons.Melee;
 
 public sealed class CMMeleeWeaponSystem : SharedCMMeleeWeaponSystem
 {
+    [Dependency] private readonly ActionBlockerSystem _actionBlockerSystem = default!;
     [Dependency] private readonly IEyeManager _eye = default!;
-    [Dependency] private readonly IInputManager _input = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly IInputManager _inputManager = default!;
     [Dependency] private readonly IMapManager _mapManager = default!;
+    [Dependency] private readonly InputSystem _inputSystem = default!;
+    [Dependency] private readonly IStateManager _stateManager = default!;
     [Dependency] private readonly MapSystem _map = default!;
     [Dependency] private readonly MeleeWeaponSystem _melee = default!;
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly TransformSystem _transform = default!;
+    [Dependency] private readonly SharedCombatModeSystem _combatModeSystem = default!;
 
     public override void Initialize()
     {
@@ -36,7 +50,7 @@ public sealed class CMMeleeWeaponSystem : SharedCMMeleeWeaponSystem
 
     private void TryPrimaryHeavyAttack()
     {
-        var mousePos = _eye.PixelToMap(_input.MouseScreenPosition);
+        var mousePos = _eye.PixelToMap(_inputManager.MouseScreenPosition);
         EntityUid grid;
 
         if (_mapManager.TryFindGridAt(mousePos, out var gridUid, out _))
@@ -56,5 +70,84 @@ public sealed class CMMeleeWeaponSystem : SharedCMMeleeWeaponSystem
 
         if (weapon.WidePrimary)
                 _melee.ClientHeavyAttack(entity, coordinates, weaponUid, weapon);
+    }
+    
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        if (!_timing.IsFirstTimePredicted)
+            return;
+
+        if (_player.LocalEntity is not { } playerEntity)
+            return;
+        
+        if (!TryComp(playerEntity, out HandsComponent? handsComponent) || handsComponent.ActiveHandEntity == null)
+            return;
+        
+        EntityUid weaponUid = handsComponent.ActiveHandEntity.Value;
+        
+        if (!TryComp(weaponUid, out MeleeWeaponComponent? meleeComponent) || !TryComp(weaponUid, out AltFireMeleeComponent? altMeleeComponent))
+            return;
+        
+        if (!_combatModeSystem.IsInCombatMode(playerEntity) || !_actionBlockerSystem.CanAttack(playerEntity, weapon: (weaponUid, meleeComponent)))
+        {
+            meleeComponent.Attacking = false;
+            return;
+        }
+        
+        var altDown = _inputSystem.CmdStates.GetState(EngineKeyFunctions.UseSecondary);
+
+        if ((meleeComponent.AutoAttack || (_inputSystem.CmdStates.GetState(EngineKeyFunctions.Use) != BoundKeyState.Down && altDown != BoundKeyState.Down)) &&
+            meleeComponent.Attacking)
+        {
+            RaisePredictiveEvent(new StopAttackEvent(GetNetEntity(weaponUid)));
+        }
+        
+        if (altDown != BoundKeyState.Down)
+            return;
+
+        if (meleeComponent.Attacking || meleeComponent.NextAttack > _timing.CurTime)
+            return;
+
+        var mousePos = _eye.PixelToMap(_inputManager.MouseScreenPosition);
+
+        if (mousePos.MapId == MapId.Nullspace)
+            return;
+
+        EntityCoordinates coordinates;
+
+        if (_mapManager.TryFindGridAt(mousePos, out var gridUid, out _))
+            coordinates = EntityCoordinates.FromMap(gridUid, mousePos, _transform, EntityManager);
+        else
+            coordinates = EntityCoordinates.FromMap(_mapManager.GetMapEntityId(mousePos.MapId), mousePos, _transform, EntityManager);
+        
+        EntityUid? target = _stateManager.CurrentState is GameplayStateBase screen ? screen.GetClickedEntity(mousePos) : null;
+        
+        var attackerPos = _transform.GetMapCoordinates(playerEntity);
+        
+        if(mousePos.MapId != attackerPos.MapId)
+            return;
+        
+        switch (altMeleeComponent.AttackType)
+        {
+            case AltFireAttackType.Light:
+                if ((attackerPos.Position - mousePos.Position).Length() > meleeComponent.Range)
+                    return;
+                
+                RaisePredictiveEvent(new LightAttackEvent(GetNetEntity(target), GetNetEntity(weaponUid), GetNetCoordinates(coordinates)));
+                break;
+            
+            case AltFireAttackType.Heavy:
+                _melee.ClientHeavyAttack(playerEntity, coordinates, weaponUid, meleeComponent);
+                break;
+            
+            case AltFireAttackType.Disarm:
+                if ((attackerPos.Position - mousePos.Position).Length() > meleeComponent.Range)
+                    return;
+                
+                RaisePredictiveEvent(new DisarmAttackEvent(GetNetEntity(target), GetNetCoordinates(coordinates)));
+                break;
+        }
     }
 }

--- a/Content.Shared/_RMC14/Weapons/Melee/AltFireMeleeComponent.cs
+++ b/Content.Shared/_RMC14/Weapons/Melee/AltFireMeleeComponent.cs
@@ -1,0 +1,22 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Weapons.Melee;
+
+/// <summary>
+/// This is used to allow ranged weapons to make melee attacks by right-clicking.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, Access(typeof(SharedCMMeleeWeaponSystem))]
+public sealed partial class AltFireMeleeComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public AltFireAttackType AttackType = AltFireAttackType.Light;
+}
+
+
+[Flags]
+public enum AltFireAttackType : byte
+{
+    Light = 0, // Standard single-target attack.
+    Heavy = 1 << 0, // Wide swing.
+    Disarm = 1 << 1
+}

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/cm_base_gun.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/cm_base_gun.yml
@@ -10,3 +10,10 @@
     skills:
       firearms: 1
   - type: UniqueAction
+  - type: MeleeWeapon
+    damage:
+      types:
+        Blunt: 5
+    soundHit:
+      collection: GenericHit
+  - type: AltFireMelee


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Any RMC gun can now be used to make melee attacks by right-clicking.

## Why / Balance
In CM13 guns can make melee attacks, which are further improved by stocks and bayonets. This adds that functionality here.

## Technical details
Implements a component that tells the weapon which attack it should make when right-clicking. The weapon must have both GunComponent and MeleeWeaponComponent for this to work.

The actual attack is handled by the overriden Update method in CMMeleeWeaponSystem.

## Media
![attack](https://github.com/RMC-14/RMC-14/assets/84070966/d6c450a0-a0a3-4c54-8baf-2da979bfa1df)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl: Sigil
- add: Guns can now be used to make melee attacks. Right-click to do so. For all current guns, this attack is single-target and, without attachments, does 5 brute.
