### PR TITLE
Makes throwing knives use throwing weapon mechanics

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Melee/knife.yml
@@ -77,6 +77,7 @@
     damage:
       types:
         Slash: 5
+  - type: LandAtCursor
   - type: DamageOtherOnHit
     damage:
       types:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
This adds the LandAtCursor comp to Throwing Knives to make them actually function like a throwing weapon. This makes them get thrown a bit faster and slide a bit past the cursor to make them easier to actually use as a weapon.

## Why / Balance
Throwing Knives and other throwing based weapons upstream use this to make them not really bad to use, ours are really bad to use, this makes them more usable.

## Media
https://github.com/user-attachments/assets/b7a1f861-5ff1-4eea-a6fa-776bf9287750

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- tweak: M11 Throwing Knives will now slide farther than your cursor when thrown, causing them to more reliably hit enemies.
