### PR TITLE
Fix stun animations for xenos

### DIFF
--- a/Content.Client/_RMC14/Xenonids/XenoVisualizerSystem.cs
+++ b/Content.Client/_RMC14/Xenonids/XenoVisualizerSystem.cs
@@ -73,7 +73,7 @@ public sealed class XenoVisualizerSystem : VisualizerSystem<XenoComponent>
             state = mobState.CurrentState;
 
         Resolve(entity, ref input, ref thrown, ref leaping, ref knocked, false);
-        if (knocked != null)
+        if (knocked != null && state != MobState.Dead)
             state = MobState.Critical;
 
         if (sprite is not { BaseRSI: { } rsi } ||

--- a/Content.Shared/_RMC14/Xenonids/Fortify/XenoFortifyComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Fortify/XenoFortifyComponent.cs
@@ -22,7 +22,7 @@ public sealed partial class XenoFortifyComponent : Component
     public float ExplosionMultiplier = 0.4f;
 
     [DataField, AutoNetworkedField]
-    public string ImmuneToStatus = "Stun";
+    public string[] ImmuneToStatuses = { "Stun", "KnockedDown" };
 
     [DataField]
     public IPhysShape Shape = new PhysShapeCircle(0.49f);

--- a/Content.Shared/_RMC14/Xenonids/Fortify/XenoFortifySystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Fortify/XenoFortifySystem.cs
@@ -77,7 +77,7 @@ public sealed class XenoFortifySystem : EntitySystem
 
     private void OnXenoFortifyBeforeStatusAdded(Entity<XenoFortifyComponent> xeno, ref BeforeStatusEffectAddedEvent args)
     {
-        if (xeno.Comp.Fortified &&  xeno.Comp.ImmuneToStatuses.Contains(args.Key))
+        if (xeno.Comp.Fortified && xeno.Comp.ImmuneToStatuses.Contains(args.Key))
             args.Cancelled = true;
     }
 

--- a/Content.Shared/_RMC14/Xenonids/Fortify/XenoFortifySystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Fortify/XenoFortifySystem.cs
@@ -12,6 +12,7 @@ using Content.Shared.Movement.Events;
 using Content.Shared.Popups;
 using Content.Shared.StatusEffect;
 using Robust.Shared.Physics.Systems;
+using System.Linq;
 using static Content.Shared._RMC14.Xenonids.Fortify.XenoFortifyComponent;
 using static Content.Shared.Physics.CollisionGroup;
 
@@ -76,7 +77,7 @@ public sealed class XenoFortifySystem : EntitySystem
 
     private void OnXenoFortifyBeforeStatusAdded(Entity<XenoFortifyComponent> xeno, ref BeforeStatusEffectAddedEvent args)
     {
-        if (xeno.Comp.Fortified && args.Key == xeno.Comp.ImmuneToStatus)
+        if (xeno.Comp.Fortified &&  xeno.Comp.ImmuneToStatuses.Contains(args.Key))
             args.Cancelled = true;
     }
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Xenos will no longer go into their stunned state if dead. Defenders fortifying will no longer go into their stun state if hit by a sadar while fortified.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Discord bugs, CM-13 parity.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
One bit added to the visualizer, for defender they are now immune to knockdown while fortified (In CM they can freely unfortify after a sadar hit and stay in their fortified pose while hit and alive.)

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/user-attachments/assets/dd3c4ff5-7bd0-4e9b-9a07-b92288c799b2



## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
no?
**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- fix: Xenos will no longer look stunned if killed by an AP rocket.
- fix: Defenders will no longer look stunned if hit by an AP rocket while fortified.
