### PR TITLE
Better Announce

### DIFF
--- a/Content.Server/_RMC14/Dropship/DropshipSystem.cs
+++ b/Content.Server/_RMC14/Dropship/DropshipSystem.cs
@@ -336,7 +336,7 @@ public sealed class DropshipSystem : SharedDropshipSystem
 
         foreach (var primaryLZCandidate in GetPrimaryLZCandidates())
         {
-            if (TryDesignatePrimaryLZ(default, primaryLZCandidate, new MarineCommunicationsComputerComponent().Sound))
+            if (TryDesignatePrimaryLZ(default, primaryLZCandidate))
                 break;
         }
     }

--- a/Content.Server/_RMC14/Marines/MarineAnnounceCommand.cs
+++ b/Content.Server/_RMC14/Marines/MarineAnnounceCommand.cs
@@ -1,0 +1,34 @@
+using Content.Server.Administration;
+using Content.Shared.Administration;
+using Robust.Shared.Console;
+
+namespace Content.Server._RMC14.Marines;
+
+[AdminCommand(AdminFlags.Moderator)]
+public sealed class MarineAnnounceCommand : IConsoleCommand
+{
+    public string Command => "marineannounce";
+    public string Description => Loc.GetString("rmc-command-marineannounce-description");
+    public string Help => Loc.GetString("rmc-command-marineannounce-help");
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        var _marineAnnounce = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<MarineAnnounceSystem>();
+        if (args.Length == 0)
+        {
+            shell.WriteError("Not enough arguments! Need at least 1.");
+            return;
+        }
+
+        if (args.Length == 1)
+        {
+            _marineAnnounce.AnnounceHighCommand(args[0]);
+        }
+        else
+        {
+            var message = string.Join(' ', new ArraySegment<string>(args, 1, args.Length-1));
+            _marineAnnounce.AnnounceHighCommand(message, args[0]);
+        }
+        shell.WriteLine("Sent!");
+    }
+}

--- a/Content.Server/_RMC14/Marines/MarineAnnounceCommand.cs
+++ b/Content.Server/_RMC14/Marines/MarineAnnounceCommand.cs
@@ -26,7 +26,7 @@ public sealed class MarineAnnounceCommand : IConsoleCommand
         }
         else
         {
-            var message = string.Join(' ', new ArraySegment<string>(args, 1, args.Length-1));
+            var message = string.Join(' ', args[1..]);
             _marineAnnounce.AnnounceHighCommand(message, args[0]);
         }
         shell.WriteLine("Sent!");

--- a/Content.Server/_RMC14/Marines/MarineAnnounceSystem.cs
+++ b/Content.Server/_RMC14/Marines/MarineAnnounceSystem.cs
@@ -118,9 +118,19 @@ public sealed class MarineAnnounceSystem : SharedMarineAnnounceSystem
         _ui.SetUiState(computer.Owner, MarineCommunicationsComputerUI.Key, state);
     }
 
