### PR TITLE
Fix eggs being buildable on top of normal doors

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
@@ -48,6 +48,7 @@ public sealed class XenoEggSystem : EntitySystem
     [Dependency] private readonly SharedMindSystem _mind = default!;
 	[Dependency] private readonly CMHandsSystem _rmcHands = default!;
 
+	private static readonly ProtoId<TagPrototype> AirlockTag = "Airlock";
 	private static readonly ProtoId<TagPrototype> StructureTag = "Structure";
 
     private EntityQuery<StepTriggerComponent> _stepTriggerQuery;
@@ -209,7 +210,7 @@ public sealed class XenoEggSystem : EntitySystem
             }
 
             if (HasComp<XenoConstructComponent>(uid) ||
-                _tags.HasTag(uid.Value, StructureTag))
+                _tags.HasAnyTag(uid.Value, StructureTag, AirlockTag))
             {
                 var msg = Loc.GetString("cm-xeno-egg-blocked");
                 _popup.PopupClient(msg, uid.Value, user, PopupType.SmallCaution);


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed xeno eggs being buildable on top of normal doors.