### PR TITLE
hide wehny/rouny and burrower/ravager from caste unlock announcements

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Hive/SharedXenoHiveSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hive/SharedXenoHiveSystem.cs
@@ -79,16 +79,16 @@ public abstract class SharedXenoHiveSystem : EntitySystem
 
         foreach (var prototype in _prototypes.EnumeratePrototypes<EntityPrototype>())
         {
-            if (prototype.TryGetComponent(out XenoComponent? xeno, _compFactory))
-            {
-                if (xeno.UnlockAt == default)
-                    continue;
+            if (!prototype.TryGetComponent(out XenoComponent? xeno, _compFactory))
+                continue;
 
-                ent.Comp.Unlocks.GetOrNew(xeno.UnlockAt).Add(prototype.ID);
+            if (xeno.UnlockAt == default || xeno.Hidden)
+                continue;
 
-                if (!ent.Comp.AnnouncementsLeft.Contains(xeno.UnlockAt))
-                    ent.Comp.AnnouncementsLeft.Add(xeno.UnlockAt);
-            }
+            ent.Comp.Unlocks.GetOrNew(xeno.UnlockAt).Add(prototype.ID);
+
+            if (!ent.Comp.AnnouncementsLeft.Contains(xeno.UnlockAt))
+                ent.Comp.AnnouncementsLeft.Add(xeno.UnlockAt);
         }
 
         foreach (var unlock in ent.Comp.Unlocks)

--- a/Content.Shared/_RMC14/Xenonids/XenoComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/XenoComponent.cs
@@ -77,5 +77,12 @@ public sealed partial class XenoComponent : Component
     [DataField, AutoNetworkedField]
     public ProtoId<EmoteSoundsPrototype>? EmoteSounds = "Xeno";
 
+    /// <summary>
+    /// Hides this xeno from the caste unlock announcements.
+    /// Use for admeme or unimplemented castes that can't be evolved to.
+    /// </summary>
+    [DataField]
+    public bool Hidden;
+
     public EmoteSoundsPrototype? Sounds;
 }

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/burrower.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/burrower.yml
@@ -40,6 +40,7 @@
     tier: 2
     hudOffset: 0,0.56
     unlockAt: 420 # 7 minutes
+    hidden: true # TODO RMC: remove when burrower is implemented
   - type: XenoDevolve
     devolvesTo:
     - CMXenoDrone

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/fun.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/fun.yml
@@ -10,6 +10,8 @@
   - type: XenoEvolution
     max: 200
     evolvesTo: [ ]
+  - type: Xeno
+    hidden: true
 
 - type: entity
   parent: CMXenoRunner
@@ -22,3 +24,5 @@
   - type: XenoEvolution
     max: 200
     evolvesTo: [ ]
+  - type: Xeno
+    hidden: true

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/ravager.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/ravager.yml
@@ -36,6 +36,7 @@
     tier: 3
     hudOffset: 0,0.1
     unlockAt: 900 # 15 minutes
+    hidden: true # TODO RMC: remove once ravager is implemented
   - type: XenoDevolve
     devolvesTo:
     - CMXenoLurker


### PR DESCRIPTION
## About the PR
title

## Why / Balance
the former are admeme only the latter are unimplemented

## Technical details
a bool :trollface:

## Media
no more rouny or wehny...
![01:31:08](https://github.com/user-attachments/assets/28e3e51c-64cd-4c9a-aa20-7eaa6d73f281)

## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- fix: Wehny is not real. Rouny is not real. Ravager is not real. Burrower is not real.