### PR TITLE
Entrenching tool fits on COMTECH belts

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
@@ -118,6 +118,7 @@
       - TrayScanner
       - GasAnalyzer
       - LightReplacer
+      - EntrenchingTool
   - type: IgnoreContentsSize
     items:
       components:
@@ -159,6 +160,7 @@
       - TrayScanner
       - GasAnalyzer
       - LightReplacer
+      - EntrenchingTool
   - type: FixedItemSizeStorage
 
 - type: entity


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
fixes https://github.com/RMC-14/RMC-14/issues/2712
name, Entrenching tool fits on COMTECH belts.
Added it to both combat and normal toolbelt whitelist
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
it makes sense, discussed a bit on the discord. A tool made for cading and filling sandbags should fit on COMTECH belts
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
nah, just added it to whitelist comp check it yourself
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

![image](https://github.com/RMC-14/RMC-14/assets/149102472/bbb003a9-e190-49f9-a9c9-dfd0e4073752)

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- add: Entrenching tools are now worthy of being in tools belts.