### PR TITLE
Fixed xenonids being able to attack and secrete resin while resting.

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Construction/Events/XenoSecreteStructureAttemptEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/Events/XenoSecreteStructureAttemptEvent.cs
@@ -1,0 +1,4 @@
+namespace Content.Shared._RMC14.Xenonids.Construction.Events;
+
+[ByRefEvent]
+public record struct XenoSecreteStructureAttemptEvent(bool Cancelled);

--- a/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
@@ -158,6 +158,12 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
             return;
         }
 
+        var attempt = new XenoSecreteStructureAttemptEvent();
+        RaiseLocalEvent(xeno, ref attempt);
+
+        if (attempt.Cancelled)
+            return;
+
         args.Handled = true;
         var ev = new XenoSecreteStructureDoAfterEvent(GetNetCoordinates(args.Target), choice);
         var doAfter = new DoAfterArgs(EntityManager, xeno, xeno.Comp.BuildDelay, ev, xeno)

--- a/Content.Shared/_RMC14/Xenonids/Rest/XenoRestSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Rest/XenoRestSystem.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Shared._RMC14.Xenonids.Charge;
+using Content.Shared._RMC14.Xenonids.Construction.Events;
 using Content.Shared._RMC14.Xenonids.Crest;
 using Content.Shared._RMC14.Xenonids.Fling;
 using Content.Shared._RMC14.Xenonids.Fortify;
@@ -12,6 +13,7 @@ using Content.Shared._RMC14.Xenonids.Stomp;
 using Content.Shared._RMC14.Xenonids.Sweep;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Actions;
+using Content.Shared.Interaction.Events;
 using Content.Shared.Movement.Events;
 using Content.Shared.Popups;
 
@@ -32,6 +34,8 @@ public sealed class XenoRestSystem : EntitySystem
 
         // TODO RMC14 generic xeno ability attempt event
         SubscribeLocalEvent<XenoRestingComponent, UpdateCanMoveEvent>(OnXenoRestingCanMove);
+        SubscribeLocalEvent<XenoRestingComponent, AttackAttemptEvent>(OnXenoRestingMeleeHit);
+        SubscribeLocalEvent<XenoRestingComponent, XenoSecreteStructureAttemptEvent>(OnXenoSecreteStructureAttempt);
         SubscribeLocalEvent<XenoRestingComponent, XenoHeadbuttAttemptEvent>(OnXenoRestingHeadbuttAttempt);
         SubscribeLocalEvent<XenoRestingComponent, XenoFortifyAttemptEvent>(OnXenoRestingFortifyAttempt);
         SubscribeLocalEvent<XenoRestingComponent, XenoTailSweepAttemptEvent>(OnXenoRestingTailSweepAttempt);
@@ -77,75 +81,86 @@ public sealed class XenoRestSystem : EntitySystem
         _actionBlocker.UpdateCanMove(xeno);
     }
 
