### PR TITLE
Add empty state to CMStorageVisualizerComponent

### DIFF
--- a/Content.Client/_RMC14/Storage/CMStorageVisualizerSystem.cs
+++ b/Content.Client/_RMC14/Storage/CMStorageVisualizerSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared._RMC14.Storage;
+using Content.Shared._RMC14.Storage;
 using Content.Shared.Storage;
 using Robust.Client.GameObjects;
 
@@ -26,7 +26,14 @@ public sealed class CMStorageVisualizerSystem : VisualizerSystem<CMStorageVisual
                 args.Sprite.LayerSetVisible(component.StorageOpen, false);
             if (component.StorageClosed != null)
                 args.Sprite.LayerSetVisible(component.StorageClosed, false);
+            if (component.StorageEmpty != null)
+                args.Sprite.LayerSetVisible(component.StorageEmpty, true);
             return;
+        }
+        else
+        {
+            if (component.StorageEmpty != null)
+                args.Sprite.LayerSetVisible(component.StorageEmpty, false);
         }
 
         // Open or closed

--- a/Content.Shared/_RMC14/Storage/CMStorageVisualizerComponent.cs
+++ b/Content.Shared/_RMC14/Storage/CMStorageVisualizerComponent.cs
@@ -1,4 +1,4 @@
-﻿namespace Content.Shared._RMC14.Storage;
+namespace Content.Shared._RMC14.Storage;
 
 /// <summary>
 /// Used to set visibility on open and closed layers when empty, open, or closed.
@@ -17,4 +17,10 @@ public sealed partial class CMStorageVisualizerComponent : Component
     /// </summary>
     [DataField]
     public string? StorageOpen;
+
+    /// <summary>
+    /// Sprite layer name of the empty state.
+    /// </summary>
+    [DataField]
+    public string? StorageEmpty;
 }

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Throwable/packets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Throwable/packets.yml
@@ -23,6 +23,11 @@
     blacklist:
       components:
       - Xeno
+  - type: Appearance
+  - type: CMStorageVisualizer
+    storageClosed: closedLayer
+    storageOpen: openLayer
+    storageEmpty: emptyLayer
 
 - type: entity
   parent: CMPacketBase
@@ -31,7 +36,11 @@
   description: It contains three HEDP high explosive grenades.
   components:
   - type: Sprite
-    state: hedp_packet
+    layers:
+    - state: hedp_packet
+      map: [ "closedLayer" ]
+    - state: hedp_packet_e
+      map: [ "openLayer", "emptyLayer" ]
 
 - type: entity
   parent: CMPacketGrenadeHighExplosive
@@ -44,6 +53,7 @@
     - id: CMGrenadeHighExplosive
       amount: 3
 
+
 - type: entity
   parent: CMPacketBase
   id: CMPacketGrenadeFrag
@@ -51,7 +61,11 @@
   description: It contains three HEFA grenades. Don't tell the HEFA order.
   components:
   - type: Sprite
-    state: hefa_packet
+    layers:
+    - state: hefa_packet
+      map: [ "closedLayer" ]
+    - state: hefa_packet_e
+      map: [ "openLayer", "emptyLayer" ]
 
 - type: entity
   parent: CMPacketGrenadeFrag


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Added optional empty state to CMStorageVisualizerComponent and enabled the open/empty sprite for the grenade packets.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Packets sprites are stored differently than the package sprites in that there is no base sprite that the open/closed sprites draw over. Since there may be other situations where storages may need a separate unique empty graphic in addition to open/closed, I went ahead and added that functionality to the visualizer component for future use.
Fixes #2358

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Optionally a separate empty layer can now be defined in addition to the open/closed layer for CMstorages.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

https://github.com/user-attachments/assets/bed27492-96dc-4cd7-9c93-835289c0fe3d



## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- fix: Grenade packets have an empty graphic.

