### PR TITLE
seperate xenonid ghost roles by caste

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/boiler.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/boiler.yml
@@ -7,6 +7,8 @@
   name: Boiler
   description: A huge, grotesque xenonid covered in glowing, oozing acid slime.
   components:
+  - type: GhostRole
+    name: cm-job-name-xeno-boiler
   - type: Sprite
     sprite: _RMC14/Mobs/Xenonids/Boiler/boiler.rsi
   - type: MobState

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/burrower.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/burrower.yml
@@ -7,6 +7,8 @@
   name: Burrower
   description: A beefy alien with sharp claws.
   components:
+  - type: GhostRole
+    name: cm-job-name-xeno-burrower
   - type: Sprite
     sprite: _RMC14/Mobs/Xenonids/Burrower/burrower.rsi
   - type: MobState

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/carrier.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/carrier.yml
@@ -7,6 +7,8 @@
   name: Carrier
   description: A strange-looking alien creature. It carries a number of scuttling jointed crablike creatures.
   components:
+  - type: GhostRole
+    name: cm-job-name-xeno-carrier
   - type: Sprite
     sprite: _RMC14/Mobs/Xenonids/Carrier/carrier.rsi
   - type: MobState

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/crusher.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/crusher.yml
@@ -7,6 +7,8 @@
   name: Crusher
   description: A huge alien with an enormous armored crest.
   components:
+  - type: GhostRole
+    name: cm-job-name-xeno-crusher
   - type: Sprite
     sprite: _RMC14/Mobs/Xenonids/Crusher/crusher.rsi
   - type: MobState

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/defender.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/defender.yml
@@ -7,6 +7,8 @@
   name: Defender
   description: A alien with an armored crest.
   components:
+  - type: GhostRole
+    name: cm-job-name-xeno-defender
   - type: Sprite
     sprite: _RMC14/Mobs/Xenonids/Defender/defender.rsi
   - type: MobState

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/drone.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/drone.yml
@@ -7,6 +7,8 @@
   name: Drone
   description: An alien drone.
   components:
+  - type: GhostRole
+    name: cm-job-name-xeno-drone
   - type: Sprite
     sprite: _RMC14/Mobs/Xenonids/Drone/drone.rsi
   - type: MobState

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/hivelord.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/hivelord.yml
@@ -7,6 +7,8 @@
   name: Hivelord
   description: A builder of really big hives.
   components:
+  - type: GhostRole
+    name: cm-job-name-xeno-hivelord
   - type: Sprite
     sprite: _RMC14/Mobs/Xenonids/Hivelord/hivelord.rsi
   - type: MobState

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/larva.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/larva.yml
@@ -5,6 +5,8 @@
   id: CMXenoLarva
   name: Larva
   components:
+  - type: GhostRole
+    name: cm-job-name-xeno-larva
   - type: Sprite
     sprite: _RMC14/Mobs/Xenonids/Larva/larva.rsi
   - type: MobState

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lesser_drone.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lesser_drone.yml
@@ -7,6 +7,8 @@
   name: Lesser Drone
   description: An alien drone. Looks... smaller.
   components:
+  - type: GhostRole
+    name: cm-job-name-xeno-lesser-drone
   - type: Sprite
     sprite: _RMC14/Mobs/Xenonids/LesserDrone/lesser_drone.rsi
   - type: MobState

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lurker.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lurker.yml
@@ -7,6 +7,8 @@
   name: Lurker
   description: A beefy, fast alien with sharp claws.
   components:
+  - type: GhostRole
+    name: cm-job-name-xeno-lurker
   - type: Sprite
     sprite: _RMC14/Mobs/Xenonids/Lurker/lurker.rsi
   - type: MobState

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/parasite.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/parasite.yml
@@ -5,6 +5,8 @@
   id: CMXenoParasite # TODO RMC14 slowly die off weeds
   name: Parasite
   components:
+  - type: GhostRole
+    name: cm-job-name-xeno-parasite
   - type: Sprite
     sprite: _RMC14/Mobs/Xenonids/Parasite/parasite.rsi
   - type: MobState

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/praetorian.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/praetorian.yml
@@ -7,6 +7,8 @@
   name: Praetorian
   description: A huge, looming beast of an alien.
   components:
+  - type: GhostRole
+    name: cm-job-name-xeno-praetorian
   - type: Sprite
     sprite: _RMC14/Mobs/Xenonids/Praetorian/praetorian.rsi
   - type: MobState

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
@@ -6,6 +6,8 @@
   name: Queen
   description: A huge, looming alien creature. The biggest and the baddest.
   components:
+  - type: GhostRole
+    name: cm-job-name-xeno-queen
   - type: Sprite
     sprite: _RMC14/Mobs/Xenonids/Queen/queen.rsi
     layers:

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/ravager.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/ravager.yml
@@ -7,6 +7,8 @@
   name: Ravager
   description: A huge, nasty red alien with enormous scythed claws.
   components:
+  - type: GhostRole
+    name: cm-job-name-xeno-ravager
   - type: Sprite
     sprite: _RMC14/Mobs/Xenonids/Ravager/ravager.rsi
   - type: MobState

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/runner.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/runner.yml
@@ -7,6 +7,8 @@
   name: Runner
   description: A small red alien that looks like it could run fairly quickly...
   components:
+  - type: GhostRole
+    name: cm-job-name-xeno-runner
   - type: Sprite
     sprite: _RMC14/Mobs/Xenonids/Runner/runner.rsi
   - type: MobState

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/sentinel.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/sentinel.yml
@@ -7,6 +7,8 @@
   name: Sentinel
   description: A slithery, spitting kind of alien.
   components:
+  - type: GhostRole
+    name: cm-job-name-xeno-sentinel
   - type: Sprite
     sprite: _RMC14/Mobs/Xenonids/Sentinel/sentinel.rsi
   - type: MobState

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/spitter.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/spitter.yml
@@ -7,6 +7,8 @@
   name: Spitter
   description: A gross, oozing alien of some kind.
   components:
+  - type: GhostRole
+    name: cm-job-name-xeno-spitter
   - type: Sprite
     sprite: _RMC14/Mobs/Xenonids/Spitter/spitter.rsi
   - type: MobState

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/warrior.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/warrior.yml
@@ -7,6 +7,8 @@
   name: Warrior
   description: A beefy alien with an armored carapace.
   components:
+  - type: GhostRole
+    name: cm-job-name-xeno-warrior
   - type: Sprite
     sprite: _RMC14/Mobs/Xenonids/Warrior/warrior.rsi
   - type: MobState


### PR DESCRIPTION
- fix #2368 

:cl: Whisper

- fix: Xenonids are now separated by caste in the ghost role panel.
