### PR TITLE
Move tactical map to the alerts bar

### DIFF
--- a/Content.Server/_RMC14/TacticalMap/TacticalMapSystem.cs
+++ b/Content.Server/_RMC14/TacticalMap/TacticalMapSystem.cs
@@ -137,7 +137,7 @@ public sealed class TacticalMapSystem : SharedTacticalMapSystem
 
     private void OnUserMapInit(Entity<TacticalMapUserComponent> ent, ref MapInitEvent args)
     {
-        //_actions.AddAction(ent, ref ent.Comp.Action, ent.Comp.ActionId);
+        _actions.AddAction(ent, ref ent.Comp.Action, ent.Comp.ActionId);
 
         if (TryGetTacticalMap(out var map))
             ent.Comp.Map = map;

--- a/Content.Server/_RMC14/TacticalMap/TacticalMapSystem.cs
+++ b/Content.Server/_RMC14/TacticalMap/TacticalMapSystem.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Content.Server._RMC14.Announce;
 using Content.Server._RMC14.Marines;
 using Content.Server.Administration.Logs;
@@ -75,6 +75,7 @@ public sealed class TacticalMapSystem : SharedTacticalMapSystem
 
         SubscribeLocalEvent<TacticalMapUserComponent, MapInitEvent>(OnUserMapInit);
         SubscribeLocalEvent<TacticalMapUserComponent, OpenTacticalMapActionEvent>(OnUserOpenAction);
+        SubscribeLocalEvent<TacticalMapUserComponent, OpenTacMapAlertEvent>(OnUserOpenAlert);
 
         SubscribeLocalEvent<TacticalMapComputerComponent, MapInitEvent>(OnComputerMapInit);
         SubscribeLocalEvent<TacticalMapComputerComponent, BeforeActivatableUIOpenEvent>(OnComputerBeforeUIOpen);
@@ -136,7 +137,7 @@ public sealed class TacticalMapSystem : SharedTacticalMapSystem
 
     private void OnUserMapInit(Entity<TacticalMapUserComponent> ent, ref MapInitEvent args)
     {
-        _actions.AddAction(ent, ref ent.Comp.Action, ent.Comp.ActionId);
+        //_actions.AddAction(ent, ref ent.Comp.Action, ent.Comp.ActionId);
 
         if (TryGetTacticalMap(out var map))
             ent.Comp.Map = map;
@@ -149,6 +150,13 @@ public sealed class TacticalMapSystem : SharedTacticalMapSystem
         if (TryGetTacticalMap(out var map))
             UpdateUserData(ent, map);
 
+        _ui.TryOpenUi(ent.Owner, TacticalMapUserUi.Key, ent);
+    }
+
+    private void OnUserOpenAlert(Entity<TacticalMapUserComponent> ent, ref OpenTacMapAlertEvent args)
+    {
+        if (TryGetTacticalMap(out var map))
+            UpdateUserData(ent, map);
         _ui.TryOpenUi(ent.Owner, TacticalMapUserUi.Key, ent);
     }
 

--- a/Content.Shared/_RMC14/TacticalMap/GrantTacMapAlertComponent.cs
+++ b/Content.Shared/_RMC14/TacticalMap/GrantTacMapAlertComponent.cs
@@ -1,0 +1,13 @@
+using Content.Shared.Inventory;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.TacticalMap;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(SharedTacticalMapSystem))]
+public sealed partial class GrantTacMapAlertComponent : Component, IClothingSlots
+{
+    [DataField, AutoNetworkedField]
+    public SlotFlags Slots { get; set; } = SlotFlags.EARS;
+}
+

--- a/Content.Shared/_RMC14/TacticalMap/OpenTacMapAlertEvent.cs
+++ b/Content.Shared/_RMC14/TacticalMap/OpenTacMapAlertEvent.cs
@@ -1,0 +1,6 @@
+using Content.Shared.Alert;
+
+namespace Content.Shared._RMC14.TacticalMap;
+
+[DataDefinition]
+public sealed partial class OpenTacMapAlertEvent : BaseAlertEvent;

--- a/Content.Shared/_RMC14/TacticalMap/TacMapMarineAlertComponent.cs
+++ b/Content.Shared/_RMC14/TacticalMap/TacMapMarineAlertComponent.cs
@@ -1,0 +1,13 @@
+using Content.Shared.Alert;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._RMC14.TacticalMap;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(SharedTacticalMapSystem))]
+public sealed partial class TacMapMarineAlertComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public ProtoId<AlertPrototype> Alert = "MarineTacMapAlert";
+}

