### PR TITLE
Fix some outer dropship tiles not being see-through

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Dropships/alamo_walls.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Dropships/alamo_walls.yml
@@ -20,6 +20,8 @@
     state: "1"
   - type: Icon
     state: "1"
+  - type: Occluder
+    enabled: false
 
 - type: entity
   parent: CMBaseAlamoWall
@@ -30,6 +32,8 @@
     state: "2"
   - type: Icon
     state: "2"
+  - type: Occluder
+    enabled: false
 
 - type: entity
   parent: CMBaseAlamoWall
@@ -60,6 +64,8 @@
     state: "5"
   - type: Icon
     state: "5"
+  - type: Occluder
+    enabled: false
 
 - type: entity
   parent: CMBaseAlamoWall
@@ -70,6 +76,8 @@
     state: "6"
   - type: Icon
     state: "6"
+  - type: Occluder
+    enabled: false
 
 - type: entity
   parent: CMBaseAlamoWall
@@ -170,6 +178,8 @@
     state: "16"
   - type: Icon
     state: "16"
+  - type: Occluder
+    enabled: false
 
 - type: entity
   parent: CMBaseAlamoWall
@@ -180,6 +190,8 @@
     state: "17"
   - type: Icon
     state: "17"
+  - type: Occluder
+    enabled: false
 
 - type: entity
   parent: CMBaseAlamoWall
@@ -230,6 +242,8 @@
     state: "22"
   - type: Icon
     state: "22"
+  - type: Occluder
+    enabled: false
 
 - type: entity
   parent: CMBaseAlamoWall
@@ -240,6 +254,8 @@
     state: "23"
   - type: Icon
     state: "23"
+  - type: Occluder
+    enabled: false
 
 - type: entity
   parent: CMBaseAlamoWall
@@ -270,6 +286,8 @@
     state: "26"
   - type: Icon
     state: "26"
+  - type: Occluder
+    enabled: false
 
 - type: entity
   parent: CMBaseAlamoWall
@@ -280,6 +298,8 @@
     state: "27"
   - type: Icon
     state: "27"
+  - type: Occluder
+    enabled: false
 
 - type: entity
   parent: CMBaseAlamoWall
@@ -290,6 +310,8 @@
     state: "28"
   - type: Icon
     state: "28"
+  - type: Occluder
+    enabled: false
 
 - type: entity
   parent: CMBaseAlamoWall
@@ -300,6 +322,8 @@
     state: "29"
   - type: Icon
     state: "29"
+  - type: Occluder
+    enabled: false
 
 - type: entity
   parent: CMBaseAlamoWall
@@ -330,6 +354,8 @@
     state: "32"
   - type: Icon
     state: "32"
+  - type: Occluder
+    enabled: false
 
 - type: entity
   parent: CMBaseAlamoWall
@@ -340,6 +366,8 @@
     state: "33"
   - type: Icon
     state: "33"
+  - type: Occluder
+    enabled: false
 
 - type: entity
   parent: CMBaseAlamoWall
@@ -350,6 +378,8 @@
     state: "34"
   - type: Icon
     state: "34"
+  - type: Occluder
+    enabled: false
 
 - type: entity
   parent: CMBaseAlamoWall
@@ -360,6 +390,8 @@
     state: "35"
   - type: Icon
     state: "35"
+  - type: Occluder
+    enabled: false
 
 - type: entity
   parent: CMBaseAlamoWall
@@ -390,6 +422,8 @@
     state: "38"
   - type: Icon
     state: "38"
+  - type: Occluder
+    enabled: false
 
 - type: entity
   parent: CMBaseAlamoWall
@@ -400,6 +434,8 @@
     state: "39"
   - type: Icon
     state: "39"
+  - type: Occluder
+    enabled: false
 
 - type: entity
   parent: CMBaseAlamoWall
@@ -410,6 +446,8 @@
     state: "40"
   - type: Icon
     state: "40"
+  - type: Occluder
+    enabled: false
 
 - type: entity
   parent: CMBaseAlamoWall
@@ -420,6 +458,8 @@
     state: "41"
   - type: Icon
     state: "41"
+  - type: Occluder
+    enabled: false
 
 - type: entity
   parent: CMBaseAlamoWall
@@ -620,6 +660,8 @@
     state: "61"
   - type: Icon
     state: "61"
+  - type: Occluder
+    enabled: false
 
 - type: entity
   parent: CMBaseAlamoWall
@@ -660,6 +702,8 @@
     state: "65"
   - type: Icon
     state: "65"
+  - type: Occluder
+    enabled: false
 
 - type: entity
   parent: CMBaseAlamoWall
@@ -670,6 +714,8 @@
     state: "66"
   - type: Icon
     state: "66"
+  - type: Occluder
+    enabled: false
 
 - type: entity
   parent: CMBaseAlamoWall
@@ -710,6 +756,8 @@
     state: "70"
   - type: Icon
     state: "70"
