### PR TITLE
Xeno Healing Parity (almost, still slightly underpowered)

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
@@ -265,7 +265,7 @@ public sealed class XenoSystem : EntitySystem
         var passiveHeal = threshold.Value / 65 + xeno.Comp.FlatHealing;
         var recovery = (CompOrNull<XenoRecoveryPheromonesComponent>(xeno)?.Multiplier ?? 0) / 2;
         var recoveryHeal = (threshold.Value / 65) * (recovery / 2);
-        return (passiveHeal + recoveryHeal) * multiplier / 2;
+        return (passiveHeal + recoveryHeal) * multiplier; // TODO RMC14 add Strain based multiplier for Gardener Drone
     }
 
     public void HealDamage(Entity<DamageableComponent?> xeno, FixedPoint2 amount)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Xeno Healing in RMC14 has roughly halved compared to 13's healing, and it's been because it actually has been halved in the formula (which does not exist in 13), this boosts up healing to near-13 levels. Of note, this still seems to be slightly slower than 13's in some cases. Of note Garden Drone's 1.05x healing recovery is also missing, for when that is implemented.

## Why / Balance
CM13 Parity

## Technical details
Removes random division by 2

## Media
Quick Video Demo (healing is still lower than what it should be for this scenario, but much much closer)
https://github.com/user-attachments/assets/da6b8390-b9e4-4c88-8582-30cb4246b9cd


## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**

:cl:
- fix: Fixed Xeno Health Regeneration being half of what it should be in 13.
