### PR TITLE
Fixes binoculars being usable when not held in the active hand

### DIFF
--- a/Content.Shared/_RMC14/Scoping/SharedScopeSystem.cs
+++ b/Content.Shared/_RMC14/Scoping/SharedScopeSystem.cs
@@ -172,7 +172,7 @@ public abstract partial class SharedScopeSystem : EntitySystem
             return false;
         }
 
-        if (!_hands.TryGetActiveItem(user, out var heldItem)/* || heldItem != ent*/)
+        if (!_hands.TryGetActiveItem(user, out var heldItem) || !scope.Comp.Attachment && heldItem != scope.Owner)
         {
             var msgError = Loc.GetString("cm-action-popup-scoping-user-must-hold", ("scope", ent));
             _popup.PopupClient(msgError, user, user);


### PR DESCRIPTION

## About the PR
See title.

## Why / Balance
Bug.

## Technical details
Readded a commented-out check.

## Media

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

:cl: Sigil
- fix: You can no longer use binoculars when not holding them in your active hand.
