### PR TITLE
feat: allow developers to customize vscode settings, closes #29285 (#29294)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "omnisharp.analyzeOpenDocumentsOnly": true,
-    "dotnet.defaultSolution": "SpaceStation14.sln"
-}


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
As discussed, cherry-picked vscode workspace settings from upstream.


## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Relevant discussion and rationale: https://github.com/space-wizards/space-station-14/pull/29294

In short - developers should be able to customize workspace settings.