### PR TITLE
dont let xenos hug marines

### DIFF
--- a/Content.Shared/Interaction/Components/InteractionPopupComponent.cs
+++ b/Content.Shared/Interaction/Components/InteractionPopupComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Whitelist; // RMC14
 using Robust.Shared.Audio;
 using Robust.Shared.Prototypes;
 
@@ -82,4 +83,10 @@ public sealed partial class InteractionPopupComponent : Component
     /// </summary>
     [DataField]
     public bool OnActivate;
+
+    /// <summary>
+    /// RMC14: If the user matches this blacklist they cannot do the interaction.
+    /// </summary>
+    [DataField]
+    public EntityWhitelist? UserBlacklist;
 }

--- a/Content.Shared/Interaction/InteractionPopupSystem.cs
+++ b/Content.Shared/Interaction/InteractionPopupSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Interaction.Components;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Popups;
+using Content.Shared.Whitelist; // RMC14
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Network;
@@ -15,6 +16,7 @@ namespace Content.Shared.Interaction;
 
 public sealed class InteractionPopupSystem : EntitySystem
 {
+    [Dependency] private readonly EntityWhitelistSystem _whitelist = default!; // RMC14
     [Dependency] private readonly IGameTiming _gameTiming = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly MobStateSystem _mobStateSystem = default!;
@@ -54,6 +56,9 @@ public sealed class InteractionPopupSystem : EntitySystem
         EntityUid user)
     {
         if (args.Handled || user == target)
+            return;
+
+        if (_whitelist.IsBlacklistPass(component.UserBlacklist, user)) // RMC14
             return;
 
         //Handling does nothing and this thing annoyingly plays way too often.

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -185,6 +185,9 @@
     interactSuccessString: hugging-success-generic
     interactSuccessSound: /Audio/Effects/thudswoosh.ogg
     messagePerceivedByOthers: hugging-success-generic-others
+    userBlacklist: # RMC14: dont let xenos hug marines
+      components:
+      - Xeno
   - type: CanHostGuardian
   - type: NpcFactionMember
     factions:


### PR DESCRIPTION
## About the PR
they shrimply cant

## Why / Balance
fixes #3436

## Technical details
added `UserBlacklist`

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- fix: Fixed Xenos being able to hug marines, that's what parasites are for.