### PR TITLE
Add Health bars and icons to ghost HUD

### DIFF
--- a/Content.Client/_RMC14/Xenonids/Hud/XenoHudOverlay.cs
+++ b/Content.Client/_RMC14/Xenonids/Hud/XenoHudOverlay.cs
@@ -84,6 +84,7 @@ public sealed class XenoHudOverlay : Overlay
         var isAdminGhost = _entity.TryGetComponent(_players.LocalEntity, out GhostComponent? ghost) &&
                            ghost.CanGhostInteract;
         var isXeno = _entity.HasComponent<XenoComponent>(_players.LocalEntity);
+        var isGhost = false;
 
         if (!_entity.HasComponent<CMGhostXenoHudComponent>(_players.LocalEntity))
         {
@@ -92,6 +93,8 @@ public sealed class XenoHudOverlay : Overlay
         }
         else
         {
+            if (_entity.HasComponent<CMGhostXenoHudComponent>(_players.LocalEntity))
+                isGhost = true;
             isXeno = true;
         }
         var handle = args.WorldHandle;
@@ -105,7 +108,8 @@ public sealed class XenoHudOverlay : Overlay
         if (isXeno)
         {
             DrawBars(in args, scaleMatrix, rotationMatrix);
-            DrawDeadIcon(in args, scaleMatrix, rotationMatrix);
+            if (!isGhost)
+                DrawDeadIcon(in args, scaleMatrix, rotationMatrix);
         }
 
         if (isXeno || isAdminGhost)

--- a/Content.Client/_RMC14/Xenonids/Pheromones/XenoPheromonesOverlay.cs
+++ b/Content.Client/_RMC14/Xenonids/Pheromones/XenoPheromonesOverlay.cs
@@ -43,7 +43,7 @@ public sealed class XenoPheromonesOverlay : Overlay
 
     protected override void Draw(in OverlayDrawArgs args)
     {
-        if (!_entity.HasComponent<XenoComponent>(_players.LocalEntity) || !_entity.HasComponent<CMGhostXenoHudComponent>(_players.LocalEntity))
+        if (!_entity.HasComponent<XenoComponent>(_players.LocalEntity) && !_entity.HasComponent<CMGhostXenoHudComponent>(_players.LocalEntity))
             return;
 
         var handle = args.WorldHandle;

--- a/Content.Client/_RMC14/Xenonids/Pheromones/XenoPheromonesOverlay.cs
+++ b/Content.Client/_RMC14/Xenonids/Pheromones/XenoPheromonesOverlay.cs
@@ -1,4 +1,5 @@
 ﻿using System.Numerics;
+using Content.Shared._RMC14.Mobs;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared._RMC14.Xenonids.Pheromones;
 using Robust.Client.GameObjects;
@@ -42,7 +43,7 @@ public sealed class XenoPheromonesOverlay : Overlay
 
     protected override void Draw(in OverlayDrawArgs args)
     {
-        if (!_entity.HasComponent<XenoComponent>(_players.LocalEntity))
+        if (!_entity.HasComponent<XenoComponent>(_players.LocalEntity) || !_entity.HasComponent<CMGhostXenoHudComponent>(_players.LocalEntity))
             return;
 
         var handle = args.WorldHandle;

--- a/Content.Server/_RMC14/Mobs/CMGhostSystem.cs
+++ b/Content.Server/_RMC14/Mobs/CMGhostSystem.cs
@@ -2,6 +2,9 @@ using Content.Shared.Ghost;
 using Content.Shared.Actions;
 using Content.Shared._RMC14.Mobs;
 using Content.Shared.Overlays;
+using Content.Shared.Weapons.Melee;
+using Content.Shared.Damage.Prototypes;
+using Robust.Shared.Prototypes;
 
 namespace Content.Server._RMC14.Mobs
 {
@@ -32,6 +35,7 @@ namespace Content.Server._RMC14.Mobs
             _actions.AddAction(uid, ref comp.ToggleXenoHudEntity, comp.ToggleXenoHud);
 
             EnsureComp<CMGhostMarineHudComponent>(uid);
+            EnsureComp<ShowHealthIconsComponent>(uid);
             EnsureComp<CMGhostXenoHudComponent>(uid);
         }
 
@@ -42,11 +46,13 @@ namespace Content.Server._RMC14.Mobs
             if (HasComp<CMGhostMarineHudComponent>(uid))
             {
                 RemComp<CMGhostMarineHudComponent>(uid);
+                RemCompDeferred<ShowHealthIconsComponent>(uid);
                 _actions.SetToggled(comp.ToggleMarineHudEntity, true);
             }
             else
             {
                 AddComp<CMGhostMarineHudComponent>(uid);
+                EnsureComp<ShowHealthIconsComponent>(uid);
                 _actions.SetToggled(comp.ToggleMarineHudEntity, false);
             }
         }

--- a/Content.Server/_RMC14/Mobs/CMGhostSystem.cs
+++ b/Content.Server/_RMC14/Mobs/CMGhostSystem.cs
@@ -2,9 +2,6 @@ using Content.Shared.Ghost;
 using Content.Shared.Actions;
 using Content.Shared._RMC14.Mobs;
 using Content.Shared.Overlays;
-using Content.Shared.Weapons.Melee;
-using Content.Shared.Damage.Prototypes;
-using Robust.Shared.Prototypes;
 
 namespace Content.Server._RMC14.Mobs
 {

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -49,6 +49,9 @@
     tags:
     - BypassInteractionRangeChecks
   - type: ActiveInputMover
+  - type: ShowHealthBars
+    damageContainers:
+    - Biological
 
 - type: entity
   id: ActionGhostBoo


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Title.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Good QoL for ghosts and such, they can see xenos health fully already so this is for marines.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Made XenoOverlay check for the ghosthudcomp thing for xenos so you don't get a double dead icon showing up. The toggle for marines now adds or removes the showhealthicons Component.

For health bars...I just gave up and added them to the base observer prototype. I could not for the life of me get them to toggle correctly without disappearing forever or not showing up at all.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

https://github.com/user-attachments/assets/41fc0f3f-1c96-4c12-89d6-91e81f24326c


## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- add: Ghosts can now see health bars and icons, and xeno pheromones
