### PR TITLE
Fix some rounds choosing the warship as primary LZ at round-start

### DIFF
--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
@@ -118,10 +118,10 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
     [ViewVariables]
     public readonly Dictionary<string, float> MarinesPerXeno = new()
     {
-        ["/Maps/_RMC14/lv624.yml"] = 4.25f,
-        ["/Maps/_RMC14/solaris.yml"] = 6.75f,
-        ["/Maps/_RMC14/prison.yml"] = 5.75f,
-        ["/Maps/_RMC14/shiva.yml"] = 6.75f,
+        ["/Maps/_RMC14/lv624.yml"] = 5f,
+        ["/Maps/_RMC14/solaris.yml"] = 7.5f,
+        ["/Maps/_RMC14/prison.yml"] = 7.5f,
+        ["/Maps/_RMC14/shiva.yml"] = 7.5f,
     };
 
     private readonly List<MapId> _almayerMaps = [];

--- a/Content.Shared/_RMC14/CCVar/RMCCVars.cs
+++ b/Content.Shared/_RMC14/CCVar/RMCCVars.cs
@@ -64,7 +64,7 @@ public sealed class RMCCVars : CVars
         CVarDef.Create("rmc.auto_balance_min", 3f, CVar.REPLICATED | CVar.SERVER);
 
     public static readonly CVarDef<float> RMCAutoBalanceMax =
-        CVarDef.Create("rmc.auto_balance_max", 7.5f, CVar.REPLICATED | CVar.SERVER);
+        CVarDef.Create("rmc.auto_balance_max", 8f, CVar.REPLICATED | CVar.SERVER);
 
     public static readonly CVarDef<int> RMCPatronLobbyMessageTimeSeconds =
         CVarDef.Create("rmc.patron_lobby_message_time_seconds", 30, CVar.REPLICATED | CVar.SERVER);
@@ -76,10 +76,10 @@ public sealed class RMCCVars : CVars
         CVarDef.Create("rmc.discord_account_linking_message_link", "", CVar.REPLICATED | CVar.SERVER);
 
     public static readonly CVarDef<int> RMCRequisitionsStartingBalance =
-        CVarDef.Create("rmc.requisitions_starting_balance", 50000, CVar.REPLICATED | CVar.SERVER);
+        CVarDef.Create("rmc.requisitions_starting_balance", 80000, CVar.REPLICATED | CVar.SERVER);
 
     public static readonly CVarDef<int> RMCRequisitionsBalanceGain =
-        CVarDef.Create("rmc.requisitions_balance_gain", 1000, CVar.REPLICATED | CVar.SERVER);
+        CVarDef.Create("rmc.requisitions_balance_gain", 1500, CVar.REPLICATED | CVar.SERVER);
 
     public static readonly CVarDef<string> RMCDiscordToken =
         CVarDef.Create("rmc.discord_token", "", CVar.SERVER | CVar.SERVERONLY | CVar.CONFIDENTIAL);
@@ -107,8 +107,10 @@ public sealed class RMCCVars : CVars
 
     public static readonly CVarDef<int> RMCCorrosiveAcidTickDelaySeconds =
         CVarDef.Create("rmc.corrosive_acid_tick_delay_seconds", 10, CVar.REPLICATED | CVar.SERVER);
+
     public static readonly CVarDef<string> RMCCorrosiveAcidDamageType =
         CVarDef.Create("rmc.corrosive_acid_damage_type", "Heat", CVar.REPLICATED | CVar.SERVER);
+
     public static readonly CVarDef<int> RMCTailStabMaxTargets =
         CVarDef.Create("rmc.tail_stab_max_targets", 1, CVar.REPLICATED | CVar.SERVER);
 
@@ -146,7 +148,7 @@ public sealed class RMCCVars : CVars
         CVarDef.Create("rmc.bioscan_variance", 2, CVar.REPLICATED | CVar.SERVER);
 
     public static readonly CVarDef<int> RMCDropshipFabricatorStartingPoints =
