### PR TITLE
Separate attachment activate and deactivate delays.

### DIFF
--- a/Content.Shared/_RMC14/Attachable/Components/AttachableToggleableComponent.cs
+++ b/Content.Shared/_RMC14/Attachable/Components/AttachableToggleableComponent.cs
@@ -46,7 +46,10 @@ public sealed partial class AttachableToggleableComponent : Component
     public bool WieldedOnly = false;
 
     [DataField, AutoNetworkedField]
-    public float DoAfter;
+    public float ActivateDelay;
+
+    [DataField, AutoNetworkedField]
+    public float DeactivateDelay;
 
     [DataField, AutoNetworkedField]
     public bool DoAfterNeedHand = true;

--- a/Content.Shared/_RMC14/Attachable/Systems/AttachableToggleableSystem.cs
+++ b/Content.Shared/_RMC14/Attachable/Systems/AttachableToggleableSystem.cs
@@ -54,7 +54,7 @@ public sealed class AttachableToggleableSystem : EntitySystem
 
         SubscribeLocalEvent<AttachableToggleablePreventShootComponent, AttachableAlteredEvent>(OnAttachableAltered,
             after: new[] { typeof(AttachableModifiersSystem) });
-        
+
         SubscribeLocalEvent<AttachableGunPreventShootComponent, AttemptShootEvent>(OnAttemptShoot);
     }
 
@@ -155,7 +155,7 @@ public sealed class AttachableToggleableSystem : EntitySystem
                 preventShootComponent.PreventShoot = false;
                 break;
         }
-        
+
         Dirty(args.Holder, preventShootComponent);
     }
 #endregion
