### PR TITLE
Fixes weapons spontaneously shrinking. Hopefully.

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Attachables/rmc_attachable_base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Attachables/rmc_attachable_base.yml
@@ -6,7 +6,6 @@
   - type: Item
     size: Small
   - type: Attachable
-  - type: ItemSizeChange
 
 - type: entity
   parent: RMCAttachableBase

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Attachables/rmc_attachable_base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Attachables/rmc_attachable_base.yml
@@ -6,6 +6,7 @@
   - type: Item
     size: Small
   - type: Attachable
+  - type: ItemSizeChange
 
 - type: entity
   parent: RMCAttachableBase

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Attachables/rmc_base_attachable_holder.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Attachables/rmc_base_attachable_holder.yml
@@ -3,6 +3,7 @@
   id: RMCBaseAttachableHolder
   components:
   - type: AttachableHolder
+  - type: ItemSizeChange
   - type: ActivatableUI
     verbText: rmc-verb-strip-attachables
     verbOnly: true


### PR DESCRIPTION

## About the PR
Another go at getting rid of weapons shrinking when you put size-changing attachmens on them.

I still can't get this to happen in localhost, so I *can't test the fix.* But I *think* the extra checks I added should stop it from continuing to happen.

Unless I'm wrong again, this will deal with #3550. I will close it manually once I can confirm that the bug is gone.

## Why / Balance
Because recurring bug.

## Technical details
What I *think* is happening to cause this is that the item size change system somehow gets an invalid size value, which results in `_sortedSizes.IndexOf(prototype)` returning a -1. The checks I added should prevent that from happening, so guns will at least not *shrink* when you put attachments on them.

I also added ItemSizeChangeComponent to the base attachable holder, so the base size value is initialised when the item spawns.

What I don't understand is how this is only happening on the live server. Somewhere in the US, there's a wizard casting spells in a server room and laughing at me.

## Media

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl: Sigil
- fix: Hopefully fixed guns shrinking when you put size-changing attachments on them. If you encounter this bug after this is merged, report it.
