### PR TITLE
Set default vote restart ghost percentage to 75, lower xeno amount default by 0.75 (~20%)

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1345,7 +1345,7 @@ namespace Content.Shared.CCVar
         ///     Config for when the restart vote should be allowed to be called based on percentage of ghosts.
         ///
         public static readonly CVarDef<int> VoteRestartGhostPercentage =
-            CVarDef.Create("vote.restart_ghost_percentage", 55, CVar.SERVERONLY);
+            CVarDef.Create("vote.restart_ghost_percentage", 75, CVar.SERVERONLY);
 
         /// <summary>
         ///     See vote.enabled, but specific to preset votes

--- a/Content.Shared/_RMC14/CCVar/CMCVars.cs
+++ b/Content.Shared/_RMC14/CCVar/CMCVars.cs
@@ -52,7 +52,7 @@ public sealed class CMCVars : CVars
         CVarDef.Create("cm.bleed_time_multiplier", 1f, CVar.REPLICATED | CVar.SERVER);
 
     public static readonly CVarDef<float> CMMarinesPerXeno =
-        CVarDef.Create("cm.marines_per_xeno", 3f, CVar.REPLICATED | CVar.SERVER);
+        CVarDef.Create("cm.marines_per_xeno", 3.75f, CVar.REPLICATED | CVar.SERVER);
 
     public static readonly CVarDef<int> RMCPatronLobbyMessageTimeSeconds =
         CVarDef.Create("rmc.patron_lobby_message_time_seconds", 30, CVar.REPLICATED | CVar.SERVER);


### PR DESCRIPTION
## About the PR
This is what we have been running the last round on.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
