### PR TITLE
Lurker Invisibility Rework

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Invisibility/XenoActiveInvisibleComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Invisibility/XenoActiveInvisibleComponent.cs
@@ -12,7 +12,7 @@ public sealed partial class XenoActiveInvisibleComponent : Component
     public TimeSpan ExpiresAt;
 
     [DataField, AutoNetworkedField]
-    public TimeSpan Cooldown = TimeSpan.FromSeconds(20);
+    public TimeSpan FullCooldown = TimeSpan.FromSeconds(20);
 
     [DataField, AutoNetworkedField]
     public FixedPoint2 SpeedMultiplier = FixedPoint2.New(1.15);

--- a/Content.Shared/_RMC14/Xenonids/Invisibility/XenoInvisibilitySystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Invisibility/XenoInvisibilitySystem.cs
@@ -1,6 +1,8 @@
-﻿using Content.Shared._RMC14.Xenonids.Leap;
+﻿using Content.Shared._RMC14.Xenonids.Devour;
+using Content.Shared._RMC14.Xenonids.Leap;
 using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared.Actions;
+using Content.Shared.DoAfter;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Popups;
 using Content.Shared.Weapons.Melee.Events;
@@ -23,6 +25,7 @@ public sealed class XenoInvisibilitySystem : EntitySystem
 
         SubscribeLocalEvent<XenoActiveInvisibleComponent, ComponentRemove>(OnXenoActiveInvisibleRemove);
         SubscribeLocalEvent<XenoActiveInvisibleComponent, MeleeHitEvent>(OnXenoActiveInvisibleMeleeHit);
+        SubscribeLocalEvent<XenoActiveInvisibleComponent, DoAfterAttemptEvent<XenoDevourDoAfterEvent>>(OnXenoDevourDoAfterAttempt);
         SubscribeLocalEvent<XenoActiveInvisibleComponent, XenoLeapHitEvent>(OnXenoActiveInvisibleLeapHit);
         SubscribeLocalEvent<XenoActiveInvisibleComponent, RefreshMovementSpeedModifiersEvent>(OnXenoActiveInvisibleRefreshSpeed);
     }
