### PR TITLE
Updates/Fix to M5-ATL Mixed/Anti Armor Crate

### DIFF
--- a/Resources/Prototypes/_RMC14/Catalog/Cargo/requisitions_catalog.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Cargo/requisitions_catalog.yml
@@ -214,7 +214,7 @@
         crate: CMCrateMagazineM96SFlak
       - cost: 3000
         crate: CMCrateMagazineM96SIncendiary
-      - cost: 4000
+      - cost: 3000
         crate: RMCCrateM5DemoSpecMixed
       - cost: 3000
         crate: RMCCrateM5DemoSpecHighExplosive

--- a/Resources/Prototypes/_RMC14/Catalog/Fills/Crates/weapon_specialist_ammo.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Fills/Crates/weapon_specialist_ammo.yml
@@ -52,6 +52,7 @@
     - id: RMCRocket84mm
       amount: 2
     - id: RMCRocket84mmAntiArmor
+      amount: 2
 
 - type: entity
   parent: CMCrateAmmo
@@ -66,7 +67,7 @@
 - type: entity
   parent: CMCrateAmmo
   id: RMCCrateM5DemoSpecAntiArmor
-  name: M5-ATL Anti-Armor Crate (HE x3)
+  name: M5-ATL Anti-Armor Crate (AP x3)
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/_RMC14/Catalog/Fills/Crates/weapon_specialist_ammo.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Fills/Crates/weapon_specialist_ammo.yml
@@ -52,7 +52,7 @@
     - id: RMCRocket84mm
       amount: 2
     - id: RMCRocket84mmAntiArmor
-      amount: 2
+      amount: 1
 
 - type: entity
   parent: CMCrateAmmo


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Adds another Anti Armor rocket to the Mixed crate. Going from 2x HE 1x AP, to now 2x HE 2x AP.

Fixes wrongly marked "M5-ATL Anti-Armor Crate (HE x3)" to (AP x3)

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Mixed crate currently costs 4k for 3 rockets, with a rocket valuing at 1k per it would make sense that the mixed crate would add up correctly.


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
