### PR TITLE
Fix Several Construction, Deconstruction, and Destruction Issues

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Materials/parts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Materials/parts.yml
@@ -24,6 +24,10 @@
   - type: Construction
     graph: CMRods
     node: CMRodMetal
+  - type: FloorTile
+    outputs:
+    - CMFloorSteelPlanetEngine
+    #RMC TODO: Lattice
 
 - type: entity
   parent: CMRodMetal

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Furniture/beds.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Furniture/beds.yml
@@ -14,6 +14,22 @@
   - type: InteractionOutline
   - type: HealOnBuckle
     damage: {}
+  - type: Construction
+    graph: RMCBed
+    node: bed
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 75
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          CMSheetMetal1:
+            min: 1
+            max: 1
 
 - type: entity
   parent: CMBed
@@ -22,6 +38,9 @@
   - type: Sprite
     sprite: _RMC14/Structures/Furniture/bed.rsi
     state: abed
+  - type: Construction
+    graph: RMCBed
+    node: altBed
 
 - type: entity
   parent: CMBed
@@ -30,6 +49,9 @@
   - type: Sprite
     sprite: _RMC14/Structures/Furniture/bed.rsi
     state: psychbed
+  - type: Construction
+    graph: RMCBed
+    node: bedPsych
 
 # Bedroll
 

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Lathe/lathe.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Lathe/lathe.yml
@@ -1,5 +1,5 @@
 ﻿- type: entity
-  parent: [ BaseMachinePowered, ConstructibleMachine ]
+  parent: [ BaseMachinePowered, RMCConstructibleMachine ]
   id: CMAutolathe
   name: autolathe
   description: It produces items using metal and glass.

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/base_structuremachines.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/base_structuremachines.yml
@@ -1,0 +1,18 @@
+- type: entity
+  abstract: true
+  id: RMCConstructibleMachine
+  components:
+  - type: Machine
+  - type: ContainerContainer
+    containers:
+      machine_board: !type:Container
+      machine_parts: !type:Container
+  - type: Construction
+    graph: CMMachineFrame
+    node: machine
+    containers:
+    - machine_parts
+    - machine_board
+  - type: LightningTarget
+    priority: 1
+

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Piping/Disposal/disposal_unit.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Piping/Disposal/disposal_unit.yml
@@ -53,4 +53,3 @@
     blacklist:
       components:
       - Xeno
- 

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Piping/Disposal/disposal_unit.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Piping/Disposal/disposal_unit.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: CMDisposalUnit
-  parent: DisposalUnit
+  parent: DisposalUnitBase
   name: disposal unit
   description: A pneumatic waste disposal unit.
   components:
@@ -21,12 +21,36 @@
       map: [ "enum.DisposalUnitVisualLayers.OverlayFull" ]
     - state: dispover-handle
       map: [ "enum.DisposalUnitVisualLayers.OverlayEngaged" ]
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 200
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
+          params:
+            volume: -6
   - type: ApcPowerReceiver
     powerLoad: 0
     needsPower: false
+#  - type: Construction | TODO RMC14: Construction graph for steps to unanchor
+  - type: DisposalUnit
   - type: ThrowInsertContainer
+    containerId: disposals
     probability: 0
+  - type: RequireProjectileTarget
   - type: InteractedBlacklist
     blacklist:
       components:
       - Xeno
+ 

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Storage/filing_cabinets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Storage/filing_cabinets.yml
@@ -1,19 +1,64 @@
 - type: entity
   abstract: true
+  parent: [ BaseStructureDynamic, BaseBagOpenClose ]
   id: CMFilingCabinetBase
   description: A large cabinet with drawers.
   suffix: Empty
   components:
+  - type: Storage
+    grid:
+    - 0,0,9,3
+    maxItemSize: Normal
+    whitelist:
+      tags:
+        - Document
+        - Folder
+        - Write
   - type: Sprite
     sprite: _RMC14/Structures/Storage/filing_cabinet.rsi
     noRot: true
+  - type: UserInterface
+    interfaces:
+      enum.StorageUiKey.Key:
+        type: StorageBoundUserInterface
+  - type: Transform
+    noRot: true
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.18,-0.48,0.18,0.48"
+        density: 200
+        mask:
+        - MachineMask
+        layer:
+        - MachineLayer
+  - type: InteractionOutline
+  - type: ContainerContainer
+    containers:
+      storagebase: !type:Container
+  - type: Damageable
+    damageContainer: Inorganic
+    damageModifierSet: Metallic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 50
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
   - type: InteractedBlacklist
     blacklist:
       components:
       - Xeno
 
 - type: entity
-  parent: [ CMFilingCabinetBase, filingCabinet ]
+  parent: CMFilingCabinetBase
   id: CMFilingCabinet
   name: filing cabinet
   components:
