### PR TITLE
M42A2 Pump Shotgun unwieldedScatter Fix

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/marine_shotguns.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/marine_shotguns.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   abstract: true
   parent: [ BaseItem, CMBaseWeaponGun, RMCBaseAttachableHolder ]
   id: RMCBaseWeaponShotgun
@@ -79,7 +79,7 @@
     recoilWielded: 2
     recoilUnwielded: 4
     scatterWielded: 10
-    scatterUnwielded: 10
+    scatterUnwielded: 20
     baseFireRate: 0.5
     burstScatterMult: 5
   - type: PumpAction


### PR DESCRIPTION
## About the PR
Changed the unwieldedScatter value of the M42A2 Pump Shotgun to be 20 instead of 10.

## Why / Balance
This is a fix to use the correct value instead of a much lower one.

## Technical details
I changed a 1 to 2

**Changelog**

:cl:
- fix: Corrected scatter for the M42A2 Pump Shotgun
