### PR TITLE
Fix the Boiler's bombard putting spray acid on cooldown

### DIFF
--- a/Content.Shared/_RMC14/Actions/ActionSharedCooldownComponent.cs
+++ b/Content.Shared/_RMC14/Actions/ActionSharedCooldownComponent.cs
@@ -7,8 +7,11 @@ namespace Content.Shared._RMC14.Actions;
 [Access(typeof(RMCActionsSystem))]
 public sealed partial class ActionSharedCooldownComponent : Component
 {
-    [DataField(required: true), AutoNetworkedField]
-    public HashSet<EntProtoId> Ids;
+    [DataField, AutoNetworkedField]
+    public EntProtoId? Id;
+
+    [DataField, AutoNetworkedField]
+    public HashSet<EntProtoId> Ids = new();
 
     [DataField, AutoNetworkedField]
     public TimeSpan Cooldown;

--- a/Content.Shared/_RMC14/Actions/RMCActionsSystem.cs
+++ b/Content.Shared/_RMC14/Actions/RMCActionsSystem.cs
@@ -32,13 +32,12 @@ public sealed class RMCActionsSystem : EntitySystem
 
         foreach (var (actionId, _) in _actions.GetActions(performer))
         {
-            if (!_actionSharedCooldownQuery.TryComp(actionId, out var shared) ||
-                !shared.Ids.Overlaps(action.Comp.Ids))
-            {
+            if (!_actionSharedCooldownQuery.TryComp(actionId, out var shared))
                 continue;
-            }
 
-            _actions.SetIfBiggerCooldown(actionId, action.Comp.Cooldown);
+            // Same ID or primary ID found in subset of other action's ids
+            if ((shared.Id != null && shared.Id == action.Comp.Id) || (action.Comp.Id != null && shared.Ids.Contains(action.Comp.Id.Value)))
+                _actions.SetIfBiggerCooldown(actionId, action.Comp.Cooldown);
         }
     }
 }

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
@@ -232,9 +232,7 @@
     useDelay: 10
   - type: ActionSharedCooldown
     ids:
-    - ActionXenoBombard
     - ActionXenoAcidShroud
-    - ActionXenoSprayAcidBoiler
 
 - type: entity
   id: ActionXenoParalyzingSlash
@@ -403,8 +401,8 @@
     range: 9
     checkCanAccess: false
   - type: ActionSharedCooldown
+    id: ActionXenoBombard
     ids:
-    - ActionXenoBombard
     - ActionXenoAcidShroud
     cooldown: 20
     onPerform: false
@@ -436,6 +434,7 @@
       state: acid_shroud
     event: !type:XenoAcidShroudActionEvent
   - type: ActionSharedCooldown
+    id: ActionXenoAcidShroud
     ids:
     - ActionXenoBombard
     - ActionXenoAcidShroud

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_self_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_self_actions.yml
@@ -75,8 +75,7 @@
     event: !type:XenoToggleCrestActionEvent
     useDelay: 2
   - type: ActionSharedCooldown
-    ids:
-    - ActionXenoToggleCrest
+    id: ActionXenoToggleCrest
     cooldown: 2
 
 - type: entity
@@ -93,8 +92,7 @@
     event: !type:XenoFortifyActionEvent
     useDelay: 5
   - type: ActionSharedCooldown
-    ids:
-    - ActionXenoToggleCrest
+    id: ActionXenoToggleCrest
     cooldown: 5
 
 - type: entity


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed the Boiler's Bombard putting Spray Acid on cooldown, Bombard now correctly only puts Acid Shroud on cooldown, and Acid Shroud puts both Bombard and Spray acid on cooldown.