### PR TITLE
rules and clarifications update

### DIFF
--- a/Resources/ServerInfo/Guidebook/_RMC14/Rules/MilitaryCommand/CMHigherStandards.xml
+++ b/Resources/ServerInfo/Guidebook/_RMC14/Rules/MilitaryCommand/CMHigherStandards.xml
@@ -9,4 +9,5 @@
   - Command are at minimum expected to report criminal activity to MP.
   - Do not immediately abandon your position as a Command role to do things unrelated to your role.
   - Do not abandon the ship during a raid. You are supposed to protect the ship and it's crew, not let hostile forces kill everyone on it without a fight.
+  - The MP are not combat roles, and should focus solely on enforcing laws in the FOB, if granted permission to do so. See deployment rule section.
 </Document>

--- a/Resources/ServerInfo/Guidebook/_RMC14/Rules/Overview.xml
+++ b/Resources/ServerInfo/Guidebook/_RMC14/Rules/Overview.xml
@@ -9,7 +9,7 @@
   - (Deployment) Medical roles (excluding corpsmen) should not be assigned marine equipment. They are not permitted to leave the areas designated by the operation commander.
   - (Deployment) The FOB is the safe, secure, designated area by the commander of the operation.
   - (Deployment) The MP are not combat roles, and should focus solely on enforcing laws in the FOB.
-  - (Deployment) The Warden is required to stay on the ship.w
+  - (Deployment) The Warden is required to stay on the ship.
 
   ##Admin Decisions Are Final.
   - Rules are enforced as intended. Every example of a rule break cannot be written, thus enforcement is subject to admin interpretation of the rule’s intention.

--- a/Resources/ServerInfo/Guidebook/_RMC14/Rules/Overview.xml
+++ b/Resources/ServerInfo/Guidebook/_RMC14/Rules/Overview.xml
@@ -1,9 +1,15 @@
 ﻿<Document>
   #RMC-14 Rules
 
-  ##Recent Changes
-  - Clarifications on EORG.
+  If you are unable to click any of the links, use the in-game guidebook version.
 
+  ##Recent Changes
+  Read the relevant sections for the entire text.
+  - (Chain of command) Staff officer has been moved to the forth in command chain, below the ASO.
+  - (Deployment) Medical roles (excluding corpsmen) should not be assigned marine equipment. They are not permitted to leave the areas designated by the operation commander.
+  - (Deployment) The FOB is the safe, secure, designated area by the commander of the operation.
+  - (Deployment) The MP are not combat roles, and should focus solely on enforcing laws in the FOB.
+  - (Deployment) The Warden is required to stay on the ship.w
 
   ##Admin Decisions Are Final.
   - Rules are enforced as intended. Every example of a rule break cannot be written, thus enforcement is subject to admin interpretation of the rule’s intention.

--- a/Resources/ServerInfo/Guidebook/_RMC14/Rules/Roleplay/CMCommandChain.xml
+++ b/Resources/ServerInfo/Guidebook/_RMC14/Rules/Roleplay/CMCommandChain.xml
@@ -6,9 +6,9 @@
   - Commanding Officer
   - Executive Officer
   - Auxiliary Support Officer
+  - Staff Officer
   - Chief MP
   - Chief Medical Officer
-  - Staff Officer
   - Chief Engineer
   - Pilot Officer
   - Intelligence Officer

--- a/Resources/ServerInfo/Guidebook/_RMC14/Rules/Roleplay/CMMarineDeployment.xml
+++ b/Resources/ServerInfo/Guidebook/_RMC14/Rules/Roleplay/CMMarineDeployment.xml
@@ -1,16 +1,19 @@
 ﻿<Document>
   #Deployment of Marine forces
   - Marines should be following their role objectives.
-  - Medics should heal their comrades, a specialist should be using their equipment.
+  - Corpsmen should heal their comrades, a specialist should be using their equipment.
   - Squad leaders should always listen to command.
   - Squad members should always follow the orders of the squad leader.
-  - Department heads (RD, CMP, CMO) should not deploy.
-  - All marines should deploy when possible.
+  - Department heads (RD, CMP, CMO, Warden) should not deploy.
+  - All marines (combat roles) should deploy when possible.
 
-  ##Ship crew may deploy, where relevant.
+  ##Ship crew may deploy, where relevant, with permission.
+  - The FOB is the safe, secure, designated area by the commander of the operation.
   - Maint techs may assist building FOB.
-  - The CMO may give permission to doctors so they may treat marines within the FOB.
+  - The CMO or operation commander may give permission to medbay so they may treat marines within the FOB.
+  - Medical roles (excluding corpsmen) are not combat roles, and should not be assigned marine equipment outside of a pistol for self defense on the planet. They are not permitted to leave the areas designated by the operation commander.
   - The CMP may give permission to MP so they may make arrests within the FOB.
+  - The MP are not combat roles, and should focus solely on enforcing laws in the FOB.
   - Combat Correspondents focus on reporting on combat and disengage when attacked.
   - CO, XO may deploy if they assign a new warship commander (The person in charge of the warship crew)
 </Document>


### PR DESCRIPTION
## Recent Changes
  Read the relevant sections for the entire text.
  - (Chain of command) Staff officer has been moved to the forth in command chain, below the ASO.
  - (Deployment) Medical roles (excluding corpsmen) should not be assigned marine equipment. They are not permitted to leave the areas designated by the operation commander.
  - (Deployment) The FOB is the safe, secure, designated area by the commander of the operation.
  - (Deployment) The MP are not combat roles, and should focus solely on enforcing laws in the FOB.
  - (Deployment) The Warden is required to stay on the ship.