### PR TITLE
Parasite Observer strain

### DIFF
--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-strains.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-strains.ftl
@@ -7,3 +7,11 @@ rmc-xeno-warden-description = You trade your acid ball, acid spray, dash, and a 
   - An ability that retrieves endangered, knocked-down or resting allies and pulls them to your location.
   - An internal hitpoint pool that fills with every slash against your enemies, which can be spent to aid your allies and yourself by healing them or curing their ailments.
 rmc-xeno-warden-popup = This one will deny her sisters' deaths until they earn it. Fight or be forgotten.
+
+rmc-xeno-observer-name = Observer
+rmc-xeno-observer-description = You lose your ability to hide, but will be able to to see further into the distance. Stalk your prey for the best opportunity or coordinate an ambush with your sisters.
+  You gain:
+  - An ability to Zoom out your field of view, like a Runner
+  You loose:
+  - Your ability to Hide
+rmc-xeno-observer-popup = This one will stalk the prey from a distance, with a greater sight.

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/parasite.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/parasite.yml
@@ -2,8 +2,9 @@
   parent:
   - CMXenoUndeveloped
   - CMXenoFlammable
-  id: CMXenoParasite # TODO RMC14 slowly die off weeds
+  id: CMXenoParasiteBase # TODO RMC14 slowly die off weeds
   name: Parasite
+  suffix: Base
   components:
   - type: GhostRole
     name: cm-job-name-xeno-parasite
@@ -23,7 +24,6 @@
     actionIds:
     - ActionXenoRest
     - ActionXenoWatch
-    - ActionXenoHide
     - ActionXenoLeap
     tier: 0
     hudOffset: 0,0.4
@@ -34,7 +34,6 @@
   - type: XenoPlasma
     maxPlasma: 10
     plasmaRegenOnWeeds: 0.1
-  - type: XenoHide
   - type: Fixtures
     fixtures:
       fix1:
@@ -94,3 +93,48 @@
     icon:
       sprite: _RMC14/Interface/map_blips.rsi
       state: parasite
+
+- type: entity
+  parent: CMXenoParasiteBase
+  id: CMXenoParasite
+  suffix: Normal
+  components:
+  - type: Xeno
+    actionIds:
+    - ActionXenoRest
+    - ActionXenoWatch
+    - ActionXenoHide
+    - ActionXenoLeap
+  - type: XenoHide
+  - type: XenoEvolution
+    strains:
+    - RMCXenoParasiteObserver
+
+- type: entity
+  parent: CMXenoParasiteBase
+  id: RMCXenoParasiteObserver # Observer Strain
+  suffix: Observer
+  components:
+  - type: Xeno
+    actionIds:
+    - ActionXenoRest
+    - ActionXenoWatch
+    - ActionXenoLeap
+    - ActionXenoZoom 
+  - type: XenoZoom
+  - type: XenoStrain
+    name: rmc-xeno-observer-name
+    description: rmc-xeno-observer-description
+    popup: rmc-xeno-observer-popup
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION

## About the PR
Added New Xeno Strain - Parasite Observer
## Why / Balance
Contributes to making more playable strains with the update!
## Technical details
This one wasnt hard, i just took major components of parasite and made them into Parasite Base, from wich Normal (Has Hiding) and Observer (No hiding, but runner's Zoom) paras separated. The Parasite has its own neat Strain description too, just like the Warden prae.

(TO NOTE - For some reason everything works OK, but the RMC-ADMIN-ACTION UI summons... Parasite Base? Instead of Parasite... Like i DID change ID to the correct one... every other way of summoining Parasites: like Eggs, Carriers, Ghost role take-overs from both of em - works FINE and WILL BE FINE in game, but this iz just a thing.  Doesnt affect gameplay, so i hope its OK, and can be fixed later when working with that UI)


## Requirements
- [x ] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes

**Changelog**

:cl:
- add: Added Parasite Observer Strain!

