### PR TITLE
Adds 30-stack of cable coil, adds them to M276 utility belt and M276 combat utility belt

### DIFF
--- a/Resources/Prototypes/_RMC14/Catalog/Fills/Clothing/belt.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Fills/Clothing/belt.yml
@@ -10,7 +10,7 @@
     - id: CMWelder
     - id: CMCrowbar
     - id: CMWirecutter
-#    - id: CMCableCoil30 TODO RMC14
+    - id: RMCCableCoil30
     - id: CMMultitool
 
 - type: entity
@@ -26,6 +26,7 @@
     - id: CMWirecutter
     - id: CMWelder
     - id: CMMultitool
+    - id: RMCCableCoil30
 
 - type: entity
   parent: CMBeltKnife

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Power/coil.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Power/coil.yml
@@ -43,6 +43,14 @@
 
 - type: entity
   parent: RMCCableCoil
+  id: RMCCableCoil30
+  suffix: 30
+  components:
+  - type: Stack
+    count: 30
+
+- type: entity
+  parent: RMCCableCoil
   id: RMCCableCoil20
   suffix: 20
   components:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Adds 30-stack cable coils and adds them to the toolbelt and combat toolbelt

## Why / Balance
CM Parity
Feature request #4212

## Technical details
Adds RMCCAbleCoil30 to coil.yaml, and references it in filler for M276 belt

## Media
![image](https://github.com/user-attachments/assets/dc957a86-1937-4da1-903b-94a0efc5f983)

## Requirements
- [./ ] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [./ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
:cl:
- add: The M276 Utility Toolbelt and M276 Combat Utility Toolbelt now contain cable coil (30 pieces)
