### PR TITLE
network hive entity to its members

### DIFF
--- a/Content.Server/_RMC14/Xenonids/XenoRoleSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/XenoRoleSystem.cs
@@ -2,7 +2,9 @@
 using Content.Server.Players.PlayTimeTracking;
 using Content.Server.Roles;
 using Content.Shared._RMC14.Xenonids;
+using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared.Roles.Jobs;
+using Robust.Server.GameStates;
 using Robust.Shared.Player;
 
 namespace Content.Server._RMC14.Xenonids;
@@ -11,11 +13,17 @@ public sealed class XenoRoleSystem : EntitySystem
 {
     [Dependency] private readonly MindSystem _mind = default!;
     [Dependency] private readonly PlayTimeTrackingSystem _playTime = default!;
+    [Dependency] private readonly PvsOverrideSystem _pvsOverride = default!;
     [Dependency] private readonly RoleSystem _role = default!;
+    [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
 
     public override void Initialize()
     {
+        base.Initialize();
+
         SubscribeLocalEvent<XenoComponent, PlayerAttachedEvent>(OnPlayerAttached);
+        SubscribeLocalEvent<XenoComponent, PlayerDetachedEvent>(OnPlayerDetached);
+        SubscribeLocalEvent<ActorComponent, HiveChangedEvent>(OnHiveChanged);
     }
 
     private void OnPlayerAttached(Entity<XenoComponent> xeno, ref PlayerAttachedEvent args)
@@ -23,8 +31,29 @@ public sealed class XenoRoleSystem : EntitySystem
         if (!_mind.TryGetMind(args.Player.UserId, out var mind))
             return;
 
+        if (_hive.GetHive(xeno.Owner) is {} hive)
+            _pvsOverride.AddForceSend(hive, args.Player);
+
         _role.MindTryRemoveRole<JobComponent>(mind.Value);
         _role.MindAddRole(mind.Value, new JobComponent { Prototype = xeno.Comp.Role });
         _playTime.PlayerRolesChanged(args.Player);
+    }
+
+    private void OnPlayerDetached(Entity<XenoComponent> xeno, ref PlayerDetachedEvent args)
+    {
+        if (_hive.GetHive(xeno.Owner) is {} hive)
+            _pvsOverride.RemoveForceSend(hive, args.Player);
+    }
+
+    private void OnHiveChanged(Entity<ActorComponent> ent, ref HiveChangedEvent args)
+    {
+        if (ent.Comp.PlayerSession is not {} session)
+            return;
+
+        if (args.OldHive is {} oldHive)
+            _pvsOverride.RemoveForceSend(oldHive, session);
+
+        if (args.Hive is {} newHive)
+            _pvsOverride.AddForceSend(newHive, session);
     }
 }


### PR DESCRIPTION
## About the PR
resolves #3231
fixes #4273
fixes #4274 (probably)

## Why / Balance
fixy

## Technical details
when a player is attached to xeno it gets pvs overriden
when a player detaches the override is removed
when a xeno with a player changes hive (like using the rmc actions menu) it gets overriden and old one is removed

im pretty sure this is bulletproof

## Media
the rouny on left is rogue, one on the right is in the same hive as drone
drone stabs both and only rogue rouny gets hurt
![01:57:24](https://github.com/user-attachments/assets/741d527c-5199-4d50-9c85-8ed89b677a07)


## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- fix: Fixed tail stab looking like you hurt your fellow xenos on your client.
