### PR TITLE
Decrease tail sweep range from 1.5 to 1.25

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Sweep/XenoTailSweepSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Sweep/XenoTailSweepSystem.cs
@@ -59,7 +59,7 @@ public sealed class XenoTailSweepSystem : EntitySystem
             return;
 
         _hit.Clear();
-        _entityLookup.GetEntitiesInRange(transform.Coordinates, 1.5f, _hit);
+        _entityLookup.GetEntitiesInRange(transform.Coordinates, 1.25f, _hit);
 
         var origin = _transform.GetMapCoordinates(xeno);
         foreach (var marine in _hit)


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed some cases where the Defender's tail sweep was able to hit through walls. This reduces the range from 1.5 tiles to 1.25.