### PR TITLE
Add extra damage from cripple strike + visual effect

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Crippling/VictimCripplingStrikeSlowedComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Crippling/VictimCripplingStrikeSlowedComponent.cs
@@ -13,4 +13,10 @@ public sealed partial class VictimCripplingStrikeSlowedComponent : Component
 
     [DataField, AutoNetworkedField]
     public FixedPoint2 SpeedMultiplier = FixedPoint2.New(0.75);
+
+    [DataField, AutoNetworkedField]
+    public float DamageMult = 1;
+
+    [DataField, AutoNetworkedField]
+    public bool WasHit = false;
 }

--- a/Content.Shared/_RMC14/Xenonids/Crippling/XenoActiveCripplingStrikeComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Crippling/XenoActiveCripplingStrikeComponent.cs
@@ -20,7 +20,7 @@ public sealed partial class XenoActiveCripplingStrikeComponent : Component
     public TimeSpan SlowDuration = TimeSpan.FromSeconds(5);
 
     [DataField, AutoNetworkedField]
-    public DamageSpecifier Damage = new();
+    public float DamageMult = 1.2f;
 
     [DataField, AutoNetworkedField]
     public EntProtoId Effect = "RMCEffectCripple";

--- a/Content.Shared/_RMC14/Xenonids/Crippling/XenoActiveCripplingStrikeComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Crippling/XenoActiveCripplingStrikeComponent.cs
@@ -1,6 +1,8 @@
-﻿using Content.Shared.FixedPoint;
+﻿using Content.Shared.Damage;
+using Content.Shared.FixedPoint;
 using Robust.Shared.GameStates;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared._RMC14.Xenonids.Crippling;
 
@@ -16,4 +18,10 @@ public sealed partial class XenoActiveCripplingStrikeComponent : Component
 
     [DataField, AutoNetworkedField]
     public TimeSpan SlowDuration = TimeSpan.FromSeconds(5);
+
+    [DataField, AutoNetworkedField]
+    public DamageSpecifier Damage = new();
+
+    [DataField, AutoNetworkedField]
+    public EntProtoId Effect = "RMCEffectCripple";
 }

--- a/Content.Shared/_RMC14/Xenonids/Crippling/XenoCripplingStrikeComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Crippling/XenoCripplingStrikeComponent.cs
@@ -8,8 +8,8 @@ namespace Content.Shared._RMC14.Xenonids.Crippling;
 [Access(typeof(XenoCripplingStrikeSystem))]
 public sealed partial class XenoCripplingStrikeComponent : Component
 {
-    [DataField]
-    public DamageSpecifier Damage = new();
+    [DataField, AutoNetworkedField]
+    public float DamageMult = 1.2f;
 
     [DataField, AutoNetworkedField]
     public FixedPoint2 PlasmaCost = 20;

--- a/Content.Shared/_RMC14/Xenonids/Crippling/XenoCripplingStrikeComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Crippling/XenoCripplingStrikeComponent.cs
@@ -1,6 +1,6 @@
-﻿using Content.Shared.FixedPoint;
+﻿using Content.Shared.Damage;
+using Content.Shared.FixedPoint;
 using Robust.Shared.GameStates;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared._RMC14.Xenonids.Crippling;
 
@@ -8,6 +8,9 @@ namespace Content.Shared._RMC14.Xenonids.Crippling;
 [Access(typeof(XenoCripplingStrikeSystem))]
 public sealed partial class XenoCripplingStrikeComponent : Component
 {
+    [DataField]
+    public DamageSpecifier Damage = new();
+
     [DataField, AutoNetworkedField]
     public FixedPoint2 PlasmaCost = 20;
 

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
@@ -252,7 +252,7 @@
   parent: ActionXenoBase
   id: ActionXenoCripplingStrike
   name: Crippling Strike (20) # TODO RMC14 proper plasma costs
-  description: Temporarily charge up a melee attack that will slow the first enemy it hits.
+  description: Temporarily charge up a melee attack that will slow the first enemy it hits and do 20% more damage.
   components:
   - type: InstantAction
     itemIconStyle: NoItem

--- a/Resources/Prototypes/_RMC14/Effects/xeno_sloweffects.yml
+++ b/Resources/Prototypes/_RMC14/Effects/xeno_sloweffects.yml
@@ -29,3 +29,11 @@
   - type: Tag
     tags:
     - HideContextMenu
+
+- type: entity
+  parent: CMEffectStomp
+  id: RMCEffectCripple
+  noSpawn: true
+  components:
+  - type: TimedDespawn
+    lifetime: 5

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lurker.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lurker.yml
@@ -57,6 +57,9 @@
     knockdownRequiresInvisibility: true
   - type: XenoTurnInvisible
   - type: XenoCripplingStrike
+    damage:
+      groups:
+        Brute: 7 # 20% of base damage
   - type: MeleeWeapon
     attackRate: 0.75
     damage:

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lurker.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lurker.yml
@@ -57,9 +57,6 @@
     knockdownRequiresInvisibility: true
   - type: XenoTurnInvisible
   - type: XenoCripplingStrike
-    damage:
-      groups:
-        Brute: 7 # 20% of base damage
   - type: MeleeWeapon
     attackRate: 0.75
     damage:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Adds the extra 120% multiplier to damage a lurker's cripple strike. Also adds the slow down arrow effect (first seen with crusher) to it.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
CM-13 parity

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Add damage to both activeCripple and Cripple comps for lurker, with the latter set to 7 in the prototype for em (because Cripple strike modifies the hit damage by 120%, but doing that would mean everyone hit would take more damage, instead of just the person hit with cripple strike)

Also renames the stomp effects yml to xeno_slow, and parents off the stomp effect for the cripple effect, just changing the lifetime.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/user-attachments/assets/a170c5bc-8f0b-4875-bee8-8864337c22e7



## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
no
**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- fix: Fixed the Lurker's Crippling Strike not doing 20% extra damage, and added a visual effect on the person hit.
