### PR TITLE
Burrower Tremor ability

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Tremor/SharedXenoTremorSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Tremor/SharedXenoTremorSystem.cs
@@ -1,0 +1,74 @@
+﻿using Content.Shared._RMC14.Marines;
+using Content.Shared._RMC14.Standing;
+using Content.Shared._RMC14.Xenonids.Plasma;
+using Content.Shared.Coordinates;
+using Content.Shared.Damage;
+using Content.Shared.Effects;
+using Content.Shared.FixedPoint;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.Standing;
+using Content.Shared.Stunnable;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Network;
+using Robust.Shared.Player;
+
+namespace Content.Shared._RMC14.Xenonids.Tremor;
+
+public sealed class XenoTremorSystem : EntitySystem
+{
+    [Dependency] private readonly MobStateSystem _mobState = default!;
+    [Dependency] private readonly SharedColorFlashEffectSystem _colorFlash = default!;
+    [Dependency] private readonly DamageableSystem _damageable = default!;
+    [Dependency] private readonly XenoPlasmaSystem _xenoPlasma = default!;
+    [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
+    [Dependency] private readonly SharedStunSystem _stun = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly StandingStateSystem _standing = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<XenoTremorComponent, XenoTremorActionEvent>(OnXenoTremorAction);
+    }
+
+    private readonly HashSet<Entity<MarineComponent>> _receivers = new();
+
+    private void OnXenoTremorAction(Entity<XenoTremorComponent> xeno, ref XenoTremorActionEvent args)
+    {
+        var ev = new XenoTremorAttemptEvent();
+        RaiseLocalEvent(xeno, ref ev);
+
+        if (ev.Cancelled)
+            return;
+
+        args.Handled = true;
+
+        if (!TryComp(xeno, out TransformComponent? xform) ||
+            _mobState.IsDead(xeno))
+        {
+            return;
+        }
+
+        if (!_xenoPlasma.TryRemovePlasmaPopup(xeno.Owner, xeno.Comp.PlasmaCost))
+            return;
+
+        _receivers.Clear();
+        _entityLookup.GetEntitiesInRange(xform.Coordinates, xeno.Comp.Range, _receivers);
+
+        if (_net.IsServer)
+            _audio.PlayPvs(xeno.Comp.Sound, xeno);
+
+        foreach (var receiver in _receivers)
+        {
+            if (_mobState.IsDead(receiver))
+                continue;
+
+            _stun.TryParalyze(receiver, xeno.Comp.ParalyzeTime, true);
+            if (_net.IsServer)
+                SpawnAttachedTo(xeno.Comp.Effect, receiver.Owner.ToCoordinates());
+
+        }
+    }
+}

--- a/Content.Shared/_RMC14/Xenonids/Tremor/XenoTremorActionEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Tremor/XenoTremorActionEvent.cs
@@ -1,0 +1,5 @@
+﻿using Content.Shared.Actions;
+
+namespace Content.Shared._RMC14.Xenonids.Tremor;
+
+public sealed partial class XenoTremorActionEvent : InstantActionEvent;

--- a/Content.Shared/_RMC14/Xenonids/Tremor/XenoTremorAttemptEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Tremor/XenoTremorAttemptEvent.cs
@@ -1,0 +1,4 @@
+﻿namespace Content.Shared._RMC14.Xenonids.Tremor;
+
+[ByRefEvent]
+public record struct XenoTremorAttemptEvent(bool Cancelled);

