### PR TITLE
prevent pulling a living queen

### DIFF
--- a/Content.Shared/_RMC14/Movement/NoPullInStateComponent.cs
+++ b/Content.Shared/_RMC14/Movement/NoPullInStateComponent.cs
@@ -1,0 +1,17 @@
+using Content.Shared.Mobs;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Movement;
+
+/// <summary>
+/// Prevents this mob being pulled when in a certain state.
+/// </summary>
+[RegisterComponent, NetworkedComponent, Access(typeof(NoPullInStateSystem))]
+public sealed partial class NoPullInStateComponent : Component
+{
+    /// <summary>
+    /// The state it cannot be pulled in.
+    /// </summary>
+    [DataField(required: true)]
+    public MobState State = MobState.Invalid;
+}

--- a/Content.Shared/_RMC14/Movement/NoPullInStateSystem.cs
+++ b/Content.Shared/_RMC14/Movement/NoPullInStateSystem.cs
@@ -1,0 +1,25 @@
+using Content.Shared.Mobs.Components;
+using Content.Shared.Movement.Pulling.Events;
+
+namespace Content.Shared._RMC14.Movement;
+
+public sealed class NoPullInStateSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<NoPullInStateComponent, PullAttemptEvent>(OnPullAttempt);
+    }
+
+    private void OnPullAttempt(Entity<NoPullInStateComponent> ent, ref PullAttemptEvent args)
+    {
+        var (uid, comp) = ent;
+        // only care when this mob is what's being pulled
+        if (uid != args.PulledUid)
+            return;
+
+        if (TryComp<MobStateComponent>(uid, out var state) && state.CurrentState == comp.State)
+            args.Cancelled = true;
+    }
+}

--- a/Content.Shared/_RMC14/Movement/NoPullInStateSystem.cs
+++ b/Content.Shared/_RMC14/Movement/NoPullInStateSystem.cs
@@ -1,10 +1,15 @@
+using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
+using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Events;
+using Content.Shared.Movement.Pulling.Systems;
 
 namespace Content.Shared._RMC14.Movement;
 
 public sealed class NoPullInStateSystem : EntitySystem
 {
+    [Dependency] private readonly PullingSystem _pulling = default!;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -21,5 +26,12 @@ public sealed class NoPullInStateSystem : EntitySystem
 
         if (TryComp<MobStateComponent>(uid, out var state) && state.CurrentState == comp.State)
             args.Cancelled = true;
+    }
+
+    private void OnStateChanged(Entity<NoPullInStateComponent> ent, ref MobStateChangedEvent args)
+    {
+        var (uid, comp) = ent;
+        if (args.NewMobState == comp.State && TryComp<PullableComponent>(uid, out var pullable))
+            _pulling.TryStopPull(uid, pullable);
     }
 }

--- a/Content.Shared/_RMC14/Movement/NoPullInStateSystem.cs
+++ b/Content.Shared/_RMC14/Movement/NoPullInStateSystem.cs
@@ -15,6 +15,7 @@ public sealed class NoPullInStateSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<NoPullInStateComponent, PullAttemptEvent>(OnPullAttempt);
+        SubscribeLocalEvent<NoPullInStateComponent, MobStateChangedEvent>(OnStateChanged);
     }
 
     private void OnPullAttempt(Entity<NoPullInStateComponent> ent, ref PullAttemptEvent args)

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
@@ -156,3 +156,5 @@
     - ActionXenoScreech
   - type: RMCXenoDamageVisuals
     prefix: queen
+  - type: NoPullInState # prevent shitty tactic of having a xeno pull queen to a cade to screech with no warning
+    state: Alive


### PR DESCRIPTION
## About the PR
you cant pull queen when shes alive

## Why / Balance
no idea about if this is frowned upon / disabled in cm13 but its a really shitty tactic to get queen to a cade **completely silently** so marines get no warning of an upcoming screech

## Technical details
added `NoPullInState` component/system

## Media
it work trust, cant pull when alive
when pulling crit queen on weeds when she wakes up, stops being pulled
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- tweak: The Queen can no longer be pulled when alive.
