### PR TITLE
Fix explosions turning weedless steel tiles into weedable underplating tiles, fix underplating sprite, tweak xeno no weeds here popup

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
@@ -153,7 +153,10 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
         var tile = _mapSystem.CoordinatesToTile(gridUid, grid, coordinates);
         if (!_xenoWeeds.CanPlaceWeeds((gridUid, grid), tile))
         {
-            _popup.PopupClient(Loc.GetString("cm-xeno-construction-failed-weeds"), xeno.Owner, xeno.Owner);
+            _popup.PopupClient(Loc.GetString("cm-xeno-construction-failed-weeds"),
+                xeno.Owner,
+                xeno.Owner,
+                PopupType.SmallCaution);
             return;
         }
 

--- a/Resources/Locale/en-US/_RMC14/tiles/tiles.ftl
+++ b/Resources/Locale/en-US/_RMC14/tiles/tiles.ftl
@@ -1,5 +1,6 @@
 tiles-cm-default = metal tile
 tiles-cm-default-no-weeds = metal tile (no weeds)
+tiles-rmc-underplating-no-weeds = plating (no weeds)
 tiles-cm-plate = metal plate tile
 tiles-cm-office = office tile
 tiles-cm-sterile = metal sterile tile

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-construction.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-construction.ftl
@@ -1,4 +1,4 @@
-cm-xeno-construction-failed-weeds = You can't plant weeds here!
+cm-xeno-construction-failed-weeds = Bad place for a garden!
 cm-xeno-construction-failed-need-weeds = You can only shape on weeds. Find some resin before you start building!
 cm-xeno-construction-failed-cant-build = You can't build there!
 cm-xeno-construction-failed-select-structure = You need to select a structure to build first! Use the "Choose Resin Structure" action.

--- a/Resources/Prototypes/Tiles/plating.yml
+++ b/Resources/Prototypes/Tiles/plating.yml
@@ -1,7 +1,7 @@
 ﻿- type: tile
   id: Plating
   name: tiles-plating
-  sprite: /Textures/Tiles/plating.png
+  sprite: /Textures/_RMC14/Tiles/shiva/plating.png
   baseTurf: Lattice
   isSubfloor: true
   footstepSounds:

--- a/Resources/Prototypes/_RMC14/Tiles/almayer.yml
+++ b/Resources/Prototypes/_RMC14/Tiles/almayer.yml
@@ -3,7 +3,7 @@
   id: CMTileBase
   baseTurf: Plating
   isSubfloor: false
-  canCrowbar: true
+  deconstructTools: [ Prying ]
   footstepSounds:
     collection: FootstepFloor
   itemDrop: CMTileItemSteel
@@ -22,7 +22,7 @@
   sprite: /Textures/_RMC14/Tiles/almayer/default.png
   weedsSpreadable: false
   baseTurf: ""
-  canCrowbar: false
+  deconstructTools: [ ]
 
 - type: tile
   parent: CMFloorSteelNoWeeds
@@ -31,7 +31,7 @@
   sprite: /Textures/_RMC14/Tiles/shiva/plating.png
   weedsSpreadable: false
   baseTurf: ""
-  canCrowbar: false
+  deconstructTools: [ ]
   isSubfloor: true
 
 - type: tile

--- a/Resources/Prototypes/_RMC14/Tiles/almayer.yml
+++ b/Resources/Prototypes/_RMC14/Tiles/almayer.yml
@@ -25,6 +25,16 @@
   canCrowbar: false
 
 - type: tile
+  parent: CMFloorSteelNoWeeds
+  id: RMCFloorUnderplatingNoWeeds
+  name: tiles-rmc-underplating-no-weeds
+  sprite: /Textures/_RMC14/Tiles/shiva/plating.png
+  weedsSpreadable: false
+  baseTurf: ""
+  canCrowbar: false
+  isSubfloor: true
+
+- type: tile
   parent: CMTileBase
   id: CMFloorPlate
   name: tiles-cm-plate

--- a/Resources/Prototypes/_RMC14/Tiles/almayer.yml
+++ b/Resources/Prototypes/_RMC14/Tiles/almayer.yml
@@ -21,6 +21,8 @@
   name: tiles-cm-default-no-weeds
   sprite: /Textures/_RMC14/Tiles/almayer/default.png
   weedsSpreadable: false
+  baseTurf: ""
+  canCrowbar: false
 
 - type: tile
   parent: CMTileBase

--- a/Resources/Prototypes/_RMC14/Tiles/planet.yml
+++ b/Resources/Prototypes/_RMC14/Tiles/planet.yml
@@ -2,7 +2,7 @@
   abstract: true
   id: CMPlanetBase
   isSubfloor: true
-  canCrowbar: false
+  deconstructTools: [ ]
   footstepSounds:
     collection: FootstepGrass
   heatCapacity: 10000


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed explosions making elevator tiles weedable.
- fix: Fixed underplating using the wrong sprite.
- tweak: Changed the popup that shows when trying to plant weeds on an invalid tile.