### PR TITLE
Fix thick resin structure plasma costs being too low

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_doors.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_doors.yml
@@ -123,3 +123,5 @@
     xenoDamage:
       types:
         Slash: 900
+  - type: XenoConstructionPlasmaCost
+    plasma: 145

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_walls.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_walls.yml
@@ -54,6 +54,8 @@
     xenoDamage:
       types:
         Slash: 338
+  - type: XenoConstructionPlasmaCost
+    plasma: 170
 
 - type: entity
   parent: CMBaseWallXeno
@@ -141,3 +143,5 @@
     xenoDamage:
       types:
         Slash: 300
+  - type: XenoConstructionPlasmaCost
+    plasma: 120


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed thick resin structures (the hivelord ones) being cheaper to build than intended. The thick wall now costs 170 plasma, up from 120. The thick membrane now costs 120, up from 95. The thick door now costs 145, up from 120.