### PR TITLE
Disables the magnetic harness

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
@@ -371,8 +371,8 @@
       entries:
       - id: RMCAttachmentB8SmartScope
         amount: 4
-      - id: RMCAttachmentMagneticHarness
-        amount: 9
+      #- id: RMCAttachmentMagneticHarness
+      #  amount: 9
       - id: RMCAttachmentRailFlashlight
         amount: 11
       - id: RMCAttachmentS42xTelescopicMiniscope

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/prep.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/prep.yml
@@ -424,8 +424,8 @@
       entries:
       - id: RMCAttachmentB8SmartScope
         amount: 2
-      - id: RMCAttachmentMagneticHarness
-        amount: 5
+      #- id: RMCAttachmentMagneticHarness
+      #  amount: 5
       - id: RMCAttachmentS42xTelescopicMiniscope
         amount: 2
 #      - id: RMCAttachmentS5RedDotSight # UNCOMMENT THIS WHEN ACCURACY IS IMPLEMENTED


### PR DESCRIPTION
## About the PR
Removes the magharn from vendors, as it's horribly bugged right now.

## Why / Balance
Currently, when you try to wield a weapon with a magharn attached, it equips to your suit storage and gives the wield virtual item to your main hand.
I can't figure out what's causing this and it's late, so it's probably best we disable the thing. I'll fix it in the next big attachments PR. I'm not happy with the implementation I came up with for it anyway.

I'm fairly confident this broke at some point *after* I implemented it, but before I actually made the previous attachments PR. I'll dig through the commits and figure out what broke it once I get started on the next PR.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- remove: Magnetic harness temporarily removed from vendors due to being horribly bugged.
