### PR TITLE
Make spaceborne gauss turrets target and instantly destroy resin structures, extend lifetime

### DIFF
--- a/Content.Server/NPC/Systems/NPCCombatSystem.Ranged.cs
+++ b/Content.Server/NPC/Systems/NPCCombatSystem.Ranged.cs
@@ -1,7 +1,6 @@
 using Content.Server.NPC.Components;
 using Content.Shared.CombatMode;
 using Content.Shared.Interaction;
-using Content.Shared.Physics;
 using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Weapons.Ranged.Events;
 using Robust.Shared.Map;
@@ -134,7 +133,7 @@ public sealed partial class NPCCombatSystem
             {
                 comp.LOSAccumulator += UnoccludedCooldown;
                 // For consistency with NPC steering.
-                comp.TargetInLOS = _interaction.InRangeUnobstructed(uid, Transform(comp.Target).Coordinates, distance + 0.1f);
+                comp.TargetInLOS = _interaction.InRangeUnobstructed(uid, comp.Target, distance + 0.1f);
             }
 
             if (!comp.TargetInLOS)

--- a/Content.Server/NPC/Systems/NPCUtilitySystem.cs
+++ b/Content.Server/NPC/Systems/NPCUtilitySystem.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+using Content.Server._RMC14.NPC;
 using Content.Server.Chemistry.Containers.EntitySystems;
 using Content.Server.Fluids.EntitySystems;
 using Content.Server.NPC.Queries;
@@ -24,7 +26,6 @@ using Microsoft.Extensions.ObjectPool;
 using Robust.Server.Containers;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
-using System.Linq;
 
 namespace Content.Server.NPC.Systems;
 
@@ -340,6 +341,10 @@ public sealed class NPCUtilitySystem : EntitySystem
                 }
 
                 return 0f;
+            }
+            case TargetIsNotDeadCon:
+            {
+                return !_mobState.IsDead(targetUid) ? 1f : 0f;
             }
             default:
                 throw new NotImplementedException();

--- a/Content.Server/_RMC14/Dropship/DropshipLandedOnPlanetEvent.cs
+++ b/Content.Server/_RMC14/Dropship/DropshipLandedOnPlanetEvent.cs
@@ -1,0 +1,4 @@
+﻿namespace Content.Server._RMC14.Dropship;
+
+[ByRefEvent]
+public readonly record struct DropshipLandedOnPlanetEvent;

--- a/Content.Server/_RMC14/Dropship/DropshipSystem.cs
+++ b/Content.Server/_RMC14/Dropship/DropshipSystem.cs
@@ -1,5 +1,6 @@
 ﻿using System.Numerics;
 using Content.Server._RMC14.Marines;
+using Content.Server._RMC14.Rules;
 using Content.Server.Doors.Systems;
 using Content.Server.Shuttles.Components;
 using Content.Server.Shuttles.Events;
@@ -46,7 +47,7 @@ public sealed class DropshipSystem : SharedDropshipSystem
 
         SubscribeLocalEvent<DropshipComponent, FTLRequestEvent>(OnRefreshUI);
         SubscribeLocalEvent<DropshipComponent, FTLStartedEvent>(OnRefreshUI);
-        SubscribeLocalEvent<DropshipComponent, FTLCompletedEvent>(OnRefreshUI);
+        SubscribeLocalEvent<DropshipComponent, FTLCompletedEvent>(OnFTLCompleted);
         SubscribeLocalEvent<DropshipComponent, FTLUpdatedEvent>(OnRefreshUI);
 
         Subs.BuiEvents<DropshipNavigationComputerComponent>(DropshipNavigationUiKey.Key,
@@ -79,6 +80,17 @@ public sealed class DropshipSystem : SharedDropshipSystem
 
         _ui.OpenUi(ent.Owner, DropshipHijackerUiKey.Key, args.User);
         _ui.SetUiState(ent.Owner, DropshipHijackerUiKey.Key, new DropshipHijackerBuiState(destinations));
+    }
+
+    private void OnFTLCompleted(Entity<DropshipComponent> ent, ref FTLCompletedEvent args)
+    {
+        OnRefreshUI(ent, ref args);
+
+        if (HasComp<RMCPlanetComponent>(args.MapUid))
+        {
+            var ev = new DropshipLandedOnPlanetEvent();
+            RaiseLocalEvent(ref ev);
+        }
     }
 
     private void OnRefreshUI<T>(Entity<DropshipComponent> ent, ref T args)

