### PR TITLE
Deconstructing Barricades return an amount of scrap material proportional to health

### DIFF
--- a/Content.Server/Construction/Conditions/MinHealth.cs
+++ b/Content.Server/Construction/Conditions/MinHealth.cs
@@ -1,0 +1,92 @@
+using Content.Server.Destructible;
+using Content.Shared.Construction;
+using Content.Shared.Damage;
+using Content.Shared.Examine;
+using Content.Shared.FixedPoint;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Content.Server.Construction.Conditions;
+
+/// <summary>
+/// Requires that the structure has at least some amount of health
+/// </summary>
+[DataDefinition]
+public sealed partial class MinHealth : IGraphCondition
+{
+    /// <summary>
+    /// If ByProportion is true, Threshold is a value less than or equal to 1, but more than 0,
+    /// which is compared to the percent of health remaining in the structure.
+    /// Else, Threshold is any positive value with at most 2 decimal points of percision,
+    /// which is compared to the current health of the structure.
+    /// </summary>
+    [DataField]
+    public FixedPoint2 Threshold = 1;
+    [DataField]
+    public bool ByProportion = false;
+
+    [DataField]
+    public bool IncludeEquals = true;
+
+    public bool Condition(EntityUid uid, IEntityManager entMan)
+    {
+        if (!entMan.TryGetComponent(uid, out DestructibleComponent? destructibleComp) ||
+            !entMan.TryGetComponent(uid, out DamageableComponent? damageComp))
+        {
+            return false;
+        }
+
+        var destructionSys = entMan.System<DestructibleSystem>();
+        var maxHealth = destructionSys.DestroyedAt(uid, destructibleComp);
+        var curHealth = maxHealth - damageComp.TotalDamage;
+        var proportionHealth = curHealth / maxHealth;
+
+        if (IncludeEquals)
+        {
+            if (ByProportion)
+            {
+                return proportionHealth >= Threshold;
+            }
+            else
+            {
+                return curHealth >= Threshold;
+            }
+        }
+        else
+        {
+            if (ByProportion)
+            {
+                return proportionHealth > Threshold;
+            }
+            else
+            {
+                return curHealth > Threshold;
+            }
+        }
+    }
+
+    public bool DoExamine(ExaminedEvent args)
+    {
+        var entMan = IoCManager.Resolve<IEntityManager>();
+        var entity = args.Examined;
+
+        if (Condition(entity, entMan))
+        {
+            return false;
+        }
+        args.PushMarkup(Loc.GetString("construction-examine-condition-low-health"));
+
+        return true;
+    }
+
+    public IEnumerable<ConstructionGuideEntry> GenerateGuideEntry()
+    {
+        yield return new ConstructionGuideEntry()
+        {
+            Localization = "construction-step-condition-low-health"
+        };
+    }
+}

--- a/Content.Server/_RMC14/Construction/Conditions/IsBarbed.cs
+++ b/Content.Server/_RMC14/Construction/Conditions/IsBarbed.cs
@@ -1,0 +1,45 @@
+using Content.Shared._RMC14.Barricade.Components;
+using Content.Shared.Construction;
+using Content.Shared.Examine;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Content.Server._RMC14.Construction.Conditions;
+
+/// <summary>
+/// Checks that the structure is barbed
+/// </summary>
+[DataDefinition]
+public sealed partial class IsBarbed : IGraphCondition
+{
+    public bool Condition(EntityUid uid, IEntityManager entMan)
+    {
+        return (entMan.TryGetComponent(uid, out BarbedComponent? barbedComp) &&
+            barbedComp.IsBarbed);
+    }
+
+    public bool DoExamine(ExaminedEvent args)
+    {
+        var entMan = IoCManager.Resolve<IEntityManager>();
+        var entity = args.Examined;
+
+        if (Condition(entity, entMan))
+        {
+            return false;
+        }
+        args.PushMarkup(Loc.GetString("construction-examine-condition-missing-barbed"));
+
+        return true;
+    }
+
+    public IEnumerable<ConstructionGuideEntry> GenerateGuideEntry()
+    {
+        yield return new ConstructionGuideEntry()
+        {
+            Localization = "construction-step-condition-missing-barbed"
+        };
+    }
+}

