### PR TITLE
Resize Felinids to normal size

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/felinid.yml
@@ -12,7 +12,6 @@
     - HeadTop
   - type: Sprite
     drawdepth: Mobs
-    scale: 0.8, 0.8
   - type: Vocal
     sounds:
       Male: RMCMaleFelinid
@@ -25,6 +24,3 @@
   parent: BaseSpeciesDummy
   id: MobFelinidDummy
   noSpawn: true
-  components:
-  - type: Sprite
-    scale: 0.8, 0.8


### PR DESCRIPTION
## About the PR
Returned Felinids to normal size, rather than 64% size.

## Why / Balance
RMC races are all modified to not give any mechanical advantages over each other, all acting the same mechanically to each other, for example, there is no advantage to being a Moth over a Human. 

Felinids break this rule, as they are resized to 64% their normal size in area (or 80% height, 80% width, for each dimension), which makes them drastically harder to hit for Xenos. Sprites must be click-targeted in order to be shoved, which the Felinid sprite's size makes harder due its reduced size. Similarly, many Xeno abilities require the same form of click targetting, such as Defender Headbutt and Warrior Fling, for two examples.

Another mechanical advantage that a small sprite brings, in a similar vein to the former, is in sprite occlusion. During gameplay, sprites may often become obstructed by other objects, such as marines, xenos, barricades, dead bodies, or various other items. The drastically reduced size of Felinids makes this far more impactful, and makes them even harder to target in scenarios where sprite occlusion may occur, such as in a cadeline or in the middle of a tense fight with many players moving about.

The solution to this is resizing them to the base size, which I find acceptable, and even preferable, for several reasons

1) **It is acceptable as reduced size is not a core trait of the Felinid identity:** Felinids, at their core, are about being cat people, and everything that comes visually (ears, tail), and auditory (the various cat sounds they can make). Sizing them up does not damper this at all for Felinids, and SS13 Felinids were normal size as well (or atleast were on codebases I am used to at the time I am familiar with them), ours are ported from Delta-V, which happen to be decreased in size, it is not a necessity for them, however.

2) **It is is preferable for Art Quality and Sprite Recognizability:** Felinid sprites are not natively sprited to be smaller, they use an artificial form of scaling which takes normal sprites are resizes them by scrunching them down. This introduces a big detractor from art quality to Felinids: Mixels!

In the below image, you can see the Human sprite uses a consistent scale for each pixel, looking clean in its sprite. Meanwhile, the Felinid sprite uses many half-pixels, or even quarter-sized-pixels, lowering the art quality of the overall model *and* the race specific features which is the main draw of Felinids, such as the ears and tail. It does not do this consistently either, as each arm/leg has pixel scrunches in different places.

![FelinidMixels](https://github.com/user-attachments/assets/9efded37-22f7-408a-a216-417cc996e51a)

As for recognizability: Any sprite that the Felinid wears or holds will also be scrunched similarly, making weapons and items that are very easily recognizable by their silhouette much harder to instantly recognize. For an example, the SADAR gets heavily squeezed pixel wise, and it becomes hard to accurately make out the silhouette at a glance.

![FelinidMixelsATL](https://github.com/user-attachments/assets/460ffc5c-a67a-46d2-a7ed-6cddcd86d7c3)

Overall, resizing Felinids fixes the gameplay issues they cause, both in click-targeting and sprite recognition, and also improves art quality for the cat features that are meant to be the main draw for the race.

## Media
A Felinid at standard scale, next to a Human.

![FelinidsResized](https://github.com/user-attachments/assets/9291d862-75ee-4998-a1b3-bb1d0539985e)


## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- tweak: Resized Felinids to normal size.