+    private void OnXenoRestingMeleeHit(Entity<XenoRestingComponent> xeno, ref AttackAttemptEvent args)
+    {
+        args.Cancel();
+    }
+
+    private void OnXenoSecreteStructureAttempt(Entity<XenoRestingComponent> xeno, ref XenoSecreteStructureAttemptEvent args)
+    {
+        _popup.PopupClient(Loc.GetString("rmc-xeno-rest-cant-secrete"), xeno, xeno);
+        args.Cancelled = true;
+    }
+
     private void OnXenoRestingHeadbuttAttempt(Entity<XenoRestingComponent> xeno, ref XenoHeadbuttAttemptEvent args)
     {
-        _popup.PopupClient(Loc.GetString("cm-xeno-rest-cant-headbutt"), xeno, xeno);
+        _popup.PopupClient(Loc.GetString("rmc-xeno-rest-cant-headbutt"), xeno, xeno);
         args.Cancelled = true;
     }
 
     private void OnXenoRestingFortifyAttempt(Entity<XenoRestingComponent> xeno, ref XenoFortifyAttemptEvent args)
     {
-        _popup.PopupClient(Loc.GetString("cm-xeno-rest-cant-fortify"), xeno, xeno);
+        _popup.PopupClient(Loc.GetString("rmc-xeno-rest-cant-fortify"), xeno, xeno);
         args.Cancelled = true;
     }
 
     private void OnXenoRestingTailSweepAttempt(Entity<XenoRestingComponent> xeno, ref XenoTailSweepAttemptEvent args)
     {
-        _popup.PopupClient(Loc.GetString("cm-xeno-rest-cant-tail-sweep"), xeno, xeno);
+        _popup.PopupClient(Loc.GetString("rmc-xeno-rest-cant-tail-sweep"), xeno, xeno);
         args.Cancelled = true;
     }
 
     private void OnXenoRestingToggleCrestAttempt(Entity<XenoRestingComponent> xeno, ref XenoToggleCrestAttemptEvent args)
     {
-        _popup.PopupClient(Loc.GetString("cm-xeno-rest-cant-toggle-crest"), xeno, xeno);
+        _popup.PopupClient(Loc.GetString("rmc-xeno-rest-cant-toggle-crest"), xeno, xeno);
         args.Cancelled = true;
     }
 
     private void OnXenoRestingLeapAttempt(Entity<XenoRestingComponent> xeno, ref XenoLeapAttemptEvent args)
     {
-        _popup.PopupClient(Loc.GetString("cm-xeno-rest-cant-leap"), xeno, xeno);
+        _popup.PopupClient(Loc.GetString("rmc-xeno-rest-cant-leap"), xeno, xeno);
         args.Cancelled = true;
     }
 
     private void OnXenoRestingLungeAttempt(Entity<XenoRestingComponent> xeno, ref XenoLungeAttemptEvent args)
     {
-        _popup.PopupClient(Loc.GetString("cm-xeno-rest-cant-lunge"), xeno, xeno);
+        _popup.PopupClient(Loc.GetString("rmc-xeno-rest-cant-lunge"), xeno, xeno);
         args.Cancelled = true;
     }
 
     private void OnXenoRestingPunchAttempt(Entity<XenoRestingComponent> xeno, ref XenoPunchAttemptEvent args)
     {
-        _popup.PopupClient(Loc.GetString("cm-xeno-rest-cant-punch"), xeno, xeno);
+        _popup.PopupClient(Loc.GetString("rmc-xeno-rest-cant-punch"), xeno, xeno);
         args.Cancelled = true;
     }
 
     private void OnXenoRestingFlingAttempt(Entity<XenoRestingComponent> xeno, ref XenoFlingAttemptEvent args)
     {
-        _popup.PopupClient(Loc.GetString("cm-xeno-rest-cant-fling"), xeno, xeno);
+        _popup.PopupClient(Loc.GetString("rmc-xeno-rest-cant-fling"), xeno, xeno);
         args.Cancelled = true;
     }
 
     private void OnXenoRestingChargettempt(Entity<XenoRestingComponent> xeno, ref XenoChargeAttemptEvent args)
     {
-        _popup.PopupClient(Loc.GetString("cm-xeno-rest-cant-charge"), xeno, xeno);
+        _popup.PopupClient(Loc.GetString("rmc-xeno-rest-cant-charge"), xeno, xeno);
         args.Cancelled = true;
     }
 
     private void OnXenoRestingStompAttempt(Entity<XenoRestingComponent> xeno, ref XenoStompAttemptEvent args)
     {
-        _popup.PopupClient(Loc.GetString("cm-xeno-rest-cant-stomp"), xeno, xeno);
+        _popup.PopupClient(Loc.GetString("rmc-xeno-rest-cant-stomp"), xeno, xeno);
         args.Cancelled = true;
     }
 
     private void OnXenoRestingGutAttempt(Entity<XenoRestingComponent> xeno, ref XenoGutAttemptEvent args)
     {
-        _popup.PopupClient(Loc.GetString("cm-xeno-rest-cant-gut"), xeno, xeno);
+        _popup.PopupClient(Loc.GetString("rmc-xeno-rest-cant-gut"), xeno, xeno);
         args.Cancelled = true;
     }
 
     private void OnXenoRestingScreechAttempt(Entity<XenoRestingComponent> xeno, ref XenoScreechAttemptEvent args)
     {
-        _popup.PopupClient(Loc.GetString("cm-xeno-rest-cant-screech"), xeno, xeno);
+        _popup.PopupClient(Loc.GetString("rmc-xeno-rest-cant-screech"), xeno, xeno);
         args.Cancelled = true;
     }
 }

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
@@ -62,18 +62,19 @@ cm-xeno-pheromones-stop = You stop emitting pheromones
 cm-xeno-none-devoured = You haven't devoured anyone!
 
 # Rest
