### PR TITLE
Add box of 4 breaching charges for $4000 to Requisitions

### DIFF
--- a/Resources/Prototypes/_RMC14/Catalog/Cargo/requisitions_catalog.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Cargo/requisitions_catalog.yml
@@ -136,6 +136,8 @@
         crate: CMCrateGrenadesHighExplosive
       - cost: 3000
         crate: CMCrateGrenadesFrag
+      - cost: 4000
+        crate: RMCCrateBreachingCharges
     - name: Food
       entries:
       - cost: 1000

--- a/Resources/Prototypes/_RMC14/Catalog/Fills/Crates/explosives.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Fills/Crates/explosives.yml
@@ -17,3 +17,13 @@
     contents:
     - id: CMPacketGrenadeFragFilled
       amount: 2
+
+- type: entity
+  parent: CMCrateExplosives
+  id: RMCCrateBreachingCharges
+  name: breaching charges crate (x4)
+  components:
+  - type: StorageFill
+    contents:
+    - id: RMCExplosiveBreachingCharge
+      amount: 4


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed Requisitions not being able to buy more breaching charges. They can now order a crate of 4 breaching charges for $4000.