### PR TITLE
Add boiler neurotoxin

### DIFF
--- a/Content.Server/_RMC14/Xenonids/NeurotoxinSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/NeurotoxinSystem.cs
@@ -1,0 +1,20 @@
+﻿using Content.Server.Chat.Systems;
+using Content.Shared._RMC14.Xenonids.Neurotoxin;
+
+namespace Content.Server._RMC14.Xenonids;
+
+public sealed class NeurotoxinSystem : SharedNeurotoxinSystem
+{
+    [Dependency] ChatSystem _chat = default!;
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<NeurotoxinComponent, NeurotoxinEmoteEvent>(OnEmote);
+    }
+
+    public void OnEmote(Entity<NeurotoxinComponent> victim, ref NeurotoxinEmoteEvent args)
+    {
+        _chat.TryEmoteWithChat(victim, args.Emote);
+    }
+}

--- a/Content.Shared/_RMC14/Xenonids/AcidShroud/XenoAcidShroudComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/AcidShroud/XenoAcidShroudComponent.cs
@@ -12,4 +12,11 @@ public sealed partial class XenoAcidShroudComponent : Component
 
     [DataField, AutoNetworkedField]
     public EntProtoId Spawn = "RMCSmokeAcidShroud";
+
+    [DataField, AutoNetworkedField]
+    public EntProtoId[] Gases = new[]
+{
+        new EntProtoId("RMCSmokeAcidShroud"),
+        new EntProtoId("RMCSmokeNeurotoxinShroud"),
+    };
 }

--- a/Content.Shared/_RMC14/Xenonids/AcidShroud/XenoAcidShroudSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/AcidShroud/XenoAcidShroudSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared._RMC14.Actions;
+using Content.Shared._RMC14.Xenonids.GasToggle;
 using Content.Shared.Coordinates;
 using Content.Shared.DoAfter;
 
@@ -13,6 +14,7 @@ public sealed class XenoAcidShroudSystem : EntitySystem
     {
         SubscribeLocalEvent<XenoAcidShroudComponent, XenoAcidShroudActionEvent>(OnAcidShroudAction);
         SubscribeLocalEvent<XenoAcidShroudComponent, XenoAcidShroudDoAfterEvent>(OnAcidShroudDoAfter);
+        SubscribeLocalEvent<XenoAcidShroudComponent, XenoGasToggleActionEvent>(OnToggleType);
     }
 
     private void OnAcidShroudAction(Entity<XenoAcidShroudComponent> ent, ref XenoAcidShroudActionEvent args)
@@ -31,5 +33,20 @@ public sealed class XenoAcidShroudSystem : EntitySystem
         args.Handled = true;
         SpawnAtPosition(ent.Comp.Spawn, ent.Owner.ToCoordinates());
         _rmcActions.ActivateSharedCooldown(GetEntity(args.ActionId), ent);
+    }
+
+    private void OnToggleType(Entity<XenoAcidShroudComponent> ent, ref XenoGasToggleActionEvent args)
+    {
+        if (ent.Comp.Gases.Length == 0)
+            return;
+
+        var index = Array.IndexOf(ent.Comp.Gases, ent.Comp.Spawn);
+        if (index == -1 || index >= ent.Comp.Gases.Length - 1)
+            index = 0;
+        else
+            index++;
+
+        ent.Comp.Spawn = ent.Comp.Gases[index];
+        Dirty(ent);
     }
 }

--- a/Content.Shared/_RMC14/Xenonids/Bombard/XenoBombardSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Bombard/XenoBombardSystem.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using Content.Shared._RMC14.Actions;
+using Content.Shared._RMC14.Xenonids.GasToggle;
 using Content.Shared._RMC14.Projectiles;
 using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared._RMC14.Xenonids.Projectile;
@@ -29,7 +30,7 @@ public sealed class XenoBombardSystem : EntitySystem
     {
         SubscribeLocalEvent<XenoBombardComponent, XenoBombardActionEvent>(OnBombard);
         SubscribeLocalEvent<XenoBombardComponent, XenoBombardDoAfterEvent>(OnBombardDoAfter);
-        SubscribeLocalEvent<XenoBombardComponent, XenoBombardToggleActionEvent>(OnToggleType);
+        SubscribeLocalEvent<XenoBombardComponent, XenoGasToggleActionEvent>(OnToggleType);
     }
 
     private void OnBombard(Entity<XenoBombardComponent> ent, ref XenoBombardActionEvent args)
@@ -100,7 +101,7 @@ public sealed class XenoBombardSystem : EntitySystem
         _popup.PopupEntity(othersMessage, ent, Filter.PvsExcept(ent), true, PopupType.MediumCaution);
     }
 
