### PR TITLE
let xenos melee rogue xenos + let xenos break weeds

### DIFF
--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
@@ -1182,7 +1182,7 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
     public void SetWeedsHive(EntityUid hive)
     {
         var query = EntityQueryEnumerator<XenoWeedsComponent>();
-        while (query.MoveNext(out var weeds, out _)
+        while (query.MoveNext(out var weeds, out _))
         {
             _hive.SetHive(weeds, hive);
         }

--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
@@ -34,7 +34,6 @@ using Content.Shared._RMC14.Xenonids;
 using Content.Shared._RMC14.Xenonids.Construction.Nest;
 using Content.Shared._RMC14.Xenonids.Evolution;
 using Content.Shared._RMC14.Xenonids.Parasite;
-using Content.Shared._RMC14.Xenonids.Weeds;
 using Content.Shared.CCVar;
 using Content.Shared.Coordinates;
 using Content.Shared.GameTicking;
@@ -186,7 +185,7 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
                 continue;
             }
 
-            SetWeedsHive(comp.Hive);
+            SetFriendlyHives(comp.Hive);
 
             SpawnSquads((uid, comp));
             SpawnAdminFaxArea();
@@ -1176,12 +1175,12 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
     }
 
     /// <summary>
-    /// Sets the hive of all loaded weeds.
+    /// Sets the hive of all loaded xeno friendly entities (e.g. weeds).
     /// Only makes sense for distress signal with 1 hive, with multiple hives you would need to determine which weeds belong to which hive
     /// </summary>
