### PR TITLE
Knockedout fixes + shake stun adjustment

### DIFF
--- a/Content.Shared/_RMC14/ShakeStun/StunShakeableComponent.cs
+++ b/Content.Shared/_RMC14/ShakeStun/StunShakeableComponent.cs
@@ -2,6 +2,10 @@
 
 namespace Content.Shared._RMC14.ShakeStun;
 
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 [Access(typeof(StunShakeableSystem))]
-public sealed partial class StunShakeableComponent : Component;
+public sealed partial class StunShakeableComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public TimeSpan DurationRemoved = TimeSpan.FromSeconds(6);
+}

--- a/Content.Shared/_RMC14/ShakeStun/StunShakeableSystem.cs
+++ b/Content.Shared/_RMC14/ShakeStun/StunShakeableSystem.cs
@@ -43,9 +43,15 @@ public sealed class StunShakeableSystem : EntitySystem
 
         shakeableUser.LastShake = time;
         Dirty(user, shakeableUser);
-
-        _statusEffects.TryRemoveStatusEffect(target, "Stun");
-        _statusEffects.TryRemoveStatusEffect(target, "KnockedDown");
+        // Only remove muted & blindness if they're at the same timer
+        // Simulating how in CM-13 you can wake up unconscious people (knockedout - knocked down, stunned, blinded, and muted)
+        if (_statusEffects.TryGetTime(user, "Muted", out var timeMute) && _statusEffects.TryGetTime(user, "TemporaryBlindness", out var timeBlind) && timeMute == timeBlind)
+        {
+            _statusEffects.TryRemoveTime(target, "Muted", ent.Comp.DurationRemoved);
+            _statusEffects.TryRemoveTime(target, "TemporaryBlindness", ent.Comp.DurationRemoved);
+        }
+        _statusEffects.TryRemoveTime(target, "Stun", ent.Comp.DurationRemoved);
+        _statusEffects.TryRemoveTime(target, "KnockedDown", ent.Comp.DurationRemoved);
         RemCompDeferred<TackledRecentlyComponent>(target);
 
         var userPopup = Loc.GetString("rmc-shake-awake-user", ("target", target));

--- a/Content.Shared/_RMC14/ShakeStun/StunShakeableSystem.cs
+++ b/Content.Shared/_RMC14/ShakeStun/StunShakeableSystem.cs
@@ -45,7 +45,7 @@ public sealed class StunShakeableSystem : EntitySystem
         Dirty(user, shakeableUser);
         // Only remove muted & blindness if they're at the same timer
         // Simulating how in CM-13 you can wake up unconscious people (knockedout - knocked down, stunned, blinded, and muted)
