### PR TITLE
Disable forcing someone to be Queen on spawn if none is spawned

### DIFF
--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
@@ -310,19 +310,8 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
                 var list = xenoCandidates[i];
                 while (list.Count > 0 && selected < totalXenos)
                 {
-                    if (queenSelected == null)
-                    {
-                        queenSelected = SpawnXeno(list, comp.QueenEnt);
-                        if (queenSelected != null)
-                        {
-                            totalXenos--;
-                            selected++;
-                        }
-                    }
-                    else if (SpawnXeno(list, comp.LarvaEnt) != null)
-                    {
+                    if (SpawnXeno(list, comp.LarvaEnt) != null)
                         selected++;
-                    }
                 }
             }
 


### PR DESCRIPTION
## About the PR
Also extra changelog from upstream merge

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: The game no longer forces at least one xeno to spawn as Queen. In the event that there is none round-start, one of the larvas can evolve into it.
- fix: Fixed the Grenadier Specialist's M83 grenade launcher shooting grenades half as far as it should have been.