### PR TITLE
fix landing signs being pullable

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Misc/landing_signs.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Misc/landing_signs.yml
@@ -8,7 +8,7 @@
   - type: Transform
     anchored: false
   - type: Physics
-    bodyType: Dynamic
+    bodyType: Static
   - type: InteractionOutline
   - type: Sprite
     drawdepth: OverMobs

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Misc/landing_signs.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Misc/landing_signs.yml
@@ -1,10 +1,14 @@
 - type: entity
-  parent: [BaseStructureDynamic, CMBaseStructureCorrodible]
+  parent: CMBaseStructureCorrodible
   abstract: true
   id: RMCBaseLandingSign
   name: sign
   description: A sign.
   components:
+  - type: Transform
+    anchored: false
+  - type: Physics
+    bodyType: Dynamic
   - type: InteractionOutline
   - type: Sprite
     drawdepth: OverMobs


### PR DESCRIPTION
so dynamic structures are anchorable normally, we want it so you can place the landing sign anywhere, not just snapgrid so we remove dynamic structure parent and turn off anchored transform