+  - type: Occluder
+    enabled: false
 
 - type: entity
   parent: CMBaseAlamoWall

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Dropships/normandy_walls.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Dropships/normandy_walls.yml
@@ -15,508 +15,1018 @@
   parent: [CMBaseNormandyWall, CMAlamoWall1]
   id: CMNormandyWall1
   suffix: 1
+  components:
+  - type: Sprite
+    state: "1"
+  - type: Icon
+    state: "1"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall2]
   id: CMNormandyWall2
   suffix: 2
+  components:
+  - type: Sprite
+    state: "2"
+  - type: Icon
+    state: "2"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall3]
   id: CMNormandyWall3
   suffix: 3
+  components:
+  - type: Sprite
+    state: "3"
+  - type: Icon
+    state: "3"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall4]
   id: CMNormandyWall4
   suffix: 4
+  components:
+  - type: Sprite
+    state: "4"
+  - type: Icon
+    state: "4"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall5]
   id: CMNormandyWall5
   suffix: 5
+  components:
+  - type: Sprite
+    state: "5"
+  - type: Icon
+    state: "5"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall6]
   id: CMNormandyWall6
   suffix: 6
+  components:
+  - type: Sprite
+    state: "6"
+  - type: Icon
+    state: "6"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall7]
   id: CMNormandyWall7
   suffix: 7
+  components:
+  - type: Sprite
+    state: "7"
+  - type: Icon
+    state: "7"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall8]
   id: CMNormandyWall8
   suffix: 8
+  components:
+  - type: Sprite
+    state: "8"
+  - type: Icon
+    state: "8"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall9]
   id: CMNormandyWall9
   suffix: 9
+  components:
+  - type: Sprite
+    state: "9"
+  - type: Icon
+    state: "9"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall10]
   id: CMNormandyWall10
   suffix: 10
+  components:
+  - type: Sprite
+    state: "10"
+  - type: Icon
+    state: "10"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall11]
   id: CMNormandyWall11
   suffix: 11
+  components:
+  - type: Sprite
+    state: "11"
+  - type: Icon
+    state: "11"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall12]
   id: CMNormandyWall12
   suffix: 12
+  components:
+  - type: Sprite
+    state: "12"
+  - type: Icon
+    state: "12"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall13]
   id: CMNormandyWall13
   suffix: 13
+  components:
+  - type: Sprite
+    state: "13"
+  - type: Icon
+    state: "13"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall14]
   id: CMNormandyWall14
   suffix: 14
+  components:
+  - type: Sprite
+    state: "14"
+  - type: Icon
+    state: "14"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall15]
   id: CMNormandyWall15
   suffix: 15
+  components:
+  - type: Sprite
+    state: "15"
+  - type: Icon
+    state: "15"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall16]
   id: CMNormandyWall16
   suffix: 16
+  components:
+  - type: Sprite
+    state: "16"
+  - type: Icon
+    state: "16"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall17]
   id: CMNormandyWall17
   suffix: 17
+  components:
+  - type: Sprite
+    state: "17"
+  - type: Icon
+    state: "17"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall18]
   id: CMNormandyWall18
   suffix: 18
+  components:
+  - type: Sprite
+    state: "18"
+  - type: Icon
+    state: "18"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall19]
   id: CMNormandyWall19
   suffix: 19
+  components:
+  - type: Sprite
+    state: "19"
+  - type: Icon
+    state: "19"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall20]
   id: CMNormandyWall20
   suffix: 20
+  components:
+  - type: Sprite
+    state: "20"
+  - type: Icon
+    state: "20"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall21]
   id: CMNormandyWall21
   suffix: 21
+  components:
+  - type: Sprite
+    state: "21"
+  - type: Icon
+    state: "21"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall22]
   id: CMNormandyWall22
   suffix: 22
+  components:
+  - type: Sprite
+    state: "22"
+  - type: Icon
+    state: "22"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall23]
   id: CMNormandyWall23
   suffix: 23
+  components:
+  - type: Sprite
+    state: "23"
+  - type: Icon
+    state: "23"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall24]
   id: CMNormandyWall24
   suffix: 24
+  components:
+  - type: Sprite
+    state: "24"
+  - type: Icon
+    state: "24"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall25]
   id: CMNormandyWall25
   suffix: 25
+  components:
+  - type: Sprite
+    state: "25"
+  - type: Icon
+    state: "25"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall26]
   id: CMNormandyWall26
   suffix: 26
+  components:
+  - type: Sprite
+    state: "26"
+  - type: Icon
+    state: "26"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall27]
   id: CMNormandyWall27
   suffix: 27
+  components:
+  - type: Sprite
+    state: "27"
+  - type: Icon
+    state: "27"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall28]
   id: CMNormandyWall28
   suffix: 28
+  components:
+  - type: Sprite
+    state: "28"
+  - type: Icon
+    state: "28"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall29]
   id: CMNormandyWall29
   suffix: 29
+  components:
+  - type: Sprite
+    state: "29"
+  - type: Icon
+    state: "29"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall30]
   id: CMNormandyWall30
   suffix: 30
