### PR TITLE
Fix gas masks to work with air tanks like the medical ones.

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Masks/masks.yml
@@ -9,7 +9,7 @@
     hideOnToggle: true
 
 - type: entity
-  parent: CMBaseMask
+  parent: ClothingMaskGas
   id: CMMaskGas
   name: gas mask
   description: A face-covering mask that can be connected to an air supply. Filters harmful gases from the air.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Gas masks now allow you to turn on internals just like the medical ones.

## Why / Balance
Because it not working is a bug, plus it helps tone down the currently very oppressive boiler smokes, especially during hijack.
And if it is not a bug, somebody needs to change the fact that oxygen tanks come in the same crate as gas masks when bought in req.

## Technical details
The med gas mask uses the base ss14 gas mask as a parent, which the standard gas mask does too now, allowing you to turn on your internals if you also have an air tank.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** __this PR does not require an ingame showcase__

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: BramvanZijp
- fix: Standard gas masks now allow for the use of internals.

