### PR TITLE
Fix weapons spec ammo erroneously using the limit was reached

### DIFF
--- a/Content.Shared/_RMC14/Vendors/CMVendorSection.cs
+++ b/Content.Shared/_RMC14/Vendors/CMVendorSection.cs
@@ -18,10 +18,10 @@ public sealed partial class CMVendorSection
 
     [DataField(required: true)]
     public List<CMVendorEntry> Entries = new();
-    
+
     // Only used by Spec Vendors to mark the kit section for RMCVendorSpecialistComponent logic.
     [DataField]
-    public int SharedSpecLimit;
+    public int? SharedSpecLimit;
 }
 
 [DataDefinition]


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed weapons specialist ammo erroneously saying that a limit was reached when trying to buy them. This limit only applies to kits.
