### PR TITLE
Hivelord replace door

### DIFF
--- a/Content.Client/Actions/ActionsSystem.cs
+++ b/Content.Client/Actions/ActionsSystem.cs
@@ -48,6 +48,7 @@ namespace Content.Client.Actions
             SubscribeLocalEvent<InstantActionComponent, ComponentHandleState>(OnInstantHandleState);
             SubscribeLocalEvent<EntityTargetActionComponent, ComponentHandleState>(OnEntityTargetHandleState);
             SubscribeLocalEvent<WorldTargetActionComponent, ComponentHandleState>(OnWorldTargetHandleState);
+            SubscribeLocalEvent<EntityWorldTargetActionComponent, ComponentHandleState>(OnEntityWorldTargetHandleState);
         }
 
         private void OnInstantHandleState(EntityUid uid, InstantActionComponent component, ref ComponentHandleState args)
@@ -74,6 +75,18 @@ namespace Content.Client.Actions
                 return;
 
             BaseHandleState<WorldTargetActionComponent>(uid, component, state);
+        }
+
+        private void OnEntityWorldTargetHandleState(EntityUid uid,
+            EntityWorldTargetActionComponent component,
+            ref ComponentHandleState args)
+        {
+            if (args.Current is not EntityWorldTargetActionComponentState state)
+                return;
+
+            component.Whitelist = state.Whitelist;
+            component.CanTargetSelf = state.CanTargetSelf;
+            BaseHandleState<EntityWorldTargetActionComponent>(uid, component, state);
         }
 
         private void BaseHandleState<T>(EntityUid uid, BaseActionComponent component, BaseActionComponentState state) where T : BaseActionComponent

--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -302,7 +302,7 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
             _actionsSystem.PerformAction(user, actionComp, actionId, action, action.Event, _timing.CurTime);
         }
         else
-            EntityManager.RaisePredictiveEvent(new RequestPerformActionEvent(EntityManager.GetNetEntity(actionId), EntityManager.GetNetEntity(args.EntityUid)));
+            EntityManager.RaisePredictiveEvent(new RequestPerformActionEvent(EntityManager.GetNetEntity(actionId), EntityManager.GetNetEntity(args.EntityUid), EntityManager.GetNetCoordinates(coords)));
 
         if (!action.Repeat)
             StopTargeting();

--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -184,15 +184,59 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
         switch (action)
         {
             case WorldTargetActionComponent mapTarget:
-                    return TryTargetWorld(args, actionId, mapTarget, user, comp) || !mapTarget.InteractOnMiss;
+                return TryTargetWorld(args, actionId, mapTarget, user, comp) || !mapTarget.InteractOnMiss;
 
             case EntityTargetActionComponent entTarget:
-                    return TryTargetEntity(args, actionId, entTarget, user, comp) || !entTarget.InteractOnMiss;
+                return TryTargetEntity(args, actionId, entTarget, user, comp) || !entTarget.InteractOnMiss;
+
+            case EntityWorldTargetActionComponent entMapTarget:
+                return TryTargetEntityWorld(args, actionId, entMapTarget, user, comp) || !entMapTarget.InteractOnMiss;
 
             default:
                 Logger.Error($"Unknown targeting action: {actionId.GetType()}");
                 return false;
         }
+    }
+
+    private bool TryTargetEntityWorld(in PointerInputCmdArgs args,
+        EntityUid actionId,
+        EntityWorldTargetActionComponent action,
+        EntityUid user,
+        ActionsComponent actionComp)
+    {
+        if (_actionsSystem == null)
+            return false;
+
+        var entity = args.EntityUid;
+        var coords = args.Coordinates;
+
+        if (!_actionsSystem.ValidateEntityWorldTarget(user, entity, coords, (actionId, action)))
+        {
+            if (action.DeselectOnMiss)
+                StopTargeting();
+
+            return false;
+        }
+
+        if (action.ClientExclusive)
+        {
+            if (action.Event != null)
+            {
+                action.Event.Entity = entity;
+                action.Event.Coords = coords;
+                action.Event.Performer = user;
+                action.Event.Action = actionId;
+            }
+
+            _actionsSystem.PerformAction(user, actionComp, actionId, action, action.Event, _timing.CurTime);
+        }
+        else
+            EntityManager.RaisePredictiveEvent(new RequestPerformActionEvent(EntityManager.GetNetEntity(actionId), EntityManager.GetNetEntity(args.EntityUid)));
+
+        if (!action.Repeat)
+            StopTargeting();
+
+        return true;
     }
 
     private bool TryTargetWorld(in PointerInputCmdArgs args, EntityUid actionId, WorldTargetActionComponent action, EntityUid user, ActionsComponent actionComp)

