### PR TITLE
Don't show toggle internals verb if no breath tools are found while off

### DIFF
--- a/Content.Server/Body/Systems/InternalsSystem.cs
+++ b/Content.Server/Body/Systems/InternalsSystem.cs
@@ -72,6 +72,9 @@ public sealed class InternalsSystem : EntitySystem
         if (!args.CanAccess || !args.CanInteract || args.Hands is null)
             return;
 
+        if (!AreInternalsWorking(ent) && ent.Comp.BreathTools.Count == 0)
+            return;
+
         var user = args.User;
 
         InteractionVerb verb = new()


### PR DESCRIPTION
## About the PR
Please god stop the context menu from bouncing

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: The Toggle Internals verb no longer shows up in the context menu if no breathing tool is equipped and internals are off.