@@ -25,7 +70,7 @@
       map: ["openLayer"]
 
 - type: entity
-  parent: [ CMFilingCabinetBase, filingCabinetTall ]
+  parent: CMFilingCabinetBase
   id: CMFilingCabinetTall
   name: tall filing cabinet
   components:
@@ -49,16 +94,37 @@
       map: ["openLayer"]
 
 - type: entity
-  parent: [ CMFilingCabinetBase, filingCabinetDrawer ]
+  parent: CMFilingCabinetBase
   id: CMFilingCabinetChest
   name: chest drawer
   components:
+  - type: Storage
+    grid:
+    - 0,0,7,2
+    maxItemSize: Normal
+    whitelist:
+      tags:
+        - Document
+        - Folder
+        - Write
   - type: Sprite
     state: chestdrawer
     layers:
     - state: chestdrawer
     - state: chestdrawer-open
       map: [ "openLayer" ]
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.22,-0.42,0.22,0.34"
+        density: 210
+        mask:
+        - MachineMask
+        layer:
+        - MachineLayer
+  - type: RequireProjectileTarget
 
 - type: entity
   parent: CMFilingCabinetChest

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Windows/directional_windows.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Windows/directional_windows.yml
@@ -28,6 +28,31 @@
     state: window
   - type: DamageMultiplierFlags
     flags: Breaching
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 150 #Excess damage check.
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: WindowShatter
+    - trigger:
+        !type:DamageTrigger
+        damage: 25 #TODO RMC14: Proper damage values.
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: WindowShatter
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          CMShardGlass:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
 
 - type: entity
   id: CMWindowReinforcedDirectional
@@ -40,6 +65,34 @@
   - type: Icon
     sprite: _RMC14/Structures/Windows/directional.rsi
     state: rwindow
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 150 #Excess damage check.
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: WindowShatter
+    - trigger:
+        !type:DamageTrigger
+        damage: 25 #TODO RMC14: Proper damage values.
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: WindowShatter
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          CMShardGlass:
+            min: 1
+            max: 1
+          CMRodMetal1:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
 
 - type: entity
   id: CMWindowTintedDirectional

--- a/Resources/Prototypes/_RMC14/Entities/Structures/hydro_tray.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/hydro_tray.yml
@@ -1,9 +1,23 @@
 - type: entity
-  parent: hydroponicsTray
+  parent: hydroponicsSoil
   name: hydroponics tray
   id: CMHydroponicsTray
   description: Used for growing plants.
   components:
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.45,-0.45,0.45,0.1"
+        density: 190
+        hard: true
+        mask:
+        - MachineMask
+        layer:
+        - BulletImpassable
+  - type: Anchorable
+  - type: Pullable
   - type: Destructible
     thresholds:
     - trigger:
@@ -34,6 +48,40 @@
     - state: over_harvest3
       map: [ "harvest_alert" ]
       visible: false
+  - type: Appearance
+  - type: GenericVisualizer
+    visuals:
+      enum.PlantHolderVisuals.HealthLight:
+        health_alert:
+          True: { visible: true }
+          False: { visible: false }
+      enum.PlantHolderVisuals.WaterLight:
+        water_alert:
+          True: { visible: true }
+          False: { visible: false }
+      enum.PlantHolderVisuals.NutritionLight:
+        nutri_alert:
+          True: { visible: true }
+          False: { visible: false }
+      enum.PlantHolderVisuals.AlertLight:
+        undefined_alert:
+          True: { visible: true }
+          False: { visible: false }
+      enum.PlantHolderVisuals.HarvestLight:
+        harvest_alert:
+          True: { visible: true }
+          False: { visible: false }
+  - type: PlantHolder
+    drawWarnings: true
+  - type: AmbientSound
+    volume: -9
+    range: 5
+    sound:
+      path: /Audio/Ambience/Objects/flowing_water_open.ogg
+  - type: GuideHelp
+    guides:
+    - Botany
+    - Chemicals
   - type: InteractedBlacklist
     blacklist:
       components:

--- a/Resources/Prototypes/_RMC14/Recipes/Construction/Graphs/furniture/bed.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Construction/Graphs/furniture/bed.yml
@@ -1,0 +1,49 @@
+- type: constructionGraph
+  parent: RMC
+  id: RMCBed
+  start: start
+  graph:
+    - node: start
+      actions:
+        - !type:DestroyEntity {}
+      edges:
+        - to: bed
+          completed:
+            - !type:SnapToGrid { }
+          steps:
+            - material: CMSteel
+              amount: 2
+              doAfter: 1
+    - node: bed
+      entity: CMBed
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: CMSheetMetal1
+              amount: 1
+          steps:
+            - tool: Screwing
+              doAfter: 1
+    - node: altBed
+      entity: RMCBedAlt
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: CMSheetMetal1
+              amount: 1
+          steps:
+            - tool: Screwing
+              doAfter: 1
+    - node: bedPsych
+      entity: RMCBedPsych
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: CMSheetMetal1
+              amount: 1
+          steps:
+            - tool: Screwing
+              doAfter: 1