--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -198,47 +198,6 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
         }
     }
 
-    private bool TryTargetEntityWorld(in PointerInputCmdArgs args,
-        EntityUid actionId,
-        EntityWorldTargetActionComponent action,
-        EntityUid user,
-        ActionsComponent actionComp)
-    {
-        if (_actionsSystem == null)
-            return false;
-
-        var entity = args.EntityUid;
-        var coords = args.Coordinates;
-
-        if (!_actionsSystem.ValidateEntityWorldTarget(user, entity, coords, (actionId, action)))
-        {
-            if (action.DeselectOnMiss)
-                StopTargeting();
-
-            return false;
-        }
-
-        if (action.ClientExclusive)
-        {
-            if (action.Event != null)
-            {
-                action.Event.Entity = entity;
-                action.Event.Coords = coords;
-                action.Event.Performer = user;
-                action.Event.Action = actionId;
-            }
-
-            _actionsSystem.PerformAction(user, actionComp, actionId, action, action.Event, _timing.CurTime);
-        }
-        else
-            EntityManager.RaisePredictiveEvent(new RequestPerformActionEvent(EntityManager.GetNetEntity(actionId), EntityManager.GetNetEntity(args.EntityUid)));
-
-        if (!action.Repeat)
-            StopTargeting();
-
-        return true;
-    }
-
     private bool TryTargetWorld(in PointerInputCmdArgs args, EntityUid actionId, WorldTargetActionComponent action, EntityUid user, ActionsComponent actionComp)
     {
         if (_actionsSystem == null)
@@ -295,6 +254,47 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
             if (action.Event != null)
             {
                 action.Event.Target = entity;
+                action.Event.Performer = user;
+                action.Event.Action = actionId;
+            }
+
+            _actionsSystem.PerformAction(user, actionComp, actionId, action, action.Event, _timing.CurTime);
+        }
+        else
+            EntityManager.RaisePredictiveEvent(new RequestPerformActionEvent(EntityManager.GetNetEntity(actionId), EntityManager.GetNetEntity(args.EntityUid)));
+
+        if (!action.Repeat)
+            StopTargeting();
+
+        return true;
+    }
+
+    private bool TryTargetEntityWorld(in PointerInputCmdArgs args,
+        EntityUid actionId,
+        EntityWorldTargetActionComponent action,
+        EntityUid user,
+        ActionsComponent actionComp)
+    {
+        if (_actionsSystem == null)
+            return false;
+
+        var entity = args.EntityUid;
+        var coords = args.Coordinates;
+
+        if (!_actionsSystem.ValidateEntityWorldTarget(user, entity, coords, (actionId, action)))
+        {
+            if (action.DeselectOnMiss)
+                StopTargeting();
+
+            return false;
+        }
+
+        if (action.ClientExclusive)
+        {
+            if (action.Event != null)
+            {
+                action.Event.Entity = entity;
+                action.Event.Coords = coords;
                 action.Event.Performer = user;
                 action.Event.Action = actionId;
             }

--- a/Content.Server/Actions/ActionOnInteractSystem.cs
+++ b/Content.Server/Actions/ActionOnInteractSystem.cs
@@ -103,31 +103,31 @@ public sealed class ActionOnInteractSystem : EntitySystem
                 args.Handled = true;
                 return;
             }
+        }
 
