### PR TITLE
Xeno nest drag drop

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestSystem.cs
@@ -2,6 +2,7 @@
 using Content.Shared.ActionBlocker;
 using Content.Shared.Coordinates;
 using Content.Shared.DoAfter;
+using Content.Shared.DragDrop;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Item;
@@ -45,6 +46,8 @@ public sealed class XenoNestSystem : EntitySystem
         SubscribeLocalEvent<XenoNestSurfaceComponent, InteractHandEvent>(OnNestInteractHand);
         SubscribeLocalEvent<XenoNestSurfaceComponent, DoAfterAttemptEvent<XenoNestDoAfterEvent>>(OnNestSurfaceDoAfterAttempt);
         SubscribeLocalEvent<XenoNestSurfaceComponent, XenoNestDoAfterEvent>(OnNestSurfaceDoAfter);
+        SubscribeLocalEvent<XenoNestSurfaceComponent, CanDropTargetEvent>(OnCanDropTarget);
+        SubscribeLocalEvent<XenoNestSurfaceComponent, DragDropTargetEvent>(OnDragDropTarget);
 
         SubscribeLocalEvent<XenoNestComponent, ComponentRemove>(OnNestRemove);
         SubscribeLocalEvent<XenoNestComponent, EntityTerminatingEvent>(OnNestTerminating);
@@ -195,6 +198,28 @@ public sealed class XenoNestSystem : EntitySystem
             }
         }
     }
+
+    #region DragDrop
+
+    private void OnCanDropTarget(Entity<XenoNestSurfaceComponent> ent, ref CanDropTargetEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        if (GetNestDirection(ent, args.Dragged) is not { } direction)
+            return;
+
+        args.CanDrop = CanNestPopup(args.User, args.Dragged, ent, direction);
+        args.Handled = true;
+    }
+
+    private void OnDragDropTarget(Entity<XenoNestSurfaceComponent> ent, ref DragDropTargetEvent args)
+    {
+        args.Handled = true;
+        TryStartNesting(args.User, ent, args.Dragged);
+    }
+
+    #endregion
 
     private void OnNestedPreventCollide(Entity<XenoNestedComponent> ent, ref PreventCollideEvent args)
     {


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Adds drag drop to nest hosts to the nest surfaces.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

A lot of players get confused when they try to nest marines and drag drop doesn't work, so addding this makes it more intuitive to nest hosts.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Adds DragDrop event handlers for XenoNestSurfaceComponent.
Splits CanDropPopup into two methods to make the drag drop not do popups when dragging, but still show popups when dropped.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/RMC-14/RMC-14/assets/10494922/cf6fc7fb-68de-44f5-9ab4-38261c481a39


## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- add: Xenonids can now drag drop hosts to nest them on nest-able surfaces.