@@ -208,9 +208,9 @@ public sealed class AttachableToggleableSystem : EntitySystem
     {
         if (!attachable.Comp.Attached)
             return;
-        
+
         args.Handled = true;
-        
+
         if (!attachable.Comp.NeedHand || !attachable.Comp.Active)
             return;
 
@@ -221,17 +221,17 @@ public sealed class AttachableToggleableSystem : EntitySystem
     {
         if (!attachable.Comp.Attached || args.Unequipped == attachable.Owner)
             return;
-        
+
         args.Handled = true;
-        
+
         RemoveAttachableActions(attachable, args.User);
-        
+
         if (!attachable.Comp.NeedHand || !attachable.Comp.Active)
             return;
 
         Toggle(attachable, args.User, attachable.Comp.DoInterrupt);
     }
-    
+
     private void OnAttachableMovementLockedMoveInput(Entity<AttachableMovementLockedComponent> user, ref MoveInputEvent args)
     {
         foreach (EntityUid attachableUid in user.Comp.AttachableList)
@@ -242,7 +242,7 @@ public sealed class AttachableToggleableSystem : EntitySystem
             {
                 continue;
             }
-            
+
             Toggle((attachableUid, toggleableComponent), user.Owner, toggleableComponent.DoInterrupt);
         }
 
@@ -293,7 +293,7 @@ public sealed class AttachableToggleableSystem : EntitySystem
         _doAfterSystem.TryStartDoAfter(new DoAfterArgs(
             EntityManager,
             args.User,
-            attachable.Comp.DoAfter,
+            (attachable.Comp.Active) ? attachable.Comp.DeactivateDelay : attachable.Comp.ActivateDelay,
             new AttachableToggleDoAfterEvent(args.SlotId),
             attachable,
             target: attachable.Owner,
@@ -354,7 +354,7 @@ public sealed class AttachableToggleableSystem : EntitySystem
                 _attachableHolderSystem.SetSupercedingAttachable(holder, null);
             return;
         }
-        
+
         if (attachable.Comp.BreakOnMove && userUid != null)
         {
             var movementLockedComponent = EnsureComp<AttachableMovementLockedComponent>(userUid.Value);
@@ -400,7 +400,7 @@ public sealed class AttachableToggleableSystem : EntitySystem
         {
             return;
         }
-        
+
         FinishToggle(attachable, (holderUid.Value, holderComponent), slotId, user, interrupted);
         Dirty(attachable);
     }
@@ -411,7 +411,7 @@ public sealed class AttachableToggleableSystem : EntitySystem
     {
         GrantAttachableActions(ent, args.User);
     }
-    
+
     private void GrantAttachableActions(Entity<AttachableToggleableComponent> ent, EntityUid user, bool doSecondTry = true)
     {
         // This is to prevent ActionContainerSystem from shitting itself if the attachment has actions other than its attachment toggle.
@@ -454,15 +454,15 @@ public sealed class AttachableToggleableSystem : EntitySystem
     {
         RemoveAttachableActions(ent, args.User);
     }
-    
+
     private void RemoveAttachableActions(Entity<AttachableToggleableComponent> ent, EntityUid user)
     {
         if (ent.Comp.Action is not { } action)
             return;
-        
+
         if (!TryComp(action, out InstantActionComponent? actionComponent) || actionComponent.AttachedEntity != user)
             return;
-        
+
         _actionsSystem.RemoveProvidedAction(user, ent, action);
     }
 

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/rail_attachments.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/rail_attachments.yml
@@ -344,7 +344,8 @@
     - RMCAttachmentRail
     - RMCAttachmentB8SmartScope
   - type: AttachableToggleable
-    doAfter: 0.8
+    activateDelay: 0.8
+    deactivateDelay: 0.0
     icon:
       sprite: _RMC14/Objects/Weapons/Guns/Attachments/rail.rsi
       state: huntingscope

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/stock_attachments.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/stock_attachments.yml
@@ -188,7 +188,8 @@
     - RMCAttachmentStock
     - RMCAttachmentM54CStockCollapsible
   - type: AttachableToggleable
-    doAfter: 0.5
+    activateDelay: 0.5
+    deactivateDelay: 0.5
     icon:
       sprite: _RMC14/Objects/Weapons/Guns/Attachments/rmc_stock.rsi
       state: m54c-col
@@ -256,7 +257,8 @@
   - type: AttachableVisuals
     suffix: ""
   - type: AttachableToggleable
-    doAfter: 0.5
+    activateDelay: 0.5
+    deactivateDelay: 0.5
     icon:
       sprite: _RMC14/Objects/Weapons/Guns/Attachments/stock.rsi
       state: m16-folding
@@ -413,7 +415,8 @@
     - RMCAttachmentStock
     - RMCAttachmentM63ArmBrace
   - type: AttachableToggleable
-    doAfter: 2.5
+    activateDelay: 2.5
+    deactivateDelay: 2.5
     icon:
       sprite: _RMC14/Objects/Weapons/Guns/Attachments/stock.rsi
       state: smg-brace
@@ -462,7 +465,8 @@
   - type: AttachableToggleablePreventShoot
     message: You need to extend the stock first!
   - type: AttachableToggleable
-    doAfter: 1.5
+    activateDelay: 1.5
+    deactivateDelay: 1.5
     icon:
       sprite: _RMC14/Objects/Weapons/Guns/Attachments/stock.rsi
       state: 44stock


### PR DESCRIPTION
## About the PR

Added the ability to set both an activation and deactivation delay independent of one another to attachments.
To showcase, have changed the smart scope to use a delay on activation but have a zero delay on deactivation.

There's some whitespace changes too which seem to be more correct with the rest of the project formatting?

## Why / Balance

This might be useful for future attachments and getting it in early means less file edits. Does mean some fields are duplicates... but there might be a solution that I'm not seeing to that through serialization?

As for the smart scope change, have found myself not hitting the button to deactivate instead opting to unwield or perform some other interrupt action. Ends up being way faster than the action especially with higher latency.

Straight up unwield is still faster for movement anyways but can remove from the PR if that part is unwanted.

## Media

[rmc-attachment-delay.webm](https://github.com/user-attachments/assets/02f1f8f8-2dd7-4cad-8b40-46b1f5005470)


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes

* `DoAfter` field is renamed to `ActivateDelay` as well as adding a new field named `DeactivateDelay`.

**Changelog**

* add: Attachment activation and deactivation delays.
* tweak: S8 Smart-Scope zero deactivation delay.
