### PR TITLE
Locks viewport size to 15x15

### DIFF
--- a/Content.Client/Options/UI/Tabs/GraphicsTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/GraphicsTab.xaml.cs
@@ -75,7 +75,7 @@ public sealed partial class GraphicsTab : Control
         ViewportScaleSlider.Visible = !ViewportStretchCheckBox.Pressed;
         IntegerScalingCheckBox.Visible = ViewportStretchCheckBox.Pressed;
         ViewportVerticalFitCheckBox.Visible = ViewportStretchCheckBox.Pressed;
-        ViewportWidthSlider.Visible = !ViewportStretchCheckBox.Pressed || !ViewportVerticalFitCheckBox.Pressed;
+        ViewportWidthSlider.Visible = false;// !ViewportStretchCheckBox.Pressed || !ViewportVerticalFitCheckBox.Pressed;
     }
 
     private void UpdateViewportWidthRange()

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1653,10 +1653,10 @@ namespace Content.Shared.CCVar
             CVarDef.Create("viewport.minimum_width", 15, CVar.REPLICATED | CVar.SERVER);
 
         public static readonly CVarDef<int> ViewportMaximumWidth =
-            CVarDef.Create("viewport.maximum_width", 21, CVar.REPLICATED | CVar.SERVER);
+            CVarDef.Create("viewport.maximum_width", 15, CVar.REPLICATED | CVar.SERVER);
 
         public static readonly CVarDef<int> ViewportWidth =
-            CVarDef.Create("viewport.width", 21, CVar.CLIENTONLY | CVar.ARCHIVE);
+            CVarDef.Create("viewport.width", 15, CVar.CLIENTONLY | CVar.ARCHIVE);
 
         public static readonly CVarDef<bool> ViewportVerticalFit =
             CVarDef.Create("viewport.vertical_fit", true, CVar.CLIENTONLY | CVar.ARCHIVE);


### PR DESCRIPTION
## About the PR
As the title says, this locks the viewport to being 15x15, instead of the previous variation from 15x15 to 21x15. Also hides the viewport width slider from the settings menu.

## Why / Balance
With a viewport wider than it is tall, players need to constantly rotate their camera to make the most of their view distance and any ranged options they might have.

*Not* doing this puts you at a disadvantage against anyone who *is* doing it, especially if they have a ranged weapon.
*Doing* it can be both disorienting and plain obnoxious with the camera frequently spinning.

Also, scopes are more effective along the wider part of the viewport and give you an even longer range than is normal for them.

CM13 never added a widescreen viewport for a reason.

## Media
Viewport and settings menu:
![viewport](https://github.com/RMC-14/RMC-14/assets/84070966/4f8e04d1-2554-4b68-8dc8-5bfff503ec1c)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- remove: You can no longer change your viewport size. It's locked to 15x15
