### PR TITLE
Fix being able to put eggs inside resin structures and building on top of eggs

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Immutable;
 using System.Linq;
 using Content.Shared._RMC14.Xenonids.Construction.Events;
+using Content.Shared._RMC14.Xenonids.Egg;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared._RMC14.Xenonids.Weeds;
@@ -51,6 +52,7 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
     private EntityQuery<XenoConstructionRequiresSupportComponent> _constructionRequiresSupportQuery;
     private EntityQuery<TransformComponent> _transformQuery;
     private EntityQuery<XenoConstructComponent> _xenoConstructQuery;
+    private EntityQuery<XenoEggComponent> _xenoEggQuery;
 
     public override void Initialize()
     {
@@ -61,6 +63,7 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
         _constructionRequiresSupportQuery = GetEntityQuery<XenoConstructionRequiresSupportComponent>();
         _transformQuery = GetEntityQuery<TransformComponent>();
         _xenoConstructQuery = GetEntityQuery<XenoConstructComponent>();
+        _xenoEggQuery = GetEntityQuery<XenoEggComponent>();
 
         SubscribeLocalEvent<XenoConstructionComponent, XenoPlantWeedsActionEvent>(OnXenoPlantWeedsAction);
 
@@ -523,7 +526,7 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
         var anchored = _mapSystem.GetAnchoredEntitiesEnumerator(gridId, grid, tile);
         while (anchored.MoveNext(out var uid))
         {
-            if (_xenoConstructQuery.HasComp(uid))
+            if (_xenoConstructQuery.HasComp(uid) || _xenoEggQuery.HasComp(uid))
             {
                 _popup.PopupClient(Loc.GetString("cm-xeno-construction-failed-cant-build"), target, xeno);
                 return false;

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-eggs.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-eggs.ftl
@@ -4,3 +4,4 @@ cm-xeno-egg-not-developed = The egg is not developed yet.
 cm-xeno-egg-failed-must-weeds = The egg must be planted on weeds.
 cm-xeno-egg-failed-plant-outside = Best not to plant this thing outside of a containment cell.
 cm-xeno-egg-failed-already-there = There's already an egg there.
+cm-xeno-egg-blocked = There's something built here already.


### PR DESCRIPTION
## About the PR
Fixes #2903

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed xenonids being able to put eggs inside resin structures and being able to build on top of eggs to hide them.
