### PR TITLE
Add dropship door locking, door fixes, fix being able to build barricades on dropships, initial cooldown

### DIFF
--- a/Content.Client/_RMC14/Dropship/DropshipNavigationBui.cs
+++ b/Content.Client/_RMC14/Dropship/DropshipNavigationBui.cs
@@ -59,7 +59,8 @@ public sealed class DropshipNavigationBui : BoundUserInterface
 
         _window = new DropshipNavigationWindow();
         _window.OnClose += OnClose;
-        SetHeader("Flight Controls");
+        SetFlightHeader("Flight Controls");
+        SetDoorHeader("Lockdown");
 
         if (_entities.TryGetComponent(Owner, out TransformComponent? transform) &&
             _entities.TryGetComponent(transform.ParentUid, out MetaDataComponent? metaData))
@@ -84,6 +85,8 @@ public sealed class DropshipNavigationBui : BoundUserInterface
             ResetDestinationButtons();
         };
 
+        _window.LockdownButton.Button.OnPressed += _ => SendPredictedMessage(new DropshipLockdownMsg());
+
         _window.OpenCentered();
         _entities.System<DropshipSystem>().Uis.Add(this);
     }
@@ -99,7 +102,7 @@ public sealed class DropshipNavigationBui : BoundUserInterface
         if (_window == null)
             return;
 
-        SetHeader("Flight Controls");
+        SetFlightHeader("Flight Controls");
 
         _window.DestinationsContainer.Visible = true;
         _window.ProgressBarContainer.Visible = false;
@@ -151,20 +154,24 @@ public sealed class DropshipNavigationBui : BoundUserInterface
         switch (travelling.State)
         {
             case FTLState.Starting:
-                SetHeader("Launch in progress"); // 10s
+                SetFlightHeader("Launch in progress");
                 _window.ProgressBarHeader.SetMarkup(Msg($"Launching in T-{time}s to {destination}"));
+                _window.LockdownButton.Disabled = false;
                 break;
             case FTLState.Travelling:
-                SetHeader($"In flight: {destination}"); // 100s
+                SetFlightHeader($"In flight: {destination}");
                 _window.ProgressBarHeader.SetMarkup(Msg($"Time until destination: T-{time}s"));
+                _window.LockdownButton.Disabled = true;
                 break;
             case FTLState.Arriving:
-                SetHeader($"Final Approach: {destination}"); // 10s
+                SetFlightHeader($"Final Approach: {destination}");
                 _window.ProgressBarHeader.SetMarkup(Msg($"Time until landing: T-{time}s"));
+                _window.LockdownButton.Disabled = true;
                 break;
             case FTLState.Cooldown:
-                SetHeader("Refueling in progress"); // 120s
+                SetFlightHeader("Refueling in progress");
                 _window.ProgressBarHeader.SetMarkup(Msg($"Ready to launch in T-{time}s"));
+                _window.LockdownButton.Disabled = false;
                 break;
             default:
                 return;
@@ -176,9 +183,14 @@ public sealed class DropshipNavigationBui : BoundUserInterface
         _window.ProgressBar.SetAsRatio(1 - startEndTime.ProgressAt(_timing.CurTime));
     }
 
-    private void SetHeader(string label)
+    private void SetFlightHeader(string label)
     {
         _window?.Header.SetMarkup($"[color=#0BDC49][font size=16][bold]{label}[/bold][/font][/color]");
+    }
+
+    private void SetDoorHeader(string label)
+    {
+        _window?.DoorHeader.SetMarkup($"[color=#0BDC49][font size=16][bold]{label}[/bold][/font][/color]");
     }
 
     private void SetCancelLaunchDisabled(bool disabled)

--- a/Content.Client/_RMC14/Dropship/DropshipNavigationWindow.xaml
+++ b/Content.Client/_RMC14/Dropship/DropshipNavigationWindow.xaml
@@ -32,6 +32,15 @@
                 <RichTextLabel Name="ProgressBarHeader" Access="Public" />
                 <ProgressBar Name="ProgressBar" Access="Public" />
             </BoxContainer>
