### PR TITLE
Xenos can no longer pull eggs

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
@@ -197,7 +197,6 @@
     whitelist:
       components:
       - Xeno
-      - XenoEgg
       - Infectable
   - type: BlockPullingDead
   - type: XenoFriendly


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Removes pulling xeno eggs from all xenos.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Fixes discord issues, it's how it is in CM-13

Drone castes can't pull eggs, only pick them up. Other castes can't pull them or pick them up. Pulling allowed you to bypass the 2-handed limit of eggs for drones, and for other xenos allowed them to quickly move them.

Parasites are unchanged, xenos in CM-13 can freely move parasites of their own hive around

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
YML

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- fix: Fixed xenonids being able to pull eggs.