### PR TITLE
Remove fire delay from guns when you switch hands

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/cm_base_gun.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/cm_base_gun.yml
@@ -22,6 +22,8 @@
     damage:
       types:
         Blunt: 5
+    soundHit:
+      collection: GenericHit
   - type: EmitSoundOnPickup
     sound:
       collection: RMCEquipGun
@@ -30,3 +32,4 @@
       collection: RMCRustleGun
   - type: Gun
     meleeCooldownOnShoot: false
+    resetOnHandSelected: false

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/cm_base_gun.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/cm_base_gun.yml
@@ -18,6 +18,7 @@
   - type: WieldDelay
   - type: AltFireMelee
   - type: MeleeWeapon
+    resetOnHandSelected: false
     attackRate: 1
     damage:
       types:


### PR DESCRIPTION
In CM13 you can dual wield like this:


https://github.com/user-attachments/assets/7ef65909-b47a-4148-9c05-a7ffddb23a51

currently, this isn't possible, because there's a cooldown

resolves #4088

I disabled the "resetOnHandSelected" datafield in this PR
also gave a melee sound for the gun