### PR TITLE
Add fill visuals to flare pouch

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/pouches.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/pouches.yml
@@ -649,7 +649,7 @@
     - 0,0,7,1 #7 slots
 
 - type: entity
-  parent: CMPouchFill
+  parent: RMCPouchFill
   id: CMPouchFlare
   name: flare pouch
   description: A pouch designed to hold flares. Refillable with an M94 flare pack.

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/pouches.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/pouches.yml
@@ -77,7 +77,7 @@
 
 - type: entity
   parent: CMPouch
-  id: CMPouchFill
+  id: RMCPouchFill
   abstract: true
   components:
   - type: Sprite

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/pouches.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/pouches.yml
@@ -628,6 +628,12 @@
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Pouches/flare.rsi
+    layers:
+    - state: icon
+    - state: open
+      map: [ "openLayer" ]
+    - state: closed
+      map: [ "closedLayer" ]
   - type: CMItemSlots
     cooldown: 1
     cooldownPopup: You need to wait before taking another flare!
@@ -637,6 +643,21 @@
       whitelist:
         tags:
         - Flare
+  - type: GenericVisualizer
+    visuals:
+      enum.CMItemSlotsLayers.Fill:
+        closedLayer:
+          Empty: { visible: false }
+          Low: { visible: false }
+          Medium: { visible: true }
+          High: { visible: true }
+          Full: { visible: true }
+        openLayer:
+          Empty: { visible: false }
+          Low: { visible: true }
+          Medium: { visible: false }
+          High: { visible: false }
+          Full: { visible: false }
 
 - type: entity
   parent: [CMPouchOpenClosed, CMPouchStorage]

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/pouches.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/pouches.yml
@@ -357,7 +357,7 @@
     - 0,0,11,1 #6 slots
 
 - type: entity
-  parent: [CMPouchStorage, CMPouchFill]
+  parent: [CMPouchStorage, CMPouchOpenClosed]
   id: CMPouchShotgun
   name: shotgun shell pouch
   description: It can contain a single box of shotgun shells. # It can contain handfuls of shells, or bullets if you choose to for some reason. # TODO RMC14

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/pouches.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/pouches.yml
@@ -76,6 +76,34 @@
           Closed: { visible: true }
 
 - type: entity
+  parent: CMPouch
+  id: CMPouchFill
+  abstract: true
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+    - state: partial
+      map: [ "partialLayer" ]
+    - state: full
+      map: [ "fullLayer" ]
+  - type: GenericVisualizer
+    visuals:
+      enum.CMItemSlotsLayers.Fill:
+        fullLayer:
+          Empty: { visible: false }
+          Low: { visible: false }
+          Medium: { visible: true }
+          High: { visible: true }
+          Full: { visible: true }
+        partialLayer:
+          Empty: { visible: false }
+          Low: { visible: true }
+          Medium: { visible: false }
+          High: { visible: false }
+          Full: { visible: false }
+
+- type: entity
   parent: [CMPouchOpenClosed, CMPouchStorage]
   id: CMPouchGeneral
   name: light general pouch
@@ -329,7 +357,7 @@
     - 0,0,11,1 #6 slots
 
 - type: entity
-  parent: [CMPouchStorage, CMPouchOpenClosed]
+  parent: [CMPouchStorage, CMPouchFill]
   id: CMPouchShotgun
   name: shotgun shell pouch
   description: It can contain a single box of shotgun shells. # It can contain handfuls of shells, or bullets if you choose to for some reason. # TODO RMC14
@@ -621,7 +649,7 @@
     - 0,0,7,1 #7 slots
 
 - type: entity
-  parent: CMPouch
+  parent: CMPouchFill
   id: CMPouchFlare
   name: flare pouch
   description: A pouch designed to hold flares. Refillable with an M94 flare pack.
@@ -631,9 +659,9 @@
     layers:
     - state: icon
     - state: open
-      map: [ "openLayer" ]
+      map: [ "partialLayer" ]
     - state: closed
-      map: [ "closedLayer" ]
+      map: [ "fullLayer" ]
   - type: CMItemSlots
     cooldown: 1
     cooldownPopup: You need to wait before taking another flare!
@@ -643,21 +671,6 @@
       whitelist:
         tags:
         - Flare
-  - type: GenericVisualizer
-    visuals:
-      enum.CMItemSlotsLayers.Fill:
-        closedLayer:
-          Empty: { visible: false }
-          Low: { visible: false }
-          Medium: { visible: true }
-          High: { visible: true }
-          Full: { visible: true }
-        openLayer:
-          Empty: { visible: false }
-          Low: { visible: true }
-          Medium: { visible: false }
-          High: { visible: false }
-          Full: { visible: false }
 
 - type: entity
   parent: [CMPouchOpenClosed, CMPouchStorage]


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Adds a visualizer to the flare pouch to show when it has low or no flares left.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Helps players distinguish whether a pouch contains flares.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

Flare pouch emptying:

https://github.com/RMC-14/RMC-14/assets/10494922/4604f1c3-3f71-41c0-a4fa-62d695282bc2

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- add: Added pouch fill level visuals.