-            // Then EntityWorld target actions
-            var entWorldOptions = GetValidActions<EntityWorldTargetActionComponent>(actionEnts, args.CanReach);
-            for (var i = entWorldOptions.Count - 1; i >= 0; i--)
+        // Then EntityWorld target actions
+        var entWorldOptions = GetValidActions<EntityWorldTargetActionComponent>(actionEnts, args.CanReach);
+        for (var i = entWorldOptions.Count - 1; i >= 0; i--)
+        {
+            var action = entWorldOptions[i];
+            if (!_actions.ValidateEntityWorldTarget(args.User, args.Target, args.ClickLocation, action))
+                entWorldOptions.RemoveAt(i);
+        }
+
+        if (entWorldOptions.Count > 0)
+        {
+            var (entActId, entAct) = _random.Pick(entWorldOptions);
+            if (entAct.Event != null)
             {
-                var action = entWorldOptions[i];
-                if (!_actions.ValidateEntityWorldTarget(args.User, args.Target.Value, args.ClickLocation, action))
-                    entWorldOptions.RemoveAt(i);
+                entAct.Event.Performer = args.User;
+                entAct.Event.Action = entActId;
+                entAct.Event.Entity = args.Target;
+                entAct.Event.Coords = args.ClickLocation;
             }
 
-            if (entWorldOptions.Count > 0)
-            {
-                var (entActId, entAct) = _random.Pick(entWorldOptions);
-                if (entAct.Event != null)
-                {
-                    entAct.Event.Performer = args.User;
-                    entAct.Event.Action = entActId;
-                    entAct.Event.Entity = args.Target.Value;
-                    entAct.Event.Coords = args.ClickLocation;
-                }
-
-                _actions.PerformAction(args.User, null, entActId, entAct, entAct.Event, _timing.CurTime, false);
-                args.Handled = true;
-                return;
-            }
+            _actions.PerformAction(args.User, null, entActId, entAct, entAct.Event, _timing.CurTime, false);
+            args.Handled = true;
+            return;
         }
 
         // else: try world target actions

--- a/Content.Server/Actions/ActionOnInteractSystem.cs
+++ b/Content.Server/Actions/ActionOnInteractSystem.cs
@@ -103,6 +103,31 @@ public sealed class ActionOnInteractSystem : EntitySystem
                 args.Handled = true;
                 return;
             }
+
+            // Then EntityWorld target actions
+            var entWorldOptions = GetValidActions<EntityWorldTargetActionComponent>(actionEnts, args.CanReach);
+            for (var i = entWorldOptions.Count - 1; i >= 0; i--)
+            {
+                var action = entWorldOptions[i];
+                if (!_actions.ValidateEntityWorldTarget(args.User, args.Target.Value, args.ClickLocation, action))
+                    entWorldOptions.RemoveAt(i);
+            }
+
+            if (entWorldOptions.Count > 0)
+            {
+                var (entActId, entAct) = _random.Pick(entWorldOptions);
+                if (entAct.Event != null)
+                {
+                    entAct.Event.Performer = args.User;
+                    entAct.Event.Action = entActId;
+                    entAct.Event.Entity = args.Target.Value;
+                    entAct.Event.Coords = args.ClickLocation;
+                }
+
+                _actions.PerformAction(args.User, null, entActId, entAct, entAct.Event, _timing.CurTime, false);
+                args.Handled = true;
+                return;
+            }
         }
 
         // else: try world target actions

--- a/Content.Shared/Actions/ActionEvents.cs
+++ b/Content.Shared/Actions/ActionEvents.cs
@@ -145,6 +145,27 @@ public abstract partial class WorldTargetActionEvent : BaseActionEvent
 }
 
 /// <summary>
+///     This is the type of event that gets raised when an <see cref="EntityWorldTargetActionComponent"/> is performed.
+///     The <see cref="BaseActionEvent.Performer"/>, <see cref="Entity"/>, and <see cref="Coords"/>
+///     fields will automatically be filled out by the <see cref="SharedActionsSystem"/>.
+/// </summary>
+/// <remarks>
+///     To define a new action for some system, you need to create an event that inherits from this class.
+/// </remarks>
+public abstract partial class EntityWorldTargetActionEvent : BaseActionEvent
+{
+    /// <summary>
+    ///     The entity that the user targeted.
+    /// </summary>
+    public EntityUid Entity;
+
+    /// <summary>
+    ///     The coordinates of the location that the user targeted.
+    /// </summary>
+    public EntityCoordinates Coords;
+}
+
+/// <summary>
 ///     Base class for events that are raised when an action gets performed. This should not generally be used outside of the action
 ///     system.
 /// </summary>

