### PR TITLE
Xenos can see the exact numbers of their health/plasma/armor by hovering its alert

### DIFF
--- a/Content.Client/Actions/UI/ActionAlertTooltip.cs
+++ b/Content.Client/Actions/UI/ActionAlertTooltip.cs
@@ -14,15 +14,14 @@ namespace Content.Client.Actions.UI
         private const float TooltipTextMaxWidth = 350;
 
         private readonly RichTextLabel _cooldownLabel;
-        private readonly RichTextLabel _resourceLabel;
+        private readonly RichTextLabel _dynamicMessageLabel;
         private readonly IGameTiming _gameTiming;
 
         /// <summary>
         /// Current cooldown displayed in this tooltip. Set to null to show no cooldown.
         /// </summary>
         public (TimeSpan Start, TimeSpan End)? Cooldown { get; set; }
-        public int? ResourceMax { get; set; }
-        public int? ResourceCurrent { get; set; }
+        public string? DynamicMessage { get; set; }
 
         public ActionAlertTooltip(FormattedMessage name, FormattedMessage? desc, string? requires = null, FormattedMessage? charges = null)
         {
@@ -73,10 +72,10 @@ namespace Content.Client.Actions.UI
                 Visible = false
             });
 
-            vbox.AddChild(_resourceLabel = new RichTextLabel
+            vbox.AddChild(_dynamicMessageLabel = new RichTextLabel
             {
                 MaxWidth = TooltipTextMaxWidth,
-                StyleClasses = {StyleNano.StyleClassTooltipActionResource},
+                StyleClasses = {StyleNano.StyleClassTooltipActionDynamicMessage},
                 Visible = false
             });
 
@@ -122,14 +121,14 @@ namespace Content.Client.Actions.UI
                 }
             }
 
-            if (!ResourceMax.HasValue || !ResourceCurrent.HasValue)
+            if (string.IsNullOrWhiteSpace(DynamicMessage))
             {
-                _resourceLabel.Visible = false;
+                _dynamicMessageLabel.Visible = false;
             }
-            else if (FormattedMessage.TryFromMarkup($"[color=#ffffff]{(int)ResourceCurrent} / {(int)ResourceMax}[/color]", out var resmarkup))
+            else if (FormattedMessage.TryFromMarkup($"[color=#ffffff]{DynamicMessage}[/color]", out var dynamicMarkup))
             {
-                _resourceLabel.SetMessage(resmarkup);
-                _resourceLabel.Visible = true;
+                _dynamicMessageLabel.SetMessage(dynamicMarkup);
+                _dynamicMessageLabel.Visible = true;
             }
         }
     }

--- a/Content.Client/Actions/UI/ActionAlertTooltip.cs
+++ b/Content.Client/Actions/UI/ActionAlertTooltip.cs
@@ -21,6 +21,8 @@ namespace Content.Client.Actions.UI
         /// Current cooldown displayed in this tooltip. Set to null to show no cooldown.
         /// </summary>
         public (TimeSpan Start, TimeSpan End)? Cooldown { get; set; }
+        public int? ResourceMax { get; set; }
+        public int? ResourceCurrent { get; set; }
 
         public ActionAlertTooltip(FormattedMessage name, FormattedMessage? desc, string? requires = null, FormattedMessage? charges = null)
         {
@@ -117,6 +119,23 @@ namespace Content.Client.Actions.UI
                 else
                 {
                     _cooldownLabel.Visible = false;
+                }
+            }
+
+            if (!ResourceMax.HasValue || !ResourceCurrent.HasValue)
+            {
+                _resourceLabel.Visible = false;
+            }
+            else
+            {
+                if (FormattedMessage.TryFromMarkup($"[color=#ffffff]500 / 500[/color]", out var markup))
+                {
+                    _resourceLabel.SetMessage(markup);
+                    _resourceLabel.Visible = true;
+                }
+                else
+                {
+                    _resourceLabel.Visible = false;
                 }
             }
         }

--- a/Content.Client/Actions/UI/ActionAlertTooltip.cs
+++ b/Content.Client/Actions/UI/ActionAlertTooltip.cs
@@ -126,17 +126,10 @@ namespace Content.Client.Actions.UI
             {
                 _resourceLabel.Visible = false;
             }
-            else
+            else if (FormattedMessage.TryFromMarkup($"[color=#ffffff]{(int)ResourceCurrent} / {(int)ResourceMax}[/color]", out var resmarkup))
             {
-                if (FormattedMessage.TryFromMarkup($"[color=#ffffff]500 / 500[/color]", out var markup))
-                {
-                    _resourceLabel.SetMessage(markup);
-                    _resourceLabel.Visible = true;
-                }
-                else
-                {
-                    _resourceLabel.Visible = false;
-                }
+                _resourceLabel.SetMessage(resmarkup);
+                _resourceLabel.Visible = true;
             }
         }
     }

