### PR TITLE
Praetorian fixes, HE mortar shell structure damage fix, job slot scaling fix, emote sound cooldown

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.Emote.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.Emote.cs
@@ -209,6 +209,9 @@ public partial class ChatSystem
 
     private void InvokeEmoteEvent(EntityUid uid, EmotePrototype proto)
     {
+        if (!_rmcEmote.CanEmote(uid))
+            return;
+
         var ev = new EmoteEvent(proto);
         RaiseLocalEvent(uid, ref ev);
     }

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -2,10 +2,10 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 using Content.Server._RMC14.Chat.Chat;
+using Content.Server._RMC14.Emote;
 using Content.Server.Administration.Logs;
 using Content.Server.Administration.Managers;
 using Content.Server.Chat.Managers;
-using Content.Server.Examine;
 using Content.Server.GameTicking;
 using Content.Server.Players.RateLimiting;
 using Content.Server.Speech.Components;
@@ -20,7 +20,6 @@ using Content.Shared.Database;
 using Content.Shared.Examine;
 using Content.Shared.Ghost;
 using Content.Shared.IdentityManagement;
-using Content.Shared.Interaction;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Players;
 using Content.Shared.Radio;
@@ -64,6 +63,7 @@ public sealed partial class ChatSystem : SharedChatSystem
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
     [Dependency] private readonly ExamineSystemShared _examineSystem = default!;
     [Dependency] private readonly CMChatSystem _cmChat = default!;
+    [Dependency] private readonly RMCEmoteSystem _rmcEmote = default!;
 
     public const int VoiceRange = 10; // how far voice goes in world units
     public const int WhisperClearRange = 2; // how far whisper goes while still being understandable, in world units

--- a/Content.Server/Speech/EntitySystems/VocalSystem.cs
+++ b/Content.Server/Speech/EntitySystems/VocalSystem.cs
@@ -1,11 +1,10 @@
+using Content.Server._RMC14.Emote;
 using Content.Server.Actions;
 using Content.Server.Chat.Systems;
-using Content.Server.Speech.Components;
 using Content.Shared.Chat.Prototypes;
 using Content.Shared.Humanoid;
 using Content.Shared.Speech;
 using Content.Shared.Speech.Components;
-using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
@@ -19,6 +18,7 @@ public sealed class VocalSystem : EntitySystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly ChatSystem _chat = default!;
     [Dependency] private readonly ActionsSystem _actions = default!;