-    public void Announce(EntityUid sender, string message, SoundSpecifier sound)
+    /// <summary>
+    /// Dispatches an announcement to Marine side.
+    /// </summary>
+    /// <param name="message">The contents of the message.</param>
+    /// <param name="sound">GlobalSound for announcement.</param>
+    /// <param name="author">The author of the message, Command by default.</param>
+    public void Announce(
+        EntityUid sender,
+        string message,
+        SoundSpecifier sound,
+        string? author = null
+        )
     {
-        // TODO RMC14 localize this
         // TODO RMC14 rank
         var job = string.Empty;
         if (_mind.TryGetMind(sender, out var mindId, out _) &&
@@ -129,9 +139,9 @@ public sealed class MarineAnnounceSystem : SharedMarineAnnounceSystem
             job = jobName;
         }
 
+        author ??= Loc.GetString("rmc-announcement-author"); // Get "Command" fluent string if author==null
         var name = Name(sender);
-        var wrappedMessage =
-            $"[font size=14][bold][color=white]Command Announcement[/color][/bold][/font]\n[font size=12][color=red]\n{message}\n\nSigned by,\n{job} {name}[/color][/font]";
+        var wrappedMessage = Loc.GetString("rmc-announcement-message", ("author", author), ("message", message), ("job", job), ("name", name));
 
         // TODO RMC14 receivers
         var filter = Filter.Empty()

--- a/Content.Server/_RMC14/Marines/MarineAnnounceSystem.cs
+++ b/Content.Server/_RMC14/Marines/MarineAnnounceSystem.cs
@@ -39,7 +39,7 @@ public sealed class MarineAnnounceSystem : SharedMarineAnnounceSystem
     [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
 
     private int _characterLimit = 1000;
-    public SoundSpecifier DefaultAnnouncementSound = new SoundPathSpecifier("/Audio/_RMC14/Announcements/Marine/notice2.ogg");
+    public readonly SoundSpecifier DefaultAnnouncementSound = new SoundPathSpecifier("/Audio/_RMC14/Announcements/Marine/notice2.ogg");
 
     public override void Initialize()
     {

--- a/Content.Shared/_RMC14/Dropship/SharedDropshipSystem.cs
+++ b/Content.Shared/_RMC14/Dropship/SharedDropshipSystem.cs
@@ -270,7 +270,10 @@ public abstract class SharedDropshipSystem : EntitySystem
         return true;
     }
 
-    public bool TryDesignatePrimaryLZ(EntityUid actor, EntityUid lz, SoundSpecifier sound)
+    public bool TryDesignatePrimaryLZ(
+        EntityUid actor,
+        EntityUid lz
+        )
     {
         if (!HasComp<DropshipDestinationComponent>(lz))
         {
@@ -301,7 +304,9 @@ public abstract class SharedDropshipSystem : EntitySystem
 
         EnsureComp<PrimaryLandingZoneComponent>(lz);
         RefreshUI();
-        _marineAnnounce.AnnounceARES(actor, $"Command Order Issued:\n\n{Name(lz)} has been designated as the primary landing zone.", sound);
+
+        var message = Loc.GetString("rmc-announcement-ares-lz-designated", ("name", Name(lz)));
+        _marineAnnounce.AnnounceARES(actor, message);
 
         return true;
     }

--- a/Content.Shared/_RMC14/Marines/Announce/MarineCommunicationsComputerComponent.cs
+++ b/Content.Shared/_RMC14/Marines/Announce/MarineCommunicationsComputerComponent.cs
@@ -14,6 +14,8 @@ public sealed partial class MarineCommunicationsComputerComponent : Component
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
     public TimeSpan? LastAnnouncement;
 
+    /*
     [DataField, AutoNetworkedField]
     public SoundSpecifier Sound = new SoundPathSpecifier("/Audio/_RMC14/Announcements/Marine/notice2.ogg");
+    */
 }

--- a/Content.Shared/_RMC14/Marines/Announce/SharedMarineAnnounceSystem.cs
+++ b/Content.Shared/_RMC14/Marines/Announce/SharedMarineAnnounceSystem.cs
@@ -34,7 +34,11 @@ public abstract class SharedMarineAnnounceSystem : EntitySystem
     {
     }
 
-    public virtual void AnnounceARES(EntityUid? source, string message, SoundSpecifier sound)
+    public virtual void AnnounceARES(
+        EntityUid? source,
+        string message, 
+        SoundSpecifier? sound = null
+        )
     {
     }
 }

--- a/Content.Shared/_RMC14/Marines/Announce/SharedMarineAnnounceSystem.cs
+++ b/Content.Shared/_RMC14/Marines/Announce/SharedMarineAnnounceSystem.cs
@@ -17,7 +17,10 @@ public abstract class SharedMarineAnnounceSystem : EntitySystem
         SubscribeLocalEvent<MarineCommunicationsComputerComponent, ActivatableUIOpenAttemptEvent>(OnMarineCommunicationsComputerOpenAttempt);
     }
 
-    private void OnMarineCommunicationsComputerOpenAttempt(Entity<MarineCommunicationsComputerComponent> ent, ref ActivatableUIOpenAttemptEvent args)
+    private void OnMarineCommunicationsComputerOpenAttempt(
+        Entity<MarineCommunicationsComputerComponent> ent,
+        ref ActivatableUIOpenAttemptEvent args
+        )
     {
         if (args.Cancelled)
             return;
@@ -30,13 +33,17 @@ public abstract class SharedMarineAnnounceSystem : EntitySystem
         }
     }
 
