### PR TITLE
Almayer fixes, 1 more SO, one more cargo tech, unpower intercoms for now

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Doors/Airlocks/accesses-almayer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Doors/Airlocks/accesses-almayer.yml
@@ -5,7 +5,7 @@
   suffix: Requisitions, Locked
   components:
   - type: AccessReader
-    access: [["CMAccessRequisitions"]]
+    access: [ [ "CMAccessRequisitions" ] ]
   - type: PaintableAirlock
     department: CMRequisitions
 
@@ -15,7 +15,7 @@
   suffix: Requisitions, Locked, Glass
   components:
   - type: AccessReader
-    access: [["CMAccessRequisitions"]]
+    access: [ [ "CMAccessRequisitions" ] ]
 
 - type: entity
   parent: CMAirlockMaint
@@ -23,7 +23,7 @@
   suffix: Requisitions, Locked, Maint
   components:
   - type: AccessReader
-    access: [["CMAccessRequisitions"]]
+    access: [ [ "CMAccessRequisitions" ] ]
   - type: PaintableAirlock
     department: CMRequisitions
 
@@ -33,7 +33,7 @@
   suffix: Kitchen, Locked
   components:
   - type: AccessReader
-    access: [["CMAccessKitchen"]]
+    access: [ [ "CMAccessKitchen" ] ]
   - type: PaintableAirlock
     department: CMRequisitions
 
@@ -43,7 +43,7 @@
   suffix: Kitchen, Locked, Glass
   components:
   - type: AccessReader
-    access: [["CMAccessKitchen"]]
+    access: [ [ "CMAccessKitchen" ] ]
   - type: PaintableAirlock
     department: CMRequisitions
 
@@ -53,7 +53,7 @@
   suffix: Kitchen, Locked, Maint
   components:
   - type: AccessReader
-    access: [["CMAccessKitchen"]]
+    access: [ [ "CMAccessKitchen" ] ]
   - type: PaintableAirlock
     department: CMRequisitions
 
@@ -64,7 +64,7 @@
   suffix: Engineering, Locked
   components:
   - type: AccessReader
-    access: [["CMAccessEngineering"]]
+    access: [ [ "CMAccessEngineering" ] ]
 
 - type: entity
   parent: CMAirlockGlassEngineer
@@ -72,7 +72,7 @@
   suffix: Engineering, Locked, Glass
   components:
   - type: AccessReader
-    access: [["CMAccessEngineering"]]
+    access: [ [ "CMAccessEngineering" ] ]
 
 - type: entity
   parent: CMAirlockMaint
@@ -80,7 +80,7 @@
   suffix: Engineering, Locked, Maint
   components:
   - type: AccessReader
-    access: [["CMAccessEngineering"]]
+    access: [ [ "CMAccessEngineering" ] ]
   - type: PaintableAirlock
     department: CMEngineering
 
@@ -90,7 +90,7 @@
   suffix: Ordnance, Locked
   components:
   - type: AccessReader
-    access: [["CMAccessOT"]]
+    access: [ [ "CMAccessOT" ] ]
 
 # Medical
 - type: entity
@@ -99,7 +99,7 @@
   suffix: Medical, Locked
   components:
   - type: AccessReader
-    access: [["CMAccessMedical"]]
+    access: [ [ "CMAccessMedical" ] ]
 
 - type: entity
   parent: CMAirlockGlassMedical
@@ -107,7 +107,7 @@
   suffix: Medical, Locked, Glass
   components:
   - type: AccessReader
-    access: [["CMAccessMedical"]]
+    access: [ [ "CMAccessMedical" ] ]
 
 - type: entity
   parent: CMAirlockMaint
@@ -115,7 +115,7 @@
   suffix: Medical, Locked, Maint
   components:
   - type: AccessReader
-    access: [["CMAccessMedical"]]
+    access: [ [ "CMAccessMedical" ] ]
   - type: PaintableAirlock
     department: CMMedbay
 
@@ -125,7 +125,7 @@
   suffix: Chemistry, Locked
   components:
   - type: AccessReader
-    access: [["CMAccessChemistry"]]
+    access: [ [ "CMAccessChemistry" ] ]
 
 - type: entity
   parent: CMAirlockMedical
@@ -133,7 +133,7 @@
   suffix: Research, Locked
   components:
   - type: AccessReader
-    access: [["CMAccessResearch"]]
+    access: [ [ "CMAccessResearch" ] ]
 
 # Correspondent
 - type: entity
@@ -142,7 +142,7 @@
   suffix: Press, Locked
   components:
   - type: AccessReader
-    access: [["CMAccessPress"]]
+    access: [ [ "CMAccessPress" ] ]
   - type: PaintableAirlock
     department: CMOther
 
@@ -152,7 +152,7 @@
   suffix: Press, Locked, Glass
   components:
   - type: AccessReader
-    access: [["CMAccessPress"]]
+    access: [ [ "CMAccessPress" ] ]
   - type: PaintableAirlock
     department: CMOther
 
@@ -162,6 +162,46 @@
   suffix: Press, Locked, Maint
   components:
   - type: AccessReader
-    access: [["CMAccessPress"]]
+    access: [ [ "CMAccessPress" ] ]
   - type: PaintableAirlock
     department: CMOther
