### PR TITLE
Fix warding pheromones giving far more crit health than intended

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Pheromones/SharedXenoPheromonesSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Pheromones/SharedXenoPheromonesSystem.cs
@@ -131,7 +131,8 @@ public abstract class SharedXenoPheromonesSystem : EntitySystem
         }
 
         // TODO RMC14 crit grace period
-        var wardingThreshold = threshold.Value * (1 + 20 * warding.Comp.Multiplier);
+        // TODO RMC14 20
+        var wardingThreshold = threshold.Value * (1 + 40 * warding.Comp.Multiplier);
         if (damageable.TotalDamage >= wardingThreshold)
             return;
 

--- a/Content.Shared/_RMC14/Xenonids/Pheromones/SharedXenoPheromonesSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Pheromones/SharedXenoPheromonesSystem.cs
@@ -130,7 +130,8 @@ public abstract class SharedXenoPheromonesSystem : EntitySystem
             return;
         }
 
-        var wardingThreshold = threshold.Value * (1.1 * warding.Comp.Multiplier);
+        // TODO RMC14 crit grace period
+        var wardingThreshold = threshold.Value * (1 + 0.03 * warding.Comp.Multiplier);
         if (damageable.TotalDamage >= wardingThreshold)
             return;
 

--- a/Content.Shared/_RMC14/Xenonids/Pheromones/SharedXenoPheromonesSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Pheromones/SharedXenoPheromonesSystem.cs
@@ -131,7 +131,7 @@ public abstract class SharedXenoPheromonesSystem : EntitySystem
         }
 
         // TODO RMC14 crit grace period
-        var wardingThreshold = threshold.Value * (1 + 0.03 * warding.Comp.Multiplier);
+        var wardingThreshold = threshold.Value * (1 + 20 * warding.Comp.Multiplier);
         if (damageable.TotalDamage >= wardingThreshold)
             return;
 


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed warding pheromones giving far more crit health than intended. It now gives (40 times the pheromone level) extra crit health, instead of multiplying crit health by 4.4 when used by the Queen, or 2.5 when used by a hivelord.
