### PR TITLE
Fix hyposprays having no medically unskilled do after

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -28,6 +28,9 @@
     - HighRiskItem
   - type: StealTarget
     stealGroup: Hypospray
+  - type: MedicallyUnskilledDoAfter
+    min: 2
+    doAfter: 3
 
 - type: entity
   name: gorlex hypospray

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Medical/hypospray.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Medical/hypospray.yml
@@ -32,6 +32,9 @@
   - type: Tag
     tags:
     - Hypospray
+  - type: MedicallyUnskilledDoAfter
+    min: 2
+    doAfter: 3
 
 - type: Tag
   id: Hypospray


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed hyposprays not having a delay on use for medically unskilled marines.