-        CVarDef.Create("rmc.dropship_fabricator_starting_points", 10000, CVar.REPLICATED | CVar.SERVER);
+        CVarDef.Create("rmc.dropship_fabricator_starting_points", 20000, CVar.REPLICATED | CVar.SERVER);
 
     public static readonly CVarDef<float> RMCDropshipFabricatorGainEverySeconds =
         CVarDef.Create("rmc.dropship_fabricator_gain_every_seconds", 3.33333f, CVar.REPLICATED | CVar.SERVER);

--- a/Content.Shared/_RMC14/Dropship/SharedDropshipSystem.cs
+++ b/Content.Shared/_RMC14/Dropship/SharedDropshipSystem.cs
@@ -1,9 +1,8 @@
 ﻿using System.Linq;
 using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Dropship.Weapon;
-using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.Marines.Announce;
-using Content.Shared._RMC14.Marines.Skills;
+using Content.Shared._RMC14.Rules;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
@@ -26,7 +25,6 @@ public abstract class SharedDropshipSystem : EntitySystem
     [Dependency] private readonly SharedMarineAnnounceSystem _marineAnnounce = default!;
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
-    [Dependency] private readonly SkillsSystem _skills = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
 
@@ -326,8 +324,8 @@ public abstract class SharedDropshipSystem : EntitySystem
             return false;
         }
 
-        if (HasComp<AlmayerComponent>(_transform.GetGrid(lz)) ||
-            HasComp<AlmayerComponent>(_transform.GetMap(lz)))
+        if (!HasComp<RMCPlanetComponent>(_transform.GetGrid(lz)) &&
+            !HasComp<RMCPlanetComponent>(_transform.GetMap(lz)))
         {
             Log.Warning($"{ToPrettyString(actor)} tried to designate entity {ToPrettyString(lz)} on the warship as primary LZ!");
             return false;
@@ -358,8 +356,11 @@ public abstract class SharedDropshipSystem : EntitySystem
         var landingZoneQuery = EntityQueryEnumerator<DropshipDestinationComponent, MetaDataComponent, TransformComponent>();
         while (landingZoneQuery.MoveNext(out var uid, out _, out var metaData, out var xform))
         {
-            if (HasComp<AlmayerComponent>(xform.ParentUid) || HasComp<AlmayerComponent>(xform.MapUid))
+            if (!HasComp<RMCPlanetComponent>(xform.ParentUid) &&
+                !HasComp<RMCPlanetComponent>(xform.MapUid))
+            {
                 continue;
+            }
 
             yield return (uid, metaData);
         }

--- a/Content.Shared/_RMC14/Dropship/Weapon/SharedDropshipWeaponSystem.cs
+++ b/Content.Shared/_RMC14/Dropship/Weapon/SharedDropshipWeaponSystem.cs
@@ -20,6 +20,7 @@ using Content.Shared.Item;
 using Content.Shared.Light.Components;
 using Content.Shared.Popups;
 using Content.Shared.Shuttles.Components;
+using Content.Shared.Shuttles.Systems;
 using Content.Shared.Throwing;
 using Content.Shared.Timing;
 using Robust.Shared.Audio.Systems;
@@ -461,7 +462,8 @@ public abstract class SharedDropshipWeaponSystem : EntitySystem
             if (!_dropship.TryGetGridDropship(weapon.Value, out dropship))
                 return;
 
-            if (!HasComp<FTLComponent>(dropship))
+            if (!TryComp(dropship, out FTLComponent? ftl) ||
+                (ftl.State != FTLState.Travelling && ftl.State != FTLState.Arriving))
             {
                 var msg = Loc.GetString("rmc-dropship-weapons-fire-not-flying");
                 _popup.PopupClient(msg, actor, PopupType.SmallCaution);


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed dropships being able to shoot their weapons while recharging or launching.
- fix: Fixed some rounds automatically choosing the hangar bays as primary landing zone on round-start, making it impossible for xenos to call down a dropship for hijack.
