### PR TITLE
Fix crash landing damage dealing damage past 719

### DIFF
--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
@@ -661,7 +661,7 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
                 },
             };
 
-            _damageable.TryChangeDamage(crashLandable, damage, true);
+            _damageable.TryChangeDamage(crashLandable, damage);
             _transform.SetMapCoordinates(crashLandable, _transform.ToMapCoordinates(targetCoords));
             break;
         }


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed crash land damage bypassing the damage limit of 719, making those that are crash-landed unrevivable.