--- a/Content.Client/Actions/UI/ActionAlertTooltip.cs
+++ b/Content.Client/Actions/UI/ActionAlertTooltip.cs
@@ -14,6 +14,7 @@ namespace Content.Client.Actions.UI
         private const float TooltipTextMaxWidth = 350;
 
         private readonly RichTextLabel _cooldownLabel;
+        private readonly RichTextLabel _resourceLabel;
         private readonly IGameTiming _gameTiming;
 
         /// <summary>
@@ -70,6 +71,13 @@ namespace Content.Client.Actions.UI
                 Visible = false
             });
 
+            vbox.AddChild(_resourceLabel = new RichTextLabel
+            {
+                MaxWidth = TooltipTextMaxWidth,
+                StyleClasses = {StyleNano.StyleClassTooltipActionCooldown},
+                Visible = false
+            });
+
             if (!string.IsNullOrWhiteSpace(requires))
             {
                 var requiresLabel = new RichTextLabel
@@ -93,23 +101,23 @@ namespace Content.Client.Actions.UI
             if (!Cooldown.HasValue)
             {
                 _cooldownLabel.Visible = false;
-                return;
-            }
-
-            var timeLeft = Cooldown.Value.End - _gameTiming.CurTime;
-            if (timeLeft > TimeSpan.Zero)
-            {
-                var duration = Cooldown.Value.End - Cooldown.Value.Start;
-
-                if (!FormattedMessage.TryFromMarkup($"[color=#a10505]{(int) duration.TotalSeconds} sec cooldown ({(int) timeLeft.TotalSeconds + 1} sec remaining)[/color]", out var markup))
-                    return;
-
-                _cooldownLabel.SetMessage(markup);
-                _cooldownLabel.Visible = true;
             }
             else
             {
-                _cooldownLabel.Visible = false;
+                var timeLeft = Cooldown.Value.End - _gameTiming.CurTime;
+                if (timeLeft > TimeSpan.Zero)
+                {
+                    var duration = Cooldown.Value.End - Cooldown.Value.Start;
+
+                    if (FormattedMessage.TryFromMarkup($"[color=#a10505]{(int) duration.TotalSeconds} sec cooldown ({(int) timeLeft.TotalSeconds + 1} sec remaining)[/color]", out var markup)){
+                        _cooldownLabel.SetMessage(markup);
+                        _cooldownLabel.Visible = true;
+                    }
+                }
+                else
+                {
+                    _cooldownLabel.Visible = false;
+                }
             }
         }
     }

--- a/Content.Client/Actions/UI/ActionAlertTooltip.cs
+++ b/Content.Client/Actions/UI/ActionAlertTooltip.cs
@@ -76,7 +76,7 @@ namespace Content.Client.Actions.UI
             vbox.AddChild(_resourceLabel = new RichTextLabel
             {
                 MaxWidth = TooltipTextMaxWidth,
-                StyleClasses = {StyleNano.StyleClassTooltipActionCooldown},
+                StyleClasses = {StyleNano.StyleClassTooltipActionResource},
                 Visible = false
             });
 

--- a/Content.Client/Stylesheets/StyleNano.cs
+++ b/Content.Client/Stylesheets/StyleNano.cs
@@ -57,7 +57,7 @@ namespace Content.Client.Stylesheets
         public const string StyleClassTooltipActionTitle = "tooltipActionTitle";
         public const string StyleClassTooltipActionDescription = "tooltipActionDesc";
         public const string StyleClassTooltipActionCooldown = "tooltipActionCooldown";
-        public const string StyleClassTooltipActionResource = "tooltipActionResource";
+        public const string StyleClassTooltipActionDynamicMessage = "tooltipActionDynamicMessage";
         public const string StyleClassTooltipActionRequirements = "tooltipActionCooldown";
         public const string StyleClassTooltipActionCharges = "tooltipActionCharges";
         public const string StyleClassHotbarSlotNumber = "hotbarSlotNumber";
@@ -993,7 +993,7 @@ namespace Content.Client.Stylesheets
                 {
                     new StyleProperty("font", notoSans15)
                 }),
