### PR TITLE
Sandbag barricades no longer have invisible bolts and can now be deconstructed

### DIFF
--- a/Content.Shared/_RMC14/Entrenching/BarricadeSandbagComponent.cs
+++ b/Content.Shared/_RMC14/Entrenching/BarricadeSandbagComponent.cs
@@ -1,0 +1,7 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Entrenching;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(BarricadeSandbagComponent))]
+public sealed partial class BarricadeSandbagComponent : Component;

--- a/Content.Shared/_RMC14/Entrenching/BarricadeSandbagComponent.cs
+++ b/Content.Shared/_RMC14/Entrenching/BarricadeSandbagComponent.cs
@@ -1,7 +1,27 @@
 using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared._RMC14.Entrenching;
 
 [RegisterComponent, NetworkedComponent]
 [Access(typeof(BarricadeSandbagComponent))]
-public sealed partial class BarricadeSandbagComponent : Component;
+public sealed partial class BarricadeSandbagComponent : Component
+{
+    /// <summary>
+    /// Optionally set stackable material received upon deconstruction.
+    /// </summary>
+    [DataField("material")]
+    public EntProtoId Material = "CMSandbagFull";
+
+    /// <summary>
+    /// Optional maximum amount of material received upon deconstruction.
+    /// </summary>
+    [DataField("maxMaterial")]
+    public int MaxMaterial = 0;
+
+    /// <summary>
+    /// Optionally set damage interval at which material is lost.
+    /// </summary>
+    [DataField("materialLossDamageInterval")]
+    public int MaterialLossDamageInterval = 75;
+}

--- a/Content.Shared/_RMC14/Entrenching/BarricadeSandbagComponent.cs
+++ b/Content.Shared/_RMC14/Entrenching/BarricadeSandbagComponent.cs
@@ -10,18 +10,18 @@ public sealed partial class BarricadeSandbagComponent : Component
     /// <summary>
     /// Optionally set stackable material received upon deconstruction.
     /// </summary>
-    [DataField("material")]
+    [DataField]
     public EntProtoId Material = "CMSandbagFull";
 
     /// <summary>
     /// Optional maximum amount of material received upon deconstruction.
     /// </summary>
-    [DataField("maxMaterial")]
+    [DataField]
     public int MaxMaterial = 0;
 
     /// <summary>
     /// Optionally set damage interval at which material is lost.
     /// </summary>
-    [DataField("materialLossDamageInterval")]
+    [DataField]
     public int MaterialLossDamageInterval = 75;
 }

--- a/Content.Shared/_RMC14/Entrenching/EntrenchingToolSystem.cs
+++ b/Content.Shared/_RMC14/Entrenching/EntrenchingToolSystem.cs
@@ -85,13 +85,15 @@ public sealed class EntrenchingToolSystem : EntitySystem
 
         if (_net.IsServer)
         {
-            var full = Spawn("CMSandbagFull", EntityManager.GetCoordinates(args.Coordinates));
+            if (!TryComp(args.Target, out BarricadeSandbagComponent? barricade))
+                return;
+            var full = Spawn(barricade.Material, EntityManager.GetCoordinates(args.Coordinates));
 
-            var bagsSalvaged = 0;
-            if (TryComp(full, out FullSandbagComponent? fullSandbag))
+            var bagsSalvaged = barricade.MaxMaterial;
+            if (bagsSalvaged <= 0 && TryComp(full, out FullSandbagComponent? fullSandbag))
                 bagsSalvaged = fullSandbag.StackRequired;
             if (TryComp(args.Target, out DamageableComponent? damageable))
-                bagsSalvaged -= Math.Max((int) damageable.TotalDamage / 75 - 1, 0);
+                bagsSalvaged -= Math.Max((int) damageable.TotalDamage / barricade.MaterialLossDamageInterval - 1, 0);
 
             Del(args.Target);
 

--- a/Content.Shared/_RMC14/Entrenching/EntrenchingToolSystem.cs
+++ b/Content.Shared/_RMC14/Entrenching/EntrenchingToolSystem.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared.DoAfter;
+﻿using Content.Shared.Damage;
+using Content.Shared.DoAfter;
 using Content.Shared.Interaction;
 using Content.Shared.Item.ItemToggle.Components;
 using Content.Shared.Maps;
@@ -35,6 +36,7 @@ public sealed class EntrenchingToolSystem : EntitySystem
         SubscribeLocalEvent<EntrenchingToolComponent, EntrenchingToolDoAfterEvent>(OnDoAfter);
         SubscribeLocalEvent<EntrenchingToolComponent, ItemToggledEvent>(OnItemToggled);
         SubscribeLocalEvent<EntrenchingToolComponent, SandbagFillDoAfterEvent>(OnSandbagFillDoAfter);
+        SubscribeLocalEvent<EntrenchingToolComponent, SandbagDismantleDoAfterEvent>(OnSandbagDismantleDoAfter);
 
         SubscribeLocalEvent<EmptySandbagComponent, InteractUsingEvent>(OnEmptyInteractUsing);
 
@@ -48,8 +50,60 @@ public sealed class EntrenchingToolSystem : EntitySystem
         if (!args.CanReach)
             return;
 
+        if (HasComp<BarricadeSandbagComponent>(args.Target))
+        {
+            DismantleSandbagBaricade(tool, ref args);
+            args.Handled = true;
+            return;
+        }
+
         StartDigging(tool, args.User, args.ClickLocation);
         args.Handled = true;
+    }
+
+    private void DismantleSandbagBaricade(Entity<EntrenchingToolComponent> tool, ref AfterInteractEvent args)
+    {
+        if (TryComp(tool, out ItemToggleComponent? toggle) && !toggle.Activated)
+            return;
+
+        _popup.PopupClient(Loc.GetString("cm-entrenching-dismantle"), args.User, args.User);
+
+        var ev = new SandbagDismantleDoAfterEvent(GetNetCoordinates(args.ClickLocation));
+        var doAfter = new DoAfterArgs(EntityManager, args.User, tool.Comp.DigDelay, ev, tool, args.Target, tool)
+        {
+            BreakOnMove = true,
+        };
+        _doAfter.TryStartDoAfter(doAfter);
+    }
+
+    private void OnSandbagDismantleDoAfter(Entity<EntrenchingToolComponent> tool, ref SandbagDismantleDoAfterEvent args)
+    {
+        if (args.Cancelled || args.Handled)
+            return;
+
+        args.Handled = true;
+
+        if (_net.IsServer)
+        {
+            var full = Spawn("CMSandbagFull", EntityManager.GetCoordinates(args.Coordinates));
+
+            var bagsSalvaged = 0;
+            if (TryComp(full, out FullSandbagComponent? fullSandbag))
+                bagsSalvaged = fullSandbag.StackRequired;
+            if (TryComp(args.Target, out DamageableComponent? damageable))
+                bagsSalvaged -= Math.Max((int) damageable.TotalDamage / 75 - 1, 0);
+
+            Del(args.Target);
+
+            if (bagsSalvaged <= 0)
+            {
+                Del(full);
+                return;
+            }
+
+            if (TryComp(full, out StackComponent? fullStack))
+                _stack.SetCount(full, bagsSalvaged, fullStack);
+        }
     }
 
     private void OnDoAfter(Entity<EntrenchingToolComponent> tool, ref EntrenchingToolDoAfterEvent args)