+    [Dependency] private readonly RMCEmoteSystem _rmcEmote = default!;
 
     public override void Initialize()
     {

--- a/Content.Server/_RMC14/Emote/RMCEmoteSystem.cs
+++ b/Content.Server/_RMC14/Emote/RMCEmoteSystem.cs
@@ -1,6 +1,10 @@
 ﻿using Content.Server.Chat.Systems;
+using Content.Server.Speech.EntitySystems;
+using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Emote;
 using Content.Shared.Chat.Prototypes;
+using Content.Shared.Speech;
+using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
@@ -9,7 +13,31 @@ namespace Content.Server._RMC14.Emote;
 public sealed class RMCEmoteSystem : SharedRMCEmoteSystem
 {
     [Dependency] private readonly ChatSystem _chat = default!;
+    [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
+
+    private TimeSpan _emoteCooldown;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<EmoteCooldownComponent, EmoteEvent>(OnEmoteCooldownEmote);
+        SubscribeLocalEvent<EmoteCooldownComponent, ScreamActionEvent>(OnCooldownScreamAction, before: [typeof(VocalSystem)]);
+
+        Subs.CVar(_config, RMCCVars.RMCEmoteCooldownSeconds, v => _emoteCooldown = TimeSpan.FromSeconds(v), true);
+    }
+
+    private void OnCooldownScreamAction(Entity<EmoteCooldownComponent> ent, ref ScreamActionEvent args)
+    {
+        // always allow off-cooldown scream action emote
+        ResetCooldown((ent, ent));
+    }
+
+    private void OnEmoteCooldownEmote(Entity<EmoteCooldownComponent> ent, ref EmoteEvent args)
+    {
+        ent.Comp.NextEmote = _timing.CurTime + _emoteCooldown;
+        Dirty(ent);
+    }
 
     public override void TryEmoteWithChat(
         EntityUid source,

--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
@@ -300,6 +300,15 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
                             slots *= 4;
 
                         Log.Info($"Setting {job} to {slots} slots.");
+                        var jobs = stationJobs.SetupAvailableJobs;
+                        if (jobs.TryGetValue(job, out var available))
+                        {
+                            for (var i = 0; i < available.Length; i++)
+                            {
+                                available[i] = slots;
+                            }
+                        }
+
                         _stationJobs.TrySetJobSlot(stationId, job, slots, stationJobs: stationJobs);
                     }
                 }

--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Content.Shared._RMC14.Actions;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Actions.Events;
 using Content.Shared.Administration.Logs;
@@ -11,7 +12,6 @@ using Content.Shared.Mind;
 using Content.Shared.Rejuvenate;
 using Content.Shared.Whitelist;
 using Robust.Shared.Audio.Systems;
-using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
 using Robust.Shared.Map;
 using Robust.Shared.Timing;
@@ -30,6 +30,7 @@ public abstract class SharedActionsSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
     [Dependency] private readonly ActionContainerSystem _actionContainer = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
+    [Dependency] private readonly RMCActionsSystem _rmcActions = default!;
 
     public override void Initialize()
     {
@@ -489,6 +490,9 @@ public abstract class SharedActionsSystem : EntitySystem
                 performEvent = instantAction.Event;
                 break;
         }
+
+        if (!_rmcActions.CanUseActionPopup(user, actionEnt))
+            return;
 
         if (performEvent != null)
         {

--- a/Content.Shared/_RMC14/CCVar/RMCCVars.cs
+++ b/Content.Shared/_RMC14/CCVar/RMCCVars.cs
@@ -198,4 +198,7 @@ public sealed class RMCCVars : CVars
 
     public static readonly CVarDef<bool> RMCJobSlotScaling =
         CVarDef.Create("rmc.job_slot_scaling", true, CVar.SERVER | CVar.REPLICATED);
+
+    public static readonly CVarDef<float> RMCEmoteCooldownSeconds =
+        CVarDef.Create("rmc.emote_cooldown_seconds", 20f, CVar.SERVER | CVar.REPLICATED);
 }

--- a/Content.Shared/_RMC14/Emote/EmoteCooldownComponent.cs
+++ b/Content.Shared/_RMC14/Emote/EmoteCooldownComponent.cs
@@ -1,0 +1,12 @@
+﻿using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Shared._RMC14.Emote;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
+[Access(typeof(SharedRMCEmoteSystem))]
+public sealed partial class EmoteCooldownComponent : Component
+{
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
+    public TimeSpan NextEmote;
+}

--- a/Content.Shared/_RMC14/Emote/SharedRMCEmoteSystem.cs
+++ b/Content.Shared/_RMC14/Emote/SharedRMCEmoteSystem.cs
@@ -1,10 +1,13 @@
 ﻿using Content.Shared.Chat.Prototypes;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
 
 namespace Content.Shared._RMC14.Emote;
 
 public abstract class SharedRMCEmoteSystem : EntitySystem
 {
+    [Dependency] private readonly IGameTiming _timing = default!;
+
     public virtual void TryEmoteWithChat(
         EntityUid source,
         ProtoId<EmotePrototype> emote,
@@ -14,5 +17,22 @@ public abstract class SharedRMCEmoteSystem : EntitySystem
         bool forceEmote = false,
         TimeSpan? cooldown = null)
     {
+    }
+
+    public bool CanEmote(Entity<EmoteCooldownComponent?> cooldown)
+    {
+        if (!Resolve(cooldown, ref cooldown.Comp, false))
+            return true;
+
+        return _timing.CurTime >= cooldown.Comp.NextEmote;
+    }
+
+    public void ResetCooldown(Entity<EmoteCooldownComponent?> cooldown)
+    {
+        if (!Resolve(cooldown, ref cooldown.Comp, false))
+            return;
+
+        cooldown.Comp.NextEmote = _timing.CurTime;
+        Dirty(cooldown);
     }
 }

--- a/Content.Shared/_RMC14/Rules/RMCPlanetMapPrototypeComponent.cs
+++ b/Content.Shared/_RMC14/Rules/RMCPlanetMapPrototypeComponent.cs
@@ -1,0 +1,15 @@
+﻿using Robust.Shared.GameStates;
+using Robust.Shared.Utility;
+
+namespace Content.Shared._RMC14.Rules;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(RMCPlanetSystem))]
+public sealed partial class RMCPlanetMapPrototypeComponent : Component
+{
+    [DataField(required: true), AutoNetworkedField]
+    public ResPath Map;
+
+    [DataField(required: true), AutoNetworkedField]
+    public string Name;
+}

