### PR TITLE
Fixes shockwave graphic compatibility error

### DIFF
--- a/Content.Shared/_RMC14/Explosion/RMCExplosionShockWaveComponent.cs
+++ b/Content.Shared/_RMC14/Explosion/RMCExplosionShockWaveComponent.cs
@@ -11,7 +11,7 @@ namespace Content.Shared._RMC14.Explosion.Components
         ///     The rate at which the wave fades, lower values means it's active for longer.
         /// </summary>
         [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]
-        public float FalloffPower = 40f;
+        public float FalloffPower = 40.0f;
 
         /// <summary>
         ///     How sharp the wave distortion is. Higher values make the wave more pronounced.

--- a/Resources/Textures/_RMC14/Shaders/shock_wave.swsl
+++ b/Resources/Textures/_RMC14/Shaders/shock_wave.swsl
@@ -30,11 +30,11 @@ void fragment() {
             highp float DiffTime = Diff * ScaleDiff;
             highp vec2 DiffTexCoord = normalize(coord - WaveCentre);
             coord += (DiffTexCoord * DiffTime) / (CurrentTime * Dist * falloffPower[i]);
-            highp vec4 Color = texture(SCREEN_TEXTURE, coord);
+            highp vec4 Color = zTextureSpec(SCREEN_TEXTURE, coord);
             Color += (Color * ScaleDiff) / (CurrentTime * Dist * 40.0);
             COLOR = Color;
         } else {
-            COLOR = texture(SCREEN_TEXTURE, UV);
+            COLOR = zTextureSpec(SCREEN_TEXTURE, UV);
         }
     }
 }


### PR DESCRIPTION
## About the PR
Fixes the graphical error with compatibility mode, other change wasn't necessary but let's just keep it consistent. 

## Why / Balance
it would be cool if shockwaves didn't bring up your screen brightness 10 fold. 

## Technical details
replaced texture with the standard zTextureSpec
## Media
 I tested it, unless I messed up the config which I don't think I did it should be working. Please test locally whoever reviews so we can be certain. 
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
:cl:
- fix: Fixes shockwave shader when compatibility mode is enabled. 