--- a/Resources/Locale/en-US/_RMC14/construction/conditions/is-barbed.ftl
+++ b/Resources/Locale/en-US/_RMC14/construction/conditions/is-barbed.ftl
@@ -1,0 +1,2 @@
+construction-examine-condition-missing-barbed = First, ensure it is barbed.
+construction-step-condition-missing-barbed = It must be barbed.

--- a/Resources/Locale/en-US/construction/conditions/min-health.ftl
+++ b/Resources/Locale/en-US/construction/conditions/min-health.ftl
@@ -1,0 +1,2 @@
+construction-examine-condition-low-health = First, repair it.
+construction-step-condition-low-health = It must be repaired.

--- a/Resources/Prototypes/_RMC14/Recipes/Construction/Graphs/structures/barricade_metal.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Construction/Graphs/structures/barricade_metal.yml
@@ -55,7 +55,7 @@
         action:
           !type:SpawnPrototype
           prototype: BarbedWire1
-        amount: 1
+          amount: 1
       - !type:DeleteEntity
       conditions:
       - !type:EntityAnchored
@@ -130,7 +130,7 @@
           action:
             !type:SpawnPrototype
             prototype: BarbedWire1
-          amount: 1
+            amount: 1
         - !type:DeleteEntity
       conditions:
         - !type:EntityAnchored
@@ -181,7 +181,7 @@
         action:
           !type:SpawnPrototype
           prototype: BarbedWire1
-        amount: 1
+          amount: 1
       - !type:DeleteEntity
       conditions:
       - !type:EntityAnchored
@@ -232,7 +232,7 @@
         action:
           !type:SpawnPrototype
           prototype: BarbedWire1
-        amount: 1
+          amount: 1
       - !type:DeleteEntity
       conditions:
       - !type:EntityAnchored

--- a/Resources/Prototypes/_RMC14/Recipes/Construction/Graphs/structures/barricade_metal.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Construction/Graphs/structures/barricade_metal.yml
@@ -20,9 +20,42 @@
     edges:
     - to: start
       completed:
-      - !type:SpawnPrototype
-        prototype: CMSheetMetal1
-        amount: 4
+      - !type:ConditionalAction
+        condition:
+          !type:MinHealth
+          threshold: 1
+          byProportion: true
+        action:
+          !type:SpawnPrototype
+          prototype: CMSheetMetal1
+          amount: 4
+        else:
+          !type:ConditionalAction
+          condition:
+            !type:MinHealth
+            threshold: 0.78
+            byProportion: true
+          action:
+            !type:SpawnPrototype
+            prototype: CMSheetMetal1
+            amount: 3
+          else:
+            !type:ConditionalAction
+            condition:
+              !type:MinHealth
+              threshold: 0.56
+              byProportion: true
+            action:
+              !type:SpawnPrototype
+              prototype: CMSheetMetal1
+              amount: 2
+      - !type:ConditionalAction
+        condition:
+          !type:IsBarbed
+        action:
+          !type:SpawnPrototype
+          prototype: BarbedWire1
+        amount: 1
       - !type:DeleteEntity
       conditions:
       - !type:EntityAnchored
@@ -62,9 +95,42 @@
     edges:
     - to: start
       completed:
-        - !type:SpawnPrototype
-          prototype: CMSheetMetal1
-          amount: 4
+        - !type:ConditionalAction
+          condition:
+            !type:MinHealth
+            threshold: 1
+            byProportion: true
+          action:
+            !type:SpawnPrototype
+            prototype: CMSheetMetal1
+            amount: 4
+          else:
+            !type:ConditionalAction
+            condition:
+              !type:MinHealth
+              threshold: 0.78
+              byProportion: true
+            action:
+              !type:SpawnPrototype
+              prototype: CMSheetMetal1
+              amount: 3
+            else:
+              !type:ConditionalAction
+              condition:
+                !type:MinHealth
+                threshold: 0.56
+                byProportion: true
+              action:
+                !type:SpawnPrototype
+                prototype: CMSheetMetal1
+                amount: 2
+        - !type:ConditionalAction
+          condition:
+            !type:IsBarbed
+          action:
+            !type:SpawnPrototype
+            prototype: BarbedWire1
+          amount: 1
         - !type:DeleteEntity
       conditions:
         - !type:EntityAnchored