+  components:
+  - type: Sprite
+    state: "30"
+  - type: Icon
+    state: "30"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall31]
   id: CMNormandyWall31
   suffix: 31
+  components:
+  - type: Sprite
+    state: "31"
+  - type: Icon
+    state: "31"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall32]
   id: CMNormandyWall32
   suffix: 32
+  components:
+  - type: Sprite
+    state: "32"
+  - type: Icon
+    state: "32"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall33]
   id: CMNormandyWall33
   suffix: 33
+  components:
+  - type: Sprite
+    state: "33"
+  - type: Icon
+    state: "33"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall34]
   id: CMNormandyWall34
   suffix: 34
+  components:
+  - type: Sprite
+    state: "34"
+  - type: Icon
+    state: "34"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall35]
   id: CMNormandyWall35
   suffix: 35
+  components:
+  - type: Sprite
+    state: "35"
+  - type: Icon
+    state: "35"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall36]
   id: CMNormandyWall36
   suffix: 36
+  components:
+  - type: Sprite
+    state: "36"
+  - type: Icon
+    state: "36"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall37]
   id: CMNormandyWall37
   suffix: 37
+  components:
+  - type: Sprite
+    state: "37"
+  - type: Icon
+    state: "37"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall38]
   id: CMNormandyWall38
   suffix: 38
+  components:
+  - type: Sprite
+    state: "38"
+  - type: Icon
+    state: "38"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall39]
   id: CMNormandyWall39
   suffix: 39
+  components:
+  - type: Sprite
+    state: "39"
+  - type: Icon
+    state: "39"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall40]
   id: CMNormandyWall40
   suffix: 40
+  components:
+  - type: Sprite
+    state: "40"
+  - type: Icon
+    state: "40"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall41]
   id: CMNormandyWall41
   suffix: 41
+  components:
+  - type: Sprite
+    state: "41"
+  - type: Icon
+    state: "41"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall42]
   id: CMNormandyWall42
   suffix: 42
+  components:
+  - type: Sprite
+    state: "42"
+  - type: Icon
+    state: "42"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall43]
   id: CMNormandyWall43
   suffix: 43
+  components:
+  - type: Sprite
+    state: "43"
+  - type: Icon
+    state: "43"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall44]
   id: CMNormandyWall44
   suffix: 44
+  components:
+  - type: Sprite
+    state: "44"
+  - type: Icon
+    state: "44"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall45]
   id: CMNormandyWall45
   suffix: 45
+  components:
+  - type: Sprite
+    state: "45"
+  - type: Icon
+    state: "45"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall46]
   id: CMNormandyWall46
   suffix: 46
+  components:
+  - type: Sprite
+    state: "46"
+  - type: Icon
+    state: "46"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall47]
   id: CMNormandyWall47
   suffix: 47
+  components:
+  - type: Sprite
+    state: "47"
+  - type: Icon
+    state: "47"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall48]
   id: CMNormandyWall48
   suffix: 48
+  components:
+  - type: Sprite
+    state: "48"
+  - type: Icon
+    state: "48"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall49]
   id: CMNormandyWall49
   suffix: 49
+  components:
+  - type: Sprite
+    state: "49"
+  - type: Icon
+    state: "49"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall50]
   id: CMNormandyWall50
   suffix: 50
+  components:
+  - type: Sprite
+    state: "50"
+  - type: Icon
+    state: "50"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall51]
   id: CMNormandyWall51
   suffix: 51
+  components:
+  - type: Sprite
+    state: "51"
+  - type: Icon
+    state: "51"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall52]
   id: CMNormandyWall52
   suffix: 52
+  components:
+  - type: Sprite
+    state: "52"
+  - type: Icon
+    state: "52"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall53]
   id: CMNormandyWall53
   suffix: 53
+  components:
+  - type: Sprite
+    state: "53"
+  - type: Icon
+    state: "53"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall54]
   id: CMNormandyWall54
   suffix: 54
+  components:
+  - type: Sprite
+    state: "54"
+  - type: Icon
+    state: "54"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall55]
   id: CMNormandyWall55
   suffix: 55
+  components:
+  - type: Sprite
+    state: "55"
+  - type: Icon
+    state: "55"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall56]
   id: CMNormandyWall56
   suffix: 56
+  components:
+  - type: Sprite
+    state: "56"
+  - type: Icon
+    state: "56"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall57]
   id: CMNormandyWall57
   suffix: 57
+  components:
+  - type: Sprite
+    state: "57"
+  - type: Icon
+    state: "57"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall58]
   id: CMNormandyWall58
   suffix: 58
+  components:
+  - type: Sprite
+    state: "58"
+  - type: Icon
+    state: "58"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall59]
   id: CMNormandyWall59
   suffix: 59
+  components:
+  - type: Sprite
+    state: "59"
+  - type: Icon
+    state: "59"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall60]
   id: CMNormandyWall60
   suffix: 60
+  components:
+  - type: Sprite
+    state: "60"
+  - type: Icon
+    state: "60"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall61]
   id: CMNormandyWall61
   suffix: 61
