### PR TITLE
Fix perished texts not using fluent functions

### DIFF
--- a/Resources/Locale/en-US/disease/miasma.ftl
+++ b/Resources/Locale/en-US/disease/miasma.ftl
@@ -16,6 +16,6 @@ rotting-rotting = [color=orange]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($ta
 rotting-bloated = [color=orange]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} unrevivable.[/color]
 rotting-extremely-bloated = [color=orange]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} unrevivable.[/color]
 
-rotting-rotting-nonmob = [color=orange]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)}They are unrevivable.[/color]
+rotting-rotting-nonmob = [color=orange]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} unrevivable.[/color]
 rotting-bloated-nonmob = [color=orange]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} unrevivable.[/color]
 rotting-extremely-bloated-nonmob = [color=orange]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} unrevivable.[/color]

--- a/Resources/Locale/en-US/disease/miasma.ftl
+++ b/Resources/Locale/en-US/disease/miasma.ftl
@@ -2,20 +2,20 @@ ammonia-smell = Something smells pungent!
 
 ## Perishable
 
-perishable-1 = [color=green]They have died recently.[/color]
-perishable-2 = [color=orangered]They have been dead for a while now.[/color]
-perishable-3 = [color=red]They have been dead for several minutes and may become unrevivable![/color]
+perishable-1 = [color=green]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-HAVE($target)} died recently.[/color]
+perishable-2 = [color=orangered]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-HAVE($target)} been dead for a while now.[/color]
+perishable-3 = [color=red]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-HAVE($target)} been dead for several minutes and may become unrevivable![/color]
 
-perishable-1-nonmob = [color=green]They have died recently.[/color]
-perishable-2-nonmob = [color=orangered]They have been dead for a while now.[/color]
-perishable-3-nonmob = [color=red]They have been dead for several minutes and may become unrevivable![/color]
+perishable-1-nonmob = [color=green]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-HAVE($target)} died recently.[/color]
+perishable-2-nonmob = [color=orangered]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-HAVE($target)} been dead for a while now.[/color]
+perishable-3-nonmob = [color=red]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-HAVE($target)} been dead for several minutes and may become unrevivable![/color]
 
 ## Rotting
 
-rotting-rotting = [color=orange]They are unrevivable.[/color]
-rotting-bloated = [color=orange]They are unrevivable.[/color]
-rotting-extremely-bloated = [color=orange]They are unrevivable.[/color]
+rotting-rotting = [color=orange]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} unrevivable.[/color]
+rotting-bloated = [color=orange]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} unrevivable.[/color]
+rotting-extremely-bloated = [color=orange]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} unrevivable.[/color]
 
-rotting-rotting-nonmob = [color=orange]They are unrevivable.[/color]
-rotting-bloated-nonmob = [color=orange]They are unrevivable.[/color]
-rotting-extremely-bloated-nonmob = [color=orange]They are unrevivable.[/color]
+rotting-rotting-nonmob = [color=orange]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)}They are unrevivable.[/color]
+rotting-bloated-nonmob = [color=orange]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} unrevivable.[/color]
+rotting-extremely-bloated-nonmob = [color=orange]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} unrevivable.[/color]


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Change perish to use the fluent functions for the subject.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Fixes #3091, looks nicer with all the other texts

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
![ded](https://github.com/user-attachments/assets/b9915fc8-8ffa-4c0b-abc8-c7bff1619476)


## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
no?
**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
nah