-                new StyleRule(new SelectorElement(typeof(RichTextLabel), new[] {StyleClassTooltipActionResource}, null, null), new[]
+                new StyleRule(new SelectorElement(typeof(RichTextLabel), new[] {StyleClassTooltipActionDynamicMessage}, null, null), new[]
                 {
                     new StyleProperty("font", notoSans15)
                 }),

--- a/Content.Client/Stylesheets/StyleNano.cs
+++ b/Content.Client/Stylesheets/StyleNano.cs
@@ -57,6 +57,7 @@ namespace Content.Client.Stylesheets
         public const string StyleClassTooltipActionTitle = "tooltipActionTitle";
         public const string StyleClassTooltipActionDescription = "tooltipActionDesc";
         public const string StyleClassTooltipActionCooldown = "tooltipActionCooldown";
+        public const string StyleClassTooltipActionResource = "tooltipActionResource";
         public const string StyleClassTooltipActionRequirements = "tooltipActionCooldown";
         public const string StyleClassTooltipActionCharges = "tooltipActionCharges";
         public const string StyleClassHotbarSlotNumber = "hotbarSlotNumber";
@@ -989,6 +990,10 @@ namespace Content.Client.Stylesheets
                     new StyleProperty("font", notoSans15)
                 }),
                 new StyleRule(new SelectorElement(typeof(RichTextLabel), new[] {StyleClassTooltipActionCooldown}, null, null), new[]
+                {
+                    new StyleProperty("font", notoSans15)
+                }),
+                new StyleRule(new SelectorElement(typeof(RichTextLabel), new[] {StyleClassTooltipActionResource}, null, null), new[]
                 {
                     new StyleProperty("font", notoSans15)
                 }),

--- a/Content.Client/UserInterface/Systems/Alerts/Controls/AlertControl.cs
+++ b/Content.Client/UserInterface/Systems/Alerts/Controls/AlertControl.cs
@@ -30,35 +30,21 @@ namespace Content.Client.UserInterface.Systems.Alerts.Controls
             }
         }
 
-        public int? ResourceMax
+        public string? DynamicMessage
         {
-            get => _resourceMax;
+            get => _dynamicMessage;
             set
             {
-                _resourceMax = value;
+                _dynamicMessage = value;
                 if (SuppliedTooltip is ActionAlertTooltip actionAlertTooltip)
                 {
-                    actionAlertTooltip.ResourceMax = value;
-                }
-            }
-        }
-
-        public int? ResourceCurrent
-        {
-            get => _resourceCurrent;
-            set
-            {
-                _resourceCurrent = value;
-                if (SuppliedTooltip is ActionAlertTooltip actionAlertTooltip)
-                {
-                    actionAlertTooltip.ResourceCurrent = value;
+                    actionAlertTooltip.DynamicMessage = value;
                 }
             }
         }
 
         private (TimeSpan Start, TimeSpan End)? _cooldown;
-        private int? _resourceMax;
-        private int? _resourceCurrent;
+        private string? _dynamicMessage;
 
         private short? _severity;
         private readonly IGameTiming _gameTiming;
@@ -99,7 +85,7 @@ namespace Content.Client.UserInterface.Systems.Alerts.Controls
         {
             var msg = FormattedMessage.FromMarkup(Loc.GetString(Alert.Name));
             var desc = FormattedMessage.FromMarkup(Loc.GetString(Alert.Description));
-            return new ActionAlertTooltip(msg, desc) {Cooldown = Cooldown, ResourceMax = ResourceMax, ResourceCurrent = ResourceCurrent};
+            return new ActionAlertTooltip(msg, desc) {Cooldown = Cooldown, DynamicMessage = DynamicMessage};
         }
 
         /// <summary>

--- a/Content.Client/UserInterface/Systems/Alerts/Controls/AlertControl.cs
+++ b/Content.Client/UserInterface/Systems/Alerts/Controls/AlertControl.cs
@@ -99,7 +99,7 @@ namespace Content.Client.UserInterface.Systems.Alerts.Controls
         {
             var msg = FormattedMessage.FromMarkup(Loc.GetString(Alert.Name));
             var desc = FormattedMessage.FromMarkup(Loc.GetString(Alert.Description));
-            return new ActionAlertTooltip(msg, desc) {Cooldown = Cooldown};
+            return new ActionAlertTooltip(msg, desc) {Cooldown = Cooldown, ResourceMax = ResourceMax, ResourceCurrent = ResourceCurrent};
         }
 
         /// <summary>

--- a/Content.Client/UserInterface/Systems/Alerts/Controls/AlertControl.cs
+++ b/Content.Client/UserInterface/Systems/Alerts/Controls/AlertControl.cs
@@ -30,7 +30,35 @@ namespace Content.Client.UserInterface.Systems.Alerts.Controls
             }
         }
 