--- a/Content.Shared/_RMC14/Entrenching/SandbagDismantleDoAfterEvent.cs
+++ b/Content.Shared/_RMC14/Entrenching/SandbagDismantleDoAfterEvent.cs
@@ -1,0 +1,17 @@
+﻿using Content.Shared.DoAfter;
+using Robust.Shared.Map;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Entrenching;
+
+[Serializable, NetSerializable]
+public sealed partial class SandbagDismantleDoAfterEvent : SimpleDoAfterEvent
+{
+    [DataField(required: true)]
+    public NetCoordinates Coordinates;
+
+    public SandbagDismantleDoAfterEvent(NetCoordinates coordinates)
+    {
+        Coordinates = coordinates;
+    }
+}

--- a/Resources/Locale/en-US/_RMC14/entrenching/entrenching.ftl
+++ b/Resources/Locale/en-US/_RMC14/entrenching/entrenching.ftl
@@ -1,3 +1,4 @@
 cm-entrenching-start-digging = You start digging
 cm-entrenching-begin-filling = You begin filling the sandbags
 cm-entrenching-stop-digging = You stop digging
+cm-entrenching-dismantle = You start removing the individual sandbags

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Walls/barricade_metal.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Walls/barricade_metal.yml
@@ -3,7 +3,6 @@
   parent: CMBaseStructureCorrodible
   id: CMBarricadeBase
   components:
-  - type: Anchorable
   - type: Rotatable
   - type: Appearance
   - type: Fixtures
@@ -33,6 +32,7 @@
   name: metal barricade
   description: A metal barricade that keeps the unwanted out. Upgradable with metal, plasteel, or metal rods for different attributes. Repair with a welder.
   components:
+  - type: Anchorable
   - type: MeleeSound
     soundGroups:
       Brute:
@@ -164,6 +164,7 @@
   name: turnstile
   description: A railing to prevent marines from stepping out of line.
   components:
+    - type: Anchorable
     - type: Sprite
       sprite: _RMC14/Structures/Walls/Barricades/barricade.rsi
       layers:
@@ -207,6 +208,7 @@
   name: handrail
   description: A railing, for your hands. Woooow.
   components:
+    - type: Anchorable
     - type: Sprite
       drawdepth: WallTops
       sprite: _RMC14/Structures/Walls/Barricades/barricade.rsi
@@ -279,6 +281,7 @@
   name: folding metal barricade
   description: A folding metal barricade weaker than the non-folding counterpart. Able to be opened and closed at a moment's notice. Repair with a welder.
   components:
+  - type: Anchorable
   - type: MeleeSound
     soundGroups:
       Brute:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Walls/sandbags.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Walls/sandbags.yml
@@ -4,6 +4,7 @@
   name: sandbag barricade
   description: A makeshift barricade made out of the sand from the ground. Tough to beat but easy to pierce.
   components:
+  - type: BarricadeSandbag
   - type: Climbable
   - type: MeleeSound
     soundGroups:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Makes it so sandbag barricades no longer have an anchorable component. They now have to be deconstructed with the entrenching tool (simply click and wait for the do after).

Once deconstructed the amount of sandbags you get back depends on how damaged the barricade was. The values should match up with cmss13. [This is what i referenced.](https://discord.com/channels/1168210010233376858/1168210011823026270/1258819675278807170)

https://github.com/snebl/RMC-14/blob/5226556bf0915e4391a9168fe62a585b7a8ce017/Content.Shared/_RMC14/Entrenching/EntrenchingToolSystem.cs#L94

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Resolves [#2823](https://github.com/RMC-14/RMC-14/issues/2823)

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adds `BarricadeSandbagComponent.cs` and `SandbagDismantleDoAfterEvent.cs`.
Most changes are in `EntrenchingToolSystem.cs`. It can now handle the use of the entrenching tool on a sandbag barricade.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/RMC-14/RMC-14/assets/96957003/99d88a4e-e7c2-4ee3-bf51-9b9b6348c8cf)
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- add: Sandbag barricades can now be deconstructed with the entrenching tool.
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
