### PR TITLE
Fix lathes giving upstream buckets instead of rmc buckets

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Lathe/lathe_recipes.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Lathe/lathe_recipes.yml
@@ -1,7 +1,7 @@
 ﻿# Divide cm13 numbers by 37.5 to get an accurate conversion
 - type: latheRecipe
   id: CMBucket
-  result: Bucket # TODO RMC14
+  result: CMBucket
   completetime: 4
   materials:
     CMSteel: 67 # 2500


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed lathes making upstream buckets instead of RMC-14 buckets, which also had an unintentionally higher capacity.
