### PR TITLE
Add parasites returning to opened eggs

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
@@ -256,12 +256,6 @@ public sealed class XenoEggSystem : EntitySystem
 			return;
 		}
 
-		if (_mind.TryGetMind(args.Used, out _, out _))
-        {
-            _popup.PopupEntity(Loc.GetString("rmc-xeno-egg-awake-child", ("parasite", args.Used)), args.User, args.User, PopupType.SmallCaution);
-            return;
-        }
-
         if (egg.Comp.State == XenoEggState.Growing || egg.Comp.State == XenoEggState.Grown)
         {
             _popup.PopupEntity(Loc.GetString("rmc-xeno-egg-has-child"), args.User, args.User, PopupType.SmallCaution);
@@ -273,7 +267,13 @@ public sealed class XenoEggSystem : EntitySystem
             return;
         }
 
-        _popup.PopupEntity(Loc.GetString("rmc-xeno-egg-return-user"), args.User, args.User);
+		if (_mind.TryGetMind(args.Used, out _, out _))
+		{
+			_popup.PopupEntity(Loc.GetString("rmc-xeno-egg-awake-child", ("parasite", args.Used)), args.User, args.User, PopupType.SmallCaution);
+			return;
+		}
+
+		_popup.PopupEntity(Loc.GetString("rmc-xeno-egg-return-user"), args.User, args.User);
         _popup.PopupEntity(Loc.GetString("rmc-xeno-egg-return", ("user", args.User), ("parasite", args.Used)), egg, Filter.PvsExcept(args.User), true);
 
         SetEggState(egg, XenoEggState.Grown);

--- a/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
@@ -257,7 +257,7 @@ public sealed class XenoEggSystem : EntitySystem
         }
         else if (egg.Comp.State != XenoEggState.Opened)
         {
-            _popup.PopupClient(Loc.GetString("rmc-xeno-egg-return-fail"), args.User);
+            _popup.PopupClient(Loc.GetString("rmc-xeno-egg-fail-return"), args.User);
             return;
         }
 

--- a/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
@@ -247,8 +247,14 @@ public sealed class XenoEggSystem : EntitySystem
 
         args.Handled = true;
 
