### PR TITLE
Fix xenos being able to attack nested infected, fix not being able to see while nested, fix fake attack effects

### DIFF
--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -630,14 +630,18 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
 
         var appliedDamage = new DamageSpecifier();
 
-        foreach (var entity in targets)
+        for (var i = targets.Count - 1; i >= 0; i--)
         {
+            var entity = targets[i];
             // We raise an attack attempt here as well,
             // primarily because this was an untargeted wideswing: if a subscriber to that event cared about
             // the potential target (such as for pacifism), they need to be made aware of the target here.
             // In that case, just continue.
             if (!Blocker.CanAttack(user, entity, (weapon, component)))
+            {
+                targets.RemoveAt(i);
                 continue;
+            }
 
             var attackedEvent = new AttackedEvent(meleeUid, user, GetCoordinates(ev.Coordinates));
             RaiseLocalEvent(entity, attackedEvent);

--- a/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestSystem.cs
@@ -35,6 +35,8 @@ public sealed class XenoNestSystem : EntitySystem
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly OccluderSystem _occluder = default!;
+    [Dependency] private readonly ISharedPlayerManager _player = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly PullingSystem _pulling = default!;
     [Dependency] private readonly StandingStateSystem _standing = default!;
@@ -44,13 +46,19 @@ public sealed class XenoNestSystem : EntitySystem
     [Dependency] private readonly IMapManager _map = default!;
     [Dependency] private readonly SharedXenoParasiteSystem _parasite = default!;
 
-    private EntityQuery<XenoWeedableComponent> _xenoWeedable;
+    private EntityQuery<OccluderComponent> _occluderQuery;
+    private EntityQuery<XenoNestComponent> _xenoNestQuery;
+    private EntityQuery<XenoNestSurfaceComponent> _xenoNestSurfaceQuery;
+    private EntityQuery<XenoWeedableComponent> _xenoWeedableQuery;
 
     public override void Initialize()
     {
         base.Initialize();
 
-        _xenoWeedable = GetEntityQuery<XenoWeedableComponent>();
+        _occluderQuery = GetEntityQuery<OccluderComponent>();
+        _xenoNestQuery = GetEntityQuery<XenoNestComponent>();
+        _xenoNestSurfaceQuery = GetEntityQuery<XenoNestSurfaceComponent>();
+        _xenoWeedableQuery = GetEntityQuery<XenoWeedableComponent>();
 
         SubscribeLocalEvent<XenoComponent, GetUsedEntityEvent>(OnXenoGetUsedEntity);
 
@@ -66,6 +74,7 @@ public sealed class XenoNestSystem : EntitySystem
 
         SubscribeLocalEvent<XenoNestableComponent, BeforeRangedInteractEvent>(OnNestableBeforeRangedInteract);
 
+        SubscribeLocalEvent<XenoNestedComponent, ComponentStartup>(OnNestedAdd);
         SubscribeLocalEvent<XenoNestedComponent, ComponentRemove>(OnNestedRemove);
         SubscribeLocalEvent<XenoNestedComponent, PreventCollideEvent>(OnNestedPreventCollide);
         SubscribeLocalEvent<XenoNestedComponent, PullAttemptEvent>(OnNestedPullAttempt);
@@ -80,7 +89,6 @@ public sealed class XenoNestSystem : EntitySystem
         SubscribeLocalEvent<XenoNestedComponent, IsEquippingAttemptEvent>(OnNestedCancel);
         SubscribeLocalEvent<XenoNestedComponent, IsUnequippingAttemptEvent>(OnNestedCancel);
         SubscribeLocalEvent<XenoNestedComponent, GetInfectedIncubationMultiplierEvent>(OnInNestGetInfectedIncubationMultiplier);
-        SubscribeLocalEvent<XenoNestedComponent, ComponentStartup>(OnNestedAdd);
     }
 
     private void OnXenoGetUsedEntity(Entity<XenoComponent> ent, ref GetUsedEntityEvent args)
@@ -177,7 +185,7 @@ public sealed class XenoNestSystem : EntitySystem
             Direction.East => new Vector2(0.5f, 0),
             Direction.North => new Vector2(0, 0.5f),
             Direction.West => new Vector2(-0.5f, 0),
-            _ => Vector2.Zero
+            _ => Vector2.Zero,
         };
 
         var nest = SpawnAttachedTo(ent.Comp.Nest, nestCoordinates);
