### PR TITLE
Fix Scout Gear being Acidable

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Back/satchels.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Back/satchels.yml
@@ -57,6 +57,8 @@
       - ScoutWhitelist
     cloakSound: /Audio/_RMC14/Effects/Cloak/cloak_scout_on.ogg
     uncloakSound: /Audio/_RMC14/Effects/Cloak/cloak_scout_off.ogg
+  - type: Corrodible
+    isCorrodible: false
 
 - type: entity
   parent: CMSatchel

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m4spr_scout_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m4spr_scout_rifle.yml
@@ -38,6 +38,8 @@
     whitelist:
       components:
       - ScoutWhitelist
+  - type: Corrodible
+    isCorrodible: false
   - type: Clothing
     sprite: _RMC14/Objects/Weapons/Guns/Rifles/m4spr_custom.rsi
   - type: MeleeWeapon


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Fixes Xenos being able to acid the Scout's M4SPR custom battle rifle and M68 Thermal Cloak.

## Why / Balance
CM13 Parity. Critical Weapon Specialist-exclusive gear is not supposed to be able to be destroyed so easily.

## Media
![image](https://github.com/user-attachments/assets/aacbb86e-ea71-4b09-8c24-98c91c816695)

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- fix: Fixed xenonids being able to apply acid to the Scout Weapon Specialist's Rifle and Thermal Cloak.

