### PR TITLE
Fix the combat toolbelt rig being able to hold more than 1 pistol

### DIFF
--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -58,7 +58,7 @@ public abstract class SharedStorageSystem : EntitySystem
     [Dependency] private   readonly SharedUserInterfaceSystem _ui = default!;
     [Dependency] protected readonly UseDelaySystem UseDelay = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
-    [Dependency] protected readonly CMStorageSystem CMStorage = default!;
+    [Dependency] protected readonly RMCStorageSystem RMCStorage = default!;
 
     private EntityQuery<ItemComponent> _itemQuery;
     private EntityQuery<StackComponent> _stackQuery;
@@ -304,7 +304,7 @@ public abstract class SharedStorageSystem : EntitySystem
     /// <param name="entity">The entity to open the UI for</param>
     public void OpenStorageUI(EntityUid uid, EntityUid entity, StorageComponent? storageComp = null, bool silent = true, bool doAfter = true)
     {
-        if (doAfter && CMStorage.OpenDoAfter(uid, entity, storageComp, silent))
+        if (doAfter && RMCStorage.OpenDoAfter(uid, entity, storageComp, silent))
             return;
 
         if (!Resolve(uid, ref storageComp, false))
@@ -909,7 +909,7 @@ public abstract class SharedStorageSystem : EntitySystem
 
         var maxSize = GetMaxItemSize((uid, storageComp));
         if (ItemSystem.GetSizePrototype(item.Size) > maxSize
-            && !CMStorage.IgnoreItemSize((uid, storageComp), insertEnt))
+            && !RMCStorage.IgnoreItemSize((uid, storageComp), insertEnt))
         {
             reason = "comp-storage-too-big";
             return false;
@@ -917,7 +917,7 @@ public abstract class SharedStorageSystem : EntitySystem
 
         if (TryComp<StorageComponent>(insertEnt, out var insertStorage)
             && GetMaxItemSize((insertEnt, insertStorage)) >= maxSize
-            && !CMStorage.IgnoreItemSize((uid, storageComp), insertEnt))
+            && !RMCStorage.IgnoreItemSize((uid, storageComp), insertEnt))
         {
             reason = "comp-storage-too-big";
             return false;
@@ -930,6 +930,12 @@ public abstract class SharedStorageSystem : EntitySystem
                 reason = "comp-storage-insufficient-capacity";
                 return false;
             }
+        }
+
+        if (!RMCStorage.CanInsertStorageLimit((uid, null, storageComp), insertEnt, out var popup))
+        {
+            reason = popup;
+            return false;
         }
 
         CheckingCanInsert = true;

--- a/Content.Shared/_RMC14/Storage/LimitedStorageComponent.cs
+++ b/Content.Shared/_RMC14/Storage/LimitedStorageComponent.cs
@@ -1,0 +1,26 @@
+﻿using Content.Shared.Whitelist;
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Storage;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(RMCStorageSystem))]
+public sealed partial class LimitedStorageComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public List<Limit> Limits = new();
+
+    [DataDefinition]
+    [Serializable, NetSerializable]
+    public partial struct Limit()
+    {
+        public int Count = 1;
+
+        [DataField(required: true)]
+        public EntityWhitelist Whitelist;
+
+        [DataField(required: true)]
+        public LocId Popup;
+    }
+}

--- a/Content.Shared/_RMC14/Storage/RemoveOnlyStorageComponent.cs
+++ b/Content.Shared/_RMC14/Storage/RemoveOnlyStorageComponent.cs
@@ -3,5 +3,5 @@
 namespace Content.Shared._RMC14.Storage;
 
 [RegisterComponent, NetworkedComponent]
-[Access(typeof(CMStorageSystem))]
+[Access(typeof(RMCStorageSystem))]
 public sealed partial class RemoveOnlyStorageComponent : Component;

--- a/Content.Shared/_RMC14/Storage/StorageSkillRequiredComponent.cs
+++ b/Content.Shared/_RMC14/Storage/StorageSkillRequiredComponent.cs
@@ -5,7 +5,7 @@ using Robust.Shared.Prototypes;
 namespace Content.Shared._RMC14.Storage;
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-[Access(typeof(CMStorageSystem))]
+[Access(typeof(RMCStorageSystem))]
 public sealed partial class StorageSkillRequiredComponent : Component
 {
     [DataField, AutoNetworkedField]

--- a/Resources/Locale/en-US/_RMC14/storage/storage.ftl
+++ b/Resources/Locale/en-US/_RMC14/storage/storage.ftl
@@ -1,1 +1,3 @@
 cm-storage-unskilled = It must have some kind of ID lock...
+rmc-storage-limit-cant-fit = That doesn't fit in there!
+rmc-storage-limit-one-gun = That is already holding a gun!

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
@@ -127,6 +127,12 @@
       - LightReplacer
       - EntrenchingTool
   - type: FixedItemSizeStorage
+  - type: LimitedStorage
+    limits:
+    - popup: rmc-storage-limit-one-gun
+      whitelist:
+        components:
+        - Gun
 
 - type: entity
   parent: CMBeltBase


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed the M276 pattern combat toolbelt rig being able to hold more than one pistol. It is now limited to one gun max.
