### PR TITLE
Fix xeno doors showing powered

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_doors.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_doors.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   id: DoorXenoResin # TODO RMC14 make them only buildable next to other resin walls
   parent: CMBaseXenoStructure
   name: resin door
@@ -69,10 +69,9 @@
   - type: Airlock
     emergencyAccessLayer: false
     animatePanel: false
+    powered: true
     openingSpriteState: closed_unlit
     closingSpriteState: closed_unlit
-  - type: ApcPowerReceiver
-    powerLoad: 0
   - type: XenoConstructionPlasmaCost
     plasma: 120
   - type: MeleeReceivedMultiplier


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Fixes #3129 

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Xenonids don't use electricity

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Removed `ApcPowerReciever` and forced `Airlock` to be `Powered`

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
![Screenshot_20240718_100253](https://github.com/user-attachments/assets/bc5fcb9d-8b88-4602-8e69-10fe0675563a)

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Resin doors are no longer powered