--- a/Content.Shared/_RMC14/Weapons/Ranged/CMGunSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/CMGunSystem.cs
@@ -2,10 +2,9 @@
 using Content.Shared._RMC14.Marines.Skills;
 using Content.Shared._RMC14.Projectiles;
 using Content.Shared._RMC14.Weapons.Common;
-using Content.Shared._RMC14.Weapons.Ranged.Prediction;
 using Content.Shared._RMC14.Weapons.Ranged.Whitelist;
-using Content.Shared.FixedPoint;
 using Content.Shared.Containers.ItemSlots;
+using Content.Shared.FixedPoint;
 using Content.Shared.Hands;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
@@ -24,7 +23,6 @@ using Content.Shared.Wieldable;
 using Content.Shared.Wieldable.Components;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
-using Robust.Shared.Network;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Events;
@@ -172,10 +170,8 @@ public sealed class CMGunSystem : EntitySystem
     /// </summary>
     private void OnCollisionCheckArc(Entity<ProjectileFixedDistanceComponent> ent, ref PreventCollideEvent args)
     {
-        int otherLayers = (int)args.OtherFixture.CollisionLayer;
-        if (Comp<ProjectileFixedDistanceComponent>(ent).ArcProj && (args.OtherFixture.CollisionLayer & blockArcCollisionGroup) == 0)
+        if (ent.Comp.ArcProj && (args.OtherFixture.CollisionLayer & blockArcCollisionGroup) == 0)
             args.Cancelled = true;
-        return;
     }
 
     private void OnEventToStopProjectile<T>(Entity<ProjectileFixedDistanceComponent> ent, ref T args)

--- a/Content.Shared/_RMC14/Xenonids/Aid/XenoAidSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Aid/XenoAidSystem.cs
@@ -1,5 +1,4 @@
-﻿using Content.Shared._RMC14.Actions;
-using Content.Shared._RMC14.Damage;
+﻿using Content.Shared._RMC14.Damage;
 using Content.Shared._RMC14.Xenonids.Energy;
 using Content.Shared._RMC14.Xenonids.Strain;
 using Content.Shared.Actions;
@@ -10,11 +9,8 @@ using Content.Shared.Interaction;
 using Content.Shared.Jittering;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Popups;
-using Content.Shared.Standing;
 using Content.Shared.StatusEffect;
-using Robust.Shared.Network;
 using Robust.Shared.Player;
-using Robust.Shared.Timing;
 
 namespace Content.Shared._RMC14.Xenonids.Aid;
 
@@ -27,7 +23,6 @@ public sealed class XenoAidSystem : EntitySystem
     [Dependency] private readonly SharedJitteringSystem _jitter = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
-    [Dependency] private readonly RMCActionsSystem _rmcActions = default!;
     [Dependency] private readonly SharedRMCDamageableSystem _rmcDamageable = default!;
     [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
     [Dependency] private readonly XenoSystem _xeno = default!;
@@ -63,9 +58,6 @@ public sealed class XenoAidSystem : EntitySystem
             _popup.PopupClient(msg, xeno, xeno, PopupType.SmallCaution);
             return;
         }
