### PR TITLE
Prevent the Queen from being pulled while alive, not stunned and not knocked down

### DIFF
--- a/Content.Shared/_RMC14/Pulling/ActivePreventPulledWhileAliveComponent.cs
+++ b/Content.Shared/_RMC14/Pulling/ActivePreventPulledWhileAliveComponent.cs
@@ -1,0 +1,7 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Pulling;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(CMPullingSystem))]
+public sealed partial class ActivePreventPulledWhileAliveComponent : Component;

--- a/Content.Shared/_RMC14/Pulling/CMPullingSystem.cs
+++ b/Content.Shared/_RMC14/Pulling/CMPullingSystem.cs
@@ -1,5 +1,4 @@
 ﻿using Content.Shared._RMC14.Xenonids.Parasite;
-using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Movement.Pulling.Components;
@@ -7,10 +6,10 @@ using Content.Shared.Movement.Pulling.Events;
 using Content.Shared.Movement.Pulling.Systems;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Popups;
+using Content.Shared.StatusEffect;
 using Content.Shared.Stunnable;
 using Content.Shared.Whitelist;
 using Robust.Shared.Audio.Systems;
-using Robust.Shared.Player;
 using Robust.Shared.Random;
 
 namespace Content.Shared._RMC14.Pulling;
@@ -20,15 +19,20 @@ public sealed class CMPullingSystem : EntitySystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly MovementSpeedModifierSystem _movementSpeed = default!;
+    [Dependency] private readonly SharedXenoParasiteSystem _parasite = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly PullingSystem _pulling = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
     [Dependency] private readonly SharedStunSystem _stun = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
-    [Dependency] private readonly SharedXenoParasiteSystem _parasite = default!;
+
+    private EntityQuery<PreventPulledWhileAliveComponent> _preventPulledWhileAliveQuery;
 
     public override void Initialize()
     {
+        _preventPulledWhileAliveQuery = GetEntityQuery<PreventPulledWhileAliveComponent>();
+
         SubscribeLocalEvent<ParalyzeOnPullAttemptComponent, PullAttemptEvent>(OnParalyzeOnPullAttempt);
         SubscribeLocalEvent<InfectOnPullAttemptComponent, PullAttemptEvent>(OnParalyzeOnPullAttempt);
 
@@ -42,6 +46,10 @@ public sealed class CMPullingSystem : EntitySystem
         SubscribeLocalEvent<BlockPullingDeadComponent, PullAttemptEvent>(OnBlockDeadPullAttempt);
         SubscribeLocalEvent<BlockPullingDeadComponent, PullStartedMessage>(OnBlockDeadPullStarted);
         SubscribeLocalEvent<BlockPullingDeadComponent, PullStoppedMessage>(OnBlockDeadPullStopped);
+
+        SubscribeLocalEvent<PreventPulledWhileAliveComponent, PullAttemptEvent>(OnPreventPulledWhileAliveAttempt);
+        SubscribeLocalEvent<PreventPulledWhileAliveComponent, PullStartedMessage>(OnPreventPulledWhileAliveStart);
+        SubscribeLocalEvent<PreventPulledWhileAliveComponent, PullStoppedMessage>(OnPreventPulledWhileAliveStop);
     }
 
     private void OnParalyzeOnPullAttempt(Entity<ParalyzeOnPullAttemptComponent> ent, ref PullAttemptEvent args)
@@ -177,6 +185,55 @@ public sealed class CMPullingSystem : EntitySystem
             RemCompDeferred<BlockPullingDeadActiveComponent>(ent);
     }
 
+    private void OnPreventPulledWhileAliveAttempt(Entity<PreventPulledWhileAliveComponent> ent, ref PullAttemptEvent args)
+    {
+        if (args.PulledUid != ent.Owner)
+            return;
+
+        if (!CanPullPreventPulledWhileAlive((ent, ent), args.PullerUid))
+        {
+            var msg = Loc.GetString("rmc-prevent-pull-alive", ("target", ent));
+            _popup.PopupClient(msg, ent, args.PullerUid, PopupType.SmallCaution);
+            args.Cancelled = true;
+        }
+    }
+
+    private void OnPreventPulledWhileAliveStart(Entity<PreventPulledWhileAliveComponent> ent, ref PullStartedMessage args)
+    {
+        if (args.PulledUid != ent.Owner)
+            return;
+
+        EnsureComp<ActivePreventPulledWhileAliveComponent>(ent);
+    }
+
+    private void OnPreventPulledWhileAliveStop(Entity<PreventPulledWhileAliveComponent> ent, ref PullStoppedMessage args)
+    {
+        if (args.PulledUid != ent.Owner)
+            return;
+
+        RemCompDeferred<ActivePreventPulledWhileAliveComponent>(ent);
+    }
+
+    private bool CanPullPreventPulledWhileAlive(Entity<PreventPulledWhileAliveComponent?> pulled, EntityUid user)
+    {
+        if (!Resolve(pulled, ref pulled.Comp, false))
+            return true;
+
+        if (!_mobState.IsAlive(pulled))
+            return true;
+
+        if (!_whitelist.IsWhitelistPassOrNull(pulled.Comp.Whitelist, user))
+            return true;
+
+        foreach (var effect in pulled.Comp.ExceptEffects)
+        {
+            if (_statusEffects.HasStatusEffect(pulled, effect))
+                return true;
+        }
+
+        return false;
+    }
+
     public override void Update(float frameTime)
     {
         var blockDeadActive = EntityQueryEnumerator<BlockPullingDeadActiveComponent, PullerComponent>();
@@ -190,6 +247,18 @@ public sealed class CMPullingSystem : EntitySystem
 
             if (_mobState.IsDead(pulling))
                 _pulling.TryStopPull(pulling, pullable, uid);
+        }
+
+        var preventPulledWhileAlive = EntityQueryEnumerator<ActivePreventPulledWhileAliveComponent, PreventPulledWhileAliveComponent, PullableComponent>();
+        while (preventPulledWhileAlive.MoveNext(out var uid, out _, out var prevent, out var pullable))
+        {
+            if (pullable.Puller is not { } puller ||
+                CanPullPreventPulledWhileAlive((uid, prevent), puller))
+            {
+                continue;
+            }
+
+            _pulling.TryStopPull(uid, pullable);
         }
     }
 }

