### PR TITLE
Fix explosion and screech shockwave effect temporarily resetting your camera to the default rotation

### DIFF
--- a/Content.Client/Entry/EntryPoint.cs
+++ b/Content.Client/Entry/EntryPoint.cs
@@ -1,3 +1,5 @@
+using Content.Client._RMC14.Explosion;
+using Content.Client._RMC14.Xenonids.Screech;
 using Content.Client.Administration.Managers;
 using Content.Client.Changelog;
 using Content.Client.Chat.Managers;
@@ -16,8 +18,6 @@ using Content.Client.Radiation.Overlays;
 using Content.Client.Replay;
 using Content.Client.Screenshot;
 using Content.Client.Singularity;
-using Content.Client._RMC14.Explosion;
-using Content.Client._RMC14.Xenonids;
 using Content.Client.Stylesheets;
 using Content.Client.Viewport;
 using Content.Client.Voting;

--- a/Content.Client/_RMC14/Explosion/RMCExplosionShockWaveOverlay.cs
+++ b/Content.Client/_RMC14/Explosion/RMCExplosionShockWaveOverlay.cs
@@ -1,9 +1,8 @@
+using System.Numerics;
 using Content.Shared._RMC14.Explosion.Components;
 using Robust.Client.Graphics;
 using Robust.Shared.Enums;
 using Robust.Shared.Prototypes;
-using System.Collections.Generic;
-using System.Numerics;
 
 namespace Content.Client._RMC14.Explosion;
 
@@ -12,7 +11,7 @@ public sealed class RMCExplosionShockWaveOverlay : Overlay, IEntityEventSubscrib
     [Dependency] private readonly IEntityManager _entMan = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
 
-    private SharedTransformSystem? _xformSystem = null;
+    private SharedTransformSystem? _xformSystem;
 
     public override OverlaySpace Space => OverlaySpace.WorldSpace;
     public override bool RequestScreenTexture => true;
@@ -34,7 +33,8 @@ public sealed class RMCExplosionShockWaveOverlay : Overlay, IEntityEventSubscrib
     private readonly float[] _falloffPower = new float[MaxCount];
     private readonly float[] _sharpness = new float[MaxCount];
     private readonly float[] _width = new float[MaxCount];
-    private int _count = 0;
+    private int _count;
+
     protected override bool BeforeDraw(in OverlayDrawArgs args)
     {
         if (args.Viewport.Eye == null || _xformSystem is null && !_entMan.TrySystem(out _xformSystem))
@@ -65,7 +65,7 @@ public sealed class RMCExplosionShockWaveOverlay : Overlay, IEntityEventSubscrib
 
             if (_count == MaxCount)
                 break;
-            }
+        }
 
         return _count > 0;
     }
@@ -85,7 +85,7 @@ public sealed class RMCExplosionShockWaveOverlay : Overlay, IEntityEventSubscrib
 
         var worldHandle = args.WorldHandle;
         worldHandle.UseShader(_shader);
-        worldHandle.DrawRect(args.WorldAABB, Color.White);
+        worldHandle.DrawRect(args.WorldBounds, Color.White);
         worldHandle.UseShader(null);
     }
 }

--- a/Content.Client/_RMC14/Xenonids/Screech/RMCXenoScreechShockWaveOverlay.cs
+++ b/Content.Client/_RMC14/Xenonids/Screech/RMCXenoScreechShockWaveOverlay.cs
@@ -1,18 +1,17 @@
+using System.Numerics;
 using Content.Shared._RMC14.Xenonids.Screech;
 using Robust.Client.Graphics;
 using Robust.Shared.Enums;
 using Robust.Shared.Prototypes;
-using System.Collections.Generic;
-using System.Numerics;
 
-namespace Content.Client._RMC14.Xenonids;
+namespace Content.Client._RMC14.Xenonids.Screech;
 
 public sealed class RMCXenoScreechShockWaveOverlay : Overlay, IEntityEventSubscriber
 {
     [Dependency] private readonly IEntityManager _entMan = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
 
-    private SharedTransformSystem? _xformSystem = null;
+    private SharedTransformSystem? _xformSystem;
 
     public override OverlaySpace Space => OverlaySpace.WorldSpace;
     public override bool RequestScreenTexture => true;
@@ -72,7 +71,7 @@ public sealed class RMCXenoScreechShockWaveOverlay : Overlay, IEntityEventSubscr
 
         var worldHandle = args.WorldHandle;
         worldHandle.UseShader(_shader);
-        worldHandle.DrawRect(args.WorldAABB, Color.White);
+        worldHandle.DrawRect(args.WorldBounds, Color.White);
         worldHandle.UseShader(null);
     }
 }


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Explosion and screech shockwave effects no longer temporarily reset your camera to the default rotation.