### PR TITLE
Fix xenos being able to open unintended UIs

### DIFF
--- a/Content.Server/Paper/PaperSystem.cs
+++ b/Content.Server/Paper/PaperSystem.cs
@@ -1,15 +1,16 @@
 using System.Linq;
 using Content.Server.Administration.Logs;
 using Content.Server.Popups;
-using Content.Shared.UserInterface;
+using Content.Shared._RMC14.UserInterface;
 using Content.Shared.Database;
 using Content.Shared.Examine;
 using Content.Shared.Interaction;
 using Content.Shared.Paper;
 using Content.Shared.Tag;
+using Content.Shared.UserInterface;
 using Robust.Server.GameObjects;
-using Robust.Shared.Player;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Player;
 using static Content.Shared.Paper.SharedPaperComponent;
 
 namespace Content.Server.Paper
@@ -24,6 +25,7 @@ namespace Content.Server.Paper
         [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
         [Dependency] private readonly MetaDataSystem _metaSystem = default!;
         [Dependency] private readonly SharedAudioSystem _audio = default!;
+        [Dependency] private readonly RMCUserInterfaceSystem _rmcUI = default!;
 
         public override void Initialize()
         {
@@ -98,6 +100,9 @@ namespace Content.Server.Paper
 
         private void OnInteractUsing(EntityUid uid, PaperComponent paperComp, InteractUsingEvent args)
         {
+            if (!_rmcUI.CanOpenUI(uid, args.User, PaperUiKey.Key))
+                return;
+
             // only allow editing if there are no stamps or when using a cyberpen
             var editable = paperComp.StampedBy.Count == 0 || _tagSystem.HasTag(args.Used, "WriteIgnoreStamps");
             if (_tagSystem.HasTag(args.Used, "Write") && editable)

--- a/Content.Shared/_RMC14/UserInterface/ActivatableUIBlacklistComponent.cs
+++ b/Content.Shared/_RMC14/UserInterface/ActivatableUIBlacklistComponent.cs
@@ -1,0 +1,12 @@
+﻿using Content.Shared.Whitelist;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.UserInterface;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(RMCUserInterfaceSystem))]
+public sealed partial class ActivatableUIBlacklistComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public EntityWhitelist Blacklist;
+}

--- a/Content.Shared/_RMC14/UserInterface/RMCUserInterfaceSystem.cs
+++ b/Content.Shared/_RMC14/UserInterface/RMCUserInterfaceSystem.cs
@@ -1,0 +1,55 @@
+﻿using Content.Shared.UserInterface;
+using Content.Shared.Whitelist;
+
+namespace Content.Shared._RMC14.UserInterface;
+
+public sealed class RMCUserInterfaceSystem : EntitySystem
+{
+    [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<ActivatableUIBlacklistComponent, ActivatableUIOpenAttemptEvent>(OnUIBlacklistAttempt);
+        SubscribeLocalEvent<UserBlacklistActivatableUIComponent, UserOpenActivatableUIAttemptEvent>(OnUIBlacklistUserAttempt);
+    }
+
+    private void OnUIBlacklistAttempt(Entity<ActivatableUIBlacklistComponent> ent, ref ActivatableUIOpenAttemptEvent args)
+    {
+        if (args.Cancelled)
+            return;
+
+        if (!CanOpenUI((ent, ent), args.User, null))
+            args.Cancel();
+    }
+
+    private void OnUIBlacklistUserAttempt(Entity<UserBlacklistActivatableUIComponent> ent, ref UserOpenActivatableUIAttemptEvent args)
+    {
+        if (args.Cancelled)
+            return;
+
+        if (TryComp(args.Target, out ActivatableUIComponent? activatable) &&
+            activatable.Key is { } key &&
+            ent.Comp.Keys.Contains(key))
+        {
+            args.Cancel();
+        }
+    }
+
+    public bool CanOpenUI(Entity<ActivatableUIBlacklistComponent?> ent, Entity<UserBlacklistActivatableUIComponent?> user, Enum? key)
+    {
+        if (Resolve(ent, ref ent.Comp, false) &&
+            _whitelist.IsBlacklistPass(ent.Comp.Blacklist, user))
+        {
+            return false;
+        }
+
+        if (key != null &&
+            Resolve(user, ref user.Comp, false) &&
+            user.Comp.Keys.Contains(key))
+        {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/Content.Shared/_RMC14/UserInterface/UserBlacklistActivatableUIComponent.cs
+++ b/Content.Shared/_RMC14/UserInterface/UserBlacklistActivatableUIComponent.cs
@@ -1,0 +1,11 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.UserInterface;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(RMCUserInterfaceSystem))]
+public sealed partial class UserBlacklistActivatableUIComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public HashSet<Enum> Keys = new();
+}

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
@@ -222,6 +222,10 @@
     - RMCXeno
   - type: RMCNightVisionVisible
   - type: CrashLandable
+  - type: UserBlacklistActivatableUI
+    keys:
+    - enum.VendingMachineUiKey.Key
+    - enum.PaperUiKey.Key
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Misc/paper.yml
@@ -59,6 +59,10 @@
             max: 1
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
+  - type: ActivatableUIBlacklist
+    blacklist:
+      components:
+      - Xeno
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Science/Dispensers/chem.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Science/Dispensers/chem.yml
@@ -29,6 +29,10 @@
   - type: ApcPowerReceiver
     needsPower: false # TODO RMC14
     powerLoad: 0
+  - type: ActivatableUIBlacklist
+    blacklist:
+      components:
+      - Xeno
 
 - type: entity
   parent: RMCDispenserChem

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/vending_machines.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/vending_machines.yml
@@ -83,6 +83,10 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+  - type: ActivatableUIBlacklist
+    blacklist:
+      components:
+      - Xeno
 
 - type: vendingMachineInventory
   id: CMVendomat


### PR DESCRIPTION
## About the PR
Chemical dispenser is the big one, then vending machines. Our automated vendors seem to all use access so that's not an issue, same with APC since that requires access to toggle, but can be fixed later. Storage was left alone for now.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed xenos being able to open UIs that they shouldn't be able to.