### PR TITLE
Make suit lights turn off when the marine dies, infected, etc

### DIFF
--- a/Content.Server/_RMC14/Marines/Armor/RMCSuitLightSystem.cs
+++ b/Content.Server/_RMC14/Marines/Armor/RMCSuitLightSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared._RMC14.Marines.Armor;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared._RMC14.Xenonids.Devour;
 using Content.Shared._RMC14.Xenonids.Parasite;
+using Content.Shared.Clothing;
 using Content.Shared.Inventory;
 using Content.Shared.Light.Components;
 using Content.Shared.Mobs;
@@ -19,9 +20,15 @@ public sealed class RMCSuitLightSystem : EntitySystem
 
     public override void Initialize()
     {
+        SubscribeLocalEvent<RMCSuitLightComponent, ClothingGotUnequippedEvent>(OnUnequip);
         SubscribeLocalEvent<MobStateChangedEvent>(OnMobStateChanged);
         SubscribeLocalEvent<VictimInfectedComponent, ComponentStartup>(OnComponentStartup);
         SubscribeLocalEvent<MarineComponent, XenoDevouredEvent>(OnDevour);
+    }
+
+    private void OnUnequip(Entity<RMCSuitLightComponent> ent, ref ClothingGotUnequippedEvent args)
+    {
+        ShortLights(ent.Owner, args.Wearer);
     }
 
     private void OnMobStateChanged(MobStateChangedEvent args)
@@ -63,7 +70,7 @@ public sealed class RMCSuitLightSystem : EntitySystem
             _lights.TurnOff(ent);
 
             var popup = Loc.GetString("rmc-suit-light-short");
-            _popup.PopupClient(popup, user);
+            _popup.PopupEntity(popup, user, user);
         }
     }
 

--- a/Content.Server/_RMC14/Marines/Armor/RMCSuitLightSystem.cs
+++ b/Content.Server/_RMC14/Marines/Armor/RMCSuitLightSystem.cs
@@ -1,27 +1,32 @@
-﻿using Content.Shared._RMC14.Xenonids.Parasite;
+﻿using Content.Server.Light.EntitySystems;
+using Content.Shared._RMC14.Marines;
+using Content.Shared._RMC14.Marines.Armor;
+using Content.Shared._RMC14.Xenonids;
+using Content.Shared._RMC14.Xenonids.Devour;
+using Content.Shared._RMC14.Xenonids.Parasite;
 using Content.Shared.Inventory;
-using Content.Shared.Inventory.Events;
-using Content.Shared.Item.ItemToggle;
+using Content.Shared.Light.Components;
 using Content.Shared.Mobs;
 using Content.Shared.Popups;
 
