### PR TITLE
fixes lightbulb fixtures not getting one hit by xenos

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Lighting/lighting.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Lighting/lighting.yml
@@ -301,7 +301,7 @@
           collection: GlassBreak
     - trigger:
         !type:DamageTrigger
-        damage: 50
+        damage: 9 # 9.15 for lesser drone
       behaviors:
       - !type:EmptyAllContainersBehaviour
       - !type:SpawnEntitiesBehavior


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
what it says on the tin; seems like the behavior for the lightbulb was overlooked in #2969
fixes #2512

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
to bring lightbulb behavior in line with that of lighttubes


https://github.com/user-attachments/assets/ba69523c-ec72-456c-9af0-65ae30ac7d43

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: lightbulbs now ALSO break in a single hit