+            <BoxContainer Orientation="Horizontal" HorizontalExpand="True" Margin="5">
+                <RichTextLabel Name="DoorHeader" Access="Public" />
+                <Control HorizontalExpand="True" />
+                <controls:DropshipButton Name="LockdownButton" Access="Public"
+                                         Margin="1" BackgroundColor="#004E25"
+                                         BorderColor="#02E74E" BorderThickness="1"
+                                         Text="Lockdown" />
+            </BoxContainer>
+            <cc:HSeparator Color="#02E74E" />
         </BoxContainer>
     </PanelContainer>
 </controls:DropshipNavigationWindow>

--- a/Content.Server/Shuttles/Systems/DockingSystem.cs
+++ b/Content.Server/Shuttles/Systems/DockingSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server._RMC14.Dropship;
 using Content.Server.Doors.Systems;
 using Content.Server.NPC.Pathfinding;
 using Content.Server.Shuttles.Components;
@@ -26,6 +27,7 @@ namespace Content.Server.Shuttles.Systems
         [Dependency] private readonly SharedJointSystem _jointSystem = default!;
         [Dependency] private readonly SharedPopupSystem _popup = default!;
         [Dependency] private readonly SharedTransformSystem _transform = default!;
+        [Dependency] private readonly DropshipSystem _dropship = default!;
 
         private const string DockingJoint = "docking";
 
@@ -76,23 +78,11 @@ namespace Content.Server.Shuttles.Systems
             {
                 if (enabled)
                 {
-                    var doorComp = CompOrNull<DoorComponent>(entity);
-                    var oldCheck = doorComp?.PerformCollisionCheck ?? false;
-
-                    if (doorComp != null)
-                        doorComp.PerformCollisionCheck = false;
-
-                    _doorSystem.StartClosing(entity);
-                    _doorSystem.OnPartialClose(entity);
-                    _doorSystem.SetBoltsDown((entity.Owner, entity.Comp2), enabled);
-
-                    if (doorComp != null)
-                        doorComp.PerformCollisionCheck = oldCheck;
+                    _dropship.LockDoor((entity, entity));
                 }
                 else
                 {
-                    _doorSystem.SetBoltsDown((entity.Owner, entity.Comp2), false);
-                    _doorSystem.TryOpen(gridUid);
+                    _dropship.UnlockDoor((entity, entity));
                 }
             }
         }

--- a/Content.Server/_RMC14/Dropship/DropshipSystem.cs
+++ b/Content.Server/_RMC14/Dropship/DropshipSystem.cs
@@ -1,32 +1,43 @@
 ﻿using System.Numerics;
 using Content.Server._RMC14.Marines;
+using Content.Server.Doors.Systems;
 using Content.Server.Shuttles.Components;
 using Content.Server.Shuttles.Events;
 using Content.Server.Shuttles.Systems;
 using Content.Shared._RMC14.Dropship;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared._RMC14.Xenonids.Announce;
+using Content.Shared.Doors.Components;
 using Content.Shared.Interaction;
 using Content.Shared.Shuttles.Systems;
 using Robust.Server.Audio;
 using Robust.Server.GameObjects;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Player;
