### PR TITLE
Add missing new queen replacement cooldown, disable hivemind chat with no Queen, make parasites only have a 25% chance to become ghost roles

### DIFF
--- a/Content.Shared/Chat/SharedChatSystem.cs
+++ b/Content.Shared/Chat/SharedChatSystem.cs
@@ -1,6 +1,7 @@
 using System.Collections.Frozen;
 using Content.Shared._RMC14.Chat;
 using Content.Shared._RMC14.Xenonids;
+using Content.Shared._RMC14.Xenonids.Evolution;
 using Content.Shared.Popups;
 using Content.Shared.Radio;
 using Content.Shared.Speech;
@@ -38,6 +39,7 @@ public abstract class SharedChatSystem : EntitySystem
 
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly XenoEvolutionSystem _xenoEvolution = default!;
 
     /// <summary>
     /// Cache of the keycodes for faster lookup.
@@ -118,6 +120,17 @@ public abstract class SharedChatSystem : EntitySystem
             channel = HasComp<XenoComponent>(source)
                 ? _prototypeManager.Index<RadioChannelPrototype>(HivemindChannel)
                 : _prototypeManager.Index<RadioChannelPrototype>(CommonChannel);
+
+            if (channel.ID == HivemindChannel &&
+                !_xenoEvolution.HasLiving<XenoEvolutionGranterComponent>(1))
+            {
+                if (!quiet)
+                    _popup.PopupEntity(Loc.GetString("rmc-no-queen-hivemind-chat"), source, source, PopupType.LargeCaution);
+
+                output = SanitizeMessageCapital(input[1..].TrimStart());
+                return false;
+            }
+
             return true;
         }
 

--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using Content.Shared._RMC14.Xenonids.Announce;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared.Actions;
 using Content.Shared.Administration.Logs;
@@ -42,6 +43,7 @@ public sealed class XenoEvolutionSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
     [Dependency] private readonly XenoSystem _xeno = default!;
+    [Dependency] private readonly SharedXenoAnnounceSystem _xenoAnnounce = default!;
 
     private readonly HashSet<EntityUid> _climbable = new();
     private readonly HashSet<EntityUid> _doors = new();
@@ -62,6 +64,8 @@ public sealed class XenoEvolutionSystem : EntitySystem
 
         SubscribeLocalEvent<XenoNewlyEvolvedComponent, PreventCollideEvent>(OnNewlyEvolvedPreventCollide);
 
+        SubscribeLocalEvent<XenoEvolutionGranterComponent, NewXenoEvolvedEvent>(OnGranterEvolved);
+
         Subs.BuiEvents<XenoEvolutionComponent>(XenoEvolutionUIKey.Key,
             subs =>
             {
@@ -73,6 +77,11 @@ public sealed class XenoEvolutionSystem : EntitySystem
             {
                 subs.Event<XenoDevolveBuiMsg>(OnXenoDevolveBui);
             });
+    }
+
+    private void OnGranterEvolved(Entity<XenoEvolutionGranterComponent> ent, ref NewXenoEvolvedEvent args)
+    {
+        _xenoAnnounce.AnnounceSameHive(ent.Owner, Loc.GetString("rmc-new-queen"));
     }
 
     private void OnXenoOpenDevolveAction(Entity<XenoDevolveComponent> xeno, ref XenoOpenDevolveActionEvent args)

--- a/Content.Shared/_RMC14/Xenonids/Hive/HiveComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hive/HiveComponent.cs
@@ -12,7 +12,7 @@ public sealed partial class HiveComponent : Component
     public Dictionary<int, FixedPoint2> TierLimits = new()
     {
         [2] = 0.5,
-        [3] = 0.2
+        [3] = 0.2,
     };
 
     [DataField, AutoNetworkedField]
@@ -29,4 +29,10 @@ public sealed partial class HiveComponent : Component
 
     [DataField, AutoNetworkedField]
     public bool SeeThroughContainers;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan? LastQueenDeath;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan NewQueenCooldown = TimeSpan.FromMinutes(5);
 }

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
@@ -24,6 +24,8 @@ rmc-xeno-evolution-devolve-title = De-Evolve To
 rmc-xeno-evolution-devolve = You devolve to {$xeno}!
 rmc-xeno-evolution-cant-evolve-damaged = We must be at full health to evolve.
 rmc-xeno-evolution-cant-devolve-damaged = We are too weak to deevolve, we must regain our health first.
+rmc-xeno-evolution-cant-evolve-recent-queen-death-minutes = We must wait about {$minutes} minutes and {$seconds} seconds for the hive to recover from the previous Queen's death.
+rmc-xeno-evolution-cant-evolve-recent-queen-death-seconds = We must wait about {$seconds} seconds for the hive to recover from the previous Queen's death.
 
 # Fortify
 cm-xeno-fortify-cant-headbutt = You can't headbutt while fortifying!

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-chat.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-chat.ftl
@@ -1,1 +1,2 @@
 ﻿rmc-no-queen-hivemind-chat = There is no Queen. You are alone.
+rmc-new-queen = A new Queen has risen to lead the Hive! Rejoice!

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-chat.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-chat.ftl
@@ -1,0 +1,1 @@
+﻿rmc-no-queen-hivemind-chat = There is no Queen. You are alone.

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/parasite.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/parasite.yml
@@ -7,6 +7,7 @@
   components:
   - type: GhostRole
     name: cm-job-name-xeno-parasite
+    prob: 0.25
   - type: Sprite
     sprite: _RMC14/Mobs/Xenonids/Parasite/parasite.rsi
   - type: MobState


### PR DESCRIPTION
## About the PR
Time to port this mechanic in the name of causing marine majors again

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed there being no cooldown for replacing a dead Queen. There is now a 5 minute cooldown.
- fix: Fixed hivemind chat not being disabled for xenonids when there is no live Queen. Local chat will still work.
- tweak: Xenonids now receive an announcement in chat when a new Queen evolves.
- tweak: Xenonid parasites now only have a 25% chance of becoming a ghost role.