+  components:
+  - type: Sprite
+    state: "61"
+  - type: Icon
+    state: "61"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall62]
   id: CMNormandyWall62
   suffix: 62
+  components:
+  - type: Sprite
+    state: "62"
+  - type: Icon
+    state: "62"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall63]
   id: CMNormandyWall63
   suffix: 63
+  components:
+  - type: Sprite
+    state: "63"
+  - type: Icon
+    state: "63"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall64]
   id: CMNormandyWall64
   suffix: 64
+  components:
+  - type: Sprite
+    state: "64"
+  - type: Icon
+    state: "64"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall65]
   id: CMNormandyWall65
   suffix: 65
+  components:
+  - type: Sprite
+    state: "65"
+  - type: Icon
+    state: "65"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall66]
   id: CMNormandyWall66
   suffix: 66
+  components:
+  - type: Sprite
+    state: "66"
+  - type: Icon
+    state: "66"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall67]
   id: CMNormandyWall67
   suffix: 67
+  components:
+  - type: Sprite
+    state: "67"
+  - type: Icon
+    state: "67"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall68]
   id: CMNormandyWall68
   suffix: 68
+  components:
+  - type: Sprite
+    state: "68"
+  - type: Icon
+    state: "68"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall69]
   id: CMNormandyWall69
   suffix: 69
+  components:
+  - type: Sprite
+    state: "69"
+  - type: Icon
+    state: "69"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall70]
   id: CMNormandyWall70
   suffix: 70
+  components:
+  - type: Sprite
+    state: "70"
+  - type: Icon
+    state: "70"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall71]
   id: CMNormandyWall71
   suffix: 71
+  components:
+  - type: Sprite
+    state: "71"
+  - type: Icon
+    state: "71"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall72]
   id: CMNormandyWall72
   suffix: 72
+  components:
+  - type: Sprite
+    state: "72"
+  - type: Icon
+    state: "72"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall73]
   id: CMNormandyWall73
   suffix: 73
+  components:
+  - type: Sprite
+    state: "73"
+  - type: Icon
+    state: "73"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall74]
   id: CMNormandyWall74
   suffix: 74
+  components:
+  - type: Sprite
+    state: "74"
+  - type: Icon
+    state: "74"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall75]
   id: CMNormandyWall75
   suffix: 75
+  components:
+  - type: Sprite
+    state: "75"
+  - type: Icon
+    state: "75"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall76]
   id: CMNormandyWall76
   suffix: 76
+  components:
+  - type: Sprite
+    state: "76"
+  - type: Icon
+    state: "76"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall77]
   id: CMNormandyWall77
   suffix: 77
+  components:
+  - type: Sprite
+    state: "77"
+  - type: Icon
+    state: "77"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall78]
   id: CMNormandyWall78
   suffix: 78
+  components:
+  - type: Sprite
+    state: "78"
+  - type: Icon
+    state: "78"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall79]
   id: CMNormandyWall79
   suffix: 79
+  components:
+  - type: Sprite
+    state: "79"
+  - type: Icon
+    state: "79"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall80]
   id: CMNormandyWall80
   suffix: 80
+  components:
+  - type: Sprite
+    state: "80"
+  - type: Icon
+    state: "80"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall81]
   id: CMNormandyWall81
   suffix: 81
+  components:
+  - type: Sprite
+    state: "81"
+  - type: Icon
+    state: "81"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall82]
   id: CMNormandyWall82
   suffix: 82
+  components:
+  - type: Sprite
+    state: "82"
+  - type: Icon
+    state: "82"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall83]
   id: CMNormandyWall83
   suffix: 83
+  components:
+  - type: Sprite
+    state: "83"
+  - type: Icon
+    state: "83"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall84]
   id: CMNormandyWall84
   suffix: 84
+  components:
+  - type: Sprite
+    state: "84"
+  - type: Icon
+    state: "84"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall85]
   id: CMNormandyWall85
   suffix: 85
+  components:
+  - type: Sprite
+    state: "85"
+  - type: Icon
+    state: "85"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall86]
   id: CMNormandyWall86
   suffix: 86
+  components:
+  - type: Sprite
+    state: "86"
+  - type: Icon
+    state: "86"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall87]
   id: CMNormandyWall87
   suffix: 87
+  components:
+  - type: Sprite
+    state: "87"
+  - type: Icon
+    state: "87"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall88]
   id: CMNormandyWall88
   suffix: 88
+  components:
+  - type: Sprite
+    state: "88"
+  - type: Icon
+    state: "88"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall89]
   id: CMNormandyWall89
   suffix: 89
+  components:
+  - type: Sprite
+    state: "89"
+  - type: Icon
+    state: "89"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall90]
   id: CMNormandyWall90
   suffix: 90
+  components:
+  - type: Sprite
+    state: "90"
+  - type: Icon
+    state: "90"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall91]
   id: CMNormandyWall91
   suffix: 91
