### PR TITLE
Fixed barbed sandbags not returning barbed wire when dismantled

### DIFF
--- a/Content.Shared/_RMC14/Entrenching/BarricadeSystem.cs
+++ b/Content.Shared/_RMC14/Entrenching/BarricadeSystem.cs
@@ -99,7 +99,7 @@ public sealed class BarricadeSystem : EntitySystem
         if (bagsSalvaged <= 0 && TryComp(full, out FullSandbagComponent? fullSandbag))
             bagsSalvaged = fullSandbag.StackRequired;
         if (TryComp(args.Target, out DamageableComponent? damageable))
-            bagsSalvaged -= Math.Max((int)damageable.TotalDamage / barricade.MaterialLossDamageInterval - 1, 0);
+            bagsSalvaged -= Math.Max((int) damageable.TotalDamage / barricade.MaterialLossDamageInterval - 1, 0);
 
         if (TryComp(args.Target, out BarbedComponent? barbed) && barbed.IsBarbed)
             Spawn(barbed.Spawn, GetCoordinates(args.Coordinates));

--- a/Content.Shared/_RMC14/Entrenching/BarricadeSystem.cs
+++ b/Content.Shared/_RMC14/Entrenching/BarricadeSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._RMC14.Barricade.Components;
 using Content.Shared.Damage;
 using Content.Shared.DoAfter;
 using Content.Shared.Interaction;
@@ -99,6 +100,9 @@ public sealed class BarricadeSystem : EntitySystem
             bagsSalvaged = fullSandbag.StackRequired;
         if (TryComp(args.Target, out DamageableComponent? damageable))
             bagsSalvaged -= Math.Max((int) damageable.TotalDamage / barricade.MaterialLossDamageInterval - 1, 0);
+
+        if (TryComp(args.Target, out BarbedComponent? barbed) && barbed.IsBarbed)
+            EntityManager.SpawnEntity(barbed.Spawn, EntityManager.GetCoordinates(args.Coordinates));
 
         Del(args.Target);
 

--- a/Content.Shared/_RMC14/Entrenching/BarricadeSystem.cs
+++ b/Content.Shared/_RMC14/Entrenching/BarricadeSystem.cs
@@ -93,16 +93,16 @@ public sealed class BarricadeSystem : EntitySystem
 
         if (!TryComp(args.Target, out BarricadeSandbagComponent? barricade))
             return;
-        var full = Spawn(barricade.Material, EntityManager.GetCoordinates(args.Coordinates));
+        var full = Spawn(barricade.Material, GetCoordinates(args.Coordinates));
 
         var bagsSalvaged = barricade.MaxMaterial;
         if (bagsSalvaged <= 0 && TryComp(full, out FullSandbagComponent? fullSandbag))
             bagsSalvaged = fullSandbag.StackRequired;
         if (TryComp(args.Target, out DamageableComponent? damageable))
-            bagsSalvaged -= Math.Max((int) damageable.TotalDamage / barricade.MaterialLossDamageInterval - 1, 0);
+            bagsSalvaged -= Math.Max((int)damageable.TotalDamage / barricade.MaterialLossDamageInterval - 1, 0);
 
         if (TryComp(args.Target, out BarbedComponent? barbed) && barbed.IsBarbed)
-            EntityManager.SpawnEntity(barbed.Spawn, EntityManager.GetCoordinates(args.Coordinates));
+            Spawn(barbed.Spawn, GetCoordinates(args.Coordinates));
 
         Del(args.Target);
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Barbed sandbags now return the barbed wire when dismantled with an entrenching tool.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Dismantling sandbags ate the barbed wire, which can be a drain if you're trying to move the barricades around.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Added a check to OnSandbagDismantleDoAfter() in BarricadeSystem.cs.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->
![image](https://github.com/user-attachments/assets/b5bcee7c-160b-4732-862d-3e86c9c66a32)
![image](https://github.com/user-attachments/assets/af527318-007d-4939-8066-ff9e1b6a9587)



## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- fix: Barbed sandbags now return the barbed wire when dismantled.