-
-        if (!_rmcActions.CanUseActionPopup(xeno, args.Action))
-            return;
 
         switch (xeno.Comp.Mode)
         {

--- a/Content.Shared/_RMC14/Xenonids/Aid/XenoAidSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Aid/XenoAidSystem.cs
@@ -91,7 +91,7 @@ public sealed class XenoAidSystem : EntitySystem
                 var targetMsg = Loc.GetString("rmc-xeno-heal-target", ("target", target));
                 _popup.PopupEntity(targetMsg, target, target);
 
-                var othersMsg = Loc.GetString("rmc-xeno-heal-target", ("user", xeno), ("target", target));
+                var othersMsg = Loc.GetString("rmc-xeno-heal-others", ("user", xeno), ("target", target));
                 var filter = Filter.Pvs(target).RemovePlayersByAttachedEntity(xeno, target);
                 _popup.PopupEntity(othersMsg, target, filter, true);
 
@@ -120,7 +120,7 @@ public sealed class XenoAidSystem : EntitySystem
                 var targetMsg = Loc.GetString("rmc-xeno-heal-ailments-target", ("target", target));
                 _popup.PopupEntity(targetMsg, target, target);
 
-                var othersMsg = Loc.GetString("rmc-xeno-heal-ailments-target", ("user", xeno), ("target", target));
+                var othersMsg = Loc.GetString("rmc-xeno-heal-ailments-others", ("user", xeno), ("target", target));
                 var filter = Filter.Pvs(target).RemovePlayersByAttachedEntity(xeno, target);
                 _popup.PopupEntity(othersMsg, target, filter, true);
 

--- a/Content.Shared/_RMC14/Xenonids/Energy/XenoEnergySystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Energy/XenoEnergySystem.cs
@@ -33,10 +33,7 @@ public sealed class XenoEnergySystem : EntitySystem
         var isHit = false;
         foreach (var hit in args.HitEntities)
         {
-            if (_xeno.FromSameHive(xeno.Owner, hit))
-                continue;
-
-            if (!_mobState.IsAlive(hit))
+            if (!_xeno.CanAbilityAttackTarget(xeno.Owner, hit))
                 continue;
 
             isHit = true;
@@ -51,7 +48,8 @@ public sealed class XenoEnergySystem : EntitySystem
 
     private void OnXenoProjectileHitUser(Entity<XenoEnergyComponent> xeno, ref XenoProjectileHitUserEvent args)
     {
-        AddEnergy(xeno, xeno.Comp.GainAttack);
+        if (_xeno.CanAbilityAttackTarget(xeno, args.Hit))
+            AddEnergy(xeno, xeno.Comp.GainAttack);
     }
 
     private void OnRejuvenate(Entity<XenoEnergyComponent> ent, ref RejuvenateEvent args)

--- a/Content.Shared/_RMC14/Xenonids/Leap/XenoLeapSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Leap/XenoLeapSystem.cs
@@ -67,13 +67,13 @@ public sealed class XenoLeapSystem : EntitySystem
         if (attempt.Cancelled)
             return;
 
-        args.Handled = true;
-
         if (xeno.Comp.PlasmaCost > FixedPoint2.Zero &&
             !_xenoPlasma.HasPlasmaPopup(xeno.Owner, xeno.Comp.PlasmaCost))
         {
             return;
         }
+
+        args.Handled = true;
 
         var ev = new XenoLeapDoAfterEvent(GetNetCoordinates(args.Target));
         var doAfter = new DoAfterArgs(EntityManager, xeno, xeno.Comp.Delay, ev, xeno)

--- a/Content.Shared/_RMC14/Xenonids/Projectile/Spit/XenoSpitSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/Spit/XenoSpitSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._RMC14.Actions;
 using Content.Shared._RMC14.Armor;
 using Content.Shared._RMC14.Atmos;
 using Content.Shared._RMC14.Explosion;
@@ -14,7 +15,6 @@ using Content.Shared.ActionBlocker;
 using Content.Shared.Damage;
 using Content.Shared.DoAfter;
 using Content.Shared.Effects;
-using Content.Shared.FixedPoint;
 using Content.Shared.Inventory;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Movement.Systems;
@@ -25,7 +25,6 @@ using Content.Shared.Whitelist;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Timing;
-using static Content.Shared._RMC14.Shields.XenoShieldSystem;
 
 namespace Content.Shared._RMC14.Xenonids.Projectile.Spit;
 
@@ -42,6 +41,7 @@ public sealed class XenoSpitSystem : EntitySystem
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly MovementSpeedModifierSystem _movementSpeed = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly RMCActionsSystem _rmcActions = default!;
     [Dependency] private readonly SharedStunSystem _stun = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
@@ -49,12 +49,10 @@ public sealed class XenoSpitSystem : EntitySystem
     [Dependency] private readonly XenoShieldSystem _xenoShield = default!;
 
     private EntityQuery<ProjectileComponent> _projectileQuery;
-    private EntityQuery<XenoShieldComponent> _xenoShieldQuery;
 
     public override void Initialize()
     {
         _projectileQuery = GetEntityQuery<ProjectileComponent>();
-        _xenoShieldQuery = GetEntityQuery<XenoShieldComponent>();
 
         SubscribeLocalEvent<XenoSpitComponent, XenoSpitActionEvent>(OnXenoSpitAction);
         SubscribeLocalEvent<XenoSlowingSpitComponent, XenoSlowingSpitActionEvent>(OnXenoSlowingSpitAction);

--- a/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileHitUserEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileHitUserEvent.cs
@@ -1,4 +1,4 @@
 ﻿namespace Content.Shared._RMC14.Xenonids.Projectile;
 
 [ByRefEvent]
-public readonly record struct XenoProjectileHitUserEvent;
+public readonly record struct XenoProjectileHitUserEvent(EntityUid Hit);

--- a/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
@@ -58,20 +58,20 @@ public sealed class XenoProjectileSystem : EntitySystem
 
     private void OnProjectileHit(Entity<XenoProjectileComponent> ent, ref ProjectileHitEvent args)
     {
-        if (_net.IsClient && !IsClientSide(ent))
-            return;
-
         if (ent.Comp.Hive is { } hive && _xeno.FromHive(args.Target, hive))
         {
             args.Handled = true;
-            QueueDel(ent);
+
+            if (_net.IsServer || IsClientSide(ent))
+                QueueDel(ent);
+
             return;
         }
 
         if (_projectileQuery.TryComp(ent, out var projectile) &&
             projectile.Shooter is { } shooter)
         {
-            var ev = new XenoProjectileHitUserEvent();
+            var ev = new XenoProjectileHitUserEvent(args.Target);
             RaiseLocalEvent(shooter, ref ev);
         }
     }

--- a/Content.Shared/_RMC14/Xenonids/Rest/ActionBlockIfRestingComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Rest/ActionBlockIfRestingComponent.cs
@@ -1,0 +1,11 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.Rest;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(XenoRestSystem))]
+public sealed partial class ActionBlockIfRestingComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public LocId Popup = "rmc-xeno-rest-cant";
+}