--- a/Content.Shared/Actions/ActionEvents.cs
+++ b/Content.Shared/Actions/ActionEvents.cs
@@ -157,12 +157,12 @@ public abstract partial class EntityWorldTargetActionEvent : BaseActionEvent
     /// <summary>
     ///     The entity that the user targeted.
     /// </summary>
-    public EntityUid Entity;
+    public EntityUid? Entity;
 
     /// <summary>
     ///     The coordinates of the location that the user targeted.
     /// </summary>
-    public EntityCoordinates Coords;
+    public EntityCoordinates? Coords;
 }
 
 /// <summary>

--- a/Content.Shared/Actions/ActionEvents.cs
+++ b/Content.Shared/Actions/ActionEvents.cs
@@ -101,6 +101,13 @@ public sealed class RequestPerformActionEvent : EntityEventArgs
         Action = action;
         EntityCoordinatesTarget = entityCoordinatesTarget;
     }
+
+    public RequestPerformActionEvent(NetEntity action, NetEntity entityTarget, NetCoordinates entityCoordinatesTarget)
+    {
+        Action = action;
+        EntityTarget = entityTarget;
+        EntityCoordinatesTarget = entityCoordinatesTarget;
+    }
 }
 
 /// <summary>

--- a/Content.Shared/Actions/EntityWorldTargetActionComponent.cs
+++ b/Content.Shared/Actions/EntityWorldTargetActionComponent.cs
@@ -1,8 +1,10 @@
 ﻿using Content.Shared.Whitelist;
+using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.Actions;
 
+[RegisterComponent, NetworkedComponent]
 public sealed partial class EntityWorldTargetActionComponent : BaseTargetActionComponent
 {
     public override BaseActionEvent? BaseEvent => Event;
@@ -10,24 +12,21 @@ public sealed partial class EntityWorldTargetActionComponent : BaseTargetActionC
     /// <summary>
     ///     The local-event to raise when this action is performed.
     /// </summary>
-    [DataField("event")]
+    [DataField]
     [NonSerialized]
     public EntityWorldTargetActionEvent? Event;
 
-    [DataField("whitelist")] public EntityWhitelist? Whitelist;
+    [DataField] public EntityWhitelist? Whitelist;
 
-    [DataField("canTargetSelf")] public bool CanTargetSelf = true;
+    [DataField] public bool CanTargetSelf = true;
 }
 
 [Serializable, NetSerializable]
-public sealed class EntityWorldTargetActionComponentState : BaseActionComponentState
+public sealed class EntityWorldTargetActionComponentState(
+    EntityWorldTargetActionComponent component,
+    IEntityManager entManager)
+    : BaseActionComponentState(component, entManager)
 {
-    public EntityWhitelist? Whitelist;
-    public bool CanTargetSelf;
-
-    public EntityWorldTargetActionComponentState(EntityTargetActionComponent component, IEntityManager entManager) : base(component, entManager)
-    {
-        Whitelist = component.Whitelist;
-        CanTargetSelf = component.CanTargetSelf;
-    }
+    public EntityWhitelist? Whitelist = component.Whitelist;
+    public bool CanTargetSelf = component.CanTargetSelf;
 }

--- a/Content.Shared/Actions/EntityWorldTargetActionComponent.cs
+++ b/Content.Shared/Actions/EntityWorldTargetActionComponent.cs
@@ -1,0 +1,33 @@
+﻿using Content.Shared.Whitelist;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Actions;
+
+public sealed partial class EntityWorldTargetActionComponent : BaseTargetActionComponent
+{
+    public override BaseActionEvent? BaseEvent => Event;
+
+    /// <summary>
+    ///     The local-event to raise when this action is performed.
+    /// </summary>
+    [DataField("event")]
+    [NonSerialized]
+    public EntityWorldTargetActionEvent? Event;
+
+    [DataField("whitelist")] public EntityWhitelist? Whitelist;
+
+    [DataField("canTargetSelf")] public bool CanTargetSelf = true;
+}
+
+[Serializable, NetSerializable]
+public sealed class EntityWorldTargetActionComponentState : BaseActionComponentState
+{
+    public EntityWhitelist? Whitelist;
+    public bool CanTargetSelf;
+
+    public EntityWorldTargetActionComponentState(EntityTargetActionComponent component, IEntityManager entManager) : base(component, entManager)
+    {
+        Whitelist = component.Whitelist;
+        CanTargetSelf = component.CanTargetSelf;
+    }
+}

--- a/Content.Shared/Actions/Events/ValidateActionEntityWorldTargetEvent.cs
+++ b/Content.Shared/Actions/Events/ValidateActionEntityWorldTargetEvent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.Map;
+
+namespace Content.Shared.Actions.Events;
+
+[ByRefEvent]
+public record struct ValidateActionEntityWorldTargetEvent(
+    EntityUid User,
+    EntityUid? Target,
+    EntityCoordinates? Coords,
+    bool Cancelled = false);

--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -455,17 +455,12 @@ public abstract class SharedActionsSystem : EntitySystem
             case EntityWorldTargetActionComponent entityWorldAction:
             {
 
-                EntityUid? actionEntity = null;
-                EntityCoordinates? actionCoords = null;
-                var entityValidated = false;
-                var worldValidated = false;
+                var actionEntity = GetEntity(ev.EntityTarget);
+                var actionCoords = GetCoordinates(ev.EntityCoordinatesTarget);
 
                 var entWorldAction = new Entity<EntityWorldTargetActionComponent>(actionEnt, entityWorldAction);
 
-                if (!ValidateEntityWorldTarget(user,
-                        GetEntity(ev.EntityTarget),
-                        GetCoordinates(ev.EntityCoordinatesTarget),
-                        entWorldAction))
+                if (!ValidateEntityWorldTarget(user, actionEntity, actionCoords, entWorldAction))
                     return;
 
                 _adminLogger.Add(LogType.Action,
@@ -473,10 +468,8 @@ public abstract class SharedActionsSystem : EntitySystem
 
                 if (entityWorldAction.Event != null)
                 {
-                    if (entityValidated)
-                        entityWorldAction.Event.Entity = actionEntity;
-                    if (worldValidated)
-                        entityWorldAction.Event.Coords = actionCoords;
+                    entityWorldAction.Event.Entity = actionEntity;
+                    entityWorldAction.Event.Coords = actionCoords;
                     Dirty(actionEnt, entityWorldAction);
                     performEvent = entityWorldAction.Event;
                 }

--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -606,13 +606,13 @@ public abstract class SharedActionsSystem : EntitySystem
             // even if we don't check for obstructions, we may still need to check the range.
             var xform = Transform(user);
 
-            if (xform.MapID != coords.GetMapId(EntityManager))
+            if (xform.MapID != _transformSystem.GetMapId(coords))
                 return false;
 
             if (action.Range <= 0)
                 return true;
 
-            return coords.InRange(EntityManager, _transformSystem, Transform(user).Coordinates, action.Range);
+            return _transformSystem.InRange(coords, Transform(user).Coordinates, action.Range);
         }
 
         return _interactionSystem.InRangeUnobstructed(user, coords, range: action.Range);

--- a/Content.Shared/_RMC14/Xenonids/Construction/Events/XenoSecreteStructureActionEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/Events/XenoSecreteStructureActionEvent.cs
@@ -2,4 +2,4 @@
 
 namespace Content.Shared._RMC14.Xenonids.Construction.Events;
 
-public sealed partial class XenoSecreteStructureActionEvent : WorldTargetActionEvent;
+public sealed partial class XenoSecreteStructureActionEvent : EntityWorldTargetActionEvent;

--- a/Content.Shared/_RMC14/Xenonids/Construction/Events/XenoSecreteStructureAttemptEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/Events/XenoSecreteStructureAttemptEvent.cs
@@ -1,4 +1,4 @@
 namespace Content.Shared._RMC14.Xenonids.Construction.Events;
 
 [ByRefEvent]
-public record struct XenoSecreteStructureAttemptEvent(bool Cancelled);
+public record struct XenoSecreteStructureAttemptEvent(EntityUid? TargetToReplace = null, bool Cancelled = false);

--- a/Content.Shared/_RMC14/Xenonids/Construction/Events/XenoSecreteStructureDoAfterEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/Events/XenoSecreteStructureDoAfterEvent.cs
@@ -9,13 +9,17 @@ namespace Content.Shared._RMC14.Xenonids.Construction.Events;
 public sealed partial class XenoSecreteStructureDoAfterEvent : DoAfterEvent
 {
     [DataField]
-    public NetCoordinates Coordinates;
+    public NetCoordinates? Coordinates;
 
     [DataField]
     public EntProtoId StructureId = "WallXenoResin";
 
-    public XenoSecreteStructureDoAfterEvent(NetCoordinates coordinates, EntProtoId structureId)
+    [DataField]
+    public NetEntity? EntityToReplace;
+
+    public XenoSecreteStructureDoAfterEvent(NetEntity? entToReplace, NetCoordinates? coordinates, EntProtoId structureId)
     {
+        EntityToReplace = entToReplace;
         Coordinates = coordinates;
         StructureId = structureId;
     }

--- a/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestSystem.cs
@@ -199,6 +199,35 @@ public sealed class XenoNestSystem : EntitySystem
         }
     }
 