-    public virtual void AnnounceRadio(EntityUid sender, string message, ProtoId<RadioChannelPrototype> channel)
+    public virtual void AnnounceRadio(
+        EntityUid sender,
+        string message,
+        ProtoId<RadioChannelPrototype> channel
+        )
     {
     }
 
     public virtual void AnnounceARES(
         EntityUid? source,
-        string message, 
+        string message,
         SoundSpecifier? sound = null
         )
     {

--- a/Resources/Locale/en-US/_RMC14/chat/announcement.ftl
+++ b/Resources/Locale/en-US/_RMC14/chat/announcement.ftl
@@ -1,0 +1,7 @@
+rmc-announcement-author = Command
+rmc-announcement-message = [font size=14][bold][color=white]{$author} Announcement[/color][/bold][/font][font size=12][color=red]
+
+    {$message}
+
+    Signed by,
+    {$job} {$name}[/color][/font]

--- a/Resources/Locale/en-US/_RMC14/chat/announcement.ftl
+++ b/Resources/Locale/en-US/_RMC14/chat/announcement.ftl
@@ -3,5 +3,19 @@ rmc-announcement-message = [font size=14][bold][color=white]{$author} Announceme
 
     {$message}
 
+rmc-announcement-message-signed = [font size=14][bold][color=white]{$author} Announcement[/color][/bold][/font][font size=12][color=red]
+
+    {$message}
+
     Signed by,
     {$job} {$name}[/color][/font]
+
+rmc-announcement-ares-message = [color=white][font size=16][bold]ARES v3.2 Operation Staging Order[/bold][/font][/color][color=red][font size=14][bold]
+
+    {$message}[/bold][/font][/color]
+
+rmc-announcement-ares-lz-designated = Command Order Issued:
+    
+    {$name} has been designated as the primary landing zone.
+
+rmc-announcement-cooldown = Please allow at least {$seconds} seconds to pass between announcements

--- a/Resources/Locale/en-US/_RMC14/chat/announcement.ftl
+++ b/Resources/Locale/en-US/_RMC14/chat/announcement.ftl
@@ -1,4 +1,5 @@
 rmc-announcement-author = Command
+rmc-announcement-author-highcommand = UNMC High Command
 rmc-announcement-message = [font size=14][bold][color=white]{$author} Announcement[/color][/bold][/font][font size=12][color=red]
 
     {$message}

--- a/Resources/Locale/en-US/_RMC14/commands/rmc-announce.ftl
+++ b/Resources/Locale/en-US/_RMC14/commands/rmc-announce.ftl
@@ -1,0 +1,2 @@
+rmc-command-marineannounce-description = Send an in-game announcement.
+rmc-command-marineannounce-help = <rmcannounce> <sender> <message> or <rmcannounce> <message> to send announcement as High Command.


### PR DESCRIPTION
## About the PR

- Localizes Announces of MarineAnnouncementSystem and Console cooldown
- Adds an upstream `announce` look-alike command - `marineannounce`, for admins to roleplay as High Command, WeYa, Provost or CMB.

## Technical details

- Replaces `MarineCommunicationsComputerComponent().Sound` with `MarineAnnounceSystem.DefaultAnnouncementSound`, leaves functionality to set your own SoundSpecifier.
- Renames method `MarineAnnounceSystem.Announce` as `MarineAnnounceSystem.AnnounceSigned`
- Adds method `MarineAnnounceSystem.AnnounceHighCommand`
- Rips `_chatManager.ChatMessageToManyFiltered` from all Announce methods and replace it with `MarineAnnounceSystem.AnnounceToMarines` for easier Filtering in the future.

## Media

![зображення](https://github.com/user-attachments/assets/7ca03b42-f68d-4c32-9a91-5ebabc68e946)

![зображення](https://github.com/user-attachments/assets/f1f6f0eb-9d1b-4f93-9cf4-4f7e7374642b)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
