### PR TITLE
Almayer is now fallback map, added Almayer to default map pool

### DIFF
--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -2,6 +2,7 @@
   id: DefaultMapPool
   maps:
   - Savannah
+  - Almayer
 
 - type: gameMapPool
   id: DefaultMapPoolAlmayer

--- a/Resources/Prototypes/Maps/saltern.yml
+++ b/Resources/Prototypes/Maps/saltern.yml
@@ -4,7 +4,6 @@
   mapPath: /Maps/saltern.yml
   minPlayers: 0
   maxPlayers: 35
-  fallback: true
   stations:
     Saltern:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/_RMC14/Maps/almayer.yml
+++ b/Resources/Prototypes/_RMC14/Maps/almayer.yml
@@ -2,9 +2,10 @@
   id: Almayer
   mapName: Almayer
   mapPath: /Maps/_RMC14/almayer.yml
-  minPlayers: 0
+  minPlayers: 90
   maxRandomOffset: 0
   randomRotation: false
+  fallback: true
   stations:
     Almayer:
       stationProto: StandardNanotrasenStation


### PR DESCRIPTION
## About the PR

- Added `fallback: true` to Almayer proto
- Removed `fallback: true` from Saltern proto
- Added Almayer to Default Map Pool
- Changed minPlayers from 0 to 90 on Almayer