### PR TITLE
Xenos drop held items on evolution/de-evolution

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
@@ -224,11 +224,11 @@ public sealed class XenoEvolutionSystem : EntitySystem
         _mind.TransferTo(mindId, newXeno);
         _mind.UnVisit(mindId);
 
-		foreach (var held in _hands.EnumerateHeld(xeno))
-			_hands.TryDrop(xeno, held);
+        foreach (var held in _hands.EnumerateHeld(xeno))
+            _hands.TryDrop(xeno, held);
 
-		// TODO RMC14 this is a hack because climbing on a newly created entity does not work properly for the client
-		var comp = EnsureComp<XenoNewlyEvolvedComponent>(newXeno);
+        // TODO RMC14 this is a hack because climbing on a newly created entity does not work properly for the client
+        var comp = EnsureComp<XenoNewlyEvolvedComponent>(newXeno);
 
         _doors.Clear();
         _entityLookup.GetEntitiesIntersecting(xeno, _doors);

--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
@@ -11,6 +11,7 @@ using Content.Shared.DoAfter;
 using Content.Shared.Doors.Components;
 using Content.Shared.FixedPoint;
 using Content.Shared.GameTicking;
+using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Mind;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
@@ -44,8 +45,9 @@ public sealed class XenoEvolutionSystem : EntitySystem
     [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
     [Dependency] private readonly XenoSystem _xeno = default!;
     [Dependency] private readonly SharedXenoAnnounceSystem _xenoAnnounce = default!;
+	[Dependency] private readonly SharedHandsSystem _hands = default!;
 
-    private readonly HashSet<EntityUid> _climbable = new();
+	private readonly HashSet<EntityUid> _climbable = new();
     private readonly HashSet<EntityUid> _doors = new();
     private readonly HashSet<EntityUid> _intersecting = new();
 
@@ -178,6 +180,9 @@ public sealed class XenoEvolutionSystem : EntitySystem
         _mind.TransferTo(mindId, newXeno);
         _mind.UnVisit(mindId);
 
+        foreach (var held in _hands.EnumerateHeld(xeno))
+            _hands.TryDrop(xeno, held);
+
         // TODO RMC14 this is a hack because climbing on a newly created entity does not work properly for the client
         var comp = EnsureComp<XenoNewlyEvolvedComponent>(newXeno);
 
@@ -219,8 +224,11 @@ public sealed class XenoEvolutionSystem : EntitySystem
         _mind.TransferTo(mindId, newXeno);
         _mind.UnVisit(mindId);
 
-        // TODO RMC14 this is a hack because climbing on a newly created entity does not work properly for the client
-        var comp = EnsureComp<XenoNewlyEvolvedComponent>(newXeno);
+		foreach (var held in _hands.EnumerateHeld(xeno))
+			_hands.TryDrop(xeno, held);
+
+		// TODO RMC14 this is a hack because climbing on a newly created entity does not work properly for the client
+		var comp = EnsureComp<XenoNewlyEvolvedComponent>(newXeno);
 
         _doors.Clear();
         _entityLookup.GetEntitiesIntersecting(xeno, _doors);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Xenos will now drop eggs/paras when the evolve/devolve.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Fixes discord issue, without this the parasites/eggs disappear.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Uses the SharedHandsSystem to drop everything the xeno is carrying.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/user-attachments/assets/433af756-87ec-4563-9064-d8c317e46ffa



## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
nah
**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
no cl smol
