### PR TITLE
Fix xenos and humans being able to gib

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
@@ -164,3 +164,5 @@
       - CMActionGhost
       Dead:
       - CMActionGhost
+  - type: Destructible
+    thresholds: []

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
@@ -43,13 +43,7 @@
   - type: Damageable
     damageContainer: Xeno
   - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTypeTrigger
-        damageType: Blunt
-        damage: 400
-      behaviors:
-      - !type:GibBehavior { }
+    thresholds: []
   - type: MobState
     allowedStates:
     - Alive


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed humanoids and xenos being gibbed when receiving exclusively Blunt (M40 HEDP) damage.