-namespace Content.Shared._RMC14.Marines.Armor;
+namespace Content.Server._RMC14.Marines.Armor;
 
 public sealed class RMCSuitLightSystem : EntitySystem
 {
     [Dependency] private readonly SharedPopupSystem _popup = default!;
-    [Dependency] private readonly ItemToggleSystem _toggle = default!;
     [Dependency] private readonly InventorySystem _inventory = default!;
+    [Dependency] private readonly HandheldLightSystem _lights = default!;
 
     public override void Initialize()
     {
-        SubscribeLocalEvent<RMCSuitLightComponent, MobStateChangedEvent>(OnMobStateChanged);
+        SubscribeLocalEvent<MobStateChangedEvent>(OnMobStateChanged);
         SubscribeLocalEvent<VictimInfectedComponent, ComponentStartup>(OnComponentStartup);
+        SubscribeLocalEvent<MarineComponent, XenoDevouredEvent>(OnDevour);
     }
 
-    private void OnMobStateChanged(Entity<RMCSuitLightComponent> ent, ref MobStateChangedEvent args)
+    private void OnMobStateChanged(MobStateChangedEvent args)
     {
-        var uid = ent.Owner;
+        var uid = args.Target;
 
         if (args.NewMobState != MobState.Dead)
             return;
@@ -41,12 +46,21 @@ public sealed class RMCSuitLightSystem : EntitySystem
             ShortLights(suit.Value.Owner, uid);
     }
 
+    private void OnDevour(Entity<MarineComponent> ent, ref XenoDevouredEvent args)
+    {
+        var uid = ent.Owner;
+        var suit = FindSuit(uid);
+
+        if (suit != null)
+            ShortLights(suit.Value.Owner, uid);
+    }
 
     public void ShortLights(EntityUid armor, EntityUid user)
     {
-        if (_toggle.IsActivated(armor))
+        if (TryComp(armor, out HandheldLightComponent? comp) && comp.Activated)
         {
-            _toggle.TryDeactivate(armor);
+            var ent = (armor, comp);
+            _lights.TurnOff(ent);
 
             var popup = Loc.GetString("rmc-suit-light-short");
             _popup.PopupClient(popup, user);
@@ -55,7 +69,7 @@ public sealed class RMCSuitLightSystem : EntitySystem
 
     public Entity<RMCSuitLightComponent>? FindSuit(EntityUid uid)
     {
-        var slots = _inventory.GetSlotEnumerator(uid, SlotFlags.OUTERCLOTHING);
+        var slots = _inventory.GetSlotEnumerator(uid, SlotFlags.All);
         while (slots.MoveNext(out var slot))
         {
             if (TryComp(slot.ContainedEntity, out RMCSuitLightComponent? comp))

--- a/Content.Shared/_RMC14/Marines/Armor/RMCSuitLightComponent.cs
+++ b/Content.Shared/_RMC14/Marines/Armor/RMCSuitLightComponent.cs
@@ -1,0 +1,10 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Marines.Armor;
+
+/// <summary>
+///     A component which toggles lights off whenever the user dies, gets infected or devoured.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(RMCSuitLightSystem))]
+public sealed partial class RMCSuitLightComponent : Component;

--- a/Content.Shared/_RMC14/Marines/Armor/RMCSuitLightComponent.cs
+++ b/Content.Shared/_RMC14/Marines/Armor/RMCSuitLightComponent.cs
@@ -6,5 +6,4 @@ namespace Content.Shared._RMC14.Marines.Armor;
 ///     A component which toggles lights off whenever the user dies, gets infected or devoured.
 /// </summary>
 [RegisterComponent, NetworkedComponent]
-[Access(typeof(RMCSuitLightSystem))]
 public sealed partial class RMCSuitLightComponent : Component;

--- a/Content.Shared/_RMC14/Marines/Armor/RMCSuitLightSystem.cs
+++ b/Content.Shared/_RMC14/Marines/Armor/RMCSuitLightSystem.cs
@@ -15,11 +15,11 @@ public sealed class RMCSuitLightSystem : EntitySystem
 
     public override void Initialize()
     {
-        SubscribeLocalEvent<MarineComponent, MobStateChangedEvent>(OnMobStateChanged);
+        SubscribeLocalEvent<RMCSuitLightComponent, MobStateChangedEvent>(OnMobStateChanged);
         SubscribeLocalEvent<VictimInfectedComponent, ComponentStartup>(OnComponentStartup);
     }
 
-    private void OnMobStateChanged(Entity<MarineComponent> ent, ref MobStateChangedEvent args)
+    private void OnMobStateChanged(Entity<RMCSuitLightComponent> ent, ref MobStateChangedEvent args)
     {
         var uid = ent.Owner;
 

--- a/Content.Shared/_RMC14/Marines/Armor/RMCSuitLightSystem.cs
+++ b/Content.Shared/_RMC14/Marines/Armor/RMCSuitLightSystem.cs
@@ -1,0 +1,67 @@
+﻿using Content.Shared._RMC14.Xenonids.Parasite;
+using Content.Shared.Inventory;
+using Content.Shared.Inventory.Events;
+using Content.Shared.Item.ItemToggle;
+using Content.Shared.Mobs;
+using Content.Shared.Popups;
+
+namespace Content.Shared._RMC14.Marines.Armor;
+
+public sealed class RMCSuitLightSystem : EntitySystem
+{
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly ItemToggleSystem _toggle = default!;
+    [Dependency] private readonly InventorySystem _inventory = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<MarineComponent, MobStateChangedEvent>(OnMobStateChanged);
+        SubscribeLocalEvent<VictimInfectedComponent, ComponentStartup>(OnComponentStartup);
+    }
+
+    private void OnMobStateChanged(Entity<MarineComponent> ent, ref MobStateChangedEvent args)
+    {
+        var uid = ent.Owner;
+
+        if (args.NewMobState != MobState.Dead)
+            return;
+
+        var suit = FindSuit(uid);
+
+        if (suit != null)
+            ShortLights(suit.Value.Owner, uid);
+    }
+
+    private void OnComponentStartup(Entity<VictimInfectedComponent> ent, ref ComponentStartup args)
+    {
+        var uid = ent.Owner;
+        var suit = FindSuit(uid);
+
+        if (suit != null)
+            ShortLights(suit.Value.Owner, uid);
+    }
+
+
+    public void ShortLights(EntityUid armor, EntityUid user)
+    {
+        if (_toggle.IsActivated(armor))
+        {
+            _toggle.TryDeactivate(armor);
+
+            var popup = Loc.GetString("rmc-suit-light-short");
+            _popup.PopupClient(popup, user);
+        }
+    }
+
+    public Entity<RMCSuitLightComponent>? FindSuit(EntityUid uid)
+    {
+        var slots = _inventory.GetSlotEnumerator(uid, SlotFlags.OUTERCLOTHING);
+        while (slots.MoveNext(out var slot))
+        {
+            if (TryComp(slot.ContainedEntity, out RMCSuitLightComponent? comp))
+                return (slot.ContainedEntity.Value, comp);
+        }
+
+        return null;
+    }
+}

--- a/Content.Shared/_RMC14/Xenonids/Devour/XenoDevourSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Devour/XenoDevourSystem.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using Content.Shared._RMC14.Armor;
+using Content.Shared._RMC14.Marines.Armor;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Buckle.Components;
 using Content.Shared.Coordinates;
@@ -42,6 +43,7 @@ public sealed class XenoDevourSystem : EntitySystem
     [Dependency] private readonly StandingStateSystem _standing = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedStunSystem _stun = default!;
+    [Dependency] private readonly RMCSuitLightSystem _suitLightSystem = default!;
 
     private EntityQuery<DevouredComponent> _devouredQuery;
     private EntityQuery<XenoDevourComponent> _xenoDevourQuery;
@@ -111,6 +113,12 @@ public sealed class XenoDevourSystem : EntitySystem
     private void OnDevouredStartup(Entity<DevouredComponent> devoured, ref ComponentStartup args)
     {
         _blocker.UpdateCanMove(devoured);
+
+        var uid = devoured.Owner;
+        var suit = _suitLightSystem.FindSuit(uid);
+
+        if (suit != null)
+            _suitLightSystem.ShortLights(suit.Value.Owner, uid);
     }
 
     private void OnDevouredRemove(Entity<DevouredComponent> devoured, ref ComponentRemove args)

--- a/Resources/Locale/en-US/_RMC14/armor/rmc-suit-light.ftl
+++ b/Resources/Locale/en-US/_RMC14/armor/rmc-suit-light.ftl
@@ -1,0 +1,1 @@
+﻿rmc-suit-light-short = Your source of light shorts out.

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/base_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/base_armor.yml
@@ -124,6 +124,7 @@
       outerClothing:
       - sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/armor_overlays.rsi
         state: lamp-on
+  - type: RMCSuitLight
   - type: PointLight
     enabled: false
     radius: 4

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
@@ -60,6 +60,7 @@
     - FootstepSound
     - DoorBumpOpener
   - type: Marine
+  - type: RMCSuitLight
   - type: HolocardState
   - type: Hunger
   - type: Thirst


### PR DESCRIPTION
CM13 parity
fixes #3611



https://github.com/user-attachments/assets/976ed532-5f8b-4d8b-98a6-90bacb850e79




:cl:
- tweak: Armor lamps now turn off when the user dies, gets infected, devoured, or unequips the armor.