-    private void OnToggleType(Entity<XenoBombardComponent> ent, ref XenoBombardToggleActionEvent args)
+    private void OnToggleType(Entity<XenoBombardComponent> ent, ref XenoGasToggleActionEvent args)
     {
         if (ent.Comp.Projectiles.Length == 0)
             return;

--- a/Content.Shared/_RMC14/Xenonids/Bombard/XenoBombardToggleActionEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Bombard/XenoBombardToggleActionEvent.cs
@@ -1,5 +1,0 @@
-using Content.Shared.Actions;
-
-namespace Content.Shared._RMC14.Xenonids.Bombard;
-
-public sealed partial class XenoBombardToggleActionEvent : InstantActionEvent;

--- a/Content.Shared/_RMC14/Xenonids/GasToggle/XenoGasToggleActionEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/GasToggle/XenoGasToggleActionEvent.cs
@@ -1,0 +1,5 @@
+using Content.Shared.Actions;
+
+namespace Content.Shared._RMC14.Xenonids.GasToggle;
+
+public sealed partial class XenoGasToggleActionEvent : InstantActionEvent;

--- a/Content.Shared/_RMC14/Xenonids/GasToggle/XenoGasToggleComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/GasToggle/XenoGasToggleComponent.cs
@@ -1,0 +1,10 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.GasToggle;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class XenoGasToggleComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public bool IsNeurotoxin = false;
+}

--- a/Content.Shared/_RMC14/Xenonids/GasToggle/XenoGasToggleSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/GasToggle/XenoGasToggleSystem.cs
@@ -1,12 +1,9 @@
 ﻿using Content.Shared.Actions;
-using Robust.Shared.Timing;
 
 namespace Content.Shared._RMC14.Xenonids.GasToggle;
 
 public sealed class XenoGasToggleSystem : EntitySystem
 {
-    [Dependency] private readonly IGameTiming _timing = default!;
-
     [Dependency] private readonly SharedActionsSystem _actions = default!;
     public override void Initialize()
     {

--- a/Content.Shared/_RMC14/Xenonids/GasToggle/XenoGasToggleSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/GasToggle/XenoGasToggleSystem.cs
@@ -1,0 +1,24 @@
+﻿using Content.Shared.Actions;
+using Robust.Shared.Timing;
+
+namespace Content.Shared._RMC14.Xenonids.GasToggle;
+
+public sealed class XenoGasToggleSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    [Dependency] private readonly SharedActionsSystem _actions = default!;
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<XenoGasToggleComponent, XenoGasToggleActionEvent>(OnToggleType);
+    }
+
+    private void OnToggleType(Entity<XenoGasToggleComponent> xeno, ref XenoGasToggleActionEvent args)
+    {
+        if (!_timing.IsFirstTimePredicted)
+            return;
+        xeno.Comp.IsNeurotoxin = !xeno.Comp.IsNeurotoxin;
+        _actions.SetToggled(args.Action, xeno.Comp.IsNeurotoxin);
+        Dirty(xeno);
+    }
+}

--- a/Content.Shared/_RMC14/Xenonids/GasToggle/XenoGasToggleSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/GasToggle/XenoGasToggleSystem.cs
@@ -15,8 +15,10 @@ public sealed class XenoGasToggleSystem : EntitySystem
 
     private void OnToggleType(Entity<XenoGasToggleComponent> xeno, ref XenoGasToggleActionEvent args)
     {
-        if (!_timing.IsFirstTimePredicted)
+        if (args.Handled)
             return;
+
+        args.Handled = true;
         xeno.Comp.IsNeurotoxin = !xeno.Comp.IsNeurotoxin;
         _actions.SetToggled(args.Action, xeno.Comp.IsNeurotoxin);
         Dirty(xeno);

--- a/Content.Shared/_RMC14/Xenonids/Neurotoxin/CoughedBloodComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Neurotoxin/CoughedBloodComponent.cs
@@ -1,0 +1,14 @@
+﻿using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.GasToggle;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class CoughedBloodComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 SlowMultiplier = 0.87f;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan ExpireTime;
+}

--- a/Content.Shared/_RMC14/Xenonids/Neurotoxin/NeurotoxinComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Neurotoxin/NeurotoxinComponent.cs
@@ -1,0 +1,76 @@
+﻿using Content.Shared.Chat.Prototypes;
+using Content.Shared.Damage;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._RMC14.Xenonids.Neurotoxin;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class NeurotoxinComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public float NeurotoxinAmount = 0;
+
+    [DataField, AutoNetworkedField]
+    public float DepletionPerSecond = 5;
+
+    [DataField, AutoNetworkedField]
+    public float StaminaDamagePerSecond = 35;
+
+    [DataField, AutoNetworkedField]
+    public float DizzyStrength = 1.2f;
+
+    [DataField, AutoNetworkedField]
+    public float DizzyStrengthOnStumble = 5.5f;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan LastMessage;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan TimeBetweenMessages = TimeSpan.FromSeconds(2);
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan AccentTime = TimeSpan.FromSeconds(10);
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan JitterTime = TimeSpan.FromSeconds(15);
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan StumbleJitterTime = TimeSpan.FromSeconds(25);
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan LastStumbleTime;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan SecondsToBlindByOne = TimeSpan.FromSeconds(3);
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan MinimumDelayBetweenEvents = TimeSpan.FromSeconds(1);
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan LastAccentTime;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan LastBlindTime;
+
+    [DataField, AutoNetworkedField]
+    public DamageSpecifier ToxinDamage = new();
+
+    [DataField, AutoNetworkedField]
+    public DamageSpecifier OxygenDamage = new();
+
+    [DataField, AutoNetworkedField]
+    public DamageSpecifier CoughDamage = new();
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan DazeLength = TimeSpan.FromSeconds(1);
+
+    [DataField, AutoNetworkedField]
+    public ProtoId<EmotePrototype> CoughId = "Cough";
+
+    [DataField, AutoNetworkedField]
+    public ProtoId<EmotePrototype> PainId = "Scream"; // TODO custom pain emote
+
+	[DataField, AutoNetworkedField]
+	public TimeSpan BloodCoughDuration = TimeSpan.FromSeconds(1);
+}

