### PR TITLE
add xeno announcement for when drone tax ends

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
@@ -57,6 +57,8 @@ public sealed class XenoEvolutionSystem : EntitySystem
     private TimeSpan _evolutionPointsRequireOvipositorAfter;
     private TimeSpan _evolutionAccumulatePointsBefore;
 
+    private bool _didAccumulationAnnouncement;
+
     private readonly HashSet<EntityUid> _climbable = new();
     private readonly HashSet<EntityUid> _doors = new();
     private readonly HashSet<EntityUid> _intersecting = new();
@@ -663,6 +665,16 @@ public sealed class XenoEvolutionSystem : EntitySystem
             else if (comp.Points > comp.Max)
             {
                 SetPoints((uid, comp), FixedPoint2.Max(comp.Points - gain, comp.Max));
+            }
+        }
+
+        if (!_didAccumulationAnnouncement && roundDuration >= _evolutionAccumulatePointsBefore)
+        {
+            _didAccumulationAnnouncement = true;
+            var query = EntityQueryEnumerator<HiveComponent>();
+            while (query.MoveNext(out var uid, out _))
+            {
+                _xenoAnnounce.AnnounceToHive(default, uid, Loc.GetString("rmc-xeno-evolution-accumulation-ended"));
             }
         }
     }

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
@@ -33,6 +33,7 @@ rmc-xeno-evolution-cant-devolve-damaged = We are too weak to deevolve, we must r
 rmc-xeno-evolution-cant-evolve-recent-queen-death-minutes = We must wait about {$minutes} minutes and {$seconds} seconds for the hive to recover from the previous Queen's death.
 rmc-xeno-evolution-cant-evolve-recent-queen-death-seconds = We must wait about {$seconds} seconds for the hive to recover from the previous Queen's death.
 rmc-xeno-evolution-failed-bad-location = We can't evolve here.
+rmc-xeno-evolution-accumulation-ended = It has been long enough, we will no longer accumulate evolution points.
 
 # Fortify
 cm-xeno-fortify-cant-headbutt = You can't headbutt while fortifying!


### PR DESCRIPTION
## About the PR
`It has been long enough, we will no longer accumulate evolution points.`

## Why / Balance
- saves someone having to either set a timer or wait patiently until evo stars going backwards to tell everyone tax is over
- if you arent aware of it, it might seem like a bug that you are *losing* evo. now it will be much more obvious

this isnt a cm13 thing so **no parity here**, just good tax fun

## Technical details
naughty system bool to track announcement being made

## Media
![01:45:51](https://github.com/user-attachments/assets/ffd23289-fc93-4f43-ba08-f62f84822c5a)


## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- add: Xenos now get an announcement when they stop accumulating evo points past the maximum (15 minutes in).
