### PR TITLE
Fix the patron perks window sometimes showing the wrong tab initially

### DIFF
--- a/Content.Client/_RMC14/LinkAccount/LinkAccountUIController.cs
+++ b/Content.Client/_RMC14/LinkAccount/LinkAccountUIController.cs
@@ -144,6 +144,16 @@ public sealed class LinkAccountUIController : UIController, IOnSystemChanged<Lin
 
             UpdateExamples();
 
+            for (var i = 0; i < _patronPerksWindow.Tabs.ChildCount; i++)
+            {
+                var child = _patronPerksWindow.Tabs.GetChild(i);
+                if (!child.GetValue(TabVisibleProperty))
+                    continue;
+
+                _patronPerksWindow.Tabs.CurrentTab = i;
+                break;
+            }
+
             _patronPerksWindow.OpenCentered();
             return;
         }

--- a/Content.Client/_RMC14/LinkAccount/PatronPerksWindow.xaml
+++ b/Content.Client/_RMC14/LinkAccount/PatronPerksWindow.xaml
@@ -4,7 +4,7 @@
     xmlns:cc="clr-namespace:Content.Client.Administration.UI.CustomControls"
     Title="{Loc 'rmc-ui-patron-perks'}"
     MinSize="625 475">
-    <TabContainer>
+    <TabContainer Name="Tabs" Access="Public">
         <BoxContainer Name="LobbyMessageTab" Access="Public" Orientation="Vertical" Margin="5">
             <Label Text="{Loc 'rmc-ui-lobby-message-description'}" />
             <LineEdit Name="LobbyMessage" Access="Public" Margin="0 10 0 0" />


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fix the patron perks window initially showing the lobby message tab even if the user's tier doesn't have that perk.