### PR TITLE
ethanol and inap overdose consequences

### DIFF
--- a/Resources/Prototypes/_RMC14/Reagents/elements.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/elements.yml
@@ -401,6 +401,13 @@
           min: 12
       - !type:Drunk
         boozePower: 2
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
+        damage:
+          groups:
+            Toxin: 0.5
 
 - type: reagent
   id: RMCSugar #Candy and grains

--- a/Resources/Prototypes/_RMC14/Reagents/medicine.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/medicine.yml
@@ -349,6 +349,25 @@
         damage:
           types:
             Asphyxiation: -1
+      - !type:AdjustReagent
+        conditions:
+        - !type:ReagentThreshold
+          min: 70
+        reagent: CMInaprovaline
+        amount: -5
+      - !type:AdjustReagent
+        conditions:
+        - !type:ReagentThreshold
+          min: 70
+        reagent: Toxin
+        amount: 2.5
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 60
+        damage:
+          groups:
+            Toxin: 0.5
       - !type:Jitter
         conditions:
         - !type:ReagentThreshold


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Ethanol overdoses give light poison damage.

Inap overdoses give light poison damage.
Inap overdoses over 70 units will be converted partially into toxin reagent, until the overdose is 70 units.
