### PR TITLE
Leap SFX now only plays on-hit

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Leap/XenoLeapSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Leap/XenoLeapSystem.cs
@@ -185,6 +185,12 @@ public sealed class XenoLeapSystem : EntitySystem
         var ev = new XenoLeapHitEvent(xeno, other);
         RaiseLocalEvent(xeno, ref ev);
 
+        if (!xeno.Comp.PlayedSound)
+        {
+            xeno.Comp.PlayedSound = true;
+            _audio.PlayPredicted(xeno.Comp.LeapSound, xeno, xeno);
+        }
+
         StopLeap(xeno);
     }
 
@@ -214,14 +220,6 @@ public sealed class XenoLeapSystem : EntitySystem
         {
             _physics.SetLinearVelocity(leaping, Vector2.Zero, body: physics);
             _physics.SetBodyStatus(leaping, physics, BodyStatus.OnGround);
-        }
-
-        if (!leaping.Comp.PlayedSound)
-        {
-            leaping.Comp.PlayedSound = true;
-            Dirty(leaping);
-
-            _audio.PlayPredicted(leaping.Comp.LeapSound, leaping, leaping);
         }
 
         RemCompDeferred<XenoLeapingComponent>(leaping);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Makes the Lurker/Runner roar that plays on leap to only play when hitting a hostile mob (either Marine, or enemy Xeno hive)

## Why / Balance
CM13 Parity, lets Runners and Lurkers jump around without alerting marines-unless they are actively attacking them

Resolves #4356 

## Technical details
Moved the SFX from the generic StopLeap that always plays, to specifically OnXenoLeapingDoHit

## Media
Runner Demo
https://github.com/user-attachments/assets/56629c75-6237-4d9b-9c72-5e08667e4bc1

Lurker Demo
https://github.com/user-attachments/assets/4f4dbe95-49f5-40b6-96b8-7430ab66bc1f

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- fix: The Lurker and Runner Leap sound effect now correctly only plays when hitting an enemy with the leap.
