### PR TITLE
Add text on examine for bursted victims

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
@@ -381,7 +381,10 @@ public abstract class SharedXenoParasiteSystem : EntitySystem
                 // Percentage of how far along we out to burst time times the number of stages, truncated. You can't go back a stage once you've reached one
                 int stage = Math.Max((int) ((infected.BurstDelay - (infected.BurstAt - time)) / infected.BurstDelay * infected.FinalStage), infected.CurrentStage);
                 if (stage != infected.CurrentStage)
+                {
                     infected.CurrentStage = stage;
+                    Dirty(uid, infected);
+                }
 
                 // Warn on the last to final stage of a burst
                 if (!infected.DidBurstWarning && stage == infected.FinalStage - 1)
@@ -454,6 +457,7 @@ public abstract class SharedXenoParasiteSystem : EntitySystem
 
             var spawned = SpawnAtPosition(infected.BurstSpawn, xform.Coordinates);
             infected.CurrentStage = 6;
+            Dirty(uid, infected);
 
             _xeno.SetHive(spawned, infected.Hive);
 

--- a/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
@@ -78,6 +78,7 @@ public abstract class SharedXenoParasiteSystem : EntitySystem
         SubscribeLocalEvent<VictimBurstComponent, UpdateMobStateEvent>(OnVictimUpdateMobState,
             after: [typeof(MobThresholdSystem), typeof(SharedXenoPheromonesSystem)]);
         SubscribeLocalEvent<VictimBurstComponent, RejuvenateEvent>(OnVictimBurstRejuvenate);
+        SubscribeLocalEvent<VictimBurstComponent, ExaminedEvent>(OnVictimBurstExamine);
     }
 
     private void OnInfectableActivate(Entity<InfectableComponent> ent, ref ActivateInWorldEvent args)
@@ -226,6 +227,12 @@ public abstract class SharedXenoParasiteSystem : EntitySystem
         RemCompDeferred<VictimBurstComponent>(burst);
     }
 
+    private void OnVictimBurstExamine(Entity<VictimBurstComponent> burst, ref ExaminedEvent args)
+    {
+        using(args.PushGroup(nameof(VictimBurstComponent)))
+            args.PushMarkup($"[color=red][bold]{Loc.GetString("rmc-xeno-infected-bursted", ("victim", burst))}[/bold][/color]");
+    }
+
     private bool StartInfect(Entity<XenoParasiteComponent> parasite, EntityUid victim, EntityUid user)
     {
         if (!CanInfectPopup(parasite, victim, user))
@@ -249,7 +256,7 @@ public abstract class SharedXenoParasiteSystem : EntitySystem
             HasComp<VictimInfectedComponent>(victim))
         {
             if (popup)
-                _popup.PopupClient(Loc.GetString("cm-xeno-failed-cant-infect", ("target", victim)), victim, user, PopupType.MediumCaution);
+                _popup.PopupClient(Loc.GetString("rmc-xeno-failed-cant-infect", ("target", victim)), victim, user, PopupType.MediumCaution);
 
             return false;
         }
@@ -259,7 +266,7 @@ public abstract class SharedXenoParasiteSystem : EntitySystem
             !_standing.IsDown(victim, standing))
         {
             if (popup)
-                _popup.PopupClient(Loc.GetString("cm-xeno-failed-cant-reach", ("target", victim)), victim, user, PopupType.MediumCaution);
+                _popup.PopupClient(Loc.GetString("rmc-xeno-failed-cant-reach", ("target", victim)), victim, user, PopupType.MediumCaution);
 
             return false;
         }
@@ -267,7 +274,7 @@ public abstract class SharedXenoParasiteSystem : EntitySystem
         if (_mobState.IsDead(victim))
         {
             if (popup)
-                _popup.PopupClient(Loc.GetString("cm-xeno-failed-target-dead"), victim, user, PopupType.MediumCaution);
+                _popup.PopupClient(Loc.GetString("rmc-xeno-failed-target-dead"), victim, user, PopupType.MediumCaution);
 
             return false;
         }