-		if (_net.IsClient)
+        if (_net.IsClient)
+            return;
+
+		if (_mobState.IsDead(args.Used))
+		{
+			_popup.PopupEntity(Loc.GetString("rmc-xeno-egg-dead-child"), args.User, args.User, PopupType.SmallCaution);
 			return;
+		}
 
 		if (_mind.TryGetMind(args.Used, out _, out _))
         {
@@ -264,12 +270,6 @@ public sealed class XenoEggSystem : EntitySystem
         else if (egg.Comp.State != XenoEggState.Opened)
         {
             _popup.PopupEntity(Loc.GetString("rmc-xeno-egg-fail-return"), args.User, args.User, PopupType.SmallCaution);
-            return;
-        }
-
-        if (_mobState.IsDead(args.Used))
-        {
-            _popup.PopupEntity(Loc.GetString("rmc-xeno-egg-dead-child"), args.User, args.User, PopupType.SmallCaution);
             return;
         }
 

--- a/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
@@ -10,6 +10,7 @@ using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
 using Content.Shared.Item;
+using Content.Shared.Mind;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
@@ -43,6 +44,7 @@ public sealed class XenoEggSystem : EntitySystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly XenoSystem _xeno = default!;
+    [Dependency] private readonly SharedMindSystem _mind = default!;
 
     private static readonly ProtoId<TagPrototype> StructureTag = "Structure";
 
@@ -239,35 +241,42 @@ public sealed class XenoEggSystem : EntitySystem
 
     private void OnXenoEggInteractUsing(Entity<XenoEggComponent> egg, ref InteractUsingEvent args)
     {
-        args.Handled = true;
         // Doesn't check hive or if a xeno is doing it
         if (!HasComp<XenoParasiteComponent>(args.Used))
             return;
 
-        if(_mobState.IsDead(args.Used))
+        args.Handled = true;
+
+		if (_net.IsClient)
+			return;
+
+		if (_mind.TryGetMind(args.Used, out _, out _))
         {
-            _popup.PopupClient(Loc.GetString("rmc-xeno-egg-dead-child"), args.User);
+            _popup.PopupEntity(Loc.GetString("rmc-xeno-egg-awake-child", ("parasite", args.Used)), args.User, args.User, PopupType.SmallCaution);
             return;
         }
 
         if (egg.Comp.State == XenoEggState.Growing || egg.Comp.State == XenoEggState.Grown)
         {
-            _popup.PopupClient(Loc.GetString("rmc-xeno-egg-has-child"), args.User);
+            _popup.PopupEntity(Loc.GetString("rmc-xeno-egg-has-child"), args.User, args.User, PopupType.SmallCaution);
             return;
         }
         else if (egg.Comp.State != XenoEggState.Opened)
         {
-            _popup.PopupClient(Loc.GetString("rmc-xeno-egg-fail-return"), args.User);
+            _popup.PopupEntity(Loc.GetString("rmc-xeno-egg-fail-return"), args.User, args.User, PopupType.SmallCaution);
             return;
         }
 
-        _popup.PopupClient(Loc.GetString("rmc-xeno-egg-return-user"), args.User);
+        if (_mobState.IsDead(args.Used))
+        {
+            _popup.PopupEntity(Loc.GetString("rmc-xeno-egg-dead-child"), args.User, args.User, PopupType.SmallCaution);
+            return;
+        }
+
+        _popup.PopupEntity(Loc.GetString("rmc-xeno-egg-return-user"), args.User, args.User);
         _popup.PopupEntity(Loc.GetString("rmc-xeno-egg-return", ("user", args.User), ("parasite", args.Used)), egg, Filter.PvsExcept(args.User), true);
 
         SetEggState(egg, XenoEggState.Grown);
-
-        if (_net.IsClient)
-            return;
 
         QueueDel(args.Used);
 

--- a/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
@@ -296,15 +296,14 @@ public sealed class XenoEggSystem : EntitySystem
             if (HasComp<XenoParasiteComponent>(user))
             {
                 if (_mobState.IsDead(user.Value))
-                    return true;
-
-                if (_timing.IsFirstTimePredicted)
-                    _popup.PopupEntity(Loc.GetString("rmc-xeno-egg-return-self", ("parasite", user)), egg);
+                    return true; 
 
                 SetEggState(egg, XenoEggState.Grown);
 
                 if (_net.IsClient)
                     return true;
+
+                _popup.PopupEntity(Loc.GetString("rmc-xeno-egg-return-self", ("parasite", user)), egg);
 
                 QueueDel(user);
 

--- a/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
@@ -250,11 +250,11 @@ public sealed class XenoEggSystem : EntitySystem
         if (_net.IsClient)
             return;
 
-		if (_mobState.IsDead(args.Used))
-		{
-			_popup.PopupEntity(Loc.GetString("rmc-xeno-egg-dead-child"), args.User, args.User, PopupType.SmallCaution);
-			return;
-		}
+        if (_mobState.IsDead(args.Used))
+        {
+            _popup.PopupEntity(Loc.GetString("rmc-xeno-egg-dead-child"), args.User, args.User, PopupType.SmallCaution);
+            return;
+        }
 
         if (egg.Comp.State == XenoEggState.Growing || egg.Comp.State == XenoEggState.Grown)
         {
@@ -267,13 +267,13 @@ public sealed class XenoEggSystem : EntitySystem
             return;
         }
 
-		if (_mind.TryGetMind(args.Used, out _, out _))
-		{
-			_popup.PopupEntity(Loc.GetString("rmc-xeno-egg-awake-child", ("parasite", args.Used)), args.User, args.User, PopupType.SmallCaution);
-			return;
-		}
+        if (_mind.TryGetMind(args.Used, out _, out _))
+        {
+            _popup.PopupEntity(Loc.GetString("rmc-xeno-egg-awake-child", ("parasite", args.Used)), args.User, args.User, PopupType.SmallCaution);
+            return;
+        }
 
-		_popup.PopupEntity(Loc.GetString("rmc-xeno-egg-return-user"), args.User, args.User);
+        _popup.PopupEntity(Loc.GetString("rmc-xeno-egg-return-user"), args.User, args.User);
         _popup.PopupEntity(Loc.GetString("rmc-xeno-egg-return", ("user", args.User), ("parasite", args.Used)), egg, Filter.PvsExcept(args.User), true);
 
         SetEggState(egg, XenoEggState.Grown);

--- a/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
@@ -61,7 +61,7 @@ public sealed class XenoEggSystem : EntitySystem
 
         SubscribeLocalEvent<XenoEggComponent, AfterAutoHandleStateEvent>(OnXenoEggAfterState);
         SubscribeLocalEvent<XenoEggComponent, GettingPickedUpAttemptEvent>(OnXenoEggPickedUpAttempt);
-        SubscribeLocalEvent<XenoEggComponent, AfterInteractUsingEvent>(OnXenoEggInteractUsing, before: [typeof(SharedXenoParasiteSystem)]);
+        SubscribeLocalEvent<XenoEggComponent, InteractUsingEvent>(OnXenoEggInteractUsing);
         SubscribeLocalEvent<XenoEggComponent, AfterInteractEvent>(OnXenoEggAfterInteract);
         SubscribeLocalEvent<XenoEggComponent, ActivateInWorldEvent>(OnXenoEggActivateInWorld);
         SubscribeLocalEvent<XenoEggComponent, StepTriggerAttemptEvent>(OnXenoEggStepTriggerAttempt);
@@ -237,7 +237,7 @@ public sealed class XenoEggSystem : EntitySystem
             args.Handled = true;
     }
 
-    private void OnXenoEggInteractUsing(Entity<XenoEggComponent> egg, ref AfterInteractUsingEvent args)
+    private void OnXenoEggInteractUsing(Entity<XenoEggComponent> egg, ref InteractUsingEvent args)
     {
         args.Handled = true;
         // Doesn't check hive or if a xeno is doing it
@@ -256,7 +256,10 @@ public sealed class XenoEggSystem : EntitySystem
             return;
         }
         else if (egg.Comp.State != XenoEggState.Opened)
-            return;
+        {
+			_popup.PopupClient(Loc.GetString("rmc-xeno-egg-return-fail"), args.User);
+			return;
+        }
 
         _popup.PopupClient(Loc.GetString("rmc-xeno-egg-return-user"), args.User);
         _popup.PopupEntity(Loc.GetString("rmc-xeno-egg-return", ("user", args.User), ("parasite", args.Used)), egg, Filter.PvsExcept(args.User), true);

--- a/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
@@ -257,8 +257,8 @@ public sealed class XenoEggSystem : EntitySystem
         }
         else if (egg.Comp.State != XenoEggState.Opened)
         {
-			_popup.PopupClient(Loc.GetString("rmc-xeno-egg-return-fail"), args.User);
-			return;
+            _popup.PopupClient(Loc.GetString("rmc-xeno-egg-return-fail"), args.User);
+            return;
         }
 
         _popup.PopupClient(Loc.GetString("rmc-xeno-egg-return-user"), args.User);

--- a/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
@@ -1,7 +1,5 @@
 using Content.Shared._RMC14.Hands;
-using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.Xenonids.Construction.Nest;
-using Content.Shared._RMC14.Xenonids.Egg;
 using Content.Shared._RMC14.Xenonids.Leap;
 using Content.Shared._RMC14.Xenonids.Pheromones;
 using Content.Shared.Atmos.Rotting;
@@ -19,10 +17,8 @@ using Content.Shared.Jittering;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
-using Content.Shared.NPC.Components;
 using Content.Shared.Popups;
 using Content.Shared.Rejuvenate;
-using Content.Shared.Rounding;
 using Content.Shared.Standing;
 using Content.Shared.StatusEffect;
 using Content.Shared.Stunnable;

--- a/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
@@ -1,6 +1,7 @@
 using Content.Shared._RMC14.Hands;
 using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.Xenonids.Construction.Nest;
+using Content.Shared._RMC14.Xenonids.Egg;
 using Content.Shared._RMC14.Xenonids.Leap;
 using Content.Shared._RMC14.Xenonids.Pheromones;
 using Content.Shared.Atmos.Rotting;
@@ -117,7 +118,7 @@ public abstract class SharedXenoParasiteSystem : EntitySystem
 
     private void OnParasiteAfterInteract(Entity<XenoParasiteComponent> ent, ref AfterInteractEvent args)
     {
-        if (!args.CanReach || args.Target == null)
+        if (!args.CanReach || args.Target == null || args.Handled)
             return;
 
         if (StartInfect(ent, args.Target.Value, args.User))

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-eggs.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-eggs.ftl
@@ -8,6 +8,7 @@ cm-xeno-egg-blocked = There's something built here already.
 
 rmc-xeno-egg-dead-child = This child is dead.
 rmc-xeno-egg-has-child = This one is occupied with a child.
+rmc-xeno-egg-awake-child = {CAPITALIZE($parasite)} doesn't want to go back in!
 rmc-xeno-egg-fail-return = This egg can't hold this child.
 rmc-xeno-egg-return-user = We place the child back into the egg.
 rmc-xeno-egg-return-self = {CAPITALIZE($parasite)} crawls back into the egg.

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-eggs.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-eggs.ftl
@@ -8,6 +8,7 @@ cm-xeno-egg-blocked = There's something built here already.
 
 rmc-xeno-egg-dead-child = This child is dead.
 rmc-xeno-egg-has-child = This one is occupied with a child.
+rmc-xeno-egg-fail-return = This egg can't hold a child.
 rmc-xeno-egg-return-user = We place the child back into the egg.
 rmc-xeno-egg-return-self = {CAPITALIZE($parasite)} crawls back into the egg.
 rmc-xeno-egg-return = {CAPITALIZE($user)} slides {$parasite} back into the egg.

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-eggs.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-eggs.ftl
@@ -8,7 +8,7 @@ cm-xeno-egg-blocked = There's something built here already.
 
 rmc-xeno-egg-dead-child = This child is dead.
 rmc-xeno-egg-has-child = This one is occupied with a child.
-rmc-xeno-egg-fail-return = This egg can't hold a child.
+rmc-xeno-egg-fail-return = This egg can't hold this child.
 rmc-xeno-egg-return-user = We place the child back into the egg.
 rmc-xeno-egg-return-self = {CAPITALIZE($parasite)} crawls back into the egg.
 rmc-xeno-egg-return = {CAPITALIZE($user)} slides {$parasite} back into the egg.

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-eggs.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-eggs.ftl
@@ -5,3 +5,10 @@ cm-xeno-egg-failed-must-weeds = The egg must be planted on weeds.
 cm-xeno-egg-failed-plant-outside = Best not to plant this thing outside of a containment cell.
 cm-xeno-egg-failed-already-there = There's already an egg there.
 cm-xeno-egg-blocked = There's something built here already.
+
+rmc-xeno-egg-dead-child = This child is dead.
+rmc-xeno-egg-has-child = This one is occupied with a child.
+rmc-xeno-egg-return-user = We place the child back into the egg.
+rmc-xeno-egg-return-self = {CAPITALIZE($parasite)} crawls back into the egg.
+rmc-xeno-egg-return = {CAPITALIZE($user)} slides {$parasite} back into the egg.
+

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-parasite.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-parasite.ftl
@@ -1,5 +1,5 @@
-rmc-xeno-failed-cant-infect = You can't infect {THE($target)}!
-rmc-xeno-failed-cant-reach = You can't reach {$target}, they need to be lying down!
-rmc-xeno-failed-target-dead = You can't infect the dead!
+rmc-xeno-failed-cant-infect = We can't infect {THE($target)}!
+rmc-xeno-failed-cant-reach = We can't reach {$target}, they need to be lying down!
+rmc-xeno-failed-target-dead = We can't infect the dead!
 rmc-xeno-infect-success = The parasite smashes against {$target}'s mask and rips it off!
-rmc-xeno-failed-parasite-dead = You can't infect with a dead parasite!
+rmc-xeno-failed-parasite-dead = We can't infect with a dead child!


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Using a parasite on an open egg now returns that parasite to the egg (it deletes them). A parasite clicking on an open egg will also return itself to the egg.

Also changed the previous can't infect with dead parasite line to be more inline with the other xeno popups.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Implements part of #2092, CM-13 parity

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Used AfterInteractUsing and ActivateInWorldEvent (with some logic in the Open method) to check for the parasite component and return the parasite (if it isn't dead) and change the egg back to it's grown state.

There was a double pop-up problem (see video below) but it's fixed now

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/user-attachments/assets/ac6edbf5-d148-46ed-8fe0-9c650a005841



## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
no?
**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- add: Parasites can crawl back into open eggs, and drone castes can also put them back in
