### PR TITLE
Fix health analyzer display

### DIFF
--- a/Content.Client/_RMC14/Medical/Scanner/HealthScannerBoundUserInterface.cs
+++ b/Content.Client/_RMC14/Medical/Scanner/HealthScannerBoundUserInterface.cs
@@ -81,7 +81,7 @@ public sealed class HealthScannerBoundUserInterface : BoundUserInterface
             {
                 var damage = threshold.Value - damageable.TotalDamage;
                 _window.HealthBar.MinValue = 0;
-                _window.HealthBar.MaxValue = threshold.Value.Float();
+                _window.HealthBar.MaxValue = 100;
 
                 if (_entities.HasComponent<VictimBurstComponent>(target))
                 {
@@ -90,6 +90,9 @@ public sealed class HealthScannerBoundUserInterface : BoundUserInterface
                 }
                 else
                 {
+                    //Scale negative values with how close to death we are - if we have a different crit and dead state
+                    if (damage < 0 && thresholdsSystem.TryGetDeadThreshold(target, out var deadThreshold) && deadThreshold != threshold)
+                        threshold = deadThreshold - threshold;
 
                     var healthValue = damage.Float() / threshold.Value.Float() * 100f;
                     _window.HealthBar.Value = healthValue;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
The health analyzer's bar correctly now is fully filled at 100%
Also, negative %'s now scale with death threshold if its different from a mob's crit threshold

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Bug, more intuitive that -100% = Dead

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
HealthBar.MaxValue is always 100 now (we always give it a value out of 100 so no need to change with threshold)
There's now a check if damage is under 0 and we have a dead threshold and it's not equal to the previous gotten threshold, to change the threshold to dead - crit so it scales correctly with the death state of the mob.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
![100%](https://github.com/RMC-14/RMC-14/assets/32827189/5c5cab9e-9137-4ebc-b89c-8af4654662c9)
![Almost crit](https://github.com/RMC-14/RMC-14/assets/32827189/526fc6e7-710d-42a7-b7a6-5c4a3c5562f1)
![Dead](https://github.com/RMC-14/RMC-14/assets/32827189/1e64f199-0fe8-4834-8f4d-63f3a224d6c6)


## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
No?
**Changelog**
nah