### PR TITLE
Fix signal flare box name and desc

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Tools/flares.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Tools/flares.yml
@@ -59,7 +59,7 @@
   parent: CMFlare
   id: RMCFlareCAS
   name: signal flare
-  description: A green USCM issued signal flare. The telemetry computer works on chemical reaction that releases smoke and light and thus works only while the flare is burning.
+  description: A green UNMC issued signal flare. The telemetry computer works on chemical reaction that releases smoke and light and thus works only while the flare is burning.
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Misc/cas_flares.rsi
@@ -177,6 +177,8 @@
 - type: entity
   parent: CMPackFlareBase
   id: RMCPackFlareCAS
+  name: M89-S signal flare pack
+  description: A packet of eight M89-S Signal Marking Flares.
   suffix: Filled
   components:
   - type: Sprite


### PR DESCRIPTION
## About the PR

Fixes #3735

**Changelog**

:cl:
- fix: Signal Flare pack now has the correct name.