+    public void TransferNested(Entity<XenoNestSurfaceComponent> from, Entity<XenoNestSurfaceComponent> to)
+    {
+        var nestCoordinates = to.Owner.ToCoordinates();
+
+        foreach (var (direction, nest) in from.Comp.Nests)
+        {
+            to.Comp.Nests.Add(direction, nest);
+
+            var offset = direction switch
+            {
+                Direction.South => new Vector2(0, -0.25f),
+                Direction.East => new Vector2(0.5f, 0),
+                Direction.North => new Vector2(0, 0.5f),
+                Direction.West => new Vector2(-0.5f, 0),
+                _ => Vector2.Zero
+            };
+            _transform.SetCoordinates(nest, nestCoordinates.Offset(offset));
+
+            if (!TryComp(nest, out XenoNestComponent? nestComp))
+                continue;
+
+            nestComp.Surface = to;
+            Dirty(nest, nestComp);
+        }
+        from.Comp.Nests.Clear();
+        Dirty(from);
+        Dirty(to);
+    }
+
     #region DragDrop
 
     private void OnCanDropTarget(Entity<XenoNestSurfaceComponent> ent, ref CanDropTargetEvent args)

--- a/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
@@ -153,7 +153,7 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
     private void OnXenoSecreteStructureAction(Entity<XenoConstructionComponent> xeno, ref XenoSecreteStructureActionEvent args)
     {
         if (xeno.Comp.BuildChoice is not { } choice ||
-            !CanSecreteOnTilePopup(xeno, choice, args.Target, true, true))
+            !CanSecreteOnTilePopup(xeno, choice, args.Coords, true, true))
         {
             return;
         }
@@ -165,7 +165,7 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
             return;
 
         args.Handled = true;
