### PR TITLE
Hive Core is now visible to Xenos through night-vision

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_hive.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_hive.yml
@@ -21,6 +21,9 @@
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
+  - type: RMCNightVisionVisible
+    priority: -1
+    transparency: 0.2
   - type: HiveCore
   - type: GhostRole
     name: roles-lesser-drone-name
@@ -57,6 +60,9 @@
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
+  - type: RMCNightVisionVisible
+    priority: -1
+    transparency: 0.1
   - type: HiveConstructionNode
     initialPlasmaCost: 400
     plasmaCost: 1000


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Allows the Hive Core to be seen when using Xeno night-vision similar to walls and eggs.

## Why / Balance
So Xenos can find the Hive Core easier, makes tracking it down for destruction less annoying

Fixes #2643, last step of implementation
Fixes #3524 

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
Constructed Hivecore
![HivecoreProper](https://github.com/user-attachments/assets/0af4f0c8-dae9-41ec-90f3-b3d01759b4e1)

Hivecore Blueprint
![HivecoreConstruction](https://github.com/user-attachments/assets/a019cf35-50a7-4e00-af77-c9d2e4bdd162)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- add: Xenonids are now able to see the hive core through walls.