+        public int ResourceMax
+        {
+            get => _resourceMax;
+            set
+            {
+                _resourceMax = value;
+                if (SuppliedTooltip is ActionAlertTooltip actionAlertTooltip)
+                {
+                    actionAlertTooltip.ResourceMax = value;
+                }
+            }
+        }
+
+        public int ResourceCurrent
+        {
+            get => _resourceCurrent;
+            set
+            {
+                _resourceCurrent = value;
+                if (SuppliedTooltip is ActionAlertTooltip actionAlertTooltip)
+                {
+                    actionAlertTooltip.ResourceCurrent = value;
+                }
+            }
+        }
+
         private (TimeSpan Start, TimeSpan End)? _cooldown;
+        private int _resourceMax;
+        private int _resourceCurrent;
 
         private short? _severity;
         private readonly IGameTiming _gameTiming;

--- a/Content.Client/UserInterface/Systems/Alerts/Controls/AlertControl.cs
+++ b/Content.Client/UserInterface/Systems/Alerts/Controls/AlertControl.cs
@@ -30,7 +30,7 @@ namespace Content.Client.UserInterface.Systems.Alerts.Controls
             }
         }
 
-        public int ResourceMax
+        public int? ResourceMax
         {
             get => _resourceMax;
             set
@@ -43,7 +43,7 @@ namespace Content.Client.UserInterface.Systems.Alerts.Controls
             }
         }
 
-        public int ResourceCurrent
+        public int? ResourceCurrent
         {
             get => _resourceCurrent;
             set
@@ -57,8 +57,8 @@ namespace Content.Client.UserInterface.Systems.Alerts.Controls
         }
 
         private (TimeSpan Start, TimeSpan End)? _cooldown;
-        private int _resourceMax;
-        private int _resourceCurrent;
+        private int? _resourceMax;
+        private int? _resourceCurrent;
 
         private short? _severity;
         private readonly IGameTiming _gameTiming;

--- a/Content.Client/UserInterface/Systems/Alerts/Widgets/AlertsUI.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Alerts/Widgets/AlertsUI.xaml.cs
@@ -97,9 +97,7 @@ public sealed partial class AlertsUI : UIWidget
                 existingAlertControl.SetSeverity(alertState.Severity);
                 if (alertState.ShowCooldown)
                     existingAlertControl.Cooldown = alertState.Cooldown;
