### PR TITLE
Make VirtualItem not block attacking

### DIFF
--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -13,6 +13,7 @@ using Content.Shared.Hands;
 using Content.Shared.Hands.Components;
 using Content.Shared.Interaction;
 using Content.Shared.Inventory;
+using Content.Shared.Inventory.VirtualItem;
 using Content.Shared.Item.ItemToggle.Components;
 using Content.Shared.Physics;
 using Content.Shared.Popups;
@@ -279,7 +280,8 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
                 return true;
             }
 
-            return false;
+            if (!HasComp<VirtualItemComponent>(held))
+                return false;
         }
 
         // Use hands clothing if applicable.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Allow attacking while a pull VirtualItem is in hand.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Allows xenos to more easily shove marines when dragging them.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

The check for item in hand cancelled the attack if the item didn't have a MeleeWeaponComponent. This change bypasses the cancel if the held item has a VirtualItemComponent.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/RMC-14/RMC-14/assets/10494922/8eeb0cda-9b36-4012-84c7-a2006106808e

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Players can now use melee attacks and shoves while dragging an entity in their active hand.