### PR TITLE
Fix xenos being 20% faster than intended at pulling marines

### DIFF
--- a/Content.Shared/_RMC14/Pulling/SlowOnPullComponent.cs
+++ b/Content.Shared/_RMC14/Pulling/SlowOnPullComponent.cs
@@ -1,4 +1,6 @@
-﻿using Robust.Shared.GameStates;
+﻿using Content.Shared.Whitelist;
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
 
 namespace Content.Shared._RMC14.Pulling;
 
@@ -8,4 +10,11 @@ public sealed partial class SlowOnPullComponent : Component
 {
     [DataField(required: true), AutoNetworkedField]
     public float Multiplier = 1;
+
+    [DataField, AutoNetworkedField]
+    public List<SlowdownWhitelist> Slowdowns = new();
+
+    [DataRecord]
+    [Serializable, NetSerializable]
+    public readonly record struct SlowdownWhitelist(float Multiplier, EntityWhitelist Whitelist);
 }

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
@@ -153,6 +153,11 @@
   - type: MovementIgnoreGravity
   - type: SlowOnPull
     multiplier: 0.6
+    slowdowns:
+    - multiplier: 0.5
+      whitelist:
+        components:
+        - Xeno
   - type: MobThresholds
     thresholds:
       0: Alive


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed xenos being 20% faster than intended at pulling marines. Marine on marine pull speed remains unchanged.