### PR TITLE
Quick equip to holster entities before inventory slots

### DIFF
--- a/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
@@ -392,7 +392,7 @@ namespace Content.Shared.Containers.ItemSlots
             return false;
         }
 
-        private static int SortEmpty(ItemSlot a, ItemSlot b)
+        public static int SortEmpty(ItemSlot a, ItemSlot b)
         {
             var aEnt = a.ContainerSlot?.ContainedEntity;
             var bEnt = b.ContainerSlot?.ContainedEntity;

--- a/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
+++ b/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Content.Shared._RMC14.Input;
 using Content.Shared.Clothing.Components;
 using Content.Shared.Containers.ItemSlots;
+using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
 using Content.Shared.Inventory;
@@ -210,14 +211,6 @@ public abstract class SharedCMInventorySystem : EntitySystem
         return true;
     }
 
-    private bool InsertSlot(EntityUid user, Entity<CMItemSlotsComponent> holster, EntityUid item)
-    {
-        if (!SlotCanInteract(user, holster, out var itemSlots))
-            return false;
-
-        return _itemSlots.TryInsertEmpty((holster, itemSlots), item, user, true);
-    }
-
     private bool PickupSlot(EntityUid user, EntityUid holster)
     {
         if (!SlotCanInteract(user, holster, out var itemSlots))
@@ -246,27 +239,133 @@ public abstract class SharedCMInventorySystem : EntitySystem
     private void Holster(EntityUid user, EntityUid item)
     {
         // TODO RMC14 try uniform-attached weapon and ammo holsters first
+        var validSlots = new List<HolsterSlot>();
+
+        var priority = 0;
         foreach (var flag in _quickEquipOrder)
         {
             var slots = _inventory.GetSlotEnumerator(user, flag);
             while (slots.MoveNext(out var slot))
             {
-                if (HasComp<CMHolsterComponent>(slot.ContainedEntity) &&
-                    TryComp(slot.ContainedEntity, out CMItemSlotsComponent? holster) &&
-                    InsertSlot(user, (slot.ContainedEntity.Value, holster), item))
+                if (slot.ContainedEntity is not { } clothing)
                 {
-                    return;
+                    // If slot is empty and can equip
+                    if (_inventory.CanEquip(user, item, slot.ID, out _))
+                    {
+                        validSlots.Add(new HolsterSlot(priority, false, slot, user, null));
+                    }
+
+                    continue;
                 }
 
-                if (slot.ContainedEntity != null)
-                    continue;
-
-                if (_inventory.TryEquip(user, item, slot.ID, true))
-                    return;
+                // If the slot item has a CMHolsterComponent
+                // And has a ItemSlotsComponent
+                // And insert succeeds
+                // then return
+                if (HasComp<CMHolsterComponent>(clothing) &&
+                    HasComp<CMItemSlotsComponent>(clothing) &&
+                    SlotCanInteract(user, clothing, out var slotComp) &&
+                    TryGetAvailableSlot((clothing, slotComp),
+                        item,
+                        user,
+                        out var itemSlot,
+                        emptyOnly: true) &&
+                    itemSlot.ContainerSlot != null)
+                {
+                    validSlots.Add(new HolsterSlot(priority, true, null, (clothing, slotComp), ItemSlot: itemSlot));
+                }
             }
         }
 
+        validSlots.Sort();
+
+        foreach (var slot in validSlots)
+        {
+            _itemSlots.TryInsertEmpty(slot.Ent, item, user, true);
+
+            if (slot.ItemSlot != null)
+            {
+                _itemSlots.TryInsert(slot.Ent, slot.ItemSlot, item, user);
+                return;
+            }
+
+            // Try equip to slot
+            if (slot.Slot != null && _inventory.TryEquip(user, item, slot.Slot.ID, true))
+                return;
+        }
+
         _popup.PopupClient(Loc.GetString("cm-inventory-unable-equip"), user, user, PopupType.SmallCaution);
+    }
+
+    private readonly record struct HolsterSlot(
+        int Priority,
+        bool IsHolster,
+        ContainerSlot? Slot,
+        Entity<ItemSlotsComponent?> Ent,
+        ItemSlot? ItemSlot) : IComparable<HolsterSlot>
+    {
+        public int CompareTo(HolsterSlot other)
+        {
+            // Sort holsters first
+            // Then sort by priority between each holster and non-holster
+
+            // If holster and holster
+            // Sort by priority higher first
+            if (IsHolster && other.IsHolster)
+                return Priority.CompareTo(other.Priority);
+
+            // If only first is holster, then sort it higher
+            if (IsHolster)
+                return -1;
+            return 1;
+        }
+    }
+
+    /// <summary>
+    /// Tries to get any slot that the <paramref name="item"/> can be inserted into.
+    /// </summary>
+    /// <param name="ent">Entity that <paramref name="item"/> is being inserted into.</param>
+    /// <param name="item">Entity being inserted into <paramref name="ent"/>.</param>
+    /// <param name="userEnt">Entity inserting <paramref name="item"/> into <paramref name="ent"/>.</param>
+    /// <param name="itemSlot">The ItemSlot on <paramref name="ent"/> to insert <paramref name="item"/> into.</param>
+    /// <param name="emptyOnly"> True only returns slots that are empty.
+    /// False returns any slot that is able to receive <paramref name="item"/>.</param>
+    /// <returns>True when a slot is found. Otherwise, false.</returns>
+    private bool TryGetAvailableSlot(Entity<ItemSlotsComponent?> ent,
+        EntityUid item,
+        Entity<HandsComponent?>? userEnt,
+        [NotNullWhen(true)] out ItemSlot? itemSlot,
+        bool emptyOnly = false)
+    {
+        // TODO Replace with ItemSlotsSystem version when upstream is merged
+        itemSlot = null;
+
+        if (userEnt is { } user && Resolve(user, ref user.Comp) && _hands.IsHolding(user, item))
+        {
+            if (!_hands.CanDrop(user, item, user.Comp))
+                return false;
+        }
+
+        if (!Resolve(ent, ref ent.Comp, false))
+            return false;
+
+        var slots = new List<ItemSlot>();
+        foreach (var slot in ent.Comp.Slots.Values)
+        {
+            if (emptyOnly && slot.ContainerSlot?.ContainedEntity != null)
+                continue;
+
+            if (_itemSlots.CanInsert(ent, item, userEnt, slot))
+                slots.Add(slot);
+        }
+
+        if (slots.Count == 0)
+            return false;
+
+        slots.Sort();
+
+        itemSlot = slots[0];
+        return true;
     }
 
     private void Unholster(EntityUid user, int startIndex, CMHolsterChoose choose)

--- a/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
+++ b/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
@@ -360,7 +360,7 @@ public abstract class SharedCMInventorySystem : EntitySystem
         if (slots.Count == 0)
             return false;
 
-        slots.Sort();
+        slots.Sort(ItemSlotsSystem.SortEmpty);
 
         itemSlot = slots[0];
         return true;

--- a/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
+++ b/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
@@ -281,16 +281,14 @@ public abstract class SharedCMInventorySystem : EntitySystem
 
         foreach (var slot in validSlots)
         {
-            _itemSlots.TryInsertEmpty(slot.Ent, item, user, true);
-
-            if (slot.ItemSlot != null)
-            {
-                _itemSlots.TryInsert(slot.Ent, slot.ItemSlot, item, user);
+            // Try insert into holster
+            if (slot.ItemSlot != null &&
+                _itemSlots.TryInsert(slot.Ent, slot.ItemSlot, item, user, excludeUserAudio: true))
                 return;
-            }
 
-            // Try equip to slot
-            if (slot.Slot != null && _inventory.TryEquip(user, item, slot.Slot.ID, true))
+            // Try equip to inventory slot
+            if (slot.Slot != null &&
+                _inventory.TryEquip(user, item, slot.Slot.ID, true))
                 return;
         }
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

When pressing the holster hotkey, it will now choose equipped holsters over inventory slots.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Better inventory management with weapons.

Porting functionality from CM13.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

TryGetAvailableSlot is going to be upstreamed as part of ItemSlotSystem, but until then, this should work.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/RMC-14/RMC-14/assets/10494922/510200c4-6e6f-4913-842c-a05333a717af


## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Holster keybinds now equip to equipped holsters before inventory slots.