+  components:
+  - type: Sprite
+    state: "91"
+  - type: Icon
+    state: "91"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall92]
   id: CMNormandyWall92
   suffix: 92
+  components:
+  - type: Sprite
+    state: "92"
+  - type: Icon
+    state: "92"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall93]
   id: CMNormandyWall93
   suffix: 93
+  components:
+  - type: Sprite
+    state: "93"
+  - type: Icon
+    state: "93"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall94]
   id: CMNormandyWall94
   suffix: 94
+  components:
+  - type: Sprite
+    state: "94"
+  - type: Icon
+    state: "94"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall95]
   id: CMNormandyWall95
   suffix: 95
+  components:
+  - type: Sprite
+    state: "95"
+  - type: Icon
+    state: "95"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall96]
   id: CMNormandyWall96
   suffix: 96
+  components:
+  - type: Sprite
+    state: "96"
+  - type: Icon
+    state: "96"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall97]
   id: CMNormandyWall97
   suffix: 97
+  components:
+  - type: Sprite
+    state: "97"
+  - type: Icon
+    state: "97"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall98]
   id: CMNormandyWall98
   suffix: 98
+  components:
+  - type: Sprite
+    state: "98"
+  - type: Icon
+    state: "98"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall99]
   id: CMNormandyWall99
   suffix: 99
+  components:
+  - type: Sprite
+    state: "99"
+  - type: Icon
+    state: "99"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall100]
   id: CMNormandyWall100
   suffix: 100
+  components:
+  - type: Sprite
+    state: "100"
+  - type: Icon
+    state: "100"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall101]
   id: CMNormandyWall101
   suffix: 101
+  components:
+  - type: Sprite
+    state: "101"
+  - type: Icon
+    state: "101"
 
 - type: entity
   parent: [CMBaseNormandyWall, CMAlamoWall102]
   id: CMNormandyWall102
   suffix: 102
+  components:
+  - type: Sprite
+    state: "102"
+  - type: Icon
+    state: "102"

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Dropships/normandy_walls.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Dropships/normandy_walls.yml
@@ -12,1053 +12,511 @@
     sprite: _RMC14/Structures/Dropships/normandy.rsi
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall1]
   id: CMNormandyWall1
   suffix: 1
-  components:
-  - type: Sprite
-    state: "1"
-  - type: Icon
-    state: "1"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall2]
   id: CMNormandyWall2
   suffix: 2
-  components:
-  - type: Sprite
-    state: "2"
-  - type: Icon
-    state: "2"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall3]
   id: CMNormandyWall3
   suffix: 3
-  components:
-  - type: Sprite
-    state: "3"
-  - type: Icon
-    state: "3"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall4]
   id: CMNormandyWall4
   suffix: 4
-  components:
-  - type: Sprite
-    state: "4"
-  - type: Icon
-    state: "4"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall5]
   id: CMNormandyWall5
   suffix: 5
-  components:
-  - type: Sprite
-    state: "5"
-  - type: Icon
-    state: "5"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall6]
   id: CMNormandyWall6
   suffix: 6
-  components:
-  - type: Sprite
-    state: "6"
-  - type: Icon
-    state: "6"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall7]
   id: CMNormandyWall7
   suffix: 7
-  components:
-  - type: Sprite
-    state: "7"
-  - type: Icon
-    state: "7"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall8]
   id: CMNormandyWall8
   suffix: 8
-  components:
-  - type: Sprite
-    state: "8"
-  - type: Icon
-    state: "8"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall9]
   id: CMNormandyWall9
   suffix: 9
-  components:
-  - type: Sprite
-    state: "9"
-  - type: Icon
-    state: "9"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall10]
   id: CMNormandyWall10
   suffix: 10
-  components:
-  - type: Sprite
-    state: "10"
-  - type: Icon
-    state: "10"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall11]
   id: CMNormandyWall11
   suffix: 11
-  components:
-  - type: Sprite
-    state: "11"
-  - type: Icon
-    state: "11"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall12]
   id: CMNormandyWall12
   suffix: 12
-  components:
-  - type: Sprite
-    state: "12"
-  - type: Icon
-    state: "12"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall13]
   id: CMNormandyWall13
   suffix: 13
-  components:
-  - type: Sprite
-    state: "13"
-  - type: Icon
-    state: "13"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall14]
   id: CMNormandyWall14
   suffix: 14
-  components:
-  - type: Sprite
-    state: "14"
-  - type: Icon
-    state: "14"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall15]
   id: CMNormandyWall15
   suffix: 15
-  components:
-  - type: Sprite
-    state: "15"
-  - type: Icon
-    state: "15"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall16]
   id: CMNormandyWall16
   suffix: 16
-  components:
-  - type: Sprite
-    state: "16"
-  - type: Icon
-    state: "16"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall17]
   id: CMNormandyWall17
   suffix: 17
-  components:
-  - type: Sprite
-    state: "17"
-  - type: Icon
-    state: "17"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall18]
   id: CMNormandyWall18
   suffix: 18
