### PR TITLE
Fix the defender's fortified wounded sprite

### DIFF
--- a/Content.Client/_RMC14/Xenonids/Damage/RMCXenoDamageVisualsSystem.cs
+++ b/Content.Client/_RMC14/Xenonids/Damage/RMCXenoDamageVisualsSystem.cs
@@ -32,7 +32,7 @@ public sealed class RMCXenoDamageVisualsSystem : VisualizerSystem<RMCXenoDamageV
 
         if (AppearanceSystem.TryGetData(uid, RMCDamageVisuals.Fortified, out bool fortified) && fortified)
         {
-            sprite.LayerSetState(layer, $"{component.Prefix}_fortified_{state}");
+            sprite.LayerSetState(layer, $"{component.Prefix}_fortify_{state}");
             return;
         }
 


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed the defender's fortified wounded state being a massive error sign.
