### PR TITLE
Require directly aiming at eggs to destroy them

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_egg.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_egg.yml
@@ -72,3 +72,4 @@
       enum.XenoParasiteGhostUI.Key:
         type: XenoParasiteGhostBui
         requireInputValidation: false
+  - type: RequireProjectileTarget


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Makes bullets pass over Eggs unless directly aimed at/targetted

## Why / Balance
CM13 Parity, requires mass egg destruction to be more deliberate and/or explosive

## Media
Video Demonstration
https://github.com/user-attachments/assets/91394a9e-03a3-4726-852b-cf40b567a39e

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**

:cl:
- tweak: Bullets will now only hit Eggs when directly aimed at