@@ -294,7 +301,7 @@ public abstract class SharedXenoParasiteSystem : EntitySystem
 
             if (any && _net.IsServer)
             {
-                _popup.PopupEntity(Loc.GetString("cm-xeno-infect-success", ("target", victim)), victim);
+                _popup.PopupEntity(Loc.GetString("rmc-xeno-infect-success", ("target", victim)), victim);
             }
         }
 
@@ -379,8 +386,8 @@ public abstract class SharedXenoParasiteSystem : EntitySystem
                 // Warn on the last to final stage of a burst
                 if (!infected.DidBurstWarning && stage == infected.FinalStage - 1)
                 {
-                    _popup.PopupEntity(Loc.GetString("cm-xeno-infection-burst-soon-self"), uid, uid, PopupType.MediumCaution);
-                    _popup.PopupEntity(Loc.GetString("cm-xeno-infection-burst-soon", ("victim", uid)), uid, Filter.PvsExcept(uid), true, PopupType.MediumCaution);
+                    _popup.PopupEntity(Loc.GetString("rmc-xeno-infection-burst-soon-self"), uid, uid, PopupType.MediumCaution);
+                    _popup.PopupEntity(Loc.GetString("rmc-xeno-infection-burst-soon", ("victim", uid)), uid, Filter.PvsExcept(uid), true, PopupType.MediumCaution);
                     _jitter.DoJitter(uid, infected.JitterTime * 6, false);
                     infected.DidBurstWarning = true;
                     continue;
@@ -393,7 +400,7 @@ public abstract class SharedXenoParasiteSystem : EntitySystem
                 {
                     if (_random.Prob(infected.MajorPainChance * frameTime))
                     {
-                        var message = Loc.GetString("cm-xeno-infection-majorpain-" + _random.Pick(new List<string> { "chest", "breathing", "heart" }));
+                        var message = Loc.GetString("rmc-xeno-infection-majorpain-" + _random.Pick(new List<string> { "chest", "breathing", "heart" }));
                         _popup.PopupEntity(message, uid, uid, PopupType.SmallCaution);
                         if (_random.Prob(0.5f))
                         {
@@ -409,13 +416,13 @@ public abstract class SharedXenoParasiteSystem : EntitySystem
                 {
                     if (_random.Prob(infected.ThroatPainChance * frameTime))
                     {
-                        var message = Loc.GetString("cm-xeno-infection-throat-" + _random.Pick(new List<string> { "sore", "mucous" }));
+                        var message = Loc.GetString("rmc-xeno-infection-throat-" + _random.Pick(new List<string> { "sore", "mucous" }));
                         _popup.PopupEntity(message, uid, uid, PopupType.SmallCaution);
                     }
                     // TODO 20% chance to take limb damage
                     else if (_random.Prob(infected.MuscleAcheChance * frameTime))
                     {
-                        _popup.PopupEntity(Loc.GetString("cm-xeno-infection-muscle-ache"), uid, PopupType.SmallCaution);
+                        _popup.PopupEntity(Loc.GetString("rmc-xeno-infection-muscle-ache"), uid, PopupType.SmallCaution);
                         if (_random.Prob(0.2f))
                             _damage.TryChangeDamage(uid, infected.InfectionDamage, true, false);
                     }
@@ -433,7 +440,7 @@ public abstract class SharedXenoParasiteSystem : EntitySystem
                 {
                     if (_random.Prob(infected.MinorPainChance * frameTime))
                     {
-                        var message = Loc.GetString("cm-xeno-infection-minorpain-" + _random.Pick(new List<string> { "stomach", "chest" }));
+                        var message = Loc.GetString("rmc-xeno-infection-minorpain-" + _random.Pick(new List<string> { "stomach", "chest" }));
                         _popup.PopupEntity(message, uid, uid, PopupType.SmallCaution);
                     }
 
@@ -464,8 +471,8 @@ public abstract class SharedXenoParasiteSystem : EntitySystem
         //TODO Minor limb damage and causes pain
         _stun.TryParalyze(victim, knockdownTime, false);
         _jitter.DoJitter(victim, jitterTime, false);
-        _popup.PopupEntity(Loc.GetString("cm-xeno-infection-shakes-self"), victim, victim, PopupType.MediumCaution);
-        _popup.PopupEntity(Loc.GetString("cm-xeno-infection-shakes", ("victim", victim)), victim, Filter.PvsExcept(victim), true, PopupType.MediumCaution);
+        _popup.PopupEntity(Loc.GetString("rmc-xeno-infection-shakes-self"), victim, victim, PopupType.MediumCaution);
+        _popup.PopupEntity(Loc.GetString("rmc-xeno-infection-shakes", ("victim", victim)), victim, Filter.PvsExcept(victim), true, PopupType.MediumCaution);
         _damage.TryChangeDamage(victim, infected.InfectionDamage, true, false);
     }
 }

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-infection.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-infection.ftl
@@ -1,16 +1,18 @@
-cm-xeno-infection-shakes = {CAPITALIZE($victim)} starts shaking uncontrollably!
-cm-xeno-infection-shakes-self = You feel something moving inside of you! You start shaking uncontrollably!
+rmc-xeno-infection-shakes = {CAPITALIZE($victim)} starts shaking uncontrollably!
+rmc-xeno-infection-shakes-self = You feel something moving inside of you! You start shaking uncontrollably!
 
-cm-xeno-infection-minorpain-chest = Your chest hurts a little bit.
-cm-xeno-infection-minorpain-stomach = Your stomach hurts.
+rmc-xeno-infection-minorpain-chest = Your chest hurts a little bit.
+rmc-xeno-infection-minorpain-stomach = Your stomach hurts.
 
-cm-xeno-infection-throat-sore = Your throat feels sore.
-cm-xeno-infection-throat-mucous = Mucous runs down the back of your throat.
-cm-xeno-infection-muscle-ache = Your muscles ache.
+rmc-xeno-infection-throat-sore = Your throat feels sore.
+rmc-xeno-infection-throat-mucous = Mucous runs down the back of your throat.
+rmc-xeno-infection-muscle-ache = Your muscles ache.
 
-cm-xeno-infection-majorpain-chest = Your chest hurts badly.
-cm-xeno-infection-majorpain-breathing = It becomes difficult to breathe.
-cm-xeno-infection-majorpain-heart = Your heart starts beating rapidly, and each beat is painful.
+rmc-xeno-infection-majorpain-chest = Your chest hurts badly.
+rmc-xeno-infection-majorpain-breathing = It becomes difficult to breathe.
+rmc-xeno-infection-majorpain-heart = Your heart starts beating rapidly, and each beat is painful.
 
-cm-xeno-infection-burst-soon = {CAPITALIZE($victim)} starts shaking violently!
-cm-xeno-infection-burst-soon-self = You feel something crawling through your insides! 
+rmc-xeno-infection-burst-soon = {CAPITALIZE($victim)} starts shaking violently!
+rmc-xeno-infection-burst-soon-self = You feel something crawling through your insides!
+
+rmc-xeno-infected-bursted = {CAPITALIZE(SUBJECT($victim))} has a giant hole in {POSS-ADJ($victim)} chest!


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Adds a line when you examine someone who has bursted.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Fixes #845

Also fixed up localization names from my previous PR to be up to date with the name. Also fixes a small bug where the client xeno infected icons weren't updating as the stage progressed.
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Just use ExaminedEvent and push markup
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
![ohno](https://github.com/RMC-14/RMC-14/assets/32827189/636880d3-ec7c-41c4-a2bc-0051df9e90b7)

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
nah
