### PR TITLE
Fix the grenadier armor not fitting items, increase slots from 2 to 3

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
@@ -155,7 +155,7 @@
     sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/m3/wo.rsi
 
 - type: entity
-  parent: CMArmorM2MP
+  parent: CMArmorM3Medium
   id: RMCArmorM3G4
   name: M3-G4 grenadier armor
   description: A custom set of M3 armor packed to the brim with padding, plating, and every form of ballistic protection under the sun. Used exclusively by Marine Grenadiers.

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
@@ -70,6 +70,7 @@
       - Knife
       - Flashlight
       - MRE
+      - Grenade
   - type: ContainerContainer
     containers:
       storagebase: !type:Container


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed the grenadier armor not being able to fit any items.
- fix: Fixed the grenadier armor only having 2 slots, it now has 3 slots.
- fix: Fixed armor not being able to fit grenades.
