### PR TITLE
Add markdown notices to Almayer files stating they are private.

### DIFF
--- a/Resources/Maps/_RMC14/almayer.yml
+++ b/Resources/Maps/_RMC14/almayer.yml
@@ -1,3 +1,6 @@
+# This file is a duplicate of the Savannah. The actual Almayer map file is currently considered private content by RMC14, along with the map file for LV624.
+# This file is to serve as a solution for a test fail that would result from the lack of its existence otherwise.
+# If you wish for this file, or LV624, to be public you may recreate them yourself and PR it to the repo.
 meta:
   format: 6
   postmapinit: false

--- a/Resources/Prototypes/_RMC14/Maps/almayer.yml
+++ b/Resources/Prototypes/_RMC14/Maps/almayer.yml
@@ -1,4 +1,7 @@
-﻿- type: gameMap
+﻿# The Almayer map file is currently considered private content by RMC14, along with the map file for LV624.
+# The Almayer map file is to serve as a solution for a test fail that would result from the lack of its existence otherwise.
+# If you wish for this file, or LV624, to be public you may recreate them yourself and PR it to the repo.
+- type: gameMap
   id: Almayer
   mapName: Almayer
   mapPath: /Maps/_RMC14/almayer.yml


### PR DESCRIPTION
## About the PR
Adds two notices (Essentially the same), to the Almayer map prototype and Savannah map file.

```
# This file is a duplicate of the Savannah. The actual Almayer map file is currently considered private content by RMC14, along with the map file for LV624.
# This file is to serve as a solution for a test fail that would result from the lack of its existence otherwise.
# If you wish for this file, or LV624, to be public you may recreate them yourself and PR it to the repo.
```

## Why / Balance
Recent and previous issues regarding clarity on their current status. This will allow for future direction to these files for clarity.

## Media
N/A.

## Breaking changes
N/A. Haven't tested ingame, but markdown should not cause a issue.