--- a/Content.Server/_RMC14/NPC/TargetIsNotDeadCon.cs
+++ b/Content.Server/_RMC14/NPC/TargetIsNotDeadCon.cs
@@ -1,0 +1,5 @@
+﻿using Content.Server.NPC.Queries.Considerations;
+
+namespace Content.Server._RMC14.NPC;
+
+public sealed partial class TargetIsNotDeadCon : UtilityConsideration;

--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
@@ -709,15 +709,17 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
 
     private bool SpawnXenoMap(Entity<CMDistressSignalRuleComponent> rule)
     {
-        // TODO RMC14 different planet-side maps
         var mapId = _mapManager.CreateMap();
+
         SelectedPlanetMap = _random.Pick(_planetMaps.Split(","));
         SelectedPlanetMapName = SelectedPlanetMap.Replace("/Maps/_RMC14/", "").Replace(".yml", "");
-        if (!_mapLoader.TryLoad(mapId, SelectedPlanetMap, out var grids) ||
-            grids.Count == 0)
-        {
+        if (!_mapLoader.TryLoad(mapId, SelectedPlanetMap, out var grids))
             return false;
-        }
+
+        EnsureComp<RMCPlanetComponent>(_mapManager.GetMapEntityId(mapId));
+
+        if (grids.Count == 0)
+            return false;
 
         if (grids.Count > 1)
             Log.Error("Multiple planet-side grids found");

--- a/Content.Server/_RMC14/Rules/RMCPlanetComponent.cs
+++ b/Content.Server/_RMC14/Rules/RMCPlanetComponent.cs
@@ -1,0 +1,4 @@
+﻿namespace Content.Server._RMC14.Rules;
+
+[RegisterComponent]
+public sealed partial class RMCPlanetComponent : Component;

--- a/Content.Server/_RMC14/Sentries/RMCSentrySystem.cs
+++ b/Content.Server/_RMC14/Sentries/RMCSentrySystem.cs
@@ -1,0 +1,22 @@
+﻿using Content.Server._RMC14.Dropship;
+using Robust.Shared.Spawners;
+
+namespace Content.Server._RMC14.Sentries;
+
+public sealed class RMCSentrySystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<DropshipLandedOnPlanetEvent>(OnDropshipLandedOnPlanet);
+    }
+
+    private void OnDropshipLandedOnPlanet(ref DropshipLandedOnPlanetEvent ev)
+    {
+        var query = EntityQueryEnumerator<TimedDespawnOnLandingComponent>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            EnsureComp<TimedDespawnComponent>(uid).Lifetime = comp.Lifetime;
+            RemCompDeferred<TimedDespawnOnLandingComponent>(uid);
+        }
+    }
+}

--- a/Content.Server/_RMC14/Sentries/TimedDespawnOnLandingComponent.cs
+++ b/Content.Server/_RMC14/Sentries/TimedDespawnOnLandingComponent.cs
@@ -1,0 +1,9 @@
+﻿namespace Content.Server._RMC14.Sentries;
+
+[RegisterComponent]
+[Access(typeof(RMCSentrySystem))]
+public sealed partial class TimedDespawnOnLandingComponent : Component
+{
+    [DataField]
+    public float Lifetime = 1200;
+}

--- a/Content.Shared/_RMC14/CCVar/CMCVars.cs
+++ b/Content.Shared/_RMC14/CCVar/CMCVars.cs
@@ -88,5 +88,5 @@ public sealed class CMCVars : CVars
     ///     Comma-separated list of maps to load as the planet in the distress signal gamemode.
     /// </summary>
     public static readonly CVarDef<string> RMCPlanetMaps =
-        CVarDef.Create("rmc.planet_maps", "/Maps/_RMC14/solaris.yml", CVar.SERVER | CVar.SERVERONLY);
+        CVarDef.Create("rmc.planet_maps", "/Maps/_RMC14/lv624.yml,/Maps/_RMC14/solaris.yml", CVar.SERVER | CVar.SERVERONLY);
 }

--- a/Content.Shared/_RMC14/Xenonids/Construction/DeleteXenoResinOnHitComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/DeleteXenoResinOnHitComponent.cs
@@ -1,0 +1,7 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.Construction;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(SharedXenoConstructionSystem))]
+public sealed partial class DeleteXenoResinOnHitComponent : Component;

