### PR TITLE
added ammo box to requesition munitions vendor

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magazine_boxes.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magazine_boxes.yml
@@ -40,8 +40,6 @@
   abstract: true
   parent: CMBoxMagazineBase
   id: CMBoxMagazineAPBase
-  name: generic magazine box (? x ?)"
-  description: A box of magazines.
   components:
   - type: GenericVisualizer
     visuals:
@@ -64,8 +62,6 @@
   abstract: true
   parent: CMBoxMagazineBase
   id: CMBoxMagazineHVBase
-  name: generic magazine box (? x ?)"
-  description: A box of magazines.
   components:
   - type: GenericVisualizer
     visuals:
@@ -579,7 +575,7 @@
 
 - type: entity
   parent: CMBoxMagazinePistolMK80Empty
-  id:  CMBoxMagazinePistolMK80
+  id: CMBoxMagazinePistolMK80
   name: magazine box (MK80 x 16)
   components:
   - type: CMItemSlots

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
@@ -331,8 +331,24 @@
       #  amount: 2
       #- id: XM51 Magazine (16g)
       #  amount: 3
-    - name: Shotgun shell boxes # I don't think we have those yet
-      entries: [ ]
+    - name: Boxes
+      entries:
+      - id: CMBoxMagazineRifleM4SPR
+        amount: 3
+      - id: CMBoxMagazineRifleM54C
+        amount: 9
+      - id: CMBoxMagazineSMGM63
+        amount: 8
+      - id: CMBoxMagazinePistolM1984
+        amount: 6
+      - id: CMBoxMagazinePistolM77AP
+        amount: 3
+      - id: CMBoxMagazineRifleM4SPRAP
+      - id: CMBoxMagazineSMGM63AP
+      - id: CMBoxMagazineRifleM54CAP
+      - id: CMBoxMagazineSMGM63Ext
+      - id: CMBoxMagazineRifleM54CExt
+      # TODO: add shotgun shell boxes
       #- id: Shotgun Shell Box (Buckshot x 100)
       #  amount: 4
       #- id: Shotgun Shell Box (Flechette x 100)
@@ -340,7 +356,6 @@
       #- id: Shotgun Shell Box (Slugs x 100)
       #  amount: 4
       #- id: Shotgun Shell Box (16g) (Breaching x 120)
-      #  amount: 1
 
  #ATTACHMENTS VENDOR
 

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
@@ -269,34 +269,28 @@
         amount: 40
       - id: CMBoxShotgunSlugs
         amount: 40
-      - id: CMMagazineRifleM4SPR
-        amount: 45
-      - id: CMMagazineRifleM54C
-        amount: 100
-      - id: CMMagazineSMGM63
-        amount: 100
+      - id: CMBoxMagazineRifleM4SPR
+        amount: 3
+      - id: CMBoxMagazineRifleM54C
+        amount: 8
+      - id: CMBoxMagazineSMGM63
+        amount: 8
       #- id: M44 Speed Loader (.44)
       #  amount: 80
-      - id: CMMagazinePistolM1984
-        amount: 102
+      - id: CMBoxMagazinePistolM1984
+        amount: 6
     - name: Armor-piercing ammunition
       entries:
-      - id: CMMagazinePistolM77AP
-        amount: 50
-      - id: CMMagazineRifleM4SPRAP
-        amount: 16
-      - id: CMMagazineSMGM63AP
-        amount: 12
-      - id: CMMagazineRifleM54CAP
-        amount: 10
-      #- id: M4A3 AP Magazine (9mm)
-      #  amount: 2
+      - id: CMBoxMagazinePistolM77AP
+        amount: 3
+      - id: CMBoxMagazineRifleM4SPRAP
+      - id: CMBoxMagazineSMGM63AP
+      - id: CMBoxMagazineRifleM54CAP
+      #- id: M4A3 AP Magazine (9mm) (a box of this with 2 magazines)
     - name: Extended ammunition
       entries:
-      - id: CMMagazineSMGM63Ext
-        amount: 10
-      - id: CMMagazineRifleM54CExt
-        amount: 8
+      - id: CMBoxMagazineSMGM63Ext
+      - id: CMBoxMagazineRifleM54CExt
     - name: Special ammunition
       entries:
       - id: RMCPowerCellSmartgun
@@ -313,10 +307,8 @@
       #  amount: 2
     - name: Restricted firearm ammunition
       entries:
-      - id: CMMagazinePistolMK80
-        amount: 11
-      - id: RMCMagazinePistolSU6
-        amount: 13
+      - id: CMBoxMagazinePistolMK80
+      - id: RMCBoxMagazinePistolSU6
       #- id: M240 Incinerator Tank
       #  amount: 3
       #- id: M41AE2 Box Magazine (10x24mm)

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
@@ -269,28 +269,34 @@
         amount: 40
       - id: CMBoxShotgunSlugs
         amount: 40
-      - id: CMBoxMagazineRifleM4SPR
-        amount: 3
-      - id: CMBoxMagazineRifleM54C
-        amount: 8
-      - id: CMBoxMagazineSMGM63
-        amount: 8
+      - id: CMMagazineRifleM4SPR
+        amount: 45
+      - id: CMMagazineRifleM54C
+        amount: 100
+      - id: CMMagazineSMGM63
+        amount: 100
       #- id: M44 Speed Loader (.44)
       #  amount: 80
-      - id: CMBoxMagazinePistolM1984
-        amount: 6
+      - id: CMMagazinePistolM1984
+        amount: 102
     - name: Armor-piercing ammunition
       entries:
-      - id: CMBoxMagazinePistolM77AP
-        amount: 3
-      - id: CMBoxMagazineRifleM4SPRAP
-      - id: CMBoxMagazineSMGM63AP
-      - id: CMBoxMagazineRifleM54CAP
-      #- id: M4A3 AP Magazine (9mm) (a box of this with 2 magazines)
+      - id: CMMagazinePistolM77AP
+        amount: 50
+      - id: CMMagazineRifleM4SPRAP
+        amount: 16
+      - id: CMMagazineSMGM63AP
+        amount: 12
+      - id: CMMagazineRifleM54CAP
+        amount: 10
+      #- id: M4A3 AP Magazine (9mm)
+      #  amount: 2
     - name: Extended ammunition
       entries:
-      - id: CMBoxMagazineSMGM63Ext
-      - id: CMBoxMagazineRifleM54CExt
+      - id: CMMagazineSMGM63Ext
+        amount: 10
+      - id: CMMagazineRifleM54CExt
+        amount: 8
     - name: Special ammunition
       entries:
       - id: RMCPowerCellSmartgun
@@ -307,8 +313,10 @@
       #  amount: 2
     - name: Restricted firearm ammunition
       entries:
-      - id: CMBoxMagazinePistolMK80
-      - id: RMCBoxMagazinePistolSU6
+      - id: CMMagazinePistolMK80
+        amount: 11
+      - id: RMCMagazinePistolSU6
+        amount: 13
       #- id: M240 Incinerator Tank
       #  amount: 3
       #- id: M41AE2 Box Magazine (10x24mm)


### PR DESCRIPTION
## About the PR
no mags were removed just added free boxes because cm13 has that

## Why / Balance
fixes #3092

## Media
- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Requesitions can now get boxes of ammo in their munitions vendor.