### PR TITLE
Adds Tuckable Features to Combat Armor

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/base_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/base_armor.yml
@@ -17,6 +17,15 @@
   - type: Clothing
     equipSound:
       path: /Audio/_RMC14/Machines/armor_equip.ogg
+  - type: Foldable
+    unfoldVerbText : "rmc-untuck"
+    foldVerbText: "rmc-tuck"
+    canFoldInsideContainer: true
+  - type: FoldableClothing
+    foldedHideLayers:
+    - Tail
+    unfoldedHideLayers: []
+  - type: HideLayerClothing
 
 - type: entity
   parent: RMCBaseArmor

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/arachnid.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/arachnid.yml
@@ -7,6 +7,8 @@
   components:
   - type: HumanoidAppearance
     species: Arachnid
+    hideLayersOnEquip:
+    - Tail
   - type: DamageVisuals
     damageOverlayGroups:
       Brute:

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/felinid.yml
@@ -10,6 +10,7 @@
     hideLayersOnEquip:
     - Hair
     - HeadTop
+    - Tail
   - type: Sprite
     drawdepth: Mobs
     scale: 0.8, 0.8

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/moth.yml
@@ -9,6 +9,7 @@
     species: Moth
     hideLayersOnEquip:
     - HeadTop
+    - Tail
   - type: MothAccent
   - type: ZombieAccentOverride
     accent: zombieMoth

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/reptilian.yml
@@ -11,6 +11,7 @@
     - Snout
     - HeadTop
     - HeadSide
+    - Tail
   - type: Icon
     sprite: Mobs/Species/Reptilian/parts.rsi
     state: full


### PR DESCRIPTION
## About the PR
You can now optionally tuck your tail, wings, and/or extra arms into your Combat Armor.

## Why / Balance
Human hair can be tucked, other races should have that same option for their distinctive parts. This can also help WS scouts hide their larger sprites, removing what was essentially a debuff for certain species.

## Technical details
Nothing new changed, just a yaml edit. Builds off of [this pr.](https://github.com/RMC-14/RMC-14/pull/3600)

## Media
![image](https://github.com/user-attachments/assets/8d05bbef-8102-48a7-932b-55d9e8784637)
![image](https://github.com/user-attachments/assets/a32d0a00-5ca3-4a35-800d-045c71d05a34)

## Breaking changes
None.

**Changelog**
:cl:
- add: Added the option for Marines with tails/wings/extra arms to tuck them into their armor.
