### PR TITLE
Xenonid nest diagonals and user position

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestSystem.cs
@@ -369,16 +369,16 @@ public sealed class XenoNestSystem : EntitySystem
         string? response = null;
         foreach (var dir in directions)
         {
-            if (nestCoords.Offset(dir.ToVec()).GetTileRef(EntityManager, _map) is { } tile &&
-                   !_turf.IsTileBlocked(tile, CollisionGroup.Impassable))
+            if (nestCoords.Offset(dir.ToVec()).GetTileRef(EntityManager, _map) is not { } tile ||
+                   _turf.IsTileBlocked(tile, CollisionGroup.Impassable))
             {
-                response = Loc.GetString("cm-xeno-nest-failed-cant-there");
+                response ??= Loc.GetString("cm-xeno-nest-failed-cant-there");
                 continue;
             }
 
             if (surface.Comp.Nests.ContainsKey(dir))
             {
-                response = Loc.GetString("cm-xeno-nest-failed-cant-already-there");
+                response ??= Loc.GetString("cm-xeno-nest-failed-cant-already-there");
                 continue;
             }
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Makes nesting try both directions when at a diagonal angle to the wall.

Makes nesting use user position instead of victim position for the direction of the nest.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Fixes nests getting put inside walls.

Makes it easier to nest hosts when at a diagonal angle, since players no longer have to move completely to a new cardinal direction for it to create a nest.

Victim position in relation to the wall is not as intuitive for placing the nests, so this makes it easier for players to find and place the hosts where they want.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Moved the GetNestDirection code into CanNestPopup so that it could be incorporated into multiple direction checking.

Adds a IsTileBlocked check for attempted directions to prevent placing nests in-between walls.

Gets diagonal directions and tries both cardinal directions using the DirectionFlags set. It prioritizes the cardinal direction that has a smaller angle.


## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

Diagonal nesting with user position (This is what is in the current PR):

https://github.com/user-attachments/assets/3c6f40a8-fef6-4fe0-a55b-4ab5e5005510

Diagonal nesting with victim position (This is with nest direction set using victim instead of user position relative to the nestable surface.):

https://github.com/user-attachments/assets/1f2ba98a-2ada-4f40-99c0-c35f8093c750

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Fixed nests sometimes getting placed in-between walls.
- tweak: Nest direction is now based on Xenonid position instead of host position.
- tweak: Xenonids now attempt to place hosts on both wall surface directions when positioned diagonally to the surface.