### PR TITLE
Fix xenonid weeds behind walls getting destroyed by explosions

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_weeds.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_weeds.yml
@@ -16,7 +16,7 @@
       fix1:
         shape:
           !type:PhysShapeAabb
-          bounds: "-0.5,-0.5,0.5,0.5"
+          bounds: "-0.45,-0.45,0.45,0.45"
         layer:
         - SlipLayer
         mask:


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed xenonid weeds behind walls getting destroyed by explosions on the other side of the wall.