### PR TITLE
Make camera recoil system only refresh offset when its values change

### DIFF
--- a/Content.Shared/Camera/CameraRecoilComponent.cs
+++ b/Content.Shared/Camera/CameraRecoilComponent.cs
@@ -8,6 +8,7 @@ namespace Content.Shared.Camera;
 public sealed partial class CameraRecoilComponent : Component
 {
     public Vector2 CurrentKick { get; set; }
+    public Vector2 LastKick { get; set; }
     public float LastKickTime { get; set; }
 
     /// <summary>

--- a/Content.Shared/Camera/SharedCameraRecoilSystem.cs
+++ b/Content.Shared/Camera/SharedCameraRecoilSystem.cs
@@ -60,9 +60,6 @@ public abstract class SharedCameraRecoilSystem : EntitySystem
             if (magnitude <= 0.005f)
             {
                 recoil.CurrentKick = Vector2.Zero;
-                var ev = new GetEyeOffsetEvent();
-                RaiseLocalEvent(uid, ref ev);
-                _eye.SetOffset(uid, ev.Offset, eye);
             }
             else // Continually restore camera to 0.
             {
@@ -79,10 +76,15 @@ public abstract class SharedCameraRecoilSystem : EntitySystem
 
                 recoil.CurrentKick = new Vector2(x, y);
 
-                var ev = new GetEyeOffsetEvent();
-                RaiseLocalEvent(uid, ref ev);
-                _eye.SetOffset(uid, ev.Offset, eye);
             }
+
+            if (recoil.CurrentKick == recoil.LastKick)
+                continue;
+
+            recoil.LastKick = recoil.CurrentKick;
+            var ev = new GetEyeOffsetEvent();
+            RaiseLocalEvent(uid, ref ev);
+            _eye.SetOffset(uid, ev.Offset, eye);
         }
     }
 

--- a/Content.Shared/Camera/SharedCameraRecoilSystem.cs
+++ b/Content.Shared/Camera/SharedCameraRecoilSystem.cs
@@ -75,7 +75,6 @@ public abstract class SharedCameraRecoilSystem : EntitySystem
                     y = 0;
 
                 recoil.CurrentKick = new Vector2(x, y);
-
             }
 
             if (recoil.CurrentKick == recoil.LastKick)


### PR DESCRIPTION
## About the PR
It was taking up 3.38% of TickUpdate time in RMC14, 3.24% of which from the raise local event.
Includes the changes in https://github.com/space-wizards/space-station-14/pull/29673

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