+using Robust.Shared.Timing;
 
 namespace Content.Server._RMC14.Dropship;
 
 public sealed class DropshipSystem : SharedDropshipSystem
 {
     [Dependency] private readonly AudioSystem _audio = default!;
+    [Dependency] private readonly DoorSystem _door = default!;
     [Dependency] private readonly MarineAnnounceSystem _marineAnnounce = default!;
     [Dependency] private readonly ShuttleSystem _shuttle = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly TransformSystem _transform = default!;
     [Dependency] private readonly UserInterfaceSystem _ui = default!;
     [Dependency] private readonly SharedXenoAnnounceSystem _xenoAnnounce = default!;
 
+    private EntityQuery<DockingComponent> _dockingQuery;
+    private EntityQuery<DoorBoltComponent> _doorBoltQuery;
+
     public override void Initialize()
     {
         base.Initialize();
+
+        _dockingQuery = GetEntityQuery<DockingComponent>();
+        _doorBoltQuery = GetEntityQuery<DoorBoltComponent>();
 
         SubscribeLocalEvent<DropshipNavigationComputerComponent, ActivateInWorldEvent>(OnActivateInWorld);
 
@@ -34,6 +45,12 @@ public sealed class DropshipSystem : SharedDropshipSystem
         SubscribeLocalEvent<DropshipComponent, FTLStartedEvent>(OnRefreshUI);
         SubscribeLocalEvent<DropshipComponent, FTLCompletedEvent>(OnRefreshUI);
         SubscribeLocalEvent<DropshipComponent, FTLUpdatedEvent>(OnRefreshUI);
+
+        Subs.BuiEvents<DropshipNavigationComputerComponent>(DropshipNavigationUiKey.Key,
+            subs =>
+            {
+                subs.Event<DropshipLockdownMsg>(OnDropshipNavigationLockdownMsg);
+            });
     }
 
     private void OnActivateInWorld(Entity<DropshipNavigationComputerComponent> ent, ref ActivateInWorldEvent args)
@@ -64,6 +81,25 @@ public sealed class DropshipSystem : SharedDropshipSystem
     private void OnRefreshUI<T>(Entity<DropshipComponent> ent, ref T args)
     {
         RefreshUI();
+    }
+
+    private void OnDropshipNavigationLockdownMsg(Entity<DropshipNavigationComputerComponent> ent, ref DropshipLockdownMsg args)
+    {
+        if (_transform.GetGrid(ent.Owner) is not { } grid ||
+            !TryComp(grid, out DropshipComponent? dropship) ||
+            dropship.Crashed ||
+            HasComp<FTLComponent>(grid))
+        {
+            return;
+        }
+
+        var time = _timing.CurTime;
+        if (time < dropship.LastLocked + dropship.LockCooldown)
+            return;
+
+        dropship.Locked = !dropship.Locked;
+        dropship.LastLocked = time;
+        SetAllDocks(grid, dropship.Locked);
     }
 
     public override bool FlyTo(Entity<DropshipNavigationComputerComponent> computer, EntityUid destination, EntityUid? user, bool hijack = false)
@@ -191,6 +227,44 @@ public sealed class DropshipSystem : SharedDropshipSystem
         {
             RefreshUI((uid, comp));
         }
+    }
+
+    private void SetAllDocks(EntityUid dropship, bool locked)
+    {
+        var enumerator = Transform(dropship).ChildEnumerator;
+        while (enumerator.MoveNext(out var child))
+        {
+            if (!_dockingQuery.HasComp(child))
+                continue;
+
+            if (locked)
+                LockDoor(child);
+            else
+                UnlockDoor(child);
+        }
+    }
+
+    public void LockDoor(Entity<DoorBoltComponent?> door)
+    {
+        var doorComp = CompOrNull<DoorComponent>(door);
+        var oldCheck = doorComp?.PerformCollisionCheck ?? false;
+        if (doorComp != null)
+            doorComp.PerformCollisionCheck = false;
+
+        _door.StartClosing(door);
+        _door.OnPartialClose(door);
+
+        if (_doorBoltQuery.Resolve(door, ref door.Comp, false))
+            _door.SetBoltsDown((door.Owner, door.Comp), true);
+
+        if (doorComp != null)
+            doorComp.PerformCollisionCheck = oldCheck;
+    }
+
+    public void UnlockDoor(Entity<DoorBoltComponent?> door)
+    {
+        if (_doorBoltQuery.Resolve(door, ref door.Comp, false))
+            _door.SetBoltsDown((door.Owner, door.Comp), false);
     }
 
     public void RaiseUpdate(EntityUid shuttle)

--- a/Content.Shared/Physics/CollisionGroup.cs
+++ b/Content.Shared/Physics/CollisionGroup.cs
@@ -23,6 +23,7 @@ public enum CollisionGroup
     BulletImpassable   = 1 << 6, // 64 Can be hit by bullets
     InteractImpassable = 1 << 7, // 128 Blocks interaction/InRangeUnobstructed
     DoorPassable       = 1 << 8, // 256 Allows door to close over top, Like blast doors over conveyors for disposals rooms/cargo.