@@ -80,9 +146,42 @@
     edges:
     - to: start
       completed:
-      - !type:SpawnPrototype
-        prototype: CMSheetMetal1
-        amount: 4
+      - !type:ConditionalAction
+        condition:
+          !type:MinHealth
+          threshold: 1
+          byProportion: true
+        action:
+          !type:SpawnPrototype
+          prototype: CMSheetMetal1
+          amount: 4
+        else:
+          !type:ConditionalAction
+          condition:
+            !type:MinHealth
+            threshold: 0.78
+            byProportion: true
+          action:
+            !type:SpawnPrototype
+            prototype: CMSheetMetal1
+            amount: 3
+          else:
+            !type:ConditionalAction
+            condition:
+              !type:MinHealth
+              threshold: 0.56
+              byProportion: true
+            action:
+              !type:SpawnPrototype
+              prototype: CMSheetMetal1
+              amount: 2
+      - !type:ConditionalAction
+        condition:
+          !type:IsBarbed
+        action:
+          !type:SpawnPrototype
+          prototype: BarbedWire1
+        amount: 1
       - !type:DeleteEntity
       conditions:
       - !type:EntityAnchored
@@ -98,9 +197,42 @@
     edges:
     - to: start
       completed:
-      - !type:SpawnPrototype
-        prototype: CMSheetMetal1
-        amount: 4
+      - !type:ConditionalAction
+        condition:
+          !type:MinHealth
+          threshold: 1
+          byProportion: true
+        action:
+          !type:SpawnPrototype
+          prototype: CMSheetMetal1
+          amount: 4
+        else:
+          !type:ConditionalAction
+          condition:
+            !type:MinHealth
+            threshold: 0.78
+            byProportion: true
+          action:
+            !type:SpawnPrototype
+            prototype: CMSheetMetal1
+            amount: 3
+          else:
+            !type:ConditionalAction
+            condition:
+              !type:MinHealth
+              threshold: 0.56
+              byProportion: true
+            action:
+              !type:SpawnPrototype
+              prototype: CMSheetMetal1
+              amount: 2
+      - !type:ConditionalAction
+        condition:
+          !type:IsBarbed
+        action:
+          !type:SpawnPrototype
+          prototype: BarbedWire1
+        amount: 1
       - !type:DeleteEntity
       conditions:
       - !type:EntityAnchored

--- a/Resources/Prototypes/_RMC14/Recipes/Construction/Graphs/structures/barricade_metal_door.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Construction/Graphs/structures/barricade_metal_door.yml
@@ -23,6 +23,12 @@
       - !type:SpawnPrototype
         prototype: CMSheetMetal1
         amount: 6
+      - !type:ConditionalAction
+        condition:
+          !type:IsBarbed
+        action:
+          !type:SpawnPrototype
+          prototype: BarbedWire1
       - !type:DeleteEntity
       conditions:
       - !type:EntityAnchored

--- a/Resources/Prototypes/_RMC14/Recipes/Construction/Graphs/structures/barricade_plasteel_door.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Construction/Graphs/structures/barricade_plasteel_door.yml
@@ -23,6 +23,12 @@
       - !type:SpawnPrototype
         prototype: CMSheetPlasteel1
         amount: 8
+      - !type:ConditionalAction
+        condition:
+          !type:IsBarbed
+        action:
+          !type:SpawnPrototype
+          prototype: BarbedWire1
       - !type:DeleteEntity
       conditions:
       - !type:EntityAnchored


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Added new Graph condition, IsBarbed, that checks if the structure has a barbed component and is presently barbed.

Using (upstream) Graph condition, MinHealth, checks are preformed on a structure's health to determine how many mats are dropped 
Using Graph condition, IsBarbed, checks are preformed on a structure's barbed status to determine if barbed wire should be dropped during deconstruction.
Fixes #3449
Cherry Picks [#30892](https://github.com/space-wizards/space-station-14/pull/30892)
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://github.com/user-attachments/assets/13f5cb98-0f52-4078-b208-3a2763d010cf


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl: blueDev2
- fix: Barricades now drop mats based on remaining health when deconstructed. Barbed barricades drop barbed wires when deconstructed
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
