### PR TITLE
make hive caste support announcement work + loc

### DIFF
--- a/Content.Server/_RMC14/Announce/XenoAnnounceSystem.cs
+++ b/Content.Server/_RMC14/Announce/XenoAnnounceSystem.cs
@@ -24,7 +24,9 @@ public sealed class XenoAnnounceSystem : SharedXenoAnnounceSystem
 
         filter.AddWhereAttachedEntity(HasComp<GhostComponent>);
 
-        _adminLogs.Add(LogType.RMCXenoAnnounce, $"{ToPrettyString(source):source} xeno announced message: {message}");
+        if (source.IsValid())
+            _adminLogs.Add(LogType.RMCXenoAnnounce, $"{ToPrettyString(source):source} xeno announced message: {message}");
+
         _chat.ChatMessageToManyFiltered(filter, ChatChannel.Radio, message, wrapped, source, false, true, null);
         _audio.PlayGlobal(sound, filter, true);
 

--- a/Content.Server/_RMC14/Xenonids/Hive/XenoHiveSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Hive/XenoHiveSystem.cs
@@ -53,8 +53,8 @@ public sealed class XenoHiveSystem : SharedXenoHiveSystem
             if (_announce.Count == 0)
                 continue;
 
-            var popup = $"The Hive can now support: {string.Join(", ", _announce)}";
-            _xenoAnnounce.AnnounceSameHive(default, popup, hive.AnnounceSound, PopupType.Large);
+            var popup = Loc.GetString("rmc-hive-supports-castes", ("castes", string.Join(", ", _announce)));
+            _xenoAnnounce.AnnounceToHive(EntityUid.Invalid, hiveId, popup, hive.AnnounceSound, PopupType.Large);
         }
     }
 }

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-chat.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-chat.ftl
@@ -1,2 +1,3 @@
 ﻿rmc-no-queen-hivemind-chat = There is no Queen. You are alone.
 rmc-new-queen = A new Queen has risen to lead the Hive! Rejoice!
+rmc-hive-supports-castes = The Hive can now support: {$castes}


### PR DESCRIPTION
## About the PR
title

## Why / Balance
it was trying to announce to Invalid's hive which obviously wont work

## Technical details
made it not log that invalid announced an automated message, that is pure garbage

## Media
![11:11:34](https://github.com/user-attachments/assets/ea7e5660-4c74-433d-b7af-1341f5f5767c)


## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- add: Xenos are now told when the hive supports certain castes.
