### PR TITLE
Add the warrior's missing lifesteal passive, fix warrior abilities being able to target weeds, items and dead marines

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Actions/XenoActionsSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Actions/XenoActionsSystem.cs
@@ -1,0 +1,22 @@
+﻿using Content.Shared.Actions.Events;
+
+namespace Content.Shared._RMC14.Xenonids.Actions;
+
+public sealed class XenoActionsSystem : EntitySystem
+{
+    [Dependency] private readonly XenoSystem _xeno = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<XenoOffensiveActionComponent, ValidateActionEntityTargetEvent>(OnValidateActionEntityTarget);
+    }
+
+    private void OnValidateActionEntityTarget(Entity<XenoOffensiveActionComponent> ent, ref ValidateActionEntityTargetEvent args)
+    {
+        if (args.Cancelled)
+            return;
+
+        if (!_xeno.CanAbilityAttackTarget(args.User, args.Target))
+            args.Cancelled = true;
+    }
+}

--- a/Content.Shared/_RMC14/Xenonids/Actions/XenoOffensiveActionComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Actions/XenoOffensiveActionComponent.cs
@@ -1,0 +1,7 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.Actions;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(XenoActionsSystem))]
+public sealed partial class XenoOffensiveActionComponent : Component;

--- a/Content.Shared/_RMC14/Xenonids/Fling/XenoFlingSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Fling/XenoFlingSystem.cs
@@ -3,11 +3,10 @@ using Content.Shared.Damage;
 using Content.Shared.Effects;
 using Content.Shared.FixedPoint;
 using Content.Shared.Mobs.Systems;
-using Content.Shared.Throwing;
 using Content.Shared.Stunnable;
+using Content.Shared.Throwing;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Network;
-using Robust.Shared.Physics.Components;
 using Robust.Shared.Player;
 
 namespace Content.Shared._RMC14.Xenonids.Fling;
@@ -22,6 +21,7 @@ public sealed class XenoFlingSystem : EntitySystem
     [Dependency] private readonly ThrowingSystem _throwing = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedStunSystem _stun = default!;
+    [Dependency] private readonly XenoSystem _xeno = default!;
 
     public override void Initialize()
     {
@@ -30,8 +30,7 @@ public sealed class XenoFlingSystem : EntitySystem
 
     private void OnXenoFlingAction(Entity<XenoFlingComponent> xeno, ref XenoFlingActionEvent args)
     {
-        // TODO RMC14 xenos of the same hive
-        if (args.Target == xeno.Owner || HasComp<XenoComponent>(args.Target))
+        if (!_xeno.CanAbilityAttackTarget(xeno, args.Target))
             return;
 
         if (args.Handled)
@@ -43,23 +42,12 @@ public sealed class XenoFlingSystem : EntitySystem
         if (attempt.Cancelled)
             return;
 
-        var targetId = args.Target;
-
-        if (_mobState.IsDead(targetId))
-            return;
-
-        if (TryComp(xeno, out XenoComponent? xenoComp) &&
-            TryComp(targetId, out XenoComponent? targetXeno) &&
-            xenoComp.Hive == targetXeno.Hive)
-        {
-            return;
-        }
-
         args.Handled = true;
 
         if (_net.IsServer)
             _audio.PlayPvs(xeno.Comp.Sound, xeno);
 
+        var targetId = args.Target;
         var damage = _damageable.TryChangeDamage(targetId, xeno.Comp.Damage);
         if (damage?.GetTotal() > FixedPoint2.Zero)
         {

--- a/Content.Shared/_RMC14/Xenonids/Lifesteal/XenoLifestealComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Lifesteal/XenoLifestealComponent.cs
@@ -1,0 +1,27 @@
+﻿using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.Lifesteal;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(XenoLifestealSystem))]
+public sealed partial class XenoLifestealComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 BasePercentage = 0.07;
+
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 MaxPercentage = 0.09;
+
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 TargetIncreasePercentage = 0.01;
+
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 MinHeal = 20;
+
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 MaxHeal = 40;
+
+    [DataField, AutoNetworkedField]
+    public float TargetRange = 3;
+}

--- a/Content.Shared/_RMC14/Xenonids/Lifesteal/XenoLifestealSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Lifesteal/XenoLifestealSystem.cs
@@ -1,8 +1,11 @@
 ﻿using Content.Shared._RMC14.Damage;
 using Content.Shared._RMC14.Marines;
