### PR TITLE
Fix MP armor speed

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
@@ -416,6 +416,9 @@
     armor: 25
     bio: 15
     explosionArmor: 20
+  - type: ClothingSpeedModifier
+    walkModifier: 0.814
+    sprintModifier: 0.814
   - type: Storage
     maxItemSize: Small
     grid:


### PR DESCRIPTION
## About the PR

Makes MP M2 armor have SLOWDOWN_ARMOR_LIGHT, just like in CM13.
