### PR TITLE
enable cat ears and tail markings for humans

### DIFF
--- a/Resources/Prototypes/Species/human.yml
+++ b/Resources/Prototypes/Species/human.yml
@@ -45,10 +45,10 @@
       points: 1
       required: false
     Tail: # the cat tail joke
-      points: 0
+      points: 1
       required: false
     HeadTop: # the cat ear joke
-      points: 0
+      points: 1
       required: false
     Chest:
       points: 1


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
This PR enables the usually unavailable cat ears and tail for humans :)
<!-- What did you change in this PR? -->

## Why / Balance
We have short cat people now, why not have normal height cat people?
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl: cooldolphin
- add: Enabled cat ears for humans.