@@ -31,12 +34,6 @@ public sealed class XenoInvisibilitySystem : EntitySystem
     {
         //if (args.Handled)
         //    return;
-
-        /* if (HasComp<XenoActiveInvisibleComponent>(xeno))
-        {
-            _popup.PopupClient(Loc.GetString("cm-xeno-invisibility-already-invisible"), xeno, xeno);
-            return;
-        } */
 
         if (!_xenoPlasma.TryRemovePlasmaPopup(xeno.Owner, xeno.Comp.PlasmaCost))
             return;
@@ -98,6 +95,12 @@ public sealed class XenoInvisibilitySystem : EntitySystem
     {
         var multiplier = xeno.Comp.SpeedMultiplier.Float();
         args.ModifySpeed(multiplier, multiplier);
+    }
+
+    private void OnXenoDevourDoAfterAttempt(Entity<XenoActiveInvisibleComponent> xeno, ref DoAfterAttemptEvent<XenoDevourDoAfterEvent> args)
+    {
+        RemCompDeferred<XenoActiveInvisibleComponent>(xeno);
+        OnRemoveInvisibility(xeno);
     }
 
     private void OnRemoveInvisibility(Entity<XenoActiveInvisibleComponent> xeno)

--- a/Content.Shared/_RMC14/Xenonids/Invisibility/XenoInvisibilitySystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Invisibility/XenoInvisibilitySystem.cs
@@ -32,21 +32,18 @@ public sealed class XenoInvisibilitySystem : EntitySystem
 
     private void OnXenoTurnInvisibleAction(Entity<XenoTurnInvisibleComponent> xeno, ref XenoTurnInvisibleActionEvent args)
     {
-        //if (args.Handled)
-        //    return;
-
         if (!_xenoPlasma.TryRemovePlasmaPopup(xeno.Owner, xeno.Comp.PlasmaCost))
             return;
 
-        if (TryComp<XenoActiveInvisibleComponent>(xeno, out var oldActive)){
+        if (TryComp<XenoActiveInvisibleComponent>(xeno, out var invis)){
             RemCompDeferred<XenoActiveInvisibleComponent>(xeno);
-            
-            foreach (var (actionId, actionComp) in _actions.GetActions(xeno))
+            OnRemoveInvisibility((xeno, invis));
+
+            if (!invis.DidPopup)
             {
-                if (actionComp.BaseEvent is XenoTurnInvisibleActionEvent)
-                {
-                    _actions.SetCooldown(actionId, xeno.Comp.Cooldown);
-                }
+                _popup.PopupClient(Loc.GetString("cm-xeno-invisibility-expire"), xeno, xeno, PopupType.SmallCaution);
+                invis.DidPopup = true;
+                Dirty(xeno, invis);
             }
         }
         else
@@ -58,8 +55,6 @@ public sealed class XenoInvisibilitySystem : EntitySystem
 
             _movementSpeed.RefreshMovementSpeedModifiers(xeno);
         }
-
-        //args.Handled = true;
     }
 
     private void OnXenoActiveInvisibleRemove(Entity<XenoActiveInvisibleComponent> xeno, ref ComponentRemove args)

--- a/Content.Shared/_RMC14/Xenonids/Invisibility/XenoTurnInvisibleComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Invisibility/XenoTurnInvisibleComponent.cs
@@ -14,10 +14,19 @@ public sealed partial class XenoTurnInvisibleComponent : Component
     public TimeSpan Duration = TimeSpan.FromSeconds(30);
 
     [DataField, AutoNetworkedField]
-    public TimeSpan Cooldown = TimeSpan.FromSeconds(20);
+    public TimeSpan FullCooldown = TimeSpan.FromSeconds(20);
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan ToggleLockoutTime = TimeSpan.FromSeconds(0.5);
 
     [DataField, AutoNetworkedField]
     public float Opacity = 0.1f;
+
+    [DataField, AutoNetworkedField]
+    public float ManualRefundMultiplier = 0.9f;
+
+    [DataField, AutoNetworkedField]
+    public float RevealedRefundMultiplier = 0.5f;
 
     [DataField, AutoNetworkedField]
     public FixedPoint2 SpeedMultiplier = FixedPoint2.New(1.15);

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
@@ -114,7 +114,6 @@ cm-xeno-charge-spit = Our next spit will be stronger.
 cm-xeno-charge-spit-expire = Our spits are back to normal.
 
 # Turn Invisible
-cm-xeno-invisibility-already-invisible = We are already invisible!
 cm-xeno-invisibility-expire = We feel our invisibility end!
 
 # Ovipositor

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_self_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_self_actions.yml
@@ -155,7 +155,7 @@
   id: ActionXenoTurnInvisible
   parent: ActionXenoBase
   name: Turn Invisible (20) # TODO RMC14 proper plasma costs
-  description: Become partially invisible for 30 seconds or until you attack. Increases your movement speed until the ability expires.
+  description: Become partially invisible for 30 seconds, or until you either damage or attempt to devour an enemy. Can be toggled off to become visible again, with a refund of 90% remaining cloak time. Increases your movement speed by 15% until the ability expires.
   components:
   - type: InstantAction
     itemIconStyle: NoItem


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Entirely reworks Lurker Invisibility to match CM13

- [X] Cloak doesn't end when hitting structures and non-enemies
- [X] Shoving doesn't break cloak
- [X] Manual Cloak Deactivation, refunds 90% Cooldown based on cloak time
- [X] Devour attempt breaks cloak and refunds 50% Cooldown based on cloak time

## Why / Balance
CM13 Parity. Lurker needs the love.

Resolves #4043 
Resolves #4354 
Resolves #4349

## Technical details
- Changes the MeleeAttack check to a MeleeHit check, only de-cloaking if they hit an enemy mob. This also correctly enables shoving Marines while cloaked.
- Added GetRefundedCooldown() and StartCooldown() as helper functions as the code is re-used several times. The refunded cooldown function is 1:1 to with CM13 (though they calculate time from start, while we calculate time until end)
- Included RemCompDeferred in RemoveInvisibility() as well as the Popup Handling.
- RemoveInvisibility() now takes a TimeSpan cooldown, which it passes to StartCooldown()
- Now tracks DoAfterAttemptEvent for XenoDevourDoAfterEvent, and instantly ends your cloak once you start for 50% refunded cloak.
- Added a short lockout timer to cloaking to prevent double-hits (cm13 parity).
- TurnInvisibleComponent now holds the Lockout Timer, and both Manual and Revealed Refund Multipliers.
- StartCooldown now accepts toggledStatus as a bool for the action bar visuals.
- No more args.Handled as we manually set variable cooldowns.

## Media
Full Demonstration
https://github.com/user-attachments/assets/2de55c19-ea1d-414c-8d3d-6d50f48ffdd4

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- add: Lurkers can now manually toggle off their invisibility, which refunds 90% of the remaining cloak time.
- add: Lurkers can now attack structures and wideswing without losing invisibility, as long as they do not hit a Marine.
- add: Lurkers can now shove Marines without losing invisibility.
- remove: Lurkers can no longer devour while invisible. Doing so de-cloaks them and refunds 50% of the remaining cloak time.

