### PR TITLE
Leave the xeno choose resin structure menu open after selection

### DIFF
--- a/Content.Client/_RMC14/Xenonids/Construction/XenoChooseStructureBui.cs
+++ b/Content.Client/_RMC14/Xenonids/Construction/XenoChooseStructureBui.cs
@@ -48,11 +48,7 @@ public sealed class XenoChooseStructureBui : BoundUserInterface
                     name += $" ({cost} plasma)";
 
                 control.Set(name, _sprite.Frame0(structure));
-                control.Button.OnPressed += _ =>
-                {
-                    SendPredictedMessage(new XenoChooseStructureBuiMsg(structureId));
-                    Refresh();
-                };
+                control.Button.OnPressed += _ => SendPredictedMessage(new XenoChooseStructureBuiMsg(structureId));
 
                 _window.StructureContainer.AddChild(control);
                 _buttons.Add(structureId, control);

--- a/Content.Client/_RMC14/Xenonids/Construction/XenoChooseStructureBui.cs
+++ b/Content.Client/_RMC14/Xenonids/Construction/XenoChooseStructureBui.cs
@@ -2,6 +2,7 @@
 using Content.Shared._RMC14.Xenonids.Construction;
 using JetBrains.Annotations;
 using Robust.Client.GameObjects;
+using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Prototypes;
 
 namespace Content.Client._RMC14.Xenonids.Construction;
@@ -13,6 +14,8 @@ public sealed class XenoChooseStructureBui : BoundUserInterface
 
     private readonly SpriteSystem _sprite;
     private readonly SharedXenoConstructionSystem _xenoConstruction;
+
+    private readonly Dictionary<EntProtoId, XenoChoiceControl> _buttons = new();
 
     [ViewVariables]
     private XenoChooseStructureWindow? _window;
@@ -28,6 +31,8 @@ public sealed class XenoChooseStructureBui : BoundUserInterface
         _window = new XenoChooseStructureWindow();
         _window.OnClose += Close;
 
+        _buttons.Clear();
+        var group = new ButtonGroup();
         if (EntMan.TryGetComponent(Owner, out XenoConstructionComponent? xeno))
         {
             foreach (var structureId in xeno.CanBuild)
@@ -36,17 +41,25 @@ public sealed class XenoChooseStructureBui : BoundUserInterface
                     continue;
 
                 var control = new XenoChoiceControl();
+                control.Button.Group = group;
+
                 var name = structure.Name;
                 if (_xenoConstruction.GetStructurePlasmaCost(structureId) is { } cost)
                     name += $" ({cost} plasma)";
 
                 control.Set(name, _sprite.Frame0(structure));
-                control.Button.OnPressed += _ => SendPredictedMessage(new XenoChooseStructureBuiMsg(structureId));
+                control.Button.OnPressed += _ =>
+                {
+                    SendPredictedMessage(new XenoChooseStructureBuiMsg(structureId));
+                    Refresh();
+                };
 
                 _window.StructureContainer.AddChild(control);
+                _buttons.Add(structureId, control);
             }
         }
 
+        Refresh();
         _window.OpenCentered();
     }
 
@@ -54,5 +67,16 @@ public sealed class XenoChooseStructureBui : BoundUserInterface
     {
         if (disposing)
             _window?.Dispose();
+    }
+
+    public void Refresh()
+    {
+        if (EntMan.GetComponentOrNull<XenoConstructionComponent>(Owner)?.BuildChoice is not { } choice ||
+            !_buttons.TryGetValue(choice, out var button))
+        {
+            return;
+        }
+
+        button.Button.Pressed = true;
     }
 }

--- a/Content.Client/_RMC14/Xenonids/Construction/XenoChooseStructureSystem.cs
+++ b/Content.Client/_RMC14/Xenonids/Construction/XenoChooseStructureSystem.cs
@@ -1,0 +1,29 @@
+﻿using Content.Shared._RMC14.Xenonids.Construction;
+using Robust.Shared.Timing;
+
+namespace Content.Client._RMC14.Xenonids.Construction;
+
+public sealed class XenoChooseStructureSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<XenoConstructionComponent, AfterAutoHandleStateEvent>(OnXenoConstructionAfterState);
+    }
+
+    private void OnXenoConstructionAfterState(Entity<XenoConstructionComponent> ent, ref AfterAutoHandleStateEvent args)
+    {
+        if (!_timing.IsFirstTimePredicted)
+            return;
+
+        if (!TryComp(ent, out UserInterfaceComponent? ui))
+            return;
+
+        foreach (var bui in ui.ClientOpenInterfaces.Values)
+        {
+            if (bui is XenoChooseStructureBui chooseUi)
+                chooseUi.Refresh();
+        }
+    }
+}

--- a/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
@@ -144,8 +144,6 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
         xeno.Comp.BuildChoice = args.StructureId;
         Dirty(xeno);
 
-        _ui.CloseUi(xeno.Owner, XenoChooseStructureUI.Key, xeno);
-
         var ev = new XenoConstructionChosenEvent(args.StructureId);
         foreach (var (id, _) in _actions.GetActions(xeno))
         {

--- a/Content.Shared/_RMC14/Xenonids/Construction/XenoConstructionComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/XenoConstructionComponent.cs
@@ -5,7 +5,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Shared._RMC14.Xenonids.Construction;
 
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true)]
 [Access(typeof(SharedXenoConstructionSystem))]
 public sealed partial class XenoConstructionComponent : Component
 {


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: The xenonid "Choose Resin Structure" window now stays open after making a selection, allowing it to be changed back and forth without reopening the window.