### PR TITLE
Remove GL chatsan

### DIFF
--- a/Resources/Locale/en-US/_RMC14/cm-chatsan.ftl
+++ b/Resources/Locale/en-US/_RMC14/cm-chatsan.ftl
@@ -247,6 +247,12 @@ cm-chatsan-replacement-grenade = boomstick
 cm-chatsan-word-grenades = grenades
 cm-chatsan-replacement-grenades = boomsticks
 
+cm-chatsan-word-gl = gl
+cm-chatsan-replacement-gl = boomstick launcher
+
+cm-chatsan-word-gls = gls
+cm-chatsan-replacement-gls = boomstick launchers
+
 cm-chatsan-word-bullet = bullet
 cm-chatsan-replacement-bullet = spit
 

--- a/Resources/Locale/en-US/speech/speech-chatsan.ftl
+++ b/Resources/Locale/en-US/speech/speech-chatsan.ftl
@@ -87,8 +87,9 @@ chatsan-replacement-31 = shut the fuck up
 chatsan-word-32 = gtg
 chatsan-replacement-32 = got to go
 
-chatsan-word-33 = gl
-chatsan-replacement-33 = good luck
+#RMC14: Disabled for grenade launcher
+#chatsan-word-33 = gl
+#chatsan-replacement-33 = good luck
 
 chatsan-word-34 = hbu
 chatsan-replacement-34 = how about you

--- a/Resources/Prototypes/_RMC14/Accents/cm_word_replacements.yml
+++ b/Resources/Prototypes/_RMC14/Accents/cm_word_replacements.yml
@@ -94,6 +94,8 @@
     cm-chatsan-word-ships: cm-chatsan-replacement-ships
     cm-chatsan-word-grenade: cm-chatsan-replacement-grenade
     cm-chatsan-word-grenades: cm-chatsan-replacement-grenades
+    cm-chatsan-word-gl: cm-chatsan-replacement-gl
+    cm-chatsan-word-gls: cm-chatsan-replacement-gls
     cm-chatsan-word-bullet: cm-chatsan-replacement-bullet
     cm-chatsan-word-bullets: cm-chatsan-replacement-bullets
     cm-chatsan-word-ammo: cm-chatsan-replacement-ammo


### PR DESCRIPTION
## About the PR
Removes the "GL" -> "Good luck" global chat sanitization.

Adds a "GL" -> "Boomstick Launcher" to xeno chat sanitization.

## Why / Balance
GL is a fairly common way to refer to grenade launchers in military settings, to the extent that I feel like it's alright to allow it. Saying GL to someone in reference to good luck is a lot easier to hand wave than saying, "We need a fucking good luck up to the front!"

Figured replacing GL for xenonids is a safe bet as well, considering people may get used to it being in reference to grenade launchers.

## Media
![image](https://github.com/user-attachments/assets/2b80d546-2f46-4555-a975-a0eccd6bc8a2)

## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame.

**Changelog**
(Don't think it needs one.)