### PR TITLE
Make all caps including surgical able to hold any combination of 2 lighters, cigarettes and matchsticks

### DIFF
--- a/Content.Shared/_RMC14/Smokeables/RMCLighterComponent.cs
+++ b/Content.Shared/_RMC14/Smokeables/RMCLighterComponent.cs
@@ -1,0 +1,6 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Smokeables;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class RMCLighterComponent : Component;

--- a/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
@@ -87,6 +87,7 @@
     netsync: false
     radius: 1.1 #smallest possible
     color: orange
+  - type: RMCLighter
 
 - type: entity
   name: cheap lighter

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Head/Helmets/marine_helmets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Head/Helmets/marine_helmets.yml
@@ -37,10 +37,10 @@
   - type: IgnoreContentsSize
     items:
       components:
+      - RMCLighter
       - RMCFlask
       - CMScalpel
       tags:
-#      - TODO RMC14 lighters
 #      - TODO RMC14 matchbox
       - Cigarette
 #      - TODO RMC14 cards

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Head/hats.yml
@@ -76,6 +76,25 @@
   - type: Tag
     tags:
     - ClothMade
+  - type: Storage
+    maxItemSize: Tiny
+    grid:
+    - 0,0,3,1 # 2 slots
+    whitelist:
+      components:
+      - RMCLighter
+      tags:
+      - Cigarette
+      - Matchstick
+  - type: ContainerContainer
+    containers:
+      storagebase: !type:Container
+        ents: [ ]
+  - type: UserInterface
+    interfaces:
+      enum.StorageUiKey.Key:
+        type: StorageBoundUserInterface
+  - type: FixedItemSizeStorage
 
 - type: entity
   parent: CMHeadCapMP


### PR DESCRIPTION
## About the PR
## Media
![image](https://github.com/RMC-14/RMC-14/assets/10968691/a918714b-c305-4cda-b625-277d2f4ff311)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak:  All caps including surgical can now hold any combination of 2 lighters, cigarettes and matchsticks.