### PR TITLE
Make bonus Req starting money scale with player count instead of being flat, ow console damage kicks you out

### DIFF
--- a/Content.Server/_RMC14/Requisitions/RequisitionsSystem.cs
+++ b/Content.Server/_RMC14/Requisitions/RequisitionsSystem.cs
@@ -46,6 +46,7 @@ public sealed partial class RequisitionsSystem : SharedRequisitionsSystem
 
     private int _starting;
     private int _gain;
+    private int _startingDollarsPerMarine;
 
     private readonly HashSet<Entity<MobStateComponent>> _toPit = new();
 
@@ -67,6 +68,7 @@ public sealed partial class RequisitionsSystem : SharedRequisitionsSystem
 
         Subs.CVar(_config, RMCCVars.RMCRequisitionsStartingBalance, v => _starting = v, true);
         Subs.CVar(_config, RMCCVars.RMCRequisitionsBalanceGain, v => _gain = v, true);
+        Subs.CVar(_config, RMCCVars.RMCRequisitionsStartingDollarsPerMarine, v => _startingDollarsPerMarine = v, true);
     }
 
     private void OnComputerMapInit(Entity<RequisitionsComputerComponent> ent, ref MapInitEvent args)
@@ -476,7 +478,7 @@ public sealed partial class RequisitionsSystem : SharedRequisitionsSystem
             {
                 account.Started = true;
                 var marines = Count<MarineComponent>();
-                account.Balance = _starting + marines * account.StartingDollarsPerMarine;
+                account.Balance = _starting + marines * _startingDollarsPerMarine;
                 Dirty(uid, account);
 
                 updateUI = true;

--- a/Content.Shared/_RMC14/CCVar/RMCCVars.cs
+++ b/Content.Shared/_RMC14/CCVar/RMCCVars.cs
@@ -76,10 +76,14 @@ public sealed class RMCCVars : CVars
         CVarDef.Create("rmc.discord_account_linking_message_link", "", CVar.REPLICATED | CVar.SERVER);
 
     public static readonly CVarDef<int> RMCRequisitionsStartingBalance =
-        CVarDef.Create("rmc.requisitions_starting_balance", 80000, CVar.REPLICATED | CVar.SERVER);
+        CVarDef.Create("rmc.requisitions_starting_balance", 0, CVar.REPLICATED | CVar.SERVER);
 
     public static readonly CVarDef<int> RMCRequisitionsBalanceGain =
-        CVarDef.Create("rmc.requisitions_balance_gain", 1500, CVar.REPLICATED | CVar.SERVER);
+        CVarDef.Create("rmc.requisitions_balance_gain", 500, CVar.REPLICATED | CVar.SERVER);
+
+    // TODO RMC14 400
+    public static readonly CVarDef<int> RMCRequisitionsStartingDollarsPerMarine =
+        CVarDef.Create("rmc.requisitions_starting_dollars_per_marine", 1900, CVar.REPLICATED | CVar.SERVER);
 
     public static readonly CVarDef<string> RMCDiscordToken =
         CVarDef.Create("rmc.discord_token", "", CVar.SERVER | CVar.SERVERONLY | CVar.CONFIDENTIAL);

--- a/Content.Shared/_RMC14/Overwatch/SharedOverwatchConsoleSystem.cs
+++ b/Content.Shared/_RMC14/Overwatch/SharedOverwatchConsoleSystem.cs
@@ -1,15 +1,20 @@
-﻿using Content.Shared._RMC14.Marines;
+﻿using System.Linq;
+using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.Marines.Squads;
 using Content.Shared._RMC14.Roles;
 using Content.Shared._RMC14.Rules;
+using Content.Shared.Damage;
+using Content.Shared.Damage.Prototypes;
+using Content.Shared.FixedPoint;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Inventory;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Movement.Events;
-using Content.Shared.Weapons.Melee.Events;
+using Content.Shared.Popups;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 
 namespace Content.Shared._RMC14.Overwatch;
@@ -21,6 +26,8 @@ public abstract class SharedOverwatchConsoleSystem : EntitySystem
     [Dependency] private readonly SharedMapSystem _map = default!;
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly ISharedPlayerManager _player = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly IPrototypeManager _prototypes = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
 
@@ -29,6 +36,10 @@ public abstract class SharedOverwatchConsoleSystem : EntitySystem
     private EntityQuery<MobStateComponent> _mobStateQuery;
     private EntityQuery<OriginalRoleComponent> _originalRoleQuery;
     private EntityQuery<RMCPlanetComponent> _planetQuery;
+
+    private ProtoId<DamageGroupPrototype> _bruteGroup = "Brute";
+    private ProtoId<DamageGroupPrototype> _burnGroup = "Burn";
+    private ProtoId<DamageGroupPrototype> _toxinGroup = "Toxin";
 
     public override void Initialize()
     {
@@ -41,7 +52,7 @@ public abstract class SharedOverwatchConsoleSystem : EntitySystem
         SubscribeLocalEvent<OverwatchConsoleComponent, BoundUIOpenedEvent>(OnBUIOpened);
 
         SubscribeLocalEvent<OverwatchWatchingComponent, MoveInputEvent>(OnWatchingMoveInput);
-        SubscribeLocalEvent<OverwatchWatchingComponent, AttackedEvent>(OnWatchingAttacked);
+        SubscribeLocalEvent<OverwatchWatchingComponent, DamageChangedEvent>(OnWatchingDamageChanged);
 
         SubscribeLocalEvent<SquadMemberComponent, SquadMemberUpdatedEvent>(OnSquadMemberUpdated);
 
@@ -75,9 +86,28 @@ public abstract class SharedOverwatchConsoleSystem : EntitySystem
         TryLocalUnwatch(ent);
     }
 
-    private void OnWatchingAttacked(Entity<OverwatchWatchingComponent> ent, ref AttackedEvent args)
+    private void OnWatchingDamageChanged(Entity<OverwatchWatchingComponent> ent, ref DamageChangedEvent args)
     {
+        if (!args.DamageIncreased || args.DamageDelta is not { } delta)
+            return;
+
+        var damage = delta.GetDamagePerGroup(_prototypes);
+        var bruteDamage = damage.GetValueOrDefault(_bruteGroup);
+        var burnDamage = damage.GetValueOrDefault(_burnGroup);
+        var toxinDamage = damage.GetValueOrDefault(_toxinGroup);
+        if (bruteDamage + burnDamage <= FixedPoint2.Zero && toxinDamage <= 10)
+            return;
+
         TryLocalUnwatch(ent);
+
+        foreach (var (uiEnt, uiKey) in _ui.GetActorUis(ent.Owner).ToArray())
+        {
+            if (uiKey is OverwatchConsoleUI.Key)
+                _ui.CloseUi(uiEnt, uiKey, ent);
+        }
+
+        if (_net.IsServer)
+            _popup.PopupEntity("The pain kicked you out of the console!", ent, ent, PopupType.MediumCaution);
     }
 
     private void OnSquadMemberUpdated(Entity<SquadMemberComponent> ent, ref SquadMemberUpdatedEvent args)

--- a/Content.Shared/_RMC14/Requisitions/Components/RequisitionsAccountComponent.cs
+++ b/Content.Shared/_RMC14/Requisitions/Components/RequisitionsAccountComponent.cs
@@ -13,9 +13,6 @@ public sealed partial class RequisitionsAccountComponent : Component
     [DataField]
     public int Balance;
 
-    [DataField]
-    public int StartingDollarsPerMarine = 400;
-
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField]
     public TimeSpan NextGain;
 

--- a/Content.Shared/_RMC14/Stealth/RMCPassiveStealthSystem.cs
+++ b/Content.Shared/_RMC14/Stealth/RMCPassiveStealthSystem.cs
@@ -28,6 +28,9 @@ public sealed class RMCPassiveStealthSystem : EntitySystem
 
     private void OnInit(Entity<RMCPassiveStealthComponent> ent, ref ComponentInit args)
     {
+        if (_timing.ApplyingState)
+            return;
+
         if (Paused(ent.Owner))
             return;
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
:cl:
- tweak: Made the bonus Requisitions starting money added on top of the regular starting cash properly scale with player count instead of being flat.
- tweak: Getting attacked will now kick you out of the Overwatch console view, making you immediately realize your peril.
- fix: Hopefully fix the bug that sometimes causes your game to die at the sight of a reactive thermal tarp.