### PR TITLE
Revise most Xeno action descriptions

### DIFF
--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
@@ -127,7 +127,7 @@
   id: ActionXenoHeadbutt
   parent: ActionXenoBase
   name: Headbutt (10) # TODO RMC14 proper plasma costs
-  description: Charge in a direction and push back any enemies in your way.
+  description: Charge towards the targeted enemy and push back the first enemy hit.
   components:
   - type: EntityTargetAction
     itemIconStyle: NoItem
@@ -157,7 +157,7 @@
   id: ActionXenoSlowingSpit
   parent: ActionXenoBase
   name: Slowing Spit (20) # TODO RMC14 proper plasma costs
-  description: Launches a projectile that will slow the first enemy that it hits, and paralyze them if they have no armor.
+  description: Launches a damageless projectile that will slow the first enemy that it hits, and paralyze them if they have no armor.
   components:
   - type: WorldTargetAction
     itemIconStyle: NoItem
@@ -173,7 +173,7 @@
   id: ActionXenoScatteredSpit
   parent: ActionXenoBase
   name: Scattered Spit (20) # TODO RMC14 proper plasma costs
-  description: Launches multiple projectiles that will briefly paralyze any enemies they hit.
+  description: Launches multiple damageless projectiles that will briefly paralyze any enemies they hit.
   components:
   - type: WorldTargetAction
     itemIconStyle: NoItem
@@ -205,7 +205,7 @@
   id: ActionXenoChargeSpit
   parent: ActionXenoBase
   name: Charge Spit (50) # TODO RMC14 proper plasma costs
-  description: Charges up your next spit, making it deal more damage but have less range.
+  description: Charges up your next spit, making it deal more damage and coat the enemy in acid, but have less range. Increases your movement speed until the ability expires.
   components:
   - type: InstantAction
     itemIconStyle: NoItem
@@ -219,7 +219,7 @@
   parent: ActionXenoBase
   id: ActionXenoSprayAcid
   name: Spray Acid (40)
-  description: Sprays acid along the ground in a line, covering tiles with it. [color=red]Will deal extra damage to barricades and anyone recently hit by a charged spit![/color]
+  description: Sprays acid along the ground in a line, covering tiles with it. [color=red]Will coat barricades in acid and significantly strengthen acid inflicted from Charge Spit![/color]
   components:
   - type: WorldTargetAction
     itemIconStyle: NoItem
@@ -287,7 +287,7 @@
   id: ActionXenoPunch
   parent: ActionXenoBase
   name: Punch
-  description: Punches the targeted marine dealing a hefty amount of damage as well as slowing the target.
+  description: Punches the targeted enemy to deal a hefty amount of damage, slowing them and pushing them away.
   components:
   - type: EntityTargetAction
     itemIconStyle: NoItem
@@ -304,7 +304,7 @@
   id: ActionXenoFling
   parent: ActionXenoBase
   name: Fling
-  description: Flings the targeted marine a few tiles and damages them.
+  description: Flings the targeted enemy a few tiles, knocking them down and damaging them.
   components:
   - type: EntityTargetAction
     itemIconStyle: NoItem
@@ -321,7 +321,7 @@
   id: ActionXenoLunge
   parent: ActionXenoBase
   name: Lunge
-  description: Lunges the warrior towards the targeted marine and grabs them.
+  description: Lunges towards the targeted enemy and grabs the first enemy hit.
   components:
   - type: EntityTargetAction
     itemIconStyle: NoItem
@@ -366,7 +366,7 @@
   id: ActionXenoStomp
   parent: ActionXenoBase
   name: Stomp (30)
-  description: Slam the ground with a 5x5 AOE slow down that affects all hostiles in range.
+  description: Slam the ground with a 5x5 AOE, slowing down and disarming all enemies in range. Deals heavy damage to targets you are on top of.
   components:
   - type: InstantAction
     itemIconStyle: NoItem
@@ -380,7 +380,7 @@
   id: ActionXenoCharge
   parent: ActionXenoBase
   name: Charge (20)
-  description: Click on a tile you want to charge at, after a brief non cancel-able windup time.
+  description: Click on a tile you want to charge at, after a brief non cancel-able windup time. [color=green]Cooldown is partially refunded upon attacking an enemy, scaling with the amount of enemies you cleave with your passive.[/color]
   components:
   - type: WorldTargetAction
     itemIconStyle: NoItem
@@ -396,7 +396,7 @@
   parent: ActionXenoBase
   id: ActionXenoBombard
   name: Bombard (200)
-  description: Fire either an acidic glob after a delay. # TODO RMC14 or neurotoxic glob
+  description: Fire either an acidic or neurotoxic glob after a delay.
   components:
   - type: WorldTargetAction
     itemIconStyle: NoItem
@@ -436,7 +436,7 @@
   parent: ActionXenoBase
   id: ActionXenoAcidShroud
   name: Acid Shroud
-  description: Create a small cloud of acid around you to cloak yourself. This will disable your other abilities for a short time to allow you to escape.
+  description: Create a small cloud of acidic or neurotoxic gas around you to cloak yourself. This will disable your other abilities for a short time to allow you to escape.
   components:
   - type: InstantAction
     itemIconStyle: NoItem

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_self_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_self_actions.yml
@@ -168,7 +168,7 @@
   id: ActionXenoDefensiveShield
   parent: ActionXenoBase
   name: Defensive Shield (50)
