### PR TITLE
Fix damaged xenos being able to evolve

### DIFF
--- a/Content.Server/_RMC14/Xenonids/Evolution/EvolutionPointsCommand.cs
+++ b/Content.Server/_RMC14/Xenonids/Evolution/EvolutionPointsCommand.cs
@@ -1,6 +1,5 @@
 ﻿using System.Linq;
 using Content.Server.Administration;
-using Content.Shared._RMC14.Vendors;
 using Content.Shared._RMC14.Xenonids.Evolution;
 using Content.Shared.Administration;
 using Robust.Shared.Toolshed;
@@ -49,7 +48,7 @@ public sealed class EvolutionPointsCommand : ToolshedCommand
         [PipedArgument] EntityUid xeno)
     {
         if (!TryComp(xeno, out XenoEvolutionComponent? evolution) ||
-            evolution.Max >= evolution.Points)
+            evolution.Points >= evolution.Max)
         {
             return xeno;
         }

--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
@@ -109,6 +109,13 @@ public sealed class XenoEvolutionSystem : EntitySystem
             return;
         }
 
+        if (TryComp(xeno, out DamageableComponent? damageable) &&
+            damageable.TotalDamage > FixedPoint2.Zero)
+        {
+            _popup.PopupEntity(Loc.GetString("rmc-xeno-evolution-cant-evolve-damaged"), xeno, xeno, PopupType.MediumCaution);
+            return;
+        }
+
         var ev = new XenoEvolutionDoAfterEvent(args.Choice);
         var doAfter = new DoAfterArgs(EntityManager, xeno, xeno.Comp.EvolutionDelay, ev, xeno);
 

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
@@ -22,6 +22,7 @@ cm-xeno-evolution-failed-cannot-support = The Hive cannot support this caste yet
 cm-xeno-evolution-failed-hive-full = The hive cannot support another Tier {$tier}, wait for either more aliens to be born or someone to die.
 rmc-xeno-evolution-devolve-title = De-Evolve To
 rmc-xeno-evolution-devolve = You devolve to {$xeno}!
+rmc-xeno-evolution-cant-evolve-damaged = We must be at full health to evolve.
 rmc-xeno-evolution-cant-devolve-damaged = We are too weak to deevolve, we must regain our health first.
 
 # Fortify


### PR DESCRIPTION
## About the PR
Fixes #2867

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed damaged xenonids being able to evolve. Xenos must now be on full health to evolve, same as devolving.
