### PR TITLE
Fix defib using wrong audio, audio spam, only one defib at a time

### DIFF
--- a/Content.Shared/Medical/DefibrillatorComponent.cs
+++ b/Content.Shared/Medical/DefibrillatorComponent.cs
@@ -86,6 +86,9 @@ public sealed partial class DefibrillatorComponent : Component
 
     [ViewVariables(VVAccess.ReadWrite), DataField("readySound")]
     public SoundSpecifier? ReadySound = new SoundPathSpecifier("/Audio/Items/Defib/defib_ready.ogg");
+
+    [DataField]
+    public EntityUid? ChargeSoundEntity;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/_RMC14/Medical/Defibrillator/RMCDefibrillatorAudioComponent.cs
+++ b/Content.Shared/_RMC14/Medical/Defibrillator/RMCDefibrillatorAudioComponent.cs
@@ -1,0 +1,11 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Medical.Defibrillator;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(CMDefibrillatorSystem))]
+public sealed partial class RMCDefibrillatorAudioComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public EntityUid? Defibrillator;
+}

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/defib.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/defib.yml
@@ -33,15 +33,10 @@
       speechVerb: Robotic
     - type: ItemToggle
       soundActivate:
-        path: /Audio/_RMC14/Medical/defib_SafetyOn.ogg
+        path: /Audio/Items/Defib/defib_safety_on.ogg
       soundDeactivate:
-        path: /Audio/_RMC14/Medical/defib_safetyOff.ogg
+        path: /Audio/Items/Defib/defib_safety_off.ogg
     - type: Defibrillator
-      zapSound: /Audio/_RMC14/Medical/defib_release.ogg
-      chargeSound: /Audio/_RMC14/Medical/defib_charge.ogg
-      failureSound: /Audio/_RMC14/Medical/defib_failed.ogg
-      successSound: /Audio/_RMC14/Medical/defib_success.ogg
-      readySound: /Audio/_RMC14/Medical/defib_ready.ogg
       zapHeal:
         types:
           Asphyxiation: -40

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Medical/defib.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Medical/defib.yml
@@ -24,6 +24,11 @@
     sprite: Objects/Specific/Medical/defib.rsi
   - type: Speech
     speechVerb: Robotic
+  - type: ItemToggle
+    soundActivate:
+      path: /Audio/_RMC14/Medical/defib_SafetyOn.ogg
+    soundDeactivate:
+      path: /Audio/_RMC14/Medical/defib_safetyOff.ogg
   - type: Defibrillator
     doAfterDuration: 6.25
     allowDoAfterMovement: false
@@ -35,6 +40,26 @@
     zapHeal:
       types:
         Asphyxiation: -200
+    zapSound:
+      path: /Audio/_RMC14/Medical/defib_release.ogg
+      params:
+        volume: -6
+    chargeSound:
+      path: /Audio/_RMC14/Medical/defib_charge.ogg
+      params:
+        volume: -8
+    failureSound:
+      path: /Audio/_RMC14/Medical/defib_failed.ogg
+      params:
+        volume: -6
+    successSound:
+      path: /Audio/_RMC14/Medical/defib_success.ogg
+      params:
+        volume: -6
+    readySound:
+      path: /Audio/_RMC14/Medical/defib_ready.ogg
+      params:
+        volume: -6
     zapDamage: 0
   - type: DoAfter
   - type: UseDelay


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed the defibrillator using the wrong audio, and its audio being able to be spammed.
- fix: Fixed the defibrillator being able to be used on more than one target at the same time.
