### PR TITLE
Fix upstream toolboxes on shivas and shotgun size

### DIFF
--- a/Resources/Maps/_RMC14/shiva.yml
+++ b/Resources/Maps/_RMC14/shiva.yml
@@ -82280,7 +82280,7 @@ entities:
     - type: Transform
       pos: 214.5,75.5
       parent: 1
-- proto: ToolboxElectrical
+- proto: RMCToolboxElectrical
   entities:
   - uid: 6240
     components:
@@ -82302,14 +82302,14 @@ entities:
     - type: Transform
       pos: 164.5,135.5
       parent: 1
-- proto: ToolboxElectricalFilled
+- proto: RMCToolboxElectricalFilled
   entities:
   - uid: 863
     components:
     - type: Transform
       pos: 43.47625,18.549507
       parent: 1
-- proto: ToolboxEmergency
+- proto: RMCToolboxEmergency
   entities:
   - uid: 1669
     components:
@@ -82341,7 +82341,7 @@ entities:
     - type: Transform
       pos: 197.5,136.5
       parent: 1
-- proto: ToolboxMechanical
+- proto: RMCToolboxMechanical
   entities:
   - uid: 2259
     components:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Tools/toolbox.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Tools/toolbox.yml
@@ -1,0 +1,40 @@
+﻿- type: entity
+  parent: ToolboxBase
+  abstract: true
+  id: RMCToolboxBase
+  components:
+  - type: Storage
+    maxItemSize: Small
+    grid:
+    - 0,0,13,1
+  - type: FixedItemSizeStorage
+
+- type: entity
+  parent: [RMCToolboxBase, ToolboxEmergency]
+  id: RMCToolboxEmergency
+  suffix: RMC14 # TODO RMC14 sprite
+
+- type: entity
+  parent: [RMCToolboxEmergency, ToolboxEmergencyFilled]
+  id: RMCToolboxEmergencyFilled
+  suffix: RMC14, Filled # TODO RMC14 sprite and fill
+
+- type: entity
+  parent: [RMCToolboxBase, ToolboxElectrical]
+  id: RMCToolboxElectrical
+  suffix: RMC14 # TODO RMC14 sprite
+
+- type: entity
+  parent: [RMCToolboxElectrical, ToolboxElectricalFilled]
+  id: RMCToolboxElectricalFilled
+  suffix: RMC14, Filled # TODO RMC14 sprite and fill
+
+- type: entity
+  parent: [RMCToolboxBase, ToolboxMechanical]
+  id: RMCToolboxMechanical
+  suffix: RMC14 # TODO RMC14 sprite
+
+- type: entity
+  parent: [RMCToolboxMechanical, ToolboxMechanicalFilled]
+  id: RMCToolboxMechanicalFilled
+  suffix: RMC14, Filled # TODO RMC14 sprite and fill

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/marine_shotguns.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/marine_shotguns.yml
@@ -3,6 +3,8 @@
   parent: [ BaseItem, CMBaseWeaponGun, RMCBaseAttachableHolder ]
   id: RMCBaseWeaponShotgun
   components:
+  - type: Item
+    size: Large
   - type: Sprite
     layers:
     - state: base


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed shotguns being a small item instead of large and Shivas having upstream toolboxes that could fit many more items than intended. Imagine the things we could have if people reported bugs, instead of silently powergaming them, leading to us wasting more time than necessary fixing them. We could have close air support, orbital bombardment, second floor of the Almayer, the construction, medical or shotgun updates. No, instead we have this bug-fix because only one person had the dignity and self-respect to report it in an AHelp and one on the Discord. Thank you anonymous users, no thank you to everyone else. Fuck my life.
