### PR TITLE
Increase ExamineDetail Range from 3 to 8 tiles

### DIFF
--- a/Content.Shared/Examine/ExamineSystemShared.cs
+++ b/Content.Shared/Examine/ExamineSystemShared.cs
@@ -41,7 +41,7 @@ namespace Content.Shared.Examine
         public const float DeadExamineRange = 0.75f;
 
         public const float ExamineRange = 16f;
-        protected const float ExamineDetailsRange = 3f;
+        protected const float ExamineDetailsRange = 8f;
 
         protected const float ExamineBlurrinessMult = 2.5f;
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Increased the range of Character Description inspects from 3 to 8, allowing players to view others' character descriptions from much farther away.

## Why / Balance
This is purely a Quality of Life change to make it easier to see other's character descriptions without having to awkwardly move super close to them, especially given many situations both RP-related and combat-related demand you to be standing in a certain spot away from the character you wish to learn more about.

This does not affect balance at all, as RMC gameplay does not have an element of deception and disguises/identity hiding like standard SS14 does, which is why the range was so low to begin with (as viewing someone in greater detail would always give the same description per-character, you can't fake this, ruining your disguise). You can not hide your identity at all as a marine, and the ability to do wouldn't be important to the gameplay anyway, so being able to see flavor text from afar should cause no balance issues.

## Media
https://github.com/user-attachments/assets/fedbaff2-d071-4197-b18d-067703a4c3d7

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- tweak: You can now view player character descriptions from much further away.

