### PR TITLE
Fix sentries fitting non-sentry mags

### DIFF
--- a/Content.Shared/_RMC14/Sentry/SentryComponent.cs
+++ b/Content.Shared/_RMC14/Sentry/SentryComponent.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Shared._RMC14.Marines.Skills;
+using Content.Shared.Tag;
 using Content.Shared.Weapons.Ranged.Components;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
@@ -55,6 +56,9 @@ public sealed partial class SentryComponent : Component
 
     [DataField, AutoNetworkedField]
     public EntProtoId[]? Upgrades = ["RMCSentrySniper", "RMCSentryMini", "RMCSentryOmni"];
+
+    [DataField, AutoNetworkedField]
+    public ProtoId<TagPrototype>? MagazineTag = "RMCMagazineSentry";
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/_RMC14/Sentry/SentrySystem.cs
+++ b/Content.Shared/_RMC14/Sentry/SentrySystem.cs
@@ -13,6 +13,7 @@ using Content.Shared.Interaction.Components;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Item;
 using Content.Shared.Popups;
+using Content.Shared.Tag;
 using Content.Shared.Tools.Systems;
 using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Weapons.Ranged.Systems;
@@ -42,6 +43,7 @@ public sealed class SentrySystem : EntitySystem
     [Dependency] private readonly SkillsSystem _skills = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly TagSystem _tag = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
     [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
@@ -214,6 +216,14 @@ public sealed class SentrySystem : EntitySystem
 
         if (!HasComp<BallisticAmmoProviderComponent>(used))
             return;
+
+        if (sentry.Comp.MagazineTag is { } magazineTag &&
+            !_tag.HasTag(used, magazineTag))
+        {
+            var msg = Loc.GetString("rmc-sentry-magazine-does-not-fit", ("sentry", sentry), ("magazine", used));
+            _popup.PopupClient(msg, sentry, user, PopupType.SmallCaution);
+            return;
+        }
 
         args.Handled = true;
 

--- a/Resources/Locale/en-US/_RMC14/rmc-sentry.ftl
+++ b/Resources/Locale/en-US/_RMC14/rmc-sentry.ftl
@@ -13,6 +13,7 @@ rmc-sentry-rotate-with-screwdriver = It can be rotated with a [color=cyan]screwd
 rmc-sentry-too-close = This is too close to {INDEFINITE($defense)} {$defense}!
 rmc-sentry-active-norot = {CAPITALIZE(THE($sentry))} is currently active. The motors will prevent you from rotating it safely.
 rmc-sentry-item-norot = You can't rotate it like this!
+rmc-sentry-magazine-does-not-fit = {CAPITALIZE(THE($magazine))} doesn't fit into {THE($sentry)}!
 
 rmc-sentry-upgrade-not-item = You need to disassemble {THE($sentry)} with a multitool before upgrading it!
 rmc-sentry-upgrade-not-holding = You need to be holding an upgrade kit in your active hand to upgrade {THE($sentry)}!


### PR DESCRIPTION
## About the PR
## Media
## Requirements
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed sentries being able to fit non-sentry magazines.