### PR TITLE
Fix xenonid stuns making a smart gun operator drop their gun

### DIFF
--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using Content.Shared._RMC14.Inventory;
 using Content.Shared.Hands.Components;
 using Content.Shared.Interaction;
 using Content.Shared.Inventory.VirtualItem;
@@ -129,6 +130,8 @@ public abstract partial class SharedHandsSystem
         if (targetDropLocation == null || isInContainer)
         {
             TransformSystem.DropNextTo((entity, itemXform), (uid, userXform));
+            var ev = new RMCDroppedEvent(uid);
+            RaiseLocalEvent(entity, ref ev, true);
             return true;
         }
 

--- a/Content.Shared/_RMC14/Armor/Magnetic/RMCMagneticSystem.cs
+++ b/Content.Shared/_RMC14/Armor/Magnetic/RMCMagneticSystem.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared.Hands;
+﻿using Content.Shared._RMC14.Inventory;
+using Content.Shared.Hands;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Inventory;
 using Content.Shared.Popups;
@@ -15,6 +16,7 @@ public sealed class RMCMagneticSystem : EntitySystem
     public override void Initialize()
     {
         SubscribeLocalEvent<RMCMagneticItemComponent, DroppedEvent>(OnMagneticItemDropped);
+        SubscribeLocalEvent<RMCMagneticItemComponent, RMCDroppedEvent>(OnMagneticItemRMCDropped);
         SubscribeLocalEvent<RMCMagneticItemComponent, ThrownEvent>(OnMagneticItemThrown);
         SubscribeLocalEvent<RMCMagneticItemComponent, DropAttemptEvent>(OnMagneticItemDropAttempt);
 
@@ -24,6 +26,11 @@ public sealed class RMCMagneticSystem : EntitySystem
     }
 
     private void OnMagneticItemDropped(Entity<RMCMagneticItemComponent> ent, ref DroppedEvent args)
+    {
+        TryReturn(ent, args.User);
+    }
+
+    private void OnMagneticItemRMCDropped(Entity<RMCMagneticItemComponent> ent, ref RMCDroppedEvent args)
     {
         TryReturn(ent, args.User);
     }

--- a/Content.Shared/_RMC14/Inventory/RMCDroppedEvent.cs
+++ b/Content.Shared/_RMC14/Inventory/RMCDroppedEvent.cs
@@ -1,0 +1,4 @@
+﻿namespace Content.Shared._RMC14.Inventory;
+
+[ByRefEvent]
+public readonly record struct RMCDroppedEvent(EntityUid User);


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed xenonid stuns making a smart gun operator drop their gun.