-        var ev = new XenoSecreteStructureDoAfterEvent(GetNetCoordinates(args.Target), choice);
+        var ev = new XenoSecreteStructureDoAfterEvent(GetNetCoordinates(args.Coords), choice);
         var doAfter = new DoAfterArgs(EntityManager, xeno, xeno.Comp.BuildDelay, ev, xeno)
         {
             BreakOnMove = true

--- a/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
@@ -413,7 +413,7 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
             return;
 
         var canReplace = args.Target != null &&
-                         !CanReplaceStructure((args.User, construction),
+                         CanReplaceStructure((args.User, construction),
                              construction.BuildChoice,
                              args.Target.Value,
                              ent.Comp.CheckStructureSelected);

--- a/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
@@ -175,7 +175,7 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
 
         args.Handled = true;
         var ev = new XenoSecreteStructureDoAfterEvent(GetNetEntity(args.Entity), GetNetCoordinates(args.Coords), choice);
-        var doAfter = new DoAfterArgs(EntityManager, xeno, xeno.Comp.BuildDelay, ev, xeno)
+        var doAfter = new DoAfterArgs(EntityManager, xeno, canReplace ? new TimeSpan(0) : xeno.Comp.BuildDelay, ev, xeno)
         {
             BreakOnMove = true
         };

--- a/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
@@ -212,8 +212,8 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
         var entity = GetEntity(args.EntityToReplace);
         if (entity != null && entity.Value.IsValid() && CanReplaceStructure(xeno, args.StructureId, entity.Value, true))
         {
-            if (GetStructurePlasmaCost(args.StructureId) is { } cost
-                && !_xenoPlasma.TryRemovePlasmaPopup(xeno.Owner, cost))
+            if (GetStructurePlasmaCost(args.StructureId) is { } cost &&
+                !_xenoPlasma.TryRemovePlasmaPopup(xeno.Owner, cost))
                 return;
 
             args.Handled = true;
@@ -224,8 +224,8 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
             var coords = _transform.GetMapCoordinates(entity.Value);
             var spawned = Spawn(args.StructureId, coords);
 
-            if (TryComp(entity, out XenoNestSurfaceComponent? nestSurface)
-                && TryComp(spawned, out XenoNestSurfaceComponent? spawnedNestSurface))
+            if (TryComp(entity, out XenoNestSurfaceComponent? nestSurface) &&
+                TryComp(spawned, out XenoNestSurfaceComponent? spawnedNestSurface))
             {
                 _xenoNest.TransferNested((entity.Value, nestSurface), (spawned, spawnedNestSurface));
             }
@@ -236,12 +236,12 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
 
         // Build new construction
         var coordinates = GetCoordinates(args.Coordinates);
-        if (coordinates != null
-            && coordinates.Value.IsValid(EntityManager)
-            && CanSecreteOnTilePopup(xeno, args.StructureId, coordinates.Value, true, true))
+        if (coordinates != null &&
+            coordinates.Value.IsValid(EntityManager) &&
+            CanSecreteOnTilePopup(xeno, args.StructureId, coordinates.Value, true, true))
         {
-            if (GetStructurePlasmaCost(args.StructureId) is { } cost
-                && !_xenoPlasma.TryRemovePlasmaPopup(xeno.Owner, cost))
+            if (GetStructurePlasmaCost(args.StructureId) is { } cost &&
+                !_xenoPlasma.TryRemovePlasmaPopup(xeno.Owner, cost))
                 return;
 
             args.Handled = true;
@@ -412,14 +412,14 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
         if (!TryComp(args.User, out XenoConstructionComponent? construction))
             return;
 
-        var canReplace = args.Target != null
-                         && !CanReplaceStructure((args.User, construction),
+        var canReplace = args.Target != null &&
+                         !CanReplaceStructure((args.User, construction),
                              construction.BuildChoice,
                              args.Target.Value,
                              ent.Comp.CheckStructureSelected);
 
-        var canCreate = args.Coords != null
-                        && CanSecreteOnTilePopup((args.User, construction),
+        var canCreate = args.Coords != null &&
+                        CanSecreteOnTilePopup((args.User, construction),
                             construction.BuildChoice,
                             args.Coords.Value,
                             ent.Comp.CheckStructureSelected,

--- a/Content.Shared/_RMC14/Xenonids/Construction/XenoConstructionUpgradeComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/XenoConstructionUpgradeComponent.cs
@@ -2,7 +2,9 @@
 
 namespace Content.Shared._RMC14.Xenonids.Construction;
 
+[RegisterComponent]
 public sealed partial class XenoConstructionUpgradeComponent : Component
 {
+    [DataField]
     public EntProtoId UpgradeProto;
 }

--- a/Content.Shared/_RMC14/Xenonids/Construction/XenoConstructionUpgradeComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/XenoConstructionUpgradeComponent.cs
@@ -1,0 +1,8 @@
+﻿using Robust.Shared.Prototypes;
+
+namespace Content.Shared._RMC14.Xenonids.Construction;
+
+public sealed partial class XenoConstructionUpgradeComponent : Component
+{
+    public EntProtoId UpgradeProto;
+}

--- a/Content.Shared/_RMC14/Xenonids/Construction/XenoConstructionUpgradeComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/XenoConstructionUpgradeComponent.cs
@@ -1,11 +1,16 @@
-﻿using Content.Shared.FixedPoint;
-using Robust.Shared.Prototypes;
+﻿using Robust.Shared.Prototypes;
 
 namespace Content.Shared._RMC14.Xenonids.Construction;
 
+/// <summary>
+/// Used for upgrading a resin structure to a thicker version.:
+/// </summary>
 [RegisterComponent]
 public sealed partial class XenoConstructionUpgradeComponent : Component
 {
+    /// <summary>
+    /// The prototypeId that is allowed to replace this entity.
+    /// </summary>
     [DataField]
     public EntProtoId Proto;
 }

--- a/Content.Shared/_RMC14/Xenonids/Construction/XenoConstructionUpgradeComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/XenoConstructionUpgradeComponent.cs
@@ -1,4 +1,5 @@
-﻿using Robust.Shared.Prototypes;
+﻿using Content.Shared.FixedPoint;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared._RMC14.Xenonids.Construction;
 
@@ -6,5 +7,5 @@ namespace Content.Shared._RMC14.Xenonids.Construction;
 public sealed partial class XenoConstructionUpgradeComponent : Component
 {
     [DataField]
-    public EntProtoId UpgradeProto;
+    public EntProtoId Proto;
 }

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_construction_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_construction_actions.yml
@@ -39,15 +39,17 @@
   name: Secrete Resin
   description: "Builds the structure chosen with the 'Choose Resin Structure' action."
   components:
-  - type: WorldTargetAction
+  - type: EntityWorldTargetAction
     itemIconStyle: NoItem
     icon:
       sprite: _RMC14/Actions/xeno_actions.rsi
       state: secrete_resin
     event: !type:XenoSecreteStructureActionEvent
     deselectOnMiss: false
+    checkCanAccess: false
     range: 20
     repeat: true
+    canTargetSelf: false
   - type: XenoConstructionAction
     checkStructureSelected: true
     checkWeeds: true

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_doors.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_doors.yml
@@ -80,6 +80,8 @@
       types:
         Slash: 600
   - type: XenoConstructionRequiresSupport
+  - type: XenoConstructionUpgrade
+    proto: DoorXenoResinThick
 
 - type: entity
   id: DoorXenoResinThick

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_walls.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_walls.yml
@@ -27,6 +27,8 @@
     xenoDamage:
       types:
         Slash: 225
+  - type: XenoConstructionUpgrade
+    upgradeProto: WallXenoResinThick
 
 - type: entity
   parent: WallXenoResin

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_walls.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_walls.yml
@@ -116,6 +116,8 @@
   - type: IconSmooth
     key: walls
     base: membrane
+  - type: XenoConstructionUpgrade
+    proto: WallXenoMembraneThick
 
 - type: entity
   parent: BaseMembraneXeno

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_walls.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_walls.yml
@@ -28,7 +28,7 @@
       types:
         Slash: 225
   - type: XenoConstructionUpgrade
-    upgradeProto: WallXenoResinThick
+    proto: WallXenoResinThick
 
 - type: entity
   parent: WallXenoResin


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Added the ability for Hivelords to upgrade resin walls, doors, and membrane to their thick versions without having to destroy the previous structure.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Faster hive reinforcement and porting features from CM13.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Added a new action type EntityWorldTargetActionComponent that provides both an EntityUid and an EntityCoordinates.

Changed XenoSecreteStructureActionEvent to use EntityWorldTargetActionComponent.

Changed 

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

Thickening walls, doors, and membrane:

https://github.com/RMC-14/RMC-14/assets/10494922/9526c807-72e2-4a31-874e-a6b0ea594473

Also works on walls with nests:

https://github.com/RMC-14/RMC-14/assets/10494922/b3a3dcf4-ce1d-4707-b2d7-1d24f57d03ca


## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- add: Hivelords can now use secrete resin to thicken the normal resin walls, doors, and membrane.