### PR TITLE
Fix IFF text always displaying on examine regardless of it actually has IFF

### DIFF
--- a/Content.Shared/_RMC14/Attachable/Systems/AttachableIFFSystem.cs
+++ b/Content.Shared/_RMC14/Attachable/Systems/AttachableIFFSystem.cs
@@ -1,6 +1,7 @@
 ﻿using Content.Shared._RMC14.Attachable.Components;
 using Content.Shared._RMC14.Attachable.Events;
 using Content.Shared._RMC14.Weapons.Ranged.IFF;
+using Content.Shared.Examine;
 using Content.Shared.Weapons.Ranged.Events;
 using Robust.Shared.Timing;
 
@@ -18,6 +19,7 @@ public sealed class AttachableIFFSystem : EntitySystem
         SubscribeLocalEvent<AttachableIFFComponent, AttachableRelayedEvent<AttachableGrantIFFEvent>>(OnAttachableIFFGrant);
 
         SubscribeLocalEvent<GunAttachableIFFComponent, AmmoShotEvent>(OnGunAttachableIFFAmmoShot);
+        SubscribeLocalEvent<GunAttachableIFFComponent, ExaminedEvent>(OnGunAttachableIFFExamined);
     }
 
     private void OnAttachableIFFAltered(Entity<AttachableIFFComponent> ent, ref AttachableAlteredEvent args)
@@ -41,6 +43,14 @@ public sealed class AttachableIFFSystem : EntitySystem
     private void OnGunAttachableIFFAmmoShot(Entity<GunAttachableIFFComponent> ent, ref AmmoShotEvent args)
     {
         _gunIFF.GiveAmmoIFF(ent, ref args, false, true);
+    }
+
+    private void OnGunAttachableIFFExamined(Entity<GunAttachableIFFComponent> ent, ref ExaminedEvent args)
+    {
+        using (args.PushGroup(nameof(GunAttachableIFFComponent)))
+        {
+            args.PushMarkup(Loc.GetString("rmc-examine-text-iff"));
+        }
     }
 
     private void UpdateGunIFF(EntityUid gun)

--- a/Content.Shared/_RMC14/Weapons/Ranged/IFF/GunIFFSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/IFF/GunIFFSystem.cs
@@ -73,9 +73,12 @@ public sealed class GunIFFSystem : EntitySystem
 
     private void OnGunIFFExamined(Entity<GunIFFComponent> ent, ref ExaminedEvent args)
     {
+        if (!ent.Comp.Enabled)
+            return;
+
         using (args.PushGroup(nameof(GunIFFComponent)))
         {
-            args.PushMarkup("[color=cyan]This gun will ignore and shoot past friendlies![/color]");
+            args.PushMarkup(Loc.GetString("rmc-examine-text-iff"));
         }
     }
 

--- a/Resources/Locale/en-US/_RMC14/weapons/guns.ftl
+++ b/Resources/Locale/en-US/_RMC14/weapons/guns.ftl
@@ -18,3 +18,4 @@ rmc-revolver-spin = You spin the cylinder.
 rmc-examine-text-scatter-max = Current maximum scatter is [color={$colour}]{TOSTRING($scatter, "F1")}[/color] degrees.
 rmc-examine-text-scatter-min = Current minimum scatter is [color={$colour}]{TOSTRING($scatter, "F1")}[/color] degrees.
 rmc-examine-text-shots-to-max-scatter = It takes [color={$colour}]{$shots}[/color] shots to reach maximum scatter.
+rmc-examine-text-iff = [color=cyan]This gun will ignore and shoot past friendlies![/color]


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
The examine event now checks if IFF is actually enabled before saying it is, also added the examine event handling to GunAttachableIFF for smartscopes since otherwise it'd not tell the player that the gun is now IFF. Localized IFF examine text as well.

## Why / Balance
The examine event would lie to you and just say the gun ignores friendlies regardless of if it does or not, as all guns have GunIFFComponent, but not all of them are actually enabled. Also, localization good (i think). 

Prevents new players on update day from unwittingly mass teamkilling because their gun lied to them.

## Media
Video Demonstration
https://github.com/user-attachments/assets/3db929d9-ba43-49f1-8f34-b54834556e48

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
- fix: Guns no longer lie to you in their examine text about having IFF