### PR TITLE
Fix being able to use nightvision items from inside your pockets

### DIFF
--- a/Content.Shared/_RMC14/NightVision/NightVisionItemComponent.cs
+++ b/Content.Shared/_RMC14/NightVision/NightVisionItemComponent.cs
@@ -1,4 +1,5 @@
-﻿using Robust.Shared.GameStates;
+﻿using Content.Shared.Inventory;
+using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 
 namespace Content.Shared._RMC14.NightVision;
@@ -18,4 +19,8 @@ public sealed partial class NightVisionItemComponent : Component
 
     [DataField, AutoNetworkedField]
     public bool Toggleable = true;
+
+    // Only allows for a single slotflag right now because some code uses strings and some code uses enums to determine slots :(
+    [DataField, AutoNetworkedField]
+    public SlotFlags SlotFlags { get; set; } = SlotFlags.EYES;
 }

--- a/Content.Shared/_RMC14/NightVision/SharedNightVisionSystem.cs
+++ b/Content.Shared/_RMC14/NightVision/SharedNightVisionSystem.cs
@@ -1,6 +1,5 @@
 ﻿using Content.Shared.Actions;
 using Content.Shared.Alert;
-using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Rounding;
 using Content.Shared.Toggleable;
@@ -14,7 +13,6 @@ public abstract class SharedNightVisionSystem : EntitySystem
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly AlertsSystem _alerts = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
-    [Dependency] private readonly InventorySystem _inventory = default!;
 
     public override void Initialize()
     {

--- a/Content.Shared/_RMC14/NightVision/SharedNightVisionSystem.cs
+++ b/Content.Shared/_RMC14/NightVision/SharedNightVisionSystem.cs
@@ -60,9 +60,7 @@ public abstract class SharedNightVisionSystem : EntitySystem
         if (args.InHands || !ent.Comp.Toggleable)
             return;
 
-        // Item not in a position for being able to affect vision
-        if (!(_inventory.InSlotWithFlags((ent,null,null), SlotFlags.MASK) ||
-                _inventory.InSlotWithFlags((ent,null,null), SlotFlags.EYES)))
+        if (ent.Comp.SlotFlags != args.SlotFlags)
             return;
 
         args.AddAction(ref ent.Comp.Action, ent.Comp.ActionId);
@@ -79,13 +77,15 @@ public abstract class SharedNightVisionSystem : EntitySystem
 
     private void OnNightVisionItemGotEquipped(Entity<NightVisionItemComponent> ent, ref GotEquippedEvent args)
     {
-        ToggleNightVisionItem(ent, args.Equipee);
+        if (ent.Comp.SlotFlags != args.SlotFlags)
+            return;
+
+        EnableNightVisionItem(ent, args.Equipee);
     }
 
     private void OnNightVisionItemGotUnequipped(Entity<NightVisionItemComponent> ent, ref GotUnequippedEvent args)
     {
-        // Item was not in an activatable slot
-        if ((args.SlotFlags != SlotFlags.MASK) && (args.SlotFlags != SlotFlags.EYES))
+        if (ent.Comp.SlotFlags != args.SlotFlags)
             return;
 
         DisableNightVisionItem(ent, args.Equipee);
@@ -149,11 +149,6 @@ public abstract class SharedNightVisionSystem : EntitySystem
 
     private void EnableNightVisionItem(Entity<NightVisionItemComponent> item, EntityUid user)
     {
-        // Check if item is in an activatable position
-        if (!(_inventory.InSlotWithFlags((item,null,null), SlotFlags.MASK) ||
-            _inventory.InSlotWithFlags((item,null,null), SlotFlags.EYES)))
-            return;
-
         DisableNightVisionItem(item, item.Comp.User);
 
         item.Comp.User = user;


### PR DESCRIPTION
Also fixes losing nightvision due to taking a nightvision item out of your pocket even when you have a nightvision item equipped in your eye/mask slot

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Nightvision items worked while in pocket slots. In addition, removing a nightvision item from a pocket slot removed your nightvision even when you had another nightvision item equipped and activated.
This PR fixes that

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Bug fix

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Added a few lines of C# to check for item slot before equipping/unequipping/activating a nightvision item

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- fix: Fixed being able to use nightvision items in pockets.

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
