### PR TITLE
adds screech shockwave

### DIFF
--- a/Content.Client/Entry/EntryPoint.cs
+++ b/Content.Client/Entry/EntryPoint.cs
@@ -17,6 +17,7 @@ using Content.Client.Replay;
 using Content.Client.Screenshot;
 using Content.Client.Singularity;
 using Content.Client._RMC14.Explosion;
+using Content.Client._RMC14.Xenonids;
 using Content.Client.Stylesheets;
 using Content.Client.Viewport;
 using Content.Client.Voting;
@@ -150,6 +151,7 @@ namespace Content.Client.Entry
 
             _overlayManager.AddOverlay(new SingularityOverlay());
             _overlayManager.AddOverlay(new RMCExplosionShockWaveOverlay());
+            _overlayManager.AddOverlay(new RMCXenoScreechShockWaveOverlay());
             _overlayManager.AddOverlay(new RadiationPulseOverlay());
             _chatManager.Initialize();
             _clientPreferencesManager.Initialize();

--- a/Content.Client/_RMC14/Xenonids/Screech/RMCXenoScreechShockWaveOverlay.cs
+++ b/Content.Client/_RMC14/Xenonids/Screech/RMCXenoScreechShockWaveOverlay.cs
@@ -34,7 +34,7 @@ public sealed class RMCXenoScreechShockWaveOverlay : Overlay, IEntityEventSubscr
         if (args.Viewport.Eye == null || _xformSystem is null && !_entMan.TrySystem(out _xformSystem))
             return false;
 
