### PR TITLE
Fix xenos not being able to open hypersleep chambers, body bags, closets, morgues and crematoriums

### DIFF
--- a/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Numerics;
+using Content.Shared._RMC14.Xenonids;
 using Content.Shared.Body.Components;
 using Content.Shared.Destructible;
 using Content.Shared.Foldable;
@@ -16,16 +17,13 @@ using Content.Shared.Tools.Systems;
 using Content.Shared.Verbs;
 using Content.Shared.Wall;
 using Content.Shared.Whitelist;
-using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Physics;
-using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
@@ -183,7 +181,8 @@ public abstract class SharedEntityStorageSystem : EntitySystem
 
         if (component.Open)
         {
-            TryCloseStorage(target);
+            if (!HasComp<XenoComponent>(user))
+                TryCloseStorage(target);
         }
         else
         {

--- a/Content.Shared/_RMC14/Interaction/InsertBlacklistComponent.cs
+++ b/Content.Shared/_RMC14/Interaction/InsertBlacklistComponent.cs
@@ -5,7 +5,7 @@ namespace Content.Shared._RMC14.Interaction;
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 [Access(typeof(RMCInteractionSystem))]
-public sealed partial class InteractedBlacklistComponent : Component
+public sealed partial class InsertBlacklistComponent : Component
 {
     [DataField(required: true), AutoNetworkedField]
     public EntityWhitelist? Blacklist;

--- a/Content.Shared/_RMC14/Interaction/RMCInteractionSystem.cs
+++ b/Content.Shared/_RMC14/Interaction/RMCInteractionSystem.cs
@@ -1,15 +1,17 @@
 ﻿using Content.Shared.Interaction.Events;
 using Content.Shared.Whitelist;
+using Robust.Shared.Containers;
 
 namespace Content.Shared._RMC14.Interaction;
 
-public sealed class CMInteractionSystem : EntitySystem
+public sealed class RMCInteractionSystem : EntitySystem
 {
     [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
 
     public override void Initialize()
     {
         SubscribeLocalEvent<InteractedBlacklistComponent, GettingInteractedWithAttemptEvent>(OnBlacklistInteractionAttempt);
+        SubscribeLocalEvent<InsertBlacklistComponent, ContainerGettingInsertedAttemptEvent>(OnInsertBlacklistContainerInsertedAttempt);
     }
 
     private void OnBlacklistInteractionAttempt(Entity<InteractedBlacklistComponent> ent, ref GettingInteractedWithAttemptEvent args)
@@ -19,5 +21,14 @@ public sealed class CMInteractionSystem : EntitySystem
 
         if (_whitelist.IsValid(ent.Comp.Blacklist, args.Uid))
             args.Cancelled = true;
+    }
+
+    private void OnInsertBlacklistContainerInsertedAttempt(Entity<InsertBlacklistComponent> ent, ref ContainerGettingInsertedAttemptEvent args)
+    {
+        if (args.Cancelled || ent.Comp.Blacklist is not { } blacklist)
+            return;
+
+        if (_whitelist.IsValid(blacklist, args.EntityUid))
+            args.Cancel();
     }
 }

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Medical/bodybags.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Medical/bodybags.yml
@@ -21,7 +21,7 @@
     state: bodybag_closed
   - type: EntityStorageVisuals
     stateDoorOpen: bodybag_open
-  - type: InteractedBlacklist
+  - type: InsertBlacklist
     blacklist:
       components:
       - Xeno

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/hypersleep.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/hypersleep.yml
@@ -49,7 +49,7 @@
         enum.HyperSleepChamberLayers.Base:
           True: { state: closed }
           False: { state: open }
-  - type: InteractedBlacklist
+  - type: InsertBlacklist
     blacklist:
       components:
       - Xeno

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Storage/closets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Storage/closets.yml
@@ -20,7 +20,7 @@
     stateBaseClosed: base
     stateDoorOpen: open
     stateDoorClosed: closed
-  - type: InteractedBlacklist
+  - type: InsertBlacklist
     blacklist:
       components:
       - Xeno

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Storage/morgue.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Storage/morgue.yml
@@ -35,7 +35,7 @@
           HasContents: {visible: true}
           HasMob: {visible: true}
           HasSoul: {visible: true}
-  - type: InteractedBlacklist
+  - type: InsertBlacklist
     blacklist:
       components:
       - Xeno
@@ -75,7 +75,7 @@
         enum.CrematoriumVisualLayers.LightContent:
           True: { visible: true }
           False: { visible: false }
-  - type: InteractedBlacklist
+  - type: InsertBlacklist
     blacklist:
       components:
       - Xeno


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed xenonids not being able to open hypersleep chambers, body bags, closets, morgues and crematoriums. Xehonids still cannot close them nor be inserted into them.