### PR TITLE
Fix equipment and gear racks being corrodible

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/base.yml
@@ -2,7 +2,6 @@
 # TODO RMC14 deny and vend states
 - type: entity
   abstract: true
-  parent: CMCorrodible
   id: ColMarTechBase
   name: ColMarTech vendor
   placement:


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed equipment and gear racks being corrodible. They can no longer be destroyed with corrosive acid.