+    DropshipImpassable = 1 << 28,
 
     MapGrid = MapGridHelpers.CollisionGroup, // Map grids, like shuttles. This is the actual grid itself, not the walls or other entities connected to the grid.
 

--- a/Content.Shared/_RMC14/Construction/CMConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Construction/CMConstructionSystem.cs
@@ -1,9 +1,0 @@
-﻿namespace Content.Shared._RMC14.Construction;
-
-public sealed class CMConstructionSystem : EntitySystem
-{
-    public bool CanConstruct(EntityUid? user)
-    {
-        return !HasComp<DisableConstructionComponent>(user);
-    }
-}

--- a/Content.Shared/_RMC14/Construction/DisableConstructionComponent.cs
+++ b/Content.Shared/_RMC14/Construction/DisableConstructionComponent.cs
@@ -3,5 +3,5 @@
 namespace Content.Shared._RMC14.Construction;
 
 [RegisterComponent, NetworkedComponent]
-[Access(typeof(CMConstructionSystem))]
+[Access(typeof(RMCConstructionSystem))]
 public sealed partial class DisableConstructionComponent : Component;

--- a/Content.Shared/_RMC14/Construction/RMCConstructionAttemptEvent.cs
+++ b/Content.Shared/_RMC14/Construction/RMCConstructionAttemptEvent.cs
@@ -1,0 +1,11 @@
+﻿using Robust.Shared.Map;
+
+namespace Content.Shared._RMC14.Construction;
+
+[ByRefEvent]
+public record struct RMCConstructionAttemptEvent(
+    EntityCoordinates Location,
+    string PrototypeName,
+    string? Popup = null,
+    bool Cancelled = false
+);

--- a/Content.Shared/_RMC14/Construction/RMCConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Construction/RMCConstructionSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Physics;
 using Content.Shared.Popups;
 using Robust.Shared.Map;
 using Robust.Shared.Physics.Collision.Shapes;
+using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Prototypes;
 
@@ -66,12 +67,16 @@ public sealed class RMCConstructionSystem : EntitySystem
 
     private void OnMapInit(Entity<RMCDropshipBlockedComponent> ent, ref MapInitEvent args)
     {
+        if (!TryComp(ent, out PhysicsComponent? physics))
+            return;
+
         var shape = new PhysShapeCircle(0.49f);
         _fixture.TryCreateFixture(
             ent,
             shape,
             ent.Comp.FixtureId,
-            collisionMask: (int) CollisionGroup.DropshipImpassable
+            collisionMask: (int) CollisionGroup.DropshipImpassable,
+            body: physics
         );
     }
 

--- a/Content.Shared/_RMC14/Construction/RMCConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Construction/RMCConstructionSystem.cs
@@ -47,7 +47,21 @@ public sealed class RMCConstructionSystem : EntitySystem
 
     private void OnDropshipMapInit(Entity<DropshipComponent> ent, ref MapInitEvent args)
     {
-        SpawnBlockers(ent);
+        _toCreate.Clear();
+
+        var enumerator = Transform(ent).ChildEnumerator;
+        while (enumerator.MoveNext(out var child))
+        {
+            if (!_doorQuery.HasComp(child))
+                continue;
+
+            _toCreate.Add(child.ToCoordinates());
+        }
+
+        foreach (var toCreate in _toCreate)
+        {
+            SpawnAtPosition(Blocker, toCreate);
+        }
     }
 
     private void OnMapInit(Entity<RMCDropshipBlockedComponent> ent, ref MapInitEvent args)
@@ -86,24 +100,5 @@ public sealed class RMCConstructionSystem : EntitySystem
     public bool CanConstruct(EntityUid? user)
     {
         return !HasComp<DisableConstructionComponent>(user);
-    }
-
-    private void SpawnBlockers(EntityUid ent)
-    {
-        _toCreate.Clear();
-
-        var enumerator = Transform(ent).ChildEnumerator;
-        while (enumerator.MoveNext(out var child))
-        {
-            if (!_doorQuery.HasComp(child))
-                continue;
-
-            _toCreate.Add(child.ToCoordinates());
-        }
-
-        foreach (var toCreate in _toCreate)
-        {
-            SpawnAtPosition(Blocker, toCreate);
-        }
     }
 }

