### PR TITLE
Make all tackle stacks expire in a fixed 4 seconds

### DIFF
--- a/Content.Shared/_RMC14/Tackle/TackleComponent.cs
+++ b/Content.Shared/_RMC14/Tackle/TackleComponent.cs
@@ -14,4 +14,7 @@ public sealed partial class TackleComponent : Component
 
     [DataField, AutoNetworkedField]
     public TimeSpan Stun = TimeSpan.FromSeconds(5);
+
+    [DataField, AutoNetworkedField]
+    public float Chance = 0.35f;
 }

--- a/Content.Shared/_RMC14/Tackle/TackleableComponent.cs
+++ b/Content.Shared/_RMC14/Tackle/TackleableComponent.cs
@@ -2,5 +2,9 @@
 
 namespace Content.Shared._RMC14.Tackle;
 
-[RegisterComponent, NetworkedComponent]
-public sealed partial class TackleableComponent : Component;
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class TackleableComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public TimeSpan ExpireAfter = TimeSpan.FromSeconds(4);
+}

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
@@ -263,6 +263,7 @@
       groups:
         Brute: 12
   - type: Tackle
+    chance: 0.35
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/boiler.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/boiler.yml
@@ -57,6 +57,7 @@
   - type: Tackle
     threshold: 5
     stun: 7
+    chance: 0.25
   - type: MovementSpeedModifier
     baseWalkSpeed: 2
     baseSprintSpeed: 3.5

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/burrower.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/burrower.yml
@@ -57,6 +57,7 @@
   - type: Tackle
     threshold: 4
     stun: 9
+    chance: 0.40
   - type: MovementSpeedModifier
     baseWalkSpeed: 2
     baseSprintSpeed: 3.5

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/carrier.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/carrier.yml
@@ -61,6 +61,7 @@
   - type: Tackle
     threshold: 3
     stun: 9
+    chance: 0.50
   - type: Fixtures
     fixtures:
       fix1:

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/crusher.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/crusher.yml
@@ -63,6 +63,7 @@
   - type: Tackle
     threshold: 5
     stun: 5
+    chance: 0.25
   - type: MovementSpeedModifier
     baseWalkSpeed: 1.66
     baseSprintSpeed: 3

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/hivelord.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/hivelord.yml
@@ -69,6 +69,7 @@
   - type: Tackle
     threshold: 3
     stun: 9
+    chance: 0.45
   - type: MovementSpeedModifier
     baseWalkSpeed: 1.66
     baseSprintSpeed: 3

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/praetorian.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/praetorian.yml
@@ -57,6 +57,7 @@
   - type: Tackle
     threshold: 3
     stun: 5
+    chance: 0.45
   - type: Fixtures
     fixtures:
       fix1:

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
@@ -88,6 +88,7 @@
   - type: Tackle
     threshold: 3
     stun: 11
+    chance: 0.55
   - type: Fixtures
     fixtures:
       fix1:

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/ravager.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/ravager.yml
@@ -54,6 +54,7 @@
   - type: Tackle
     threshold: 4
     stun: 9
+    chance: 0.35
   - type: Flammable
     damage:
       types:

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/rouny.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/rouny.yml
@@ -17,5 +17,5 @@
     max: 300
     evolvesTo: [ ]
   - type: Tackle
-    threshold: 2
-    stun: 20 #lol
+    threshold: 5
+    stun: 8

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/runner.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/runner.yml
@@ -78,6 +78,7 @@
   - type: Tackle
     threshold: 5
     stun: 8
+    chance: 0.40
   - type: MovementSpeedModifier
     baseWalkSpeed: 5.55
     baseSprintSpeed: 10

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/sentinel.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/sentinel.yml
@@ -61,5 +61,6 @@
   - type: Tackle
     threshold: 4
     stun: 8
+    chance: 0.50
   - type: RMCXenoDamageVisuals
     prefix: sentinel

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/spitter.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/spitter.yml
@@ -67,6 +67,7 @@
   - type: Tackle
     threshold: 4
     stun: 9
+    chance: 0.45
   - type: MovementSpeedModifier
     baseWalkSpeed: 2
     baseSprintSpeed: 3.5


### PR DESCRIPTION
## About the PR
Chance doesn't actually do anything yet I just wanted to note it down for each caste in case I need it for the future.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed tackle stacks lasting for longer than intended. All tackle stacks now expire after a fixed 4 seconds for all xenonid castes, after which they all need to be reapplied. This specially affects castes with long stun times and makes it harder for a single xenonid to keep many people down at the same time.
- fix: Fixed a graphical client bug where tackling would sometimes briefly knockdown a marine then instantly expire, or make a marine be permanently horizontal until tackled down again.
