### PR TITLE
[Discussion Required] Adds ColMarTech Command Gear Rack (Command supply vendor)

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/vending_machines.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/vending_machines.yml
@@ -268,6 +268,50 @@
     CMHeadsetAlpha: 6
     # Crew Monitor
 
+# RMC14 Command Supplies Vendor
+- type: entity
+  parent: ColMarTechBase
+  id: CMVendorCommandSupplies
+  name: ColMarTech Command Gear Rack
+  description: Contains various command equipment, clothing, and gear.
+  components:
+  - type: Sprite
+    sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/equipment.rsi # RMC14 TODO: Custom Sprite, generic equipment is fine but not ideal.
+  - type: CMAutomatedVendor
+    sections:
+    - name: Encryption Keys
+      entries: 
+      - id: CMEncryptionKeyCommand
+        amount: 4 # Fairly arbitrary number. Balance as needed. 
+      - id: CMEncryptionKeyMilitaryPolice
+        amount: 2 # Kept low, the need to replace MPs should be infrequent.
+      - id: CMEncryptionKeyIntel
+        amount: 4 # To give to SLs or FTLs.
+    - name: Command and Control #Rename?
+      entries: 
+      - id: RMCTabletCO
+        amount: 2
+    - name: Clothing
+      entries: 
+      - id: CMGlassesSecurity
+        amount: 4
+      - id: CMHandsBlackMarine
+        amount: 4
+      - id: CMHandsLightBrown
+        amount: 4
+      - id: CMHandsBlackMarine
+        amount: 4
+      - id: CMHeadCapMP
+        amount: 2
+      - id: CMHeadBeretTan
+        amount: 2
+      - id: CMCoatOfficer
+        amount: 2
+      - id: CMCoatLong
+        amount: 2
+  - type: AccessReader
+    access: [["CMAccessCommand"]]
+
 
 # Nutriments
 - type: entity


### PR DESCRIPTION
## About the PR
Adds a new vending machine locked to command access. It contains various items members of marine command may use regularly. Such as clothing, extra headset keys, and command tablets. Currently uses the generic equipment vendor sprite, I have it marked down that a custom sprite would be nice.

## Why / Balance
This originally started from a feedback thread I open discussing a possible solution to allow command to promote marines into the SL position and give out additional radio keys. After more discussion it was found that req had a vendor to provide squad keys and other misc keys (JTAC, Intel, ETC). So, I expanded the idea into a more generic vendor for command staff to get supplies from, while still solving the original problem.

As for the original problem, there is no way to replace dead SLs currently (Without pushing into the hive they were taken to and ripping off their headset, which is quite informal and not a ideal solution.). While there is the system in CM13 to promote, I believe that to be a long ways away in current development and this is to serve as a intermediate solution. This solution is not risk free, nor infinite. A marine (Or Command Member) still has to deliver the key to the promoted member, or that marine has to be pulled off of the front lines to receive it.

**MP Keys**, I believe the same matter goes for replacing MPs, just on a much smaller scale. CMPs should have the capacity to replace MPs if required, just not as significant of a issue. If its determined the MP keys should be removed, that is acceptable.

**Intel Keys**, I've recently seen FTLs purchasing intel keys to allow better communication between squads if SLs are busy or happen to die. I believe allowing command members to give a few of these keys to FTLs would help encourage a vastly underused channel's use. I've heard that its possible marine common will be removed, making the key more useful, but right now it requires much coordination and is still very unofficial. This would make intel as a channel much more used I believe.

**Command Tablets & Clothing**, I am unsure if should stay and I'm open to discussion around them. With the clothing, none of it is currently accessible (For most of the items.) and I believe it would be nice to give officers some distinction between eachother. Visibility as a officer is less of a problem due to the HUD Icons. 

## Technical details
YML.

## Media
TODO once contents are finalized.

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None. Though its worth noting that this would have to be mapped on ships. If this gets merged, I will open two issues saying it needs to be mapped.

**Changelog**

:cl:
- add: A new ColMarTech vendor has been added. This vendor is restricted to command and will have clothing, command tablets, and additional radio keys, command included, to allow for promotion of new SLs if required during a operation.