-
-                existingAlertControl.ResourceMax = alertState.ResourceMax;
-                existingAlertControl.ResourceCurrent = alertState.ResourceCurrent;
+                existingAlertControl.DynamicMessage = alertState.DynamicMessage;
             }
             else
             {
@@ -145,14 +143,12 @@ public sealed partial class AlertsUI : UIWidget
         if (alertState.ShowCooldown)
             cooldown = alertState.Cooldown;
 
-        int? resourceMax = alertState.ResourceMax;
-        int? resourceCurrent = alertState.ResourceCurrent;
+        string? dynamicMessage = alertState.DynamicMessage;
 
         var alertControl = new AlertControl(alert, alertState.Severity)
         {
             Cooldown = cooldown,
-            ResourceMax = resourceMax,
-            ResourceCurrent = resourceCurrent
+            DynamicMessage = dynamicMessage,
         };
         alertControl.OnPressed += AlertControlPressed;
         return alertControl;

--- a/Content.Client/UserInterface/Systems/Alerts/Widgets/AlertsUI.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Alerts/Widgets/AlertsUI.xaml.cs
@@ -97,6 +97,9 @@ public sealed partial class AlertsUI : UIWidget
                 existingAlertControl.SetSeverity(alertState.Severity);
                 if (alertState.ShowCooldown)
                     existingAlertControl.Cooldown = alertState.Cooldown;
+
+                existingAlertControl.ResourceMax = alertState.ResourceMax;
+                existingAlertControl.ResourceCurrent = alertState.ResourceCurrent;
             }
             else
             {
@@ -142,9 +145,14 @@ public sealed partial class AlertsUI : UIWidget
         if (alertState.ShowCooldown)
             cooldown = alertState.Cooldown;
 
+        int? resourceMax = alertState.ResourceMax;
+        int? resourceCurrent = alertState.ResourceCurrent;
+
         var alertControl = new AlertControl(alert, alertState.Severity)
         {
-            Cooldown = cooldown
+            Cooldown = cooldown,
+            ResourceMax = resourceMax,
+            ResourceCurrent = resourceCurrent
         };
         alertControl.OnPressed += AlertControlPressed;
         return alertControl;

--- a/Content.Shared/Alert/AlertState.cs
+++ b/Content.Shared/Alert/AlertState.cs
@@ -8,6 +8,8 @@ public struct AlertState
 {
     public short? Severity;
     public (TimeSpan, TimeSpan)? Cooldown;
+    public int? ResourceMax;
+    public int? ResourceCurrent;
     public bool AutoRemove;
     public bool ShowCooldown;
     public ProtoId<AlertPrototype> Type;

--- a/Content.Shared/Alert/AlertState.cs
+++ b/Content.Shared/Alert/AlertState.cs
@@ -8,8 +8,7 @@ public struct AlertState
 {
     public short? Severity;
     public (TimeSpan, TimeSpan)? Cooldown;
-    public int? ResourceMax;
-    public int? ResourceCurrent;
+    public string? DynamicMessage;
     public bool AutoRemove;
     public bool ShowCooldown;
     public ProtoId<AlertPrototype> Type;

--- a/Content.Shared/Alert/AlertsSystem.cs
+++ b/Content.Shared/Alert/AlertsSystem.cs
@@ -78,7 +78,9 @@ public abstract class AlertsSystem : EntitySystem
     ///     be erased if there is currently a cooldown for the alert)</param>
     /// <param name="autoRemove">if true, the alert will be removed at the end of the cooldown</param>
     /// <param name="showCooldown">if true, the cooldown will be visibly shown over the alert icon</param>
-    public void ShowAlert(EntityUid euid, ProtoId<AlertPrototype> alertType, short? severity = null, (TimeSpan, TimeSpan)? cooldown = null, bool autoRemove = false, bool showCooldown = true )
+    /// <param name="resourceMax">maximum value of a resource</param>
+    /// <param name="resourceCurrent">current value of a resource</param>
+    public void ShowAlert(EntityUid euid, ProtoId<AlertPrototype> alertType, short? severity = null, (TimeSpan, TimeSpan)? cooldown = null, bool autoRemove = false, bool showCooldown = true, int? resourceMax = null, int? resourceCurrent = null )
     {
         // This should be handled as part of networking.
         if (_timing.ApplyingState)
@@ -96,7 +98,9 @@ public abstract class AlertsSystem : EntitySystem
                 alertStateCallback.Severity == severity &&
                 alertStateCallback.Cooldown == cooldown &&
                 alertStateCallback.AutoRemove == autoRemove &&
-                alertStateCallback.ShowCooldown == showCooldown)
+                alertStateCallback.ShowCooldown == showCooldown &&
+                alertStateCallback.ResourceMax == resourceMax &&
+                alertStateCallback.ResourceCurrent == resourceCurrent)
             {
                 return;
             }
@@ -105,7 +109,7 @@ public abstract class AlertsSystem : EntitySystem
             alertsComponent.Alerts.Remove(alert.AlertKey);
 
             var state = new AlertState
-                { Cooldown = cooldown, Severity = severity, Type = alertType, AutoRemove = autoRemove, ShowCooldown = showCooldown};
+                { Cooldown = cooldown, Severity = severity, Type = alertType, AutoRemove = autoRemove, ShowCooldown = showCooldown, ResourceMax = resourceMax, ResourceCurrent = resourceCurrent};
             alertsComponent.Alerts[alert.AlertKey] = state;
 
             // Keeping a list of AutoRemove alerts, so Update() doesn't need to check every alert
@@ -133,7 +137,7 @@ public abstract class AlertsSystem : EntitySystem
     /// </summary>
     public void ClearAlertCategory(EntityUid euid, ProtoId<AlertCategoryPrototype> category)
     {
-        if(!TryComp(euid, out AlertsComponent? alertsComponent))
+        if (!TryComp(euid, out AlertsComponent? alertsComponent))
             return;
 
         var key = AlertKey.ForCategory(category);

--- a/Content.Shared/Alert/AlertsSystem.cs
+++ b/Content.Shared/Alert/AlertsSystem.cs
@@ -78,9 +78,8 @@ public abstract class AlertsSystem : EntitySystem
     ///     be erased if there is currently a cooldown for the alert)</param>
     /// <param name="autoRemove">if true, the alert will be removed at the end of the cooldown</param>
     /// <param name="showCooldown">if true, the cooldown will be visibly shown over the alert icon</param>
-    /// <param name="resourceMax">maximum value of a resource</param>
-    /// <param name="resourceCurrent">current value of a resource</param>
-    public void ShowAlert(EntityUid euid, ProtoId<AlertPrototype> alertType, short? severity = null, (TimeSpan, TimeSpan)? cooldown = null, bool autoRemove = false, bool showCooldown = true, int? resourceMax = null, int? resourceCurrent = null )
+    /// <param name="dynamicMessage">a custom message that can be dynamically updated or edited</param>
+    public void ShowAlert(EntityUid euid, ProtoId<AlertPrototype> alertType, short? severity = null, (TimeSpan, TimeSpan)? cooldown = null, bool autoRemove = false, bool showCooldown = true, string? dynamicMessage = null)
     {
         // This should be handled as part of networking.
         if (_timing.ApplyingState)
@@ -99,8 +98,7 @@ public abstract class AlertsSystem : EntitySystem
                 alertStateCallback.Cooldown == cooldown &&
                 alertStateCallback.AutoRemove == autoRemove &&
                 alertStateCallback.ShowCooldown == showCooldown &&
-                alertStateCallback.ResourceMax == resourceMax &&
-                alertStateCallback.ResourceCurrent == resourceCurrent)
+                alertStateCallback.DynamicMessage == dynamicMessage)
             {
                 return;
             }
@@ -109,7 +107,7 @@ public abstract class AlertsSystem : EntitySystem
             alertsComponent.Alerts.Remove(alert.AlertKey);
 
             var state = new AlertState
-                { Cooldown = cooldown, Severity = severity, Type = alertType, AutoRemove = autoRemove, ShowCooldown = showCooldown, ResourceMax = resourceMax, ResourceCurrent = resourceCurrent};
+                { Cooldown = cooldown, Severity = severity, Type = alertType, AutoRemove = autoRemove, ShowCooldown = showCooldown, DynamicMessage = dynamicMessage};
             alertsComponent.Alerts[alert.AlertKey] = state;
 
             // Keeping a list of AutoRemove alerts, so Update() doesn't need to check every alert
@@ -137,7 +135,7 @@ public abstract class AlertsSystem : EntitySystem
     /// </summary>
     public void ClearAlertCategory(EntityUid euid, ProtoId<AlertCategoryPrototype> category)
     {
-        if (!TryComp(euid, out AlertsComponent? alertsComponent))
+        if(!TryComp(euid, out AlertsComponent? alertsComponent))
             return;
 
         var key = AlertKey.ForCategory(category);

--- a/Content.Shared/Mobs/Components/MobThresholdsComponent.cs
+++ b/Content.Shared/Mobs/Components/MobThresholdsComponent.cs
@@ -46,6 +46,13 @@ public sealed partial class MobThresholdsComponent : Component
     /// </summary>
     [DataField("allowRevives")]
     public bool AllowRevives;
+
+    /// <summary>
+    /// Whether or not the exact health is displayed in the Alert for the entity.
+    /// </summary>
+    /// 
+    [DataField("displayDamageInAlert")]
+    public bool DisplayDamageInAlert = false;
 }
 
 [Serializable, NetSerializable]
@@ -63,13 +70,16 @@ public sealed class MobThresholdsComponentState : ComponentState
 
     public bool AllowRevives;
 
+    public bool DisplayDamageInAlert;
+
     public MobThresholdsComponentState(Dictionary<FixedPoint2, MobState> unsortedThresholds,
         bool triggersAlerts,
         MobState currentThresholdState,
         Dictionary<MobState,
         ProtoId<AlertPrototype>> stateAlertDict,
         bool showOverlays,
-        bool allowRevives)
+        bool allowRevives,
+        bool displayDamageInAlert)
     {
         UnsortedThresholds = unsortedThresholds;
         TriggersAlerts = triggersAlerts;
@@ -77,5 +87,6 @@ public sealed class MobThresholdsComponentState : ComponentState
         StateAlertDict = stateAlertDict;
         ShowOverlays = showOverlays;
         AllowRevives = allowRevives;
+        DisplayDamageInAlert = displayDamageInAlert;
     }
 }