--- a/Content.Shared/_RMC14/Xenonids/Rest/XenoRestSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Rest/XenoRestSystem.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared._RMC14.Xenonids.Charge;
+﻿using Content.Shared._RMC14.Actions;
+using Content.Shared._RMC14.Xenonids.Charge;
 using Content.Shared._RMC14.Xenonids.Construction.Events;
 using Content.Shared._RMC14.Xenonids.Crest;
 using Content.Shared._RMC14.Xenonids.Fling;
@@ -32,7 +33,6 @@ public sealed class XenoRestSystem : EntitySystem
 
         SubscribeLocalEvent<XenoComponent, XenoRestActionEvent>(OnXenoRestAction);
 
-        // TODO RMC14 generic xeno ability attempt event
         SubscribeLocalEvent<XenoRestingComponent, UpdateCanMoveEvent>(OnXenoRestingCanMove);
         SubscribeLocalEvent<XenoRestingComponent, AttackAttemptEvent>(OnXenoRestingMeleeHit);
         SubscribeLocalEvent<XenoRestingComponent, XenoSecreteStructureAttemptEvent>(OnXenoSecreteStructureAttempt);
@@ -48,6 +48,20 @@ public sealed class XenoRestSystem : EntitySystem
         SubscribeLocalEvent<XenoRestingComponent, XenoStompAttemptEvent>(OnXenoRestingStompAttempt);
         SubscribeLocalEvent<XenoRestingComponent, XenoGutAttemptEvent>(OnXenoRestingGutAttempt);
         SubscribeLocalEvent<XenoRestingComponent, XenoScreechAttemptEvent>(OnXenoRestingScreechAttempt);
+        SubscribeLocalEvent<ActionBlockIfRestingComponent, RMCActionUseAttemptEvent>(OnXenoRestingActionUseAttempt);
+    }
+
+    private void OnXenoRestingActionUseAttempt(Entity<ActionBlockIfRestingComponent> ent, ref RMCActionUseAttemptEvent args)
+    {
+        if (args.Cancelled)
+            return;
+
+        var user = args.User;
+        if (HasComp<XenoRestingComponent>(user))
+        {
+            args.Cancelled = true;
+            _popup.PopupClient(Loc.GetString(ent.Comp.Popup), user, user, PopupType.SmallCaution);
+        }
     }
 
     private void OnXenoRestingCanMove(Entity<XenoRestingComponent> xeno, ref UpdateCanMoveEvent args)

--- a/Content.Shared/_RMC14/Xenonids/Retrieve/XenoRetrieveSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Retrieve/XenoRetrieveSystem.cs
@@ -6,13 +6,11 @@ using Content.Shared._RMC14.Stun;
 using Content.Shared._RMC14.Xenonids.Rest;
 using Content.Shared.Coordinates;
 using Content.Shared.DoAfter;
