### PR TITLE
Add phoron as a reagent, make phoron bars grindable

### DIFF
--- a/Resources/Locale/en-US/_RMC14/reagents/pyrotechnic.ftl
+++ b/Resources/Locale/en-US/_RMC14/reagents/pyrotechnic.ftl
@@ -1,0 +1,2 @@
+reagent-name-rmcphoron = Phoron
+reagent-desc-rmcphoron = A special form of metallic plasma that is not found on Earth. While phoron is highly flammable and extremely toxic, its high energy density makes it one of the best solid fuel alternatives. Liquid phoron is often used for research purposes and in the medical industry a catalyst to many advanced chemicals.

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Materials/Sheets/other.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Materials/Sheets/other.yml
@@ -3,15 +3,8 @@
   parent: SheetOtherBase
   id: CMSheetPhoron
   name: phoron
-  suffix: "Full"
+  suffix: Full
   components:
-  - type: Sprite
-    sprite: _RMC14/Objects/Materials/Sheets/phoron.rsi
-    state: phoron
-  - type: Item
-    size: Normal
-    sprite: _RMC14/Objects/Materials/Sheets/phoron.rsi
-    heldPrefix: phoron
   - type: Material
   - type: PhysicalComposition
     materialComposition:
@@ -19,7 +12,22 @@
   - type: Stack
     stackType: CMPhoron
     count: 50
+  - type: Sprite
+    state: phoron
+    sprite: _RMC14/Objects/Materials/Sheets/phoron.rsi
+  - type: Item
+    heldPrefix: phoron
+    size: Normal
+    sprite: _RMC14/Objects/Materials/Sheets/phoron.rsi
   - type: Appearance
+  - type: Extractable
+    grindableSolutionName: phoron
+  - type: SolutionContainerManager
+    solutions:
+      phoron:
+        reagents:
+        - ReagentId: RMCPhoron
+          Quantity: 10
   - type: Tag
     tags:
     - Sheet
@@ -27,7 +35,7 @@
 - type: entity
   parent: CMSheetPhoron
   id: CMSheetPhoron25
-  suffix: "25"
+  suffix: 25
   components:
   - type: Stack
     count: 25
@@ -35,7 +43,7 @@
 - type: entity
   parent: CMSheetPhoron
   id: CMSheetPhoron1
-  suffix: "1"
+  suffix: Single
   components:
   - type: Stack
     count: 1

--- a/Resources/Prototypes/_RMC14/Reagents/pyrotechnic.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/pyrotechnic.yml
@@ -1,0 +1,27 @@
+# TODO RMC14 other effects
+- type: reagent
+  parent: [ CMReagent, BasePyrotechnic ]
+  id: RMCPhoron
+  name: reagent-name-rmcphoron
+  desc: reagent-desc-rmcphoron
+  physicalDesc: reagent-physical-desc-shiny
+  flavor: bitter
+  color: "#E71B00"
+  tileReactions:
+  - !type:FlammableTileReaction {}
+  reactiveEffects:
+    Flammable:
+      methods: [ Touch ]
+      effects:
+      - !type:FlammableReaction
+        multiplier: 0.2
+  metabolisms:
+    Poison:
+      metabolismRate: 0.05
+      effects:
+      - !type:HealthChange
+        damage:
+          types:
+            Poison: 0.25
+      - !type:FlammableReaction
+        multiplier: 0.2


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Made phoron bars grindable into its own reagent. 

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Made phoron bars grindable into its own reagent due to some chemical recipes for medicine requiring it.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://github.com/RMC-14/RMC-14/assets/75623951/6e28688a-ba97-4c7d-b806-74776cc9bac2

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Made phoron bars grindable.
- add: Added phoron as a reagent.
