### PR TITLE
Add random fog breaks to LV

### DIFF
--- a/Content.Server/_RMC14/Fog/FogComponent.cs
+++ b/Content.Server/_RMC14/Fog/FogComponent.cs
@@ -1,0 +1,5 @@
+﻿namespace Content.Server._RMC14.Fog;
+
+[RegisterComponent]
+[Access(typeof(FogSystem))]
+public sealed partial class FogComponent : Component;

--- a/Content.Server/_RMC14/Fog/FogSystem.cs
+++ b/Content.Server/_RMC14/Fog/FogSystem.cs
@@ -1,0 +1,71 @@
+﻿using Content.Server.GameTicking;
+using Content.Shared._RMC14.Map;
+using Content.Shared.Whitelist;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+using Robust.Shared.Utility;
+
+namespace Content.Server._RMC14.Fog;
+
+public sealed class FogSystem : EntitySystem
+{
+    [Dependency] private readonly EntityWhitelistSystem _entityWhitelist = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly RMCMapSystem _rmcMap = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<GameRunLevelChangedEvent>(OnGameRunLevelChanged);
+    }
+
+    private void OnGameRunLevelChanged(GameRunLevelChangedEvent ev)
+    {
+        if (ev.New != GameRunLevel.InRound)
+            return;
+
+        var allRemovers = new Dictionary<EntProtoId, List<Entity<RandomAnchoredRemoverComponent>>>();
+        var removerQuery = EntityQueryEnumerator<RandomAnchoredRemoverComponent>();
+        while (removerQuery.MoveNext(out var uid, out var remover))
+        {
+            allRemovers.GetOrNew(remover.Group).Add((uid, remover));
+        }
+
+        if (allRemovers.Count == 0)
+            return;
+
+        var (chosenId, chosen) = _random.Pick(allRemovers);
+        foreach (var toRemove in chosen)
+        {
+            var anchoredEnumerator = _rmcMap.GetAnchoredEntitiesEnumerator(toRemove);
+            while (anchoredEnumerator.MoveNext(out var anchored))
+            {
+                if (anchored == toRemove.Owner)
+                    continue;
+
+                if (_entityWhitelist.IsWhitelistPass(toRemove.Comp.Whitelist, anchored))
+                    QueueDel(anchored);
+            }
+        }
+
+        foreach (var removers in allRemovers.Values)
+        {
+            foreach (var remover in removers)
+            {
+                QueueDel(remover);
+            }
+        }
+
+        var spawnerQuery = EntityQueryEnumerator<RandomAnchoredSpawnerComponent>();
+        while (spawnerQuery.MoveNext(out var uid, out var spawner))
+        {
+            if (spawner.Group != chosenId ||
+                spawner.Spawn is not { } spawn)
+            {
+                continue;
+            }
+
+            Spawn(spawn, _transform.GetMoverCoordinates(uid));
+        }
+    }
+}

--- a/Content.Server/_RMC14/Fog/RandomAnchoredRemoverComponent.cs
+++ b/Content.Server/_RMC14/Fog/RandomAnchoredRemoverComponent.cs
@@ -1,0 +1,20 @@
+﻿using Content.Shared.Whitelist;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._RMC14.Fog;
+
+/// <summary>
+///     Marks any entities anchored on the same tile as eligible to be removed at round-start.
+///     Only anchored entities that pass <see cref="Whitelist"/> will be deleted.
+///     A group is randomly chosen from all the ones available, grouped by <see cref="Group"/>
+/// </summary>
+[RegisterComponent]
+[Access(typeof(FogSystem))]
+public sealed partial class RandomAnchoredRemoverComponent : Component
+{
+    [DataField(required: true)]
+    public EntProtoId Group = string.Empty;
+
+    [DataField(required: true), AutoNetworkedField]
+    public EntityWhitelist? Whitelist;
+}

--- a/Content.Server/_RMC14/Fog/RandomAnchoredSpawnerComponent.cs
+++ b/Content.Server/_RMC14/Fog/RandomAnchoredSpawnerComponent.cs
@@ -1,0 +1,18 @@
+﻿using Robust.Shared.Prototypes;
+
+namespace Content.Server._RMC14.Fog;
+
+/// <summary>
+///     Spawns the given entity on the same tile at round-start if a <see cref="RandomAnchoredRemoverComponent"/>
+///     of the same group gets chosen.
+/// </summary>
+[RegisterComponent]
+[Access(typeof(FogSystem))]
+public sealed partial class RandomAnchoredSpawnerComponent : Component
+{
+    [DataField(required: true)]
+    public EntProtoId Group;
+
+    [DataField(required: true), AutoNetworkedField]
+    public EntProtoId? Spawn;
+}

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Walls/fog_walls.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Walls/fog_walls.yml
@@ -31,6 +31,7 @@
         - WallLayer
         density: 1000
   - type: Occluder
+  - type: Fog
 
 - type: entity
   parent: RMCFogWallPermanent
@@ -48,3 +49,67 @@
   components:
   - type: TimedDespawn
     lifetime: 900
+
+- type: entity
+  parent: MarkerBase
+  id: RMCFogWallRemoverOne
+  name: random fog remover
+  description: Marks this fog for random removal at round-start.
+  suffix: group one
+  components:
+  - type: Sprite
+    drawdepth: Overdoors
+    sprite: Markers/cross.rsi
+    state: red
+  - type: RandomAnchoredRemover
+    group: RMCFogWallRemoverOne
+    whitelist:
+      components:
+      - Fog
+
+- type: entity
+  parent: MarkerBase
+  id: RMCFogWallAdderOne
+  name: random fog spawner
+  description: Marks a spot for random fog spawning at round-start.
+  suffix: group one, 25 minutes
+  components:
+  - type: Sprite
+    drawdepth: Overdoors
+    sprite: Markers/cross.rsi
+    state: green
+  - type: RandomAnchoredSpawner
+    group: RMCFogWallRemoverOne
+    spawn: RMCFogWall25
+
+- type: entity
+  parent: RMCFogWallRemoverOne
+  id: RMCFogWallRemoverTwo
+  suffix: group two
+  components:
+  - type: RandomAnchoredRemover
+    group: RMCFogWallRemoverTwo
+
+- type: entity
+  parent: RMCFogWallAdderOne
+  id: RMCFogWallAdderTwo
+  suffix: group two, 25 minutes
+  components:
+  - type: RandomAnchoredSpawner
+    group: RMCFogWallRemoverTwo
+
+- type: entity
+  parent: RMCFogWallRemoverOne
+  id: RMCFogWallRemoverThree
+  suffix: group three
+  components:
+  - type: RandomAnchoredRemover
+    group: RMCFogWallRemoverThree
+
+- type: entity
+  parent: RMCFogWallAdderOne
+  id: RMCFogWallAdderThree
+  suffix: group three, 25 minutes
+  components:
+  - type: RandomAnchoredSpawner
+    group: RMCFogWallRemoverThree


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Not nightmare inserts but close enough for now so we can add survivors soon

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [ ] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
:cl:
- add: Added LV's missing random fog breaks. Every round that LV is chosen as the planet map, one of three spots in the fog will randomly be chosen to be opened up at round-start, located at the far west of the river, the far east, and the bridge near the middle.