### PR TITLE
Add/Xeno interact/UI blacklist system

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/XenoInteractBlacklistComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/XenoInteractBlacklistComponent.cs
@@ -1,0 +1,12 @@
+using Content.Shared.Whitelist;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids;
+
+[RegisterComponent]
+[Access(typeof(XenoSystem))]
+public sealed partial class XenoInteractBlacklistComponent : Component
+{
+    [DataField("blacklist")]
+    public EntityWhitelist? Blacklist = null;
+}

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
@@ -209,6 +209,7 @@
       - VendingMachine
       - ActivatableUIRequiresPower
       - RequisitionsComputer
+      - IVDrip
       - PowerCellSlot
       - Bin
       - GasMixer

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
@@ -199,6 +199,24 @@
       - Xeno
       - XenoEgg
       - Infectable
+  - type: XenoInteractBlacklist
+    blacklist:
+      components:
+      - HyperSleepChamber
+      - HandheldLight
+      - DisposalUnit
+      - CMAutomatedVendor
+      - VendingMachine
+      - ActivatableUIRequiresPower
+      - RequisitionsComputer
+      - PowerCellSlot
+      - Bin
+      - GasMixer
+      - GasFilter
+      - GasPressurePump
+      - GasVolumePump
+      - GasOutletInjector
+      - GasValve
   - type: BlockPullingDead
   - type: XenoFriendly
   - type: Undisposable


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Added a blacklist system to `XenoSystem` that allows placing components in `base_xeno.yml` blacklist that will prevent the xeno from interacting with and/or being shown a UI for those components

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
I think a system like this is more usable than adding checks to item/structure/machines/etc system files individually

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
The component you choose to add to the blacklist must have a check for either `InteractionAttemptEvent` or `UserOpenActivatableUIAttemptEvent` for it to work.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
I tested a whole bunch of things but the components I chose to include in the blacklist apply to a lot of stuff, `ActivatableUIRequiresPower` specifically, so there may be something I missed and a xeno will not be able to interact with something unintentionally. And yes, the dropship nav computer and console on the dropship is unaffected.

I also will be having a look around for areas where a `XenoComponent` check was done to prevent interaction and removing those in a separate PR. If that should be a part of this PR then I can do that.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
