### PR TITLE
Fixes attachment size modifiers

### DIFF
--- a/Content.Shared/_RMC14/Attachable/Components/AttachableSizeModsComponent.cs
+++ b/Content.Shared/_RMC14/Attachable/Components/AttachableSizeModsComponent.cs
@@ -9,6 +9,4 @@ public sealed partial class AttachableSizeModsComponent : Component
 {
     [DataField, AutoNetworkedField]
     public List<AttachableSizeModifierSet> Modifiers = new();
-
-    public int ResetIncrement = 0;
 }

--- a/Content.Shared/_RMC14/Attachable/Systems/AttachableHolderSystem.cs
+++ b/Content.Shared/_RMC14/Attachable/Systems/AttachableHolderSystem.cs
@@ -3,6 +3,7 @@ using System.Numerics;
 using Content.Shared._RMC14.Attachable.Components;
 using Content.Shared._RMC14.Attachable.Events;
 using Content.Shared._RMC14.Input;
+using Content.Shared._RMC14.Item;
 using Content.Shared._RMC14.Weapons.Common;
 using Content.Shared._RMC14.Weapons.Ranged;
 using Content.Shared._RMC14.Wieldable.Events;
@@ -72,6 +73,7 @@ public sealed class AttachableHolderSystem : EntitySystem
         SubscribeLocalEvent<AttachableHolderComponent, ContainerGettingInsertedAttemptEvent>(RelayEvent);
         SubscribeLocalEvent<AttachableHolderComponent, ContainerGettingRemovedAttemptEvent>(RelayEvent);
         SubscribeLocalEvent<AttachableHolderComponent, EntGotRemovedFromContainerMessage>(RelayEvent);
