### PR TITLE
Access lock Booze-Mat

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/food.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/food.yml
@@ -48,6 +48,10 @@
     layers:
     - state: "off"
     - state: "normal-unshaded"
+  - type: AccessReader
+    access:
+    - [ "CMAccessKitchen" ]
+    - [ "CMAccessColonyPublic" ]
   - type: CMAutomatedVendor
     sections:
     - name: Alcohol


### PR DESCRIPTION
## About the PR

Access lock Booze-Mat for Kitchen or Colony accesses.

"No more drunk marines, only drunk officers" update.

**Changelog**

:cl:
- fix: Booze-O-Mat is now access locked!