### PR TITLE
Fix Rest description lying about Plasma, Plasma Upkeep Descriptions

### DIFF
--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_self_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_self_actions.yml
@@ -99,7 +99,7 @@
   id: ActionXenoResinWalker
   parent: ActionXenoBase
   name: Resin Walker (50) # TODO RMC14 proper plasma costs
-  description: Run faster on weeds.
+  description: Run faster on weeds. Consumes 30 plasma per second.
   components:
   - type: InstantAction
     itemIconStyle: NoItem

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_self_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_self_actions.yml
@@ -2,7 +2,7 @@
   id: ActionXenoRest
   parent: ActionXenoBase
   name: Rest
-  description: Lie down to regenerate health and plasma more quickly while on weeds.
+  description: Lie down to regenerate health more quickly while on weeds.
   components:
   - type: InstantAction
     itemIconStyle: NoItem
@@ -16,7 +16,7 @@
   parent: CMGuidebookActionXenoBase
   id: CMGuidebookActionXenoRest
   name: Rest
-  description: Lie down to regenerate health and plasma more quickly while on weeds.
+  description: Lie down to regenerate health more quickly while on weeds.
   components:
   - type: Sprite
     state: resting
@@ -37,7 +37,7 @@
   id: ActionXenoPheromones
   parent: ActionXenoBase
   name: Emit Pheromones (35) # TODO RMC14 proper plasma costs
-  description: Gives a buff to nearby xenonids.
+  description: Gives a buff to nearby xenonids. Consumes 2.5 plasma per second.
   components:
   - type: InstantAction
     itemIconStyle: NoItem

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_self_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_self_actions.yml
@@ -37,7 +37,7 @@
   id: ActionXenoPheromones
   parent: ActionXenoBase
   name: Emit Pheromones (35) # TODO RMC14 proper plasma costs
-  description: Gives a buff to nearby xenonids. Consumes 2.5 plasma per second.
+  description: Gives a buff to nearby xenonids. [color=cyan]Consumes 2.5 plasma per second.[/color]
   components:
   - type: InstantAction
     itemIconStyle: NoItem
@@ -99,7 +99,7 @@
   id: ActionXenoResinWalker
   parent: ActionXenoBase
   name: Resin Walker (50) # TODO RMC14 proper plasma costs
-  description: Run faster on weeds. Consumes 30 plasma per second.
+  description: Run faster on weeds. [color=cyan]Consumes 30 plasma per second.[/color]
   components:
   - type: InstantAction
     itemIconStyle: NoItem


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Rest has never restored Plasma, despite what the description claims, this has taught some pretty bad habits over time as the vast majority of Xeno players will rest for no reason, thinking they're regenerating Plasma.

Also added Plasma Upkeep descriptions to Pheromones and Resin Walker. (2.5 every second for Pheromones, 15 every half second for Resin Walker, displayed as 30 every second for simplicity)

## Why / Balance
Lying is bad.

Also knowing how much plasma your abilities use is good, instead of only the toggle cost.

## Media
![image](https://github.com/user-attachments/assets/36b2072c-3883-4832-82e3-998416fef2d2)
![image](https://github.com/user-attachments/assets/c06f57e5-c72d-4d13-8f96-362d967e8721)
![image](https://github.com/user-attachments/assets/953ad321-56eb-42f9-bdfc-defeb93b7fe8)

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- fix: The Rest action description no longer falsely claims to regenerate plasma, as resting has no effect on plasma regeneration.
- add: Pheromone and Resin Walker descriptions now state how much Plasma they consume per second.