### PR TITLE
Add empty visuals to flare pack

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Tools/flares.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Tools/flares.yml
@@ -119,7 +119,6 @@
     layers:
     - state: m94_e
       map: [ "emptyLayer" ]
-      visible: false
     - state: m94
       map: [ "fullLayer" ]
   - type: Appearance

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Tools/flares.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Tools/flares.yml
@@ -117,7 +117,27 @@
   - type: Sprite
     sprite: _RMC14/Objects/Storage/boxes.rsi
     layers:
+    - state: m94_e
+      map: [ "emptyLayer" ]
+      visible: false
     - state: m94
+      map: [ "fullLayer" ]
+  - type: Appearance
+  - type: GenericVisualizer
+    visuals:
+      enum.CMItemSlotsLayers.Fill:
+        fullLayer:
+          Empty: { visible: false }
+          Low: { visible: true }
+          Medium: { visible: true }
+          High: { visible: true }
+          Full: { visible: true }
+        emptyLayer:
+          Empty: { visible: true }
+          Low: { visible: false }
+          Medium: { visible: false }
+          High: { visible: false }
+          Full: { visible: false }
 
 - type: entity
   parent: CMPackFlareBase


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Added the empty layer state to the flare pack.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Shows which items are empty at a glance.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

Emptying flare pack:

https://github.com/RMC-14/RMC-14/assets/10494922/b8e8dda8-9d24-4d57-8056-ab8cae162130

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- add: Added empty sprite for the flare pack.