### PR TITLE
Tweak bursting

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
@@ -3,7 +3,6 @@ using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Xenonids.Announce;
 using Content.Shared._RMC14.Xenonids.Egg;
 using Content.Shared._RMC14.Xenonids.Hive;
-using Content.Shared._RMC14.Xenonids.Parasite;
 using Content.Shared.Actions;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Climbing.Components;

--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
@@ -591,9 +591,6 @@ public sealed class XenoEvolutionSystem : EntitySystem
                 continue;
             }
 
-            if (HasComp<BursterComponent>(uid))
-                continue;
-
             if (comp.Points < comp.Max || roundDuration < _evolutionAccumulatePointsBefore)
             {
                 if (needsOvipositor && comp.RequiresGranter && !hasGranter)

--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Xenonids.Announce;
 using Content.Shared._RMC14.Xenonids.Egg;
 using Content.Shared._RMC14.Xenonids.Hive;
+using Content.Shared._RMC14.Xenonids.Parasite;
 using Content.Shared.Actions;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Climbing.Components;
@@ -589,6 +590,9 @@ public sealed class XenoEvolutionSystem : EntitySystem
                 _audio.PlayEntity(comp.EvolutionReadySound, uid, uid);
                 continue;
             }
+
+            if (HasComp<BursterComponent>(uid))
+                continue;
 
             if (comp.Points < comp.Max || roundDuration < _evolutionAccumulatePointsBefore)
             {

--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
@@ -54,9 +54,9 @@ public sealed class XenoEvolutionSystem : EntitySystem
     [Dependency] private readonly SharedXenoAnnounceSystem _xenoAnnounce = default!;
     [Dependency] private readonly SharedXenoHiveSystem _xenoHive = default!;
     [Dependency] private readonly SharedHandsSystem _hands = default!;
-	[Dependency] private readonly SharedContainerSystem _container = default!;
+    [Dependency] private readonly SharedContainerSystem _container = default!;
 
-	private TimeSpan _evolutionPointsRequireOvipositorAfter;
+    private TimeSpan _evolutionPointsRequireOvipositorAfter;
     private TimeSpan _evolutionAccumulatePointsBefore;
 
     private readonly HashSet<EntityUid> _climbable = new();

--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
@@ -22,6 +22,7 @@ using Content.Shared.Popups;
 using Content.Shared.Prototypes;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Configuration;
+using Robust.Shared.Containers;
 using Robust.Shared.Network;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Player;
@@ -53,8 +54,9 @@ public sealed class XenoEvolutionSystem : EntitySystem
     [Dependency] private readonly SharedXenoAnnounceSystem _xenoAnnounce = default!;
     [Dependency] private readonly SharedXenoHiveSystem _xenoHive = default!;
     [Dependency] private readonly SharedHandsSystem _hands = default!;
+	[Dependency] private readonly SharedContainerSystem _container = default!;
 
-    private TimeSpan _evolutionPointsRequireOvipositorAfter;
+	private TimeSpan _evolutionPointsRequireOvipositorAfter;
     private TimeSpan _evolutionAccumulatePointsBefore;
 
     private readonly HashSet<EntityUid> _climbable = new();
@@ -318,6 +320,14 @@ public sealed class XenoEvolutionSystem : EntitySystem
 
         if (!_prototypes.TryIndex(newXeno, out var prototype))
             return true;
+
+        if(_container.IsEntityInContainer(xeno))
+        {
+            if (doPopup)
+                _popup.PopupEntity(Loc.GetString("rmc-xeno-evolution-failed-bad-location"), xeno, xeno, PopupType.MediumCaution);
+
+            return false;
+        }
 
         // TODO RMC14 revive jelly when added should not bring back dead queens
         if (prototype.TryGetComponent(out XenoEvolutionCappedComponent? capped, _compFactory) &&

--- a/Content.Shared/_RMC14/Xenonids/Parasite/BursterComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Parasite/BursterComponent.cs
@@ -1,0 +1,10 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.Parasite;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class BursterComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public EntityUid BurstFrom;
+}

--- a/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
@@ -17,6 +17,7 @@ using Content.Shared.Jittering;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
+using Content.Shared.Movement.Events;
 using Content.Shared.Popups;
 using Content.Shared.Rejuvenate;
 using Content.Shared.Standing;
@@ -83,6 +84,8 @@ public abstract class SharedXenoParasiteSystem : EntitySystem
             after: [typeof(MobThresholdSystem), typeof(SharedXenoPheromonesSystem)]);
         SubscribeLocalEvent<VictimBurstComponent, RejuvenateEvent>(OnVictimBurstRejuvenate);
         SubscribeLocalEvent<VictimBurstComponent, ExaminedEvent>(OnVictimBurstExamine);
