### PR TITLE
Make machete and throwing knife devour usable

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
@@ -146,6 +146,7 @@
     sprite: _RMC14/Objects/Clothing/Belt/knife.rsi
   - type: ItemSlots
   - type: CMHolster
+  - type: UsableWhileDevoured
   - type: CMItemSlots
     cooldown: 1
     cooldownPopup: You need to wait before drawing another knife!

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Pouches/weapons.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Pouches/weapons.yml
@@ -97,6 +97,7 @@
           tags:
           - Machete
   - type: Appearance
+  - type: UsableWhileDevoured
   - type: Tag
     tags:
     - Pouch

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Melee/knife.yml
@@ -75,7 +75,7 @@
   - type: UsableWhileDevoured
     damage:
       types:
-        Slash: 2
+        Slash: 3
   - type: Item
     size: Small
     sprite: _RMC14/Objects/Weapons/Melee/m11_knife.rsi
@@ -113,7 +113,7 @@
   - type: UsableWhileDevoured
     damage:
       types:
-        Slash: 25
+        Slash: 21
   - type: Item
     size: Large
     sprite: _RMC14/Objects/Weapons/Melee/machete.rsi

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Melee/knife.yml
@@ -72,6 +72,10 @@
     damage:
       types:
         Slash: 50
+  - type: UsableWhileDevoured
+    damage:
+      types:
+        Slash: 2
   - type: Item
     size: Small
     sprite: _RMC14/Objects/Weapons/Melee/m11_knife.rsi
@@ -106,6 +110,10 @@
     damage:
       types:
         Slash: 4
+  - type: UsableWhileDevoured
+    damage:
+      types:
+        Slash: 25
   - type: Item
     size: Large
     sprite: _RMC14/Objects/Weapons/Melee/machete.rsi


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
title

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
CM-13 parity. Both do less damage in general while devoured (60% of their original, so machete at 21 and throwing knife at 3) to match bayonet.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- tweak: You can use a machete or throwing knife while devoured