### PR TITLE
Make barbed wire damage pierce all armor and increase damage from 6 to 10

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Walls/barricade_metal.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Walls/barricade_metal.yml
@@ -80,7 +80,7 @@
   - type: Barbed
     thornsDamage:
       types:
-        Slash: 6
+        Slash: 10
   - type: Construction
     graph: BarricadeMetalGraph
     node: nodeMetal
@@ -343,7 +343,7 @@
   - type: Barbed
     thornsDamage:
       types:
-        Slash: 6
+        Slash: 10
   - type: Construction
     graph: BarricadeMetalDoorGraph
     node: nodeBarricadeMetalDoor

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Walls/sandbags.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Walls/sandbags.yml
@@ -46,7 +46,7 @@
   - type: Barbed
     thornsDamage:
       types:
-        Slash: 6
+        Slash: 10
 
 - type: entity
   parent: BaseItem


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed barbed wire damage not piercing through xeno armor. It now always deals the same amount of damage, regardless of armor.
- fix: Fixed barbed wire damage being too low. It now deals 10 damage, up from 6.