+
+- type: entity
+  parent: CMAirlockSecurity
+  id: CMAirlockSecurityLocked
+  suffix: Security, Locked
+  components:
+  - type: AccessReader
+    access: [ [ "CMAccessBrig" ], [ "CMAccessCommand" ] ]
+
+- type: entity
+  parent: CMAirlockGlassSecurity
+  id: CMAirlockGlassSecurityLocked
+  suffix: Security, Locked
+  components:
+  - type: AccessReader
+    access: [ [ "CMAccessBrig" ], [ "CMAccessCommand" ] ]
+
+- type: entity
+  parent: CMDoubleDoorSecurityGlass
+  id: CMDoubleDoorSecurityGlassLocked
+  suffix: Security, Glass, Locked
+  components:
+  - type: AccessReader
+    access: [ [ "CMAccessBrig" ], [ "CMAccessCommand" ] ]
+
+- type: entity
+  parent: CMDoubleDoorSecuritySolid
+  id: CMDoubleDoorSecuritySolidLocked
+  suffix: Security, Solid, Locked
+  components:
+  - type: AccessReader
+    access: [ [ "CMAccessBrig" ], [ "CMAccessCommand" ] ]
+
+- type: entity
+  parent: CMDoubleDoorMedicalGlass
+  id: CMDoubleDoorMedicalGlassLocked
+  suffix: Medical, Glass
+  components:
+  - type: AccessReader
+    access: [ [ "CMAccessMedical" ], [ "CMAccessCommand" ] ]

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Doors/Windoors/accesses.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Doors/Windoors/accesses.yml
@@ -5,7 +5,7 @@
   suffix: Kitchen, Locked
   components:
   - type: AccessReader
-    access: [["CMAccessKitchen"]]
+    access: [ [ "CMAccessKitchen" ] ]
 
 # Secure
 - type: entity
@@ -14,7 +14,7 @@
   suffix: Brig, Locked
   components:
   - type: AccessReader
-    access: [["CMAccessBrig"]]
+    access: [ [ "CMAccessBrig" ] ]
 
 - type: entity
   parent: CMWindoorSecure
@@ -22,7 +22,7 @@
   suffix: Requisitions, Locked
   components:
   - type: AccessReader
-    access: [["CMAccessRequisitions"]]
+    access: [ [ "CMAccessRequisitions" ] ]
 
 - type: entity
   parent: CMWindoorSecure
@@ -30,7 +30,7 @@
   suffix: Medical, Locked
   components:
   - type: AccessReader
-    access: [["CMAccessMedical"]]
+    access: [ [ "CMAccessMedical" ] ]
 
 - type: entity
   parent: CMWindoorSecure
@@ -38,4 +38,12 @@
   suffix: Engineering, Locked
   components:
   - type: AccessReader
-    access: [["CMAccessEngineering"]]
+    access: [ [ "CMAccessEngineering" ] ]
+
+- type: entity
+  parent: CMWindoorSecure
+  id: CMWindoorSecureCommand
+  suffix: Command, Locked
+  components:
+  - type: AccessReader
+    access: [ [ "CMAccessCommand" ] ]

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Wallmounts/intercom.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Wallmounts/intercom.yml
@@ -7,8 +7,8 @@
   components:
   - type: WallMount
   - type: ApcPowerReceiver
-    powerLoad: 0 # TODO RMC14 power
-    needsPower: false
+    powerLoad: 100 # TODO RMC14 power
+    needsPower: true
   - type: Electrified
     enabled: false
     usesApcPower: true

--- a/Resources/Prototypes/_RMC14/Maps/almayer.yml
+++ b/Resources/Prototypes/_RMC14/Maps/almayer.yml
@@ -16,7 +16,7 @@
           #Command
           CMCommandingOfficer: [1, 1]
           CMExecutiveOfficer: [1, 1]
-          CMStaffOfficer: [1, 1]
+          CMStaffOfficer: [2, 2]
           CMSeniorEnlistedAdvisor: [2, 2]
 
           #Military Police
@@ -44,7 +44,7 @@
 
           #Requisition
           CMQuartermaster: [1, 1]
-          CMCargoTech: [3, 3]
+          CMCargoTech: [4, 4]
 #          CMMessTech: [1, 1]
 
           #Marines


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed anyone being able to walk through the Almayer's medbay, and hospital corpsmen being able to walk into the medbay's chemistry rooms. The marine tide must now walk through the top or bottom hallways towards the hangar.
- fix: Fixed security airlocks not being security locked on the Almayer.
- fix: Temporarily unpowered all Intercoms until the xenonids are no longer able to speak in plain English through them.
- add: Added the Almayer's north and south hangar pod doors, and meeting room security checkpoints shutters.
- add: Added medical equipment racks and chemical dispensers to the Almayer's medbay.
- add: Added a command tablet next to the groundside operations console on the Almayer.
- tweak: Moved the liaison's spawn point on the Almayer into a temporary room with a fax and paper.
- tweak: Moved the correspondent's spawn point on the Almayer into a temporary room with two cameras.
- tweak: Added one more staff officer slot on the Almayer, and one more cargo tech slot.
