### PR TITLE
Make lesser drones from the hivecore raffles, fix role description

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lesser_drone.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lesser_drone.yml
@@ -10,6 +10,9 @@
   components:
   - type: GhostRole
     name: cm-job-name-xeno-lesser-drone
+    description: roles-lesser-drone-description
+    raffle:
+      settings: short
   - type: Sprite
     sprite: _RMC14/Mobs/Xenonids/LesserDrone/lesser_drone.rsi
   - type: MobState

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_hive.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_hive.yml
@@ -38,6 +38,8 @@
   - type: GhostRole
     name: roles-lesser-drone-name
     description: roles-lesser-drone-description
+    raffle:
+      settings: short
   - type: GhostRoleMobSpawner
     availableTakeovers: 2
     deleteOnSpawn: false


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
For fairness on high player counts, adds the 10 second raffle timer to hive core lesser drones.

:cl: whisper
- fix: Fixed lesser drones from the hive core not being raffled.

