### PR TITLE
blood bags are no longer destructible

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Medical/iv.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Medical/iv.yml
@@ -82,16 +82,6 @@
   - type: Damageable
     damageContainer: Inorganic
     damageModifierSet: Glass
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 50
-      behaviors:
-      - !type:SpillBehavior
-        solution: pack
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
   - type: DamageOnHighSpeedImpact
     minimumSpeed: 2
     damage:


### PR DESCRIPTION
- fix #2715

:cl: whisper

- fix: Blood bags are no longer destructible, they can still be melted with acid.
