### PR TITLE
Fix nested marines getting moved into walls, weed errors, reweeding unweeded walls

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestSurfaceComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestSurfaceComponent.cs
@@ -1,4 +1,5 @@
-﻿using Robust.Shared.GameStates;
+﻿using Content.Shared._RMC14.Xenonids.Weeds;
+using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 
 namespace Content.Shared._RMC14.Xenonids.Construction.Nest;
@@ -15,4 +16,8 @@ public sealed partial class XenoNestSurfaceComponent : Component
 
     [DataField, AutoNetworkedField]
     public Dictionary<Direction, EntityUid> Nests = new();
+
+    [DataField, AutoNetworkedField]
+    [Access(typeof(XenoNestSystem), typeof(SharedXenoWeedsSystem))]
+    public EntityUid? Weedable;
 }

--- a/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestSystem.cs
@@ -1,4 +1,5 @@
 ﻿using System.Numerics;
+using Content.Shared._RMC14.Xenonids.Weeds;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Coordinates;
 using Content.Shared.DoAfter;
@@ -37,18 +38,22 @@ public sealed class XenoNestSystem : EntitySystem
 
     private readonly List<Direction> _candidateNests = new();
 
+    private EntityQuery<XenoWeedableComponent> _xenoWeedable;
+
     public override void Initialize()
     {
         base.Initialize();
 
+        _xenoWeedable = GetEntityQuery<XenoWeedableComponent>();
+
         SubscribeLocalEvent<XenoComponent, GetUsedEntityEvent>(OnXenoGetUsedEntity);
 
-        // TODO RMC14 make nests part of the wall entity so drag and drop can work
-        SubscribeLocalEvent<XenoNestSurfaceComponent, InteractHandEvent>(OnNestInteractHand);
-        SubscribeLocalEvent<XenoNestSurfaceComponent, DoAfterAttemptEvent<XenoNestDoAfterEvent>>(OnNestSurfaceDoAfterAttempt);
+        SubscribeLocalEvent<XenoNestSurfaceComponent, InteractHandEvent>(OnSurfaceInteractHand);
+        SubscribeLocalEvent<XenoNestSurfaceComponent, DoAfterAttemptEvent<XenoNestDoAfterEvent>>(OnSurfaceDoAfterAttempt);
         SubscribeLocalEvent<XenoNestSurfaceComponent, XenoNestDoAfterEvent>(OnNestSurfaceDoAfter);
-        SubscribeLocalEvent<XenoNestSurfaceComponent, CanDropTargetEvent>(OnCanDropTarget);
-        SubscribeLocalEvent<XenoNestSurfaceComponent, DragDropTargetEvent>(OnDragDropTarget);
+        SubscribeLocalEvent<XenoNestSurfaceComponent, CanDropTargetEvent>(OnSurfaceCanDropTarget);
+        SubscribeLocalEvent<XenoNestSurfaceComponent, DragDropTargetEvent>(OnSurfaceDragDropTarget);
+        SubscribeLocalEvent<XenoNestSurfaceComponent, EntityTerminatingEvent>(OnSurfaceTerminating);
 
         SubscribeLocalEvent<XenoNestComponent, ComponentRemove>(OnNestRemove);
         SubscribeLocalEvent<XenoNestComponent, EntityTerminatingEvent>(OnNestTerminating);
@@ -83,7 +88,7 @@ public sealed class XenoNestSystem : EntitySystem
         args.Used = pulling;
     }
 
-    private void OnNestInteractHand(Entity<XenoNestSurfaceComponent> ent, ref InteractHandEvent args)
+    private void OnSurfaceInteractHand(Entity<XenoNestSurfaceComponent> ent, ref InteractHandEvent args)
     {
         if (CompOrNull<PullerComponent>(args.User)?.Pulling is not { } pulling)
             return;
@@ -121,7 +126,7 @@ public sealed class XenoNestSystem : EntitySystem
             _standing.Down(ent);
     }
 
-    private void OnNestSurfaceDoAfterAttempt(Entity<XenoNestSurfaceComponent> ent, ref DoAfterAttemptEvent<XenoNestDoAfterEvent> args)
+    private void OnSurfaceDoAfterAttempt(Entity<XenoNestSurfaceComponent> ent, ref DoAfterAttemptEvent<XenoNestDoAfterEvent> args)
     {
         if (args.DoAfter.Args.Target is not { } target ||
             TerminatingOrDeleted(target) ||
@@ -204,7 +209,7 @@ public sealed class XenoNestSystem : EntitySystem
 
     #region DragDrop
 
-    private void OnCanDropTarget(Entity<XenoNestSurfaceComponent> ent, ref CanDropTargetEvent args)
+    private void OnSurfaceCanDropTarget(Entity<XenoNestSurfaceComponent> ent, ref CanDropTargetEvent args)
     {
         if (args.Handled)
             return;
@@ -213,10 +218,21 @@ public sealed class XenoNestSystem : EntitySystem
         args.Handled = true;
     }
 
-    private void OnDragDropTarget(Entity<XenoNestSurfaceComponent> ent, ref DragDropTargetEvent args)
+    private void OnSurfaceDragDropTarget(Entity<XenoNestSurfaceComponent> ent, ref DragDropTargetEvent args)
     {
         args.Handled = true;
         TryStartNesting(args.User, ent, args.Dragged);
+    }
+
+    private void OnSurfaceTerminating(Entity<XenoNestSurfaceComponent> ent, ref EntityTerminatingEvent args)
+    {
+        if (!TerminatingOrDeleted(ent.Comp.Weedable) &&
+            _xenoWeedable.TryComp(ent.Comp.Weedable, out var weedable) &&
+            weedable.Entity == ent)
+        {
+            weedable.Entity = null;
+            Dirty(ent.Comp.Weedable.Value, weedable);
+        }
     }
 
     #endregion

--- a/Content.Shared/_RMC14/Xenonids/Weeds/XenoWeedableComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Weeds/XenoWeedableComponent.cs
@@ -1,4 +1,5 @@
-﻿using Robust.Shared.GameStates;
+﻿using Content.Shared._RMC14.Xenonids.Construction.Nest;
+using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 
 namespace Content.Shared._RMC14.Xenonids.Weeds;
@@ -11,5 +12,6 @@ public sealed partial class XenoWeedableComponent : Component
     public EntProtoId Spawn;
 
     [DataField, AutoNetworkedField]
+    [Access(typeof(SharedXenoWeedsSystem), typeof(XenoNestSystem))]
     public EntityUid? Entity;
 }

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_nest.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_nest.yml
@@ -7,8 +7,6 @@
     snap:
     - Wall
   components:
-  - type: Transform
-    anchored: true
   - type: Physics
     bodyType: Static
   - type: Sprite


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed nested marines getting knocked back into walls by grenade explosions.