### PR TITLE
Explosions now stun and throw mobs

### DIFF
--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
@@ -468,7 +468,7 @@ public sealed partial class ExplosionSystem
         {
             var pos = _transformSystem.GetWorldPosition(xform);
             var adjustedThrowForce = throwForce;
-            if (HasComp<MobStateComponent>(uid)) 
+            if (HasComp<MobStateComponent>(uid))
             {
                 adjustedThrowForce /= 5;
                 _stun.TryKnockdown(uid, TimeSpan.FromSeconds(1), true);

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
@@ -468,11 +468,16 @@ public sealed partial class ExplosionSystem
         {
             var pos = _transformSystem.GetWorldPosition(xform);
             var adjustedThrowForce = throwForce;
-            if (HasComp<MobStateComponent>(uid))
+
+            if (TryComp<MobThresholdsComponent>(uid, out var thresholdComp))
             {
+                if (!thresholdComp.CanStunOnExplosion)
+                    return;
+
                 adjustedThrowForce /= 5;
                 _stun.TryKnockdown(uid, TimeSpan.FromSeconds(1), true);
             }
+            
             _throwingSystem.TryThrow(
                 uid,
                  pos - epicenter.Position,

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
@@ -463,16 +463,21 @@ public sealed partial class ExplosionSystem
             && throwForce > 0
             && !EntityManager.IsQueuedForDeletion(uid)
             && _physicsQuery.TryGetComponent(uid, out var physics)
-            && physics.BodyType == BodyType.Dynamic)
+            && (physics.BodyType == BodyType.Dynamic || physics.BodyType == BodyType.KinematicController))
         {
             var pos = _transformSystem.GetWorldPosition(xform);
+            var adjustedThrowForce = throwForce;
+            if (_stun.TryKnockdown(uid, TimeSpan.FromSeconds(1), true))
+            {
+                adjustedThrowForce /= 3;
+            }
             _throwingSystem.TryThrow(
                 uid,
                  pos - epicenter.Position,
                 physics,
                 xform,
                 _projectileQuery,
-                throwForce);
+                adjustedThrowForce);
         }
     }
 

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
@@ -15,6 +15,7 @@ using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Dynamics;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
+using Content.Shared.Mobs.Components;
 using Robust.Shared.Utility;
 using TimedDespawnComponent = Robust.Shared.Spawners.TimedDespawnComponent;
 
@@ -467,9 +468,10 @@ public sealed partial class ExplosionSystem
         {
             var pos = _transformSystem.GetWorldPosition(xform);
             var adjustedThrowForce = throwForce;
-            if (_stun.TryKnockdown(uid, TimeSpan.FromSeconds(1), true))
+            if (HasComp<MobStateComponent>(uid)) 
             {
-                adjustedThrowForce /= 4;
+                adjustedThrowForce /= 5;
+                _stun.TryKnockdown(uid, TimeSpan.FromSeconds(1), true);
             }
             _throwingSystem.TryThrow(
                 uid,

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
@@ -469,7 +469,7 @@ public sealed partial class ExplosionSystem
             var adjustedThrowForce = throwForce;
             if (_stun.TryKnockdown(uid, TimeSpan.FromSeconds(1), true))
             {
-                adjustedThrowForce /= 3;
+                adjustedThrowForce /= 4;
             }
             _throwingSystem.TryThrow(
                 uid,

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
@@ -16,6 +16,7 @@ using Content.Shared.Explosion;
 using Content.Shared.GameTicking;
 using Content.Shared.Inventory;
 using Content.Shared.Projectiles;
+using Content.Shared.Stunnable;
 using Content.Shared.Throwing;
 using Robust.Server.GameStates;
 using Robust.Server.Player;
@@ -47,6 +48,7 @@ public sealed partial class ExplosionSystem : EntitySystem
     [Dependency] private readonly IAdminLogManager _adminLogger = default!;
     [Dependency] private readonly IChatManager _chat = default!;
     [Dependency] private readonly ThrowingSystem _throwingSystem = default!;
+    [Dependency] private readonly SharedStunSystem _stun = default!;
     [Dependency] private readonly PvsOverrideSystem _pvsSys = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedTransformSystem _transformSystem = default!;

--- a/Content.Shared/Mobs/Components/MobThresholdsComponent.cs
+++ b/Content.Shared/Mobs/Components/MobThresholdsComponent.cs
@@ -17,6 +17,12 @@ public sealed partial class MobThresholdsComponent : Component
     [DataField("triggersAlerts")]
     public bool TriggersAlerts = true;
 
+    [DataField("canStunOnExplosion")]
+    /// <summary>
+    /// If the mob can be thrown or stunned on explosions. 
+    /// </summary>
+    public bool CanStunOnExplosion = true;
+
     [DataField("currentThresholdState")]
     public MobState CurrentThresholdState;
 

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/crusher.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/crusher.yml
@@ -15,6 +15,7 @@
     - Critical
     - Dead
   - type: MobThresholds
+    canStunOnExplosion: false
     thresholds:
       0: Alive
       700: Critical

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
@@ -19,6 +19,7 @@
     - Critical
     - Dead
   - type: MobThresholds
+    canStunOnExplosion: false
     thresholds:
       0: Alive
       500: Critical


### PR DESCRIPTION
## About the PR
Title

## Why / Balance
Similar to CM13, explosions should stun mobs in close vicinity, xenos shouldn't be able to dance around nades, same goes for marines. This makes nades a double edged sword where they are now relatively more impactful if used correctly but if you screw up then the ff damage can also be significant. 

## Technical details
We can maybe make this an optional parameter instead, so that some mobs like queen and crusher can potentially be immune to these effects.  

## Media

https://github.com/RMC-14/RMC-14/assets/73014819/80a2da72-ac73-47be-9ed6-d9478063e315

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
:cl:
- add: Explosions will stun & toss mobs in close vicinity