-using Content.Shared.Emoting;
 using Content.Shared.Interaction;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Physics;
 using Content.Shared.Popups;
 using Content.Shared.Standing;
-using Content.Shared.Throwing;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
@@ -85,9 +83,6 @@ public sealed class XenoRetrieveSystem : EntitySystem
             _popup.PopupClient(msg, xeno, xeno, PopupType.SmallCaution);
             return;
         }
-
-        if (!_rmcActions.CanUseActionPopup(xeno, args.Action))
-            return;
 
         args.Handled = true;
         var ev = new XenoRetrieveDoAfterEvent(GetNetEntity(args.Action));

--- a/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
@@ -27,7 +27,6 @@ using Content.Shared.Radio;
 using Content.Shared.Standing;
 using Content.Shared.Storage.Components;
 using Content.Shared.Storage.EntitySystems;
-using Content.Shared.Tools.Components;
 using Content.Shared.Tools.Systems;
 using Content.Shared.UserInterface;
 using Content.Shared.Weapons.Melee.Events;
@@ -316,12 +315,6 @@ public sealed class XenoSystem : EntitySystem
         _damageable.TryChangeDamage(xeno, heal, true);
     }
 
-    // TODO RMC14 generalize this for survivors, synthetics, enemy hives, etc
-    public bool CanHitLiving(EntityUid xeno, EntityUid defender)
-    {
-        return _marineQuery.HasComponent(defender);
-    }
-
     public bool FromSameHive(Entity<XenoComponent?> xenoOne, Entity<XenoComponent?> xenoTwo)
     {
         if (!_xenoQuery.Resolve(xenoOne, ref xenoOne.Comp, false) ||
@@ -345,11 +338,16 @@ public sealed class XenoSystem : EntitySystem
     {
         if (xeno == target)
             return false;
-        // TODO RMC14 use hive member instead
-        if (TryComp<XenoComponent>(xeno, out var comp1) && TryComp<XenoComponent>(target, out var comp2) && comp1.Hive == comp2.Hive)
-            return false;
 
-        if (HasComp<MobStateComponent>(target) && _mobState.IsDead(target))
+        // TODO RMC14 use hive member instead
+        if (TryComp<XenoComponent>(xeno, out var comp1) &&
+            TryComp<XenoComponent>(target, out var comp2) &&
+            comp1.Hive == comp2.Hive)
+        {
+            return false;
+        }
+
+        if (_mobState.IsDead(target))
             return false;
 
         if (_xenoNestedQuery.HasComp(target))

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
@@ -93,6 +93,7 @@ rmc-xeno-rest-cant-stomp = You can't stomp while resting!
 rmc-xeno-rest-cant-gut = You can't gut while resting!
 rmc-xeno-rest-cant-screech = You can't screech while resting!
 rmc-xeno-rest-cant-secrete = You can't secrete while resting!
+rmc-xeno-rest-cant = You can't do that while resting!
 
 # Toggle Crest Defense
 cm-xeno-toggle-crest-cant-fortify = You can't fortify while your crest is lowered!

--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -15,7 +15,7 @@
   description: AAAAAAAAAAAAAAAAAAAAAAAAA
   components:
   - type: InstantAction
-    useDelay: 10
+    useDelay: 20
     icon: Interface/Actions/scream.png
     event: !type:ScreamActionEvent
     checkCanInteract: false

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
@@ -182,6 +182,7 @@
     useDelay: 1.5
     range: 15
     checkCanAccess: false
+  - type: ActionBlockIfResting
 
 - type: entity
   id: ActionXenoScatteredSpit
@@ -198,6 +199,7 @@
     useDelay: 8
     range: 15
     checkCanAccess: false
+  - type: ActionBlockIfResting
 
 - type: entity
   id: ActionXenoSpit
@@ -214,6 +216,7 @@
     useDelay: 2
     range: 15
     checkCanAccess: false
+  - type: ActionBlockIfResting
 
 - type: entity
   id: ActionXenoChargeSpit
@@ -243,6 +246,7 @@
     event: !type:XenoSprayAcidActionEvent
     useDelay: 8
     range: 6
+  - type: ActionBlockIfResting
 
 - type: entity
   parent: ActionXenoSprayAcid
@@ -279,6 +283,7 @@
     useDelay: 18
     range: 15
     checkCanAccess: false
+  - type: ActionBlockIfResting
 
 - type: entity
   id: ActionXenoParalyzingSlash

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_utility_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_utility_actions.yml
@@ -31,6 +31,7 @@
     cost: 100
   - type: ActionCooldown
     cooldown: 10
+  - type: ActionBlockIfResting
 
 - type: entity
   parent: ActionXenoBase
@@ -48,6 +49,7 @@
     useDelay: 10
   - type: XenoActionPlasma
     cost: 100
+  - type: ActionBlockIfResting
 
 - type: entity
   parent: ActionXenoBase

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
@@ -223,3 +223,4 @@
   - type: TacticalMapUser
     actionId: RMCActionOpenTacticalMapMarine
     marines: true
+  - type: EmoteCooldown

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/praetorian.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/praetorian.yml
@@ -88,6 +88,7 @@
     barricadeDamage:
       types:
         Heat: 5
+    doAfter: 0.5
   - type: TacticalMapIcon
     icon:
       sprite: _RMC14/Interface/map_blips.rsi
@@ -149,6 +150,12 @@
   - type: XenoEnergy
   - type: XenoRetrieve
   - type: XenoAid
+  - type: XenoSprayAcid
+    acid: XenoAcidSprayStrong
+    barricadeDamage:
+      types:
+        Heat: 5
+    doAfter: 0.5
   - type: MeleeWeapon
     damage:
       groups:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/marine_shotguns.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/marine_shotguns.yml
@@ -29,6 +29,7 @@
       path: /Audio/_RMC14/Weapons/Guns/Gunshots/gun_shotgun.ogg
     soundEmpty:
       path: /Audio/Weapons/Guns/Empty/empty.ogg
+    resetOnHandSelected: true
   - type: RMCSelectiveFire
     baseFireModes:
     - SemiAuto

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_projectiles.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_projectiles.yml
@@ -281,3 +281,6 @@
     maxRange: 6
   - type: ClusterLimitHits
     limit: 4
+  - type: ContainerContainer
+    containers:
+      cluster-payload: !type:Container

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_projectiles.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_projectiles.yml
@@ -249,11 +249,18 @@
         shape:
           !type:PhysShapeAabb
           bounds: "-0.1,-0.1,0.1,0.1"
-        hard: true
+        hard: false
         mask:
         - Impassable
         - BulletImpassable
         - XenoProjectileImpassable
+      fix2:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.1,-0.1,0.1,0.1"
+        hard: true
+        mask:
+        - Impassable
         - BarricadeImpassable
   - type: Sprite
     sprite: _RMC14/Objects/Xeno/xeno_acid_ball.rsi

--- a/Resources/Prototypes/_RMC14/explosion.yml
+++ b/Resources/Prototypes/_RMC14/explosion.yml
@@ -25,7 +25,7 @@
     types:
       Blunt: 5
       Heat: 5
-      Structural: 27
+      Structural: 90
   tileBreakChance: [0, 0.5, 1]
   tileBreakIntensity: [0, 10, 30]
   tileBreakRerollReduction: 20


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

## Requirements
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
:cl:
- fix: Fixed Praetorian acid ball pushing marines around like a pinball.
- fix: Fixed Warden Praetorian acid spray having no delay and not stunning for 2 seconds.
- fix: Fixed job slot scaling with pop not working.
- fix: Fixed shotguns having no delay to fire when swapping between them.
- fix: Fixed Lurker pounce and Praetorian dash going on cooldown if you try to use them without plasma.
- fix: Fixed HE mortar shell damage being lower than intended, not even breaking one regular wall. A single HE shell will now destroy a 3x3 of regular walls (3000 hp), but only deal 6000 damage to a reinforced wall (9000 hp). This doesn't change the damage it does to xenonids or marines, only structures.
- fix: Fixed some Praetorian and Warden Praetorian abilities being usable while resting. Spit, spray acid, acid ball, retrieve and aid xenonid now are correctly no longer usable while the Praetorian is resting.
- fix: Fixed the popup for the Warden Praetorian's aid xenonid being incorrect for players other than the Praetorian and the target.
- fix: Fixed the Warden Praetorian being able to gain internal hitpoints from spitting at a wall.
- fix: Ported 13's 20-second cooldown for emote sounds. Anyone angered by this change should take it up with the hordes of people yawn and emote spamming during briefing in the middle of a Brigadier-General aboard the Almayer, or those spamming emotes in the dropship. Admins have better things to do than handle this dogshit rp every round. The scream hotbar action will always bypass this cooldown, also on a 20 second cooldown.