### PR TITLE
fix: damage divisors for metal barricades and sandbags

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Walls/barricade_metal.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Walls/barricade_metal.yml
@@ -73,7 +73,7 @@
         acts: [ "Destruction" ]
   - type: DamageVisuals
     thresholds: [4, 8, 12]
-    damageDivisor: 2
+    damageDivisor: 25
     trackAllDamage: true
     damageOverlay:
       sprite: _RMC14/Structures/Walls/Barricades/metal_barricade_cracks.rsi
@@ -102,7 +102,7 @@
       damageModifierSet: CMBurnBarricade
     - type: DamageVisuals
       thresholds: [4, 8, 12]
-      damageDivisor: 2
+      damageDivisor: 25
       trackAllDamage: true
       damageOverlay:
         sprite: _RMC14/Structures/Walls/Barricades/burn_barricade_cracks.rsi
@@ -126,7 +126,7 @@
       damageModifierSet: CMBruteBarricade
     - type: DamageVisuals
       thresholds: [4, 8, 12]
-      damageDivisor: 2
+      damageDivisor: 25
       trackAllDamage: true
       damageOverlay:
         sprite: _RMC14/Structures/Walls/Barricades/brute_barricade_cracks.rsi
@@ -149,7 +149,7 @@
       damageCoefficient: 0.5
     - type: DamageVisuals
       thresholds: [4, 8, 12]
-      damageDivisor: 2
+      damageDivisor: 25
       trackAllDamage: true
       damageOverlay:
         sprite: _RMC14/Structures/Walls/Barricades/explosive_barricade_cracks.rsi

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Walls/sandbags.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Walls/sandbags.yml
@@ -39,7 +39,7 @@
         acts: [ "Destruction" ]
   - type: DamageVisuals
     thresholds: [4, 8, 12]
-    damageDivisor: 2
+    damageDivisor: 25
     trackAllDamage: true
     damageOverlay:
       sprite: _RMC14/Structures/Walls/Barricades/sandbag_cracks.rsi


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Adjusted damage divisors for the purpose of thresholds calculation for metal barricades and sandbags.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Currently metal barricades and sandbags display last stage of destruction before full destruction even on slightest hits, which is a bug. This fixes damage sprites distribution so that they show up properly.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Just updated damageDivisors to correspond to actual health values and thresholds.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
None.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Fixed metal barricades and sandbags damage thresholds for them to look more progressively more broken rather then almost fully destroyed after a slightest hit.

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