-    public void SetWeedsHive(EntityUid hive)
+    public void SetFriendlyHives(EntityUid hive)
     {
-        var query = EntityQueryEnumerator<XenoWeedsComponent>();
+        var query = EntityQueryEnumerator<XenoFriendlyComponent>();
         while (query.MoveNext(out var weeds, out _))
         {
             _hive.SetHive(weeds, hive);

--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
@@ -34,6 +34,7 @@ using Content.Shared._RMC14.Xenonids;
 using Content.Shared._RMC14.Xenonids.Construction.Nest;
 using Content.Shared._RMC14.Xenonids.Evolution;
 using Content.Shared._RMC14.Xenonids.Parasite;
+using Content.Shared._RMC14.Xenonids.Weeds;
 using Content.Shared.CCVar;
 using Content.Shared.Coordinates;
 using Content.Shared.GameTicking;
@@ -184,6 +185,8 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
                 // TODO: how should the gamemode handle failure? restart immediately or create an alert for admins
                 continue;
             }
+
+            SetWeedsHive(comp.Hive);
 
             SpawnSquads((uid, comp));
             SpawnAdminFaxArea();
@@ -1170,6 +1173,19 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
     private void EndRound()
     {
         _roundEnd.EndRound();
+    }
+
+    /// <summary>
+    /// Sets the hive of all loaded weeds.
+    /// Only makes sense for distress signal with 1 hive, with multiple hives you would need to determine which weeds belong to which hive
+    /// </summary>
+    public void SetWeedsHive(EntityUid hive)
+    {
+        var query = EntityQueryEnumerator<XenoWeedsComponent>();
+        while (query.MoveNext(out var weeds, out _)
+        {
+            _hive.SetHive(weeds, hive);
+        }
     }
 }
 

--- a/Content.Server/_RMC14/Xenonids/Weeds/XenoWeedsSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Weeds/XenoWeedsSystem.cs
@@ -1,6 +1,7 @@
 ﻿using System.Numerics;
 using Content.Server.Spreader;
 using Content.Shared._RMC14.Xenonids.Construction.Nest;
+using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Weeds;
 using Content.Shared.Atmos;
 using Content.Shared.Coordinates;
@@ -11,6 +12,7 @@ namespace Content.Server._RMC14.Xenonids.Weeds;
 public sealed class XenoWeedsSystem : SharedXenoWeedsSystem
 {
     [Dependency] private readonly MapSystem _mapSystem = default!;
+    [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
 
     private readonly List<EntityUid> _anchored = new();
 
@@ -71,6 +73,8 @@ public sealed class XenoWeedsSystem : SharedXenoWeedsSystem
             neighborWeedsComp.IsSource = false;
             neighborWeedsComp.Source = source;
             sourceWeeds?.Spread.Add(neighborWeeds);
+
+            _hive.SetSameHive(ent.Owner, neighborWeeds);
 
             Dirty(neighborWeeds, neighborWeedsComp);
 

--- a/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestSystem.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using Content.Shared._RMC14.Map;
+using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Parasite;
 using Content.Shared._RMC14.Xenonids.Weeds;
 using Content.Shared.ActionBlocker;
@@ -39,6 +40,7 @@ public sealed class XenoNestSystem : EntitySystem
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly OccluderSystem _occluder = default!;
+    [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
     [Dependency] private readonly SharedXenoParasiteSystem _parasite = default!;
     [Dependency] private readonly ISharedPlayerManager _player = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
@@ -193,6 +195,8 @@ public sealed class XenoNestSystem : EntitySystem
 
         var nest = SpawnAttachedTo(ent.Comp.Nest, nestCoordinates);
         _transform.SetCoordinates(nest, nestCoordinates.Offset(offset));
+
+        _hive.SetSameHive(args.User, nest);
 
         ent.Comp.Nests[direction.Value] = nest;
         Dirty(ent);

--- a/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
@@ -170,6 +170,7 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
         {
             var weeds = Spawn(args.Prototype, coordinates);
             _adminLogs.Add(LogType.RMCXenoPlantWeeds, $"Xeno {ToPrettyString(xeno):xeno} planted weeds {ToPrettyString(weeds):weeds} at {coordinates}");
+            _hive.SetSameHive(xeno.Owner, weeds);
         }
     }
 

--- a/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
@@ -157,9 +157,8 @@ public sealed class XenoSystem : EntitySystem
         if (args.Target is not { } target)
             return;
 
-        // TODO RMC14 different hives
         // TODO RMC14 this still falsely plays the hit red flash effect on xenos if others are hit in a wide swing
-        if (_xenoFriendlyQuery.HasComp(target) ||
+        if ((_xenoFriendlyQuery.HasComp(target) && _hive.FromSameHive(xeno.Owner, target)) ||
             _mobState.IsDead(target))
         {
             args.Cancel();

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_weeds.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_weeds.yml
@@ -75,7 +75,6 @@
         weed14: ""
     - 0:
         weed15: ""
-  - type: XenoFriendly
   - type: Damageable
     damageContainer: StructuralXeno
   - type: Destructible
@@ -236,7 +235,6 @@
     base: weedwall
     mode: Corners
   - type: XenoNestSurface
-  - type: XenoFriendly
   - type: Damageable
     damageContainer: StructuralXeno
   - type: Destructible

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_weeds.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_weeds.yml
@@ -75,6 +75,7 @@
         weed14: ""
     - 0:
         weed15: ""
+  - type: XenoFriendly
   - type: Damageable
     damageContainer: StructuralXeno
   - type: Destructible
@@ -235,6 +236,7 @@
     base: weedwall
     mode: Corners
   - type: XenoNestSurface
+  - type: XenoFriendly
   - type: Damageable
     damageContainer: StructuralXeno
   - type: Destructible


### PR DESCRIPTION
## About the PR
xenos can now fight eachother if they are not in the same hive

weeds now have a hive so xenos can break other hives' weeds

distress signal assigns the hive after loading the planet map, xeno v xeno would need something smarter

## Why / Balance
- there was a todo
- they already can with abilities so

## Technical details
if the target has XenoFriendly now it also checks if they are in the same hive
so you can bonk rogue xenos and for xeno v xeno you can break the other hives weeds and whatever else

## Media
figure out which xeno is rogue 99% impossible
![02:09:42](https://github.com/user-attachments/assets/58ad1608-d5de-45fe-baf1-9ef7dd05eaa3)


## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun