### PR TITLE
Make spaceborne gauss turrets shoot twice as fast, pierce all armor

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/sentry.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/sentry.yml
@@ -29,4 +29,3 @@
   - type: CMArmorPiercing
     amount: 100
   - type: DeleteXenoResinOnHit
-

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/sentry.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/sentry.yml
@@ -25,7 +25,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 15
+        Piercing: 20
   - type: CMArmorPiercing
     amount: 100
   - type: DeleteXenoResinOnHit

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/sentry.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/sentry.yml
@@ -25,8 +25,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 30
+        Piercing: 15
   - type: CMArmorPiercing
-    amount: 35
+    amount: 100
   - type: DeleteXenoResinOnHit
 

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Sentries/static_sentries.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Sentries/static_sentries.yml
@@ -36,7 +36,7 @@
   - type: CombatMode
     toggleMouseRotator: false
   - type: Gun
-    fireRate: 3
+    fireRate: 6
     selectedMode: FullAuto
     availableModes:
     - FullAuto


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: The turrets guarding landing zones round-start now shoot twice as fast and pierce all armor, with a DPS of 120 (up from 90)