### PR TITLE
feat: draw pheromones overlay above fov

### DIFF
--- a/Content.Client/_RMC14/Xenonids/Pheromones/XenoPheromonesOverlay.cs
+++ b/Content.Client/_RMC14/Xenonids/Pheromones/XenoPheromonesOverlay.cs
@@ -26,7 +26,7 @@ public sealed class XenoPheromonesOverlay : Overlay
 
     private readonly ShaderInstance _shader;
 
-    public override OverlaySpace Space => OverlaySpace.WorldSpaceBelowFOV;
+    public override OverlaySpace Space => OverlaySpace.WorldSpace;
 
     public XenoPheromonesOverlay()
     {


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Pheromones overlay is now drawn above FOV.

Closes #2907.

## Why / Balance
Xenos already see each other behind walls including health, there is no reason for them to not see pheromones overlay too.

Otherwise it's rather confusing to see xenos around without pheromones overlay. Leaves the impression they got none pheros active.

## Technical details
Changed pheromones overlay layer to the one above FOV.

## Media
![image](https://github.com/RMC-14/RMC-14/assets/108279/ec4406a0-3d19-4747-9782-938384d2b9e2)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Pheromones icons are now shown even without direct line of sight.

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
-->
