### PR TITLE
Remove some verbs from xenos

### DIFF
--- a/Content.Server/Body/Systems/InternalsSystem.cs
+++ b/Content.Server/Body/Systems/InternalsSystem.cs
@@ -2,6 +2,7 @@ using Content.Server.Atmos.Components;
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Body.Components;
 using Content.Server.Popups;
+using Content.Shared._RMC14.Xenonids;
 using Content.Shared.Alert;
 using Content.Shared.Atmos;
 using Content.Shared.DoAfter;
@@ -70,6 +71,9 @@ public sealed class InternalsSystem : EntitySystem
         Entity<InternalsComponent> ent,
         ref GetVerbsEvent<InteractionVerb> args)
     {
+        if (HasComp<XenoComponent>(args.User))
+            return;
+
         if (!args.CanAccess || !args.CanInteract || args.Hands is null)
             return;
 

--- a/Content.Server/Light/EntitySystems/ExpendableLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/ExpendableLightSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared._RMC14.Dropship.Weapon;
+using Content.Shared._RMC14.Xenonids;
 using Content.Shared.Clothing.Components;
 using Content.Shared.Clothing.EntitySystems;
 using Content.Shared.IgnitionSource;
@@ -192,7 +193,7 @@ namespace Content.Server.Light.EntitySystems
 
         private void AddIgniteVerb(Entity<ExpendableLightComponent> ent, ref GetVerbsEvent<ActivationVerb> args)
         {
-            if (!args.CanAccess || !args.CanInteract)
+            if (!args.CanAccess || !args.CanInteract || HasComp<XenoComponent>(args.User))
                 return;
 
             if (ent.Comp.CurrentState != ExpendableLightState.BrandNew)

--- a/Content.Server/Prayer/PrayerSystem.cs
+++ b/Content.Server/Prayer/PrayerSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.Administration.Logs;
 using Content.Server.Bible.Components;
 using Content.Server.Chat.Managers;
 using Content.Server.Popups;
+using Content.Shared._RMC14.Xenonids;
 using Content.Shared.Database;
 using Content.Shared.Popups;
 using Content.Shared.Chat;
@@ -40,6 +41,10 @@ public sealed class PrayerSystem : EntitySystem
 
         // this is to prevent ghosts from using it
         if (!args.CanInteract)
+            return;
+
+        // Nobody to answer their prayers :(
+        if (HasComp<XenoComponent>(args.User))
             return;
 
         var prayerVerb = new ActivationVerb

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Interactions.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Interactions.cs
@@ -1,4 +1,5 @@
 using Content.Shared._RMC14.Weapons.Ranged;
+using Content.Shared._RMC14.Xenonids;
 using Content.Shared.Actions;
 using Content.Shared.Examine;
 using Content.Shared.Hands;
@@ -13,6 +14,9 @@ public abstract partial class SharedGunSystem
     private void OnExamine(EntityUid uid, GunComponent component, ExaminedEvent args)
     {
         if (!args.IsInDetailsRange || !component.ShowExamineText)
+            return;
+
+        if (HasComp<XenoComponent>(args.Examiner))
             return;
 
         using (args.PushGroup(nameof(GunComponent)))
@@ -32,6 +36,9 @@ public abstract partial class SharedGunSystem
     private void OnAltVerb(EntityUid uid, GunComponent component, GetVerbsEvent<AlternativeVerb> args)
     {
         if (!args.CanAccess || !args.CanInteract || component.SelectedMode == component.AvailableModes)
+            return;
+
+        if (HasComp<XenoComponent>(args.User))
             return;
 
         var nextMode = GetNextMode(component);

--- a/Content.Shared/_RMC14/Attachable/Systems/AttachableHolderSystem.cs
+++ b/Content.Shared/_RMC14/Attachable/Systems/AttachableHolderSystem.cs
@@ -226,6 +226,9 @@ public sealed class AttachableHolderSystem : EntitySystem
 
     private void OnAttachableHolderGetVerbs(Entity<AttachableHolderComponent> holder, ref GetVerbsEvent<EquipmentVerb> args)
     {
+        if (HasComp<XenoComponent>(args.User))
+            return;
+
         EnsureSlots(holder);
         var userUid = args.User;
 
@@ -458,7 +461,7 @@ public sealed class AttachableHolderSystem : EntitySystem
 
         var ev = new AttachableAlteredEvent(holder.Owner, AttachableAlteredType.Detached, userUid);
         RaiseLocalEvent(attachableUid, ref ev);
-        
+
         var holderEv = new AttachableHolderAttachablesAlteredEvent(attachableUid, slotId, AttachableAlteredType.Detached);
         RaiseLocalEvent(holder.Owner, ref holderEv);
 
@@ -594,7 +597,7 @@ public sealed class AttachableHolderSystem : EntitySystem
 
         if (!HasComp<AttachableToggleableComponent>(attachableUid))
             return;
-        
+
         if (!TryComp<AttachableToggleableComponent>(attachableUid, out var toggleableComponent))
             return;
 
@@ -668,7 +671,7 @@ public sealed class AttachableHolderSystem : EntitySystem
 
         return holder.Comp.Slots.ContainsKey(slotId);
     }
-    
+
     public bool TryGetHolder(EntityUid attachable, [NotNullWhen(true)] out EntityUid? holderUid)
     {
         if (!TryComp(attachable, out TransformComponent? transformComponent) ||
@@ -678,7 +681,7 @@ public sealed class AttachableHolderSystem : EntitySystem
             holderUid = null;
             return false;
         }
-        
+
         holderUid = transformComponent.ParentUid;
         return true;
     }

--- a/Content.Shared/_RMC14/Webbing/SharedWebbingSystem.cs
+++ b/Content.Shared/_RMC14/Webbing/SharedWebbingSystem.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using Content.Shared._RMC14.Xenonids;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
 using Content.Shared.Item;
@@ -33,7 +34,7 @@ public abstract class SharedWebbingSystem : EntitySystem
 
     private void OnWebbingClothingGetVerbs(Entity<WebbingClothingComponent> clothing, ref GetVerbsEvent<InteractionVerb> args)
     {
-        if (!args.CanAccess || !args.CanInteract)
+        if (!args.CanAccess || !args.CanInteract || HasComp<XenoComponent>(args.User))
             return;
 
         if (!HasWebbing((clothing, clothing), out _))


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Removed some verbs from xenos
Xenos can no longer:
- light flares
- remove webbings
- toggle weapon attachables
- toggle internals
- attempt to pray
- see or change gun fire modes

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Feel like most of these are unintentional

Resolves #3848, resolves #3202


## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Added checks for XenoComponent in various GetVerbsEvent handlers

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- fix: Xenos can no longer light flares on ground.
- fix: Xenos can no longer remove webbings from jumpsuits.
- fix: Xenos can no longer toggle attachables or internals.
- fix: Xenos can no longer see or change gun fire modes.
- fix: Xenos can no longer (attempt to) pray.

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
