### PR TITLE
Make base chair abstract

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Furniture/chairs.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Furniture/chairs.yml
@@ -1,9 +1,9 @@
 # Basic chair
 - type: entity
+  abstract: true
   parent: SeatBase
   id: CMSeatBase
-  name: chair
-  description: A rectangular metallic frame sitting on four legs with a back panel. Designed to fit the sitting position, more or less comfortably.
+  name: abstract chair
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Furniture/chairs.rsi

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -603,3 +603,6 @@ CMBucket: RMCBucket
 # 2024-08-09
 CMFogWall: RMCFogWall25
 CMFogWallShort: RMCFogWall15
+
+# 2024-08-12
+CMSeatBase: CMChair


### PR DESCRIPTION
## About the PR

- CMSeatBase is now abstract.
- Added migration CMSeatBase -> CMChair

CMSeatBase never was intended to be spawned, it have no construction steps, cant be unanchored.