### PR TITLE
Make podlocks fully impassable.

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Doors/Shutters/poddoor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Doors/Shutters/poddoor.yml
@@ -9,6 +9,17 @@
     layers:
     - state: closed
       map: ["enum.DoorVisualLayers.Base"]
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.49,-0.49,0.49,0.49" # don't want this colliding with walls or they won't close
+        density: 100
+        mask:
+        - FullTileMask
+        layer:
+        - FullTileLayer
   - type: AccessReader
   - type: Door
     canPry: false


### PR DESCRIPTION
## About the PR
Fixes #3343 
Podlocks inherit from shutters which have the same collisions as normal airlocks, meaning all the lil critters can crawl under them due to not being LowImpassable. Because so many of these podlocks are used to separate LV hangars from space and then some, apparently larva on Fiorina are making frequent spacewalks, much to the jealously of other xenonids. No one should enter space. The secret that air does not exist, breathing is optional, and walking in space is a lovely holiday must not be shared or propogated.

## Why / Balance
 It doesn't make much sense that podlocks aren't fully impassable and hermetically sealed considering they are frequently used to seal against space on Fiorina, and especially since they separate vertically halfway up the sprite, making the act of crawling "under" them weird. Larva and parasites should also not be able to strike marines through passageways that are only supposed to be passable by way of a breaching charge (in cases where podlocks do not border space).

## Media

- [X] this PR does not require an ingame showcase

**Changelog**
:cl:
