### PR TITLE
fix m1984 regular mags accepting 9mm AP

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/pistol.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/pistol.yml
@@ -26,7 +26,7 @@
   - type: Tag
     tags:
     - Cartridge
-    - CMCartridgePistol9mm
+    - CMCartridgePistol9mmAP
   - type: CartridgeAmmo
     proto: CMBulletPistolM77AP
 

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Magazines/pistol.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Magazines/pistol.yml
@@ -47,7 +47,7 @@
     mayTransfer: True
     whitelist:
       tags:
-      - CMCartridgePistol9mm
+      - CMCartridgePistol9mmAP
     proto: CMCartridgePistolM77AP
     capacity: 19
   - type: Sprite

--- a/Resources/Prototypes/_RMC14/tags.yml
+++ b/Resources/Prototypes/_RMC14/tags.yml
@@ -5,6 +5,9 @@
   id: CMCartridgePistol9mm
 
 - type: Tag
+  id: CMCartridgePistol9mmAP
+
+- type: Tag
   id: CMCartridgeRevolver44
 
 - type: Tag


### PR DESCRIPTION

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
1984

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


:cl: Whisper

- fix: Fixed M1984 accepting 9mm AP in regular mags.

