### PR TITLE
Fix Queen's screech not properly knocking down marines

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Screech/SharedXenoScreechSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Screech/SharedXenoScreechSystem.cs
@@ -1,9 +1,8 @@
 ﻿using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared.Coordinates;
-using Content.Shared.Interaction;
+using Content.Shared.Examine;
 using Content.Shared.Mobs.Systems;
-using Content.Shared.Physics;
 using Content.Shared.Stunnable;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Network;
@@ -15,8 +14,8 @@ public sealed class XenoScreechSystem : EntitySystem
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly XenoPlasmaSystem _xenoPlasma = default!;
     [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
+    [Dependency] private readonly ExamineSystemShared _examineSystem = default!;
     [Dependency] private readonly INetManager _net = default!;
-    [Dependency] private readonly SharedInteractionSystem _interactionSystem = default!;
     [Dependency] private readonly SharedStunSystem _stun = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
 
@@ -28,7 +27,6 @@ public sealed class XenoScreechSystem : EntitySystem
     }
 
     private readonly HashSet<Entity<MarineComponent>> _receivers = new();
-    private readonly CollisionGroup _opaqueObjectsMask = CollisionGroup.Opaque;
 
     private void OnXenoScreechAction(Entity<XenoScreechComponent> xeno, ref XenoScreechActionEvent args)
     {
@@ -60,10 +58,7 @@ public sealed class XenoScreechSystem : EntitySystem
             if (_mobState.IsDead(receiver))
                 continue;
 
-            if (!_interactionSystem.InRangeUnobstructed(xeno.Owner,
-                    receiver.Owner,
-                    xeno.Comp.StunRange,
-                    collisionMask: _opaqueObjectsMask))
+            if (!_examineSystem.InRangeUnOccluded(xeno.Owner, receiver.Owner))
                 continue;
 
             if (TryComp(xeno, out XenoComponent? xenoComp) &&
@@ -84,10 +79,7 @@ public sealed class XenoScreechSystem : EntitySystem
             if (_mobState.IsDead(receiver))
                 continue;
 
-            if (!_interactionSystem.InRangeUnobstructed(xeno.Owner,
-                    receiver.Owner,
-                    xeno.Comp.ParalyzeRange,
-                    collisionMask: _opaqueObjectsMask))
+            if (!_examineSystem.InRangeUnOccluded(xeno.Owner, receiver.Owner))
                 continue;
 
             if (TryComp(xeno, out XenoComponent? xenoComp) &&


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Some people noticed the queen's screech wasn't behaving as expected, often leaving several people unstunned.

The queen's screech now uses occlusion (what you can see) rather than obstruction (what doesn't have something physical in the way)

fixes https://github.com/RMC-14/RMC-14/issues/3000

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Apparently, marines are considered "opaque". Standing in the same tile as another marine made you both immune to the screech since you were occluding one another.

Still has parity with CM13's screech, at least intuitively. You can screech through transparent objects there.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Swaps out `SharedInteractionSystem`'s `InRangeUnobstructed` to `ExamineSystemShared`'s `InRangeUnOccluded` (the check used for SS14's ninja dash, for example).

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

For showcasing purposes *only*, my local build has the screech cooldown reduced.

Before the bugfix:

https://github.com/user-attachments/assets/b2fe77bc-fd48-4dbb-846d-02ea381f9467

After the bugfix:

https://github.com/user-attachments/assets/3b4353df-d60a-4f54-b9ef-65728c10c40f

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: The Queen's screech is no longer blocked by marines. Apparently, marines are opaque.
