### PR TITLE
Show planet in chat

### DIFF
--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -274,6 +274,13 @@ namespace Content.Server.GameTicking
                     Loc.GetString("job-greet-station-name", ("stationName", metaData.EntityName)));
             }
 
+            if(_distressSignal?.SelectedPlanetMapName != null)
+            {
+                _chatManager.DispatchServerMessage(player,
+                    Loc.GetString("job-greet-planet-name", ("planetName",_distressSignal.SelectedPlanetMapName)));
+            }
+
+
             // Arrivals is unable to do this during spawning as no actor is attached yet.
             // We also want this message last.
             if (!silent && lateJoin && _arrivals.Enabled)

--- a/Resources/Locale/en-US/job/job.ftl
+++ b/Resources/Locale/en-US/job/job.ftl
@@ -1,4 +1,5 @@
 job-greet-station-name = Welcome aboard {$stationName}.
+job-greet-planet-name = Currently Orbiting {$planetName}
 job-greet-introduce-job-name = Your role is: {$jobName}.
 job-greet-important-disconnect-admin-notify = You are playing a job that is important for Game Progression. If you have to disconnect, please notify the admins via ahelp.
 job-greet-supervisors-warning = As the {$jobName} you answer directly to {$supervisors}. Special circumstances may change this.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
When a player late joins tell them the current planet when they join

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Resolves #3329

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Checks if the planet is null and if not runs the code

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


:cl: gorillagaming
- add: Players are now notified of the current planet when they spawn as well!

