### PR TITLE
Fix shield protecting more than normal for large damage amounts

### DIFF
--- a/Content.Shared/_RMC14/Shields/XenoShieldSystem.cs
+++ b/Content.Shared/_RMC14/Shields/XenoShieldSystem.cs
@@ -50,16 +50,19 @@ public sealed partial class XenoShieldSystem : EntitySystem
 
         if (ent.Comp.ShieldAmount <= 0)
         {
+            var usableShield = ent.Comp.ShieldAmount + args.Damage.GetTotal();
+            ent.Comp.ShieldAmount = 0;
+
             foreach (var type in args.Damage.DamageDict)
             {
-                if (ent.Comp.ShieldAmount == 0)
+                if (usableShield == 0)
                     break;
 
                 if (type.Value > 0)
                 {
-                    var tempVal = Math.Min(type.Value.Double(), -ent.Comp.ShieldAmount.Double());
+                    var tempVal = Math.Min(type.Value.Double(), usableShield.Double());
                     args.Damage.DamageDict[type.Key] -= tempVal;
-                    ent.Comp.ShieldAmount += tempVal;
+                    usableShield -= tempVal;
                 }
             }
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Title. Changed the math for this.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Bug.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
So before, if you had say 15 shield and took 9000 damage, 8985 damage would be minused from the damage because 8985 (the shield amount you would have had) IS smaller than 9000...

Now if shield amount goes below 0, the shieldamount (before the math) is used to compare with damage and reduce it, so the above scenario correctly makes you take 8985 damage instead of...15. 

As far as I'm aware this should work for both large and small values fine.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- fix: Fix shields blocking more damage on break than they should