--- a/Content.Shared/_RMC14/Xenonids/Neurotoxin/NeurotoxinComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Neurotoxin/NeurotoxinComponent.cs
@@ -12,10 +12,10 @@ public sealed partial class NeurotoxinComponent : Component
     public float NeurotoxinAmount = 0;
 
     [DataField, AutoNetworkedField]
-    public float DepletionPerSecond = 5;
+    public float DepletionPerSecond = 1;
 
     [DataField, AutoNetworkedField]
-    public float StaminaDamagePerSecond = 35;
+    public float StaminaDamagePerSecond = 7;
 
     [DataField, AutoNetworkedField]
     public float DizzyStrength = 1.2f;

--- a/Content.Shared/_RMC14/Xenonids/Neurotoxin/NeurotoxinComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Neurotoxin/NeurotoxinComponent.cs
@@ -42,16 +42,13 @@ public sealed partial class NeurotoxinComponent : Component
     public TimeSpan LastStumbleTime;
 
     [DataField, AutoNetworkedField]
-    public TimeSpan SecondsToBlindByOne = TimeSpan.FromSeconds(3);
+    public TimeSpan BlindTime = TimeSpan.FromSeconds(3);
 
     [DataField, AutoNetworkedField]
     public TimeSpan MinimumDelayBetweenEvents = TimeSpan.FromSeconds(1);
 
     [DataField, AutoNetworkedField]
     public TimeSpan LastAccentTime;
-
-    [DataField, AutoNetworkedField]
-    public TimeSpan LastBlindTime;
 
     [DataField, AutoNetworkedField]
     public DamageSpecifier ToxinDamage = new();

--- a/Content.Shared/_RMC14/Xenonids/Neurotoxin/NeurotoxinComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Neurotoxin/NeurotoxinComponent.cs
@@ -18,10 +18,10 @@ public sealed partial class NeurotoxinComponent : Component
     public float StaminaDamagePerSecond = 7;
 
     [DataField, AutoNetworkedField]
-    public float DizzyStrength = 1.2f;
+    public float DizzyStrength = 12;
 
     [DataField, AutoNetworkedField]
-    public float DizzyStrengthOnStumble = 5.5f;
+    public float DizzyStrengthOnStumble = 55;
 
     [DataField, AutoNetworkedField]
     public TimeSpan LastMessage;

--- a/Content.Shared/_RMC14/Xenonids/Neurotoxin/NeurotoxinComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Neurotoxin/NeurotoxinComponent.cs
@@ -71,6 +71,6 @@ public sealed partial class NeurotoxinComponent : Component
     [DataField, AutoNetworkedField]
     public ProtoId<EmotePrototype> PainId = "Scream"; // TODO custom pain emote
 
-	[DataField, AutoNetworkedField]
-	public TimeSpan BloodCoughDuration = TimeSpan.FromSeconds(1);
+    [DataField, AutoNetworkedField]
+    public TimeSpan BloodCoughDuration = TimeSpan.FromSeconds(1);
 }

--- a/Content.Shared/_RMC14/Xenonids/Neurotoxin/NeurotoxinEmoteEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Neurotoxin/NeurotoxinEmoteEvent.cs
@@ -1,0 +1,6 @@
+﻿using Content.Shared.Chat.Prototypes;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._RMC14.Xenonids.Neurotoxin;
+
+public record struct NeurotoxinEmoteEvent(ProtoId<EmotePrototype> Emote);

--- a/Content.Shared/_RMC14/Xenonids/Neurotoxin/NeurotoxinInjectorComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Neurotoxin/NeurotoxinInjectorComponent.cs
@@ -1,0 +1,28 @@
+﻿using Content.Shared.Damage;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.Neurotoxin;
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(SharedNeurotoxinSystem))]
+public sealed partial class NeurotoxinInjectorComponent : Component
+{
+    [DataField(required: true), AutoNetworkedField]
+    public float NeuroPerSecond;
+
+    [DataField, AutoNetworkedField]
+    public bool AffectsDead;
+
+    [DataField, AutoNetworkedField]
+    public bool AffectsInfectedNested;
+
+    //Passed onto neurotoxin
+
+    [DataField, AutoNetworkedField]
+    public DamageSpecifier ToxinDamage = new();
+
+    [DataField, AutoNetworkedField]
+    public DamageSpecifier OxygenDamage = new();
+
+    [DataField, AutoNetworkedField]
+    public DamageSpecifier CoughDamage = new();
+}

--- a/Content.Shared/_RMC14/Xenonids/Neurotoxin/SharedNeurotoxinSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Neurotoxin/SharedNeurotoxinSystem.cs
@@ -142,7 +142,6 @@ public abstract class SharedNeurotoxinSystem : EntitySystem
 
             if (_random.Prob(coughChance * frameTime))
             {
-                // TODO RMC14 make em cough - same as above
                 EnsureComp<CoughedBloodComponent>(uid, out var bloodCough);
                 bloodCough.ExpireTime = time + neuro.BloodCoughDuration;
                 _damage.TryChangeDamage(uid, neuro.CoughDamage); // TODO RMC-14 specifically chest damage

--- a/Content.Shared/_RMC14/Xenonids/Neurotoxin/SharedNeurotoxinSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Neurotoxin/SharedNeurotoxinSystem.cs
@@ -1,0 +1,279 @@
+﻿using Content.Shared._RMC14.Marines;
+using Content.Shared._RMC14.Xenonids.Construction.Nest;
+using Content.Shared._RMC14.Xenonids.GasToggle;
+using Content.Shared._RMC14.Xenonids.Parasite;
+using Content.Shared.ActionBlocker;
+using Content.Shared.Coordinates;
+using Content.Shared.Damage;
+using Content.Shared.Damage.Systems;
+using Content.Shared.Drunk;
+using Content.Shared.Eye.Blinding.Systems;
+using Content.Shared.Jittering;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.Movement.Systems;
+using Content.Shared.Popups;
+using Content.Shared.Rejuvenate;
+using Content.Shared.Speech.EntitySystems;
+using Content.Shared.StatusEffect;
+using Content.Shared.Throwing;
+using Robust.Shared.Network;
+using Robust.Shared.Player;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+
+namespace Content.Shared._RMC14.Xenonids.Neurotoxin;
+
+public abstract class SharedNeurotoxinSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
+    [Dependency] private readonly StaminaSystem _stamina = default!;
+    [Dependency] private readonly SharedDrunkSystem _drunk = default!; // Used in place of dizziness
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
+    [Dependency] private readonly SharedSlurredSystem _slurred = default!;
+    [Dependency] private readonly SharedStutteringSystem _stutter = default!;
+    [Dependency] private readonly SharedJitteringSystem _jitter = default!;
+    [Dependency] private readonly BlindableSystem _blinding = default!;
+    [Dependency] private readonly DamageableSystem _damage = default!;
+    [Dependency] private readonly ThrowingSystem _throwing = default!; //It's how this fakes movement
+    [Dependency] private readonly ActionBlockerSystem _blocker = default!;
+
+    private readonly HashSet<Entity<MarineComponent>> _marines = new();
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<NeurotoxinComponent, RejuvenateEvent>(OnRejuvenate);
+        SubscribeLocalEvent<CoughedBloodComponent, RefreshMovementSpeedModifiersEvent>(OnCoughedBloodRefreshSpeed);
+    }
+
+    private void OnRejuvenate(Entity<NeurotoxinComponent> ent, ref RejuvenateEvent args)
+    {
+        RemCompDeferred<NeurotoxinComponent>(ent);
+    }
+
+    private void OnCoughedBloodRefreshSpeed(Entity<CoughedBloodComponent> victim, ref RefreshMovementSpeedModifiersEvent args)
+    {
+        var multiplier = victim.Comp.SlowMultiplier.Float();
+        args.ModifySpeed(multiplier, multiplier);
+    }
+
+
+
+    public override void Update(float frameTime)
+    {
+        if (_net.IsClient)
+            return;
+
+        var time = _timing.CurTime;
+        var neurotoxinInjectorQuery = EntityQueryEnumerator<NeurotoxinInjectorComponent>();
+
+        while (neurotoxinInjectorQuery.MoveNext(out var uid, out var neuroGas))
+        {
+            _marines.Clear();
+            _entityLookup.GetEntitiesInRange(uid.ToCoordinates(), 0.5f, _marines);
+
+            foreach (var marine in _marines)
+            {
+                if (!neuroGas.AffectsDead && _mobState.IsDead(marine))
+                    continue;
+
+                if (!neuroGas.AffectsInfectedNested &&
+                    HasComp<XenoNestedComponent>(marine) &&
+                    HasComp<VictimInfectedComponent>(marine))
+                {
+                    continue;
+                }
+
+                if (!EnsureComp<NeurotoxinComponent>(marine, out var builtNeurotoxin))
+                {
+                    builtNeurotoxin.LastMessage = time;
+                    builtNeurotoxin.LastBlindTime = time;
+                    builtNeurotoxin.LastAccentTime = time;
+                    builtNeurotoxin.LastStumbleTime = time;
+                }
+                // TODO RMC14 blurriness added here too
+                builtNeurotoxin.NeurotoxinAmount += neuroGas.NeuroPerSecond * frameTime;
+                builtNeurotoxin.ToxinDamage = neuroGas.ToxinDamage;
+                builtNeurotoxin.OxygenDamage = neuroGas.OxygenDamage;
+                builtNeurotoxin.CoughDamage = neuroGas.CoughDamage;
+            }
+        }
+
+        var neuroToxinQuery = EntityQueryEnumerator<NeurotoxinComponent>();
+
+        while (neuroToxinQuery.MoveNext(out var uid, out var neuro))
+        {
+            neuro.NeurotoxinAmount -= frameTime * neuro.DepletionPerSecond;
+
+            if(neuro.NeurotoxinAmount <= 0)
+            {
+                RemCompDeferred<NeurotoxinComponent>(uid);
+                continue;
+            }
+
+            if (_mobState.IsDead(uid))
+                continue;
+
+            //Basic Effects
+            _stamina.TakeStaminaDamage(uid, neuro.StaminaDamagePerSecond * frameTime);
+            _drunk.TryApplyDrunkenness(uid, neuro.DizzyStrength, false);
+
+            NeurotoxinNonStackingEffects(uid, neuro, time, out var coughChance, out var stumbleChance);
+            NeurotoxinStackingEffects(uid, neuro, frameTime, time);
+
+            if (_random.Prob(stumbleChance * frameTime) && time - neuro.LastStumbleTime >= neuro.MinimumDelayBetweenEvents)
+            {
+                neuro.LastStumbleTime = time;
+                // This is how we randomly move them - by throwing
+                if(_blocker.CanMove(uid))
+                    _throwing.TryThrow(uid, _random.NextAngle().ToVec().Normalized(), 1, animated: false, playSound: false, doSpin: false);
+                _popup.PopupEntity(Loc.GetString("rmc-stumble-others", ("victim", uid)), uid, Filter.PvsExcept(uid), true, PopupType.SmallCaution);
+                _popup.PopupEntity(Loc.GetString("rmc-stumble"), uid, uid, PopupType.MediumCaution);
+                _statusEffects.TryAddStatusEffect(uid, "Muted", neuro.DazeLength * 5, true, "Muted");
+                _jitter.DoJitter(uid, neuro.StumbleJitterTime, true);
+                _drunk.TryApplyDrunkenness(uid, neuro.DizzyStrengthOnStumble, false);
+                var ev = new NeurotoxinEmoteEvent() { Emote = neuro.PainId };
+                RaiseLocalEvent(uid, ev);
+            }
+
+            if (_random.Prob(coughChance * frameTime))
+            {
+                // TODO RMC14 make em cough - same as above
+                EnsureComp<CoughedBloodComponent>(uid, out var bloodCough);
+                bloodCough.ExpireTime = time + neuro.BloodCoughDuration;
+                _damage.TryChangeDamage(uid, neuro.CoughDamage); // TODO RMC-14 specifically chest damage
+                _popup.PopupEntity(Loc.GetString("rmc-bloodcough"), uid, uid, PopupType.MediumCaution);
+                var ev = new NeurotoxinEmoteEvent() { Emote = neuro.CoughId };
+                RaiseLocalEvent(uid, ev);
+            }
+
+        }
+
+        var bloodCoughQuery = EntityQueryEnumerator<CoughedBloodComponent>();
+
+        while (bloodCoughQuery.MoveNext(out var uid, out var cough))
+        {
+            if(time > cough.ExpireTime)
+                RemCompDeferred<CoughedBloodComponent>(uid);
+        }
+
+    }
+
+    private void NeurotoxinNonStackingEffects(EntityUid victim, NeurotoxinComponent neurotoxin, TimeSpan time, out float coughChance, out float stumbleChance)
+    {
+        string message = "rmc-neuro-tired";
+        PopupType poptype = PopupType.Small;
+        coughChance = 0;
+        stumbleChance = 0;
+        if (neurotoxin.NeurotoxinAmount <= 9)
+        {
+            //Do nothing, the intial conditions are already set
+        }
+        else if (neurotoxin.NeurotoxinAmount <= 14)
+        {
+            message = "rmc-neuro-numb";
+            poptype = PopupType.SmallCaution;
+            coughChance = 0.10f;
+        }
+        else if (neurotoxin.NeurotoxinAmount <= 19)
+        {
+            int chance = _random.Next(4);
+            if(chance == 0)
+            {
+                message = "rmc-neuro-where";
+                poptype = PopupType.Large;
+            }
+            else
+            {
+                message = _random.Pick(new List<string> {"rmc-neuro-very-numb", "rmc-neuro-erratic", "rmc-neuro-panic"});
+                poptype = PopupType.MediumCaution;
+            }
+            coughChance = 0.10f;
+            stumbleChance = 0.05f;
+        }
+        else if (neurotoxin.NeurotoxinAmount <= 24)
+        {
+            message = "rmc-neuro-sting";
+            poptype = PopupType.MediumCaution;
+            coughChance = 0.25f;
+            stumbleChance = 0.25f;
+
+        }
+        else
+        {
+            int chance = _random.Next(7);
+            if (chance == 0)
+            {
+                message = "rmc-neuro-what";
+                poptype = PopupType.Large;
+            }
+            else if (chance == 1)
+            {
+                message = "rmc-neuro-hearing";
+                poptype = PopupType.MediumCaution;
+            }
+            else
+            {
+                message = _random.Pick(new List<string> { "rmc-neuro-pain", "rmc-neuro-agh", "rmc-neuro-so-numb", "rmc-neuro-limbs", "rmc-neuro-think"});
+                poptype = PopupType.LargeCaution;
+            }
+            coughChance = 0.25f;
+            stumbleChance = 0.25f;
+        }
+
+        if (time - neurotoxin.LastMessage >= neurotoxin.TimeBetweenMessages)
+        {
+            neurotoxin.LastMessage = time;
+            _popup.PopupEntity(Loc.GetString(message), victim, poptype);
+        }
+    }
+
+    private void NeurotoxinStackingEffects(EntityUid victim, NeurotoxinComponent neurotoxin, float frameTime, TimeSpan currTime)
+    {
+        if (neurotoxin.NeurotoxinAmount >= 10)
+        {
+            // TODO RMC14 eye blur here
+            if (currTime - neurotoxin.LastAccentTime >= neurotoxin.MinimumDelayBetweenEvents)
+            {
+                neurotoxin.LastAccentTime = currTime;
+                if (_random.Prob(0.5f))
+                    _slurred.DoSlur(victim, neurotoxin.AccentTime);
+                else
+                    _stutter.DoStutter(victim, neurotoxin.AccentTime, true);
+            }
+        }
+
+        if (neurotoxin.NeurotoxinAmount >= 15)
+        {
+            // TODO RMC14 Agony effect - gives fake damage, pain needs this too so maybe then
+            _jitter.DoJitter(victim, neurotoxin.JitterTime, true);
+            // TODO RMC14 Hallucinations would and be checked and then done through a function
+            // Will need...alot of work
+        }
+        // Might need adjusting if they become blind too fast or too slow
+        if (neurotoxin.NeurotoxinAmount >= 20 && (currTime - neurotoxin.LastBlindTime) >= neurotoxin.SecondsToBlindByOne)
+        {
+            neurotoxin.LastBlindTime = currTime;
+
+            _blinding.AdjustEyeDamage((victim, null), 1);
+        }
+
+        if (neurotoxin.NeurotoxinAmount >= 27)
+        {
+            // TODO RMC14 gives weldervision too
+            _statusEffects.TryAddStatusEffect(victim, "Muted", neurotoxin.DazeLength, true, "Muted");
+            _damage.TryChangeDamage(victim, neurotoxin.ToxinDamage * frameTime);
+            // TODO RMC14 starts to make em deaf
+        }
+
+        if (neurotoxin.NeurotoxinAmount >= 50)
+        {
+            // TODO RMC14 also gives liver damage
+            _damage.TryChangeDamage(victim, neurotoxin.OxygenDamage * frameTime);
+        }
+    }
+}

--- a/Content.Shared/_RMC14/Xenonids/Neurotoxin/SharedNeurotoxinSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Neurotoxin/SharedNeurotoxinSystem.cs
@@ -37,7 +37,6 @@ public abstract class SharedNeurotoxinSystem : EntitySystem
     [Dependency] private readonly SharedSlurredSystem _slurred = default!;
     [Dependency] private readonly SharedStutteringSystem _stutter = default!;
     [Dependency] private readonly SharedJitteringSystem _jitter = default!;
-    [Dependency] private readonly BlindableSystem _blinding = default!;
     [Dependency] private readonly DamageableSystem _damage = default!;
     [Dependency] private readonly ThrowingSystem _throwing = default!; //It's how this fakes movement
     [Dependency] private readonly ActionBlockerSystem _blocker = default!;
@@ -91,7 +90,6 @@ public abstract class SharedNeurotoxinSystem : EntitySystem
                 if (!EnsureComp<NeurotoxinComponent>(marine, out var builtNeurotoxin))
                 {
                     builtNeurotoxin.LastMessage = time;
-                    builtNeurotoxin.LastBlindTime = time;
                     builtNeurotoxin.LastAccentTime = time;
                     builtNeurotoxin.LastStumbleTime = time;
                 }
@@ -253,12 +251,10 @@ public abstract class SharedNeurotoxinSystem : EntitySystem
             // TODO RMC14 Hallucinations would and be checked and then done through a function
             // Will need...alot of work
         }
-        // Might need adjusting if they become blind too fast or too slow
-        if (neurotoxin.NeurotoxinAmount >= 20 && (currTime - neurotoxin.LastBlindTime) >= neurotoxin.SecondsToBlindByOne)
-        {
-            neurotoxin.LastBlindTime = currTime;
 
-            _blinding.AdjustEyeDamage((victim, null), 1);
+        if (neurotoxin.NeurotoxinAmount >= 20)
+        {
+            _statusEffects.TryAddStatusEffect(victim, "TemporaryBlindness", neurotoxin.BlindTime, true, "TemporaryBlindness");
         }
 
         if (neurotoxin.NeurotoxinAmount >= 27)
@@ -266,7 +262,7 @@ public abstract class SharedNeurotoxinSystem : EntitySystem
             // TODO RMC14 gives weldervision too
             _statusEffects.TryAddStatusEffect(victim, "Muted", neurotoxin.DazeLength, true, "Muted");
             _damage.TryChangeDamage(victim, neurotoxin.ToxinDamage * frameTime);
-            // TODO RMC14 starts to make em deaf
+            // TODO RMC14 tempoarary deafness
         }
 
         if (neurotoxin.NeurotoxinAmount >= 50)

--- a/Resources/Locale/en-US/_RMC14/neurotoxin.ftl
+++ b/Resources/Locale/en-US/_RMC14/neurotoxin.ftl
@@ -1,0 +1,24 @@
+﻿rmc-neuro-tired = Your whole body is feeling numb as you quickly tire out!
+
+rmc-neuro-numb = You body starts feeling numb, you can't feel your fingers!
+
+rmc-neuro-where = Why am I here?
+rmc-neuro-very-numb = Your entire body feels numb!
+rmc-neuro-erratic = You notice your movement is erratic!
+rmc-neuro-panic = You panic as numbness takes over your body!
+
+rmc-neuro-sting = Your eyes sting, you can't see!
+
+rmc-neuro-what = What am I doing?
+rmc-neuro-hearing = Your hearing fades away, you can't hear anything!
+rmc-neuro-pain = A sharp pain eminates from your abdomen!
+rmc-neuro-agh = EVERYTHING IS HURTING!! AGH!!!
+rmc-neuro-so-numb = Your entire body is numb, you can't feel anything!
+rmc-neuro-limbs = You can't feel your limbs at all!
+rmc-neuro-think = Your mind goes blank, you can't think of anything!
+
+rmc-stumble = You stumble!
+rmc-stumble-others = {CAPITALIZE($victim)} misteps in {POSS-ADJ($victim)} confusion!
+
+rmc-bloodcough = You cough up blood!
+

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
@@ -418,7 +418,10 @@
     icon:
       sprite: _RMC14/Actions/xeno_actions.rsi
       state: shift_spit_acid_glob
-    event: !type:XenoBombardToggleActionEvent
+    iconOn:
+      sprite: _RMC14/Actions/xeno_actions.rsi
+      state: shift_spit_neuro_glob
+    event: !type:XenoGasToggleActionEvent
     useDelay: 1
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
@@ -415,6 +415,7 @@
   components:
   - type: InstantAction
     itemIconStyle: NoItem
+    backgroundOn: null
     icon:
       sprite: _RMC14/Actions/xeno_actions.rsi
       state: shift_spit_acid_glob

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/boiler.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/boiler.yml
@@ -30,7 +30,7 @@
     - ActionXenoTailStabCorrosive
     - ActionXenoAcidStrong
     - ActionXenoBombard
-#    - ActionXenoToggleGasType
+    - ActionXenoToggleGasType
     - ActionXenoSprayAcidBoiler
     - ActionXenoZoom
     - ActionXenoAcidShroud
@@ -57,6 +57,7 @@
     doAfter: 0.5
   - type: XenoBombard
   - type: XenoAcidShroud
+  - type: XenoGasToggle
   - type: XenoTailStab
     inject:
       RMCMolecularAcid: 1 # TODO RMC14 2

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/boiler.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/boiler.yml
@@ -60,7 +60,7 @@
   - type: XenoGasToggle
   - type: XenoTailStab
     inject:
-      RMCMolecularAcid: 1 # TODO RMC14 2
+      RMCMolecularAcid: 1 # TODO RMC14 6
   - type: XenoSprayAcid
     acid: XenoAcidSprayStrong
     barricadeDamage:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_projectiles.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_projectiles.yml
@@ -181,3 +181,17 @@
     layers:
     - state: neuro_glob
       shader: unshaded
+  - type: TimedDespawn
+    lifetime: 10
+  - type: XenoProjectile
+    deleteOnFriendlyXeno: false
+  - type: SmokeOnTrigger
+    smokePrototype: RMCSmokeNeurotoxin
+    duration: 30
+    spreadAmount: 50
+  - type: SpawnOnTerminate
+    spawn: RMCSmokeNeurotoxin
+    popup: rmc-glob-land
+    popupType: LargeCaution
+  - type: ProjectileMaxRange
+    max: 10

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_smoke.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_smoke.yml
@@ -83,15 +83,15 @@
     spawn: RMCSmokeNeurotoxin
     range: 3
   - type: NeurotoxinInjector
-    neuroPerSecond: 30
+    neuroPerSecond: 6
     affectsDead: false
     affectsInfectedNested: false
     toxinDamage:
         groups:
-          Toxin: 10
+          Toxin: 2
     oxygenDamage:
         types:
-          Asphyxiation: 750
+          Asphyxiation: 150
     coughDamage:
         groups:
           Brute: 5

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_smoke.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_smoke.yml
@@ -83,7 +83,7 @@
     spawn: RMCSmokeNeurotoxin
     range: 3
   - type: NeurotoxinInjector
-    neuroPerSecond: 12
+    neuroPerSecond: 30
     affectsDead: false
     affectsInfectedNested: false
     toxinDamage:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_smoke.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_smoke.yml
@@ -35,6 +35,8 @@
     spawn: RMCSmokeAcid
     range: 2
   - type: DamageOverTime
+    affectsDead: false
+    affectsInfectedNested: false
     damage:
       groups:
         Burn: 20
@@ -43,6 +45,65 @@
     barricadeDamage:
       types:
         Heat: 11.5
+
+- type: entity
+  id: RMCSmokeNeurotoxin
+  name: neurotoxin gas
+  noSpawn: true
+  components:
+  - type: Transform
+    anchored: true
+  - type: Physics
+  - type: Fixtures
+    fixtures:
+      fix1:
+        hard: false
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.4,-0.4,0.4,0.4"
+        mask:
+        - ItemMask
+        layer:
+        - SlipLayer
+  - type: Occluder
+  - type: Sprite
+    sprite: _RMC14/Effects/smoke.rsi
+    state: smoke2
+    color: "#FFBF58"
+  - type: TimedDespawn
+    lifetime: 10
+  - type: Tag
+    tags:
+    - HideContextMenu
+  - type: Appearance
+  - type: ActiveEdgeSpreader
+  - type: EdgeSpreader
+    id: RMCSmokeNeurotoxin
+  - type: EvenSmoke
+    spawn: RMCSmokeNeurotoxin
+    range: 3
+  - type: NeurotoxinInjector
+    neuroPerSecond: 12
+    affectsDead: false
+    affectsInfectedNested: false
+    toxinDamage:
+        groups:
+          Toxin: 10
+    oxygenDamage:
+        types:
+          Asphyxiation: 750
+    coughDamage:
+        groups:
+          Brute: 5
+  - type: DamageOverTime
+    affectsDead: false
+    affectsInfectedNested: false
+    damage:
+      types:
+        Asphyxiation: 5
+    barricadeDamage: # This is required...
+      types:
+        Heat: 0
 
 - type: entity
   parent: RMCSmokeAcid
@@ -54,6 +115,20 @@
     spawn: RMCSmokeAcidShroud
     range: 1
 
+- type: entity
+  parent: RMCSmokeNeurotoxin
+  id: RMCSmokeNeurotoxinShroud
+  name: neurotoxin gas
+  noSpawn: true
+  components:
+  - type: EvenSmoke
+    spawn: RMCSmokeNeurotoxinShroud
+    range: 1
+
 - type: edgeSpreader
   id: RMCSmokeAcid
+  updatesPerSecond: 2
+
+- type: edgeSpreader
+  id: RMCSmokeNeurotoxin
   updatesPerSecond: 2


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
the title. See below for more details

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Closes #408 and closes #325
CM-13 parityyy
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Well, this is going to be a bit

So to start off - what it doesn't do:
Dizziness uses drunkness so it's not quite the same as cm-13s
No Eye Blurr
No Welder vision
No Hallucinations (someone else can have fun trying to get these in)
No Deafness or liver damage
No Agony effect and thus no fake damage (maybe when we get pain)

The stamina damage and all the other slew of effects are mostly there though, with most being status effects and stumbling using the throw system like fling and punch. Neurotoxin is injected via the NeurotoxinInjectorComponent, which has been added long with the neuro gas.

The BombardToggleGasEvent has been renamed to be more general, as acid shroud now also uses it and I added a system to make sure the action gets toggled correctly too.

Values are probably all over the place. Damage numbers and stuff have been kept the same as CM-13 even though they might be faster there (to match acid gas rn). So right now it takes 10 seconds in the gas to start instant dying.

The neurogas expands 1 tile farther out to match cm-13, though I think it's supposed to spread slightly slower (5 instead of 6 which is acid's spread speed). I couldn't find a way to do that so they spread at the same speed.
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/user-attachments/assets/b2579a4d-f57a-45bb-b7c2-14479e466fc4

(Not 100% accurate to the current timings)


## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- add: Added Boiler's neurotoxin gas, which is more oriented for capturing and causes a slew of chaotic effects if it builds up enough.
