### PR TITLE
Make marines per xeno autobalance dependent on the planet map chosen

### DIFF
--- a/Content.Shared/_RMC14/CCVar/CMCVars.cs
+++ b/Content.Shared/_RMC14/CCVar/CMCVars.cs
@@ -52,7 +52,7 @@ public sealed class CMCVars : CVars
         CVarDef.Create("cm.bleed_time_multiplier", 1f, CVar.REPLICATED | CVar.SERVER);
 
     public static readonly CVarDef<float> CMMarinesPerXeno =
-        CVarDef.Create("cm.marines_per_xeno", 3.5f, CVar.REPLICATED | CVar.SERVER);
+        CVarDef.Create("cm.marines_per_xeno", 5.5f, CVar.REPLICATED | CVar.SERVER);
 
     public static readonly CVarDef<bool> RMCAutoBalance =
         CVarDef.Create("rmc.auto_balance", true, CVar.SERVER);
@@ -64,7 +64,7 @@ public sealed class CMCVars : CVars
         CVarDef.Create("rmc.auto_balance_min", 3f, CVar.SERVER);
 
     public static readonly CVarDef<float> RMCAutoBalanceMax =
-        CVarDef.Create("rmc.auto_balance_max", 4.5f, CVar.SERVER);
+        CVarDef.Create("rmc.auto_balance_max", 6f, CVar.SERVER);
 
     public static readonly CVarDef<int> RMCPatronLobbyMessageTimeSeconds =
         CVarDef.Create("rmc.patron_lobby_message_time_seconds", 30, CVar.REPLICATED | CVar.SERVER);


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Marines-per-xeno ratio autobalancing after each round now has different values for each planet map.
