### PR TITLE
Make the lifesaver bag a 3-row storage

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
@@ -243,7 +243,7 @@
   - type: Storage
     maxItemSize: Small
     grid:
-    - 0,0,41,1 # 21 slots
+    - 0,0,13,5 # 21 slots
     whitelist:
       tags:
       - DiscreteHealthAnalyzer


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed the lifesaver bag's storage UI being extremely long, it is now split into 3 rows instead. Same storage space as before.