### PR TITLE
Add ActiveInputMover

### DIFF
--- a/Content.Shared/_RMC14/CCVar/RMCCVars.cs
+++ b/Content.Shared/_RMC14/CCVar/RMCCVars.cs
@@ -119,4 +119,7 @@ public sealed class RMCCVars : CVars
 
     public static readonly CVarDef<bool> RMCGasTileOverlayUpdate =
         CVarDef.Create("rmc.gas_tile_overlay_update", false, CVar.REPLICATED | CVar.SERVER);
+
+    public static readonly CVarDef<bool> RMCActiveInputMoverEnabled =
+        CVarDef.Create("rmc.active_input_mover_enabled", true, CVar.REPLICATED | CVar.SERVER);
 }

--- a/Content.Shared/_RMC14/Input/ActiveInputMoverComponent.cs
+++ b/Content.Shared/_RMC14/Input/ActiveInputMoverComponent.cs
@@ -1,0 +1,7 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Input;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(RMCInputSystem))]
+public sealed partial class ActiveInputMoverComponent : Component;

--- a/Content.Shared/_RMC14/Input/RMCInputSystem.cs
+++ b/Content.Shared/_RMC14/Input/RMCInputSystem.cs
@@ -1,0 +1,60 @@
+﻿using Content.Shared._RMC14.CCVar;
+using Content.Shared.Movement.Components;
+using Robust.Shared.Configuration;
+using Robust.Shared.Player;
+
+namespace Content.Shared._RMC14.Input;
+
+public sealed class RMCInputSystem : EntitySystem
+{
+    [Dependency] private readonly IConfigurationManager _config = default!;
+
+    private bool _activeInputMoverEnabled;
+
+    private EntityQuery<ActorComponent> _actorQuery;
+
+    public override void Initialize()
+    {
+        _actorQuery = GetEntityQuery<ActorComponent>();
+
+        SubscribeLocalEvent<InputMoverComponent, MapInitEvent>(OnInputMapInit);
+
+        SubscribeLocalEvent<ActiveInputMoverComponent, MapInitEvent>(OnActiveMapInit);
+        SubscribeLocalEvent<ActiveInputMoverComponent, PlayerAttachedEvent>(OnActiveAttached);
+        SubscribeLocalEvent<ActiveInputMoverComponent, PlayerDetachedEvent>(OnActiveDetached);
+
+        Subs.CVar(_config, RMCCVars.RMCActiveInputMoverEnabled, v => _activeInputMoverEnabled = v, true);
+    }
+
+    private void OnInputMapInit(Entity<InputMoverComponent> ent, ref MapInitEvent args)
+    {
+        EnsureComp<ActiveInputMoverComponent>(ent);
+    }
+
+    private void OnActiveMapInit(Entity<ActiveInputMoverComponent> ent, ref MapInitEvent args)
+    {
+        if (!_activeInputMoverEnabled)
+            return;
+
+        if (_actorQuery.HasComp(ent))
+            EnsureComp<InputMoverComponent>(ent);
+        else
+            RemCompDeferred<InputMoverComponent>(ent);
+    }
+
+    private void OnActiveAttached(Entity<ActiveInputMoverComponent> ent, ref PlayerAttachedEvent args)
+    {
+        if (!_activeInputMoverEnabled)
+            return;
+
+        EnsureComp<InputMoverComponent>(ent);
+    }
+
+    private void OnActiveDetached(Entity<ActiveInputMoverComponent> ent, ref PlayerDetachedEvent args)
+    {
+        if (!_activeInputMoverEnabled)
+            return;
+
+        RemCompDeferred<InputMoverComponent>(ent);
+    }
+}

--- a/Resources/Prototypes/Body/Organs/human.yml
+++ b/Resources/Prototypes/Body/Organs/human.yml
@@ -67,6 +67,7 @@
   - type: FlavorProfile
     flavors:
       - people
+  - type: ActiveInputMover
 
 - type: entity
   id: OrganHumanEyes

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
@@ -196,3 +196,4 @@
             sprite: _RMC14/Effects/xeno_spray_acid.rsi
             state: human_acid_enhanced
             visible: true
+  - type: ActiveInputMover

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
@@ -225,6 +225,7 @@
     keys:
     - enum.VendingMachineUiKey.Key
     - enum.PaperUiKey.Key
+  - type: ActiveInputMover
 
 - type: entity
   abstract: true


### PR DESCRIPTION
## About the PR
Ticking input movers on physics solve is about ~12.6% of server perf, this should help with late round high player counts.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed an issue related to player movement that was causing lag specially late-round at high player counts. Report any issues relating to not being able to move when you should be able to in AHelp (F1) if they come up.