--- a/Content.Shared/_RMC14/Xenonids/Tremor/XenoTremorComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Tremor/XenoTremorComponent.cs
@@ -1,0 +1,36 @@
+﻿using System.Numerics;
+using Content.Shared.Damage;
+using Content.Shared.FixedPoint;
+using Robust.Shared.Audio;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._RMC14.Xenonids.Tremor;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(XenoTremorSystem))]
+public sealed partial class XenoTremorComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 PlasmaCost = 100;
+
+    [DataField]
+    public DamageSpecifier Damage = new();
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan ParalyzeTime = TimeSpan.FromSeconds(0.4);
+
+
+    [DataField, AutoNetworkedField]
+    public float Range = 3;
+
+    [DataField, AutoNetworkedField]
+    public EntProtoId SelfEffect = "CMEffectSelfStomp";
+
+    [DataField, AutoNetworkedField]
+    public EntProtoId Effect = "CMEffectStomp";
+
+    // TODO RMC14 bang.ogg
+    [DataField, AutoNetworkedField]
+    public SoundSpecifier Sound = new SoundPathSpecifier("/Audio/_RMC14/Xeno/alien_footstep_charge1.ogg");
+}

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
@@ -377,6 +377,34 @@
     useDelay: 18
 
 - type: entity
+  id: ActionXenoBurrow
+  parent: ActionXenoBase
+  name: Burrow 
+  description: Burrow underground and wait there for a short amount of time, either to emerge and ambush prey or to tunnel away.
+  components:
+  - type: InstantAction
+    itemIconStyle: NoItem
+    icon:
+      sprite: _RMC14/Actions/xeno_actions.rsi
+      state: stomp
+    event: !type:XenoStompActionEvent
+    useDelay: 60
+
+- type: entity
+  id: ActionXenoTremor
+  parent: ActionXenoBase
+  name: Tremor (100)
+  description: Tremor causes an area of effect stun in a 7x7 space around the burrower.
+  components:
+  - type: InstantAction
+    itemIconStyle: NoItem
+    icon:
+      sprite: _RMC14/Actions/xeno_actions.rsi
+      state: stomp
+    event: !type:XenoTremorActionEvent
+    useDelay: 20
+
+- type: entity
   id: ActionXenoCharge
   parent: ActionXenoBase
   name: Charge (20)

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/burrower.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/burrower.yml
@@ -31,17 +31,23 @@
     - ActionXenoTailStab
     - ActionXenoAcidNormal
     - ActionXenoOrderConstruction
-    #    - ActionXenoDigTunnel
     - ActionXenoPlantWeeds
-    #    - ActionXenoBurrow
-    #    - ActionXenoTremor
+    - ActionXenoTremor
     - ActionXenoDevolve
     tier: 2
     hudOffset: 0,0.56
     unlockAt: 420 # 7 minutes
+  - type: XenoConstruction
+    canBuild:
+    - WallXenoResin
+    - WallXenoMembrane
+    - DoorXenoResin
+    canOrderConstruction:
+    - HiveCoreXenoConstructionNode
   - type: XenoDevolve
     devolvesTo:
     - CMXenoDrone
+  - type: XenoTremor
   - type: XenoPlasma
     plasma: 600
     maxPlasma: 600


### PR DESCRIPTION

## About the PR
Added Burrower's Tremor ability. 7 by 7 radius, Plasma cost 100, Delay 60 seconds 
Added Burrower's Missing Construction component (Fixes building and laying weeds)

Added Server.Shared RMC14 Xenoid component - "Tremor"
Added Construction component to Burrower
Added Tremor Action component to Burrower
Added Tremor Action to Xeno Offencive actions

## Why / Balance
Contributes to adding Burrower in the game sooner. 

Delay 60 seconds  because Its a 7 by 7 paralise stun, dont think it should be spammed too much so the delay is long for balancing reasons. but can be changed later
## Technical details
Server.Shared RMC14 Xenoid - Tremor Component is based on Stomp Component
## Media
## Requirements
- [X ] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
(signed by Lordin)
## Breaking changes

https://github.com/user-attachments/assets/de26e72e-ba61-4b34-8d41-91dfd8a35f13



**Changelog**
Added Burrower's Tremor ability

:cl:
- add: Added Burrower's Tremor ability
- fix: Fixed Burrower prototype not having Construction component. Now Burrower can place weeds again

