### PR TITLE
Make the MM blood dispenser an automated vendor

### DIFF
--- a/Resources/Locale/en-US/_RMC14/medical/refillable.ftl
+++ b/Resources/Locale/en-US/_RMC14/medical/refillable.ftl
@@ -1,3 +1,3 @@
-cm-refillable-solution-full = {THE($target)} is full!
-cm-refillable-solution-cannot-refill = {THE($user)} cannot refill the {$target}.
-cm-refillable-solution-whirring-noise = {THE($user)} makes a whirring noise as it refills your {$target}.
+cm-refillable-solution-full = {CAPITALIZE(THE($target))} is full!
+cm-refillable-solution-cannot-refill = {CAPITALIZE(THE($user))} cannot refill the {$target}.
+cm-refillable-solution-whirring-noise = {CAPITALIZE(THE($user))} makes a whirring noise as it refills your {$target}.

--- a/Resources/Prototypes/_RMC14/Access/Groups/marine_access_groups.yml
+++ b/Resources/Prototypes/_RMC14/Access/Groups/marine_access_groups.yml
@@ -34,6 +34,7 @@
   - CMAccessMarinePrep
   - CMAccessMedPrep
   - CMAccessDropship
+  - CMAccessMedical
 
 - type: accessGroup
   id: CombatTech

--- a/Resources/Prototypes/_RMC14/Catalog/VendingMachines/Inventories/blood.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/VendingMachines/Inventories/blood.yml
@@ -1,4 +1,0 @@
-- type: vendingMachineInventory
-  id: CMVendorBlood
-  startingInventory:
-    CMBloodPackFull: 30 #TODO RMC14 different blood groups

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/medical.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/medical.yml
@@ -251,15 +251,36 @@
 #        amount: 7
 
 - type: entity
-  parent: CMVendor
+  parent: ColMarTechBase
   id: CMVendorBlood
   name: MM Blood Dispenser
   description: The Marine Med Brand Blood Pack Dispensary is the premier, top-of-the-line blood dispenser of 2105! Get yours today! #dont update year, that`s a joke from cm13
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/blood.rsi
-  - type: VendingMachine
-    pack: CMVendorBlood
+    snapCardinals: true
+    layers:
+    - state: "off"
+      map: ["enum.VendingMachineVisualLayers.Base"]
+    - state: "off"
+      map: [ "enum.VendingMachineVisualLayers.BaseUnshaded" ]
+      shader: unshaded
+    - state: "panel"
+      map: ["enum.WiresVisualLayers.MaintenancePanel"]
   - type: ApcPowerReceiver
     needsPower: false # TODO RMC14
     powerLoad: 0
+  - type: AccessReader
+    access:
+    - [ "CMAccessMedical" ]
+  - type: CMAutomatedVendor
+    sections:
+    - name: Blood Packs
+      entries:
+      - id: CMBloodPackFull
+        amount: 30
+    - name: Miscellaneous
+      entries:
+      - id: CMBloodPack
+        amount: 5
+        name: empty blood pack


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: Added 5 empty blood packs to the MM blood dispenser.
- fix: Fixed the Hospital Corpsman not having medical access.
- tweak: The MM blood dispenser now uses the fancy vendor UI, and no longer has a delay to vending blood packs.
