### PR TITLE
Make stored items not be destroyed by explosions, fix helmets fitting too many items, make helmets 2-slot storages

### DIFF
--- a/Content.Shared/_RMC14/Drink/RMCFlaskComponent.cs
+++ b/Content.Shared/_RMC14/Drink/RMCFlaskComponent.cs
@@ -1,0 +1,6 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Drink;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class RMCFlaskComponent : Component;

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Back/backpacks.yml
@@ -40,6 +40,9 @@
     interfaces:
       enum.StorageUiKey.Key:
         type: StorageBoundUserInterface
+  - type: ExplosionResistance
+    damageCoefficient: 0
+    worn: false
 
 - type: entity
   parent: CMPersonalStorageBase

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
@@ -23,6 +23,9 @@
     interfaces:
       enum.StorageUiKey.Key:
         type: StorageBoundUserInterface
+  - type: ExplosionResistance
+    damageCoefficient: 0
+    worn: false
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Head/Helmets/marine_helmets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Head/Helmets/marine_helmets.yml
@@ -34,6 +34,28 @@
   - type: ExplosionResistance
     damageCoefficient: 0
     worn: false
+  - type: IgnoreContentsSize
+    items:
+      components:
+      - RMCFlask
+      - CMScalpel
+      tags:
+#      - TODO RMC14 lighters
+#      - TODO RMC14 matchbox
+      - Cigarette
+#      - TODO RMC14 cards
+      - Slice
+#      - TODO RMC14 glasses (eyewear)
+#      - TODO RMC14 walkman and casettes
+#      - TODO RMC14 helmet garb
+      - Pen
+      - Crayon
+#      - TODO RMC14 handful of bullets
+      - Flashlight
+      - Brutepack
+      - CMOintment
+      - CMAutoInjector
+      - PillPacket
 
 - type: entity
   parent: ArmorHelmetM10

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Head/Helmets/marine_helmets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Head/Helmets/marine_helmets.yml
@@ -10,7 +10,7 @@
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/Head/Helmets/m10/standard.rsi
   - type: Storage #hopefully in the future someone smarter than me can add storage(?) for integrated things like netting, HUD, etc. but for now this is for hiding snacks
-    maxItemSize: Small
+    maxItemSize: Tiny
     grid:
     - 0,0,2,1
     blacklist:

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Head/Helmets/marine_helmets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Head/Helmets/marine_helmets.yml
@@ -12,7 +12,7 @@
   - type: Storage #hopefully in the future someone smarter than me can add storage(?) for integrated things like netting, HUD, etc. but for now this is for hiding snacks
     maxItemSize: Tiny
     grid:
-    - 0,0,2,1
+    - 0,0,3,1 # TODO RMC14 7, but 2 slots are reserved for garbs
     blacklist:
       tags:
       - Pouch
@@ -56,6 +56,7 @@
       - CMOintment
       - CMAutoInjector
       - PillPacket
+  - type: FixedItemSizeStorage
 
 - type: entity
   parent: ArmorHelmetM10

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Head/Helmets/marine_helmets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Head/Helmets/marine_helmets.yml
@@ -31,6 +31,9 @@
   - type: RMCNameItemOnVend
     item: Helmet
   - type: RMCBulkyArmor
+  - type: ExplosionResistance
+    damageCoefficient: 0
+    worn: false
 
 - type: entity
   parent: ArmorHelmetM10

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
@@ -94,6 +94,9 @@
   - type: RMCNameItemOnVend
     item: Armor
   - type: RMCBulkyArmor
+  - type: ExplosionResistance
+    damageCoefficient: 0
+    worn: false
 
 - type: entity
   parent: CMArmorM3Medium

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
@@ -362,7 +362,7 @@
       - Gun
       - BallisticAmmoProvider
       - Stunbaton
-      - # TODO RMC14 motion detector, walkman
+#      - # TODO RMC14 motion detector, walkman
       tags:
       - Handcuffs
       - Grenade

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/pouches.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/pouches.yml
@@ -20,6 +20,9 @@
   - type: Tag
     tags:
     - Pouch
+  - type: ExplosionResistance
+    damageCoefficient: 0
+    worn: false
 
 - type: entity
   parent: [CMPouch, BaseStorageItem]

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/webbing.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/webbing.yml
@@ -28,6 +28,9 @@
       grid:
       - 0,0,5,1 # 3 slots
     - type: FixedItemSizeStorage
+    - type: ExplosionResistance
+      damageCoefficient: 0
+      worn: false
   - type: ExplosionResistance
     damageCoefficient: 0
     worn: false
@@ -67,6 +70,9 @@
         - CMMagazineRifle
         - CMMagazineSniper
         - MRE
+    - type: ExplosionResistance
+      damageCoefficient: 0
+      worn: false
 
 - type: entity
   parent: CMWebbingBase
@@ -91,6 +97,9 @@
       grid:
       - 0,0,9,1 # 5 slots
     - type: FixedItemSizeStorage
+    - type: ExplosionResistance
+      damageCoefficient: 0
+      worn: false
 
 - type: entity
   parent: CMWebbingBase
@@ -115,3 +124,6 @@
       grid:
       - 0,0,9,1 # 5 slots
     - type: FixedItemSizeStorage
+    - type: ExplosionResistance
+      damageCoefficient: 0
+      worn: false

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/webbing.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/webbing.yml
@@ -28,6 +28,9 @@
       grid:
       - 0,0,5,1 # 3 slots
     - type: FixedItemSizeStorage
+  - type: ExplosionResistance
+    damageCoefficient: 0
+    worn: false
 
 - type: entity
   parent: CMWebbingBase

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Drinks/canteen.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Drinks/canteen.yml
@@ -29,6 +29,7 @@
       - !type:SpillBehavior { }
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
+  - type: RMCFlask
 
 - type: entity
   parent: CMCanteenBase


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed explosions destroying destroyable items inside backpacks, belts, pouches, webbings, armors and helmets. Any items stored inside will no longer be destroyed by an explosion.
- tweak: Helmets now have two slots for items instead of a single 3 space area, allowing for two injectors, bandages, ointments or pill packets to fit inside, for example.
- fix: Fixed small items fitting into helmets. Only tiny items and the following items can be fit into helmets: auto injectors, pill packets, bandages, ointment, flasks, scalpels, cigarettes, pizza slices, pens, crayons and flashlights, 