### PR TITLE
M42A2 Scatter Correction

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/marine_shotguns.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/marine_shotguns.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   abstract: true
   parent: [ BaseItem, CMBaseWeaponGun, RMCBaseAttachableHolder ]
   id: RMCBaseWeaponShotgun
@@ -79,7 +79,7 @@
     recoilWielded: 2
     recoilUnwielded: 4
     scatterWielded: 10
-    scatterUnwielded: 10
+    scatterUnwielded: 20
     baseFireRate: 0.5
     burstScatterMult: 5
   - type: PumpAction

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/marine_shotguns.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/marine_shotguns.yml
@@ -1,4 +1,4 @@
-- type: entity
+﻿- type: entity
   abstract: true
   parent: [ BaseItem, CMBaseWeaponGun, RMCBaseAttachableHolder ]
   id: RMCBaseWeaponShotgun
@@ -79,7 +79,7 @@
     recoilWielded: 2
     recoilUnwielded: 4
     scatterWielded: 10
-    scatterUnwielded: 20
+    scatterUnwielded: 10
     baseFireRate: 0.5
     burstScatterMult: 5
   - type: PumpAction


### PR DESCRIPTION
## About the PR
Changed the M42A2 Pump Shotgun's unwieldedScatter component.

## Why / Balance
Value was incorrectly 10. To correctly match the unwieldedScatter value in CM13 it needs to be 20.

## Technical details
I changed a 1 to a 2 and then fought with github for 3 hours.

:cl:
- fix: Fixed the M42A2 Scatter being too accurate.

