### PR TITLE
Fix spaceborne gauss turrets hitting marines and not destroying resin structures in a single hit

### DIFF
--- a/Content.Shared/_RMC14/Attachable/Systems/AttachableIFFSystem.cs
+++ b/Content.Shared/_RMC14/Attachable/Systems/AttachableIFFSystem.cs
@@ -2,6 +2,7 @@
 using Content.Shared._RMC14.Attachable.Events;
 using Content.Shared._RMC14.Weapons.Ranged.IFF;
 using Content.Shared.Weapons.Ranged.Events;
+using Robust.Shared.Timing;
 
 namespace Content.Shared._RMC14.Attachable.Systems;
 
@@ -9,6 +10,7 @@ public sealed class AttachableIFFSystem : EntitySystem
 {
     [Dependency] private readonly AttachableHolderSystem _holder = default!;
     [Dependency] private readonly GunIFFSystem _gunIFF = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
 
     public override void Initialize()
     {
@@ -48,6 +50,9 @@ public sealed class AttachableIFFSystem : EntitySystem
 
         var ev = new AttachableGrantIFFEvent();
         _holder.RelayEvent((gun, holder), ref ev);
+
+        if (_timing.ApplyingState)
+            return;
 
         if (ev.Grants)
             EnsureComp<GunAttachableIFFComponent>(gun);

--- a/Content.Shared/_RMC14/Attachable/Systems/AttachableIFFSystem.cs
+++ b/Content.Shared/_RMC14/Attachable/Systems/AttachableIFFSystem.cs
@@ -38,7 +38,7 @@ public sealed class AttachableIFFSystem : EntitySystem
 
     private void OnGunAttachableIFFAmmoShot(Entity<GunAttachableIFFComponent> ent, ref AmmoShotEvent args)
     {
-        _gunIFF.GiveAmmoIFF(ent, ref args);
+        _gunIFF.GiveAmmoIFF(ent, ref args, false);
     }
 
     private void UpdateGunIFF(EntityUid gun)

--- a/Content.Shared/_RMC14/Weapons/Ranged/IFF/GunIFFComponent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/IFF/GunIFFComponent.cs
@@ -2,6 +2,10 @@
 
 namespace Content.Shared._RMC14.Weapons.Ranged.IFF;
 
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 [Access(typeof(GunIFFSystem))]
-public sealed partial class GunIFFComponent : Component;
+public sealed partial class GunIFFComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public bool Intrinsic;
+}

--- a/Content.Shared/_RMC14/Weapons/Ranged/IFF/GunIFFSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/IFF/GunIFFSystem.cs
@@ -65,7 +65,7 @@ public sealed class GunIFFSystem : EntitySystem
 
     private void OnGunIFFAmmoShot(Entity<GunIFFComponent> ent, ref AmmoShotEvent args)
     {
-        GiveAmmoIFF(ent, ref args);
+        GiveAmmoIFF(ent, ref args, ent.Comp.Intrinsic);
     }
 
     private void OnProjectileIFFPreventCollide(Entity<ProjectileIFFComponent> ent, ref PreventCollideEvent args)
@@ -97,16 +97,29 @@ public sealed class GunIFFSystem : EntitySystem
         Dirty(user);
     }
 
-    public void GiveAmmoIFF(EntityUid gun, ref AmmoShotEvent args)
+    public void GiveAmmoIFF(EntityUid gun, ref AmmoShotEvent args, bool intrinsic)
     {
-        if (!_container.TryGetContainingContainer((gun, null), out var container) ||
-            !_userIFFQuery.HasComp(container.Owner))
+        EntityUid owner;
+        if (intrinsic)
+        {
+            owner = gun;
+        }
+        else if (_container.TryGetContainingContainer((gun, null), out var container))
+        {
+            owner = container.Owner;
+        }
+        else
+        {
+            return;
+        }
+
+        if (!_userIFFQuery.HasComp(owner))
         {
             return;
         }
 
         var ev = new GetIFFFactionEvent(null, SlotFlags.IDCARD);
-        RaiseLocalEvent(container.Owner, ref ev);
+        RaiseLocalEvent(owner, ref ev);
 
         if (ev.Faction is not { } id)
             return;

--- a/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
@@ -277,7 +277,7 @@ public sealed class XenoSystem : EntitySystem
             return;
         }
 
-        _damageable.TryChangeDamage(xeno, heal);
+        _damageable.TryChangeDamage(xeno, heal, true);
     }
 
     // TODO RMC14 generalize this for survivors, synthetics, enemy hives, etc

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/sentry.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/sentry.yml
@@ -14,7 +14,7 @@
 - type: entity
   parent: BaseBullet
   id: CMBulletSentry10x50mm
-  name: bullet (10x28mm)
+  name: bullet (10x50mm)
   noSpawn: true
   components:
   - type: Sprite
@@ -28,4 +28,5 @@
         Piercing: 30
   - type: CMArmorPiercing
     amount: 35
+  - type: DeleteXenoResinOnHit
 

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Sentries/static_sentries.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Sentries/static_sentries.yml
@@ -62,6 +62,7 @@
   - type: NoRotateOnInteract
   - type: NoRotateOnMove
   - type: GunIFF
+    intrinsic: true
 
 - type: entity
   parent: RMCBaseTurret


### PR DESCRIPTION
## About the PR
## Media

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed spaceborne gauss turrets not destroying resin structures in one shot.
- fix: Fixed spaceborne gauss turrets hitting marines if they were in the way.