### PR TITLE
Comprehensive Pull Speed Rework (Large Runner Nerf included)

### DIFF
--- a/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
+++ b/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
@@ -128,7 +128,7 @@ public sealed class RMCPullingSystem : EntitySystem
 
     private void OnSlowPullStarted(Entity<SlowOnPullComponent> ent, ref PullStartedMessage args)
     {
-        if (ent.Owner == args.PulledUid)
+        if (ent.Owner == args.PullerUid)
         {
             EnsureComp<PullingSlowedComponent>(args.PullerUid);
             _movementSpeed.RefreshMovementSpeedModifiers(args.PullerUid);
@@ -137,9 +137,9 @@ public sealed class RMCPullingSystem : EntitySystem
 
     private void OnSlowPullStopped(Entity<SlowOnPullComponent> ent, ref PullStoppedMessage args)
     {
-        if (ent.Owner == args.PulledUid)
+        if (ent.Owner == args.PullerUid)
         {
-            RemCompDeferred<PullingSlowedComponent>(args.PullerUid);
+            RemComp<PullingSlowedComponent>(args.PullerUid);
             _movementSpeed.RefreshMovementSpeedModifiers(args.PullerUid);
         }
     }
@@ -147,8 +147,7 @@ public sealed class RMCPullingSystem : EntitySystem
     private void OnPullingSlowedMovementSpeed(Entity<PullingSlowedComponent> ent, ref RefreshMovementSpeedModifiersEvent args)
     {
         if (HasComp<BypassInteractionChecksComponent>(ent) ||
-            !TryComp(ent, out PullerComponent? puller) ||
-            !TryComp(puller.Pulling, out SlowOnPullComponent? slow))
+            !TryComp(ent, out SlowOnPullComponent? slow))
         {
             return;
         }

--- a/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
+++ b/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
@@ -147,14 +147,18 @@ public sealed class RMCPullingSystem : EntitySystem
     private void OnPullingSlowedMovementSpeed(Entity<PullingSlowedComponent> ent, ref RefreshMovementSpeedModifiersEvent args)
     {
         if (HasComp<BypassInteractionChecksComponent>(ent) ||
+            !TryComp(ent, out PullerComponent? puller) ||
             !TryComp(ent, out SlowOnPullComponent? slow))
         {
             return;
         }
 
+        if (puller.Pulling == null)
+            return;
+
         foreach (var slowdown in slow.Slowdowns)
         {
-            if (_whitelist.IsWhitelistPass(slowdown.Whitelist, ent))
+            if (_whitelist.IsWhitelistPass(slowdown.Whitelist, puller.Pulling.Value))
             {
                 args.ModifySpeed(slowdown.Multiplier, slowdown.Multiplier);
                 return;

--- a/Content.Shared/_RMC14/Pulling/SlowOnPullComponent.cs
+++ b/Content.Shared/_RMC14/Pulling/SlowOnPullComponent.cs
@@ -8,7 +8,7 @@ namespace Content.Shared._RMC14.Pulling;
 [Access(typeof(RMCPullingSystem))]
 public sealed partial class SlowOnPullComponent : Component
 {
-    [DataField(required: true), AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public float Multiplier = 1;
 
     [DataField, AutoNetworkedField]

--- a/Content.Shared/_RMC14/Xenonids/XenoHeavyComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/XenoHeavyComponent.cs
@@ -1,0 +1,7 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(XenoSystem))]
+public sealed partial class XenoHeavyComponent : Component;

--- a/Content.Shared/_RMC14/Xenonids/XenoLightComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/XenoLightComponent.cs
@@ -1,0 +1,7 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(XenoSystem))]
+public sealed partial class XenoLightComponent : Component;

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
@@ -171,12 +171,19 @@
   - type: UserLimitHits
   - type: MovementIgnoreGravity
   - type: SlowOnPull
-    multiplier: 0.6
     slowdowns:
-    - multiplier: 0.5
+    - multiplier: 0.7575
       whitelist:
         components:
-        - Xeno
+        - Marine
+    - multiplier: 0.8725
+      whitelist:
+        components:
+        - XenoLight
+    - multiplier: 0.59
+      whitelist:
+        components:
+        - XenoHeavy
   - type: MobThresholds
     thresholds:
       0: Alive

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
@@ -215,7 +215,19 @@
     - Hivemind
   - type: StandingState
   - type: SlowOnPull
-    multiplier: 0.75
+    slowdowns:
+      - multiplier: 0.6
+        whitelist:
+          components:
+          - Marine
+      - multiplier: 0.665
+        whitelist:
+          components:
+          - XenoLight
+      - multiplier: 0.445
+        whitelist:
+          components:
+          - XenoHeavy
   - type: PullWhitelist
     whitelist:
       components:

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/boiler.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/boiler.yml
@@ -39,6 +39,7 @@
     tier: 3
     hudOffset: 0,0.35
     unlockAt: 900 # 15 minutes
+  - type: XenoHeavy
   - type: XenoDevolve
     devolvesTo:
     - CMXenoSpitter
@@ -80,7 +81,19 @@
     baseWalkSpeed: 2
     baseSprintSpeed: 3.5
   - type: SlowOnPull
-    multiplier: 0.5
+    slowdowns:
+    - multiplier: 0.6375
+      whitelist:
+        components:
+        - Marine
+    - multiplier: 0.7075
+      whitelist:
+        components:
+        - XenoLight
+    - multiplier: 0.475
+      whitelist:
+        components:
+        - XenoHeavy
   - type: PointLight
     enabled: true
     radius: 1.8

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/burrower.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/burrower.yml
@@ -41,6 +41,7 @@
     hudOffset: 0,0.56
     unlockAt: 420 # 7 minutes
     hidden: true # TODO RMC: remove when burrower is implemented
+  - type: XenoLight
   - type: XenoDevolve
     devolvesTo:
     - CMXenoDrone
@@ -64,6 +65,20 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 2
     baseSprintSpeed: 3.5
+  - type: SlowOnPull
+    slowdowns:
+    - multiplier: 0.6425
+      whitelist:
+        components:
+        - Marine
+    - multiplier: 0.7125
+      whitelist:
+        components:
+        - XenoLight
+    - multiplier: 0.4775
+      whitelist:
+        components:
+        - XenoHeavy
 #  - type: RMCXenoDamageVisuals # TODO RMC14
 #    prefix: burrower
   - type: TacticalMapIcon

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/carrier.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/carrier.yml
@@ -53,6 +53,7 @@
     tier: 2
     hudOffset: 0,0.19
     unlockAt: 300 # 5 minutes
+  - type: XenoHeavy
   - type: XenoDevolve
     devolvesTo:
     - CMXenoDrone
@@ -80,7 +81,19 @@
     baseWalkSpeed: 2
     baseSprintSpeed: 3.5
   - type: SlowOnPull
-    multiplier: 0.5
+    slowdowns:
+    - multiplier: 0.6375
+      whitelist:
+        components:
+        - Marine
+    - multiplier: 0.7075
+      whitelist:
+        components:
+        - XenoLight
+    - multiplier: 0.475
+      whitelist:
+        components:
+        - XenoHeavy
   - type: EggPlantTime
     plantTime: 1
   - type: WhitelistPickup

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/crusher.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/crusher.yml
@@ -36,6 +36,7 @@
     tier: 3
     hudOffset: 0,0.375
     unlockAt: 900 # 15 minutes
+  - type: XenoHeavy
   - type: XenoDevolve
     devolvesTo:
     - CMXenoWarrior
@@ -74,7 +75,19 @@
     baseWalkSpeed: 1.66
     baseSprintSpeed: 3
   - type: SlowOnPull
-    multiplier: 0.5
+    slowdowns:
+    - multiplier: 0.68
+      whitelist:
+        components:
+        - Marine
+    - multiplier: 0.755
+      whitelist:
+        components:
+        - XenoLight
+    - multiplier: 0.5275
+      whitelist:
+        components:
+        - XenoHeavy
   - type: XenoBrutalize
   - type: RMCSize
     size: Immobile

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/defender.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/defender.yml
@@ -37,6 +37,7 @@
     tier: 1
     hudOffset: 0,0.2
     unlockAt: 240 # 4 minutes
+  - type: XenoLight
   - type: XenoDevolve
     devolvesTo:
     - CMXenoLarva

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/drone.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/drone.yml
@@ -31,6 +31,7 @@
     tier: 1
     bypassTierCount: true
     unlockAt: 60 # 1 minute
+  - type: XenoLight
   - type: XenoDevolve
     devolvesTo:
     - CMXenoLarva

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/hivelord.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/hivelord.yml
@@ -41,6 +41,7 @@
     tier: 2
     hudOffset: 0,0.35
     unlockAt: 180 # 3 minutes
+  - type: XenoHeavy
   - type: XenoDevolve
     devolvesTo:
     - CMXenoDrone
@@ -75,7 +76,19 @@
     baseWalkSpeed: 1.66
     baseSprintSpeed: 3
   - type: SlowOnPull
-    multiplier: 0.5
+    slowdowns:
+    - multiplier: 0.6925
+      whitelist:
+        components:
+        - Marine
+    - multiplier: 0.765
+      whitelist:
+        components:
+        - XenoLight
+    - multiplier: 0.53
+      whitelist:
+        components:
+        - XenoHeavy
   - type: WhitelistPickup
     whitelist:
       components:

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/larva.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/larva.yml
@@ -30,6 +30,7 @@
     unlockAt: 0
     healOffWeeds: true
     emoteSounds: Larva
+  - type: XenoLight
   - type: XenoPlasma
     maxPlasma: 10
     plasmaRegenOnWeeds: 0.1

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lesser_drone.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lesser_drone.yml
@@ -41,6 +41,7 @@
     contributesToVictory: false
     countedInSlots: false
     unlockAt: 0
+  - type: XenoLight
   - type: XenoAcid
   - type: XenoConstruction
     buildDelay: 4

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lurker.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lurker.yml
@@ -36,6 +36,7 @@
     tier: 2
     hudOffset: 0,0.16
     unlockAt: 540 # 9 minutes
+  - type: XenoLight
   - type: XenoDevolve
     devolvesTo:
     - CMXenoRunner
@@ -71,6 +72,20 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.7
     baseSprintSpeed: 5
+  - type: SlowOnPull
+    slowdowns:
+    - multiplier: 0.53
+      whitelist:
+        components:
+        - Marine
+    - multiplier: 0.59
+      whitelist:
+        components:
+        - XenoLight
+    - multiplier: 0.375
+      whitelist:
+        components:
+        - XenoHeavy
   - type: RMCXenoDamageVisuals
     prefix: lurker
   - type: TacticalMapIcon

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/praetorian.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/praetorian.yml
@@ -39,6 +39,7 @@
     tier: 3
     hudOffset: 0,0.16
     unlockAt: 900 # 15 minutes
+  - type: XenoHeavy
   - type: XenoDevolve
     devolvesTo:
     - CMXenoWarrior
@@ -96,7 +97,19 @@
       state: praetorian
   - type: AcidTrap
   - type: SlowOnPull
-    multiplier: 0.5
+    slowdowns:
+    - multiplier: 0.5875
+      whitelist:
+        components:
+        - Marine
+    - multiplier: 0.645
+      whitelist:
+        components:
+        - XenoLight
+    - multiplier: 0.4275
+      whitelist:
+        components:
+        - XenoHeavy
 
 - type: entity
   parent: CMXenoPraetorianBase
@@ -168,3 +181,17 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.2
     baseSprintSpeed: 3.4
+  - type: SlowOnPull
+    slowdowns:
+    - multiplier: 0.64
+      whitelist:
+        components:
+        - Marine
+    - multiplier: 0.7025
+      whitelist:
+        components:
+        - XenoLight
+    - multiplier: 0.475
+      whitelist:
+        components:
+        - XenoHeavy

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
@@ -61,6 +61,7 @@
     tier: 0
     bypassTierCount: true
     unlockAt: 0
+  - type: XenoHeavy
   - type: XenoAcid
   - type: XenoConstruction
     canBuild:
@@ -114,7 +115,19 @@
     baseWalkSpeed: 1.4
     baseSprintSpeed: 2.5
   - type: SlowOnPull
-    multiplier: 0.5
+    slowdowns:
+    - multiplier: 0.505
+      whitelist:
+        components:
+        - Marine
+    - multiplier: 0.5475
+      whitelist:
+        components:
+        - XenoLight
+    - multiplier: 0.43
+      whitelist:
+        components:
+        - XenoHeavy
   - type: MobMover
   - type: FootstepModifier
     footstepSoundCollection:

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/ravager.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/ravager.yml
@@ -37,6 +37,7 @@
     hudOffset: 0,0.1
     unlockAt: 900 # 15 minutes
     hidden: true # TODO RMC: remove once ravager is implemented
+  - type: XenoHeavy
   - type: XenoDevolve
     devolvesTo:
     - CMXenoLurker
@@ -84,7 +85,19 @@
     baseWalkSpeed: 2
     baseSprintSpeed: 3.5
   - type: SlowOnPull
-    multiplier: 0.5
+    slowdowns:
+    - multiplier: 0.6125
+      whitelist:
+        components:
+        - Marine
+    - multiplier: 0.6675
+      whitelist:
+        components:
+        - XenoLight
+    - multiplier: 0.445
+      whitelist:
+        components:
+        - XenoHeavy
   - type: RMCSize
     size: Big
 #  - type: RMCXenoDamageVisuals # TODO RMC14

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/runner.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/runner.yml
@@ -58,6 +58,7 @@
     tier: 1
     hudOffset: 0,0.63
     unlockAt: 300 # 5 minutes
+  - type: XenoLight
   - type: XenoDevolve
     devolvesTo:
     - CMXenoLarva
@@ -91,6 +92,20 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 5.55
     baseSprintSpeed: 10
+  - type: SlowOnPull
+    slowdowns:
+    - multiplier: 0.3825
+      whitelist:
+        components:
+        - Marine
+    - multiplier: 0.425
+      whitelist:
+        components:
+        - XenoLight
+    - multiplier: 0.24
+      whitelist:
+        components:
+        - XenoHeavy
   - type: RMCSize
     size: SmallXeno
   - type: RMCXenoDamageVisuals

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/sentinel.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/sentinel.yml
@@ -37,6 +37,7 @@
     tier: 1
     hudOffset: 0,0.157
     unlockAt: 300 # 5 minutes
+  - type: XenoLight
   - type: XenoDevolve
     devolvesTo:
     - CMXenoLarva

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/spitter.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/spitter.yml
@@ -37,6 +37,7 @@
     tier: 2
     hudOffset: 0,0.16
     unlockAt: 540 # 9 minutes
+  - type: XenoHeavy
   - type: XenoDevolve
     devolvesTo:
     - CMXenoSentinel
@@ -75,6 +76,20 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 2
     baseSprintSpeed: 3.5
+  - type: SlowOnPull
+    slowdowns:
+    - multiplier: 0.6375
+      whitelist:
+        components:
+        - Marine
+    - multiplier: 0.7075
+      whitelist:
+        components:
+        - XenoLight
+    - multiplier: 0.475
+      whitelist:
+        components:
+        - XenoHeavy
   - type: RMCXenoDamageVisuals
     prefix: spitter
   - type: TacticalMapIcon

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/warrior.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/warrior.yml
@@ -36,6 +36,7 @@
     tier: 2
     hudOffset: 0,0.25
     unlockAt: 540 # 9 minutes
+  - type: XenoLight
   - type: XenoDevolve
     devolvesTo:
     - CMXenoDefender
@@ -65,6 +66,20 @@
   - type: Tackle # min: 2, max: 4
     threshold: 4
     stun: 5
+  - type: SlowOnPull
+    slowdowns:
+    - multiplier: 0.4525
+      whitelist:
+        components:
+        - Marine
+    - multiplier: 0.5025
+      whitelist:
+        components:
+        - XenoLight
+    - multiplier: 0.3625
+      whitelist:
+        components:
+        - XenoHeavy
   - type: XenoLifesteal
   - type: RMCXenoDamageVisuals
     prefix: warrior


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
This PR entirely reworks pull speeds across the board on a per-xeno basis to 1:1 match CM13's pull speeds, as our pull speeds were nowhere near accurate. This includes a heavy -25% nerf to Runner's pull speed as well as -10% to Warrior's, as well as fixing every other Xeno's (and Marine's!) pull speed. Chart showing the accurate pull speeds below. 

![image](https://github.com/user-attachments/assets/74ae1e75-f501-4f96-9a06-dbb036b72164)

The SlowOnPull component has been reworked to use the puller's values instead of the pulled target's values for speed, and has 3 different types of pulling: Marine, Xeno Light, and Xeno Heavy, just like how 13 handles it.

**Methodology**
I manually recorded every single Xeno and Xeno strain's pull speed in Tiles per Second on CM13 on various targets: Marine, Light Xeno (Runner), and Heavy Xeno (Crusher), as the way they calculate speed isn't compatible with ours. I then verified which Xeno fit in which group, and if the groups could change on Size increase (they could not).

The CM13 speeds were then recreated in RMC14 by observing the physics component's LinearVelocity, adjusting the ratio until the two numbers were as close to each other as possible, using a fixed step size of 0.0025 in the multiplier.

All observations recorded in a spreadsheet here: https://docs.google.com/spreadsheets/d/1R3rwyPR-ycfzGCg9SvlM3wZzngwuH2WwpUhjhSeq9g4/edit?usp=sharing

## Why / Balance
Pure, raw CM13 parity. Nerfs Runner + Queen strats, buffs Marine pulling, minorly buffs other Xenos when capping marines but makes it harder to save fellow Xenos due to Xenos-pulling-Xenos being nerfed heavily, especially when pulling High Value Targets like Tier 3s and Hivelords. Makes it easier for Marines to secure kills without a Runner instantly taking a crit Tier 3 off screen behind resin.

## Technical details
Reworks SlowOnPull's implementation in RMCPullingSystem to use the puller's speed values depending on what they're pulling, instead of everything of a certain type reading from the pulled object's speed values. Xeno Pull Speeds are way too individualized and variable for the former approach.

Adds XenoLight and XenoHeavy as components that affect pulling tier speed. RMCSize was not sufficient for this implementation as the Defender must always be treated as a light Xeno regardless of how much it mechanically increases its size when it Crests.

## Media
Video Demonstration (Compressed to fit on GitHub, uncompressed version available in Discord, any specific testing available upon request in Discord)
https://github.com/user-attachments/assets/1069e83e-2703-4194-bfb4-4ae9bd831354

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- tweak: Runner's pulling speed on marines has been decreased by about ~23.5%, moving slightly slower than a Marine wearing Heavy Armor.
- tweak: Warrior's pulling speed on marines has been decreased by about ~10%.
- tweak: All other Xenos pull Marines somewhat faster.
- tweak: Marines now pull other Marines faster.
- tweak: All Xenos besides Hivelord and Crusher now pull other Xenos slower.
- tweak: Hivelords and Crushers now pull other Xenos faster.
- tweak: Marines now pull Xeno corpses faster.