-        var query = _entMan.EntityQueryEnumerator<XenoScreechShockWaveComponent, TransformComponent>();
+        var query = _entMan.EntityQueryEnumerator<RMCXenoScreechShockWaveComponent, TransformComponent>();
 
         if (query.MoveNext(out var uid, out var distortion, out var xform))
         {

--- a/Content.Client/_RMC14/Xenonids/Screech/RMCXenoScreechShockWaveOverlay.cs
+++ b/Content.Client/_RMC14/Xenonids/Screech/RMCXenoScreechShockWaveOverlay.cs
@@ -1,0 +1,78 @@
+using Content.Shared._RMC14.Xenonids.Screech;
+using Robust.Client.Graphics;
+using Robust.Shared.Enums;
+using Robust.Shared.Prototypes;
+using System.Collections.Generic;
+using System.Numerics;
+
+namespace Content.Client._RMC14.Xenonids;
+
+public sealed class RMCXenoScreechShockWaveOverlay : Overlay, IEntityEventSubscriber
+{
+    [Dependency] private readonly IEntityManager _entMan = default!;
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+
+    private SharedTransformSystem? _xformSystem = null;
+
+    public override OverlaySpace Space => OverlaySpace.WorldSpace;
+    public override bool RequestScreenTexture => true;
+
+    private readonly ShaderInstance _shader;
+
+    public RMCXenoScreechShockWaveOverlay()
+    {
+        IoCManager.InjectDependencies(this);
+        _shader = _prototypeManager.Index<ShaderPrototype>("RMCXenoScreechShockWave").Instance().Duplicate();
+    }
+
+    private Vector2 _position;
+    private float _waveStrength;
+    private float _waveSpeed;
+    private float _downScale;
+    protected override bool BeforeDraw(in OverlayDrawArgs args)
+    {
+        if (args.Viewport.Eye == null || _xformSystem is null && !_entMan.TrySystem(out _xformSystem))
+            return false;
+
+        var query = _entMan.EntityQueryEnumerator<XenoScreechShockWaveComponent, TransformComponent>();
+
+        if (query.MoveNext(out var uid, out var distortion, out var xform))
+        {
+            if (xform.MapID != args.MapId)
+                return false;
+
+            var mapPos = _xformSystem.GetWorldPosition(uid);
+            var tempCoords = args.Viewport.WorldToLocal(mapPos);
+
+            // normalized coords, 0 - 1 plane. This is pure hell, we subtract 1 because fragment calculates from the bottom and local goes from the top of the viewport
+            tempCoords.Y = 1 - (tempCoords.Y / args.Viewport.Size.Y);
+            tempCoords.X /= args.Viewport.Size.X;
+
+            _position = tempCoords;
+            _waveStrength = distortion.WaveStrength;
+            _waveSpeed = distortion.WaveSpeed;
+            _downScale = distortion.DownScale;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    protected override void Draw(in OverlayDrawArgs args)
+    {
+        if (ScreenTexture == null || args.Viewport.Eye == null)
+            return;
+
+        _shader?.SetParameter("position", _position);
+        _shader?.SetParameter("waveSpeed", _waveSpeed);
+        _shader?.SetParameter("downScale", _downScale);
+        _shader?.SetParameter("waveStrength", _waveStrength);
+        _shader?.SetParameter("SCREEN_TEXTURE", ScreenTexture);
+
+        var worldHandle = args.WorldHandle;
+        worldHandle.UseShader(_shader);
+        worldHandle.DrawRect(args.WorldAABB, Color.White);
+        worldHandle.UseShader(null);
+    }
+}

--- a/Content.Shared/_RMC14/Xenonids/Screech/RMCXenoScreechShockWaveComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Screech/RMCXenoScreechShockWaveComponent.cs
@@ -1,0 +1,28 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.Screech;
+
+[RegisterComponent, NetworkedComponent]
+[AutoGenerateComponentState]
+[Access(typeof(XenoScreechSystem))]
+public sealed partial class RMCXenoScreechShockWaveComponent : Component
+{
+    /// <summary>
+    ///   The speed of each individual wave from the center axis.
+    /// </summary>
+    [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]
+    public float WaveSpeed = 15.3f;
+
+    /// <summary>
+    ///     The size of each wave in its width and distortion effect
+    /// </summary>
+    [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]
+    public float WaveStrength = 1.0f;
+
+    /// <summary>
+    ///     The scale of the effect, lower number means a larger total area while smaller numbers downscale it and reduce the effected area.
+    /// </summary>
+    [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]
+    public float DownScale = 1.5f;
+}
+

--- a/Resources/Prototypes/_RMC14/Effects/screech.yml
+++ b/Resources/Prototypes/_RMC14/Effects/screech.yml
@@ -5,6 +5,7 @@
   components:
   - type: TimedDespawn
     lifetime: 3.2
+  - type: RMCXenoScreechShockWave
   - type: Sprite
     sprite: _RMC14/Effects/xeno_screech.rsi
     noRot: true

--- a/Resources/Prototypes/_RMC14/Shaders/shaders.yml
+++ b/Resources/Prototypes/_RMC14/Shaders/shaders.yml
@@ -2,3 +2,8 @@
   id: RMCShockWave
   kind: source
   path: "/Textures/_RMC14/Shaders/shock_wave.swsl"
+
+- type: shader
+  id: RMCXenoScreechShockWave
+  kind: source
+  path: "/Textures/_RMC14/Shaders/screech_shock_wave.swsl"

--- a/Resources/Textures/_RMC14/Shaders/screech_shock_wave.swsl
+++ b/Resources/Textures/_RMC14/Shaders/screech_shock_wave.swsl
@@ -1,0 +1,28 @@
+uniform sampler2D SCREEN_TEXTURE;
+uniform highp float waveStrength;
+uniform highp vec2 position;
+uniform highp float waveSpeed;
+uniform highp float downScale;
+
+void fragment()
+{
+    highp vec2 st = UV;
+    highp vec2 WaveCentre = position;
+    highp float ratio = SCREEN_PIXEL_SIZE.y / SCREEN_PIXEL_SIZE.x * 0.5;
+    WaveCentre.y *= ratio; 
+    highp float dist = distance(vec2(st.x, st.y * ratio), WaveCentre) * downScale;
+    highp float val = dist;
+    highp float a = 3.0;
+    highp float cosFuns = cos(val * 20.0 - TIME * waveSpeed);
+    highp float powFuns = pow(val * 2.5, a);
+    highp float limtedPowFuns = 0.5 * pow(a / (a + powFuns), 2.0);
+    highp float finalRes = smoothstep(0.0, 1.0, limtedPowFuns * cosFuns) * waveStrength;
+    highp vec3 col = finalRes * vec3(1.0);
+    st = st * 2.0 - 1.0;
+    st *= 1.0 + finalRes * 0.1;
+    st = st * 0.5 + 0.5;
+    highp vec4 texCol = zTextureSpec(SCREEN_TEXTURE, st);
+    texCol += (texCol * finalRes) / (dist * 10.0);
+
+    COLOR = texCol;
+}


### PR DESCRIPTION
## About the PR
title

## Why / Balance
visually pleasing

## Technical details
If you're wondering why I didn't just use the previous shockwave shader and just mess with the parameters to create the effect; it would be because It just didn't look good and it wasn't what I was looking for. The previous shockwave overlay can be generic enough to be used for various explosions but not for this since it's more of a pulsating wave with a different set of parameters & math to create the effect. Hence why I implemented a whole new separate overlay and component since the old fields didn't match to the new shader parameters. 

## Media

https://github.com/RMC-14/RMC-14/assets/73014819/8373173e-1737-4a1f-bbde-e916dc96d3c7

- [x] I have added screenshots/videos to this PR showcasing its changes ingame

## Breaking changes
N/A

**Changelog**

:cl:
- add: Adds shockwave overlay to queen's screech