+        SubscribeLocalEvent<AttachableHolderComponent, GetItemSizeModifiersEvent>(RelayEvent);
 
         CommandBinds.Builder
             .Bind(CMKeyFunctions.RMCActivateAttachableBarrel,

--- a/Content.Shared/_RMC14/Attachable/Systems/AttachableModifiersSystem.Size.cs
+++ b/Content.Shared/_RMC14/Attachable/Systems/AttachableModifiersSystem.Size.cs
@@ -1,31 +1,22 @@
-using System.Diagnostics.CodeAnalysis;
 using Content.Shared._RMC14.Attachable.Components;
 using Content.Shared._RMC14.Attachable.Events;
-using Content.Shared.Item;
-using Robust.Shared.Prototypes;
+using Content.Shared._RMC14.Item;
 
 namespace Content.Shared._RMC14.Attachable.Systems;
 
 public sealed partial class AttachableModifiersSystem : EntitySystem
 {
-    private readonly List<ItemSizePrototype> _sortedSizes = new();
+    [Dependency] private readonly ItemSizeChangeSystem _itemSizeChangeSystem = default!;
 
     private void InitializeSize()
     {
-        SubscribeLocalEvent<PrototypesReloadedEventArgs>(OnPrototypesReloaded);
-
         SubscribeLocalEvent<AttachableSizeModsComponent, AttachableAlteredEvent>(OnAttachableAltered);
-
-        InitItemSizes();
+        SubscribeLocalEvent<AttachableSizeModsComponent, GetItemSizeModifiersEvent>(OnGetItemSizeModifiers);
     }
 
-    private void OnAttachableAltered(Entity<AttachableSizeModsComponent> attachable,
-        ref AttachableAlteredEvent args)
+    private void OnAttachableAltered(Entity<AttachableSizeModsComponent> attachable, ref AttachableAlteredEvent args)
     {
         if (attachable.Comp.Modifiers.Count == 0)
-            return;
-
-        if (!TryComp(args.Holder, out ItemComponent? itemComponent))
             return;
 
         switch (args.Alteration)
@@ -36,96 +27,20 @@ public sealed partial class AttachableModifiersSystem : EntitySystem
             case AttachableAlteredType.DetachedDeactivated:
                 break;
 
-            case AttachableAlteredType.Detached:
-                ResetSize(args.Holder, itemComponent, attachable.Comp.ResetIncrement);
-                break;
-
             default:
-                ResetSize(args.Holder, itemComponent, attachable.Comp.ResetIncrement);
-                IncrementSize(
-                    attachable,
-                    args.Holder,
-                    itemComponent,
-                    attachable.Comp.Modifiers,
-                    out attachable.Comp.ResetIncrement);
+                _itemSizeChangeSystem.RefreshItemSizeModifiers(args.Holder);
                 break;
         }
     }
 
-    private void OnPrototypesReloaded(PrototypesReloadedEventArgs args)
+    private void OnGetItemSizeModifiers(Entity<AttachableSizeModsComponent> attachable, ref GetItemSizeModifiersEvent args)
     {
-        if (!args.ByType.ContainsKey(typeof(ItemSizePrototype)) &&
-            args.Removed?.ContainsKey(typeof(ItemSizePrototype)) != true)
+        foreach(var modSet in attachable.Comp.Modifiers)
         {
-            return;
+            if (!CanApplyModifiers(attachable.Owner, modSet.Conditions))
+                return;
+
+            args.Size += modSet.Size;
         }
-
-        InitItemSizes();
-    }
-
-    private void InitItemSizes()
-    {
-        _sortedSizes.Clear();
-        _sortedSizes.AddRange(_prototypeManager.EnumeratePrototypes<ItemSizePrototype>());
-        _sortedSizes.Sort();
-    }
-
-    private void IncrementSize(
-        Entity<AttachableSizeModsComponent> attachable,
-        EntityUid holder,
-        ItemComponent itemComponent,
-        List<AttachableSizeModifierSet> modifiers,
-        out int resetIncrement)
-    {
-        resetIncrement = 0;
-        int sizeIncrement = 0;
-
-        foreach (var modSet in modifiers)
-        {
-            if (!CanApplyModifiers(attachable, modSet.Conditions))
-                continue;
-            
-            sizeIncrement += modSet.Size;
-        }
-
-        if (TryGetIncrementedSize(itemComponent.Size, sizeIncrement, out var newSize, out resetIncrement))
-            _itemSystem.SetSize(holder, newSize.Value, itemComponent);
-    }
-
-    private void ResetSize(EntityUid holder, ItemComponent itemComponent, int resetIncrement)
-    {
-        if (TryGetIncrementedSize(itemComponent.Size, resetIncrement, out var newSize, out _))
-            _itemSystem.SetSize(holder, newSize.Value, itemComponent);
-    }
-
-    private bool TryGetIncrementedSize(
-        ProtoId<ItemSizePrototype> size,
-        int increment,
-        [NotNullWhen(true)] out ProtoId<ItemSizePrototype>? newSize,
-        out int resetIncrement)
-    {
-        var sizeIndex = -1;
-
-        for (var index = 0; index < _sortedSizes.Count; index++)
-        {
-            if (size.ToString().Equals(_sortedSizes[index].ID))
-            {
-                sizeIndex = index;
-                break;
-            }
-        }
-
-        if (sizeIndex == -1)
-        {
-            resetIncrement = 0;
-            newSize = null;
-            return false;
-        }
-
-        var newSizeIndex = MathHelper.Clamp(sizeIndex + increment, 0, _sortedSizes.Count - 1);
-        resetIncrement = sizeIndex - newSizeIndex;
-
-        newSize = _sortedSizes[newSizeIndex];
-        return true;
     }
 }

--- a/Content.Shared/_RMC14/Attachable/Systems/AttachableModifiersSystem.cs
+++ b/Content.Shared/_RMC14/Attachable/Systems/AttachableModifiersSystem.cs
@@ -1,10 +1,8 @@
 using Content.Shared._RMC14.Attachable.Components;
 using Content.Shared._RMC14.Weapons.Ranged;
 using Content.Shared._RMC14.Wieldable;
-using Content.Shared.Item;
 using Content.Shared.Whitelist;
 using Content.Shared.Wieldable.Components;
-using Robust.Shared.Prototypes;
 
 namespace Content.Shared._RMC14.Attachable.Systems;
 
@@ -13,9 +11,7 @@ public sealed partial class AttachableModifiersSystem : EntitySystem
     [Dependency] private readonly AttachableHolderSystem _attachableHolderSystem = default!;
     [Dependency] private readonly CMGunSystem _cmGunSystem = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
-    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly RMCWieldableSystem _wieldableSystem = default!;
-    [Dependency] private readonly SharedItemSystem _itemSystem = default!;
 
     public override void Initialize()
     {

--- a/Content.Shared/_RMC14/Item/GetItemSizeModifiersEvent.cs
+++ b/Content.Shared/_RMC14/Item/GetItemSizeModifiersEvent.cs
@@ -1,0 +1,5 @@
+
+namespace Content.Shared._RMC14.Item;
+
+[ByRefEvent]
+public record struct GetItemSizeModifiersEvent(int Size);

--- a/Content.Shared/_RMC14/Item/ItemSizeChangeComponent.cs
+++ b/Content.Shared/_RMC14/Item/ItemSizeChangeComponent.cs
@@ -1,0 +1,11 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Item;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(ItemSizeChangeSystem))]
+public sealed partial class ItemSizeChangeComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public int BaseSize;
+}

