### PR TITLE
Fix crushers, defenders, runners and lurkers sometimes being able to charge/leap through barricades

### DIFF
--- a/Resources/ConfigPresets/RMC14/rmc.toml
+++ b/Resources/ConfigPresets/RMC14/rmc.toml
@@ -63,6 +63,7 @@ max_connections = 1024
 [physics]
 maxlinvelocity = 51
 grid_splitting = false
+target_minimum_tickrate = 120
 
 [replay]
 auto_record = true


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed crushers, defenders, runners and other xenonid castes sometimes being able to charge or leap through barricades.
