### PR TITLE
Make biohazardous barricades take CMRods not SS14 Rods

### DIFF
--- a/Resources/Prototypes/_RMC14/Recipes/Construction/Graphs/structures/barricade_metal.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Construction/Graphs/structures/barricade_metal.yml
@@ -37,7 +37,7 @@
       completed:
       - !type:SnapToGrid
       steps:
-      - material: MetalRod
+      - material: CMRodMetal
         amount: 6
         doAfter: 6
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Made biohazardous barricades actually craftable.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Boilers are really messing up cades, and this should be an option.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Just want to give the heads up that this is a web edit because I am unable to build SS14 at the moment, but this should be a relatively quick fix. Just changed the SS14 MetalRod to CMRodMetal

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Biohazardous barricades are now constructible with six metal rods.

