### PR TITLE
Fix hypo not being inject only

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Medical/hypospray.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Medical/hypospray.yml
@@ -16,6 +16,9 @@
     fillBaseName: hypospray
     emptySpriteName: hypospray
     changeColor: true
+  - type: Hypospray
+    onlyAffectsMobs: false
+    injectOnly: true
   - type: Item
     size: Small
     sprite: _RMC14/Objects/Medical/hypospray.rsi

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Medical/hypospray.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Medical/hypospray.yml
@@ -21,7 +21,6 @@
     sprite: _RMC14/Objects/Medical/hypospray.rsi
   - type: Hypospray
     transferAmount: 5
-    onlyAffectsMobs: false
     injectOnly: true
     injectSound: /Audio/_RMC14/Medical/hypospray.ogg
   - type: Appearance

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Medical/hypospray.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Medical/hypospray.yml
@@ -16,14 +16,13 @@
     fillBaseName: hypospray
     emptySpriteName: hypospray
     changeColor: true
-  - type: Hypospray
-    onlyAffectsMobs: false
-    injectOnly: true
   - type: Item
     size: Small
     sprite: _RMC14/Objects/Medical/hypospray.rsi
   - type: Hypospray
     transferAmount: 5
+    onlyAffectsMobs: false
+    injectOnly: true
     injectSound: /Audio/_RMC14/Medical/hypospray.ogg
   - type: Appearance
   - type: SolutionContainerManager


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Title. It's not supposed to be able to draw from containers.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
CM-13 parity

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
no

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- fix: Fixed hyposprays being able to draw from containers. Use a bottle on it to refill it.
