### PR TITLE
Allow LesserDrone playtime to count towards Xeno Drone caste playtime

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Xeno/Departments/xeno_job_groups.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Xeno/Departments/xeno_job_groups.yml
@@ -39,6 +39,7 @@
     - CMXenoCarrier
     - CMXenoDrone
     - CMXenoHivelord
+    - CMXenoLesserDrone
     - CMXenoQueen
 
 - type: entity


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Xeno drone caste playtime (required for unlocking the Queen role) includes Hivelords, Carriers, and even the Queen itself, but it does not include the Lesser Drone role. This change adds the Lesser Drone role to the list.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
The gameplay of a lesser drone is incredibly similar to a regular drone's, giving similar gameplay experience to that of regular drone caste members. Sometimes it gives even more if they are working directly under the Queen, common since the Queen often nests near the core where Lessers spawn. Adding lesser drones to the list also helps late joiners gain progress towards unlocking the Queen since the Lesser Drone ghost role is much less contested than the Larva role.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Just adds `CMXenoLesserDrone` to the list of jobs inside role-timer-xeno-drones

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- add: Lesser Drone playtime now counts as drone caste playtime. For the Queen (unlock)!
