### PR TITLE
Fix showing the inventory button to xenos

### DIFF
--- a/Content.Client/UserInterface/Systems/Inventory/InventoryUIController.cs
+++ b/Content.Client/UserInterface/Systems/Inventory/InventoryUIController.cs
@@ -134,6 +134,9 @@ public sealed class InventoryUIController : UIController, IOnStateEntered<Gamepl
         if (clientInv == null)
         {
             _inventoryHotbar?.ClearButtons();
+            if (_inventoryButton != null)
+                _inventoryButton.Visible = false;
+
             return;
         }
 
@@ -411,6 +414,8 @@ public sealed class InventoryUIController : UIController, IOnStateEntered<Gamepl
         {
             slotGroup.ClearButtons();
         }
+
+        UpdateInventoryHotbar(null);
     }
 
     private void SpriteUpdated(SlotSpriteUpdate update)


### PR DESCRIPTION
## About the PR
Includes the changes in https://github.com/space-wizards/space-station-14/pull/29728

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed showing the inventory button in the bottom left to xenonids, which have no inventory slots.