### PR TITLE
Make SL/Queen trackers account for camera rotation

### DIFF
--- a/Content.Shared/_RMC14/Mortar/SharedMortarSystem.cs
+++ b/Content.Shared/_RMC14/Mortar/SharedMortarSystem.cs
@@ -11,7 +11,6 @@ using Content.Shared.DoAfter;
 using Content.Shared.Examine;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
-using Content.Shared.Movement.Components;
 using Content.Shared.Popups;
 using Content.Shared.UserInterface;
 using Robust.Shared.Audio.Systems;
@@ -48,12 +47,10 @@ public abstract class SharedMortarSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
 
-    private EntityQuery<InputMoverComponent> _inputMoverQuery;
     private EntityQuery<TransformComponent> _transformQuery;
 
     public override void Initialize()
     {
-        _inputMoverQuery = GetEntityQuery<InputMoverComponent>();
         _transformQuery = GetEntityQuery<TransformComponent>();
 
         SubscribeLocalEvent<MortarComponent, UseInHandEvent>(OnMortarUseInHand, before: [typeof(ActivatableUISystem)]);
@@ -442,12 +439,6 @@ public abstract class SharedMortarSystem : EntitySystem
             var distance = distanceVec.Length();
             if (distance > range)
                 continue;
-
-            if (_inputMoverQuery.TryComp(recipient, out var inputMover) &&
-                inputMover.RelativeRotation != Angle.Zero)
-            {
-                distanceVec = (-inputMover.RelativeRotation).RotateVec(distanceVec);
-            }
 
             var direction = distanceVec.GetDir().ToString().ToUpperInvariant();
             var msg = distance < 1

--- a/Content.Shared/_RMC14/Mortar/SharedMortarSystem.cs
+++ b/Content.Shared/_RMC14/Mortar/SharedMortarSystem.cs
@@ -11,6 +11,7 @@ using Content.Shared.DoAfter;
 using Content.Shared.Examine;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
+using Content.Shared.Movement.Components;
 using Content.Shared.Popups;
 using Content.Shared.UserInterface;
 using Robust.Shared.Audio.Systems;
@@ -47,10 +48,12 @@ public abstract class SharedMortarSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
 
+    private EntityQuery<InputMoverComponent> _inputMoverQuery;
     private EntityQuery<TransformComponent> _transformQuery;
 
     public override void Initialize()
     {
+        _inputMoverQuery = GetEntityQuery<InputMoverComponent>();
         _transformQuery = GetEntityQuery<TransformComponent>();
 
         SubscribeLocalEvent<MortarComponent, UseInHandEvent>(OnMortarUseInHand, before: [typeof(ActivatableUISystem)]);
@@ -439,6 +442,12 @@ public abstract class SharedMortarSystem : EntitySystem
             var distance = distanceVec.Length();
             if (distance > range)
                 continue;
+
+            if (_inputMoverQuery.TryComp(recipient, out var inputMover) &&
+                inputMover.RelativeRotation != Angle.Zero)
+            {
+                distanceVec = (-inputMover.RelativeRotation).RotateVec(distanceVec);
+            }
 
             var direction = distanceVec.GetDir().ToString().ToUpperInvariant();
             var msg = distance < 1


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
Fixes https://github.com/RMC-14/RMC-14/issues/3923

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
:cl:
- fix: Fixed Queen/SL trackers not accounting for the player's camera rotation. Having your camera rotated will now change where the tracker points.