### PR TITLE
"M4RA" box fix, now says M4SPR

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magazine_boxes.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magazine_boxes.yml
@@ -352,7 +352,7 @@
 - type: entity
   parent: CMBoxMagazineRifleM4SPREmpty
   id: CMBoxMagazineRifleM4SPR
-  name: magazine box (M4RA x 16)
+  name: magazine box (M4SPR x 16)
   suffix: Filled
   components:
   - type: CMItemSlots
@@ -392,7 +392,7 @@
 - type: entity
   parent: CMBoxMagazineRifleM4SPRAPEmpty
   id: CMBoxMagazineRifleM4SPRAP
-  name: magazine box (AP M4RA x 16)
+  name: magazine box (AP M4SPR x 16)
   components:
   - type: CMItemSlots
     startingItem: CMMagazineRifleM4SPRAP


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
should fix this
![image](https://github.com/RMC-14/RMC-14/assets/130668733/829ac41e-016a-4bbd-89dd-8aa71d54d048)


**Changelog**

:cl: JoeHammad
- tweak: fixed M4SPR box name
