### PR TITLE
Wall bugfixes

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Walls/prison_walls.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Walls/prison_walls.yml
@@ -12,7 +12,7 @@
     sprite: _RMC14/Structures/Walls/prison_wall.rsi
     state: metal
   - type: IconSmooth
-    key: wall
+    key: walls
     base: metal
 
 - type: entity
@@ -28,7 +28,7 @@
     sprite: _RMC14/Structures/Walls/prison_rwall.rsi
     state: rwall
   - type: IconSmooth
-    key: wall
+    key: walls
     base: rwall
 
 - type: entity
@@ -44,7 +44,7 @@
     sprite: _RMC14/Structures/Walls/prison_rwall.rsi
     state: hwall
   - type: IconSmooth
-    key: wall
+    key: walls
     base: rwall
 
 - type: entity
@@ -60,5 +60,5 @@
     sprite: _RMC14/Structures/Walls/bone_resin.rsi
     state: bone_resin
   - type: IconSmooth
-    key: wall
+    key: walls
     base: bone_resin

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Walls/shiva_walls.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Walls/shiva_walls.yml
@@ -48,7 +48,7 @@
     sprite: _RMC14/Structures/Walls/shiva_fab.rsi
     state: shiva_fab
   - type: IconSmooth
-    key: wall
+    key: walls
     base: shiva_fab
 
 - type: entity
@@ -64,7 +64,7 @@
     sprite: _RMC14/Structures/Walls/shiva_fab_r.rsi
     state: shiva_fab_r
   - type: IconSmooth
-    key: wall
+    key: walls
     base: shiva_fab_r
 
 - type: entity
@@ -80,7 +80,7 @@
     sprite: _RMC14/Structures/Walls/shiva_fab_oj.rsi
     state: shiva_fab_oj
   - type: IconSmooth
-    key: wall
+    key: walls
     base: shiva_fab_oj
 
 - type: entity
@@ -96,7 +96,7 @@
     sprite: _RMC14/Structures/Walls/shiva_fab_blu.rsi
     state: shiva_fab_blu
   - type: IconSmooth
-    key: wall
+    key: walls
     base: shiva_fab_blu
 
 - type: entity
@@ -112,7 +112,7 @@
     sprite: _RMC14/Structures/Walls/shiva_fab_pnk.rsi
     state: shiva_fab_pnk
   - type: IconSmooth
-    key: wall
+    key: walls
     base: shiva_fab_pnk
 
 - type: entity
@@ -128,7 +128,7 @@
     sprite: _RMC14/Structures/Walls/shiva_fab_wht.rsi
     state: shiva_fab_wht
   - type: IconSmooth
-    key: wall
+    key: walls
     base: shiva_fab_wht
 
 - type: entity
@@ -144,5 +144,5 @@
     sprite: _RMC14/Structures/Walls/shiva_fab_red.rsi
     state: shiva_fab_red
   - type: IconSmooth
-    key: wall
+    key: walls
     base: shiva_fab_red

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Walls/solaris_walls.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Walls/solaris_walls.yml
@@ -12,7 +12,7 @@
     sprite: _RMC14/Structures/Walls/solaris_wall.rsi
     state: solaris_interior
   - type: IconSmooth
-    key: wall
+    key: walls
     base: solaris_interior
 
 - type: entity
@@ -28,7 +28,7 @@
     sprite: _RMC14/Structures/Walls/solaris_rwall.rsi
     state: solaris_interior_r
   - type: IconSmooth
-    key: wall
+    key: walls
     base: solaris_interior_r
 
 - type: entity
@@ -44,7 +44,7 @@
     sprite: _RMC14/Structures/Walls/solaris_rwall.rsi
     state: solaris_interior_h
   - type: IconSmooth
-    key: wall
+    key: walls
     base: solaris_interior_r
 
 - type: entity
@@ -60,5 +60,5 @@
     sprite: _RMC14/Structures/Walls/solaris_rock.rsi
     state: solaris_rock
   - type: IconSmooth
-    key: wall
+    key: walls
     base: solaris_rock

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Walls/walls.yml
@@ -334,3 +334,5 @@
   - type: Icon
     sprite: _RMC14/Structures/Walls/elevator.rsi
     state: wall_broke
+  - type: Occluder
+    enabled: false


### PR DESCRIPTION
## About the PR
Certain walls using the IconSmooth component had the wrong key due to a typo ("wall" instead of "walls"), making them refuse to smooth with anything else. This started to snowball as every mapper thus far has copied the previous mapper's homework, resulting in more of the same typo. This PR fixes that before it gets even more out of hand.
Also turned off occlusion on the broken elevator wall because I forgot to do that when I added it and it's bothering me.

## Why / Balance
Windows may still be slightly fucked and smooth weirdly, but walls need to be unfucked regardless.

## Media

Before:
![before](https://github.com/RMC-14/RMC-14/assets/123379145/34040f81-7c4a-47e6-a5f6-5dd2cbf50eb9)

After:
![after](https://github.com/RMC-14/RMC-14/assets/123379145/f76bd27a-73c8-4084-bf11-8b60623cacdb)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
