### PR TITLE
Fix hijack condition, only count marines and xenos aboard main ship after hijack

### DIFF
--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleComponent.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleComponent.cs
@@ -63,6 +63,12 @@ public sealed partial class CMDistressSignalRuleComponent : Component
     [DataField]
     public TimeSpan CheckEvery = TimeSpan.FromSeconds(5);
 
+    [DataField, AutoNetworkedField]
+    public TimeSpan? AbandonedAt;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan AbandonedDelay = TimeSpan.FromMinutes(5);
+
     // TODO RMC14
     // [DataField]
     // public SoundSpecifier MajorMarineAudio = new SoundCollectionSpecifier("CMMarineMajor");

--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleComponent.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleComponent.cs
@@ -31,7 +31,7 @@ public sealed partial class CMDistressSignalRuleComponent : Component
 
     // TODO RMC14
     [DataField]
-    public bool XenosEverOnShip;
+    public bool Hijack;
 
     [DataField]
     public ProtoId<JobPrototype> QueenJob = "CMXenoQueen";

--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
@@ -495,6 +495,7 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
                 _almayerMaps.Add(xform.MapID);
             }
 
+            var time = Timing.CurTime;
             var xenosAlive = false;
             var xenos = EntityQueryEnumerator<ActorComponent, XenoComponent, MobStateComponent, TransformComponent>();
             while (xenos.MoveNext(out var xenoId, out _, out var xeno, out var mobState, out var xform))
@@ -503,7 +504,10 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
                     continue;
 
                 if (_mobState.IsAlive(xenoId, mobState) &&
-                    (!distress.Hijack || _almayerMaps.Contains(xform.MapID)))
+                    (distress.AbandonedAt == null ||
+                     time < distress.AbandonedAt ||
+                     !distress.Hijack ||
+                     _almayerMaps.Contains(xform.MapID)))
                 {
                     xenosAlive = true;
                 }
@@ -520,7 +524,10 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
                     continue;
 
                 if (_mobState.IsAlive(marineId, mobState) &&
-                    (!distress.Hijack || _almayerMaps.Contains(xform.MapID)))
+                    (distress.AbandonedAt == null ||
+                     time < distress.AbandonedAt ||
+                     !distress.Hijack ||
+                     _almayerMaps.Contains(xform.MapID)))
                 {
                     marinesAlive = true;
                 }

--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
@@ -488,6 +488,10 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
                     distress.Hijack = true;
             }
 
+            var time = Timing.CurTime;
+            if (distress.Hijack)
+                distress.AbandonedAt ??= time + distress.AbandonedDelay;
+
             _almayerMaps.Clear();
             var almayerQuery = EntityQueryEnumerator<AlmayerComponent, TransformComponent>();
             while (almayerQuery.MoveNext(out _, out var xform))
@@ -495,7 +499,6 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
                 _almayerMaps.Add(xform.MapID);
             }
 
-            var time = Timing.CurTime;
             var xenosAlive = false;
             var xenos = EntityQueryEnumerator<ActorComponent, XenoComponent, MobStateComponent, TransformComponent>();
             while (xenos.MoveNext(out var xenoId, out _, out var xeno, out var mobState, out var xform))


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Marines and xenos that are abandoned and left on the planet after a hijack will no longer be counted for round end.