-cm-xeno-rest-cant-headbutt = You can't headbutt while resting!
-cm-xeno-rest-cant-fortify = You can't fortify while resting!
-cm-xeno-rest-cant-tail-sweep = You can't tail sweep while resting!
-cm-xeno-rest-cant-toggle-crest = You can't lower your crest while resting!
-cm-xeno-rest-cant-leap = You can't leap while resting!
-cm-xeno-rest-cant-lunge = You can't lunge while resting!
-cm-xeno-rest-cant-punch = You can't punch while resting!
-cm-xeno-rest-cant-fling = You can't punch while resting!
-cm-xeno-rest-cant-charge = You can't punch while resting!
-cm-xeno-rest-cant-stomp = You can't punch while resting!
-cm-xeno-rest-cant-gut = You can't punch while resting!
-cm-xeno-rest-cant-screech = You can't punch while resting!
+rmc-xeno-rest-cant-headbutt = You can't headbutt while resting!
+rmc-xeno-rest-cant-fortify = You can't fortify while resting!
+rmc-xeno-rest-cant-tail-sweep = You can't tail sweep while resting!
+rmc-xeno-rest-cant-toggle-crest = You can't lower your crest while resting!
+rmc-xeno-rest-cant-leap = You can't leap while resting!
+rmc-xeno-rest-cant-lunge = You can't lunge while resting!
+rmc-xeno-rest-cant-punch = You can't punch while resting!
+rmc-xeno-rest-cant-fling = You can't fling while resting!
+rmc-xeno-rest-cant-charge = You can't charge while resting!
+rmc-xeno-rest-cant-stomp = You can't stomp while resting!
+rmc-xeno-rest-cant-gut = You can't gut while resting!
+rmc-xeno-rest-cant-screech = You can't screech while resting!
+rmc-xeno-rest-cant-secrete = You can't secrete while resting!
 
 # Toggle Crest Defense
 cm-xeno-toggle-crest-cant-fortify = You can't fortify while your crest is lowered!


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Makes it so you cannot attack, tackle, wideswing, or tail-stab as a resting xenonid.

You also can't secrete resin while resting and get an appropriate message when attempting to do so (similar to when attempting to do other abilities while resting).

Also fixes some related locale entries (`cm-` to `rmc-`, and some popup warnings mislabeling most abilities as "punch")

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Fixes [#2382](https://github.com/RMC-14/RMC-14/issues/2382)
Fixes [#2744](https://github.com/RMC-14/RMC-14/issues/2744) (duplicate imo)

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adds `XenoSecreteStructureAttemptEvent.cs` since there wasn't already an event for this. It is implemented similarly to other `Xeno[...]AttemptEvent.cs` scripts.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/RMC-14/RMC-14/assets/96957003/a8309846-af74-4e54-a58b-98ee60738848)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- fix: Fixed xenonids being able to attack and build while resting.
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