--- a/Content.Shared/_RMC14/Construction/RMCConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Construction/RMCConstructionSystem.cs
@@ -1,0 +1,109 @@
+﻿using Content.Shared._RMC14.Dropship;
+using Content.Shared.Construction.Components;
+using Content.Shared.Coordinates;
+using Content.Shared.Doors.Components;
+using Content.Shared.Physics;
+using Content.Shared.Popups;
+using Robust.Shared.Map;
+using Robust.Shared.Physics.Collision.Shapes;
+using Robust.Shared.Physics.Systems;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._RMC14.Construction;
+
+public sealed class RMCConstructionSystem : EntitySystem
+{
+    [Dependency] private readonly FixtureSystem _fixture = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    private static readonly EntProtoId Blocker = "RMCDropshipDoorBlocker";
+
+    private readonly List<EntityCoordinates> _toCreate = new();
+    private EntityQuery<DoorComponent> _doorQuery;
+
+    public override void Initialize()
+    {
+        _doorQuery = GetEntityQuery<DoorComponent>();
+
+        SubscribeLocalEvent<RMCConstructionAttemptEvent>(OnConstructionAttempt);
+
+        SubscribeLocalEvent<DropshipComponent, MapInitEvent>(OnDropshipMapInit);
+
+        SubscribeLocalEvent<RMCDropshipBlockedComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<RMCDropshipBlockedComponent, AnchorAttemptEvent>(OnAnchorAttempt);
+        SubscribeLocalEvent<RMCDropshipBlockedComponent, UserAnchoredEvent>(OnUserAnchored);
+    }
+
+    private void OnConstructionAttempt(ref RMCConstructionAttemptEvent ev)
+    {
+        if (_transform.GetGrid(ev.Location) is { } grid &&
+            HasComp<DropshipComponent>(grid))
+        {
+            ev.Popup = Loc.GetString("rmc-construction-not-proper-surface", ("construction", ev.PrototypeName));
+            ev.Cancelled = true;
+        }
+    }
+
+    private void OnDropshipMapInit(Entity<DropshipComponent> ent, ref MapInitEvent args)
+    {
+        SpawnBlockers(ent);
+    }
+
+    private void OnMapInit(Entity<RMCDropshipBlockedComponent> ent, ref MapInitEvent args)
+    {
+        var shape = new PhysShapeCircle(0.49f);
+        _fixture.TryCreateFixture(
+            ent,
+            shape,
+            ent.Comp.FixtureId,
+            collisionMask: (int) CollisionGroup.DropshipImpassable
+        );
+    }
+
+    private void OnAnchorAttempt(Entity<RMCDropshipBlockedComponent> ent, ref AnchorAttemptEvent args)
+    {
+        if (args.Cancelled)
+            return;
+
+        if (_transform.GetGrid(ent.Owner) is not { } grid)
+            return;
+
+        if (HasComp<DropshipComponent>(grid))
+        {
+            var msg = Loc.GetString("rmc-construction-not-proper-surface", ("construction", Name(ent)));
+            _popup.PopupClient(msg, ent, args.User);
+            args.Cancel();
+        }
+    }
+
+    private void OnUserAnchored(Entity<RMCDropshipBlockedComponent> ent, ref UserAnchoredEvent args)
+    {
+        if (TryComp(ent.Owner, out TransformComponent? xform))
+            _transform.Unanchor(ent.Owner, xform);
+    }
+
+    public bool CanConstruct(EntityUid? user)
+    {
+        return !HasComp<DisableConstructionComponent>(user);
+    }
+
+    private void SpawnBlockers(EntityUid ent)
+    {
+        _toCreate.Clear();
+
+        var enumerator = Transform(ent).ChildEnumerator;
+        while (enumerator.MoveNext(out var child))
+        {
+            if (!_doorQuery.HasComp(child))
+                continue;
+
+            _toCreate.Add(child.ToCoordinates());
+        }
+
+        foreach (var toCreate in _toCreate)
+        {
+            SpawnAtPosition(Blocker, toCreate);
+        }
+    }
+}

