### PR TITLE
Add autobalancing for marines_per_xeno CVar

### DIFF
--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
@@ -439,7 +439,7 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
                 DistressSignalRuleResult.MajorMarineVictory => -1,
                 DistressSignalRuleResult.MinorMarineVictory => -1,
                 DistressSignalRuleResult.MajorXenoVictory => 1,
-                DistressSignalRuleResult.MinorXenoVictory => 0,
+                DistressSignalRuleResult.MinorXenoVictory => 0, // hijack but all xenos die
                 DistressSignalRuleResult.AllDied => 0,
                 _ => throw new ArgumentOutOfRangeException(),
             };

--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
@@ -431,7 +431,7 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
             return;
 
         var rules = QueryAllRules();
-        while (rules.MoveNext(out var uid, out var comp, out _))
+        while (rules.MoveNext(out var comp, out _))
         {
             var adjust = comp.Result switch
             {

--- a/Content.Shared/_RMC14/CCVar/CMCVars.cs
+++ b/Content.Shared/_RMC14/CCVar/CMCVars.cs
@@ -52,7 +52,19 @@ public sealed class CMCVars : CVars
         CVarDef.Create("cm.bleed_time_multiplier", 1f, CVar.REPLICATED | CVar.SERVER);
 
     public static readonly CVarDef<float> CMMarinesPerXeno =
-        CVarDef.Create("cm.marines_per_xeno", 4f, CVar.REPLICATED | CVar.SERVER);
+        CVarDef.Create("cm.marines_per_xeno", 3.5f, CVar.REPLICATED | CVar.SERVER);
+
+    public static readonly CVarDef<bool> RMCAutoBalance =
+        CVarDef.Create("rmc.auto_balance", true, CVar.SERVER);
+
+    public static readonly CVarDef<float> RMCAutoBalanceStep =
+        CVarDef.Create("rmc.auto_balance_step", 0.25f, CVar.SERVER);
+
+    public static readonly CVarDef<float> RMCAutoBalanceMin =
+        CVarDef.Create("rmc.auto_balance_min", 3f, CVar.SERVER);
+
+    public static readonly CVarDef<float> RMCAutoBalanceMax =
+        CVarDef.Create("rmc.auto_balance_max", 4.5f, CVar.SERVER);
 
     public static readonly CVarDef<int> RMCPatronLobbyMessageTimeSeconds =
         CVarDef.Create("rmc.patron_lobby_message_time_seconds", 30, CVar.REPLICATED | CVar.SERVER);


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: Temporarily added an autobalance feature that will change the ratio of marines per xeno round-start depending on round outcome. This was already being done by the hosts manually from time to time but is now automatic.