### PR TITLE
Decrease min spread and angle increase of M54C, massively decrease angle increase of M4SPR and increase angle decay on both

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/marine_rifles.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/marine_rifles.yml
@@ -65,10 +65,10 @@
     soundGunshot:
       collection: CMM54CShoot
   - type: GunWieldBonus
-    minAngle: -15
+    minAngle: -25
     maxAngle: -40
-    angleIncrease: -8
-    angleDecay: 0
+    angleIncrease: -9
+    angleDecay: 5
   - type: ItemSlots
     slots:
       gun_magazine:
@@ -126,10 +126,10 @@
     soundGunshot:
       collection: CMM54CShoot
   - type: GunWieldBonus
-    minAngle: -15
+    minAngle: -25
     maxAngle: -45
-    angleIncrease: -8
-    angleDecay: 0
+    angleIncrease: -9
+    angleDecay: 5
   - type: ItemSlots
     slots:
       gun_magazine:
@@ -174,7 +174,7 @@
   - type: GunWieldBonus
     minAngle: -20
     maxAngle: -50
-    angleIncrease: -5
+    angleIncrease: -22
     angleDecay: 10
   - type: ItemSlots
     slots:


### PR DESCRIPTION
## About the PR
marine major sticker

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Increased the M54C's initial accuracy and on short bursts while wielded. Minimum spread from 15º to 5º, angle increase per shot from 5º to 1º, angle decay per second from 5º to 10º.
- tweak: Massively increased the M4SPR's accuracy while wielded. Its angle now increases by 3º per shot, down from 20º.