### PR TITLE
Fix marines not being able to take out their boot knife to attack xenonids while devoured

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Shoes/boots.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Shoes/boots.yml
@@ -1,6 +1,6 @@
 # Dress Shoes
 - type: entity
-  parent: ClothingShoesBaseButcherable
+  parent: ClothingShoesBase
   id: CMShoesLaceup
   name: laceup shoes
   description: The height of fashion, and they're pre-polished!
@@ -44,6 +44,7 @@
           - Knife
   - type: CMHolster
   - type: CMItemSlots
+  - type: UsableWhileDevoured
 
 - type: entity
   parent: CMBootsBlack


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed marines not being able to take out their boot knife to attack xenonids while devoured.