### PR TITLE
Make xenos able to see non-xenos hidden in lockers after a hijack

### DIFF
--- a/Content.Client/_RMC14/NightVision/NightVisionOverlay.cs
+++ b/Content.Client/_RMC14/NightVision/NightVisionOverlay.cs
@@ -1,5 +1,6 @@
 ﻿using System.Numerics;
 using Content.Shared._RMC14.NightVision;
+using Content.Shared._RMC14.Xenonids;
 using Content.Shared._RMC14.Xenonids.Construction.Nest;
 using Content.Shared.Mobs.Components;
 using Robust.Client.GameObjects;
@@ -44,25 +45,26 @@ public sealed class NightVisionOverlay : Overlay
         var entities = _entity.EntityQueryEnumerator<MobStateComponent, SpriteComponent, TransformComponent>();
         while (entities.MoveNext(out var uid, out _, out var sprite, out var xform))
         {
-            Render((uid, sprite, xform), eye?.Position.MapId, handle, eyeRot);
+            Render((uid, sprite, xform), eye?.Position.MapId, handle, eyeRot, nightVision.SeeThroughContainers);
         }
 
         var nests = _entity.EntityQueryEnumerator<XenoNestComponent, SpriteComponent, TransformComponent>();
         while (nests.MoveNext(out var uid, out _, out var sprite, out var xform))
         {
-            Render((uid, sprite, xform), eye?.Position.MapId, handle, eyeRot);
+            Render((uid, sprite, xform), eye?.Position.MapId, handle, eyeRot, nightVision.SeeThroughContainers);
         }
 
         handle.SetTransform(Matrix3x2.Identity);
     }
 
-    private void Render(Entity<SpriteComponent, TransformComponent> ent, MapId? map, DrawingHandleWorld handle, Angle eyeRot)
+    private void Render(Entity<SpriteComponent, TransformComponent> ent, MapId? map, DrawingHandleWorld handle, Angle eyeRot, bool seeThroughContainers)
     {
         var (uid, sprite, xform) = ent;
         if (xform.MapID != map)
             return;
 
-        if (_container.IsEntityOrParentInContainer(uid))
+        var seeThrough = seeThroughContainers && !_entity.HasComponent<XenoComponent>(uid);
+        if (!seeThrough && _container.IsEntityOrParentInContainer(uid))
             return;
 
         var position = _transform.GetWorldPosition(xform);

--- a/Content.Shared/_RMC14/NightVision/NightVisionComponent.cs
+++ b/Content.Shared/_RMC14/NightVision/NightVisionComponent.cs
@@ -6,6 +6,7 @@ using Robust.Shared.Serialization;
 namespace Content.Shared._RMC14.NightVision;
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true)]
+[Access(typeof(SharedNightVisionSystem))]
 public sealed partial class NightVisionComponent : Component
 {
     [DataField]
@@ -19,6 +20,9 @@ public sealed partial class NightVisionComponent : Component
 
     [DataField, AutoNetworkedField]
     public bool Innate;
+
+    [DataField, AutoNetworkedField]
+    public bool SeeThroughContainers;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/_RMC14/NightVision/SharedNightVisionSystem.cs
+++ b/Content.Shared/_RMC14/NightVision/SharedNightVisionSystem.cs
@@ -178,4 +178,13 @@ public abstract class SharedNightVisionSystem : EntitySystem
             RemCompDeferred<NightVisionComponent>(user.Value);
         }
     }
+
+    public void SetSeeThroughContainers(Entity<NightVisionComponent?> ent, bool see)
+    {
+        if (!Resolve(ent, ref ent.Comp, false))
+            return;
+
+        ent.Comp.SeeThroughContainers = see;
+        Dirty(ent);
+    }
 }

--- a/Content.Shared/_RMC14/Xenonids/Hive/HiveComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hive/HiveComponent.cs
@@ -26,4 +26,7 @@ public sealed partial class HiveComponent : Component
 
     [DataField, AutoNetworkedField]
     public SoundSpecifier AnnounceSound = new SoundPathSpecifier("/Audio/_RMC14/Xeno/alien_distantroar_3.ogg", AudioParams.Default.WithVolume(-6));
+
+    [DataField, AutoNetworkedField]
+    public bool SeeThroughContainers;
 }

--- a/Content.Shared/_RMC14/Xenonids/Hive/SharedXenoHiveSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hive/SharedXenoHiveSystem.cs
@@ -1,4 +1,5 @@
-﻿using Robust.Shared.Map;
+﻿using Content.Shared._RMC14.NightVision;
+using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
@@ -10,6 +11,7 @@ public abstract class SharedXenoHiveSystem : EntitySystem
     [Dependency] private readonly IComponentFactory _compFactory = default!;
     [Dependency] private readonly MetaDataSystem _metaData = default!;
     [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly SharedNightVisionSystem _nightVision = default!;
     [Dependency] private readonly IPrototypeManager _prototypes = default!;
 
     public override void Initialize()
@@ -62,5 +64,21 @@ public abstract class SharedXenoHiveSystem : EntitySystem
 
         member.Comp.Hive = hive;
         Dirty(member);
+    }
+
+    public void SetSeeThroughContainers(Entity<HiveComponent?> hive, bool see)
+    {
+        if (!Resolve(hive, ref hive.Comp, false))
+            return;
+
+        hive.Comp.SeeThroughContainers = see;
+        var xenos = EntityQueryEnumerator<XenoComponent>();
+        while (xenos.MoveNext(out var uid, out var xeno))
+        {
+            if (xeno.Hive != hive)
+                continue;
+
+            _nightVision.SetSeeThroughContainers(uid, see);
+        }
     }
 }

--- a/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
@@ -2,6 +2,7 @@
 using Content.Shared._RMC14.Damage;
 using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.Medical.Scanner;
+using Content.Shared._RMC14.NightVision;
 using Content.Shared._RMC14.Vendors;
 using Content.Shared._RMC14.Xenonids.Construction.Nest;
 using Content.Shared._RMC14.Xenonids.Evolution;
@@ -39,6 +40,7 @@ public sealed class XenoSystem : EntitySystem
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly MobThresholdSystem _mobThresholds = default!;
     [Dependency] private readonly MovementSpeedModifierSystem _movementSpeed = default!;
+    [Dependency] private readonly SharedNightVisionSystem _nightVision = default!;
     [Dependency] private readonly StandingStateSystem _standing = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
@@ -219,6 +221,8 @@ public sealed class XenoSystem : EntitySystem
 
         xeno.Comp.Hive = hive;
         Dirty(xeno, xeno.Comp);
+
+        _nightVision.SetSeeThroughContainers(xeno.Owner, hiveEnt.Comp.SeeThroughContainers);
     }
 
     public void SetSameHive(Entity<XenoComponent?> to, Entity<XenoComponent?> from)


### PR DESCRIPTION
## About the PR
Admins are free from hell

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Xenos can now see non-xenos hidden in lockers after a hijack.