--- a/Content.Shared/Mobs/Systems/MobThresholdSystem.cs
+++ b/Content.Shared/Mobs/Systems/MobThresholdSystem.cs
@@ -37,7 +37,8 @@ public sealed class MobThresholdSystem : EntitySystem
             component.CurrentThresholdState,
             component.StateAlertDict,
             component.ShowOverlays,
-            component.AllowRevives);
+            component.AllowRevives,
+            component.DisplayDamageInAlert);
     }
 
     private void OnHandleState(EntityUid uid, MobThresholdsComponent component, ref ComponentHandleState args)
@@ -388,6 +389,15 @@ public sealed class MobThresholdSystem : EntitySystem
             return;
         }
 
+        int? healthMax = null;
+        int? healthCurrent = null;
+
+        if (threshold.DisplayDamageInAlert && TryGetIncapThreshold(target, out var critThreshold, threshold))
+        {
+            healthMax = (int?)critThreshold;
+            healthCurrent = (int?)critThreshold - (int?)damageable.TotalDamage;
+        }
+
         if (alertPrototype.SupportsSeverity)
         {
             var severity = _alerts.GetMinSeverity(currentAlert);
@@ -402,11 +412,11 @@ public sealed class MobThresholdSystem : EntitySystem
                         _alerts.GetMaxSeverity(currentAlert),
                         percentage.Value.Float()));
             }