--- a/Content.Shared/_RMC14/Construction/RMCDropshipBlockedComponent.cs
+++ b/Content.Shared/_RMC14/Construction/RMCDropshipBlockedComponent.cs
@@ -1,0 +1,11 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Construction;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(RMCConstructionSystem))]
+public sealed partial class RMCDropshipBlockedComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public string FixtureId = "rmc_dropship_blocked";
+}

--- a/Content.Shared/_RMC14/Dropship/DropshipComponent.cs
+++ b/Content.Shared/_RMC14/Dropship/DropshipComponent.cs
@@ -2,6 +2,7 @@ using Content.Shared.Radio;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared._RMC14.Dropship;
 
@@ -23,4 +24,16 @@ public sealed partial class DropshipComponent : Component
 
     [DataField, AutoNetworkedField]
     public SoundSpecifier MarineHijackSound = new SoundPathSpecifier("/Audio/_RMC14/Announcements/ARES/hijack.ogg", AudioParams.Default.WithVolume(-6));
+
+    [DataField, AutoNetworkedField]
+    public bool Locked;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan LockCooldown = TimeSpan.FromSeconds(1);
+
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField]
+    public TimeSpan LastLocked;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan RoundStartDelay = TimeSpan.FromMinutes(15);
 }

--- a/Content.Shared/_RMC14/Dropship/DropshipNavigationUI.cs
+++ b/Content.Shared/_RMC14/Dropship/DropshipNavigationUI.cs
@@ -25,6 +25,9 @@ public sealed class DropshipNavigationLaunchMsg(NetEntity target) : BoundUserInt
 }
 
 [Serializable, NetSerializable]