-        if (_statusEffects.TryGetTime(user, "Muted", out var timeMute) && _statusEffects.TryGetTime(user, "TemporaryBlindness", out var timeBlind) && timeMute == timeBlind)
+        if (_statusEffects.TryGetTime(target, "Muted", out var timeMute) && _statusEffects.TryGetTime(target, "TemporaryBlindness", out var timeBlind) && timeMute == timeBlind)
         {
             _statusEffects.TryRemoveTime(target, "Muted", ent.Comp.DurationRemoved);
             _statusEffects.TryRemoveTime(target, "TemporaryBlindness", ent.Comp.DurationRemoved);

--- a/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
@@ -8,7 +8,6 @@ using Content.Shared.Damage;
 using Content.Shared.DoAfter;
 using Content.Shared.DragDrop;
 using Content.Shared.Examine;
-using Content.Shared.Eye.Blinding.Systems;
 using Content.Shared.Ghost;
 using Content.Shared.Humanoid;
 using Content.Shared.Interaction;
@@ -36,7 +35,6 @@ public abstract class SharedXenoParasiteSystem : EntitySystem
 {
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
-    [Dependency] private readonly BlindableSystem _blindable = default!;
     [Dependency] private readonly SharedContainerSystem _container = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly CMHandsSystem _cmHands = default!;
@@ -75,7 +73,6 @@ public abstract class SharedXenoParasiteSystem : EntitySystem
 
         SubscribeLocalEvent<VictimInfectedComponent, MapInitEvent>(OnVictimInfectedMapInit);
         SubscribeLocalEvent<VictimInfectedComponent, ComponentRemove>(OnVictimInfectedRemoved);
-        SubscribeLocalEvent<VictimInfectedComponent, CanSeeAttemptEvent>(OnVictimInfectedCancel);
         SubscribeLocalEvent<VictimInfectedComponent, ExaminedEvent>(OnVictimInfectedExamined);
         SubscribeLocalEvent<VictimInfectedComponent, RejuvenateEvent>(OnVictimInfectedRejuvenate);
 
@@ -203,13 +200,17 @@ public abstract class SharedXenoParasiteSystem : EntitySystem
 
     private void OnVictimInfectedRemoved(Entity<VictimInfectedComponent> victim, ref ComponentRemove args)
     {
-        _blindable.UpdateIsBlind(victim.Owner);
+        if (_status.HasStatusEffect(victim, "Muted", null) && _status.HasStatusEffect(victim, "TemporaryBlindness", null))
+        {
+            _status.TryRemoveStatusEffect(victim, "Muted");
+            _status.TryRemoveStatusEffect(victim, "TemporaryBlindness");
+        }
         _standing.Stand(victim);
     }
 
     private void OnVictimInfectedCancel<T>(Entity<VictimInfectedComponent> victim, ref T args) where T : CancellableEntityEventArgs
     {
-        if (victim.Comp.LifeStage <= ComponentLifeStage.Running && !victim.Comp.Recovered)
+        if (victim.Comp.LifeStage <= ComponentLifeStage.Running)
             args.Cancel();
     }
 
@@ -345,16 +346,15 @@ public abstract class SharedXenoParasiteSystem : EntitySystem
         var time = _timing.CurTime;
         var victimComp = EnsureComp<VictimInfectedComponent>(victim);
         victimComp.AttachedAt = time;
-        victimComp.RecoverAt = time + parasite.Comp.ParalyzeTime;
         victimComp.Hive = CompOrNull<XenoComponent>(parasite)?.Hive ?? default;
         _stun.TryParalyze(victim, parasite.Comp.ParalyzeTime, true);
         _status.TryAddStatusEffect(victim, "Muted", parasite.Comp.ParalyzeTime, true, "Muted");
+        _status.TryAddStatusEffect(victim, "TemporaryBlindness", parasite.Comp.ParalyzeTime, true, "TemporaryBlindness");
         RefreshIncubationMultipliers(victim);
 
         var container = _container.EnsureContainer<ContainerSlot>(victim, victimComp.ContainerId);
         _container.Insert(parasite.Owner, container);
 
-        _blindable.UpdateIsBlind(victim);
         _appearance.SetData(parasite, victimComp.InfectedLayer, true);
 
         // TODO RMC14 also do damage to the parasite
@@ -402,12 +402,6 @@ public abstract class SharedXenoParasiteSystem : EntitySystem
                 _appearance.SetData(uid, infected.InfectedLayer, false);
                 if (_container.TryGetContainer(uid, infected.ContainerId, out var container))
                     _container.EmptyContainer(container);
-            }
-
-            if (infected.RecoverAt < time && !infected.Recovered)
-            {
-                infected.Recovered = true;
-                _blindable.UpdateIsBlind(uid);
             }
 
             if (_net.IsClient)
@@ -525,6 +519,8 @@ public abstract class SharedXenoParasiteSystem : EntitySystem
             return;
         //TODO Minor limb damage and causes pain
         _stun.TryParalyze(victim, knockdownTime, false);
+        _status.TryAddStatusEffect(victim, "Muted", knockdownTime, true, "Muted");
+        _status.TryAddStatusEffect(victim, "TemporaryBlindness", knockdownTime, true, "TemporaryBlindness");
         _jitter.DoJitter(victim, jitterTime, false);
         _popup.PopupEntity(Loc.GetString("rmc-xeno-infection-shakes-self"), victim, victim, PopupType.MediumCaution);
         _popup.PopupEntity(Loc.GetString("rmc-xeno-infection-shakes", ("victim", victim)), victim, Filter.PvsExcept(victim), true, PopupType.MediumCaution);

--- a/Content.Shared/_RMC14/Xenonids/Parasite/VictimInfectedComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Parasite/VictimInfectedComponent.cs
@@ -44,12 +44,6 @@ public sealed partial class VictimInfectedComponent : Component
     [DataField, AutoNetworkedField]
     public bool FellOff;
 
-    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
-    public TimeSpan RecoverAt;
-
-    [DataField, AutoNetworkedField]
-    public bool Recovered;
-
     [DataField, AutoNetworkedField]
     public TimeSpan BurstDelay = TimeSpan.FromMinutes(8);
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Current instances where CM-13 would use the paralyze status now properly apply all effects that should be with it (mostly just in parasite system, I forgot the shaking from infection should both mute you and blind you).

Also shaking someone out of a stun from recent infection should now clear up their blindness & muteness too.

Shaking someone out of a stun no longer removes the status, instead subtracting 6 seconds from the status effect timer.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Fixes discord issue, CM-13 parity

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
So we don't have a combined status effect that does stun, blind, and muted at the same time. We do have seperate status effects for each of them however. SharedParasiteSystem now uses the TempBlind status instead of what it was doing before.

Shaking now checks for blind & muted and if they exist and their times are the same removes duration from them. Stuns and knocked down also only remove duration now. It's 6 seconds to each [Copied from CM-13].

Not sure if there's a better way to just make a "knocked out"/Unconscious status that does all of these. 

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/user-attachments/assets/7ab9a1fc-0d70-44d4-a349-49451d1ace9b



## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
hope not
**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- tweak: Shaking someone out of a stun now only removes 6 seconds from the stun instead of instantly ending it per help.
- fix: When shaken out of the initial infected state, you lose the blindness & muteness that came with it
