### PR TITLE
Fix xenonid eggs being able to be placed under vendors, lockers, crates, chairs, etc

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestSystem.cs
@@ -404,7 +404,7 @@ public sealed class XenoNestSystem : EntitySystem
         foreach (var dir in directions)
         {
             if (nestCoords.Offset(dir.ToVec()).GetTileRef(EntityManager, _map) is not { } tile ||
-                   _turf.IsTileBlocked(tile, CollisionGroup.Impassable))
+                _turf.IsTileBlocked(tile, CollisionGroup.Impassable))
             {
                 response ??= Loc.GetString("cm-xeno-nest-failed-cant-there");
                 continue;

--- a/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared._RMC14.Xenonids.Parasite;
 using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared._RMC14.Xenonids.Weeds;
 using Content.Shared.Actions;
+using Content.Shared.Buckle.Components;
 using Content.Shared.DoAfter;
 using Content.Shared.FixedPoint;
 using Content.Shared.Hands.Components;
@@ -215,7 +216,8 @@ public sealed class XenoEggSystem : EntitySystem
             }
 
             if (HasComp<XenoConstructComponent>(uid) ||
-                _tags.HasAnyTag(uid.Value, StructureTag, AirlockTag))
+                _tags.HasAnyTag(uid.Value, StructureTag, AirlockTag) ||
+                HasComp<StrapComponent>(uid))
             {
                 var msg = Loc.GetString("cm-xeno-egg-blocked");
                 _popup.PopupClient(msg, uid.Value, user, PopupType.SmallCaution);

--- a/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
@@ -11,6 +11,7 @@ using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
 using Content.Shared.Item;
+using Content.Shared.Maps;
 using Content.Shared.Mind;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
@@ -26,6 +27,7 @@ using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
+using static Content.Shared.Physics.CollisionGroup;
 
 namespace Content.Shared._RMC14.Xenonids.Egg;
 
@@ -37,18 +39,19 @@ public sealed class XenoEggSystem : EntitySystem
     [Dependency] private readonly SharedInteractionSystem _interaction = default!;
     [Dependency] private readonly SharedXenoParasiteSystem _parasite = default!;
     [Dependency] private readonly SharedMapSystem _map = default!;
+    [Dependency] private readonly SharedMindSystem _mind = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly XenoPlasmaSystem _plasma = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedStunSystem _stun = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly CMHandsSystem _rmcHands = default!;
     [Dependency] private readonly TagSystem _tags = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly TurfSystem _turf = default!;
     [Dependency] private readonly XenoSystem _xeno = default!;
-    [Dependency] private readonly SharedMindSystem _mind = default!;
-    [Dependency] private readonly CMHandsSystem _rmcHands = default!;
 
 	private static readonly ProtoId<TagPrototype> AirlockTag = "Airlock";
 	private static readonly ProtoId<TagPrototype> StructureTag = "Structure";
@@ -222,6 +225,14 @@ public sealed class XenoEggSystem : EntitySystem
 
             if (HasComp<XenoWeedsComponent>(uid))
                 hasWeeds = true;
+        }
+
+        if (_turf.IsTileBlocked(gridId, tile, Impassable | MidImpassable | HighImpassable, grid))
+        {
+            var msg = Loc.GetString("cm-xeno-egg-blocked");
+            _popup.PopupClient(msg, args.ClickLocation, user, PopupType.SmallCaution);
+            args.Handled = true;
+            return;
         }
 
         // TODO RMC14 only on hive weeds


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Fixes https://github.com/RMC-14/RMC-14/issues/3804
Fixes https://github.com/RMC-14/RMC-14/issues/3805
Fixes https://github.com/RMC-14/RMC-14/issues/3806
Fixes https://github.com/RMC-14/RMC-14/issues/3915
Fixes https://github.com/RMC-14/RMC-14/issues/3696

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
:cl:
- fix: Fixed xenonid eggs being able to be placed under vendors, lockers, crates, chairs, etc.