### PR TITLE
Fix figurines not fitting into helmets

### DIFF
--- a/Content.Shared/_RMC14/Figurines/FigurineComponent.cs
+++ b/Content.Shared/_RMC14/Figurines/FigurineComponent.cs
@@ -1,0 +1,6 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Figurines;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class FigurineComponent : Component;

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Head/Helmets/marine_helmets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Head/Helmets/marine_helmets.yml
@@ -40,6 +40,7 @@
       - RMCLighter
       - RMCFlask
       - CMScalpel
+      - PatronFigurine
       tags:
 #      - TODO RMC14 matchbox
       - Cigarette

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Head/Helmets/marine_helmets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Head/Helmets/marine_helmets.yml
@@ -40,7 +40,7 @@
       - RMCLighter
       - RMCFlask
       - CMScalpel
-      - PatronFigurine
+      - Figurine
       tags:
 #      - TODO RMC14 matchbox
       - Cigarette

--- a/Resources/Prototypes/_RMC14/Entities/Objects/patron_figurines.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/patron_figurines.yml
@@ -7,6 +7,7 @@
   - type: Sprite
     sprite: _RMC14/Objects/patron_figurines.rsi
     scale: 0.5, 0.5
+  - type: Figurine
 
 - type: entity
   parent: MarkerBase


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed Patron figurines not being able to fit into helmets.