### PR TITLE
Temporarily remove heavy assault rifle mags from vendors until the heavy assault rifle is available

### DIFF
--- a/Resources/Prototypes/_RMC14/Catalog/Cargo/requisitions_catalog.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Cargo/requisitions_catalog.yml
@@ -14,8 +14,8 @@
         crate: CMCrateBoxMagazineRifleM54CAP
       - cost: 3000
         crate: CMCrateBoxMagazineRifleM54CExt
-      - cost: 2000
-        crate: RMCCrateMagazineRifleM54CE2
+#      - cost: 2000
+#        crate: RMCCrateMagazineRifleM54CE2
       - cost: 2000
         crate: CMCrateBoxMagazineRifleM4SPR
       - cost: 4000

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
@@ -319,8 +319,8 @@
         amount: 13
       #- id: M240 Incinerator Tank
       #  amount: 3
-      - id: CMMagazineRifleM54CE2
-        amount: 3
+#      - id: CMMagazineRifleM54CE2
+#        amount: 3
       #- id: M41A MK1 Magazine (10x24mm)
       #  amount: 5
       #- id: M41A MK1 AP Magazine (10x24mm)


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Temporarily remove heavy assault rifle mags from vendors until the heavy assault rifle is available, to not confuse people about where to get it.