### PR TITLE
Fix Spray Acid not costing Plasma to use

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Spray/XenoSprayAcidComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Spray/XenoSprayAcidComponent.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Shared.Damage;
+using Content.Shared.FixedPoint;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
@@ -11,6 +12,9 @@ public sealed partial class XenoSprayAcidComponent : Component
 {
     [DataField, AutoNetworkedField]
     public EntProtoId Acid = "XenoAcidSprayWeak";
+
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 PlasmaCost = 40;
 
     [DataField, AutoNetworkedField]
     public TimeSpan Delay = TimeSpan.FromSeconds(0.2);

--- a/Content.Shared/_RMC14/Xenonids/Spray/XenoSprayAcidSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Spray/XenoSprayAcidSystem.cs
@@ -2,6 +2,7 @@
 using Content.Shared._RMC14.Entrenching;
 using Content.Shared._RMC14.Map;
 using Content.Shared._RMC14.OnCollide;
+using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Coordinates;
@@ -32,6 +33,7 @@ public sealed class XenoSprayAcidSystem : EntitySystem
     [Dependency] private readonly TagSystem _tag = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly XenoPlasmaSystem _xenoPlasma = default!;
 
     private static readonly ProtoId<TagPrototype> StructureTag = "Structure";
     private static readonly ProtoId<ReagentPrototype> AcidRemovedBy = "Water";
@@ -72,6 +74,9 @@ public sealed class XenoSprayAcidSystem : EntitySystem
 
         distance = MathF.Floor(distance);
         if (distance == 0)
+            return;
+
+        if (!_xenoPlasma.TryRemovePlasmaPopup(xeno.Owner, xeno.Comp.PlasmaCost))
             return;
 
         var x = start.X;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Fixes the Spitter's and Boiler's Spray Acid ability not costing Plasma to use

## Why / Balance
This is a bug. It was reported to cost 40 plasma, but did not use any
Fixes #3577 

## Media
https://github.com/user-attachments/assets/dbb6debe-5126-41fc-9ef1-6a1f88136c62

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed Spitter/Boiler's Spray Acid ability not costing plasma to use. It now correctly costs 40 plasma.
