### PR TITLE
Fix dropship blockers blocking its doors from closing, doors opening during FTL if locked down, not being able to lockdown outside FTL travel

### DIFF
--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -463,11 +463,14 @@ namespace Content.Server.GameTicking
                 {
                     var mapName = _gameMapManager.GetSelectedMap()?.MapName;
                     mapName ??= Loc.GetString("discord-round-notifications-unknown-map");
-                    content = Loc.GetString("rmc-discord-round-notifications-started",
+                    content = Loc.GetString("rmc-discord-round-notifications-end",
                         ("id", RoundId),
                         ("operation", operation),
                         ("planet", planet),
-                        ("ship", mapName));
+                        ("ship", mapName),
+                        ("hours", Math.Truncate(duration.TotalHours)),
+                        ("minutes", duration.Minutes),
+                        ("seconds", duration.Seconds));
                 }
 
                 var payload = new WebhookPayload { Content = content };

--- a/Content.Server/_RMC14/Dropship/DropshipSystem.cs
+++ b/Content.Server/_RMC14/Dropship/DropshipSystem.cs
@@ -89,8 +89,13 @@ public sealed class DropshipSystem : SharedDropshipSystem
     {
         if (_transform.GetGrid(ent.Owner) is not { } grid ||
             !TryComp(grid, out DropshipComponent? dropship) ||
-            dropship.Crashed ||
-            HasComp<FTLComponent>(grid))
+            dropship.Crashed)
+        {
+            return;
+        }
+
+        if (TryComp(grid, out FTLComponent? ftl) &&
+            ftl.State is FTLState.Travelling or FTLState.Arriving)
         {
             return;
         }

--- a/Content.Server/_RMC14/Dropship/DropshipSystem.cs
+++ b/Content.Server/_RMC14/Dropship/DropshipSystem.cs
@@ -30,6 +30,7 @@ public sealed class DropshipSystem : SharedDropshipSystem
     [Dependency] private readonly SharedXenoAnnounceSystem _xenoAnnounce = default!;
 
     private EntityQuery<DockingComponent> _dockingQuery;
+    private EntityQuery<DoorComponent> _doorQuery;
     private EntityQuery<DoorBoltComponent> _doorBoltQuery;
 
     public override void Initialize()
@@ -37,6 +38,7 @@ public sealed class DropshipSystem : SharedDropshipSystem
         base.Initialize();
 
         _dockingQuery = GetEntityQuery<DockingComponent>();
+        _doorQuery = GetEntityQuery<DoorComponent>();
         _doorBoltQuery = GetEntityQuery<DoorBoltComponent>();
 
         SubscribeLocalEvent<DropshipNavigationComputerComponent, ActivateInWorldEvent>(OnActivateInWorld);
@@ -246,19 +248,20 @@ public sealed class DropshipSystem : SharedDropshipSystem
 
     public void LockDoor(Entity<DoorBoltComponent?> door)
     {
-        var doorComp = CompOrNull<DoorComponent>(door);
-        var oldCheck = doorComp?.PerformCollisionCheck ?? false;
-        if (doorComp != null)
+        if (_doorQuery.TryComp(door, out var doorComp) &&
+            doorComp.State != DoorState.Closed)
+        {
+            var oldCheck = doorComp.PerformCollisionCheck;
             doorComp.PerformCollisionCheck = false;
 
-        _door.StartClosing(door);
-        _door.OnPartialClose(door);
+            _door.StartClosing(door);
+            _door.OnPartialClose(door);
+
+            doorComp.PerformCollisionCheck = oldCheck;
+        }
 
         if (_doorBoltQuery.Resolve(door, ref door.Comp, false))
             _door.SetBoltsDown((door.Owner, door.Comp), true);
-
-        if (doorComp != null)
-            doorComp.PerformCollisionCheck = oldCheck;
     }
 
     public void UnlockDoor(Entity<DoorBoltComponent?> door)

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -15,12 +15,12 @@ using Content.Shared.Stunnable;
 using Content.Shared.Tag;
 using Content.Shared.Tools.Systems;
 using Robust.Shared.Audio;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Network;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Timing;
-using Robust.Shared.Audio.Systems;
-using Robust.Shared.Network;
 
 namespace Content.Shared.Doors.Systems;
 
@@ -572,6 +572,9 @@ public abstract partial class SharedDoorSystem : EntitySystem
                 continue;
 
             if (_entityLookup.GetWorldAABB(otherPhysics.Owner).IntersectPercentage(doorAABB) < IntersectPercentage)
+                continue;
+
+            if (otherPhysics.CollisionLayer == (int) CollisionGroup.DropshipImpassable)
                 continue;
 
             yield return otherPhysics.Owner;


### PR DESCRIPTION
## About the PR
Also fixes the discord message for round ends being the wrong one.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
