### PR TITLE
Fix the Boiler's bombard not taking plasma to use

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Bombard/XenoBombardComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Bombard/XenoBombardComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared.FixedPoint;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
@@ -10,6 +11,9 @@ public sealed partial class XenoBombardComponent : Component
 {
     [DataField, AutoNetworkedField]
     public int Range = 10;
+
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 PlasmaCost = 200;
 
     [DataField, AutoNetworkedField]
     public TimeSpan Delay = TimeSpan.FromSeconds(4.5);

--- a/Content.Shared/_RMC14/Xenonids/Bombard/XenoBombardSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Bombard/XenoBombardSystem.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using Content.Shared._RMC14.Actions;
 using Content.Shared._RMC14.Projectiles;
+using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared.DoAfter;
 using Content.Shared.Popups;
 using Content.Shared.Weapons.Ranged.Systems;
@@ -20,6 +21,7 @@ public sealed class XenoBombardSystem : EntitySystem
     [Dependency] private readonly RMCActionsSystem _rmcActions = default!;
     [Dependency] private readonly RMCProjectileSystem _rmcProjectile = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly XenoPlasmaSystem _xenoPlasma = default!;
 
     public override void Initialize()
     {
@@ -36,6 +38,9 @@ public sealed class XenoBombardSystem : EntitySystem
             return;
 
         args.Handled = true;
+
+        if (!_xenoPlasma.HasPlasmaPopup(ent.Owner, ent.Comp.PlasmaCost))
+            return;
 
         var direction = target.Position - source.Position;
         if (direction.Length() > ent.Comp.Range)
@@ -64,6 +69,9 @@ public sealed class XenoBombardSystem : EntitySystem
             return;
 
         args.Handled = true;
+
+        if (!_xenoPlasma.TryRemovePlasmaPopup(ent.Owner, ent.Comp.PlasmaCost))
+            return;
 
         if (_net.IsClient)
             return;


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed the Boiler's bombard ability not taking plasma to use. It now correctly takes 200 plasma to use.