### PR TITLE
hive member unification and many fixes

### DIFF
--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
@@ -3,6 +3,7 @@ using Content.Server._RMC14.Dropship;
 using Content.Server._RMC14.Marines;
 using Content.Server._RMC14.Rules.CrashLand;
 using Content.Server._RMC14.Stations;
+using Content.Server._RMC14.Xenonids.Hive;
 using Content.Server.Administration.Components;
 using Content.Server.Administration.Managers;
 using Content.Server.Atmos.EntitySystems;
@@ -84,7 +85,7 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
     [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly DropshipSystem _dropship = default!;
     [Dependency] private readonly GunIFFSystem _gunIFF = default!;
-    [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
+    [Dependency] private readonly XenoHiveSystem _hive = default!;
     [Dependency] private readonly HungerSystem _hunger = default!;
     [Dependency] private readonly MarineSystem _marines = default!;
     [Dependency] private readonly MindSystem _mind = default!;
@@ -202,10 +203,12 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
 
             OperationName = GetRandomOperationName();
 
-            comp.Hive = Spawn(comp.HiveId);
+            // TODO: come up with random name like operation name, in a function that can be reused for hive v hive
+            comp.Hive = _hive.CreateHive("xenonid hive", comp.HiveId);
             if (!SpawnXenoMap((uid, comp)))
             {
                 Log.Error("Failed to load xeno map");
+                // TODO: how should the gamemode handle failure? restart immediately or create an alert for admins
                 continue;
             }
 
@@ -274,7 +277,7 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
                 var xenoEnt = SpawnAtPosition(ent, point.ToCoordinates());
 
                 _xeno.MakeXeno(xenoEnt);
-                _xeno.SetHive(xenoEnt, comp.Hive);
+                _hive.SetHive(xenoEnt, comp.Hive);
                 return xenoEnt;
             }
 

--- a/Content.Server/_RMC14/Xenonids/Construction/XenoHiveCoreSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Construction/XenoHiveCoreSystem.cs
@@ -27,7 +27,7 @@ public sealed class XenoHiveCoreSystem : SharedXenoHiveCoreSystem
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly RMCDamageableSystem _rmcDamageable = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
-    [Dependency] private readonly XenoSystem _xeno = default!;
+    [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
 
     public override void Initialize()
     {
@@ -55,17 +55,13 @@ public sealed class XenoHiveCoreSystem : SharedXenoHiveCoreSystem
 
     private void OnHiveCoreDestruction(Entity<HiveCoreComponent> ent, ref DestructionEventArgs args)
     {
-        if (TryComp(ent, out HiveMemberComponent? member) &&
-            TryComp(member.Hive, out HiveComponent? hive))
-        {
-            hive.NewCoreAt = _timing.CurTime + hive.NewCoreCooldown;
-        }
+        if (_hive.GetHive(ent.Owner) is {} hive)
+            hive.Comp.NewCoreAt = _timing.CurTime + hive.Comp.NewCoreCooldown;
     }
 
     private void OnXenoSpawnerUsed(Entity<XenoComponent> xeno, ref GhostRoleSpawnerUsedEvent args)
     {
-        if (TryComp(args.Spawner, out HiveMemberComponent? member))
-            _xeno.SetHive((xeno, xeno), member.Hive);
+        _hive.SetSameHive(args.Spawner, xeno.Owner);
 
         if (TryComp(args.Spawner, out HiveCoreComponent? core))
             core.LiveLesserDrones.Add(xeno);

--- a/Content.Server/_RMC14/Xenonids/Hive/HiveCommand.cs
+++ b/Content.Server/_RMC14/Xenonids/Hive/HiveCommand.cs
@@ -28,16 +28,16 @@ public sealed class HiveCommand : ToolshedCommand
 
         var amount = 0;
         var xenos = EntityManager.EntityQueryEnumerator<XenoComponent>();
-        var xenoSystem = EntityManager.System<XenoSystem>();
+        var hiveSystem = EntityManager.System<SharedXenoHiveSystem>();
         while (xenos.MoveNext(out var uid, out var xeno))
         {
-            if (xeno.Hive != null)
+            if (hiveSystem.HasHive(uid))
                 continue;
 
-            xenoSystem.SetHive(uid, firstHive);
+            hiveSystem.SetHive(uid, firstHive);
             amount++;
         }
 
-        ctx.WriteLine($"Set the hive of {amount} xenos to {firstHive}.");
+        ctx.WriteLine($"Set the hive of {amount} rogue xenos to {firstHive}.");
     }
 }

--- a/Content.Server/_RMC14/Xenonids/Hive/XenoHiveSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Hive/XenoHiveSystem.cs
@@ -12,8 +12,11 @@ public sealed class XenoHiveSystem : SharedXenoHiveSystem
     [Dependency] private readonly XenoAnnounceSystem _xenoAnnounce = default!;
     [Dependency] private readonly GameTicker _gameTicker = default!;
     [Dependency] private readonly IPrototypeManager _prototypes = default!;
+    [Dependency] private readonly MetaDataSystem _metaData = default!;
 
     private readonly List<string> _announce = [];
+
+    public readonly EntProtoId DefaultHive = "CMXenoHive";
 
     public override void Update(float frameTime)
     {
@@ -56,5 +59,15 @@ public sealed class XenoHiveSystem : SharedXenoHiveSystem
             var popup = $"The Hive can now support: {string.Join(", ", _announce)}";
             _xenoAnnounce.AnnounceSameHive(default, popup, hive.AnnounceSound, PopupType.Large);
         }
+    }
+
+    /// <summary>
+    /// Create a new hive with a name.
+    /// </summary>
+    public EntityUid CreateHive(string name, EntProtoId? proto = null)
+    {
+        var ent = Spawn(proto ?? DefaultHive);
+        _metaData.SetEntityName(ent, name);
+        return ent;
     }
 }

--- a/Content.Server/_RMC14/Xenonids/Watch/XenoWatchSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Watch/XenoWatchSystem.cs
@@ -2,6 +2,7 @@
 using Content.Server.Popups;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared._RMC14.Xenonids.Evolution;
