### PR TITLE
Fix spaceborne gauss turrets not shooting crit xenos

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Sentries/static_sentries.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Sentries/static_sentries.yml
@@ -100,6 +100,7 @@
       operator: !type:GunOperator
         targetKey: Target
         requireLOS: true
+        targetState: Critical
       services:
       - !type:UtilityService
         id: RangedService
@@ -120,9 +121,6 @@
   - !type:TargetDistanceCon
     curve: !type:PresetCurve
       preset: TargetDistance
-  - !type:TargetHealthCon
-    curve: !type:PresetCurve
-      preset: TargetHealth
   - !type:TargetAccessibleCon
     curve: !type:BoolCurve
   - !type:TargetInLOSOrCurrentCon


### PR DESCRIPTION
## About the PR
Fixes https://github.com/RMC-14/RMC-14/issues/3460

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed spaceborne gauss turrets not shooting at crit xenonids. They will no longer be merciful.