-  components:
-  - type: Sprite
-    state: "18"
-  - type: Icon
-    state: "18"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall19]
   id: CMNormandyWall19
   suffix: 19
-  components:
-  - type: Sprite
-    state: "19"
-  - type: Icon
-    state: "19"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall20]
   id: CMNormandyWall20
   suffix: 20
-  components:
-  - type: Sprite
-    state: "20"
-  - type: Icon
-    state: "20"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall21]
   id: CMNormandyWall21
   suffix: 21
-  components:
-  - type: Sprite
-    state: "21"
-  - type: Icon
-    state: "21"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall22]
   id: CMNormandyWall22
   suffix: 22
-  components:
-  - type: Sprite
-    state: "22"
-  - type: Icon
-    state: "22"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall23]
   id: CMNormandyWall23
   suffix: 23
-  components:
-  - type: Sprite
-    state: "23"
-  - type: Icon
-    state: "23"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall24]
   id: CMNormandyWall24
   suffix: 24
-  components:
-  - type: Sprite
-    state: "24"
-  - type: Icon
-    state: "24"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall25]
   id: CMNormandyWall25
   suffix: 25
-  components:
-  - type: Sprite
-    state: "25"
-  - type: Icon
-    state: "25"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall26]
   id: CMNormandyWall26
   suffix: 26
-  components:
-  - type: Sprite
-    state: "26"
-  - type: Icon
-    state: "26"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall27]
   id: CMNormandyWall27
   suffix: 27
-  components:
-  - type: Sprite
-    state: "27"
-  - type: Icon
-    state: "27"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall28]
   id: CMNormandyWall28
   suffix: 28
-  components:
-  - type: Sprite
-    state: "28"
-  - type: Icon
-    state: "28"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall29]
   id: CMNormandyWall29
   suffix: 29
-  components:
-  - type: Sprite
-    state: "29"
-  - type: Icon
-    state: "29"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall30]
   id: CMNormandyWall30
   suffix: 30
-  components:
-  - type: Sprite
-    state: "30"
-  - type: Icon
-    state: "30"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall31]
   id: CMNormandyWall31
   suffix: 31
-  components:
-  - type: Sprite
-    state: "31"
-  - type: Icon
-    state: "31"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall32]
   id: CMNormandyWall32
   suffix: 32
-  components:
-  - type: Sprite
-    state: "32"
-  - type: Icon
-    state: "32"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall33]
   id: CMNormandyWall33
   suffix: 33
-  components:
-  - type: Sprite
-    state: "33"
-  - type: Icon
-    state: "33"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall34]
   id: CMNormandyWall34
   suffix: 34
-  components:
-  - type: Sprite
-    state: "34"
-  - type: Icon
-    state: "34"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall35]
   id: CMNormandyWall35
   suffix: 35
-  components:
-  - type: Sprite
-    state: "35"
-  - type: Icon
-    state: "35"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall36]
   id: CMNormandyWall36
   suffix: 36
-  components:
-  - type: Sprite
-    state: "36"
-  - type: Icon
-    state: "36"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall37]
   id: CMNormandyWall37
   suffix: 37
-  components:
-  - type: Sprite
-    state: "37"
-  - type: Icon
-    state: "37"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall38]
   id: CMNormandyWall38
   suffix: 38
-  components:
-  - type: Sprite
-    state: "38"
-  - type: Icon
-    state: "38"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall39]
   id: CMNormandyWall39
   suffix: 39
-  components:
-  - type: Sprite
-    state: "39"
-  - type: Icon
-    state: "39"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall40]
   id: CMNormandyWall40
   suffix: 40
-  components:
-  - type: Sprite
-    state: "40"
-  - type: Icon
-    state: "40"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall41]
   id: CMNormandyWall41
   suffix: 41
-  components:
-  - type: Sprite
-    state: "41"
-  - type: Icon
-    state: "41"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall42]
   id: CMNormandyWall42
   suffix: 42
-  components:
-  - type: Sprite
-    state: "42"
-  - type: Icon
-    state: "42"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall43]
   id: CMNormandyWall43
   suffix: 43
-  components:
-  - type: Sprite
-    state: "43"
-  - type: Icon
-    state: "43"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall44]
   id: CMNormandyWall44
   suffix: 44
-  components:
-  - type: Sprite
-    state: "44"
-  - type: Icon
-    state: "44"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall45]
   id: CMNormandyWall45
   suffix: 45
-  components:
-  - type: Sprite
-    state: "45"
-  - type: Icon
-    state: "45"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall46]
   id: CMNormandyWall46
   suffix: 46
-  components:
-  - type: Sprite
-    state: "46"
-  - type: Icon
-    state: "46"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall47]
   id: CMNormandyWall47
   suffix: 47
-  components:
-  - type: Sprite
-    state: "47"
-  - type: Icon
-    state: "47"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall48]
   id: CMNormandyWall48
   suffix: 48
-  components:
-  - type: Sprite
-    state: "48"
-  - type: Icon
-    state: "48"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall49]
   id: CMNormandyWall49
   suffix: 49
