### PR TITLE
Display operation name in the groundside console UI

### DIFF
--- a/Content.Client/_RMC14/Marines/Announce/MarineCommunicationsComputerBui.cs
+++ b/Content.Client/_RMC14/Marines/Announce/MarineCommunicationsComputerBui.cs
@@ -17,20 +17,26 @@ public sealed class MarineCommunicationsComputerBui(EntityUid owner, Enum uiKey)
 
         _window = new MarineCommunicationsComputerWindow();
         _window.Send.OnPressed += _ => SendPredictedMessage(new MarineCommunicationsComputerMsg( Rope.Collapse(_window.Text.TextRope)));
-
-        if (State is MarineCommunicationsComputerBuiState s)
-            _window.PlanetName.Text = s.Planet;
+        NameUpdates();
 
         _window.OpenCentered();
     }
 
     protected override void UpdateState(BoundUserInterfaceState state)
     {
+        NameUpdates();
+    }
+
+    private void NameUpdates()
+    {
         if (_window == null)
             return;
 
         if (State is MarineCommunicationsComputerBuiState s)
+        {
             _window.PlanetName.Text = s.Planet;
+            _window.OperationName.Text = s.Operation;
+        }
     }
 
     protected override void Dispose(bool disposing)

--- a/Content.Client/_RMC14/Marines/Announce/MarineCommunicationsComputerWindow.xaml
+++ b/Content.Client/_RMC14/Marines/Announce/MarineCommunicationsComputerWindow.xaml
@@ -7,6 +7,10 @@
             <Label Text="Planet: " />
             <Label Name="PlanetName" Access="Public" />
         </BoxContainer>
+        <BoxContainer Orientation="Horizontal">
+            <Label Text="Operation: " />
+            <Label Name="OperationName" Access="Public" />
+        </BoxContainer>
         <TextEdit Name="Text" Access="Public" HorizontalExpand="True" VerticalExpand="True" />
         <Button Name="Send" Access="Public" Text="Send" HorizontalExpand="True" />
     </BoxContainer>

--- a/Content.Client/_RMC14/Marines/Announce/MarineCommunicationsComputerWindow.xaml
+++ b/Content.Client/_RMC14/Marines/Announce/MarineCommunicationsComputerWindow.xaml
@@ -1,7 +1,9 @@
 ﻿<controls:MarineCommunicationsComputerWindow
     xmlns="https://spacestation14.io"
     xmlns:controls="clr-namespace:Content.Client._RMC14.Marines.Announce"
-    Title="Groundside Operations">
+    xmlns:cc="clr-namespace:Content.Client.Administration.UI.CustomControls"
+    Title="Groundside Operations"
+    MinSize="400 350">
     <BoxContainer Orientation="Vertical" Margin="5">
         <BoxContainer Orientation="Horizontal">
             <Label Text="Planet: " />
@@ -11,6 +13,7 @@
             <Label Text="Operation: " />
             <Label Name="OperationName" Access="Public" />
         </BoxContainer>
+        <cc:HSeparator Color="#4972A1" Margin="0 5" />
         <TextEdit Name="Text" Access="Public" HorizontalExpand="True" VerticalExpand="True" />
         <Button Name="Send" Access="Public" Text="Send" HorizontalExpand="True" />
     </BoxContainer>

--- a/Content.Server/_RMC14/Marines/MarineAnnounceSystem.cs
+++ b/Content.Server/_RMC14/Marines/MarineAnnounceSystem.cs
@@ -87,10 +87,10 @@ public sealed class MarineAnnounceSystem : SharedMarineAnnounceSystem
 
     private void UpdatePlanetMap(Entity<MarineCommunicationsComputerComponent> computer)
     {
-        if (_distressSignal.SelectedPlanetMapName is not { } planet)
-            return;
+        var planet = _distressSignal.SelectedPlanetMapName ?? string.Empty;
+        var operation = _distressSignal.OperationName ?? string.Empty;
 
-        var state = new MarineCommunicationsComputerBuiState(planet);
+        var state = new MarineCommunicationsComputerBuiState(planet, operation);
         _ui.SetUiState(computer.Owner, MarineCommunicationsComputerUI.Key, state);
     }
 

--- a/Content.Shared/_RMC14/Marines/Announce/MarineCommunicationsComputerUI.cs
+++ b/Content.Shared/_RMC14/Marines/Announce/MarineCommunicationsComputerUI.cs
@@ -15,7 +15,8 @@ public sealed class MarineCommunicationsComputerMsg(string text) : BoundUserInte
 }
 
 [Serializable, NetSerializable]
-public sealed class MarineCommunicationsComputerBuiState(string planet) : BoundUserInterfaceState
+public sealed class MarineCommunicationsComputerBuiState(string planet, string operation) : BoundUserInterfaceState
 {
     public readonly string Planet = planet;
+    public readonly string Operation = operation;
 }


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: The current operation name is now displayed in the groundside operations console and the command tablet.