### PR TITLE
Larva now transfers control to the burst victim

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
@@ -520,10 +520,7 @@ public abstract class SharedXenoParasiteSystem : EntitySystem
             if (infected.TransferMindOnBurst)
             {
                 if (!_net.IsClient && _mind.TryGetMind(uid, out var mindId, out _))
-                {
-                    _mind.WipeMind(mindId);
                     _mind.TransferTo(mindId, spawned);
-                }
             }
 
             _xeno.SetHive(spawned, infected.Hive);

--- a/Content.Shared/_RMC14/Xenonids/Parasite/VictimInfectedComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Parasite/VictimInfectedComponent.cs
@@ -127,4 +127,7 @@ public sealed partial class VictimInfectedComponent : Component
 
     [DataField]
     public DamageSpecifier InfectionDamage = new() { DamageDict = new() { { "Blunt", 1 } } };
+
+    [DataField]
+    public bool TransferMindOnBurst = true;
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

## Why / Balance
CM13 parity

also more forgiving for marines who were captured, as they aren't round removed

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media

https://github.com/user-attachments/assets/11955401-1d00-42c3-9881-e8642402529b



- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
:cl:
- tweak: Bursted larvas will now be under control of the burst victim.
