### PR TITLE
Crusher Melee AOE

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Brutalize/XenoBrutalizeComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Brutalize/XenoBrutalizeComponent.cs
@@ -1,0 +1,34 @@
+﻿using Content.Shared.Actions;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._RMC14.Xenonids.Brutalize;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(XenoBrutalizeSystem))]
+public sealed partial class XenoBrutalizeComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public int MaxTargets = 8;
+
+    [DataField, AutoNetworkedField]
+    public float AOEDamageMult = 0.4f;
+
+    [DataField, AutoNetworkedField]
+    public EntProtoId Effect = "RMCEffectExtraSlash";
+
+    [DataField, AutoNetworkedField]
+    public float Range = 1;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan BaseCooldownReduction = TimeSpan.FromSeconds(1.5);
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan AddtionalCooldownReductions = TimeSpan.FromSeconds(0.5);
+
+    [DataField, AutoNetworkedField]
+    public string CummulativeCooldownAction = "ActionXenoCharge";
+
+    [DataField, AutoNetworkedField]
+    public string BaseCooldownAction = "ActionXenoDefensiveShield";
+}

--- a/Content.Shared/_RMC14/Xenonids/Brutalize/XenoBrutalizeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Brutalize/XenoBrutalizeSystem.cs
@@ -1,0 +1,86 @@
+﻿using System.Linq;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Coordinates;
+using Content.Shared.Damage;
+using Content.Shared.Effects;
+using Content.Shared.FixedPoint;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.Weapons.Melee.Events;
+using Robust.Shared.Network;
+using Robust.Shared.Player;
+using Content.Shared._RMC14.Xenonids.Charge;
+using Content.Shared.Actions;
+
+namespace Content.Shared._RMC14.Xenonids.Brutalize;
+
+public sealed class XenoBrutalizeSystem : EntitySystem
+{
+    [Dependency] private readonly XenoSystem _xeno = default!;
+    [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
+    [Dependency] private readonly DamageableSystem _damageable = default!;
+    [Dependency] private readonly SharedColorFlashEffectSystem _colorFlash = default!;
+    [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly SharedActionsSystem _actions = default!;
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<XenoBrutalizeComponent, MeleeHitEvent>(OnBrutalMeleeHit);
+    }
+
+    private void OnBrutalMeleeHit(Entity<XenoBrutalizeComponent> xeno, ref MeleeHitEvent args)
+    {
+        EntityUid? mainTarget = null;
+        foreach (var ent in args.HitEntities)
+        {
+            if (!_xeno.CanHitLiving(xeno, ent))
+                continue;
+
+            mainTarget = ent;
+            break;
+        }
+
+        if (mainTarget == null)
+            return;
+
+        int currHits = 0;
+        var damage = args.BaseDamage * xeno.Comp.AOEDamageMult;
+
+        foreach (var extra in _entityLookup.GetEntitiesInRange<MobStateComponent>(_transform.GetMapCoordinates(mainTarget.Value), xeno.Comp.Range))
+        {
+            if (!_xeno.CanHitLiving(xeno, extra) || _mobState.IsDead(extra))
+                continue;
+
+            if (args.HitEntities.Contains(extra))
+                continue;
+
+            currHits++;
+
+            var myDamage = _damageable.TryChangeDamage(extra, damage);
+            if (myDamage?.GetTotal() > FixedPoint2.Zero)
+            {
+                var filter = Filter.Pvs(extra, entityManager: EntityManager).RemoveWhereAttachedEntity(o => o == xeno.Owner);
+                _colorFlash.RaiseEffect(Color.Red, new List<EntityUid> { extra }, filter);
+            }
+
+            if (currHits >= xeno.Comp.MaxTargets)
+                break;
+
+            if (_net.IsServer)
+                SpawnAttachedTo(xeno.Comp.Effect, extra.Owner.ToCoordinates());
+        }
+
+        if (!TryComp<XenoComponent>(xeno, out var act))
+            return;
+
+        if (TryComp<InstantActionComponent>(act.Actions[xeno.Comp.BaseCooldownAction], out var basAct) && basAct.Cooldown != null)
+            _actions.SetCooldown(act.Actions[xeno.Comp.BaseCooldownAction], basAct.Cooldown.Value.Start, basAct.Cooldown.Value.End - xeno.Comp.BaseCooldownReduction);
+
+
+        if (TryComp<WorldTargetActionComponent>(act.Actions[xeno.Comp.CummulativeCooldownAction], out var culAct) && culAct.Cooldown != null)
+            _actions.SetCooldown(act.Actions[xeno.Comp.CummulativeCooldownAction], culAct.Cooldown.Value.Start, culAct.Cooldown.Value.End - (xeno.Comp.BaseCooldownReduction + currHits
+             * xeno.Comp.AddtionalCooldownReductions));
+    }
+}

--- a/Resources/Prototypes/_RMC14/Effects/slash.yml
+++ b/Resources/Prototypes/_RMC14/Effects/slash.yml
@@ -1,0 +1,15 @@
+- type: entity
+  id: RMCEffectExtraSlash
+  noSpawn: true
+  components:
+  - type: TimedDespawn
+    lifetime: 0.4
+  - type: Sprite
+    sprite: _RMC14/Effects/attacks.rsi
+    noRot: true
+    state: slash
+    drawdepth: Effects
+  - type: EffectVisuals
+  - type: Tag
+    tags:
+    - HideContextMenu

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/crusher.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/crusher.yml
@@ -69,5 +69,6 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 1.66
     baseSprintSpeed: 3
+  - type: XenoBrutalize
   - type: RMCXenoDamageVisuals
     prefix: crusher


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Crusher's "Brutalizer" ability (as the wiki calls it) has been implemented. The first living target hit in an attack will also have up to 8 living targets be damaged (at 40% of the damage the main target took) by this effect. The crusher will also have her cooldowns reduced depending on how many targets this effect hit (at a minimum of 1.5 secs with 0 brutalize hits, with 0.5 per brutalize target. Defensive Shield only regens by 1.5 per any hit)

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
CM-13 parity, fixes #3413

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
New system for this ability. It checks in a range after getting the first valid living hit for other valid entities and damages them with 40% of the damage gotten from MeleeHitEvent. As long as a main target is found, the crusher will get -1.5 seconds to her charge and defensive shield abilities. The additional hits give -0.5 each, but only to charge (doing it for defensive shield gave it unlimited uptime in CM-13 so they don't)

It basically hits in a circle around the first target. It does not count any entities that would've been hit in a wideswing as valid targets. (To prevent additional damage from wideswings).

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/user-attachments/assets/a5e23609-6482-4b06-b6ce-f7d786ff562d



## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
no

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- add: Added the Brutalizer passive to the Crusher, which gives her an AOE effect that hits every nearby the first person hit at 40% damage. Attacks now reduce the Crusher's Defensive Shield and Charge abilities' cooldowns, with additional hits reducing Charge's even more.
