### PR TITLE
Add more items to armor whitelists

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
@@ -86,6 +86,7 @@
       - CMBurnKit
       - CMTraumaKit
       - Bottle
+      - Pill
   - type: ContainerContainer
     containers:
       storagebase: !type:Container
@@ -373,6 +374,7 @@
       - CMBurnKit
       - CMTraumaKit
       - Bottle
+      - Pill
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
@@ -427,3 +429,4 @@
       - CMBurnKit
       - CMTraumaKit
       - Bottle
+      - Pill

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
@@ -87,6 +87,7 @@
       - CMTraumaKit
       - Bottle
       - Pill
+      - Powercell
   - type: ContainerContainer
     containers:
       storagebase: !type:Container
@@ -353,7 +354,7 @@
       # Motion detectors
       # Walkman
       tags:
-      - CMMagazineRifle
+      - CMMagazineRifle # same as marine armor
       - CMMagazineSmg
       - CMMagazineSniper
       - CMMagazinePistol
@@ -375,6 +376,7 @@
       - CMTraumaKit
       - Bottle
       - Pill
+      - Powercell
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
@@ -430,3 +432,4 @@
       - CMTraumaKit
       - Bottle
       - Pill
+      - Powercell

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
@@ -87,7 +87,7 @@
       - CMTraumaKit
       - Bottle
       - Pill
-      - Powercell
+      - PowerCell
   - type: ContainerContainer
     containers:
       storagebase: !type:Container
@@ -376,7 +376,7 @@
       - CMTraumaKit
       - Bottle
       - Pill
-      - Powercell
+      - PowerCell
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
@@ -432,4 +432,4 @@
       - CMTraumaKit
       - Bottle
       - Pill
-      - Powercell
+      - PowerCell

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
@@ -74,6 +74,18 @@
       - Flashlight
       - MRE
       - Grenade
+      - CMAutoInjector
+      - Cigarette
+      - PillPacket
+      - PillCanister
+      - CMSurgicalCase
+      - Syringe
+      - Hypospray
+      - CMOintment
+      - Brutepack
+      - CMBurnKit
+      - CMTraumaKit
+      - Bottle
   - type: ContainerContainer
     containers:
       storagebase: !type:Container
@@ -95,6 +107,9 @@
       - CMMagazineSniper
       - CMMagazinePistol
       - MRE
+      - PillPacket
+      - PillCanister
+      - CMSurgicalCase
   - type: RMCNameItemOnVend
     item: Armor
   - type: RMCBulkyArmor
@@ -341,10 +356,23 @@
       - CMMagazineSmg
       - CMMagazineSniper
       - CMMagazinePistol
-      - Flashlight
+      - Sidearm
       - Knife
+      - Flashlight
       - MRE
       - Grenade
+      - CMAutoInjector
+      - Cigarette
+      - PillPacket
+      - PillCanister
+      - CMSurgicalCase
+      - Syringe
+      - Hypospray
+      - CMOintment
+      - Brutepack
+      - CMBurnKit
+      - CMTraumaKit
+      - Bottle
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
@@ -378,4 +406,24 @@
 #      - # TODO RMC14 motion detector, walkman
       tags:
       - Handcuffs
+      - CMMagazineRifle # same as marine armor
+      - CMMagazineSmg
+      - CMMagazineSniper
+      - CMMagazinePistol
+      - Sidearm
+      - Knife
+      - Flashlight
       - Grenade
+      - MRE
+      - CMAutoInjector
+      - Cigarette
+      - PillPacket
+      - PillCanister
+      - CMSurgicalCase
+      - Syringe
+      - Hypospray
+      - CMOintment
+      - Brutepack
+      - CMBurnKit
+      - CMTraumaKit
+      - Bottle

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Medical/hypospray.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Medical/hypospray.yml
@@ -29,4 +29,10 @@
         maxVol: 30
   - type: UseDelay
     delay: 0.333
+  - type: Tag
+    tags:
+    - Hypospray
+
+- type: Tag
+  id: Hypospray
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Adds many more items to armor whitelists, including syringes, hypospsrays, pill packets/canisters, trauma/burn kits, ointment and gauze, bottles, surgical cases, and cigarettes.

Also copies a good chunk of the normal armor whitelist to the mp and smartgunner specific armors (they hold about all the same things in cm-13)

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Fixes #2717, CM-13 parity

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Nah
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
shouldn't
**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- add: All armors can hold more types of items, mostly different medical items