+public sealed class DropshipLockdownMsg : BoundUserInterfaceMessage;
+
+[Serializable, NetSerializable]
 public enum DropshipNavigationUiKey
 {
     Key

--- a/Content.Shared/_RMC14/Xenonids/Acid/XenoAcidSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Acid/XenoAcidSystem.cs
@@ -67,7 +67,7 @@ public sealed class XenoAcidSystem : EntitySystem
         if (!TryComp(target, out CorrodibleComponent? corrodible) ||
             !corrodible.IsCorrodible)
         {
-            _popup.PopupClient(Loc.GetString("cm-xeno-acid-not-corrodible", ("target", target)), xeno, xeno);
+            _popup.PopupClient(Loc.GetString("cm-xeno-acid-not-corrodible", ("target", target)), xeno, xeno, PopupType.SmallCaution);
             return false;
         }
 

--- a/Resources/Locale/en-US/_RMC14/construction/rmc-construction.ftl
+++ b/Resources/Locale/en-US/_RMC14/construction/rmc-construction.ftl
@@ -1,0 +1,1 @@
+﻿rmc-construction-not-proper-surface = The {$construction} must be constructed on a proper surface!

--- a/Resources/Locale/en-US/_RMC14/dropship/rmc-dropship.ftl
+++ b/Resources/Locale/en-US/_RMC14/dropship/rmc-dropship.ftl
@@ -1,0 +1,1 @@
+﻿rmc-dropship-pre-flight-fueling = The shuttle is still undergoing pre-flight fueling and cannot depart yet. Please wait another {$minutes} minutes before trying again.

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
@@ -37,7 +37,7 @@ cm-xeno-leap-cancelled = You cancel your leap!
 cm-xeno-weeds-source-already-here = There is already a resin node here!
 
 # Corrosive acid
-cm-xeno-acid-not-corrodible = You can't corrode {THE($target)}!
+cm-xeno-acid-not-corrodible = We cannot dissolve {THE($target)}!
 cm-xeno-acid-already-corroding = {THE($target)} already has corrosive acid on it!
 
 # Paralyzing Slash

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Base/base_structure.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Base/base_structure.yml
@@ -75,6 +75,7 @@
   - type: XenoWeedable
     spawn: XenoWeedsWall
   - type: XenoConstructionSupport
+  - type: RMCDropshipBlocked
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Doors/Windoors/windoor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Doors/Windoors/windoor.yml
@@ -35,6 +35,7 @@
   - type: ApcPowerReceiver
     powerLoad: 0
     needsPower: false
+  - type: RMCDropshipBlocked
 
 - type: entity
   parent: BaseSecureWindoor
@@ -73,3 +74,4 @@
   - type: ApcPowerReceiver
     powerLoad: 0
     needsPower: false
+  - type: RMCDropshipBlocked

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Doors/cm_door.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Doors/cm_door.yml
@@ -3,6 +3,8 @@
   parent: BaseStructure
   id: CMBaseDoor
   name: door
+  placement:
+    mode: SnapgridCenter
   components:
   - type: MeleeSound
     soundGroups:
@@ -133,8 +135,7 @@
     - Airlock
     # This tag is used to nagivate the Airlock construction graph. It's needed because the construction graph is shared between Airlock, AirlockGlass, and HighSecDoor
   - type: PryUnpowered
-  placement:
-    mode: SnapgridCenter
+  - type: RMCDropshipBlocked
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Dropships/alamo_doors.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Dropships/alamo_doors.yml
@@ -28,6 +28,8 @@
     openingSpriteState: door_opening
     openSpriteState: door_open
     closedSpriteState: door_closed
+    canCrush: false
+    performCollisionCheck: true
   - type: Airlock
     denySpriteState: door_deny
   - type: ApcPowerReceiver

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Dropships/alamo_doors.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Dropships/alamo_doors.yml
@@ -36,6 +36,16 @@
     powerLoad: 0
   - type: Docking
   - type: DockingSignalControl
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 1000
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+  - type: Corrodible
+    isCorrodible: false
 
 - type: entity
   parent: CMBaseDoor

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Dropships/dropship_entities.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Dropships/dropship_entities.yml
@@ -1,0 +1,19 @@
+﻿- type: entity
+  parent: MarkerBase
+  id: RMCDropshipDoorBlocker
+  name: dropship door blocker
+  description: Blocks barricades from being pulled into the dropship.
+  components:
+  - type: Transform
+    anchored: true
+  - type: Physics
+    bodyType: Static
+  - type: Fixtures
+    fixtures:
+      dropship:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.49,-0.49,0.49,0.49"
+        density: 100
+        layer:
+        - DropshipImpassable

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/machine_frame.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/machine_frame.yml
@@ -50,6 +50,7 @@
         node: missingWires
       - !type:DoActsBehavior
         acts: ["Destruction"]
+  - type: RMCDropshipBlocked
 
 - type: entity
   parent: MachineFrameDestroyed

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Walls/barricade_metal.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Walls/barricade_metal.yml
@@ -24,6 +24,7 @@
     damageContainer: Inorganic
     damageModifierSet: CMBarricade
   - type: InteractionOutline
+  - type: RMCDropshipBlocked
 
 # Metal Barricade Tree
 - type: entity

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Walls/girder.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Walls/girder.yml
@@ -34,6 +34,7 @@
       - !type:PlaySoundBehavior
         sound:
           collection: MetalBreak
+  - type: RMCDropshipBlocked
 
 - type: entity
   parent: CMGirder

--- a/Resources/Prototypes/_RMC14/Entities/Structures/fence.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/fence.yml
@@ -28,3 +28,4 @@
   - type: Construction
     graph: CMFence
     node: fenceMetal
+  - type: RMCDropshipBlocked


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: The dropship crew hatches can now be locked by the pilot from the navigation computer.
- fix: Fixed dropship doors not closing during travel if someone is in the way.
- fix: Fixed being able to build barricades and other fortifications on or move existing ones onto dropships.
- fix: Fixed dropships having no initial cooldown, They now need 15 minutes of round time to pass before they can start flying.
- fix: Fixed dropship crew hatches being corrodible.
- tweak: The health of dropship crew hatches has been doubled to 1000 as a temporary measure until separate prying timers for xenos and marines is implemented.