+using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Watch;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Popups;
@@ -14,6 +15,7 @@ namespace Content.Server._RMC14.Xenonids.Watch;
 public sealed class XenoWatchSystem : SharedWatchXenoSystem
 {
     [Dependency] private readonly SharedEyeSystem _eye = default!;
+    [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly TransformSystem _transform = default!;
@@ -97,6 +99,9 @@ public sealed class XenoWatchSystem : SharedWatchXenoSystem
     {
         args.Handled = true;
 
+        if (_hive.GetHive(ent.Owner) is not {} hive)
+            return;
+
         if (!HasQueenPopup(ent))
             return;
 
@@ -104,19 +109,16 @@ public sealed class XenoWatchSystem : SharedWatchXenoSystem
 
         var xenos = new List<Xeno>();
 
-        if (ent.Comp.Hive != default)
+        var query = EntityQueryEnumerator<XenoComponent, HiveMemberComponent, MetaDataComponent>();
+        while (query.MoveNext(out var uid, out _, out var member, out var metaData))
         {
-            var query = EntityQueryEnumerator<XenoComponent, MetaDataComponent>();
-            while (query.MoveNext(out var uid, out var xeno, out var metaData))
-            {
-                if (uid == ent.Owner || xeno.Hive != ent.Comp.Hive)
-                    continue;
+            if (uid == ent.Owner || member.Hive != hive.Owner)
+                continue;
 
-                if (_mobState.IsDead(uid))
-                    continue;
+            if (_mobState.IsDead(uid))
+                continue;
 
-                xenos.Add(new Xeno(GetNetEntity(uid), Name(uid, metaData), metaData.EntityPrototype?.ID));
-            }
+            xenos.Add(new Xeno(GetNetEntity(uid), Name(uid, metaData), metaData.EntityPrototype?.ID));
         }
 
         xenos.Sort((a, b) => string.CompareOrdinal(a.Name, b.Name));
@@ -124,7 +126,7 @@ public sealed class XenoWatchSystem : SharedWatchXenoSystem
         _ui.SetUiState(ent.Owner, XenoWatchUIKey.Key, new XenoWatchBuiState(xenos));
     }
 
-    public override void Watch(Entity<XenoComponent?, ActorComponent?, EyeComponent?> watcher, Entity<XenoComponent?> toWatch)
+    public override void Watch(Entity<HiveMemberComponent?, ActorComponent?, EyeComponent?> watcher, Entity<HiveMemberComponent?> toWatch)
     {
         base.Watch(watcher, toWatch);
 
@@ -134,13 +136,10 @@ public sealed class XenoWatchSystem : SharedWatchXenoSystem
         if (watcher.Owner == toWatch.Owner)
             return;
 
-        if (!Resolve(watcher, ref watcher.Comp1, ref watcher.Comp2, ref watcher.Comp3) ||
-            !Resolve(toWatch, ref toWatch.Comp))
-        {
+        if (!_hive.FromSameHive((watcher, watcher.Comp1), toWatch))
             return;
-        }
 
-        if (watcher.Comp1.Hive != toWatch.Comp.Hive || toWatch.Comp.Hive == default)
+        if (!Resolve(watcher, ref watcher.Comp2, false))
             return;
 
         _eye.SetTarget(watcher, toWatch, watcher);

--- a/Content.Shared/_RMC14/Xenonids/Aid/XenoAidSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Aid/XenoAidSystem.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Shared._RMC14.Damage;
 using Content.Shared._RMC14.Xenonids.Energy;
+using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Strain;
 using Content.Shared.Actions;
 using Content.Shared.Coordinates;
@@ -24,8 +25,8 @@ public sealed class XenoAidSystem : EntitySystem
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedRMCDamageableSystem _rmcDamageable = default!;
+    [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
     [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
-    [Dependency] private readonly XenoSystem _xeno = default!;
     [Dependency] private readonly XenoEnergySystem _xenoEnergy = default!;
     [Dependency] private readonly XenoStrainSystem _xenoStrain = default!;
 
@@ -38,7 +39,7 @@ public sealed class XenoAidSystem : EntitySystem
     private void OnXenoAidAction(Entity<XenoAidComponent> xeno, ref XenoAidActionEvent args)
     {
         var target = args.Target;
-        if (!_xeno.FromSameHive(xeno.Owner, target))
+        if (!_hive.FromSameHive(xeno.Owner, target))
         {
             var msg = Loc.GetString("rmc-xeno-not-same-hive");
             _popup.PopupClient(msg, xeno, xeno, PopupType.SmallCaution);

--- a/Content.Shared/_RMC14/Xenonids/Bombard/XenoBombardSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Bombard/XenoBombardSystem.cs
@@ -2,6 +2,7 @@ using System.Numerics;
 using Content.Shared._RMC14.Actions;
 using Content.Shared._RMC14.Projectiles;
 using Content.Shared._RMC14.Xenonids.GasToggle;
+using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared._RMC14.Xenonids.Projectile;
 using Content.Shared.DoAfter;
@@ -18,13 +19,13 @@ public sealed class XenoBombardSystem : EntitySystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly SharedGunSystem _gun = default!;
+    [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly RMCActionsSystem _rmcActions = default!;
     [Dependency] private readonly RMCProjectileSystem _rmcProjectile = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly XenoPlasmaSystem _xenoPlasma = default!;
-    [Dependency] private readonly XenoProjectileSystem _xenoProjectile = default!;
 
     public override void Initialize()
     {
@@ -82,7 +83,7 @@ public sealed class XenoBombardSystem : EntitySystem
 
         var direction = args.Coordinates.Position - source.Position;
         var projectile = Spawn(ent.Comp.Projectile, source);
-        _xenoProjectile.SetSameHive(projectile, ent.Owner);
+        _hive.SetSameHive(ent.Owner, projectile);
 
         var max = EnsureComp<ProjectileMaxRangeComponent>(projectile);
         _rmcProjectile.SetMaxRange((projectile, max), direction.Length());

--- a/Content.Shared/_RMC14/Xenonids/Construction/ResinHole/SharedXenoResinHoleSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/ResinHole/SharedXenoResinHoleSystem.cs
@@ -2,6 +2,7 @@ using Content.Shared.Mobs.Systems;
 using Content.Shared.DoAfter;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
+using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Parasite;
 using Content.Shared._RMC14.Hands;
 using Robust.Shared.Prototypes;
@@ -15,6 +16,7 @@ public abstract partial class SharedXenoResinHoleSystem : EntitySystem
     [Dependency] protected readonly SharedAppearanceSystem _appearanceSystem = default!;
     [Dependency] protected readonly MobStateSystem _mobState = default!;
     [Dependency] protected readonly CMHandsSystem _rmcHands = default!;
+    [Dependency] protected readonly SharedXenoHiveSystem _hive = default!;
     [Dependency] protected readonly INetManager _net = default!;
     [Dependency] protected readonly SharedPopupSystem _popup = default!;
     [Dependency] protected readonly SharedDoAfterSystem _doAfter = default!;
@@ -93,12 +95,10 @@ public abstract partial class SharedXenoResinHoleSystem : EntitySystem
         if (resinHole.Comp.TrapPrototype != null)
             return;
 
-        if (!TryComp<XenoComponent>(args.User, out var xeno))
-            return;
-
         resinHole.Comp.TrapPrototype = XenoResinHoleComponent.ParasitePrototype;
         _popup.PopupEntity(Loc.GetString("rmc-xeno-construction-resin-hole-enter-parasite", ("parasite", args.User)), resinHole);
-        resinHole.Comp.Hive = xeno.Hive; // Yes, parasites claim any resin traps as their own
+        // Yes, parasites claim any resin traps as their own
+        _hive.SetSameHive(args.User, resinHole.Owner);
         QueueDel(args.User);
 
         _appearanceSystem.SetData(resinHole.Owner, XenoResinHoleVisuals.Contained, ContainedTrap.Parasite);

--- a/Content.Shared/_RMC14/Xenonids/Construction/ResinHole/XenoResinHoleComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/ResinHole/XenoResinHoleComponent.cs
@@ -25,12 +25,6 @@ public sealed partial class XenoResinHoleComponent : Component
 	[DataField]
 	public EntProtoId? TrapPrototype = null;
 
-	/// <summary>
-	/// The hive that will get announcements when the hole is broken or activated
-	/// </summary>
-	[DataField]
-	public EntityUid? Hive = null;
-
     [DataField]
     public TimeSpan StepStunDuration = TimeSpan.FromSeconds(2.5);
 

--- a/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
@@ -338,11 +338,7 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
         var coordinates = target.SnapToGrid(EntityManager, _map);
         var structure = Spawn(args.StructureId, coordinates);
 
-        if (TryComp(xeno, out XenoComponent? xenoComp))
-        {
-            var member = EnsureComp<HiveMemberComponent>(structure);
-            _hive.SetHive((structure, member), xenoComp.Hive);
-        }
+        _hive.SetSameHive(xeno.Owner, structure);
 
         _adminLogs.Add(LogType.RMCXenoOrderConstruction, $"Xeno {ToPrettyString(xeno):xeno} ordered construction of {ToPrettyString(structure):structure} at {coordinates}");
     }
@@ -390,29 +386,29 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
         if (_net.IsClient)
             return;
 
-        var hive = CompOrNull<HiveMemberComponent>(target)?.Hive;
         var spawn = Spawn(node.Spawn, transform.Coordinates);
-        var member = EnsureComp<HiveMemberComponent>(spawn);
-        _hive.SetHive((spawn, member), hive);
+        var hive = _hive.GetHive(target);
+        _hive.SetHive(spawn, target);
 
         _adminLogs.Add(LogType.RMCXenoOrderConstructionComplete, $"Xeno {ToPrettyString(xeno):xeno} completed construction of {ToPrettyString(target):xeno} which turned into {ToPrettyString(spawn):spawn} at {transform.Coordinates}");
 
         QueueDel(target);
 
-        if (TryComp(spawn, out HiveConstructionUniqueComponent? unique))
-        {
-            var uniques = EntityQueryEnumerator<HiveConstructionUniqueComponent>();
-            while (uniques.MoveNext(out var uid, out var otherUnique))
-            {
-                if (uid == spawn)
-                    continue;
+        if (!TryComp<HiveConstructionUniqueComponent>(spawn, out var unique))
+            return;
 
-                if (otherUnique.Id == unique.Id &&
-                    !TerminatingOrDeleted(uid) &&
-                    !EntityManager.IsQueuedForDeletion(uid))
-                {
-                    QueueDel(uid);
-                }
+        var uniques = EntityQueryEnumerator<HiveConstructionUniqueComponent, HiveMemberComponent>();
+        while (uniques.MoveNext(out var uid, out var otherUnique, out var member))
+        {
+            // don't troll other hives or itself
+            if (uid == spawn || member.Hive == hive?.Owner)
+                continue;
+
+            if (otherUnique.Id == unique.Id &&
+                !TerminatingOrDeleted(uid) &&
+                !EntityManager.IsQueuedForDeletion(uid))
+            {
+                QueueDel(uid);
             }
         }
     }
@@ -674,9 +670,7 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
                 return false;
             }
 
-            if (TryComp(xeno, out XenoComponent? xenoComp) &&
-                TryComp(xenoComp.Hive, out HiveComponent? hive) &&
-                hive.NewCoreAt > _timing.CurTime)
+            if (_hive.GetHive(xeno.Owner) is {} hive && hive.Comp.NewCoreAt > _timing.CurTime)
             {
                 if (_net.IsServer)
                     _popup.PopupEntity(Loc.GetString("rmc-xeno-cant-build-new-yet", ("choice", choiceProto.Name)), xeno, xeno, PopupType.MediumCaution);

--- a/Content.Shared/_RMC14/Xenonids/Egg/XenoEggComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Egg/XenoEggComponent.cs
@@ -39,9 +39,6 @@ public sealed partial class XenoEggComponent : Component
     [DataField, AutoNetworkedField]
     public EntProtoId Spawn = "CMXenoParasite";
 
-    [DataField, AutoNetworkedField]
-    public EntityUid? Hive;
-
     public SoundSpecifier PlantSound = new SoundPathSpecifier("/Audio/Effects/Fluids/splat.ogg");
 }
 

--- a/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
@@ -2,6 +2,7 @@ using Content.Shared._RMC14.Dropship;
 using Content.Shared._RMC14.Hands;
 using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.Xenonids.Construction;
+using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Parasite;
 using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared._RMC14.Xenonids.Weeds;
@@ -45,6 +46,7 @@ public sealed class XenoEggSystem : EntitySystem
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly SharedHandsSystem _hands = default!;
     [Dependency] private readonly SharedInteractionSystem _interaction = default!;
+    [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
     [Dependency] private readonly SharedXenoParasiteSystem _parasite = default!;
     [Dependency] private readonly SharedMapSystem _map = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
@@ -59,7 +61,6 @@ public sealed class XenoEggSystem : EntitySystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly TurfSystem _turf = default!;
-    [Dependency] private readonly XenoSystem _xeno = default!;
     [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
 
@@ -436,13 +437,12 @@ public sealed class XenoEggSystem : EntitySystem
         if (_net.IsClient)
             return true;
 
-        if (TryComp(egg, out TransformComponent? xform))
-        {
-            spawned = SpawnAtPosition(egg.Comp.Spawn, xform.Coordinates);
-            _xeno.SetHive(spawned.Value, egg.Comp.Hive);
-            if (spawned != null && TryComp<ParasiteAIComponent>(spawned, out var ai))
-                _parasite.GoIdle((spawned.Value, ai));
-        }
+        var coords = Transform(egg).Coordinates;
+        spawned = SpawnAtPosition(egg.Comp.Spawn, coords);
+        _hive.SetSameHive(egg.Owner, spawned.Value);
+        // TODO: create EggHatchedEvent to uncouple it from ai?
+        if (TryComp<ParasiteAIComponent>(spawned, out var ai))
+            _parasite.GoIdle((spawned.Value, ai));
 
         return true;
     }
@@ -630,12 +630,8 @@ public sealed class XenoEggSystem : EntitySystem
             Dirty(uid, attached);
 
             var egg = SpawnAtPosition(capable.Spawn, xform.Coordinates.Offset(capable.Offset));
-            if (TryComp(egg, out XenoEggComponent? eggComp) &&
-                TryComp(uid, out XenoComponent? xeno))
-            {
-                eggComp.Hive = xeno.Hive;
-                Dirty(egg, eggComp);
-            }
+            // egg belongs to whichever hive planted it, not the queen. you can steal eggs to claim them for your hive
+            _hive.SetSameHive(uid, egg);
 
             _transform.SetLocalRotation(egg, Angle.Zero);
         }

--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
@@ -52,7 +52,6 @@ public sealed class XenoEvolutionSystem : EntitySystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
-    [Dependency] private readonly XenoSystem _xeno = default!;
     [Dependency] private readonly SharedXenoAnnounceSystem _xenoAnnounce = default!;
     [Dependency] private readonly SharedXenoHiveSystem _xenoHive = default!;
     [Dependency] private readonly SharedHandsSystem _hands = default!;
@@ -152,12 +151,11 @@ public sealed class XenoEvolutionSystem : EntitySystem
         var time = _timing.CurTime;
         if (_prototypes.TryIndex(args.Choice, out var choice) &&
             choice.HasComponent<XenoEvolutionGranterComponent>(_compFactory) &&
-            TryComp(xeno, out XenoComponent? xenoComp) &&
-            TryComp(xenoComp.Hive, out HiveComponent? hive) &&
-            hive.LastQueenDeath is { } lastQueenDeath &&
-            time < lastQueenDeath + hive.NewQueenCooldown)
+            _xenoHive.GetHive(xeno.Owner) is { } hive &&
+            hive.Comp.LastQueenDeath is { } lastQueenDeath &&
+            time < lastQueenDeath + hive.Comp.NewQueenCooldown)
         {
-            var left = lastQueenDeath + hive.NewQueenCooldown - time;
+            var left = lastQueenDeath + hive.Comp.NewQueenCooldown - time;
             var msg = Loc.GetString("rmc-xeno-evolution-cant-evolve-recent-queen-death-minutes",
                 ("minutes", left.Minutes),
                 ("seconds", left.Seconds));
@@ -398,16 +396,15 @@ public sealed class XenoEvolutionSystem : EntitySystem
 
         if (newXenoComp != null &&
             !newXenoComp.BypassTierCount &&
-            TryComp(xeno, out XenoComponent? oldXenoComp) &&
-            oldXenoComp.Hive is { } oldHive &&
-            _xenoHive.TryGetTierLimit(oldHive, newXenoComp.Tier, out var limit))
+            _xenoHive.GetHive(xeno.Owner) is {} oldHive &&
+            _xenoHive.TryGetTierLimit((oldHive, oldHive.Comp), newXenoComp.Tier, out var limit))
         {
             var existing = 0;
             var total = 0;
-            var current = EntityQueryEnumerator<XenoComponent>();
-            while (current.MoveNext(out var existingComp))
+            var current = EntityQueryEnumerator<XenoComponent, HiveMemberComponent>();
+            while (current.MoveNext(out var existingComp, out var member))
             {
-                if (existingComp.Hive != oldHive || !existingComp.CountedInSlots)
+                if (member.Hive != oldHive.Owner || !existingComp.CountedInSlots)
                     continue;
 
                 total++;
@@ -418,7 +415,7 @@ public sealed class XenoEvolutionSystem : EntitySystem
                 existing++;
             }
 
-            if (_xenoHive.TryGetFreeSlots(oldHive, newXeno, out var freeSlots))
+            if (_xenoHive.TryGetFreeSlots((oldHive, oldHive.Comp), newXeno, out var freeSlots))
                 existing -= freeSlots;
 
             if (total != 0 && existing / (float) total >= limit)
@@ -536,7 +533,7 @@ public sealed class XenoEvolutionSystem : EntitySystem
     {
         var coordinates = _transform.GetMoverCoordinates(xeno);
         var newXeno = Spawn(proto, coordinates);
-        _xeno.SetSameHive(newXeno, xeno);
+        _xenoHive.SetSameHive(xeno, newXeno);
 
         if (_mind.TryGetMind(xeno, out var mindId, out _))
         {

--- a/Content.Shared/_RMC14/Xenonids/Headbutt/XenoHeadbuttSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Headbutt/XenoHeadbuttSystem.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Shared._RMC14.Xenonids.Animation;
+using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared.Coordinates;
 using Content.Shared.Damage;
@@ -20,6 +21,7 @@ public sealed class XenoHeadbuttSystem : EntitySystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedColorFlashEffectSystem _colorFlash = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
+    [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly ThrowingSystem _throwing = default!;
     [Dependency] private readonly PullingSystem _pulling = default!;
@@ -96,12 +98,8 @@ public sealed class XenoHeadbuttSystem : EntitySystem
         if (_net.IsServer)
             _audio.PlayPvs(xeno.Comp.Sound, xeno);
 
-        if (TryComp(xeno, out XenoComponent? xenoComp) &&
-            TryComp(targetId, out XenoComponent? targetXeno) &&
-            xenoComp.Hive == targetXeno.Hive)
-        {
+        if (_hive.FromSameHive(xeno.Owner, targetId))
             return;
-        }
 
         var damage = _damageable.TryChangeDamage(targetId, xeno.Comp.Damage);
         if (damage?.GetTotal() > FixedPoint2.Zero)

--- a/Content.Shared/_RMC14/Xenonids/Hive/HiveMemberComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hive/HiveMemberComponent.cs
@@ -2,7 +2,6 @@
 
 namespace Content.Shared._RMC14.Xenonids.Hive;
 
-// TODO RMC14 replace other hive properties with this component
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 [Access(typeof(SharedXenoHiveSystem))]
 public sealed partial class HiveMemberComponent : Component

--- a/Content.Shared/_RMC14/Xenonids/Hive/SharedXenoHiveSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hive/SharedXenoHiveSystem.cs
@@ -5,7 +5,6 @@ using Content.Shared.FixedPoint;
 using Content.Shared.Mobs;
 using Content.Shared.Popups;
 using Robust.Shared.Map;
-using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
@@ -16,16 +15,22 @@ namespace Content.Shared._RMC14.Xenonids.Hive;
 public abstract class SharedXenoHiveSystem : EntitySystem
 {
     [Dependency] private readonly IComponentFactory _compFactory = default!;
-    [Dependency] private readonly MetaDataSystem _metaData = default!;
-    [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly SharedNightVisionSystem _nightVision = default!;
     [Dependency] private readonly IPrototypeManager _prototypes = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedXenoAnnounceSystem _xenoAnnounce = default!;
 
+    private EntityQuery<HiveComponent> _query;
+    private EntityQuery<HiveMemberComponent> _memberQuery;
+
     public override void Initialize()
     {
+        base.Initialize();
+
+        _query = GetEntityQuery<HiveComponent>();
+        _memberQuery = GetEntityQuery<HiveMemberComponent>();
+
         SubscribeLocalEvent<HiveComponent, MapInitEvent>(OnMapInit);
 
         SubscribeLocalEvent<XenoEvolutionGranterComponent, MobStateChangedEvent>(OnGranterMobStateChanged);
@@ -36,11 +41,10 @@ public abstract class SharedXenoHiveSystem : EntitySystem
         if (args.NewMobState != MobState.Dead)
             return;
 
-        if (TryComp(ent, out XenoComponent? xeno) &&
-            TryComp(xeno.Hive, out HiveComponent? hive))
+        if (GetHive(ent.Owner) is {} hive)
         {
-            hive.LastQueenDeath = _timing.CurTime;
-            Dirty(xeno.Hive.Value, hive);
+            hive.Comp.LastQueenDeath = _timing.CurTime;
+            Dirty(hive);
         }
     }
 
@@ -72,72 +76,134 @@ public abstract class SharedXenoHiveSystem : EntitySystem
         ent.Comp.AnnouncementsLeft.Sort();
     }
 
-    public void CreateHive(string name)
+    /// <summary>
+    /// Tries to get the hive from a member, returning null if it has no hive or it is invalid.
+    /// </summary>
+    public Entity<HiveComponent>? GetHive(Entity<HiveMemberComponent?> member)
     {
-        if (_net.IsClient)
-            return;
+        if (!_memberQuery.Resolve(member, ref member.Comp))
+            return null;
 
-        var ent = Spawn(null, MapCoordinates.Nullspace);
-        EnsureComp<HiveComponent>(ent);
-        _metaData.SetEntityName(ent, name);
+        if (member.Comp.Hive is not {} uid || TerminatingOrDeleted(uid))
+            return null;
+
+        if (!_query.TryComp(uid, out var comp))
+            return null;
+
+        return (uid, comp);
     }
 
-    public void SetHive(Entity<HiveMemberComponent> member, EntityUid? hive)
+    /// <summary>
+    /// Returns true if the entity has a valid hive, i.e. it isn't a rogue xeno.
+    /// Only use this if you don't need to use the hive for anything after.
+    /// </summary>
+    public bool HasHive(Entity<HiveMemberComponent?> member)
     {
-        if (member.Comp.Hive == hive)
+        return GetHive(member) != null;
+    }
+
+    /// <summary>
+    /// Sets the hive for a member, if it's different.
+    /// If it does not have HiveMemberComponent this method adds it.
+    /// </summary>
+    public void SetHive(Entity<HiveMemberComponent?> member, EntityUid? hive)
+    {
+        var comp = member.Comp ?? EnsureComp<HiveMemberComponent>(member);
+
+        var old = comp.Hive;
+        if (old == hive)
             return;
 
-        member.Comp.Hive = hive;
-        Dirty(member);
+        Entity<HiveComponent>? hiveEnt = null;
+        if (_query.TryComp(hive, out var hiveComp))
+            hiveEnt = (hive.Value, hiveComp);
+        else if (hive != null)
+            return; // invalid hive was passed, prevent it breaking anything else
+
+        comp.Hive = hive;
+        Dirty(member, comp);
+
+        var ev = new HiveChangedEvent(hiveEnt, old);
+        RaiseLocalEvent(member, ref ev);
+    }
+
+    /// <summary>
+    /// Sets the hive of the destination entity to that of the source entity, if it has one.
+    /// If the source has no hive this is a no-op.
+    /// If dest does not have HiveMemberComponent this method adds it like with <see cref="SetHive"/>.
+    /// </summary>
+    public void SetSameHive(Entity<HiveMemberComponent?> src, Entity<HiveMemberComponent?> dest)
+    {
+        if (GetHive(src) is {} hive)
+            SetHive(dest, hive);
+    }
+
+    /// <summary>
+    /// Returns true if the entities have the same hive and it isn't null.
+    /// Rogue xenos don't have the same hive as they aren't in one!
+    /// </summary>
+    public bool FromSameHive(Entity<HiveMemberComponent?> a, Entity<HiveMemberComponent?> b)
+    {
+        if (GetHive(a) is not {} aHive)
+            return false;
+
+        return IsMember(b, aHive);
+    }
+
+    /// <summary>
+    /// Returns true if the entity is a member of a specific hive.
+    /// If the hive is null this always returns false, you cannot use this to check for rogue xenos.
+    /// </summary>
+    public bool IsMember(Entity<HiveMemberComponent?> member, EntityUid? hive)
+    {
+        if (hive == null || GetHive(member) is not {} memberHive)
+            return false;
+
+        return memberHive.Owner == hive;
     }
 
     public void SetSeeThroughContainers(Entity<HiveComponent?> hive, bool see)
     {
-        if (!Resolve(hive, ref hive.Comp, false))
+        if (!_query.Resolve(hive, ref hive.Comp, false))
             return;
 
         hive.Comp.SeeThroughContainers = see;
-        var xenos = EntityQueryEnumerator<XenoComponent>();
-        while (xenos.MoveNext(out var uid, out var xeno))
+        var xenos = EntityQueryEnumerator<XenoComponent, HiveMemberComponent, NightVisionComponent>();
+        while (xenos.MoveNext(out var uid, out _, out var member, out var nv))
         {
-            if (xeno.Hive != hive)
+            if (member.Hive != hive)
                 continue;
 
-            _nightVision.SetSeeThroughContainers(uid, see);
+            _nightVision.SetSeeThroughContainers((uid, nv), see);
         }
     }
 
-    public void AnnounceNeedsOvipositorToSameHive(Entity<XenoComponent?> xeno)
+    public void AnnounceNeedsOvipositorToSameHive(Entity<HiveMemberComponent?> xeno)
     {
-        if (!Resolve(xeno, ref xeno.Comp, false))
+        if (GetHive(xeno) is not {} hive || hive.Comp.GotOvipositorPopup)
             return;
 
-        if (!TryComp(xeno.Comp.Hive, out HiveComponent? hive) ||
-            hive.GotOvipositorPopup)
-        {
-            return;
-        }
+        hive.Comp.GotOvipositorPopup = true;
+        Dirty(hive);
 
-        hive.GotOvipositorPopup = true;
-        Dirty(xeno.Comp.Hive.Value, hive);
-
+        // TODO: loc
         var msg = "Enough time has passed, we require the Queen in oviposition for evolution.";
-        var xenos = EntityQueryEnumerator<ActorComponent, XenoComponent>();
-        while (xenos.MoveNext(out var uid, out _, out var otherXeno))
+        var xenos = EntityQueryEnumerator<XenoComponent, HiveMemberComponent, ActorComponent>();
+        while (xenos.MoveNext(out var uid, out _, out var member, out _))
         {
-            if (uid == xeno.Owner || xeno.Comp.Hive != otherXeno.Hive)
+            if (uid == xeno.Owner || member.Hive != hive)
                 continue;
 
             _popup.PopupEntity(msg, uid, uid, PopupType.LargeCaution);
         }
 
-        _xenoAnnounce.AnnounceToHive(default, xeno.Comp.Hive.Value, msg);
+        _xenoAnnounce.AnnounceToHive(default, hive, msg);
     }
 
     public bool TryGetTierLimit(Entity<HiveComponent?> hive, int tier, out FixedPoint2 value)
     {
         value = default;
-        if (!Resolve(hive, ref hive.Comp, false))
+        if (!_query.Resolve(hive, ref hive.Comp, false))
             return false;
 
         return hive.Comp.TierLimits.TryGetValue(tier, out value);
@@ -146,9 +212,15 @@ public abstract class SharedXenoHiveSystem : EntitySystem
     public bool TryGetFreeSlots(Entity<HiveComponent?> hive, EntProtoId caste, out int value)
     {
         value = default;
-        if (!Resolve(hive, ref hive.Comp, false))
+        if (!_query.Resolve(hive, ref hive.Comp, false))
             return false;
 
         return hive.Comp.FreeSlots.TryGetValue(caste, out value);
     }
 }
+
+/// <summary>
+/// Raised on an entity after its hive is changed.
+/// </summary>
+[ByRefEvent]
+public record struct HiveChangedEvent(Entity<HiveComponent>? Hive, EntityUid? OldHive);

--- a/Content.Shared/_RMC14/Xenonids/Hive/SharedXenoHiveSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hive/SharedXenoHiveSystem.cs
@@ -81,7 +81,7 @@ public abstract class SharedXenoHiveSystem : EntitySystem
     /// </summary>
     public Entity<HiveComponent>? GetHive(Entity<HiveMemberComponent?> member)
     {
-        if (!_memberQuery.Resolve(member, ref member.Comp))
+        if (!_memberQuery.Resolve(member, ref member.Comp, false))
             return null;
 
         if (member.Comp.Hive is not {} uid || TerminatingOrDeleted(uid))

--- a/Content.Shared/_RMC14/Xenonids/Leap/XenoLeapSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Leap/XenoLeapSystem.cs
@@ -1,4 +1,5 @@
 ﻿using System.Numerics;
+using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Invisibility;
 using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared.ActionBlocker;
@@ -32,6 +33,7 @@ public sealed class XenoLeapSystem : EntitySystem
     [Dependency] private readonly SharedBroadphaseSystem _broadphase = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
+    [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
@@ -40,7 +42,6 @@ public sealed class XenoLeapSystem : EntitySystem
     [Dependency] private readonly SharedStunSystem _stun = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
-    [Dependency] private readonly XenoSystem _xeno = default!;
     [Dependency] private readonly XenoPlasmaSystem _xenoPlasma = default!;
 
     private EntityQuery<PhysicsComponent> _physicsQuery;
@@ -150,7 +151,7 @@ public sealed class XenoLeapSystem : EntitySystem
         if (_standing.IsDown(other))
             return;
 
-        if (_xeno.FromSameHive(xeno.Owner, other))
+        if (_hive.FromSameHive(xeno.Owner, other))
         {
             StopLeap(xeno);
             return;

--- a/Content.Shared/_RMC14/Xenonids/Lunge/XenoLungeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Lunge/XenoLungeSystem.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Shared._RMC14.Marines;
+﻿using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared.Coordinates;
 using Content.Shared.Movement.Pulling.Events;
 using Content.Shared.Movement.Pulling.Systems;
@@ -21,6 +22,7 @@ public sealed class XenoLungeSystem : EntitySystem
     [Dependency] private readonly PullingSystem _pulling = default!;
     [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
     [Dependency] private readonly SharedStunSystem _stun = default!;
+    [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
     [Dependency] private readonly XenoSystem _xeno = default!;
 
     private EntityQuery<PhysicsComponent> _physicsQuery;
@@ -79,12 +81,8 @@ public sealed class XenoLungeSystem : EntitySystem
         if (_timing.IsFirstTimePredicted && xeno.Comp.Charge != null)
             xeno.Comp.Charge = null;
 
-        if (TryComp(xeno, out XenoComponent? xenoComp) &&
-            TryComp(targetId, out XenoComponent? targetXeno) &&
-            xenoComp.Hive == targetXeno.Hive)
-        {
+        if (_hive.FromSameHive(xeno.Owner, targetId))
             return;
-        }
 
         _stun.TryParalyze(targetId, xeno.Comp.StunTime, true);
 

--- a/Content.Shared/_RMC14/Xenonids/Projectile/Spit/XenoSpitSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/Spit/XenoSpitSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared._RMC14.Atmos;
 using Content.Shared._RMC14.Explosion;
 using Content.Shared._RMC14.OnCollide;
 using Content.Shared._RMC14.Shields;
+using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Projectile.Spit.Ball;
 using Content.Shared._RMC14.Xenonids.Projectile.Spit.Charge;
 using Content.Shared._RMC14.Xenonids.Projectile.Spit.Scattered;
@@ -36,6 +37,7 @@ public sealed class XenoSpitSystem : EntitySystem
     [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly EntityWhitelistSystem _entityWhitelist = default!;
+    [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
     [Dependency] private readonly InventorySystem _inventory = default!;
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
@@ -189,7 +191,7 @@ public sealed class XenoSpitSystem : EntitySystem
             return;
 
         var target = args.Target;
-        if (_xenoProjectile.SameHive(spit.Owner, target))
+        if (_hive.FromSameHive(spit.Owner, target))
         {
             QueueDel(spit);
             return;

--- a/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileComponent.cs
@@ -8,7 +8,4 @@ public sealed partial class XenoProjectileComponent : Component
 {
     [DataField, AutoNetworkedField]
     public bool DeleteOnFriendlyXeno;
-
-    [DataField, AutoNetworkedField]
-    public EntityUid? Hive;
 }

--- a/Content.Shared/_RMC14/Xenonids/Retrieve/XenoRetrieveSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Retrieve/XenoRetrieveSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared._RMC14.Actions;
 using Content.Shared._RMC14.Emote;
 using Content.Shared._RMC14.Line;
 using Content.Shared._RMC14.Stun;
+using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Rest;
 using Content.Shared.Coordinates;
 using Content.Shared.DoAfter;
@@ -23,6 +24,7 @@ public sealed class XenoRetrieveSystem : EntitySystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly SharedInteractionSystem _interaction = default!;
+    [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
     [Dependency] private readonly LineSystem _line = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
@@ -33,7 +35,6 @@ public sealed class XenoRetrieveSystem : EntitySystem
     [Dependency] private readonly StandingStateSystem _standing = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
-    [Dependency] private readonly XenoSystem _xeno = default!;
 
     public override void Initialize()
     {
@@ -45,7 +46,7 @@ public sealed class XenoRetrieveSystem : EntitySystem
     private void OnXenoRetrieveAction(Entity<XenoRetrieveComponent> xeno, ref XenoRetrieveActionEvent args)
     {
         var target = args.Target;
-        if (!_xeno.FromSameHive(xeno.Owner, target))
+        if (!_hive.FromSameHive(xeno.Owner, target))
         {
             var msg = Loc.GetString("rmc-xeno-not-same-hive");
             _popup.PopupClient(msg, xeno, xeno, PopupType.SmallCaution);

--- a/Content.Shared/_RMC14/Xenonids/Screech/SharedXenoScreechSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Screech/SharedXenoScreechSystem.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Shared._RMC14.Marines;
+using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared.Coordinates;
 using Content.Shared.Examine;
@@ -12,6 +13,7 @@ namespace Content.Shared._RMC14.Xenonids.Screech;
 public sealed class XenoScreechSystem : EntitySystem
 {
     [Dependency] private readonly MobStateSystem _mobState = default!;
+    [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
     [Dependency] private readonly XenoPlasmaSystem _xenoPlasma = default!;
     [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
     [Dependency] private readonly ExamineSystemShared _examineSystem = default!;
@@ -61,12 +63,8 @@ public sealed class XenoScreechSystem : EntitySystem
             if (!_examineSystem.InRangeUnOccluded(xeno.Owner, receiver.Owner))
                 continue;
 
-            if (TryComp(xeno, out XenoComponent? xenoComp) &&
-                TryComp(receiver, out XenoComponent? targetXeno) &&
-                xenoComp.Hive == targetXeno.Hive)
-            {
+            if (_hive.FromSameHive(xeno.Owner, receiver.Owner))
                 continue;
-            }
 
             _stun.TryStun(receiver, xeno.Comp.StunTime, false);
         }
@@ -82,12 +80,8 @@ public sealed class XenoScreechSystem : EntitySystem
             if (!_examineSystem.InRangeUnOccluded(xeno.Owner, receiver.Owner))
                 continue;
 
-            if (TryComp(xeno, out XenoComponent? xenoComp) &&
-                TryComp(receiver, out XenoComponent? targetXeno) &&
-                xenoComp.Hive == targetXeno.Hive)
-            {
+            if (_hive.FromSameHive(xeno.Owner, receiver.Owner))
                 continue;
-            }
 
             _stun.TryParalyze(receiver, xeno.Comp.ParalyzeTime, true);
         }

--- a/Content.Shared/_RMC14/Xenonids/Stab/SharedXenoTailStabSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Stab/SharedXenoTailStabSystem.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using System.Numerics;
 using Content.Shared._RMC14.CCVar;
+using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Actions;
 using Content.Shared.Chemistry.EntitySystems;
@@ -32,6 +33,7 @@ public abstract class SharedXenoTailStabSystem : EntitySystem
     [Dependency] private readonly SharedColorFlashEffectSystem _colorFlash = default!;
     [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
+    [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
     [Dependency] private readonly SharedInteractionSystem _interaction = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedSolutionContainerSystem _solutionContainer = default!;
@@ -92,7 +94,7 @@ public abstract class SharedXenoTailStabSystem : EntitySystem
         // ray on the right side of the box
         var rightRay = new CollisionRay(boxRotated.BottomRight, (boxRotated.TopRight - boxRotated.BottomRight).Normalized(), AttackMask);
 
-        var hive = CompOrNull<XenoComponent>(stab)?.Hive;
+        var hive = _hive.GetHive(stab.Owner);
 
         bool Ignored(EntityUid uid)
         {
@@ -102,13 +104,7 @@ public abstract class SharedXenoTailStabSystem : EntitySystem
             if (!HasComp<MobStateComponent>(uid))
                 return true;
 
-            if (TryComp(uid, out XenoComponent? otherXeno) &&
-                hive == otherXeno.Hive)
-            {
-                return true;
-            }
-
-            return false;
+            return _hive.IsMember(uid, hive);
         }
 
         // dont open allocations ahead

--- a/Content.Shared/_RMC14/Xenonids/Watch/SharedWatchXenoSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Watch/SharedWatchXenoSystem.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared.Movement.Events;
+﻿﻿using Content.Shared._RMC14.Xenonids.Hive;
+using Content.Shared.Movement.Events;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
 
@@ -49,7 +50,7 @@ public abstract class SharedWatchXenoSystem : EntitySystem
     {
     }
 
-    public virtual void Watch(Entity<XenoComponent?, ActorComponent?, EyeComponent?> watcher, Entity<XenoComponent?> toWatch)
+    public virtual void Watch(Entity<HiveMemberComponent?, ActorComponent?, EyeComponent?> watcher, Entity<HiveMemberComponent?> toWatch)
     {
     }
 

--- a/Content.Shared/_RMC14/Xenonids/Word/XenoWordQueenSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Word/XenoWordQueenSystem.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text.RegularExpressions;
 using Content.Shared._RMC14.Chat;
 using Content.Shared._RMC14.Xenonids.Announce;
+using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared.Actions;
 using Content.Shared.CCVar;
@@ -21,6 +22,7 @@ public sealed class XenoWordQueenSystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
     [Dependency] private readonly SharedXenoAnnounceSystem _xenoAnnounce = default!;
+    [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
     [Dependency] private readonly XenoPlasmaSystem _xenoPlasma = default!;
 
     private readonly Regex _newLineRegex = new("\n{3,}", RegexOptions.Compiled);
@@ -58,7 +60,7 @@ public sealed class XenoWordQueenSystem : EntitySystem
         if (!_xenoPlasma.HasPlasmaPopup(queen.Owner, queen.Comp.PlasmaCost))
             return;
 
-        if (!TryComp(queen, out XenoComponent? queenXeno))
+        if (_hive.GetHive(queen.Owner) is not {} hive)
         {
             _popup.PopupClient(Loc.GetString("cm-xeno-words-of-the-queen-nobody-hear-you"), queen, queen, PopupType.LargeCaution);
             return;
@@ -72,7 +74,7 @@ public sealed class XenoWordQueenSystem : EntitySystem
 
         var xenos = Filter
             .Empty()
-            .AddWhereAttachedEntity(ent => TryComp(ent, out XenoComponent? otherXeno) && otherXeno.Hive == queenXeno.Hive);
+            .AddWhereAttachedEntity(ent => _hive.IsMember(ent, hive));
 
         if (xenos.Count <= 1)
         {

--- a/Content.Shared/_RMC14/Xenonids/XenoComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/XenoComponent.cs
@@ -48,9 +48,6 @@ public sealed partial class XenoComponent : Component
     public TimeSpan NextRegenTime;
 
     [DataField, AutoNetworkedField]
-    public EntityUid? Hive;
-
-    [DataField, AutoNetworkedField]
     public HashSet<ProtoId<AccessLevelPrototype>> AccessLevels = new() { "CMAccessXeno" };
 
     [DataField, AutoNetworkedField]

--- a/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
@@ -42,6 +42,7 @@ public sealed class XenoSystem : EntitySystem
     [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly SharedEntityStorageSystem _entityStorage = default!;
+    [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly MobThresholdSystem _mobThresholds = default!;
     [Dependency] private readonly MovementSpeedModifierSystem _movementSpeed = default!;
@@ -96,6 +97,7 @@ public sealed class XenoSystem : EntitySystem
         SubscribeLocalEvent<XenoComponent, DamageModifyEvent>(OnXenoDamageModify);
         SubscribeLocalEvent<XenoComponent, RefreshMovementSpeedModifiersEvent>(OnXenoRefreshSpeed);
         SubscribeLocalEvent<XenoComponent, MeleeHitEvent>(OnXenoMeleeHit);
+        SubscribeLocalEvent<XenoComponent, HiveChangedEvent>(OnHiveChanged);
 
         Subs.CVar(_config, RMCCVars.CMXenoDamageDealtMultiplier, v => _xenoDamageDealtMultiplier = v, true);
         Subs.CVar(_config, RMCCVars.CMXenoDamageReceivedMultiplier, v => _xenoDamageReceivedMultiplier = v, true);
@@ -222,6 +224,12 @@ public sealed class XenoSystem : EntitySystem
         }
     }
 
+    private void OnHiveChanged(Entity<XenoComponent> ent, ref HiveChangedEvent args)
+    {
+        // leaving the hive makes you lose container vision post hijack :)
+        _nightVision.SetSeeThroughContainers(ent.Owner, args.Hive?.Comp.SeeThroughContainers ?? false);
+    }
+
     private void UpdateXenoSpeedMultiplier(float speed)
     {
         _xenoSpeedMultiplier = speed;
@@ -236,36 +244,6 @@ public sealed class XenoSystem : EntitySystem
     public void MakeXeno(Entity<XenoComponent?> xeno)
     {
         EnsureComp<XenoComponent>(xeno);
-    }
-
-    public void SetHive(Entity<XenoComponent?> xeno, Entity<HiveComponent?>? hive)
-    {
-        if (!Resolve(xeno, ref xeno.Comp))
-            return;
-
-        if (hive == null)
-        {
-            xeno.Comp.Hive = null;
-            Dirty(xeno, xeno.Comp);
-            return;
-        }
-
-        var hiveEnt = hive.Value;
-        if (!Resolve(hiveEnt, ref hiveEnt.Comp))
-            return;
-
-        xeno.Comp.Hive = hive;
-        Dirty(xeno, xeno.Comp);
-
-        _nightVision.SetSeeThroughContainers(xeno.Owner, hiveEnt.Comp.SeeThroughContainers);
-    }
-
-    public void SetSameHive(Entity<XenoComponent?> to, Entity<XenoComponent?> from)
-    {
-        if (!Resolve(from, ref from.Comp))
-            return;
-
-        SetHive(to, from.Comp.Hive);
     }
 
     private FixedPoint2 GetWeedsHealAmount(Entity<XenoComponent> xeno)
@@ -315,37 +293,14 @@ public sealed class XenoSystem : EntitySystem
         _damageable.TryChangeDamage(xeno, heal, true);
     }
 
-    public bool FromSameHive(Entity<XenoComponent?> xenoOne, Entity<XenoComponent?> xenoTwo)
-    {
-        if (!_xenoQuery.Resolve(xenoOne, ref xenoOne.Comp, false) ||
-            !_xenoQuery.Resolve(xenoTwo, ref xenoTwo.Comp, false))
-        {
-            return false;
-        }
-
-        return xenoOne.Comp.Hive == xenoTwo.Comp.Hive;
-    }
-
-    public bool FromHive(Entity<XenoComponent?> xeno, Entity<HiveComponent?> hive)
-    {
-        if (!_xenoQuery.Resolve(xeno, ref xeno.Comp, false))
-            return false;
-
-        return xeno.Comp.Hive == hive;
-    }
-
     public bool CanAbilityAttackTarget(EntityUid xeno, EntityUid target, bool hitNonMarines = false)
     {
         if (xeno == target)
             return false;
 
-        // TODO RMC14 use hive member instead
-        if (TryComp<XenoComponent>(xeno, out var comp1) &&
-            TryComp<XenoComponent>(target, out var comp2) &&
-            comp1.Hive == comp2.Hive)
-        {
+        // hiveless xenos can attack eachother
+        if (_hive.FromSameHive(xeno, target))
             return false;
-        }
 
         if (_mobState.IsDead(target))
             return false;


### PR DESCRIPTION
## About the PR
- removed hive member from Xeno / XenoEgg / XenoProjectile
  the thing for when a marine is infected should have its own field still i think, it would be weird a marine getting infected suddenly being a full fledged member of the hive (only xeno agent patent pending antag should!)
- added proper hive member api to SharedXenoHiveSystem
- moved hive creation to server since nothing called it from shared anyway
- fixed a bunch of subtle bugs that wouldve appeared with multiple hives

## Why / Balance
5 different things with Hive member and C-F tier apis for using them
:bug: :hammer:

## Technical details
the hive member api: `GetHive / SetHive / SetSameHive / FromSameHive / IsMember`
morbillion things changed to use it
very nice to use no adding .Value everywhere it just works (only have to sometimes use (hive, hive.Comp) because Entity trollage but it could be fixed in the future)

added `HiveChangedEvent` to not have night vision tightly coupled to xenos hive changing

bugs squished:
- if you don't have a hive tracker would display like there's no queen, now you don't get a tracker since you don't have a hive, naughty rogue xeno
- previously 2 rogue xenos couldnt use abilities on eachother because it did dumb hive == hive check, now it gets IsSameHive for friendly fire prevention. rogue xenos can now use lunge etc on eachother probably
- probably more i forgor
- using rmc actions to create a new hive didnt set the xeno's hive to it, now it does so you don't have to do that manually
- fix unique construction ignoring the other construct's hive i assume that in xeno v xeno each hive can still have their own core and its not just ping racing
- some tiny micro optimisations, mostly from using entityqueries
- rogue xenos can shoot/lunge/headbutt eachother
- rogue xenos trying to use the watch action get nothing instead of an empty list (this is actually parity too i checked the dm)

## Media
:trollface:

## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
removed `Hive` field and system's api from `XenoComponent` and `XenoEggComponent`, they use `HiveMemberComponent` and `SharedXenoHiveSystem` now
`SetSameHive` in hive system takes src, dest instead of dest, src

**Changelog**
no cl no fun
