### PR TITLE
feat: allow climbing metal barricades

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Walls/barricade_metal.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Walls/barricade_metal.yml
@@ -32,6 +32,7 @@
   name: metal barricade
   description: A metal barricade that keeps the unwanted out. Upgradable with metal, plasteel, or metal rods for different attributes. Repair with a welder.
   components:
+  - type: Climbable
   - type: Anchorable
   - type: MeleeSound
     soundGroups:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Allowed climbing for metal barricades without barbed wire.

Closes #2832.

## Why / Balance
* https://github.com/RMC-14/RMC-14/issues/2832
* They are the same size, same purpose and same-ish mechancis as sandbags, which can be climbed without barbed wire.

## Technical details
* Verified that metal barricade can be climbed by both marines and aliens.
* Verified that metal barricade with barbed wire can not be climbed.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

None.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
-->

:cl:
- add: Added an ability to climb metal barricades that do not have barbed wire.
