### PR TITLE
The planet name is now displayed on the groundside operations computer and command tablet

### DIFF
--- a/Content.Client/_RMC14/Marines/Announce/MarineCommunicationsComputerBui.cs
+++ b/Content.Client/_RMC14/Marines/Announce/MarineCommunicationsComputerBui.cs
@@ -1,8 +1,10 @@
 ﻿using Content.Shared._RMC14.Marines.Announce;
+using JetBrains.Annotations;
 using Robust.Shared.Utility;
 
 namespace Content.Client._RMC14.Marines.Announce;
 
+[UsedImplicitly]
 public sealed class MarineCommunicationsComputerBui(EntityUid owner, Enum uiKey) : BoundUserInterface(owner, uiKey)
 {
     [ViewVariables]
@@ -15,7 +17,20 @@ public sealed class MarineCommunicationsComputerBui(EntityUid owner, Enum uiKey)
 
         _window = new MarineCommunicationsComputerWindow();
         _window.Send.OnPressed += _ => SendPredictedMessage(new MarineCommunicationsComputerMsg( Rope.Collapse(_window.Text.TextRope)));
+
+        if (State is MarineCommunicationsComputerBuiState s)
+            _window.PlanetName.Text = s.Planet;
+
         _window.OpenCentered();
+    }
+
+    protected override void UpdateState(BoundUserInterfaceState state)
+    {
+        if (_window == null)
+            return;
+
+        if (State is MarineCommunicationsComputerBuiState s)
+            _window.PlanetName.Text = s.Planet;
     }
 
     protected override void Dispose(bool disposing)

--- a/Content.Client/_RMC14/Marines/Announce/MarineCommunicationsComputerWindow.xaml
+++ b/Content.Client/_RMC14/Marines/Announce/MarineCommunicationsComputerWindow.xaml
@@ -3,6 +3,10 @@
     xmlns:controls="clr-namespace:Content.Client._RMC14.Marines.Announce"
     Title="Groundside Operations">
     <BoxContainer Orientation="Vertical" Margin="5">
+        <BoxContainer Orientation="Horizontal">
+            <Label Text="Planet: " />
+            <Label Name="PlanetName" Access="Public" />
+        </BoxContainer>
         <TextEdit Name="Text" Access="Public" HorizontalExpand="True" VerticalExpand="True" />
         <Button Name="Send" Access="Public" Text="Send" HorizontalExpand="True" />
     </BoxContainer>

--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
@@ -739,6 +739,15 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
 
         SelectedPlanetMap = _random.Pick(_planetMaps.Split(","));
         SelectedPlanetMapName = SelectedPlanetMap.Replace("/Maps/_RMC14/", "").Replace(".yml", "");
+
+        // TODO RMC14 save these somewhere and avert the shitcode
+        SelectedPlanetMapName = SelectedPlanetMapName switch
+        {
+            "lv624" => "LV624",
+            "solaris" => "Solaris",
+            _ => SelectedPlanetMapName,
+        };
+
         if (!_mapLoader.TryLoad(mapId, SelectedPlanetMap, out var grids))
             return false;
 

--- a/Content.Shared/_RMC14/Marines/Announce/MarineCommunicationsComputerUI.cs
+++ b/Content.Shared/_RMC14/Marines/Announce/MarineCommunicationsComputerUI.cs
@@ -13,3 +13,9 @@ public sealed class MarineCommunicationsComputerMsg(string text) : BoundUserInte
 {
     public readonly string Text = text;
 }
+
+[Serializable, NetSerializable]
+public sealed class MarineCommunicationsComputerBuiState(string planet) : BoundUserInterfaceState
+{
+    public readonly string Planet = planet;
+}


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: The planet's name for the current round is now shown in the groundside operations console and the command tablet.