### PR TITLE
Fix the cigar case, cig pack and matchbox not having a storage whitelist

### DIFF
--- a/Resources/Prototypes/_RMC14/Catalog/VendingMachines/Inventories/cigs.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/VendingMachines/Inventories/cigs.yml
@@ -1,8 +1,8 @@
 - type: vendingMachineInventory
   id: CMVendorCigs
   startingInventory:
-    CigPackBlack: 50 #TODO RMC14 lucky sloths
-    CigarCase: 20 #TODO RMC14 tarbacktube
-    Matchbox: 15
+    CMCigPackBlack: 50 #TODO RMC14 lucky sloths
+    CMCigarCase: 20 #TODO RMC14 tarbacktube
+    CMMatchbox: 15
     Lighter: 25
     #TODO RMC14 Zippo 10

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Smokeables/case.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Smokeables/case.yml
@@ -1,0 +1,10 @@
+﻿- type: entity
+  parent: CigarCase
+  id: CMCigarCase
+  components:
+  - type: Storage
+    grid:
+    - 0,0,3,1
+    whitelist:
+      tags:
+      - Cigar

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Smokeables/cig_packs.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Smokeables/cig_packs.yml
@@ -1,0 +1,8 @@
+﻿- type: entity
+  parent: CigPackBlack
+  id: CMCigPackBlack
+  components:
+  - type: Storage
+    whitelist:
+      tags:
+      - Cigarette

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Smokeables/matches.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Smokeables/matches.yml
@@ -1,0 +1,11 @@
+﻿- type: entity
+  name: match box
+  parent: Matchbox
+  id: CMMatchbox
+  components:
+  - type: Storage
+    grid:
+    - 0,0,2,1
+    whitelist:
+      tags:
+      - Matchstick


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed the nomads packet being able to fit items other than cigarettes, the cigar case being able to fit items other than cigars, and the match box being able to fit items other than matches.
