### PR TITLE
Bug fix - the system now announces the death of the queen if it falls into a chasm

### DIFF
--- a/Content.Shared/Chasm/ChasmSystem.cs
+++ b/Content.Shared/Chasm/ChasmSystem.cs
@@ -65,6 +65,9 @@ public sealed class ChasmSystem : EntitySystem
 
         if (playSound)
             _audio.PlayPredicted(component.FallingSound, chasm, tripper);
+		
+		var ev = new ChasmFallingEvent(chasm, tripper);
+		RaiseLocalEvent(tripper, ref ev);
     }
 
     private void OnStepTriggerAttempt(EntityUid uid, ChasmComponent component, ref StepTriggerAttemptEvent args)
@@ -76,4 +79,11 @@ public sealed class ChasmSystem : EntitySystem
     {
         args.Cancel();
     }
+}
+
+[ByRefEvent]
+public readonly record struct ChasmFallingEvent(EntityUid Chasm, EntityUid Tripper)
+{
+	public readonly EntityUid Chasm = Chasm;
+	public readonly EntityUid Tripper = Tripper;
 }

--- a/Content.Shared/_RMC14/Xenonids/Announce/SharedXenoAnnounceSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Announce/SharedXenoAnnounceSystem.cs
@@ -11,6 +11,7 @@ public abstract class SharedXenoAnnounceSystem : EntitySystem
     public override void Initialize()
     {
         SubscribeLocalEvent<XenoAnnounceDeathComponent, MobStateChangedEvent>(OnAnnounceDeathMobStateChanged);
+		SubscribeLocalEvent<XenoAnnounceDeathComponent, ChasmFallingEvent>(OnChasmFalling);
     }
 
     private void OnAnnounceDeathMobStateChanged(Entity<XenoAnnounceDeathComponent> ent, ref MobStateChangedEvent args)
@@ -23,6 +24,11 @@ public abstract class SharedXenoAnnounceSystem : EntitySystem
         else
             AnnounceSameHive(ent.Owner, Loc.GetString(ent.Comp.Message, ("xeno", ent.Owner)), color: ent.Comp.Color);
     }
+	
+	private void OnChasmFalling(Entity<XenoAnnounceDeathComponent> ent, ref ChasmFallingEvent args)
+	{
+		AnnounceSameHive(ent.Owner, Loc.GetString(ent.Comp.Message, ("xeno", ent.Owner)), color: ent.Comp.Color);
+	}
 
     public string WrapHive(string message, Color? color = null)
     {


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
There is a bug: if the queen falls into a chasm the system does not announce it.
Now should work properply.

## Why / Balance
bug fix

## Technical details
This is so because the SharedXenoAnnounce system is subscribed to the MobStateChangedEvent but falling into a chasm does not raise it. So I created an event and an event handler for that.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
--> the death announce system now has one less bug

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

- fix: Fixed SharedXenoAnnounceSystem not working properly when the queen falls into a chasm