-            _alerts.ShowAlert(target, currentAlert, severity);
+            _alerts.ShowAlert(target, currentAlert, severity, resourceMax: healthMax, resourceCurrent: healthCurrent);
         }
         else
         {
-            _alerts.ShowAlert(target, currentAlert);
+            _alerts.ShowAlert(target, currentAlert, resourceMax: healthMax, resourceCurrent: healthCurrent);
         }
     }
 

--- a/Content.Shared/Mobs/Systems/MobThresholdSystem.cs
+++ b/Content.Shared/Mobs/Systems/MobThresholdSystem.cs
@@ -389,13 +389,12 @@ public sealed class MobThresholdSystem : EntitySystem
             return;
         }
 
-        int? healthMax = null;
-        int? healthCurrent = null;
+        string? healthMessage = null;
 
-        if (threshold.DisplayDamageInAlert && TryGetIncapThreshold(target, out var critThreshold, threshold))
+        if (threshold.DisplayDamageInAlert && TryGetIncapThreshold(target, out var healthMax, threshold))
         {
-            healthMax = (int?)critThreshold;
-            healthCurrent = (int?)critThreshold - (int?)damageable.TotalDamage;
+            int healthCurrent = (int)healthMax - (int)damageable.TotalDamage;
+            healthMessage = healthCurrent + " / " + healthMax;
         }
 
         if (alertPrototype.SupportsSeverity)
@@ -412,11 +411,11 @@ public sealed class MobThresholdSystem : EntitySystem
                         _alerts.GetMaxSeverity(currentAlert),
                         percentage.Value.Float()));
             }
-            _alerts.ShowAlert(target, currentAlert, severity, resourceMax: healthMax, resourceCurrent: healthCurrent);
+            _alerts.ShowAlert(target, currentAlert, severity, dynamicMessage: healthMessage);
         }
         else
         {
-            _alerts.ShowAlert(target, currentAlert, resourceMax: healthMax, resourceCurrent: healthCurrent);
+            _alerts.ShowAlert(target, currentAlert, dynamicMessage: healthMessage);
         }
     }
 

--- a/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
+++ b/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
@@ -58,7 +58,7 @@ public sealed class CMArmorSystem : EntitySystem
     {
         if (TryComp<XenoComponent>(armored, out var xeno)){
             string? armorMessage = armored.Comp.Armor + " / " + armored.Comp.Armor;
-            _alerts.ShowAlert(armored, xeno.ArmorAlert, 0, dynamicMessage: armorMessage); //TODO RMC14 update resourceCurrent when Armor level can actually change
+            _alerts.ShowAlert(armored, xeno.ArmorAlert, 0, dynamicMessage: armorMessage); //TODO RMC14 update message when Armor level can actually change
         }
     }
 

--- a/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
+++ b/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
@@ -57,7 +57,7 @@ public sealed class CMArmorSystem : EntitySystem
     private void OnMapInit(Entity<CMArmorComponent> armored, ref MapInitEvent args)
     {
         if (TryComp<XenoComponent>(armored, out var xeno))
-            _alerts.ShowAlert(armored, xeno.ArmorAlert, 0);
+            _alerts.ShowAlert(armored, xeno.ArmorAlert, 0, resourceMax: (int?)armored.Comp.Armor, resourceCurrent: (int?)armored.Comp.Armor); //TODO RMC14 update resourceCurrent when Armor level can actually change
     }
 
     private void OnRemove(Entity<CMArmorComponent> armored, ref ComponentRemove args)

