### PR TITLE
fix barricades not anchoring again after being unanchored

### DIFF
--- a/Content.Shared/_RMC14/Construction/RMCConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Construction/RMCConstructionSystem.cs
@@ -33,7 +33,6 @@ public sealed class RMCConstructionSystem : EntitySystem
 
         SubscribeLocalEvent<RMCDropshipBlockedComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<RMCDropshipBlockedComponent, AnchorAttemptEvent>(OnAnchorAttempt);
-        SubscribeLocalEvent<RMCDropshipBlockedComponent, UserAnchoredEvent>(OnUserAnchored);
     }
 
     private void OnConstructionAttempt(ref RMCConstructionAttemptEvent ev)
@@ -94,12 +93,6 @@ public sealed class RMCConstructionSystem : EntitySystem
             _popup.PopupClient(msg, ent, args.User);
             args.Cancel();
         }
-    }
-
-    private void OnUserAnchored(Entity<RMCDropshipBlockedComponent> ent, ref UserAnchoredEvent args)
-    {
-        if (TryComp(ent.Owner, out TransformComponent? xform))
-            _transform.Unanchor(ent.Owner, xform);
     }
 
     public bool CanConstruct(EntityUid? user)

--- a/Content.Shared/_RMC14/Construction/RMCConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Construction/RMCConstructionSystem.cs
@@ -33,6 +33,7 @@ public sealed class RMCConstructionSystem : EntitySystem
 
         SubscribeLocalEvent<RMCDropshipBlockedComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<RMCDropshipBlockedComponent, AnchorAttemptEvent>(OnAnchorAttempt);
+        SubscribeLocalEvent<RMCDropshipBlockedComponent, UserAnchoredEvent>(OnUserAnchored);
     }
 
     private void OnConstructionAttempt(ref RMCConstructionAttemptEvent ev)
@@ -93,6 +94,16 @@ public sealed class RMCConstructionSystem : EntitySystem
             _popup.PopupClient(msg, ent, args.User);
             args.Cancel();
         }
+    }
+    private void OnUserAnchored(Entity<RMCDropshipBlockedComponent> ent, ref UserAnchoredEvent args)
+    {
+        if (!TryComp(ent.Owner, out TransformComponent? xform) ||
+            !HasComp<DropshipComponent>(xform.GridUid))
+        {
+            return;
+        }
+
+        _transform.Unanchor(ent.Owner, xform);
     }
 
     public bool CanConstruct(EntityUid? user)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Closes #2975. I don't really know if this was here for a reason and removing it will break everything, but by doing so it's possible to actually create a barricade, unanchor it, move it around and then anchor it again for good (that is, it can't be pulled even after being anchored like before)

## Why / Balance
To make anchoring of barricades work as intended

## Technical details


## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes

**Changelog**
:cl: MendaxxDev, DrSmugleaf
- fix: Fixed not being able to anchor barricades outside of dropships.