--- a/Content.Shared/_RMC14/Item/ItemSizeChangeSystem.cs
+++ b/Content.Shared/_RMC14/Item/ItemSizeChangeSystem.cs
@@ -1,0 +1,87 @@
+using Content.Shared._RMC14.Attachable.Systems;
+using Content.Shared.Item;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._RMC14.Item;
+
+public sealed partial class ItemSizeChangeSystem : EntitySystem
+{
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+    [Dependency] private readonly SharedItemSystem _itemSystem = default!;
+
+    private readonly List<ItemSizePrototype> _sortedSizes = new();
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<PrototypesReloadedEventArgs>(OnPrototypesReloaded);
+
+        SubscribeLocalEvent<ItemSizeChangeComponent, MapInitEvent>(OnMapInit,
+            before: new[] { typeof(AttachableHolderSystem) });
+
+        InitItemSizes();
+    }
+
+    private void OnPrototypesReloaded(PrototypesReloadedEventArgs args)
+    {
+        if (!args.ByType.ContainsKey(typeof(ItemSizePrototype)) && args.Removed?.ContainsKey(typeof(ItemSizePrototype)) != true)
+            return;
+
+        InitItemSizes();
+    }
+
+    private void InitItemSizes()
+    {
+        _sortedSizes.Clear();
+
+        foreach (var prototype in _prototypeManager.EnumeratePrototypes<ItemSizePrototype>())
+        {
+            if (prototype.ID.Equals("Invalid"))
+                continue;
+
+            _sortedSizes.Add(prototype);
+        }
+
+        _sortedSizes.Sort();
+    }
+
+    private void OnMapInit(Entity<ItemSizeChangeComponent> item, ref MapInitEvent args)
+    {
+        InitItem(item);
+    }
+
+    public void RefreshItemSizeModifiers(Entity<ItemSizeChangeComponent?> item)
+    {
+        if (item.Comp == null)
+        {
+            if (!TryComp(item.Owner, out ItemSizeChangeComponent? sizeChangeComponent))
+            {
+                item.Comp = EnsureComp<ItemSizeChangeComponent>(item.Owner);
+                InitItem((item.Owner, item.Comp));
+            }
+            else
+                item.Comp = sizeChangeComponent;
+        }
+
+        if (!TryComp(item.Owner, out ItemComponent? itemComponent))
+            return;
+
+        var ev = new GetItemSizeModifiersEvent(item.Comp.BaseSize);
+        RaiseLocalEvent(item.Owner, ref ev);
+
+        ev.Size = Math.Clamp(ev.Size, 0, _sortedSizes.Count > 0 ? _sortedSizes.Count - 1 : 0);
+
+        if (_sortedSizes.Count <= ev.Size)
+            return;
+
+        _itemSystem.SetSize(item, _sortedSizes[ev.Size], itemComponent);
+        Dirty(item);
+    }
+
+    private void InitItem(Entity<ItemSizeChangeComponent> item)
+    {
+        if (!TryComp(item.Owner, out ItemComponent? itemComponent) || !_prototypeManager.TryIndex(itemComponent.Size, out ItemSizePrototype? prototype))
+            return;
+
+        item.Comp.BaseSize = _sortedSizes.IndexOf(prototype);
+    }
+}

--- a/Content.Shared/_RMC14/Item/ItemSizeChangeSystem.cs
+++ b/Content.Shared/_RMC14/Item/ItemSizeChangeSystem.cs
@@ -74,7 +74,6 @@ public sealed partial class ItemSizeChangeSystem : EntitySystem
             return;
 
         _itemSystem.SetSize(item, _sortedSizes[ev.Size], itemComponent);
-        Dirty(item);
     }
 
     private void InitItem(Entity<ItemSizeChangeComponent> item)
@@ -83,5 +82,6 @@ public sealed partial class ItemSizeChangeSystem : EntitySystem
             return;
 
         item.Comp.BaseSize = _sortedSizes.IndexOf(prototype);
+        Dirty(item);
     }
 }


### PR DESCRIPTION
## About the PR
Attachments can no longer permanently increase or reduce the size of the thing they're attached to. They can no longer make the size invalid.

## Why / Balance
Because bug.

## Technical details
Changed how size modifiers work to allow for things other than attachments to apply those modifiers. Also made the code less shit.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: Sigil
- fix: Attachments that modify the size of their holder now properly apply and remove their modifiers.
