### PR TITLE
Gives barricades a use delay

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Walls/barricade_metal.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Walls/barricade_metal.yml
@@ -349,7 +349,7 @@
       components:
       - Xeno
   - type: UseDelay
-    delay: 0.7
+    delay: 0.3
 
 - type: entity
   parent: CMBarricadeMetalDoor

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Walls/barricade_metal.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Walls/barricade_metal.yml
@@ -348,6 +348,8 @@
     blacklist:
       components:
       - Xeno
+  - type: UseDelay
+    delay: 0.7
 
 - type: entity
   parent: CMBarricadeMetalDoor


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Makes any toggle-able barricades have a small delay upon use
<!-- What did you change in this PR? -->

## Why / Balance
To prevent the semi-often case of people spamming them for the ratchet sound, and so people can't try and cheese their instant blocking methods.
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
Adds `UseDelay` to the barricades proto.
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

**Changelog**
:cl: Sphiral
- tweak: Barricades now have a 0.7 use delay
