### PR TITLE
Fix devoured knife damage and attack rate being too high and not piercing armor

### DIFF
--- a/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
+++ b/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
@@ -168,7 +168,7 @@ public sealed class CMArmorSystem : EntitySystem
         var armorPiercing = args.ArmorPiercing;
         if (args.Tool != null)
         {
-            var piercingEv = new CMGetArmorPiercingEvent();
+            var piercingEv = new CMGetArmorPiercingEvent(ent);
             RaiseLocalEvent(args.Tool.Value, ref piercingEv);
             armorPiercing += piercingEv.Piercing;
         }

--- a/Content.Shared/_RMC14/Armor/CMGetArmorPiercingEvent.cs
+++ b/Content.Shared/_RMC14/Armor/CMGetArmorPiercingEvent.cs
@@ -1,4 +1,4 @@
 ﻿namespace Content.Shared._RMC14.Armor;
 
 [ByRefEvent]
-public record struct CMGetArmorPiercingEvent(int Piercing);
+public record struct CMGetArmorPiercingEvent(EntityUid Target, int Piercing = 0);

--- a/Content.Shared/_RMC14/Attachable/Systems/AttachableModifiersSystem.Melee.cs
+++ b/Content.Shared/_RMC14/Attachable/Systems/AttachableModifiersSystem.Melee.cs
@@ -20,8 +20,11 @@ public sealed partial class AttachableModifiersSystem : EntitySystem
 
     private void ApplyModifierSet(Entity<AttachableWeaponMeleeModsComponent> attachable, AttachableWeaponMeleeModifierSet modSet, ref MeleeHitEvent args)
     {
-        if (!CanApplyModifiers(attachable.Owner, modSet.Conditions))
+        if (!_attachableHolderSystem.TryGetHolder(attachable, out _) ||
+            !CanApplyModifiers(attachable.Owner, modSet.Conditions))
+        {
             return;
+        }
 
         if (modSet.BonusDamage != null)
             args.BonusDamage += modSet.BonusDamage;

--- a/Content.Shared/_RMC14/Xenonids/Devour/UsableWhileDevouredComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Devour/UsableWhileDevouredComponent.cs
@@ -1,7 +1,15 @@
-﻿using Robust.Shared.GameStates;
+﻿using Content.Shared.Damage;
+using Robust.Shared.GameStates;
 
 namespace Content.Shared._RMC14.Xenonids.Devour;
 
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 [Access(typeof(XenoDevourSystem))]
-public sealed partial class UsableWhileDevouredComponent : Component;
+public sealed partial class UsableWhileDevouredComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public DamageSpecifier? Damage;
+
+    [DataField, AutoNetworkedField]
+    public float AttackRateMultiplier = 0.55f;
+}

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Melee/knife.yml
@@ -32,6 +32,9 @@
   - type: DisarmMalus
     malus: 0.225
   - type: UsableWhileDevoured
+    damage:
+      types:
+        Slash: 15
   - type: AttachableVisuals
     rsi: _RMC14/Objects/Weapons/Guns/Attachments/barrel.rsi
     prefix: bayonet


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed devoured knife damage and attack rate being higher than intended and not piercing armor. The damage is now a fixed 15, down from 45, and the attacks per second have been lowered from 1 to 0.55.