### PR TITLE
Makes Wehny into a temporary boss 

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/wehny.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/wehny.yml
@@ -75,10 +75,12 @@
       groups:
         Brute: 50
   - type: Tackle
-    threshold: 5
-    stun: 8
+    threshold: 1
+    stun: 15
   - type: MovementSpeedModifier
     baseWalkSpeed: 5.55
     baseSprintSpeed: 20
+  - type: TimedDespawn 
+    lifetime: 120 #perfect for admins to spawn in on round-end, or, for the more daring admemes, to give xenos a chance to regroup from an insane marine stomp
 #  - type: RMCXenoDamageVisuals # TODO RMC14
 #    prefix: runner

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/wehny.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/wehny.yml
@@ -75,7 +75,7 @@
       groups:
         Brute: 50
   - type: Tackle
-    threshold: 1
+    threshold: 4
     stun: 15
   - type: MovementSpeedModifier
     baseWalkSpeed: 5.55

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/wehny.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/wehny.yml
@@ -75,8 +75,8 @@
       groups:
         Brute: 50
   - type: Tackle
-    threshold: 4
-    stun: 15
+    threshold: 5
+    stun: 8
   - type: MovementSpeedModifier
     baseWalkSpeed: 5.55
     baseSprintSpeed: 20


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Wehnies will now despawn after 2 minutes. 
## Why / Balance
Smugleaf said that Wehny is too OP, even for a shitpost boss xeno. This makes Wehny into a temporary entity, so admins don't need to worry about a single xenonid destroying the entire server. Only most of the server. (also tackle has been made better, but only slightly). 2 minutes was chosen since that's roughly the time it takes for the lobby to load after the round ends, letting admins have a wehny terrorize the server for the full two minutes. 
## Technical details
simple YML work
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


