### PR TITLE
Fixes the spec GL firing through doors.

### DIFF
--- a/Content.Shared/_RMC14/Weapons/Ranged/CMGunSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/CMGunSystem.cs
@@ -45,6 +45,8 @@ public sealed class CMGunSystem : EntitySystem
     private EntityQuery<PhysicsComponent> _physicsQuery;
     private EntityQuery<ProjectileComponent> _projectileQuery;
 
+    private int blockArcCollisionGroup = (int)(CollisionGroup.HighImpassable | CollisionGroup.Impassable);
+
     public override void Initialize()
     {
         _physicsQuery = GetEntityQuery<PhysicsComponent>();
@@ -151,8 +153,7 @@ public sealed class CMGunSystem : EntitySystem
     private void OnCollisionCheckArc(Entity<ProjectileFixedDistanceComponent> ent, ref PreventCollideEvent args)
     {
         int otherLayers = (int)args.OtherFixture.CollisionLayer;
-        int impassableLayer = (int)CollisionGroup.Impassable;
-        if (((Comp<ProjectileFixedDistanceComponent>(ent).ArcProj) && !((args.OtherFixture.CollisionLayer & impassableLayer) == impassableLayer)))
+        if (Comp<ProjectileFixedDistanceComponent>(ent).ArcProj && (args.OtherFixture.CollisionLayer & blockArcCollisionGroup) == 0)
             args.Cancelled = true;
         return;
     }


### PR DESCRIPTION

## About the PR
Closes #3480

## Why / Balance
Because bug.

## Technical details
Fixed the collision layer check.

This will make the grenades bounce off tabletop devices like booze dispensers and fax machines. Can't do much about that unless we change everything's collision layers. So GL users will just have to be careful what they're trying to shoot past.

## Media

https://github.com/user-attachments/assets/edfd542f-92cf-4f0a-a16a-47a07b767fae

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: Sigil
- fix: The spec GL can no longer phase its grenades through doors.