--- a/Resources/Prototypes/_RMC14/Recipes/Construction/Graphs/structures/window_directional.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Construction/Graphs/structures/window_directional.yml
@@ -1,0 +1,22 @@
+- type: constructionGraph
+  id: RMCWindowDirectional
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: windowDirectional
+          steps:
+            - material: CMGlass
+              amount: 1
+              doAfter: 1
+        - to: windowReinforcedDirectional
+          steps:
+            - material: CMGlassReinforced
+              amount: 1
+              doAfter: 1
+
+    - node: windowDirectional
+      entity: CMWindowDirectional
+
+    - node: windowReinforcedDirectional
+      entity: CMWindowReinforcedDirectional

--- a/Resources/Prototypes/_RMC14/Recipes/Construction/furniture.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Construction/furniture.yml
@@ -217,3 +217,23 @@
   canBuildInImpassable: false
   conditions:
     - !type:TileNotBlocked
+
+#misc
+
+- type: construction
+  parent: RMC
+  id: RMCBed
+  name: bed
+  description: A mattress seated on a rectangular metallic frame.
+  graph: RMCBed
+  startNode: start
+  targetNode: bed
+  category: construction-category-cm-furniture
+  icon:
+    sprite: _RMC14/Structures/Furniture/bed.rsi
+    state: bed
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  conditions:
+    - !type:TileNotBlocked

--- a/Resources/Prototypes/_RMC14/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Construction/structures.yml
@@ -112,6 +112,44 @@
   conditions:
     - !type:TileNotBlocked
 
+# Directional Windows
+- type: construction
+  parent: RMC
+  name: directional window
+  id: RMCWindowDirectional
+  graph: RMCWindowDirectional
+  startNode: start
+  targetNode: windowDirectional
+  category: construction-category-cm-structures
+  description: A glass window. It looks thin and flimsy.
+  canBuildInImpassable: true
+  conditions:
+    - !type:EmptyOrWindowValidInTile
+    - !type:NoWindowsInTile
+  icon:
+    sprite: _RMC14/Structures/Windows/directional.rsi
+    state: window
+  objectType: Structure
+  placementMode: SnapgridCenter
+
+- type: construction
+  parent: RMC
+  name: directional reinforced window
+  id: RMCWindowReinforcedDirectional
+  graph: RMCWindowDirectional
+  startNode: start
+  targetNode: windowReinforcedDirectional
+  category: construction-category-cm-structures
+  description: A glass window reinforced with bracing rods. It looks rather strong.
+  canBuildInImpassable: true
+  conditions:
+    - !type:EmptyOrWindowValidInTile
+    - !type:NoWindowsInTile
+  icon:
+    sprite: _RMC14/Structures/Windows/directional.rsi
+    state: rwindow
+  objectType: Structure
+  placementMode: SnapgridCenter
 
 # Windoors
 - type: construction


### PR DESCRIPTION
## About the PR
Fixes #2836
Fixes #3212
Fixes #3927
Fixes #3186
Fixes #4217
Fixes #4219 (Note: Doesn't cover the chem machine issue mentioned in the comments.)
Fixes #4277

## Details / Balance
All changes should be _mostly_ accurate to how it works in CM13, as I have figured out how to run my own dev build now.

**Disposal Units**
- No longer deconstructable.
- When destroyed drop nothing.

**Filing Cabinets**
- No longer deconstructable.
- When destroyed drop nothing.

**Beds**
- Constructible using 2 steel.
- Deconstruct into 1 steel.
- When destroyed drop 1 steel.

**Hydroponics Trays**
- No longer deconstructable.
- When destroyed drop nothing.

**Regular Directional Window**
- Constructible using 1 glass.
- No longer deconstructable.
- When destroyed drop 1 glass shard.

**Reinforced Directional Window**
- Constructible using 1 reinforced glass.
- No longer deconstructable.
- When destroyed drop 1 glass shard and 1 metal rod.

**Autolathe**
- Constructible using the proper machine board.
- deconstructable into the proper parts and proper machine frame.
- When destoryed break into the proper machine frame.

**Metal Rods**
- Place into engine floors instead of base game reinforced floors.
(Note: Plasteel rods still make floors, when they shouldn't be.)

## Technical details
A fair bit of reparenting to handle some objects parenting construction graphs when they should have none.

## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] This PR does not require an ingame showcase

**Changelog**
- fix: Fixed disposal units, filing cabinets, beds, hydroponics trays, directional windows, and autolathes dropping the wrong resources.
- fix: Fixed rods placing down the wrong tile type.