### PR TITLE
Make xenonids unable to devolve if damaged

### DIFF
--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
@@ -22,6 +22,7 @@ cm-xeno-evolution-failed-cannot-support = The Hive cannot support this caste yet
 cm-xeno-evolution-failed-hive-full = The hive cannot support another Tier {$tier}, wait for either more aliens to be born or someone to die.
 rmc-xeno-evolution-devolve-title = De-Evolve To
 rmc-xeno-evolution-devolve = You devolve to {$xeno}!
+rmc-xeno-evolution-cant-devolve-damaged = We are too weak to deevolve, we must regain our health first.
 
 # Fortify
 cm-xeno-fortify-cant-headbutt = You can't headbutt while fortifying!


### PR DESCRIPTION
## About the PR
Fixes https://github.com/RMC-14/RMC-14/issues/2742

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed xenonids being able to devolve if damaged. Xenonids now must be on full health before devolving.