-  components:
-  - type: Sprite
-    state: "49"
-  - type: Icon
-    state: "49"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall50]
   id: CMNormandyWall50
   suffix: 50
-  components:
-  - type: Sprite
-    state: "50"
-  - type: Icon
-    state: "50"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall51]
   id: CMNormandyWall51
   suffix: 51
-  components:
-  - type: Sprite
-    state: "51"
-  - type: Icon
-    state: "51"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall52]
   id: CMNormandyWall52
   suffix: 52
-  components:
-  - type: Sprite
-    state: "52"
-  - type: Icon
-    state: "52"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall53]
   id: CMNormandyWall53
   suffix: 53
-  components:
-  - type: Sprite
-    state: "53"
-  - type: Icon
-    state: "53"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall54]
   id: CMNormandyWall54
   suffix: 54
-  components:
-  - type: Sprite
-    state: "54"
-  - type: Icon
-    state: "54"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall55]
   id: CMNormandyWall55
   suffix: 55
-  components:
-  - type: Sprite
-    state: "55"
-  - type: Icon
-    state: "55"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall56]
   id: CMNormandyWall56
   suffix: 56
-  components:
-  - type: Sprite
-    state: "56"
-  - type: Icon
-    state: "56"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall57]
   id: CMNormandyWall57
   suffix: 57
-  components:
-  - type: Sprite
-    state: "57"
-  - type: Icon
-    state: "57"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall58]
   id: CMNormandyWall58
   suffix: 58
-  components:
-  - type: Sprite
-    state: "58"
-  - type: Icon
-    state: "58"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall59]
   id: CMNormandyWall59
   suffix: 59
-  components:
-  - type: Sprite
-    state: "59"
-  - type: Icon
-    state: "59"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall60]
   id: CMNormandyWall60
   suffix: 60
-  components:
-  - type: Sprite
-    state: "60"
-  - type: Icon
-    state: "60"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall61]
   id: CMNormandyWall61
   suffix: 61
-  components:
-  - type: Sprite
-    state: "61"
-  - type: Icon
-    state: "61"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall62]
   id: CMNormandyWall62
   suffix: 62
-  components:
-  - type: Sprite
-    state: "62"
-  - type: Icon
-    state: "62"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall63]
   id: CMNormandyWall63
   suffix: 63
-  components:
-  - type: Sprite
-    state: "63"
-  - type: Icon
-    state: "63"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall64]
   id: CMNormandyWall64
   suffix: 64
-  components:
-  - type: Sprite
-    state: "64"
-  - type: Icon
-    state: "64"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall65]
   id: CMNormandyWall65
   suffix: 65
-  components:
-  - type: Sprite
-    state: "65"
-  - type: Icon
-    state: "65"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall66]
   id: CMNormandyWall66
   suffix: 66
-  components:
-  - type: Sprite
-    state: "66"
-  - type: Icon
-    state: "66"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall67]
   id: CMNormandyWall67
   suffix: 67
-  components:
-  - type: Sprite
-    state: "67"
-  - type: Icon
-    state: "67"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall68]
   id: CMNormandyWall68
   suffix: 68
-  components:
-  - type: Sprite
-    state: "68"
-  - type: Icon
-    state: "68"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall69]
   id: CMNormandyWall69
   suffix: 69
-  components:
-  - type: Sprite
-    state: "69"
-  - type: Icon
-    state: "69"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall70]
   id: CMNormandyWall70
   suffix: 70
-  components:
-  - type: Sprite
-    state: "70"
-  - type: Icon
-    state: "70"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall71]
   id: CMNormandyWall71
   suffix: 71
-  components:
-  - type: Sprite
-    state: "71"
-  - type: Icon
-    state: "71"
-  - type: Occluder
-    enabled: false
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall72]
   id: CMNormandyWall72
   suffix: 72
-  components:
-  - type: Sprite
-    state: "72"
-  - type: Icon
-    state: "72"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall73]
   id: CMNormandyWall73
   suffix: 73
-  components:
-  - type: Sprite
-    state: "73"
-  - type: Icon
-    state: "73"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall74]
   id: CMNormandyWall74
   suffix: 74
-  components:
-  - type: Sprite
-    state: "74"
-  - type: Icon
-    state: "74"
-  - type: Occluder
-    enabled: false
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall75]
   id: CMNormandyWall75
   suffix: 75
-  components:
-  - type: Sprite
-    state: "75"
-  - type: Icon
-    state: "75"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall76]
   id: CMNormandyWall76
   suffix: 76
-  components:
-  - type: Sprite
-    state: "76"
-  - type: Icon
-    state: "76"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall77]
   id: CMNormandyWall77
   suffix: 77
-  components:
-  - type: Sprite
-    state: "77"
-  - type: Icon
-    state: "77"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall78]
   id: CMNormandyWall78
   suffix: 78
-  components:
-  - type: Sprite
-    state: "78"
-  - type: Icon
-    state: "78"
-  - type: Occluder
-    enabled: false
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall79]
   id: CMNormandyWall79
   suffix: 79
