### PR TITLE
Various emote fixes

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/dwarf.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/dwarf.yml
@@ -14,9 +14,9 @@
     scale: 1, 0.8
   - type: Vocal
     sounds:
-      Male: CMMaleHuman
-      Unsexed: CMMaleHuman #sorry fem-leaning enbies
-      Female: CMFemaleHuman
+      Male: RMCMaleHuman
+      Unsexed: RMCMaleHuman #sorry fem-leaning enbies
+      Female: RMCFemaleHuman
   - type: ReplacementAccent
     accent: dwarf
   - type: Speech

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/felinid.yml
@@ -12,9 +12,9 @@
     scale: 0.8, 0.8
   - type: Vocal
     sounds:
-      Male: CMMaleFelinid
-      Unsexed: CMMaleFelinid
-      Female: CMFemaleFelinid
+      Male: RMCMaleFelinid
+      Unsexed: RMCMaleFelinid
+      Female: RMCFemaleFelinid
   - type: Speech
     allowedEmotes: ['Hiss', 'Meow', 'Mew', 'Growl', 'Purr']
 

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/human.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/human.yml
@@ -7,6 +7,6 @@
   components:
   - type: Vocal
     sounds:
-      Male: CMMaleHuman
-      Unsexed: CMMaleHuman #sorry fem-leaning enbies
-      Female: CMFemaleHuman
+      Male: RMCMaleHuman
+      Unsexed: RMCMaleHuman #sorry fem-leaning enbies
+      Female: RMCFemaleHuman

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/slime.yml
@@ -18,9 +18,9 @@
     proto: slime
   - type: Vocal
     sounds:
-      Male: MaleSlime
-      Female: FemaleSlime
-      Unsexed: MaleSlime
+      Male: CMMaleSlime
+      Female: CMFemaleSlime
+      Unsexed: CMMaleSlime
   - type: DamageVisuals
     damageOverlayGroups:
       Brute:

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/slime.yml
@@ -18,9 +18,9 @@
     proto: slime
   - type: Vocal
     sounds:
-      Male: CMMaleSlime
-      Female: CMFemaleSlime
-      Unsexed: CMMaleSlime
+      Male: RMCMaleSlime
+      Female: RMCFemaleSlime
+      Unsexed: RMCMaleSlime
   - type: DamageVisuals
     damageOverlayGroups:
       Brute:

--- a/Resources/Prototypes/_RMC14/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/_RMC14/Voice/speech_emote_sounds.yml
@@ -32,6 +32,8 @@
       collection: MaleCry
     Whistle:
       collection: Whistles
+    Gasp:
+      collection: MaleGasp
 
 - type: emoteSounds
   id: CMFemaleHuman
@@ -66,6 +68,8 @@
       collection: FemaleCry
     Whistle:
       collection: Whistles
+    Gasp:
+      collection: FemaleGasp
 
 - type: emoteSounds
   id: CMMaleFelinid
@@ -142,3 +146,79 @@
       collection: FemaleGasp
     DefaultDeathgasp:
       collection: FemaleDeathGasp
+
+- type: emoteSounds
+  id: CMMaleSlime
+  params:
+    variation: 0.125
+  sounds:
+    Squish:
+      collection: Squishes
+    Scream:
+      collection: CMMaleScreams
+    Laugh:
+      collection: MaleLaugh
+    Sneeze:
+      collection: MaleSneezes
+    Cough:
+      collection: MaleCoughs
+    CatMeow:
+      collection: CatMeows
+    CatHisses:
+      collection: CatHisses
+    MonkeyScreeches:
+      collection: MonkeyScreeches
+    RobotBeep:
+      collection: RobotBeeps
+    Yawn:
+      collection: MaleYawn
+    Snore:
+      collection: Snores
+    Honk:
+      collection: BikeHorn
+    Sigh:
+      collection: MaleSigh
+    Crying:
+      collection: MaleCry
+    Whistle:
+      collection: Whistles
+    Gasp:
+      collection: MaleGasp
+
+- type: emoteSounds
+  id: CMFemaleSlime
+  params:
+    variation: 0.125
+  sounds:
+    Squish:
+      collection: Squishes
+    Scream:
+      collection: CMFemaleScreams
+    Laugh:
+      collection: FemaleLaugh
+    Sneeze:
+      collection: FemaleSneezes
+    Cough:
+      collection: FemaleCoughs
+    CatMeow:
+      collection: CatMeows
+    CatHisses:
+      collection: CatHisses
+    MonkeyScreeches:
+      collection: MonkeyScreeches
+    RobotBeep:
+      collection: RobotBeeps
+    Yawn:
+      collection: FemaleYawn
+    Snore:
+      collection: Snores
+    Honk:
+      collection: BikeHorn
+    Sigh:
+      collection: FemaleSigh
+    Crying:
+      collection: FemaleCry
+    Whistle:
+      collection: Whistles
+    Gasp:
+      collection: FemaleGasp

