### PR TITLE
Add an extra staff officer and cargo tech slot on Savannah as well

### DIFF
--- a/Resources/Prototypes/_RMC14/Maps/savannah.yml
+++ b/Resources/Prototypes/_RMC14/Maps/savannah.yml
@@ -17,7 +17,7 @@
             # Command
             CMCommandingOfficer: [1, 1]
             CMExecutiveOfficer: [1, 1]
-            CMStaffOfficer: [1, 1]
+            CMStaffOfficer: [2, 2]
             CMSeniorEnlistedAdvisor: [1, 1]
 
             # Military Police
@@ -45,7 +45,7 @@
 
             # Requisition
             CMQuartermaster: [1, 1]
-            CMCargoTech: [3, 3]
+            CMCargoTech: [4, 4]
 #            CMMessTech: [1, 1]
 
             # Marines


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Savannah now has a second Staff Officer slot and a fourth Cargo Tech slot, just like the Almayer.
