### PR TITLE
Add examine text to each dropship weapon point for gun and ammo loaded

### DIFF
--- a/Resources/Locale/en-US/_RMC14/dropship/rmc-dropship.ftl
+++ b/Resources/Locale/en-US/_RMC14/dropship/rmc-dropship.ftl
@@ -59,6 +59,10 @@ rmc-dropship-weapons-fire-not-skilled = You don't have the training to fire this
 rmc-dropship-weapons-fire-no-ammo = {$weapon} has no ammo.
 rmc-dropship-weapons-fire-cooldown = {$weapon} just fired, wait for it to cool down.
 
+rmc-dropship-weapons-point-gun = It has a {$weapon} loaded.
+rmc-dropship-weapons-point-ammo = It has a {$ammo} loaded.
+rmc-dropship-weapons-rounds-left = It has {$current} out of {$max} rounds left.
+
 rmc-dropship-flyby-no-skill = You don't have the skill to perform a flyby.
 
 rmc-dropship-fabricator-title = Part Fabricator

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Dropships/alamo_walls.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Dropships/alamo_walls.yml
@@ -655,6 +655,7 @@
   parent: CMBaseAlamoWall
   id: CMAlamoWall61
   name: port wing weapon attach point
+  description: A place where heavy equipment can be installed with a powerloader.
   suffix: 61
   components:
   - type: Sprite
@@ -706,6 +707,7 @@
   parent: CMBaseAlamoWall
   id: CMAlamoWall65
   name: starboard wing weapon attach point
+  description: A place where heavy equipment can be installed with a powerloader.
   suffix: 65
   components:
   - type: Sprite
@@ -919,6 +921,7 @@
   parent: CMBaseAlamoWall
   id: CMAlamoWall84
   name: port fore weapon attach point
+  description: A place where heavy equipment can be installed with a powerloader.
   suffix: 84
   components:
   - type: Sprite
@@ -940,6 +943,7 @@
   parent: CMAlamoWall84
   id: CMAlamoWall84Flipped
   name: starboard fore weapon attach point
+  description: A place where heavy equipment can be installed with a powerloader.
   suffix: 84, Flipped
   components:
   - type: Sprite
@@ -952,6 +956,7 @@
   parent: CMBaseAlamoWall
   id: CMAlamoWall85
   name: electronic system attach point
+  description: A place where heavy equipment can be installed with a powerloader.
   suffix: 85
   components:
   - type: Sprite

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Dropships/normandy_walls.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Dropships/normandy_walls.yml
@@ -615,6 +615,7 @@
   parent: [CMBaseNormandyWall, CMAlamoWall61]
   id: CMNormandyWall61
   name: port wing weapon attach point
+  description: A place where heavy equipment can be installed with a powerloader.
   suffix: 61
   components:
   - type: Sprite
@@ -659,6 +660,7 @@
   parent: [CMBaseNormandyWall, CMAlamoWall65]
   id: CMNormandyWall65
   name: starboard wing weapon attach point
+  description: A place where heavy equipment can be installed with a powerloader.
   suffix: 65
   components:
   - type: Sprite
@@ -853,6 +855,7 @@
   parent: [CMBaseNormandyWall, CMAlamoWall84]
   id: CMNormandyWall84
   name: port fore weapon attach point
+  description: A place where heavy equipment can be installed with a powerloader.
   suffix: 84
   components:
   - type: Sprite
@@ -867,6 +870,7 @@
   parent: [CMNormandyWall84, CMAlamoWall84Flipped]
   id: CMNormandyWall84Flipped
   name: starboard fore weapon attach point
+  description: A place where heavy equipment can be installed with a powerloader.
   suffix: 84, Flipped
   components:
   - type: Sprite
@@ -879,6 +883,7 @@
   parent: [CMBaseNormandyWall, CMAlamoWall85]
   id: CMNormandyWall85
   name: electronic system attach point
+  description: A place where heavy equipment can be installed with a powerloader.
   suffix: 85
   components:
   - type: Sprite


### PR DESCRIPTION
## About the PR
## Media
## Requirements
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: Examining a dropship weapon attach point will now tell you what gun and ammo it has loaded, and how many rounds it has left.
