### PR TITLE
Fix xeno hud and medhud appearing while a scout is invisible

### DIFF
--- a/Content.Client/StatusIcon/StatusIconSystem.cs
+++ b/Content.Client/StatusIcon/StatusIconSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._RMC14.Stealth;
 using Content.Shared.CCVar;
 using Content.Shared.Ghost;
 using Content.Shared.StatusIcon;
@@ -83,6 +84,9 @@ public sealed class StatusIconSystem : SharedStatusIconSystem
             return false;
 
         if (data.HideOnStealth && TryComp<StealthComponent>(ent, out var stealth) && stealth.Enabled)
+            return false;
+
+        if (data.HideOnStealth && HasComp<EntityActiveInvisibleComponent>(ent))
             return false;
 
         if (data.ShowTo != null && !_entityWhitelist.IsValid(data.ShowTo, viewer))

--- a/Content.Client/_RMC14/Xenonids/Hud/XenoHudOverlay.cs
+++ b/Content.Client/_RMC14/Xenonids/Hud/XenoHudOverlay.cs
@@ -23,6 +23,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using static Robust.Shared.Utility.SpriteSpecifier;
+using Content.Shared._RMC14.Stealth;
 
 namespace Content.Client._RMC14.Xenonids.Hud;
 
@@ -50,6 +51,7 @@ public sealed class XenoHudOverlay : Overlay
     private readonly EntityQuery<XenoPlasmaComponent> _xenoPlasmaQuery;
     private readonly EntityQuery<TransformComponent> _xformQuery;
     private readonly EntityQuery<XenoShieldComponent> _xenoShieldQuery;
+    private readonly EntityQuery<EntityActiveInvisibleComponent> _invisQuery;
 
     private readonly ShaderInstance _shader;
 
@@ -78,6 +80,7 @@ public sealed class XenoHudOverlay : Overlay
         _xenoPlasmaQuery = _entity.GetEntityQuery<XenoPlasmaComponent>();
         _xformQuery = _entity.GetEntityQuery<TransformComponent>();
         _xenoShieldQuery = _entity.GetEntityQuery<XenoShieldComponent>();
+        _invisQuery = _entity.GetEntityQuery<EntityActiveInvisibleComponent>();
 
         _shader = _prototype.Index<ShaderPrototype>("unshaded").Instance();
         ZIndex = 1;
@@ -180,6 +183,9 @@ public sealed class XenoHudOverlay : Overlay
             if (_xenoParasiteQuery.HasComp(uid))
                 continue;
 
+            if (_invisQuery.HasComp(uid))
+                continue;
+
             var bounds = sprite.Bounds;
             var worldPos = _transform.GetWorldPosition(xform, _xformQuery);
 
@@ -212,6 +218,9 @@ public sealed class XenoHudOverlay : Overlay
                 continue;
 
             if (_container.IsEntityOrParentInContainer(uid, xform: xform))
+                continue;
+
+            if (_invisQuery.HasComp(uid))
                 continue;
 
             var bounds = sprite.Bounds;
@@ -247,6 +256,9 @@ public sealed class XenoHudOverlay : Overlay
                 continue;
 
             if (_container.IsEntityOrParentInContainer(uid, xform: xform))
+                continue;
+
+            if (_invisQuery.HasComp(uid))
                 continue;
 
             var bounds = sprite.Bounds;

--- a/Content.Shared/_RMC14/Armor/ThermalCloak/ThermalCloakSystem.cs
+++ b/Content.Shared/_RMC14/Armor/ThermalCloak/ThermalCloakSystem.cs
@@ -2,6 +2,7 @@ using Content.Shared._RMC14.Chemistry;
 using Content.Shared._RMC14.NightVision;
 using Content.Shared._RMC14.Stealth;
 using Content.Shared._RMC14.Weapons.Ranged.IFF;
+using Content.Shared._RMC14.Xenonids.Devour;
 using Content.Shared._RMC14.Xenonids.Projectile;
 using Content.Shared.Actions;
 using Content.Shared.Coordinates;
@@ -10,6 +11,7 @@ using Content.Shared.Humanoid;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
+using Content.Shared.Mobs;
 using Content.Shared.Popups;
 using Content.Shared.Projectiles;
 using Content.Shared.Weapons.Ranged.Components;
@@ -44,6 +46,8 @@ public sealed class ThermalCloakSystem : EntitySystem
         SubscribeLocalEvent<ThermalCloakComponent, GotUnequippedEvent>(OnUnequipped);
 
         SubscribeLocalEvent<EntityActiveInvisibleComponent, VaporHitEvent>(OnVaporHit);
+        SubscribeLocalEvent<EntityActiveInvisibleComponent, MobStateChangedEvent>(OnMobStateChanged);
+        SubscribeLocalEvent<EntityActiveInvisibleComponent, XenoDevouredEvent>(OnDevour);
 
         SubscribeLocalEvent<GunComponent, AttemptShootEvent>(OnAttemptShoot);
         SubscribeLocalEvent<ExplodeOnTriggerComponent, UseInHandEvent>(OnTimerUse);
@@ -234,14 +238,27 @@ public sealed class ThermalCloakSystem : EntitySystem
         }
     }
 
+    private void OnAcidProjectile(Entity<UncloakOnHitComponent> ent, ref ProjectileHitEvent args)
+    {
+        TrySetInvisibility(args.Target, false, true);
+    }
+
     private void OnVaporHit(Entity<EntityActiveInvisibleComponent> ent, ref VaporHitEvent args)
     {
         TrySetInvisibility(ent.Owner, false, true);
     }
 
-    private void OnAcidProjectile(Entity<UncloakOnHitComponent> ent, ref ProjectileHitEvent args)
+    private void OnMobStateChanged(Entity<EntityActiveInvisibleComponent> ent, ref MobStateChangedEvent args)
     {
-        TrySetInvisibility(args.Target, false, true);
+        if (args.NewMobState != MobState.Dead)
+            return;
+
+        TrySetInvisibility(ent.Owner, false, true);
+    }
+
+    private void OnDevour(Entity<EntityActiveInvisibleComponent> ent, ref XenoDevouredEvent args)
+    {
+        TrySetInvisibility(ent.Owner, false, true);
     }
 
     private Entity<ThermalCloakComponent>? FindWornCloak(EntityUid player)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/065009e2-cfa4-400e-9699-d2999f4bd106)


resolves #4181


:cl:
- fix: Fixed xeno hud icons being visible while a scout is invisible.
- fix: Fixed scout specialists not becoming visible on death.