### PR TITLE
flares despawn shortly after expiring

### DIFF
--- a/Content.Server/Light/EntitySystems/ExpendableLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/ExpendableLightSystem.cs
@@ -13,6 +13,7 @@ using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Player;
+using Robust.Shared.Spawners;
 using Robust.Shared.Utility;
 
 namespace Content.Server.Light.EntitySystems
@@ -137,6 +138,7 @@ namespace Content.Server.Light.EntitySystems
                     _appearance.SetData(ent, ExpendableLightVisuals.Behavior, string.Empty, appearance);
                     var ignite = new IgnitionEvent(false);
                     RaiseLocalEvent(ent, ref ignite);
+                    EnsureComp<TimedDespawnComponent>(ent);
                     break;
             }
         }


### PR DESCRIPTION
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Garbage cleanup, unlike empty mags these serve no purpose but to take up space on the screen, among performance reasons I suppose.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adding onto UpdateVisualizer, whenever the item progresses to the spent sprite, the TimedDespawnComponent is given so the item is deleted after the default 5 seconds have passed, similar to current blood puddles.

I think this is the least obtrusive way to add this functionality without touching more than this one upstream file.

I also do not know much about coding.

/shrug

**Changelog**

:cl: Whisper
- add: Spent flares will now despawn.