--- a/Content.Shared/_RMC14/TacticalMap/TacMapMarineAlertSystem.cs
+++ b/Content.Shared/_RMC14/TacticalMap/TacMapMarineAlertSystem.cs
@@ -1,0 +1,51 @@
+using Content.Shared.Alert;
+using Content.Shared.Inventory;
+using Content.Shared.Inventory.Events;
+using Robust.Shared.Timing;
+
+
+namespace Content.Shared._RMC14.TacticalMap;
+
+public sealed class TacMapMarineAlertSystem : EntitySystem
+{
+    [Dependency] private readonly AlertsSystem _alerts = default!;
+    [Dependency] private readonly InventorySystem _inv = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<GrantTacMapAlertComponent, GotEquippedEvent>(OnGotEquipped);
+        SubscribeLocalEvent<GrantTacMapAlertComponent, GotUnequippedEvent>(OnGotUnequipped);
+
+        SubscribeLocalEvent<TacMapMarineAlertComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<TacMapMarineAlertComponent, ComponentRemove>(OnRemove);
+    }
+    private void OnGotEquipped(Entity<GrantTacMapAlertComponent> ent, ref GotEquippedEvent args)
+    {
+        if (_timing.ApplyingState)
+            return;
+
+        if ((ent.Comp.Slots & args.SlotFlags) == 0)
+            return;
+
+        EnsureComp<TacMapMarineAlertComponent>(args.Equipee);
+    }
+    private void OnGotUnequipped(Entity<GrantTacMapAlertComponent> ent, ref GotUnequippedEvent args)
+    {
+        if (_timing.ApplyingState)
+            return;
+
+        if ((ent.Comp.Slots & args.SlotFlags) == 0)
+            return;
+        if (!_inv.TryGetInventoryEntity<GrantTacMapAlertComponent>(args.Equipee, out _))
+            RemCompDeferred<TacMapMarineAlertComponent>(args.Equipee);
+    }
+    private void OnMapInit(Entity<TacMapMarineAlertComponent> ent, ref MapInitEvent args)
+    {
+        _alerts.ShowAlert(ent, ent.Comp.Alert);
+    }
+    private void OnRemove(Entity<TacMapMarineAlertComponent> ent, ref ComponentRemove args)
+    {
+        _alerts.ClearAlert(ent, ent.Comp.Alert);
+    }
+}

--- a/Content.Shared/_RMC14/TacticalMap/TacMapXenoAlertComponent.cs
+++ b/Content.Shared/_RMC14/TacticalMap/TacMapXenoAlertComponent.cs
@@ -1,0 +1,13 @@
+using Content.Shared.Alert;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._RMC14.TacticalMap;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(SharedTacticalMapSystem))]
+public sealed partial class TacMapXenoAlertComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public ProtoId<AlertPrototype> Alert = "XenoTacMapAlert";
+}

--- a/Content.Shared/_RMC14/TacticalMap/TacMapXenoAlertSystem.cs
+++ b/Content.Shared/_RMC14/TacticalMap/TacMapXenoAlertSystem.cs
@@ -1,0 +1,23 @@
+using Content.Shared.Alert;
+
+namespace Content.Shared._RMC14.TacticalMap;
+
+public sealed class TacMapXenoAlertSystem : EntitySystem
+{
+    [Dependency] private readonly AlertsSystem _alerts = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<TacMapXenoAlertComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<TacMapXenoAlertComponent, ComponentRemove>(OnRemove);
+    }
+
+    private void OnMapInit(Entity<TacMapXenoAlertComponent> ent, ref MapInitEvent args)
+    {
+        _alerts.ShowAlert(ent, ent.Comp.Alert);
+    }
+    private void OnRemove(Entity<TacMapXenoAlertComponent> ent, ref ComponentRemove args)
+    {
+        _alerts.ClearAlert(ent, ent.Comp.Alert);
+    }
+}

--- a/Resources/Prototypes/_RMC14/Alerts/alerts.yml
+++ b/Resources/Prototypes/_RMC14/Alerts/alerts.yml
@@ -84,3 +84,21 @@
 #  clickEvent: !type:SelectTrackerAlertEvent
   minSeverity: 0
   maxSeverity: 10
+
+- type: alert
+  id: MarineTacMapAlert
+  icons:
+  - sprite: /Textures/_RMC14/Structures/Machines/map_table.rsi
+    state: maptable
+  name: Tactical Map
+  description: Click to open the Tactical Map.
+  clickEvent: !type:OpenTacMapAlertEvent
+
+- type: alert
+  id: XenoTacMapAlert
+  icons:
+  - sprite: /Textures/_RMC14/Actions/xeno_actions.rsi
+    state: toggle_queen_zoom
+  name: Tactical Map
+  description: Click to open the Tactical Map.
+  clickEvent: !type:OpenTacMapAlertEvent

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/ship_headsets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/ship_headsets.yml
@@ -30,6 +30,7 @@
       key_slots:
       - CMEncryptionKeyCommon
   - type: GrantMarineIcons
+  - type: GrantTacMapAlert
 
 - type: entity
   parent: RMCHeadsetShip

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
@@ -237,6 +237,7 @@
   - type: RequireProjectileTarget
     active: false
   - type: TacticalMapTracked
+  - type: TacMapXenoAlert
   - type: TacticalMapUser
     actionId: RMCActionOpenTacticalMapXeno
     xenos: true


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
moved the tacmap action to the alerts bar
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
the tacmap messed up the order of the actions bar too often so i felt that it'd be better if it was moved to the alerts bar.
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
i'm going to be completely honest, i don't know how the hell it works. but it does work, i think. i tested it and it worked on my machine.
the (marine side) code works like the squad tracker alert code, as in a headset is needed to be equipped for it to work.
the xeno side just moved it from the actions bar to the alert bar.
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

![image](https://github.com/user-attachments/assets/e9db8c65-14a1-4575-bd7d-00e94339d13e)


## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- tweak: The tactical map can now be opened from the alerts sidebar instead of only the actions bar.
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