--- a/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
@@ -18,6 +18,7 @@ using Content.Shared.Interaction;
 using Content.Shared.Maps;
 using Content.Shared.Physics;
 using Content.Shared.Popups;
+using Content.Shared.Projectiles;
 using Content.Shared.Prototypes;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
@@ -91,6 +92,8 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
 
         SubscribeLocalEvent<XenoConstructionSupportComponent, ComponentRemove>(OnCheckAdjacentCollapse);
         SubscribeLocalEvent<XenoConstructionSupportComponent, EntityTerminatingEvent>(OnCheckAdjacentCollapse);
+
+        SubscribeLocalEvent<DeleteXenoResinOnHitComponent, ProjectileHitEvent>(OnDeleteXenoResinHit);
 
         Subs.BuiEvents<XenoConstructionComponent>(XenoChooseStructureUI.Key, subs =>
         {
@@ -484,6 +487,12 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
                     QueueDel(uid);
             }
         }
+    }
+
+    private void OnDeleteXenoResinHit(Entity<DeleteXenoResinOnHitComponent> ent, ref ProjectileHitEvent args)
+    {
+        if (_net.IsServer && _xenoConstructQuery.HasComp(args.Target))
+            QueueDel(args.Target);
     }
 
     public FixedPoint2? GetStructurePlasmaCost(EntProtoId prototype)

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/sentry.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/sentry.yml
@@ -15,3 +15,4 @@
         Piercing: 30
   - type: CMArmorPiercing
     amount: 35
+  - type: DeleteXenoResinOnHit

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Sentries/static_sentries.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Sentries/static_sentries.yml
@@ -47,7 +47,7 @@
     capacity: 99999
   - type: HTN
     rootTask:
-      task: TurretCompound
+      task: RMCTurretCompound
     blackboard:
       RotateSpeed: !type:Single
         3.141
@@ -72,6 +72,55 @@
   - type: NpcFactionMember
     factions:
     - UNMC
-  - type: TimedDespawn
-    lifetime: 1200
+  - type: TimedDespawnOnLanding
   - type: MarineIFF
+
+- type: htnCompound
+  id: RMCTurretCompound
+  branches:
+  - tasks:
+    - !type:HTNPrimitiveTask
+      operator: !type:UtilityOperator
+        proto: RMCNearbyGunTargets
+
+    - !type:HTNPrimitiveTask
+      preconditions:
+      - !type:KeyExistsPrecondition
+        key: Target
+      - !type:TargetInRangePrecondition
+        targetKey: Target
+        # TODO: Non-scuffed
+        rangeKey: RangedRange
+      - !type:TargetInLOSPrecondition
+        targetKey: Target
+        rangeKey: RangedRange
+      operator: !type:GunOperator
+        targetKey: Target
+        requireLOS: true
+      services:
+      - !type:UtilityService
+        id: RangedService
+        proto: RMCNearbyGunTargets
+        key: Target
+
+  - tasks:
+    - !type:HTNCompoundTask
+      task: IdleSpinCompound
+
+- type: utilityQuery
+  id: RMCNearbyGunTargets
+  query:
+  - !type:NearbyHostilesQuery
+  considerations:
+  - !type:TargetIsNotDeadCon
+    curve: !type:BoolCurve
+  - !type:TargetDistanceCon
+    curve: !type:PresetCurve
+      preset: TargetDistance
+  - !type:TargetHealthCon
+    curve: !type:PresetCurve
+      preset: TargetHealth
+  - !type:TargetAccessibleCon
+    curve: !type:BoolCurve
+  - !type:TargetInLOSOrCurrentCon
+    curve: !type:BoolCurve

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Base/base_structure.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Base/base_structure.yml
@@ -33,6 +33,9 @@
         collection: XenoResinBreak
   - type: XenoConstruct
   - type: RMCWallExplosionDeletable
+  - type: NpcFactionMember
+    factions:
+    - RMCXeno
 
 - type: entity
   id: CMCorrodible


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: The turrets guarding landing zones at round-start will now automatically target nearby resin structures and destroy them in a single shot.
- tweak: The turrets guarding landing zones at round-start will now last 20 minutes after a dropship lands, instead of 20 minutes from round start, keeping the landing zones safer for longer.