### PR TITLE
Change GunIFFSystem to use a datafield

### DIFF
--- a/Content.Shared/_RMC14/Attachable/Systems/AttachableIFFSystem.cs
+++ b/Content.Shared/_RMC14/Attachable/Systems/AttachableIFFSystem.cs
@@ -40,7 +40,7 @@ public sealed class AttachableIFFSystem : EntitySystem
 
     private void OnGunAttachableIFFAmmoShot(Entity<GunAttachableIFFComponent> ent, ref AmmoShotEvent args)
     {
-        _gunIFF.GiveAmmoIFF(ent, ref args, false);
+        _gunIFF.GiveAmmoIFF(ent, ref args, false, true);
     }
 
     private void UpdateGunIFF(EntityUid gun)

--- a/Content.Shared/_RMC14/Weapons/Ranged/IFF/GunIFFComponent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/IFF/GunIFFComponent.cs
@@ -8,4 +8,7 @@ public sealed partial class GunIFFComponent : Component
 {
     [DataField, AutoNetworkedField]
     public bool Intrinsic;
+
+    [DataField, AutoNetworkedField]
+    public bool Enabled;
 }

--- a/Content.Shared/_RMC14/Weapons/Ranged/IFF/ProjectileIFFComponent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/IFF/ProjectileIFFComponent.cs
@@ -9,4 +9,7 @@ public sealed partial class ProjectileIFFComponent : Component
 {
     [DataField(required: true), AutoNetworkedField]
     public EntProtoId<IFFFactionComponent>? Faction;
+
+    [DataField, AutoNetworkedField]
+    public bool Enabled;
 }

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/marine_pistols.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/marine_pistols.yml
@@ -313,6 +313,7 @@
       types:
         Blunt: 8
   - type: GunIFF
+    enabled: true
   - type: Gun
     shotsPerBurst: 3
     selectedMode: SemiAuto

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SmartGuns/smart_gun.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SmartGuns/smart_gun.yml
@@ -8,6 +8,7 @@
   - type: Corrodible
     isCorrodible: false
   - type: GunIFF
+    enabled: true
   - type: WieldDelay
     baseDelay: 0.4
   - type: WieldableSpeedModifiers

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Snipers/marine_snipers.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Snipers/marine_snipers.yml
@@ -72,6 +72,7 @@
   - type: Corrodible
     isCorrodible: false
   - type: GunIFF
+    enabled: true
   - type: RMCNameItemOnVend
     item: PrimaryGun
   - type: AttachableHolder

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/cm_base_gun.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/cm_base_gun.yml
@@ -3,6 +3,8 @@
   id: CMBaseWeaponGun
   components:
   - type: GunUnskilledPenalty
+  - type: GunIFF
+    enabled: false
   - type: Clothing
     quickEquip: false
   - type: GunSkilledRecoil

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Sentries/static_sentries.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Sentries/static_sentries.yml
@@ -63,6 +63,7 @@
   - type: NoRotateOnInteract
   - type: NoRotateOnMove
   - type: GunIFF
+    enabled: true
     intrinsic: true
 
 - type: entity


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
GunIFF and ProjectileIFF now rely on a datafield rather than just the component, and ProjectileIFF is always present. I've tested attachments & guns with IFF base (as well as guns without either) and they all seemed to work fine still. 

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
This is so that the ProjectileIFF's faction can be always present, for things like giving specific entities friendly fire immunity.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Above. Attachments always give IFF and OnGunIFFAmmoShot now uses the datafield. 

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