@@ -239,7 +247,7 @@ public sealed class XenoNestSystem : EntitySystem
     private void OnSurfaceTerminating(Entity<XenoNestSurfaceComponent> ent, ref EntityTerminatingEvent args)
     {
         if (!TerminatingOrDeleted(ent.Comp.Weedable) &&
-            _xenoWeedable.TryComp(ent.Comp.Weedable, out var weedable) &&
+            _xenoWeedableQuery.TryComp(ent.Comp.Weedable, out var weedable) &&
             weedable.Entity == ent)
         {
             weedable.Entity = null;
@@ -457,5 +465,45 @@ public sealed class XenoNestSystem : EntitySystem
 
         RemCompDeferred<XenoNestedComponent>(nested);
         QueueDel(nest);
+    }
+
+    private bool TryGetNestedWallOccluder(Entity<XenoNestedComponent> nested, out Entity<OccluderComponent> occluder)
+    {
+        occluder = default;
+        if (!_xenoNestQuery.TryComp(nested.Comp.Nest, out var nest))
+            return false;
+
+        if (nest.Surface is not { } surface)
+            return false;
+
+        if (_occluderQuery.TryComp(surface, out var occluderComp))
+        {
+            occluder = (surface, occluderComp);
+            return true;
+        }
+
+        if (_xenoNestSurfaceQuery.TryComp(surface, out var nestSurface) &&
+            _occluderQuery.TryComp(nestSurface.Weedable, out occluderComp))
+        {
+            occluder = (nestSurface.Weedable.Value, occluderComp);
+            return true;
+        }
+
+        return false;
+    }
+
+    public override void Update(float frameTime)
+    {
+        if (_net.IsServer)
+            return;
+
+        if (_player.LocalEntity is not { } ent)
+            return;
+
+        if (TryComp(ent, out XenoNestedComponent? nested) &&
+            TryGetNestedWallOccluder((ent, nested), out var occluder))
+        {
+            _occluder.SetEnabled(occluder, false, occluder);
+        }
     }
 }

--- a/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared._RMC14.Vendors;
 using Content.Shared._RMC14.Xenonids.Construction.Nest;
 using Content.Shared._RMC14.Xenonids.Evolution;
 using Content.Shared._RMC14.Xenonids.Hive;
+using Content.Shared._RMC14.Xenonids.Parasite;
 using Content.Shared._RMC14.Xenonids.Pheromones;
 using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared._RMC14.Xenonids.Rest;
@@ -51,9 +52,11 @@ public sealed class XenoSystem : EntitySystem
     private EntityQuery<MarineComponent> _marineQuery;
     private EntityQuery<MobStateComponent> _mobStateQuery;
     private EntityQuery<MobThresholdsComponent> _mobThresholdsQuery;
+    private EntityQuery<XenoFriendlyComponent> _xenoFriendlyQuery;
     private EntityQuery<XenoNestedComponent> _xenoNestedQuery;
     private EntityQuery<XenoPlasmaComponent> _xenoPlasmaQuery;
     private EntityQuery<XenoRecoveryPheromonesComponent> _xenoRecoveryQuery;
+    private EntityQuery<VictimInfectedComponent> _victimInfectedQuery;
 
     private float _xenoDamageDealtMultiplier;
     private float _xenoDamageReceivedMultiplier;
@@ -68,9 +71,11 @@ public sealed class XenoSystem : EntitySystem
         _marineQuery = GetEntityQuery<MarineComponent>();
         _mobStateQuery = GetEntityQuery<MobStateComponent>();
         _mobThresholdsQuery = GetEntityQuery<MobThresholdsComponent>();
+        _xenoFriendlyQuery = GetEntityQuery<XenoFriendlyComponent>();
         _xenoNestedQuery = GetEntityQuery<XenoNestedComponent>();
         _xenoPlasmaQuery = GetEntityQuery<XenoPlasmaComponent>();
         _xenoRecoveryQuery = GetEntityQuery<XenoRecoveryPheromonesComponent>();
+        _victimInfectedQuery = GetEntityQuery<VictimInfectedComponent>();
 
         SubscribeLocalEvent<XenoComponent, MapInitEvent>(OnXenoMapInit);
         SubscribeLocalEvent<XenoComponent, GetAccessTagsEvent>(OnXenoGetAdditionalAccess);
@@ -144,8 +149,15 @@ public sealed class XenoSystem : EntitySystem
 
         // TODO RMC14 different hives
         // TODO RMC14 this still falsely plays the hit red flash effect on xenos if others are hit in a wide swing
-        if (HasComp<XenoFriendlyComponent>(target) ||
+        if (_xenoFriendlyQuery.HasComp(target) ||
             _mobState.IsDead(target))
+        {
+            args.Cancel();
+            return;
+        }
+
+        if (_xenoNestedQuery.HasComp(target) &&
+            _victimInfectedQuery.HasComp(target))
         {
             args.Cancel();
         }


### PR DESCRIPTION
## About the PR
This does make it so the client can see through the wall they are nested on but that's way better than the black screen of nestium
Includes the changes in https://github.com/space-wizards/space-station-14/pull/30661

## Media
![Content Client_nkoNmEjY0Q](https://github.com/user-attachments/assets/9118bff4-73cc-4151-a23a-3887634108ec)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed nested marines not being able to see anything.
- fix: Fixed xenonids being able to attack marines that are both nested and infected.
- fix: Fixed the client sometimes falsely showing the red color flash effect when attacking something that they can't, like allied xenonids.