### PR TITLE
Fix marines not being able to shake stunned marines awake

### DIFF
--- a/Content.Shared/_RMC14/ShakeStun/StunShakeableComponent.cs
+++ b/Content.Shared/_RMC14/ShakeStun/StunShakeableComponent.cs
@@ -1,0 +1,7 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.ShakeStun;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(StunShakeableSystem))]
+public sealed partial class StunShakeableComponent : Component;

--- a/Content.Shared/_RMC14/ShakeStun/StunShakeableSystem.cs
+++ b/Content.Shared/_RMC14/ShakeStun/StunShakeableSystem.cs
@@ -1,0 +1,42 @@
+﻿using Content.Shared.Interaction;
+using Content.Shared.Popups;
+using Content.Shared.StatusEffect;
+using Robust.Shared.Player;
+
+namespace Content.Shared._RMC14.ShakeStun;
+
+public sealed class StunShakeableSystem : EntitySystem
+{
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<StunShakeableComponent, InteractHandEvent>(OnStunShakeableInteractHand);
+    }
+
+    private void OnStunShakeableInteractHand(Entity<StunShakeableComponent> ent, ref InteractHandEvent args)
+    {
+        var user = args.User;
+        if (!HasComp<StunShakeableUserComponent>(user))
+            return;
+
+        var target = args.Target;
+        var any = _statusEffects.TryRemoveStatusEffect(target, "Stun");
+        if (_statusEffects.TryRemoveStatusEffect(target, "KnockedDown"))
+            any = true;
+
+        if (!any)
+            return;
+
+        var userPopup = Loc.GetString("rmc-shake-awake-user", ("target", target));
+        _popup.PopupClient(userPopup, target, user);
+
+        var targetPopup = Loc.GetString("rmc-shake-awake-target", ("user", user));
+        _popup.PopupEntity(targetPopup, target, target);
+
+        var othersPopup = Loc.GetString("rmc-shake-awake-others", ("user", user), ("target", target));
+        var others = Filter.PvsExcept(target).RemovePlayerByAttachedEntity(user);
+        _popup.PopupEntity(othersPopup, target, others, true);
+    }
+}

--- a/Content.Shared/_RMC14/ShakeStun/StunShakeableSystem.cs
+++ b/Content.Shared/_RMC14/ShakeStun/StunShakeableSystem.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared.Interaction;
+﻿using Content.Shared._RMC14.Tackle;
+using Content.Shared.Interaction;
 using Content.Shared.Popups;
 using Content.Shared.StatusEffect;
 using Robust.Shared.Player;
@@ -28,7 +29,8 @@ public sealed class StunShakeableSystem : EntitySystem
 
         var target = args.Target;
         if (!_statusEffects.HasStatusEffect(target, Stun) &&
-            !_statusEffects.HasStatusEffect(target, KnockedDown))
+            !_statusEffects.HasStatusEffect(target, KnockedDown) &&
+            !HasComp<TackledRecentlyComponent>(target))
         {
             return;
         }
@@ -44,6 +46,7 @@ public sealed class StunShakeableSystem : EntitySystem
 
         _statusEffects.TryRemoveStatusEffect(target, "Stun");
         _statusEffects.TryRemoveStatusEffect(target, "KnockedDown");
+        RemCompDeferred<TackledRecentlyComponent>(target);
 
         var userPopup = Loc.GetString("rmc-shake-awake-user", ("target", target));
         _popup.PopupClient(userPopup, target, user);

--- a/Content.Shared/_RMC14/ShakeStun/StunShakeableUserComponent.cs
+++ b/Content.Shared/_RMC14/ShakeStun/StunShakeableUserComponent.cs
@@ -1,7 +1,15 @@
 ﻿using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared._RMC14.ShakeStun;
 
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
 [Access(typeof(StunShakeableSystem))]
-public sealed partial class StunShakeableUserComponent : Component;
+public sealed partial class StunShakeableUserComponent : Component
+{
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
+    public TimeSpan LastShake;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan Cooldown = TimeSpan.FromSeconds(1);
+}

--- a/Content.Shared/_RMC14/ShakeStun/StunShakeableUserComponent.cs
+++ b/Content.Shared/_RMC14/ShakeStun/StunShakeableUserComponent.cs
@@ -1,0 +1,7 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.ShakeStun;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(StunShakeableSystem))]
+public sealed partial class StunShakeableUserComponent : Component;

--- a/Resources/Locale/en-US/_RMC14/shake/rmc-shake.ftl
+++ b/Resources/Locale/en-US/_RMC14/shake/rmc-shake.ftl
@@ -1,0 +1,3 @@
+﻿rmc-shake-awake-user = You shake {$target} trying to wake {OBJECT($target)} up!
+rmc-shake-awake-target = {$user} shakes you trying to wake you up!
+rmc-shake-awake-others = {$user} shakes {$target} trying to wake {OBJECT($target)} up!

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
@@ -170,3 +170,5 @@
     factions:
     - UNMC
   - type: RMCNightVisionVisible
+  - type: StunShakeable
+  - type: StunShakeableUser


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed marines not being able to shake stunned marines awake. Any marine can now click on another marine with an empty hand to remove stuns on them. This includes xenonid tackles, Warrior lunge, Queen screech, and any other kind of stun. Cooldown of 1 second between shakes.