--- a/Resources/Prototypes/_RMC14/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/_RMC14/Voice/speech_emote_sounds.yml
@@ -1,6 +1,6 @@
 # species
 - type: emoteSounds
-  id: CMMaleHuman
+  id: RMCMaleHuman
   params:
     variation: 0.125
   sounds:
@@ -36,7 +36,7 @@
       collection: MaleGasp
 
 - type: emoteSounds
-  id: CMFemaleHuman
+  id: RMCFemaleHuman
   params:
     variation: 0.125
   sounds:
@@ -72,7 +72,7 @@
       collection: FemaleGasp
 
 - type: emoteSounds
-  id: CMMaleFelinid
+  id: RMCMaleFelinid
   params:
     variation: 0.125
   sounds:
@@ -110,7 +110,7 @@
       collection: MaleDeathGasp
 
 - type: emoteSounds
-  id: CMFemaleFelinid
+  id: RMCFemaleFelinid
   params:
     variation: 0.125
   sounds:
@@ -148,7 +148,7 @@
       collection: FemaleDeathGasp
 
 - type: emoteSounds
-  id: CMMaleSlime
+  id: RMCMaleSlime
   params:
     variation: 0.125
   sounds:
@@ -186,7 +186,7 @@
       collection: MaleGasp
 
 - type: emoteSounds
-  id: CMFemaleSlime
+  id: RMCFemaleSlime
   params:
     variation: 0.125
   sounds:

--- a/Resources/Prototypes/_RMC14/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/_RMC14/Voice/speech_emotes.yml
@@ -2,6 +2,12 @@
   id: Hiss
   name: rmc-emote-name-hiss
   category: Vocal
+  whitelist:
+    components:
+    - Vocal
+  blacklist:
+    components:
+    - BorgChassis
   available: false
   icon: Interface/Actions/scream.png
   chatMessages: ["rmc-emote-hiss"]
@@ -17,6 +23,12 @@
   id: Meow
   name: rmc-emote-name-meow
   category: Vocal
+  whitelist:
+    components:
+    - Vocal
+  blacklist:
+    components:
+    - BorgChassis
   available: false
   icon: Interface/Actions/scream.png
   chatMessages: ["rmc-emote-meow"]
@@ -40,6 +52,12 @@
   id: Mew
   name: rmc-emote-name-mew
   category: Vocal
+  whitelist:
+    components:
+    - Vocal
+  blacklist:
+    components:
+    - BorgChassis
   available: false
   icon: Interface/Actions/scream.png
   chatMessages: ["rmc-emote-mew"]
@@ -55,6 +73,12 @@
   id: Growl
   name: rmc-emote-name-growl
   category: Vocal
+  whitelist:
+    components:
+    - Vocal
+  blacklist:
+    components:
+    - BorgChassis
   available: false
   icon: Interface/Actions/scream.png
   chatMessages: ["rmc-emote-growl"]
@@ -70,6 +94,12 @@
   id: Purr
   name: rmc-emote-name-purr
   category: Vocal
+  whitelist:
+    components:
+    - Vocal
+  blacklist:
+    components:
+    - BorgChassis
   available: false
   icon: Interface/Actions/scream.png
   chatMessages: ["rmc-emote-purr"]


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Ghosts can't use felinid emotes (Think only dead felinids could? Either way they have a proper whitelist/blacklist now)
Slimes now use the RMC versions of screams (They have their own collections)
Added missing gasp sound collections for RMC humans
Changed the sound collection names to RMC

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Bugs, missing stuff, eventual consistency

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
N/A

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
Nope
**Changelog**
nah
