### PR TITLE
Fix breaking a Warrior Lunge not cancelling the stun and knockdown on the target, fix punch and fling not breaking self pulls on the target entity

### DIFF
--- a/Content.Shared/_RMC14/Pulling/ActivePreventPulledWhileAliveComponent.cs
+++ b/Content.Shared/_RMC14/Pulling/ActivePreventPulledWhileAliveComponent.cs
@@ -3,5 +3,5 @@
 namespace Content.Shared._RMC14.Pulling;
 
 [RegisterComponent, NetworkedComponent]
-[Access(typeof(CMPullingSystem))]
+[Access(typeof(RMCPullingSystem))]
 public sealed partial class ActivePreventPulledWhileAliveComponent : Component;

--- a/Content.Shared/_RMC14/Pulling/BlockPullingDeadActiveComponent.cs
+++ b/Content.Shared/_RMC14/Pulling/BlockPullingDeadActiveComponent.cs
@@ -3,5 +3,5 @@
 namespace Content.Shared._RMC14.Pulling;
 
 [RegisterComponent, NetworkedComponent]
-[Access(typeof(CMPullingSystem))]
+[Access(typeof(RMCPullingSystem))]
 public sealed partial class BlockPullingDeadActiveComponent : Component;

--- a/Content.Shared/_RMC14/Pulling/BlockPullingDeadComponent.cs
+++ b/Content.Shared/_RMC14/Pulling/BlockPullingDeadComponent.cs
@@ -3,5 +3,5 @@
 namespace Content.Shared._RMC14.Pulling;
 
 [RegisterComponent, NetworkedComponent]
-[Access(typeof(CMPullingSystem))]
+[Access(typeof(RMCPullingSystem))]
 public sealed partial class BlockPullingDeadComponent : Component;

