### PR TITLE
Add marineIcon toolshed command

### DIFF
--- a/Content.Server/_RMC14/Marines/Icons/IconCommand.cs
+++ b/Content.Server/_RMC14/Marines/Icons/IconCommand.cs
@@ -1,0 +1,82 @@
+using System.Linq;
+using Content.Server.Administration;
+using Content.Shared._RMC14.Marines;
+using Content.Shared.Administration;
+using Robust.Shared.Toolshed;
+using Robust.Shared.Utility;
+
+namespace Content.Server._RMC14.Marines.Icons;
+
+[ToolshedCommand, AdminCommand(AdminFlags.VarEdit)]
+public sealed class IconCommand : ToolshedCommand
+{
+    private SharedMarineSystem? _marineSystem;
+
+    [CommandImplementation("get_human_readable")]
+    public String? GetHumanReadable([PipedArgument] EntityUid marine)
+    {
+        SpriteSpecifier? icon = EntityManager.GetComponentOrNull<MarineComponent>(marine)?.Icon;
+
+        switch (icon)
+        {
+            case SpriteSpecifier.Texture t:
+                return "Texture path: " + t.TexturePath.CanonPath;
+            case SpriteSpecifier.Rsi r:
+                return "RSI: " + r.RsiPath.Filename + "+" + r.RsiState;
+            case SpriteSpecifier.EntityPrototype e:
+                return "EntityPrototype: " + e.EntityPrototypeId;
+            case null:
+                return "No icon.";
+            default:  // This case should, in theory, never be hit. The above four cases cover all options.
+                return "Something is very wrong here.";
+        }
+    }
+
+    [CommandImplementation("get")]
+    public SpriteSpecifier? Get([PipedArgument] EntityUid marine)
+    {
+        return EntityManager.GetComponentOrNull<MarineComponent>(marine)?.Icon;
+    }
+
+    [CommandImplementation("set")]
+    public EntityUid Set([CommandInvocationContext] IInvocationContext ctx,
+        [PipedArgument] EntityUid marine,
+        [CommandArgument] String rsiState)
+    {
+        _marineSystem ??= GetSys<SharedMarineSystem>();
+
+        SpriteSpecifier.Rsi icon = new SpriteSpecifier.Rsi(new("_RMC14/Interface/cm_job_icons.rsi"), rsiState);
+
+        // TODO RMC14: Make this idiot proof. Right now it's very easy to cause this command to render a big ol' error on everyone's screen.
+
+        _marineSystem.SetMarineIcon(marine, icon);
+
+        return marine;
+    }
+
+    [CommandImplementation("set")]
+    public IEnumerable<EntityUid> Set([CommandInvocationContext] IInvocationContext ctx,
+        [PipedArgument] IEnumerable<EntityUid> marines,
+        [CommandArgument] String rsiState)
+    {
+        return marines.Select(marine => Set(ctx, marine, rsiState));
+    }
+
+    [CommandImplementation("del")]
+    public EntityUid Del([CommandInvocationContext] IInvocationContext ctx,
+        [PipedArgument] EntityUid marine)
+    {
+        _marineSystem ??= GetSys<SharedMarineSystem>();
+
+        _marineSystem.ClearMarineIcon(marine);
+
+        return marine;
+    }
+
+    [CommandImplementation("del")]
+    public IEnumerable<EntityUid> Del([CommandInvocationContext] IInvocationContext ctx,
+        [PipedArgument] IEnumerable<EntityUid> marines)
+    {
+        return marines.Select(marine => Del(ctx, marine));
+    }
+}

--- a/Content.Shared/_RMC14/Marines/SharedMarineSystem.cs
+++ b/Content.Shared/_RMC14/Marines/SharedMarineSystem.cs
@@ -57,6 +57,24 @@ public abstract class SharedMarineSystem : EntitySystem
         return ev;
     }
 
+    public void SetMarineIcon(EntityUid marine, SpriteSpecifier specifier)
+    {
+        if (TryComp<MarineComponent>(marine, out var comp))
+        {
+            comp.Icon = specifier;
+            Dirty(marine, comp);
+        }
+    }
+
+    public void ClearMarineIcon(EntityUid marine)
+    {
+        if (TryComp<MarineComponent>(marine, out var comp))
+        {
+            comp.Icon = null;
+            Dirty(marine, comp);
+        }
+    }
+
     public void MakeMarine(EntityUid uid, SpriteSpecifier? icon)
     {
         var marine = EnsureComp<MarineComponent>(uid);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Adds an admin command to modify marine icons of entities.

Usage:
- `self nearby 5 with Marine icon:set "hudsquad_pvm"`: Sets all marines' icons within 5 tiles from you to be provost marshals (I think).
- `self icon:set "hudsquad_mt"`: Set your icon to maint tech.
- ...

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Because having to type an entire sprite path every time irked me. Also because I accidentally demoted all past, present and future CMO's to Doctor once.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Had to make some helper methods in SharedMarineSystem cause only that has write access to the Marine component.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
ADMIN:
- add: Marine icon command.