+using Content.Shared._RMC14.Xenonids.Construction.Nest;
 using Content.Shared.Coordinates;
 using Content.Shared.Damage;
 using Content.Shared.FixedPoint;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Components;
 using Content.Shared.Popups;
 using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.Player;
@@ -20,11 +23,15 @@ public sealed class XenoLifestealSystem : EntitySystem
 
     private EntityQuery<DamageableComponent> _damageableQuery;
     private EntityQuery<MarineComponent> _marineQuery;
+    private EntityQuery<MobStateComponent> _mobStateQuery;
+    private EntityQuery<XenoNestedComponent> _xenoNestedQuery;
 
     public override void Initialize()
     {
         _damageableQuery = GetEntityQuery<DamageableComponent>();
         _marineQuery = GetEntityQuery<MarineComponent>();
+        _mobStateQuery = GetEntityQuery<MobStateComponent>();
+        _xenoNestedQuery = GetEntityQuery<XenoNestedComponent>();
 
         SubscribeLocalEvent<XenoLifestealComponent, MeleeHitEvent>(OnMeleeHit);
     }
@@ -39,6 +46,15 @@ public sealed class XenoLifestealSystem : EntitySystem
         {
             if (!_marineQuery.HasComp(hit))
                 continue;
+
+            if (_xenoNestedQuery.HasComp(hit))
+                continue;
+
+            if (_mobStateQuery.TryComp(hit, out var mobState) &&
+                mobState.CurrentState == MobState.Dead)
+            {
+                continue;
+            }
 
             found = true;
             break;
@@ -62,6 +78,15 @@ public sealed class XenoLifestealSystem : EntitySystem
         {
             if (!_marineQuery.HasComp(hit))
                 continue;
+
+            if (_xenoNestedQuery.HasComp(hit))
+                continue;
+
+            if (_mobStateQuery.TryComp(hit, out var mobState) &&
+                mobState.CurrentState == MobState.Dead)
+            {
+                continue;
+            }
 
             lifesteal += xeno.Comp.TargetIncreasePercentage;
             if (lifesteal >= xeno.Comp.MaxPercentage)

--- a/Content.Shared/_RMC14/Xenonids/Lifesteal/XenoLifestealSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Lifesteal/XenoLifestealSystem.cs
@@ -1,0 +1,75 @@
+﻿using Content.Shared._RMC14.Damage;
+using Content.Shared._RMC14.Marines;
+using Content.Shared.Coordinates;
+using Content.Shared.Damage;
+using Content.Shared.FixedPoint;
+using Content.Shared.Weapons.Melee.Events;
+
+namespace Content.Shared._RMC14.Xenonids.Lifesteal;
+
+public sealed class XenoLifestealSystem : EntitySystem
+{
+    [Dependency] private readonly CMDamageableSystem _cmDamageable = default!;
+    [Dependency] private readonly DamageableSystem _damageable = default!;
+    [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
+
+    private readonly HashSet<Entity<MarineComponent>> _targets = new();
+
+    private EntityQuery<DamageableComponent> _damageableQuery;
+    private EntityQuery<MarineComponent> _marineQuery;
+
+    public override void Initialize()
+    {
+        _damageableQuery = GetEntityQuery<DamageableComponent>();
+        _marineQuery = GetEntityQuery<MarineComponent>();
+
+        SubscribeLocalEvent<XenoLifestealComponent, MeleeHitEvent>(OnMeleeHit);
+    }
+
+    private void OnMeleeHit(Entity<XenoLifestealComponent> ent, ref MeleeHitEvent args)
+    {
+        if (!args.IsHit)
+            return;
+
+        var found = false;
+        foreach (var hit in args.HitEntities)
+        {
+            if (!_marineQuery.HasComp(hit))
+                continue;
+
+            found = true;
+            break;
+        }
+
+        if (!found)
+            return;
+
+        if (!_damageableQuery.TryComp(ent, out var damageable))
+            return;
+
+        var total = damageable.TotalDamage;
+        if (total == FixedPoint2.Zero)
+            return;
+
+        _targets.Clear();
+        _entityLookup.GetEntitiesInRange(ent.Owner.ToCoordinates(), ent.Comp.TargetRange, _targets);
+
+        var lifesteal = ent.Comp.BasePercentage;
+        foreach (var hit in _targets)
+        {
+            if (!_marineQuery.HasComp(hit))
+                continue;
+
+            lifesteal += ent.Comp.TargetIncreasePercentage;
+            if (lifesteal >= ent.Comp.MaxPercentage)
+            {
+                lifesteal = ent.Comp.MaxPercentage;
+                break;
+            }
+        }
+
+        var amount = -FixedPoint2.Clamp(total * lifesteal, ent.Comp.MinHeal, ent.Comp.MaxHeal);
+        var heal = _cmDamageable.DistributeTypes(ent.Owner, amount);
+        _damageable.TryChangeDamage(ent, heal, true);
+    }
+}

--- a/Content.Shared/_RMC14/Xenonids/Lifesteal/XenoLifestealSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Lifesteal/XenoLifestealSystem.cs
@@ -3,7 +3,9 @@ using Content.Shared._RMC14.Marines;
 using Content.Shared.Coordinates;
 using Content.Shared.Damage;
 using Content.Shared.FixedPoint;
+using Content.Shared.Popups;
 using Content.Shared.Weapons.Melee.Events;
+using Robust.Shared.Player;
 
 namespace Content.Shared._RMC14.Xenonids.Lifesteal;
 
@@ -12,6 +14,7 @@ public sealed class XenoLifestealSystem : EntitySystem
     [Dependency] private readonly CMDamageableSystem _cmDamageable = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
 
     private readonly HashSet<Entity<MarineComponent>> _targets = new();
 
@@ -26,7 +29,7 @@ public sealed class XenoLifestealSystem : EntitySystem
         SubscribeLocalEvent<XenoLifestealComponent, MeleeHitEvent>(OnMeleeHit);
     }
 
-    private void OnMeleeHit(Entity<XenoLifestealComponent> ent, ref MeleeHitEvent args)
+    private void OnMeleeHit(Entity<XenoLifestealComponent> xeno, ref MeleeHitEvent args)
     {
         if (!args.IsHit)
             return;
@@ -44,7 +47,7 @@ public sealed class XenoLifestealSystem : EntitySystem
         if (!found)
             return;
 
-        if (!_damageableQuery.TryComp(ent, out var damageable))
+        if (!_damageableQuery.TryComp(xeno, out var damageable))
             return;
 
         var total = damageable.TotalDamage;
@@ -52,24 +55,34 @@ public sealed class XenoLifestealSystem : EntitySystem
             return;
 
         _targets.Clear();
-        _entityLookup.GetEntitiesInRange(ent.Owner.ToCoordinates(), ent.Comp.TargetRange, _targets);
+        _entityLookup.GetEntitiesInRange(xeno.Owner.ToCoordinates(), xeno.Comp.TargetRange, _targets);
 
-        var lifesteal = ent.Comp.BasePercentage;
+        var lifesteal = xeno.Comp.BasePercentage;
         foreach (var hit in _targets)
         {
             if (!_marineQuery.HasComp(hit))
                 continue;
 
-            lifesteal += ent.Comp.TargetIncreasePercentage;
-            if (lifesteal >= ent.Comp.MaxPercentage)
+            lifesteal += xeno.Comp.TargetIncreasePercentage;
+            if (lifesteal >= xeno.Comp.MaxPercentage)
             {
-                lifesteal = ent.Comp.MaxPercentage;
+                lifesteal = xeno.Comp.MaxPercentage;
                 break;
             }
         }
 
-        var amount = -FixedPoint2.Clamp(total * lifesteal, ent.Comp.MinHeal, ent.Comp.MaxHeal);
-        var heal = _cmDamageable.DistributeTypes(ent.Owner, amount);
-        _damageable.TryChangeDamage(ent, heal, true);
+        var amount = -FixedPoint2.Clamp(total * lifesteal, xeno.Comp.MinHeal, xeno.Comp.MaxHeal);
+        var heal = _cmDamageable.DistributeTypes(xeno.Owner, amount);
+        _damageable.TryChangeDamage(xeno, heal, true);
+
+        if (lifesteal >= xeno.Comp.MaxPercentage)
+        {
+            var marines = Filter.PvsExcept(xeno).RemoveWhereAttachedEntity(e => !_marineQuery.HasComp(e));
+            var marineMsg = Loc.GetString("rmc-lifesteal-more-marine", ("xeno", xeno.Owner));
+            _popup.PopupEntity(marineMsg, xeno, marines, true, PopupType.SmallCaution);
+
+            var selfMsg = Loc.GetString("rmc-lifesteal-more-self");
+            _popup.PopupClient(selfMsg, xeno, xeno);
+        }
     }
 }

--- a/Content.Shared/_RMC14/Xenonids/Lunge/XenoLungeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Lunge/XenoLungeSystem.cs
@@ -1,8 +1,8 @@
 ﻿using Content.Shared._RMC14.Marines;
 using Content.Shared.Coordinates;
-using Content.Shared.Throwing;
-using Content.Shared.Stunnable;
 using Content.Shared.Movement.Pulling.Systems;
+using Content.Shared.Stunnable;
+using Content.Shared.Throwing;
 using Robust.Shared.Network;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Timing;
@@ -18,6 +18,7 @@ public sealed class XenoLungeSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly PullingSystem _pulling = default!;
     [Dependency] private readonly SharedStunSystem _stun = default!;
+    [Dependency] private readonly XenoSystem _xeno = default!;
 
     private EntityQuery<PhysicsComponent> _physicsQuery;
     private EntityQuery<ThrownItemComponent> _thrownItemQuery;
@@ -33,8 +34,7 @@ public sealed class XenoLungeSystem : EntitySystem
 
     private void OnXenoLungeAction(Entity<XenoLungeComponent> xeno, ref XenoLungeActionEvent args)
     {
-        // TODO RMC14 xenos of the same hive
-        if (args.Target == xeno.Owner || HasComp<XenoComponent>(args.Target))
+        if (!_xeno.CanAbilityAttackTarget(xeno, args.Target))
             return;
 
         if (args.Handled)

--- a/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
@@ -290,6 +290,18 @@ public sealed class XenoSystem : EntitySystem
         return xenoOne.Comp.Hive == xenoTwo.Comp.Hive;
     }
 
+    public bool CanAbilityAttackTarget(EntityUid xeno, EntityUid target)
+    {
+        // TODO RMC14 xenos of the same hive
+        if (xeno == target)
+            return false;
+
+        if (_mobState.IsDead(target))
+            return false;
+
+        return HasComp<MarineComponent>(target);
+    }
+
     public override void Update(float frameTime)
     {
         var query = EntityQueryEnumerator<XenoComponent>();

--- a/Resources/Locale/en-US/_RMC14/lifesteal/rmc-lifesteal.ftl
+++ b/Resources/Locale/en-US/_RMC14/lifesteal/rmc-lifesteal.ftl
@@ -1,0 +1,2 @@
+﻿rmc-lifesteal-more-marine = {$xeno} glows as it heals even more from its injuries!
+rmc-lifesteal-more-self = We glow as we heal even more from our injuries!

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
@@ -258,6 +258,7 @@
     range: 1
     useDelay: 4.5
     deselectOnMiss: false
+  - type: XenoOffensiveAction
 
 - type: entity
   id: ActionXenoFling
@@ -274,12 +275,13 @@
     range: 1
     useDelay: 7
     deselectOnMiss: false
+  - type: XenoOffensiveAction
 
 - type: entity
   id: ActionXenoLunge
   parent: ActionXenoBase
   name: Lunge
-  description: Lunges the warrior towards the targeted marine and puts them into a choke hold (like grabbing them).
+  description: Lunges the warrior towards the targeted marine and grabs them.
   components:
   - type: EntityTargetAction
     itemIconStyle: NoItem
@@ -290,6 +292,7 @@
     range: 5
     useDelay: 10
     deselectOnMiss: false
+  - type: XenoOffensiveAction
 
 - type: entity
   id: ActionXenoScreech

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
@@ -257,6 +257,7 @@
     event: !type:XenoPunchActionEvent
     range: 1
     useDelay: 4.5
+    deselectOnMiss: false
 
 - type: entity
   id: ActionXenoFling
@@ -272,6 +273,7 @@
     event: !type:XenoFlingActionEvent
     range: 1
     useDelay: 7
+    deselectOnMiss: false
 
 - type: entity
   id: ActionXenoLunge
@@ -287,6 +289,7 @@
     event: !type:XenoLungeActionEvent
     range: 5
     useDelay: 10
+    deselectOnMiss: false
 
 - type: entity
   id: ActionXenoScreech

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/warrior.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/warrior.yml
@@ -64,3 +64,4 @@
   - type: Tackle
     threshold: 4
     stun: 5
+  - type: XenoLifesteal


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Added the Warrior's missing passive: lifesteal on melee hits. Limited to 1 heal per melee attack, it heals the Warrior for 7% of its current missing health, adding 1% for each marine that is within a 3 tile radius of it, to a maximum of 9% total. Minimum heal of 20, maximum heal of 40. A popup is displayed to the Warrior and marines if the max of 9% is reached. This does not count nested nor dead marines.
- fix: Fixed the Warrior's abilities being able to target weeds, items, and dead marines. Warrior abilities now remain selected until a valid target is clicked, or the ability is cancelled with right click.