-  components:
-  - type: Sprite
-    state: "79"
-  - type: Icon
-    state: "79"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall80]
   id: CMNormandyWall80
   suffix: 80
-  components:
-  - type: Sprite
-    state: "80"
-  - type: Icon
-    state: "80"
-  - type: Occluder
-    enabled: false
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall81]
   id: CMNormandyWall81
   suffix: 81
-  components:
-  - type: Sprite
-    state: "81"
-  - type: Icon
-    state: "81"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall82]
   id: CMNormandyWall82
   suffix: 82
-  components:
-  - type: Sprite
-    state: "82"
-  - type: Icon
-    state: "82"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall83]
   id: CMNormandyWall83
   suffix: 83
-  components:
-  - type: Sprite
-    state: "83"
-  - type: Icon
-    state: "83"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall84]
   id: CMNormandyWall84
   suffix: 84
-  components:
-  - type: Sprite
-    state: "84"
-  - type: Icon
-    state: "84"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall85]
   id: CMNormandyWall85
   suffix: 85
-  components:
-  - type: Sprite
-    state: "85"
-  - type: Icon
-    state: "85"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall86]
   id: CMNormandyWall86
   suffix: 86
-  components:
-  - type: Sprite
-    state: "86"
-  - type: Icon
-    state: "86"
-  - type: Occluder
-    enabled: false
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall87]
   id: CMNormandyWall87
   suffix: 87
-  components:
-  - type: Sprite
-    state: "87"
-  - type: Icon
-    state: "87"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall88]
   id: CMNormandyWall88
   suffix: 88
-  components:
-  - type: Sprite
-    state: "88"
-  - type: Icon
-    state: "88"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall89]
   id: CMNormandyWall89
   suffix: 89
-  components:
-  - type: Sprite
-    state: "89"
-  - type: Icon
-    state: "89"
-  - type: Occluder
-    enabled: false
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall90]
   id: CMNormandyWall90
   suffix: 90
-  components:
-  - type: Sprite
-    state: "90"
-  - type: Icon
-    state: "90"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall91]
   id: CMNormandyWall91
   suffix: 91
-  components:
-  - type: Sprite
-    state: "91"
-  - type: Icon
-    state: "91"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall92]
   id: CMNormandyWall92
   suffix: 92
-  components:
-  - type: Sprite
-    state: "92"
-  - type: Icon
-    state: "92"
-  - type: Occluder
-    enabled: false
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall93]
   id: CMNormandyWall93
   suffix: 93
-  components:
-  - type: Sprite
-    state: "93"
-  - type: Icon
-    state: "93"
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall94]
   id: CMNormandyWall94
   suffix: 94
-  components:
-  - type: Sprite
-    state: "94"
-  - type: Icon
-    state: "94"
-  - type: Occluder
-    enabled: false
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall95]
   id: CMNormandyWall95
   suffix: 95
-  components:
-  - type: Sprite
-    state: "95"
-  - type: Icon
-    state: "95"
-  - type: Occluder
-    enabled: false
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall96]
   id: CMNormandyWall96
   suffix: 96
-  components:
-  - type: Sprite
-    state: "96"
-  - type: Icon
-    state: "96"
-  - type: Occluder
-    enabled: false
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall97]
   id: CMNormandyWall97
   suffix: 97
-  components:
-  - type: Sprite
-    state: "97"
-  - type: Icon
-    state: "97"
-  - type: Occluder
-    enabled: false
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall98]
   id: CMNormandyWall98
   suffix: 98
-  components:
-  - type: Sprite
-    state: "98"
-  - type: Icon
-    state: "98"
-  - type: Occluder
-    enabled: false
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall99]
   id: CMNormandyWall99
   suffix: 99
-  components:
-  - type: Sprite
-    state: "99"
-  - type: Icon
-    state: "99"
-  - type: Occluder
-    enabled: false
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall100]
   id: CMNormandyWall100
   suffix: 100
-  components:
-  - type: Sprite
-    state: "100"
-  - type: Icon
-    state: "100"
-  - type: Occluder
-    enabled: false
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall101]
   id: CMNormandyWall101
   suffix: 101
-  components:
-  - type: Sprite
-    state: "101"
-  - type: Icon
-    state: "101"
-  - type: Occluder
-    enabled: false
 
 - type: entity
-  parent: CMBaseNormandyWall
+  parent: [CMBaseNormandyWall, CMAlamoWall102]
   id: CMNormandyWall102
   suffix: 102
-  components:
-  - type: Sprite
-    state: "102"
-  - type: Icon
-    state: "102"
-  - type: Occluder
-    enabled: false


### PR DESCRIPTION
## About the PR
Fixes https://github.com/RMC-14/RMC-14/issues/2513

## Media
![image](https://github.com/RMC-14/RMC-14/assets/10968691/7fbd9afb-9bfd-4262-a78d-a2146bfd22c6)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed some dropship tiles not being see-through. This includes the engines on the sides, and the winglets next to the side and bottom crew hatches.