### PR TITLE
Fix several Speedloader Reload bugs

### DIFF
--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Revolver.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Revolver.cs
@@ -133,7 +133,7 @@ public partial class SharedGunSystem
                 return false;
             }
 
-            for (var i = 0; i <= component.Capacity - 1; i++)
+            for (var i = 0; i < component.Capacity; i++)
             {
                 var index = (component.CurrentIndex + i) % component.Capacity;
 

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Revolver.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Revolver.cs
@@ -133,7 +133,7 @@ public partial class SharedGunSystem
                 return false;
             }
 
-            for (var i = Math.Min(ev.Ammo.Count - 1, component.Capacity - 1); i >= 0; i--)
+            for (var i = 0; i <= component.Capacity - 1; i++)
             {
                 var index = (component.CurrentIndex + i) % component.Capacity;
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
This fixes two 2-year old Upstream bugs that caused partial reloads with Speedloaders to break in many many ways. Partial reloads will now function as expected. This has an open upstream PR at https://github.com/space-wizards/space-station-14/pull/32396

## Why / Balance
Fixes Revolvercode, lets you properly reload Revolvers.

Resolves #3420 
Resolves #4103 

## Technical details
The i index here just tells how many slots in the Revolver the loop will look at, so I removed the Math.Min involving the amount of ammo to be loaded, as it is entirely irrelevant to how many chambers the Revolver has. There is already a Break condition present for when there isn't enough ammo that handles this correctly. Also changes the i-- behavior to i++ because by trying to reload the Revolver in reverse it put the ammo in only the farthest of slots compared to where your current index is.

## Media

https://github.com/user-attachments/assets/d82fc7c2-e9d5-4a85-807e-be44565f55da



## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Fixed Revolvers not correctly reloading from Speedloaders when the Revolver is partially loaded.
- fix: Speedloaders will now prioritize loading the active and upcoming chambers in a Revolver when the Speedloader is only partially filled, rather than the ones farthest away.
