### PR TITLE
Fix being able to shoot or attack while lying down, drop items when lying down

### DIFF
--- a/Content.Shared/_RMC14/Buckle/ActiveBuckleClimbingComponent.cs
+++ b/Content.Shared/_RMC14/Buckle/ActiveBuckleClimbingComponent.cs
@@ -3,7 +3,7 @@
 namespace Content.Shared._RMC14.Buckle;
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-[Access(typeof(CMBuckleSystem))]
+[Access(typeof(RMCBuckleSystem))]
 public sealed partial class ActiveBuckleClimbingComponent : Component
 {
     [DataField, AutoNetworkedField]

--- a/Content.Shared/_RMC14/Buckle/BuckleClimbableComponent.cs
+++ b/Content.Shared/_RMC14/Buckle/BuckleClimbableComponent.cs
@@ -3,5 +3,5 @@
 namespace Content.Shared._RMC14.Buckle;
 
 [RegisterComponent, NetworkedComponent]
-[Access(typeof(CMBuckleSystem))]
+[Access(typeof(RMCBuckleSystem))]
 public sealed partial class BuckleClimbableComponent : Component;

--- a/Content.Shared/_RMC14/Buckle/RMCBuckleSystem.cs
+++ b/Content.Shared/_RMC14/Buckle/RMCBuckleSystem.cs
@@ -3,7 +3,7 @@ using Robust.Shared.Physics.Events;
 
 namespace Content.Shared._RMC14.Buckle;
 
-public sealed class CMBuckleSystem : EntitySystem
+public sealed class RMCBuckleSystem : EntitySystem
 {
     [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
 

--- a/Content.Shared/_RMC14/Standing/DropItemsOnRestComponent.cs
+++ b/Content.Shared/_RMC14/Standing/DropItemsOnRestComponent.cs
@@ -1,0 +1,7 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Standing;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(RMCStandingSystem))]
+public sealed partial class DropItemsOnRestComponent : Component;

--- a/Content.Shared/_RMC14/Standing/RMCStandingSystem.cs
+++ b/Content.Shared/_RMC14/Standing/RMCStandingSystem.cs
@@ -1,0 +1,73 @@
+﻿using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Interaction.Events;
+using Content.Shared.Inventory.Events;
+using Content.Shared.Item;
+using Content.Shared.Standing;
+
+namespace Content.Shared._RMC14.Standing;
+
+public sealed class RMCStandingSystem : EntitySystem
+{
+    [Dependency] private readonly SharedHandsSystem _hands = default!;
+    [Dependency] private readonly StandingStateSystem _standing = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<DropItemsOnRestComponent, DownedEvent>(OnDropDowned);
+        SubscribeLocalEvent<DropItemsOnRestComponent, PickupAttemptEvent>(CancelIfResting);
+        SubscribeLocalEvent<DropItemsOnRestComponent, IsEquippingAttemptEvent>(OnDropIsEquippingAttempt);
+        SubscribeLocalEvent<DropItemsOnRestComponent, IsUnequippingAttemptEvent>(OnDropIsUnequippingAttempt);
+        SubscribeLocalEvent<DropItemsOnRestComponent, AttackAttemptEvent>(CancelIfResting);
+    }
+
+    private void OnDropDowned(Entity<DropItemsOnRestComponent> drop, ref DownedEvent args)
+    {
+        foreach (var hand in _hands.EnumerateHands(drop))
+        {
+            _hands.TryDrop(drop, hand);
+        }
+    }
+
+    private void CancelIfResting<T>(Entity<DropItemsOnRestComponent> drop, ref T args) where T : CancellableEntityEventArgs
+    {
+        TryCancelIfResting(drop, ref args);
+    }
+
+    private void OnDropIsEquippingAttempt(Entity<DropItemsOnRestComponent> drop, ref IsEquippingAttemptEvent args)
+    {
+        if (args.Cancelled)
+            return;
+
+        if (args.Equipee == args.EquipTarget &&
+            TryCancelIfResting(drop, ref args))
+        {
+            args.Reason = "rmc-cant-while-resting";
+        }
+    }
+
+    private void OnDropIsUnequippingAttempt(Entity<DropItemsOnRestComponent> drop, ref IsUnequippingAttemptEvent args)
+    {
+        if (args.Cancelled)
+            return;
+
+        if (args.Unequipee == args.UnEquipTarget &&
+            TryCancelIfResting(drop, ref args))
+        {
+            args.Reason = "rmc-cant-while-resting";
+        }
+    }
+
+    private bool TryCancelIfResting<T>(Entity<DropItemsOnRestComponent> drop, ref T args) where T : CancellableEntityEventArgs
+    {
+        if (args.Cancelled)
+            return false;
+
+        if (_standing.IsDown(drop))
+        {
+            args.Cancel();
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/Content.Shared/_RMC14/Standing/RMCStandingSystem.cs
+++ b/Content.Shared/_RMC14/Standing/RMCStandingSystem.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared.Hands.EntitySystems;
+﻿using Content.Shared.Buckle.Components;
+using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Item;
@@ -13,15 +14,18 @@ public sealed class RMCStandingSystem : EntitySystem
 
     public override void Initialize()
     {
-        SubscribeLocalEvent<DropItemsOnRestComponent, DownedEvent>(OnDropDowned);
+        SubscribeLocalEvent<DropItemsOnRestComponent, BuckledEvent>(OnDropBuckled);
         SubscribeLocalEvent<DropItemsOnRestComponent, PickupAttemptEvent>(CancelIfResting);
         SubscribeLocalEvent<DropItemsOnRestComponent, IsEquippingAttemptEvent>(OnDropIsEquippingAttempt);
         SubscribeLocalEvent<DropItemsOnRestComponent, IsUnequippingAttemptEvent>(OnDropIsUnequippingAttempt);
         SubscribeLocalEvent<DropItemsOnRestComponent, AttackAttemptEvent>(CancelIfResting);
     }
 
-    private void OnDropDowned(Entity<DropItemsOnRestComponent> drop, ref DownedEvent args)
+    private void OnDropBuckled(Entity<DropItemsOnRestComponent> drop, ref BuckledEvent args)
     {
+        if (!_standing.IsDown(drop))
+            return;
+
         foreach (var hand in _hands.EnumerateHands(drop))
         {
             _hands.TryDrop(drop, hand);

--- a/Resources/Locale/en-US/_RMC14/buckle/rmc-buckle.ftl
+++ b/Resources/Locale/en-US/_RMC14/buckle/rmc-buckle.ftl
@@ -1,0 +1,1 @@
+﻿rmc-cant-while-resting = You can't do that while resting!

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
@@ -197,3 +197,4 @@
             state: human_acid_enhanced
             visible: true
   - type: ActiveInputMover
+  - type: DropItemsOnRest


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed being able to attack or shoot while lying down. This includes beds and roller beds.
- fix: You now drop your items when lying down. Remember to holster your gun, or grab the marine's gun if you are a corpsman.