### PR TITLE
Dead paras can't be used to infect

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
@@ -303,6 +303,13 @@ public abstract class SharedXenoParasiteSystem : EntitySystem
             return false;
         }
 
+        if(_mobState.IsDead(parasite))
+        {
+            if(popup)
+				_popup.PopupClient(Loc.GetString("rmc-xeno-failed-parasite-dead"), victim, user, PopupType.MediumCaution);
+
+            return false;
+		}
         return true;
     }
 

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-parasite.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-parasite.ftl
@@ -2,3 +2,4 @@ rmc-xeno-failed-cant-infect = You can't infect {THE($target)}!
 rmc-xeno-failed-cant-reach = You can't reach {$target}, they need to be lying down!
 rmc-xeno-failed-target-dead = You can't infect the dead!
 rmc-xeno-infect-success = The parasite smashes against {$target}'s mask and rips it off!
+rmc-xeno-failed-parasite-dead = You can't infect with a dead parasite!


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Dead parasites can no longer be used by xenos to infect hosts.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Fixes discord issue, bug

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
SharedParasiteSystem now also checks if the parasite is dead when it can infect.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/user-attachments/assets/585dd7bb-c8f3-4c6e-86d3-cdf43589a0d0



## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- fix: Dead parasites can no longer be used to infect hosts