+
+        SubscribeLocalEvent<BursterComponent, MoveInputEvent>(OnTryMove);
     }
 
     private void OnInfectableActivate(Entity<InfectableComponent> ent, ref ActivateInWorldEvent args)
@@ -412,7 +415,7 @@ public abstract class SharedXenoParasiteSystem : EntitySystem
                 continue;
 
             // 20 seconds before burst, spawn the larva
-            if (infected.BurstAt - infected.SpawnLarvaBefore < time && infected.SpawnedLarva == null)
+            if (infected.BurstAt <= time && infected.SpawnedLarva == null)
             {
                 var spawned = SpawnAtPosition(infected.BurstSpawn, xform.Coordinates);
                 _xeno.SetHive(spawned, infected.Hive);
@@ -420,10 +423,17 @@ public abstract class SharedXenoParasiteSystem : EntitySystem
                 var larvaContainer = _container.EnsureContainer<ContainerSlot>(uid, infected.LarvaContainerId);
                 _container.Insert(spawned, larvaContainer);
 
+                infected.CurrentStage = 6;
+                Dirty(uid, infected);
+
                 infected.SpawnedLarva = spawned;
+
+                EnsureComp<BursterComponent>(spawned, out var burster);
+                burster.BurstFrom = uid;
+
             }
 
-            if (infected.BurstAt > time)
+            if (infected.BurstAt + infected.AutoBurstTime > time)
             {
                 // Embryo dies if unrevivable when dead
                 // Kill the embryo if we've rotted or are a simplemob
@@ -452,11 +462,9 @@ public abstract class SharedXenoParasiteSystem : EntitySystem
                 {
                     _popup.PopupEntity(Loc.GetString("rmc-xeno-infection-burst-soon-self"), uid, uid, PopupType.MediumCaution);
                     _popup.PopupEntity(Loc.GetString("rmc-xeno-infection-burst-soon", ("victim", uid)), uid, Filter.PvsExcept(uid), true, PopupType.MediumCaution);
-                    
+
                     var knockdownTime = infected.BaseKnockdownTime * 75;
-                    _jitter.DoJitter(uid, knockdownTime, false);
-                    _stun.TryParalyze(uid, knockdownTime, false);
-                    _status.TryAddStatusEffect(uid, "TemporaryBlindness", knockdownTime, true, "TemporaryBlindness");
+                    InfectionShakes(uid, infected, knockdownTime, knockdownTime, false);
                     infected.DidBurstWarning = true;
 
                     continue;
@@ -473,10 +481,7 @@ public abstract class SharedXenoParasiteSystem : EntitySystem
                         _popup.PopupEntity(message, uid, uid, PopupType.LargeCaution);
 
                         var knockdownTime = infected.BaseKnockdownTime * 10;
-                        _jitter.DoJitter(uid, knockdownTime, false);
-                        _stun.TryParalyze(uid, knockdownTime, false);
-                        _status.TryAddStatusEffect(uid, "TemporaryBlindness", knockdownTime, true, "TemporaryBlindness");
-                        _damage.TryChangeDamage(uid, infected.InfectionDamage, true, false);
+                        InfectionShakes(uid, infected, knockdownTime, knockdownTime, false);
                     }
                 }
                 else if (stage >= infected.FinalSymptomsStart)
