### PR TITLE
Make Dropship flattening range less aggressively generous

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -868,7 +868,7 @@ public sealed partial class ShuttleSystem
             // Shift it slightly
             aabb = aabb.Translated(-grid.TileSizeHalfVector);
             // Create a small border around it.
-            aabb = aabb.Enlarged(0.2f);
+            aabb = aabb.Enlarged(-0.2f);
             aabbs.Add(aabb);
 
             // Handle clearing biome stuff as relevant.


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: The Dropship landing gibbing you now has half a tile less range.