### PR TITLE
Add custom admin deliveries

### DIFF
--- a/Content.Server/_RMC14/Requisitions/RequisitionsSystem.cs
+++ b/Content.Server/_RMC14/Requisitions/RequisitionsSystem.cs
@@ -206,10 +206,15 @@ public sealed partial class RequisitionsSystem : SharedRequisitionsSystem
         return closest;
     }
 
+    private int GetElevatorCapacity(Entity<RequisitionsElevatorComponent> elevator)
+    {
+        var side = (int) (elevator.Comp.Radius * 2 + 1);
+        return side * side;
+    }
+
     private bool IsFull(Entity<RequisitionsElevatorComponent> elevator)
     {
-        var side = elevator.Comp.Radius * 2 + 1;
-        return elevator.Comp.Orders.Count >= side * side;
+        return elevator.Comp.Orders.Count >= GetElevatorCapacity(elevator);
     }
 
     private void SendUIState(Entity<RequisitionsComputerComponent> computer)
@@ -360,9 +365,11 @@ public sealed partial class RequisitionsSystem : SharedRequisitionsSystem
             var coordinates = _transform.GetMoverCoordinates(elevator);
             var xOffset = comp.Radius;
             var yOffset = comp.Radius;
+            int remainingDeliveries = GetElevatorCapacity(elevator);
             foreach (var order in comp.Orders)
             {
                 var crate = SpawnAtPosition(order.Crate, coordinates.Offset(new Vector2(xOffset, yOffset)));
+                remainingDeliveries--;
 
                 foreach (var prototype in order.Entities)
                 {
@@ -384,6 +391,34 @@ public sealed partial class RequisitionsSystem : SharedRequisitionsSystem
             }
 
             comp.Orders.Clear();
+
+            var query = EntityQueryEnumerator<RequisitionsCustomDeliveryComponent>();
+
+            while (query.MoveNext(out var entityUid, out var deliveryComp))
+            {
+                // If elevator is full, abort and break out of the loop. Any remaining custom deliveries will be on
+                // the next elevator shipment.
+                if (remainingDeliveries <= 0)
+                    break;
+
+                // Remove the component so it doesn't get "delivered" again next elevator cycle.
+                RemCompDeferred<RequisitionsCustomDeliveryComponent>(entityUid);
+
+                // Teleport to the spot.
+                _transform.SetCoordinates(entityUid, coordinates.Offset(new Vector2(xOffset, yOffset)));
+                remainingDeliveries--; // Decrement available delivery slots count.
+
+                // Update the next spot to teleport to.
+                yOffset--;
+                if (yOffset < -comp.Radius)
+                {
+                    yOffset = comp.Radius;
+                    xOffset--;
+                }
+
+                if (xOffset < -comp.Radius)
+                    xOffset = comp.Radius;
+            }
         }
     }
 

--- a/Content.Server/_RMC14/Requisitions/RequisitionsSystem.cs
+++ b/Content.Server/_RMC14/Requisitions/RequisitionsSystem.cs
@@ -208,7 +208,7 @@ public sealed partial class RequisitionsSystem : SharedRequisitionsSystem
 
     private int GetElevatorCapacity(Entity<RequisitionsElevatorComponent> elevator)
     {
-        var side = (int) (elevator.Comp.Radius * 2 + 1);
+        var side = (int) MathF.Floor(elevator.Comp.Radius * 2 + 1);
         return side * side;
     }
 

--- a/Content.Shared/_RMC14/Requisitions/Components/RequisitionsCustomDeliveryComponent.cs
+++ b/Content.Shared/_RMC14/Requisitions/Components/RequisitionsCustomDeliveryComponent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Requisitions.Components;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(SharedRequisitionsSystem))]
+public sealed partial class RequisitionsCustomDeliveryComponent : Component
+{
+
+}


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

- Adds the `RequisitionsCustomDelivery` component.
- When **any** (I hope there's only ever one) requisitions elevator raises, it will enumerate entities with this new component and teleport them onto the elevator into a free spot as soon as the other regularly ordered items have all been spawned as well.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Admins need a better in-character way to deliver items to the marine crew. Now they can deliver anything! Crates they filled up themselves, briefcases, marines, walls, xenos, rats, .... The possibilities are endless!

Admin usage:
- Prepare the item/entity you want to custom deliver.
- Add the RequisitionsCustomDelivery component.
- Without any additional admin interaction, this item will now automatically appear on the next elevator cycle, and the component will be removed.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

This PR isolates the cargo elevator's order capacity into a separate method for easy access from multiple places. Now, when the elevator raises and the order spawning logic is ran, it will keep track of the number of available spots on the elevator with this method. Each time an item is spawned through either a regular order or a custom delivery, this counter is decremented.

It is only possible for the elevator's capacity to be exceeded in the section of code dealing with custom orders. If the code notices at this point that there is no room left on the elevator, it aborts and any remaining unteleported items will be teleported next elevator cycle.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

Admin-only change, no CL.
