### PR TITLE
fix(CMFax): Make the Fax use the new default paper.

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/fax_machine.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/fax_machine.yml
@@ -26,6 +26,9 @@
     blacklist:
       components:
       - Xeno
+  - type: FaxMachine
+    printPaperId: CMPaper
+    printOfficePaperId: CMPaper
 
 - type: entity
   parent: CMFax


### PR DESCRIPTION
## About the PR
The upstream FaxMachine component has options to set the paper entity now thus allowing the default paper to be CMPaper when you Open File to print something from a fax machine.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- fix: Fax Machines now print local files using the CMPaper sprite.