--- a/Content.Shared/_RMC14/Pulling/PreventPulledWhileAliveComponent.cs
+++ b/Content.Shared/_RMC14/Pulling/PreventPulledWhileAliveComponent.cs
@@ -6,7 +6,7 @@ using Robust.Shared.Prototypes;
 namespace Content.Shared._RMC14.Pulling;
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-[Access(typeof(CMPullingSystem))]
+[Access(typeof(RMCPullingSystem))]
 public sealed partial class PreventPulledWhileAliveComponent : Component
 {
     [DataField, AutoNetworkedField]

--- a/Content.Shared/_RMC14/Pulling/PullWhitelistComponent.cs
+++ b/Content.Shared/_RMC14/Pulling/PullWhitelistComponent.cs
@@ -4,7 +4,7 @@ using Robust.Shared.GameStates;
 namespace Content.Shared._RMC14.Pulling;
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-[Access(typeof(CMPullingSystem))]
+[Access(typeof(RMCPullingSystem))]
 public sealed partial class PullWhitelistComponent : Component
 {
     [DataField(required: true), AutoNetworkedField]

--- a/Content.Shared/_RMC14/Pulling/PullingSlowedComponent.cs
+++ b/Content.Shared/_RMC14/Pulling/PullingSlowedComponent.cs
@@ -3,5 +3,5 @@
 namespace Content.Shared._RMC14.Pulling;
 
 [RegisterComponent, NetworkedComponent]
-[Access(typeof(CMPullingSystem))]
+[Access(typeof(RMCPullingSystem))]
 public sealed partial class PullingSlowedComponent : Component;

--- a/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
+++ b/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
@@ -14,7 +14,7 @@ using Robust.Shared.Random;
 
 namespace Content.Shared._RMC14.Pulling;
 
-public sealed class CMPullingSystem : EntitySystem
+public sealed class RMCPullingSystem : EntitySystem
 {
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
@@ -231,6 +231,18 @@ public sealed class CMPullingSystem : EntitySystem
         }
 
         return false;
+    }
+
+    public void TryStopUserPullIfPulling(EntityUid user, EntityUid target)
+    {
+        if (!TryComp(user, out PullerComponent? puller) ||
+            puller.Pulling != target ||
+            !TryComp(puller.Pulling, out PullableComponent? pullable))
+        {
+            return;
+        }
+
+        _pulling.TryStopPull(puller.Pulling.Value, pullable, user);
     }
 
     public override void Update(float frameTime)

--- a/Content.Shared/_RMC14/Pulling/SlowOnPullComponent.cs
+++ b/Content.Shared/_RMC14/Pulling/SlowOnPullComponent.cs
@@ -5,7 +5,7 @@ using Robust.Shared.Serialization;
 namespace Content.Shared._RMC14.Pulling;
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-[Access(typeof(CMPullingSystem))]
+[Access(typeof(RMCPullingSystem))]
 public sealed partial class SlowOnPullComponent : Component
 {
     [DataField(required: true), AutoNetworkedField]

--- a/Content.Shared/_RMC14/Xenonids/Fling/XenoFlingSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Fling/XenoFlingSystem.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared.Coordinates;
+﻿using Content.Shared._RMC14.Pulling;
+using Content.Shared.Coordinates;
 using Content.Shared.Damage;
 using Content.Shared.Effects;
 using Content.Shared.FixedPoint;
@@ -14,10 +15,10 @@ namespace Content.Shared._RMC14.Xenonids.Fling;
 public sealed class XenoFlingSystem : EntitySystem
 {
     [Dependency] private readonly SharedAudioSystem _audio = default!;
-    [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly SharedColorFlashEffectSystem _colorFlash = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly RMCPullingSystem _rmcPulling = default!;
     [Dependency] private readonly ThrowingSystem _throwing = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedStunSystem _stun = default!;
@@ -48,6 +49,8 @@ public sealed class XenoFlingSystem : EntitySystem
             _audio.PlayPvs(xeno.Comp.Sound, xeno);
 
         var targetId = args.Target;
+        _rmcPulling.TryStopUserPullIfPulling(xeno, targetId);
+
         var damage = _damageable.TryChangeDamage(targetId, xeno.Comp.Damage);
         if (damage?.GetTotal() > FixedPoint2.Zero)
         {

--- a/Content.Shared/_RMC14/Xenonids/Lunge/XenoLungeStunnedComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Lunge/XenoLungeStunnedComponent.cs
@@ -1,0 +1,17 @@
+﻿using Content.Shared.StatusEffect;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Shared._RMC14.Xenonids.Lunge;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
+[Access(typeof(XenoLungeSystem))]
+public sealed partial class XenoLungeStunnedComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public ProtoId<StatusEffectPrototype>[] Effects = new ProtoId<StatusEffectPrototype>[] {"Stun", "KnockedDown"};
+
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
+    public TimeSpan ExpireAt;
+}

--- a/Content.Shared/_RMC14/Xenonids/Punch/XenoPunchSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Punch/XenoPunchSystem.cs
@@ -1,8 +1,11 @@
-﻿using Content.Shared.Coordinates;
+﻿using Content.Shared._RMC14.Pulling;
+using Content.Shared.Coordinates;
 using Content.Shared.Damage;
 using Content.Shared.Effects;
 using Content.Shared.FixedPoint;
 using Content.Shared.Mobs.Systems;
+using Content.Shared.Movement.Pulling.Components;
+using Content.Shared.Movement.Pulling.Systems;
 using Content.Shared.Throwing;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Network;
@@ -13,10 +16,10 @@ namespace Content.Shared._RMC14.Xenonids.Punch;
 public sealed class XenoPunchSystem : EntitySystem
 {
     [Dependency] private readonly SharedAudioSystem _audio = default!;
-    [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly SharedColorFlashEffectSystem _colorFlash = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly RMCPullingSystem _rmcPulling = default!;
     [Dependency] private readonly ThrowingSystem _throwing = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly XenoSystem _xeno = default!;
@@ -46,6 +49,8 @@ public sealed class XenoPunchSystem : EntitySystem
             _audio.PlayPvs(xeno.Comp.Sound, xeno);
 
         var targetId = args.Target;
+        _rmcPulling.TryStopUserPullIfPulling(xeno, targetId);
+
         var damage = _damageable.TryChangeDamage(targetId, xeno.Comp.Damage);
         if (damage?.GetTotal() > FixedPoint2.Zero)
         {


### PR DESCRIPTION
## About the PR
## Media
## Requirements
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed a Warrior stopping its pull not cancelling the stun and knockdown from it. If a Warrior stops pulling someone after hitting them with a Lunge, the target will now correctly instantly get up.
- fix: Fixed Warrior Punch and Fling not cancelling pulls if done while pulling the target. Punch and Fling will now correctly break your pull on the target if you happen to be pulling them before using either ability.