@@ -533,21 +538,13 @@ public abstract class SharedXenoParasiteSystem : EntitySystem
                 continue;
             }
 
-            RemCompDeferred<VictimInfectedComponent>(uid);
+            Burst((uid, infected));
 
-            if (_container.TryGetContainer(uid, infected.LarvaContainerId, out var container))
-                _container.EmptyContainer(container);
-
-            Dirty(uid, infected);
-
-            EnsureComp<VictimBurstComponent>(uid);
-
-            _audio.PlayPvs(infected.BurstSound, uid);
         }
     }
 
     // Shakes chances decrease as symptom stages progress, and they get longer
-    private void InfectionShakes(EntityUid victim, VictimInfectedComponent infected, TimeSpan knockdownTime, TimeSpan jitterTime)
+    private void InfectionShakes(EntityUid victim, VictimInfectedComponent infected, TimeSpan knockdownTime, TimeSpan jitterTime, bool popups = true)
     {
         // Don't activate when unconscious
         if (_mobState.IsIncapacitated(victim))
@@ -557,8 +554,36 @@ public abstract class SharedXenoParasiteSystem : EntitySystem
         _status.TryAddStatusEffect(victim, "Muted", knockdownTime, true, "Muted");
         _status.TryAddStatusEffect(victim, "TemporaryBlindness", knockdownTime, true, "TemporaryBlindness");
         _jitter.DoJitter(victim, jitterTime, false);
-        _popup.PopupEntity(Loc.GetString("rmc-xeno-infection-shakes-self"), victim, victim, PopupType.MediumCaution);
-        _popup.PopupEntity(Loc.GetString("rmc-xeno-infection-shakes", ("victim", victim)), victim, Filter.PvsExcept(victim), true, PopupType.MediumCaution);
         _damage.TryChangeDamage(victim, infected.InfectionDamage, true, false);
+        if (!popups)
+            return;
+        _popup.PopupEntity(Loc.GetString("rmc-xeno-infection-shakes-self"), victim, victim, PopupType.MediumCaution);
+        _popup.PopupEntity(Loc.GetString("rmc-xeno-infection-shakes", ("victim", victim)), victim, Filter.PvsExcept(victim), true, PopupType.MediumCaution);        
+    }
+
+    private void Burst(Entity<VictimInfectedComponent> burstFrom)
+    {
+        if (_net.IsClient)
+            return;
+        RemCompDeferred<VictimInfectedComponent>(burstFrom);
+
+        if (_container.TryGetContainer(burstFrom, burstFrom.Comp.LarvaContainerId, out var container))
+        {
+            foreach (var larva in container.ContainedEntities)
+                RemCompDeferred<BursterComponent>(larva);
+            _container.EmptyContainer(container);
+        }
+
+        Dirty(burstFrom, burstFrom.Comp);
+
+        EnsureComp<VictimBurstComponent>(burstFrom);
+
+        _audio.PlayPvs(burstFrom.Comp.BurstSound, burstFrom);
+    }
+
+    private void OnTryMove(Entity<BursterComponent> burster, ref MoveInputEvent args)
+    {
+        if(TryComp<VictimInfectedComponent>(burster.Comp.BurstFrom, out var infected))
+            Burst((burster.Comp.BurstFrom, infected));
     }
 }

