### PR TITLE
Fix incorrect thermal cloak whitelist

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Back/satchels.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Back/satchels.yml
@@ -48,7 +48,7 @@
     restrictWeapons: true
     whitelist:
       components:
-      - Marine
+      - ScoutWhitelist
     cloakSound: /Audio/_RMC14/Effects/Cloak/cloak_scout_on.ogg
     uncloakSound: /Audio/_RMC14/Effects/Cloak/cloak_scout_off.ogg
 


### PR DESCRIPTION
This was a value I left for easier testing, it should've been whitelisted to scouts-only. 