### PR TITLE
make sandbags cheaper

### DIFF
--- a/Resources/Prototypes/_RMC14/Catalog/Cargo/requisitions_catalog.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Cargo/requisitions_catalog.yml
@@ -98,9 +98,9 @@
         crate: CMCrateClothingOfficerOutfit
     - name: Engineering
       entries:
-      - cost: 2000
+      - cost: 1500
         crate: CMCrateEmptySandbags
-      - cost: 3000
+      - cost: 2500
         crate: CMCrateSandbagsConstructionKit
       - cost: 2000
         crate: CMCrateMetalSheets

--- a/Resources/Prototypes/_RMC14/Catalog/Fills/Crates/engineering.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Fills/Crates/engineering.yml
@@ -10,7 +10,7 @@
 - type: entity
   id: CMCrateSandbagsConstructionKit
   parent: CMCrateConstruction
-  name: sandbags construction lit
+  name: sandbags construction kit
   components:
   - type: StorageFill
     contents:


### PR DESCRIPTION
## About the PR
$2000 -> $1500, similar for the kit that has entrenching tools (which i think are extremely overpriced but whatever)

also fixed a typo lit -> kit

## Why / Balance
- sandbags are far less versatile than metal so they shouldnt cost the same
- they need filling instead of just being able to use it immediately
- they cant be used on the almayer since no sand

**Changelog**
:cl:
- tweak: Sandbags are now cheaper to buy at Requesitions.
