### PR TITLE
Remove nesting the dead

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestSystem.cs
@@ -332,6 +332,14 @@ public sealed class XenoNestSystem : EntitySystem
             return false;
         }
 
+        if (_mobState.IsDead(victim))
+        {
+            if (!silent)
+                _popup.PopupClient(Loc.GetString("rmc-xeno-nest-failed-dead", ("target", victim)), surface, user);
+
+            return false;
+        }
+
         if (!Resolve(surface, ref surface.Comp))
         {
             if (!silent)

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-nest.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-nest.ftl
@@ -1,12 +1,13 @@
-cm-xeno-nest-securing-self = You secrete a thick, vile resin, securing {$target} into the alien nest!
+cm-xeno-nest-securing-self = We secrete a thick, vile resin, securing {$target} into the alien nest!
 cm-xeno-nest-securing-target = {$user} secretes a thick, vile resin, securing you into the alien nest!
 cm-xeno-nest-securing-observer = {$user} secretes a thick, vile resin, securing {$target} into the alien nest!
 
-cm-xeno-nest-pin-self = You pin {$target} into the alien nest, preparing the securing resin.
+cm-xeno-nest-pin-self = We pin {$target} into the alien nest, preparing the securing resin.
 cm-xeno-nest-pin-target = {$user} pins you into the alien nest, preparing the securing resin.
 cm-xeno-nest-pin-observer = {$user} pins {$target} into the alien nest, preparing the securing resin.
 
 cm-xeno-nest-failed = {$target} can't be put into a nest!
 cm-xeno-nest-failed-target-resisting = {$target} is resisting, ground them!
-cm-xeno-nest-failed-cant-there = You can't create a nest there!
+cm-xeno-nest-failed-cant-there = We can't create a nest there!
 cm-xeno-nest-failed-cant-already-there = There is already someone nested there!
+rmc-xeno-nest-failed-dead = This host is dead.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
You can't nest the dead anymore. Also some hivemind-ification of nesting messages

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
CM-13 parity
Fixes #3512

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
CanBeNested checks if the mob is dead now.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
no
**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- fix: Xenos can no longer nest the dead.