--- a/Content.Shared/_RMC14/Pulling/PreventPulledWhileAliveComponent.cs
+++ b/Content.Shared/_RMC14/Pulling/PreventPulledWhileAliveComponent.cs
@@ -1,0 +1,17 @@
+﻿using Content.Shared.StatusEffect;
+using Content.Shared.Whitelist;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._RMC14.Pulling;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(CMPullingSystem))]
+public sealed partial class PreventPulledWhileAliveComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public EntityWhitelist? Whitelist;
+
+    [DataField, AutoNetworkedField]
+    public HashSet<ProtoId<StatusEffectPrototype>> ExceptEffects = new();
+}

--- a/Content.Shared/_RMC14/ShakeStun/StunShakeableSystem.cs
+++ b/Content.Shared/_RMC14/ShakeStun/StunShakeableSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared.Interaction;
 using Content.Shared.Popups;
 using Content.Shared.StatusEffect;
 using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
 namespace Content.Shared._RMC14.ShakeStun;
@@ -13,8 +14,10 @@ public sealed class StunShakeableSystem : EntitySystem
     [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
 
-    private const string Stun = "Stun";
-    private const string KnockedDown = "KnockedDown";
+    private static readonly ProtoId<StatusEffectPrototype> Stun = "Stun";
+    private static readonly ProtoId<StatusEffectPrototype> KnockedDown = "KnockedDown";
+    private static readonly ProtoId<StatusEffectPrototype> Muted = "Muted";
+    private static readonly ProtoId<StatusEffectPrototype> TemporaryBlindness = "TemporaryBlindness";
 
     public override void Initialize()
     {
@@ -43,15 +46,17 @@ public sealed class StunShakeableSystem : EntitySystem
 
         shakeableUser.LastShake = time;
         Dirty(user, shakeableUser);
+
         // Only remove muted & blindness if they're at the same timer
         // Simulating how in CM-13 you can wake up unconscious people (knockedout - knocked down, stunned, blinded, and muted)
-        if (_statusEffects.TryGetTime(target, "Muted", out var timeMute) && _statusEffects.TryGetTime(target, "TemporaryBlindness", out var timeBlind) && timeMute == timeBlind)
+        if (_statusEffects.TryGetTime(target, Muted, out var timeMute) && _statusEffects.TryGetTime(target, TemporaryBlindness, out var timeBlind) && timeMute == timeBlind)
         {
-            _statusEffects.TryRemoveTime(target, "Muted", ent.Comp.DurationRemoved);
-            _statusEffects.TryRemoveTime(target, "TemporaryBlindness", ent.Comp.DurationRemoved);
+            _statusEffects.TryRemoveTime(target, Muted, ent.Comp.DurationRemoved);
+            _statusEffects.TryRemoveTime(target, TemporaryBlindness, ent.Comp.DurationRemoved);
         }
-        _statusEffects.TryRemoveTime(target, "Stun", ent.Comp.DurationRemoved);
-        _statusEffects.TryRemoveTime(target, "KnockedDown", ent.Comp.DurationRemoved);
+
+        _statusEffects.TryRemoveTime(target, Stun, ent.Comp.DurationRemoved);
+        _statusEffects.TryRemoveTime(target, KnockedDown, ent.Comp.DurationRemoved);
         RemCompDeferred<TackledRecentlyComponent>(target);
 
         var userPopup = Loc.GetString("rmc-shake-awake-user", ("target", target));

--- a/Resources/Locale/en-US/_RMC14/pulling/pulling.ftl
+++ b/Resources/Locale/en-US/_RMC14/pulling/pulling.ftl
@@ -6,3 +6,5 @@ rmc-pull-paralyze-others = {$puller} tries to pull {$pulled}, but gets a tail sw
 
 rmc-pull-infect-self = You try to pull {$pulled}, but get jumped on and infected in the process!
 rmc-pull-infect-others = {$puller} tries to pull {$pulled}, but gets jumped on and infected in the process!
+
+rmc-prevent-pull-alive = You can't pull {THE($target)} while {SUBJECT($target)} {CONJUGATE-BE($target)} alive!

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
@@ -156,3 +156,10 @@
     - ActionXenoScreech
   - type: RMCXenoDamageVisuals
     prefix: queen
+  - type: PreventPulledWhileAlive
+    whitelist:
+      components:
+      - Xeno
+    exceptEffects:
+    - Stun
+    - Knockeddown

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
@@ -162,4 +162,4 @@
       - Xeno
     exceptEffects:
     - Stun
-    - Knockeddown
+    - KnockedDown


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed the Queen making no stomp sound when pulled. By making her unable to be pulled while alive, not stunned and not knocked down. You did this to yourselves. This is the best you are getting for now because I don't feel like ahelping more people about it while I go fix footstep sound code.