--- a/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
@@ -437,9 +437,12 @@ public abstract class SharedXenoParasiteSystem : EntitySystem
             {
                 // Embryo dies if unrevivable when dead
                 // Kill the embryo if we've rotted or are a simplemob
-                if (_mobState.IsDead(uid) && (HasComp<InfectStopOnDeathComponent>(uid) || _rotting.IsRotten(uid)) && infected.SpawnedLarva == null)
+                if (_mobState.IsDead(uid) && (HasComp<InfectStopOnDeathComponent>(uid) || _rotting.IsRotten(uid)))
                 {
-                    RemCompDeferred<VictimInfectedComponent>(uid);
+                    if (infected.SpawnedLarva != null)
+                        Burst((uid, infected));
+                    else
+                        RemCompDeferred<VictimInfectedComponent>(uid);
                     continue;
                 }
                 // Stasis slows this, while nesting makes it happen sooner

--- a/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
@@ -437,7 +437,7 @@ public abstract class SharedXenoParasiteSystem : EntitySystem
             {
                 // Embryo dies if unrevivable when dead
                 // Kill the embryo if we've rotted or are a simplemob
-                if (_mobState.IsDead(uid) && (HasComp<InfectStopOnDeathComponent>(uid) || _rotting.IsRotten(uid)))
+                if (_mobState.IsDead(uid) && (HasComp<InfectStopOnDeathComponent>(uid) || _rotting.IsRotten(uid)) && infected.SpawnedLarva == null)
                 {
                     RemCompDeferred<VictimInfectedComponent>(uid);
                     continue;

--- a/Content.Shared/_RMC14/Xenonids/Parasite/VictimInfectedComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Parasite/VictimInfectedComponent.cs
@@ -60,10 +60,10 @@ public sealed partial class VictimInfectedComponent : Component
     public TimeSpan BurstDelay = TimeSpan.FromMinutes(8);
 
     /// <summary>
-    ///     When the larva should be spawned before burst.
+    ///     When the larva should be kicked out after the intial burst time.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public TimeSpan SpawnLarvaBefore = TimeSpan.FromSeconds(20);
+    public TimeSpan AutoBurstTime = TimeSpan.FromSeconds(60);
 
     [DataField, AutoNetworkedField]
     public TimeSpan AttachedAt;
@@ -114,7 +114,7 @@ public sealed partial class VictimInfectedComponent : Component
     public int FinalSymptomsStart = 4;
 
     [DataField]
-    public int BurstWarningStart = 5;
+    public int BurstWarningStart = 6;
 
     [DataField]
     public float ShakesChance = 0.08f;

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
@@ -26,6 +26,7 @@ rmc-xeno-evolution-cant-evolve-damaged = We must be at full health to evolve.
 rmc-xeno-evolution-cant-devolve-damaged = We are too weak to deevolve, we must regain our health first.
 rmc-xeno-evolution-cant-evolve-recent-queen-death-minutes = We must wait about {$minutes} minutes and {$seconds} seconds for the hive to recover from the previous Queen's death.
 rmc-xeno-evolution-cant-evolve-recent-queen-death-seconds = We must wait about {$seconds} seconds for the hive to recover from the previous Queen's death.
+rmc-xeno-evolution-failed-bad-location = We can't evolve here.
 
 # Fortify
 cm-xeno-fortify-cant-headbutt = You can't headbutt while fortifying!


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
There is now 60 seconds before a larva autobursts. It now also doesn't eat into the original burst time, and is instead added onto it.

It properly sets the stage to stage 6 when the larva spawns. The larva can now move to instantly burst instead of waiting out the timer.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
CM-13 parity.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Evo system now checks for a burster component and doesn't give points if found. This burster component is also checked for movement to burst the target, and is removed upon bursting.

InputMoveEvent on the burster component will burst the victim instantly. Rotting will also make autobursting happen.

Some cleanup was done to remove redundancy. Some other notes:
There is a seperate countdown for a larva autobursting and when a player takes them. The first is about 60 seconds and the second is 20. Leaving it at 60 for now until that's implemented in (probably with queue).

Also prevent evolving while in a container, for obvious reasons.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/user-attachments/assets/e18f5d8c-0fa8-44ad-ae3e-68126d5fefe5



## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- fix: Larva auto-burst time has been upped to 60 (from 20) seconds
- fix: Larva can now move to burst immediately from their host
