### PR TITLE
fix(healthscanner): Add a basic component to allow for scanning.

### DIFF
--- a/Content.Server/_RMC14/Medical/Scanner/HealthScannerSystem.cs
+++ b/Content.Server/_RMC14/Medical/Scanner/HealthScannerSystem.cs
@@ -107,7 +107,7 @@ public sealed class HealthScannerSystem : EntitySystem
     /// <returns></returns>
     private bool CanUseHealthScannerPopup(Entity<HealthScannerComponent> scanner, EntityUid user, ref EntityUid target)
     {
-        if (HasComp<CMStasisBagComponent>(target) && TryComp(target, out EntityStorageComponent? entityStorage))
+        if (HasComp<HealthScannableContainerComponent>(target) && TryComp(target, out EntityStorageComponent? entityStorage))
         {
             foreach (var entity in entityStorage.Contents.ContainedEntities)
             {

--- a/Content.Shared/_RMC14/Medical/Scanner/HealthScannableContainerComponent.cs
+++ b/Content.Shared/_RMC14/Medical/Scanner/HealthScannableContainerComponent.cs
@@ -1,0 +1,8 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Medical.Scanner;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentPause]
+public sealed partial class HealthScannableContainerComponent : Component
+{
+}

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Medical/bodybags.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Medical/bodybags.yml
@@ -25,6 +25,7 @@
     blacklist:
       components:
       - Xeno
+  - type: HealthScannableContainer
 
 - type: entity
   parent: CMBodyBag


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Instead of relying on the CMStasisBag component while checking to see if the scanner will look into a container, I've added a basic component to add on any container that should be looked in, this adds it on CMBodyBag which is the parent of CMStasisBag. This also allows for future additions like CMMorgue or other items that could contain someone who needs to be health scanned.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.

- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- fix: Allow for body bags to be health scanned.