--- a/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
+++ b/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
@@ -56,8 +56,10 @@ public sealed class CMArmorSystem : EntitySystem
 
     private void OnMapInit(Entity<CMArmorComponent> armored, ref MapInitEvent args)
     {
-        if (TryComp<XenoComponent>(armored, out var xeno))
-            _alerts.ShowAlert(armored, xeno.ArmorAlert, 0, resourceMax: (int?)armored.Comp.Armor, resourceCurrent: (int?)armored.Comp.Armor); //TODO RMC14 update resourceCurrent when Armor level can actually change
+        if (TryComp<XenoComponent>(armored, out var xeno)){
+            string? armorMessage = armored.Comp.Armor + " / " + armored.Comp.Armor;
+            _alerts.ShowAlert(armored, xeno.ArmorAlert, 0, dynamicMessage: armorMessage); //TODO RMC14 update resourceCurrent when Armor level can actually change
+        }
     }
 
     private void OnRemove(Entity<CMArmorComponent> armored, ref ComponentRemove args)

--- a/Content.Shared/_RMC14/Xenonids/Plasma/XenoPlasmaSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Plasma/XenoPlasmaSystem.cs
@@ -133,7 +133,8 @@ public sealed class XenoPlasmaSystem : EntitySystem
         var level = MathF.Max(0f, xeno.Comp.Plasma.Float());
         var max = _alerts.GetMaxSeverity(xeno.Comp.Alert);
         var severity = max - ContentHelpers.RoundToLevels(level, xeno.Comp.MaxPlasma, max + 1);
-        _alerts.ShowAlert(xeno, xeno.Comp.Alert, (short) severity);
+        var currentPlasma = xeno.Comp.Plasma;
+        _alerts.ShowAlert(xeno, xeno.Comp.Alert, (short) severity, resourceMax: (int?) xeno.Comp.MaxPlasma, resourceCurrent: (int?) currentPlasma.Int());
     }
 
     public bool HasPlasma(Entity<XenoPlasmaComponent> xeno, FixedPoint2 plasma)

--- a/Content.Shared/_RMC14/Xenonids/Plasma/XenoPlasmaSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Plasma/XenoPlasmaSystem.cs
@@ -133,8 +133,8 @@ public sealed class XenoPlasmaSystem : EntitySystem
         var level = MathF.Max(0f, xeno.Comp.Plasma.Float());
         var max = _alerts.GetMaxSeverity(xeno.Comp.Alert);
         var severity = max - ContentHelpers.RoundToLevels(level, xeno.Comp.MaxPlasma, max + 1);
-        var currentPlasma = xeno.Comp.Plasma;
-        _alerts.ShowAlert(xeno, xeno.Comp.Alert, (short) severity, resourceMax: (int?) xeno.Comp.MaxPlasma, resourceCurrent: (int?) currentPlasma.Int());
+        string? plasmaResourceMessage = (int)xeno.Comp.Plasma + " / " + xeno.Comp.MaxPlasma;
+        _alerts.ShowAlert(xeno, xeno.Comp.Alert, (short) severity, dynamicMessage: plasmaResourceMessage);
     }
 
     public bool HasPlasma(Entity<XenoPlasmaComponent> xeno, FixedPoint2 plasma)

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
@@ -58,6 +58,7 @@
       Alive: XenoHealth
       Critical: XenoCrit
       Dead: XenoDead
+    displayDamageInAlert: true
   - type: MobStateActions
     actions:
       Critical:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Lets Xenos see how much current health, plasma, and armor they have in real time, as well as their maximum amount, by hovering over the corresponding alert type on the side of the screen.

Progress
- [X] Generic Alert resource support
- [X] Plasma 
- [X] Health
- [X] Armor

## Why / Balance
CM13 parity
![image](https://github.com/user-attachments/assets/c719828d-ddba-4ad7-adcb-28668b891db3)

resolves #4147 

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Gives Alerts/AlertState the generic functionality of displaying current/maximum resources in the format of "x / y". Nullable ints added to AlertState to store them, and added the ability to input these ints in relevant files, and when ShowAlert is called the variable follows the path of AlertsSystem -> AlertsUI.xaml -> AlertControl (client) -> ActionAlertTooltip (client) as usual with the new optional variables. The number updates whenever the relevant resource updates in a similar manner to the cooldown display system.

Adds a boolean to MobThresholdsComponent that is false by default that will display the health in the Alert, this is given only to Xenos, marines and other mobs are unaffected by this change.

Resource meters will not display on any alerts besides the ones that explicitly fill in their variable (plasma, health, armor), as the display does not become visible if either of the values are null.

Alert's cooldown display code restructured to not immediately return since the previous formatting assumed it'd only ever do one thing dynamically. Functionality of the cooldown display code is 100% preserved.

## Media
Video demonstration (up-to-date with rewrite)
https://github.com/user-attachments/assets/bd2d0faf-aad0-41e9-a9ed-f2fc0b41e096

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
:cl:
- add: Xenos can now see their exact Health, Plasma, and Armor by hovering over each respective alert on the right side of the screen.

