### PR TITLE
Fix xenonids being able to secrete resin structures on top of nested marines

### DIFF
--- a/Content.Shared/_RMC14/Map/RMCMapSystem.cs
+++ b/Content.Shared/_RMC14/Map/RMCMapSystem.cs
@@ -42,6 +42,22 @@ public sealed class RMCMapSystem : EntitySystem
         return new RMCAnchoredEntitiesEnumerator(_transform, anchored, facing);
     }
 
+    public RMCAnchoredEntitiesEnumerator GetAnchoredEntitiesEnumerator(EntityCoordinates coords, Direction? offset = null, DirectionFlag facing = DirectionFlag.None)
+    {
+        if (_transform.GetGrid(coords) is not { } gridId ||
+            !_mapGridQuery.TryComp(gridId, out var gridComp))
+        {
+            return RMCAnchoredEntitiesEnumerator.Empty;
+        }
+
+        if (offset != null)
+            coords = coords.Offset(offset.Value);
+
+        var indices = _map.CoordinatesToTile(gridId, gridComp, coords);
+        var anchored = _map.GetAnchoredEntitiesEnumerator(gridId, gridComp, indices);
+        return new RMCAnchoredEntitiesEnumerator(_transform, anchored, facing);
+    }
+
     public bool TryGetTileRefForEnt(EntityUid ent, out Entity<MapGridComponent> grid, out TileRef tile)
     {
         grid = default;

--- a/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using Content.Shared._RMC14.Map;
 using Content.Shared._RMC14.Xenonids.Construction.Events;
+using Content.Shared._RMC14.Xenonids.Construction.Nest;
 using Content.Shared._RMC14.Xenonids.Egg;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Plasma;
@@ -21,7 +22,6 @@ using Content.Shared.Physics;
 using Content.Shared.Popups;
 using Content.Shared.Projectiles;
 using Content.Shared.Prototypes;
-using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
@@ -49,6 +49,7 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly TurfSystem _turf = default!;
     [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
+    [Dependency] private readonly XenoNestSystem _xenoNest = default!;
     [Dependency] private readonly XenoPlasmaSystem _xenoPlasma = default!;
     [Dependency] private readonly SharedXenoWeedsSystem _xenoWeeds = default!;
 
@@ -63,6 +64,7 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
     private EntityQuery<XenoConstructComponent> _xenoConstructQuery;
     private EntityQuery<XenoEggComponent> _xenoEggQuery;
     private EntityQuery<XenoWeedsComponent> _xenoWeedsQuery;
+
     private const string XenoStructuresAnimation = "RMCEffect";
 
     public override void Initialize()
@@ -538,7 +540,8 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
         return target.GetTileRef(EntityManager, _map) is { } tile &&
                !tile.IsSpace() &&
                tile.GetContentTileDefinition().Sturdy &&
-               !_turf.IsTileBlocked(tile, CollisionGroup.Impassable);
+               !_turf.IsTileBlocked(tile, CollisionGroup.Impassable) &&
+               !_xenoNest.HasAdjacentNestFacing(target);
     }
 
     private bool InRangePopup(EntityUid xeno, EntityCoordinates target, float range)


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed xenonids being able to build resin structures on top of nested marines.