### PR TITLE
Podlocks no longer show a damage visual when being attacked, to show that they are invincible to damage

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Doors/Shutters/poddoor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Doors/Shutters/poddoor.yml
@@ -21,9 +21,6 @@
   - type: Appearance
   - type: RadiationBlocker
     resistance: 8
-  - type: Damageable
-    damageContainer: StructuralInorganic
-    damageModifierSet: StrongMetallic
   - type: ContainerFill
     containers:
       board: [ DoorElectronics ]

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Doors/Shutters/shutters.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Doors/Shutters/shutters.yml
@@ -61,6 +61,7 @@
     key: walls
     mode: NoSprite
   - type: Airtight
+  - type: Occluder
   - type: RMCWallExplosionDeletable
   # TODO RMC14 Add linkable buttons and open/close logic to the shutters, thanks
 


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed shutters not occluding vision when closed.
- fix: Fixed shutters and podlocks showing a red damage visual effect when they are invincible to damage.