-  description: Gain a temporary shield that blocks the next 200 damage (and is immune to explosive damage) that lasts 7 seconds. Any damage that impacts the shield is reduced by 10 before processing. Cooldown is partially refunded upon attacking an enemy.
+  description: Gain a temporary shield that blocks the next 200 damage (and is immune to explosive damage) that lasts 7 seconds. Any damage that impacts the shield is reduced by 10 before processing. [color=green]Cooldown is partially refunded upon attacking an enemy.[/color]
   components:
   - type: InstantAction
     itemIconStyle: NoItem

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_self_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_self_actions.yml
@@ -65,7 +65,7 @@
   id: ActionXenoToggleCrest
   parent: ActionXenoBase
   name: Toggle Crest Defense
-  description: Increases your resistance to projectile damage but slows you down.
+  description: Increases your resistance to direct damage but slows you down.
   components:
   - type: InstantAction
     itemIconStyle: NoItem
@@ -82,7 +82,7 @@
   id: ActionXenoFortify
   parent: ActionXenoBase
   name: Fortify
-  description: Become immobile and extremely resistant to projectile damage.
+  description: Become immobile and impassable to mobs, dramatically increasing your resistance to direct damage. Damage is further reduced from the direction you are facing.
   components:
   - type: InstantAction
     itemIconStyle: NoItem
@@ -155,7 +155,7 @@
   id: ActionXenoTurnInvisible
   parent: ActionXenoBase
   name: Turn Invisible (20) # TODO RMC14 proper plasma costs
-  description: Become partially invisible for a short time or until you attack.
+  description: Become partially invisible for 30 seconds or until you attack. Increases your movement speed until the ability expires.
   components:
   - type: InstantAction
     itemIconStyle: NoItem
@@ -168,7 +168,7 @@
   id: ActionXenoDefensiveShield
   parent: ActionXenoBase
   name: Defensive Shield (50)
-  description: Gain a temporary shield that blocks the next 200 damage (And is immune to explosive damage) lasting 7 seconds. Any damage that impacts the shield is reduced by 10 before processing.
+  description: Gain a temporary shield that blocks the next 200 damage (and is immune to explosive damage) that lasts 7 seconds. Any damage that impacts the shield is reduced by 10 before processing. Cooldown is partially refunded upon attacking an enemy.
   components:
   - type: InstantAction
     itemIconStyle: NoItem

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_utility_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_utility_actions.yml
@@ -2,7 +2,7 @@
   id: ActionXenoTransferPlasma
   parent: ActionXenoBase
   name: Transfer plasma (50) # TODO RMC14 proper plasma costs
-  description: Give plasma to a nearby xeno
+  description: Give plasma to a nearby xenonid.
   components:
   - type: EntityTargetAction
     itemIconStyle: NoItem


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Most Xeno action descriptions either don't give the player much information, or just flat out lie to the player. This PR fixes these cases and also makes some of the wording more consistent.

## Why / Balance
**Drone/Hivelord**
- Fixed Give Plasma's description, prior it didn't mention xenonids or use punctuation.

**Defender**
- Charge: Formerly implied that it was both tile targeted and able to hit multiple enemies, wording updated to describe its player-targeted and single-target nature. 
- Toggle Crest Defense: Formerly stated it only reduced projectile damage, but it also decreases melee damage as well. Given the two terms are directly opposed to each other it wasn't intuitive. Things that Crest actually doesn't reduce are indirect damage sources, such as barbed wire on cades.
- Fortify: Same as above, but now mentions you become impassible, this is a rmc14-unique mechanic due to use not having bodyblocking, so wasn't present in the original 13 description. Also mentions now directional damage reduction.

**Warrior**
- Overall de-specified marines, as it was the only Xeno to do this. Updated each ability with its actual effects as many did not tell the full effects. Made Lunge more clear that it can be intercepted.

**Crusher**
- Charge/Shield: Now mentions its CD refunding properties from its passive, important to know as there is no way to currently view these less noticeable passive effects in-game.
- Stomp: Mentions its disarming properties, as well as damaging enemies you stand on.

**Sentinel**
- Clarified that the projectiles do not deal damage, as it is one of the most common misconceptions across all Xeno castes, due to targets glowing red when you hit them still, and not having any way to actually tell what a Marine's HP is.

**Spitter**
- Clarifies the effects of Charge Spit by mentioning its DoT effect
- Clarifies the effects of Spray Acid on cades and enemies afflicted by Charge Spit DoT
- Mentions Charged Spit's movement speed increase

**Boiler**
- Adds Neurotoxic Gas to Bombard's description, since it was forgotten about when Neuro was added.
- Acid Shroud: Clarifies that what you produce is the same gas as bombard, and that you can make a cloud of either kind.

**Lurker**
- Invisibility now tells the player the duration of the cloak, as saying "a short time" is both not very useful for planning, and also wrong (30 seconds is a fairly long time)
- Now mentions Invisibility's movement speed increasing properties, which are slightly hard to notice in-game.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Changed most Xeno ability descriptions to give more complete and correct information.

