### PR TITLE
Increase default projectile speed from 41 to 51

### DIFF
--- a/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
@@ -187,7 +187,7 @@ public sealed partial class GunComponent : Component
     /// The base value for how fast the projectile moves.
     /// </summary>
     [DataField]
-    public float ProjectileSpeed = 41f;
+    public float ProjectileSpeed = 51f;
 
     /// <summary>
     /// How fast the projectile moves.


### PR DESCRIPTION
## About the PR
Should be good now with https://github.com/RMC-14/RMC-14/pull/2889
This does mean any further projectile speed increases )extended barrel for example) don't work until we increase physics.maxlinvelocity, but the default was slightly lower than 13's.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Default projectile speed has been increased by 24%