### PR TITLE
Fix tactical map drawing and blips positions being incorrect with UI scales that aren't 100%

### DIFF
--- a/Content.Client/_RMC14/TacticalMap/TacticalMapControl.xaml.cs
+++ b/Content.Client/_RMC14/TacticalMap/TacticalMapControl.xaml.cs
@@ -88,7 +88,7 @@ public sealed partial class TacticalMapControl : TextureRect
         {
             foreach (var blip in _blips)
             {
-                var position = GetDrawPosition(blip.Indices) * 3;
+                var position = GetDrawPosition(blip.Indices) * 3 * UIScale;
                 var rect = UIBox2.FromDimensions(position, new Vector2(14, 14));
                 handle.DrawTextureRect(background, rect, blip.Color);
                 handle.DrawTextureRect(system.Frame0(blip.Image), rect);
@@ -101,8 +101,8 @@ public sealed partial class TacticalMapControl : TextureRect
         var lineVectors = new Vector2[6];
         foreach (var line in Lines)
         {
-            var start = line.Start + offset;
-            var end = line.End + offset;
+            var start = (line.Start + offset) * UIScale;
+            var end = (line.End + offset) * UIScale;
             var diff = end - start;
             var box = Box2.CenteredAround(start + diff / 2, new Vector2(5, (int) diff.Length()));
             var boxRotated = new Box2Rotated(box, diff.ToWorldAngle(), start + diff / 2);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
:cl:
- fix: Fixed tactical map drawing and blips positions being incorrect with UI scales that aren't 100%