### PR TITLE
Shotgun fire delay visuals fix

### DIFF
--- a/Content.Shared/_RMC14/Weapons/Ranged/ShootUseDelayComponent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/ShootUseDelayComponent.cs
@@ -2,18 +2,5 @@
 
 namespace Content.Shared._RMC14.Weapons.Ranged;
 
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-public sealed partial class ShootUseDelayComponent : Component
-{
-    [DataField, AutoNetworkedField]
-    public TimeSpan LastPopup;
-
-    [DataField, AutoNetworkedField]
-    public TimeSpan PopupCooldown = TimeSpan.FromSeconds(0.5);
-
-    [DataField, AutoNetworkedField]
-    public TimeSpan Delay = TimeSpan.FromSeconds(2);
-
-    [DataField, AutoNetworkedField]
-    public string DelayId = "CMShootUseDelay";
-}
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ShootUseDelayComponent : Component;

--- a/Content.Shared/_RMC14/Weapons/Ranged/ShootUseDelaySystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/ShootUseDelaySystem.cs
@@ -1,52 +1,27 @@
-﻿using Content.Shared.Popups;
-using Content.Shared.Timing;
+﻿using Content.Shared.Timing;
+using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Weapons.Ranged.Events;
 using Content.Shared.Weapons.Ranged.Systems;
-using Robust.Shared.Timing;
 
 namespace Content.Shared._RMC14.Weapons.Ranged;
 
 public sealed class ShootUseDelaySystem : EntitySystem
 {
-    [Dependency] private readonly SharedPopupSystem _popup = default!;
-    [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly UseDelaySystem _useDelay = default!;
+
+    private const string shootUseDelayId = "CMShootUseDelay";
 
     public override void Initialize()
     {
-        SubscribeLocalEvent<ShootUseDelayComponent, MapInitEvent>(OnMapInit);
-        SubscribeLocalEvent<ShootUseDelayComponent, ShotAttemptedEvent>(OnShotAttempted);
         SubscribeLocalEvent<ShootUseDelayComponent, GunShotEvent>(OnGunShot);
-    }
-
-    private void OnMapInit(Entity<ShootUseDelayComponent> ent, ref MapInitEvent args)
-    {
-        _useDelay.SetLength(ent.Owner, ent.Comp.Delay, ent.Comp.DelayId);
-    }
-
-    private void OnShotAttempted(Entity<ShootUseDelayComponent> ent, ref ShotAttemptedEvent args)
-    {
-        var time = _timing.CurTime;
-        if (TryComp(ent, out UseDelayComponent? useDelay) &&
-            _useDelay.TryGetDelayInfo((ent, useDelay), out var info, ent.Comp.DelayId) &&
-            info.EndTime >= time)
-        {
-            if (time >= ent.Comp.LastPopup + ent.Comp.PopupCooldown)
-            {
-                var timeLeft = info.EndTime - time;
-                ent.Comp.LastPopup = _timing.CurTime;
-                Dirty(ent);
-                var seconds = $"{timeLeft.TotalSeconds:F1}";
-                _popup.PopupClient(Loc.GetString("cm-gun-use-delay", ("seconds", seconds)), args.User, args.User);
-            }
-
-            args.Cancel();
-        }
     }
 
     private void OnGunShot(Entity<ShootUseDelayComponent> ent, ref GunShotEvent args)
     {
-        if (TryComp(ent, out UseDelayComponent? useDelay))
-            _useDelay.TryResetDelay((ent, useDelay), true, ent.Comp.DelayId);
+        if (!TryComp(ent, out UseDelayComponent? delayComponent) || !TryComp(ent, out GunComponent? gunComponent))
+            return;
+
+        _useDelay.SetLength((ent.Owner, delayComponent), TimeSpan.FromSeconds(1f / gunComponent.FireRate), shootUseDelayId);
+        _useDelay.TryResetDelay((ent.Owner, delayComponent), true, id: shootUseDelayId);
     }
 }

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/under_attachments.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/under_attachments.yml
@@ -350,7 +350,6 @@
         volume: 5
   - type: ShootAtFixedPoint
     maxFixedRange: 7
-  - type: UseDelay
   - type: UniqueAction
   - type: BreechLoaded
     needOpenClose: true

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/marine_shotguns.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/marine_shotguns.yml
@@ -67,6 +67,7 @@
     sprite: _RMC14/Objects/Weapons/Guns/Shotguns/m42a2.rsi
   - type: Gun
     shotsPerBurst: 1
+  - type: ShootUseDelay
   - type: RMCSelectiveFire
     baseFireModes:
     - SemiAuto


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Makes the firing delay visual on shotguns show up properly.

Closes #3278.

## Why / Balance
Removed it and forgot to fix it in the attachments PR.

## Technical details
This only returns the visuals. The popup is gone. The reason for this is that I changed ShootUseDelayComponent to interact with the gun's actual fire delay, instead of having its own value it used to override the gun. That didn't interact properly with attachments, and having two separate systems handling fire delays in completely different ways is stupid and would have probably caused *some* sort of issue down the line.

The reason the popup is gone is that the clientside gun system only sends a shoot request if it's not too early for the next shot. So without either bringing back the original way this was handled, or heavily rewriting the gun system, I can't do much.

In any case, all the other guns do just fine without popups. No reason shotguns can't do the same.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: Sigil
- fix: Shotguns now show their fire delay visual as before. The popup, however, is gone due to technical reasons.
