### PR TITLE
Make parasite traps more consistent

### DIFF
--- a/Content.Server/_RMC14/Xenonids/Construction/ResinHole/XenoResinHoleSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Construction/ResinHole/XenoResinHoleSystem.cs
@@ -486,6 +486,9 @@ public sealed partial class XenoResinHoleSystem : SharedXenoResinHoleSystem
         {
             var trapEntity = SpawnAtPosition(trapEntityProto, _transform.GetMoverCoordinates(resinHole));
             _hive.SetSameHive(resinHole.Owner, trapEntity);
+
+            if (trapEntityProto == XenoResinHoleComponent.ParasitePrototype)
+                EnsureComp<TrapParasiteComponent>(trapEntity);
         }
 
         string msg = destroyed ? "cm-xeno-construction-resin-hole-destroyed" : "rmc-xeno-construction-resin-hole-activate";

--- a/Content.Shared/_RMC14/Xenonids/Construction/ResinHole/XenoResinHoleComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/ResinHole/XenoResinHoleComponent.cs
@@ -31,7 +31,7 @@ public sealed partial class XenoResinHoleComponent : Component
     public EntProtoId? TrapPrototype = null;
 
     [DataField]
-    public TimeSpan StepStunDuration = TimeSpan.FromSeconds(2.5);
+    public TimeSpan StepStunDuration = TimeSpan.FromSeconds(2.0);
 
     [DataField]
     public TimeSpan AddParasiteDelay = TimeSpan.FromSeconds(3.0);

--- a/Content.Shared/_RMC14/Xenonids/Leap/XenoLeapComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Leap/XenoLeapComponent.cs
@@ -1,11 +1,12 @@
-﻿using Content.Shared.FixedPoint;
+﻿using Content.Shared._RMC14.Xenonids.Parasite;
+using Content.Shared.FixedPoint;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared._RMC14.Xenonids.Leap;
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-[Access(typeof(XenoLeapSystem))]
+[Access(typeof(XenoLeapSystem), typeof(SharedXenoParasiteSystem))]
 public sealed partial class XenoLeapComponent : Component
 {
     [DataField, AutoNetworkedField]

--- a/Content.Shared/_RMC14/Xenonids/Parasite/TrapParasiteComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Parasite/TrapParasiteComponent.cs
@@ -1,0 +1,23 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.Parasite;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+
+public sealed partial class TrapParasiteComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public TimeSpan JumpTime = TimeSpan.FromSeconds(1.5);
+
+	[DataField, AutoNetworkedField]
+	public TimeSpan DisableTime = TimeSpan.FromSeconds(0.25);
+
+	[DataField, AutoNetworkedField]
+    public TimeSpan LeapAt;
+
+	[DataField, AutoNetworkedField]
+	public TimeSpan DisableAt;
+
+	[DataField, AutoNetworkedField]
+    public TimeSpan NormalLeapDelay;
+}


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Resin traps filled with parasites will now have the parasites not do any doafters; Instead after 1.5 seconds the parasite will perform and instant leap/infect on the nearest person available.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Parity. In CM the parasite is forced sleeped for 1.5 seconds and then forced to leap at a target. This is pretty close.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
New comp, TrapParasiteComponent, which is added to parasites from activated traps. It modifies the parasite's leap time and infect also changes it's doafter time when it's detected. When removed the leap time is put back to normal.

After 1.5 seconds the NPC is woken up and the AI takes over the rest. A few things will remove the comp (Time, Becoming a player, being picked up, getting a leap/infection off)

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

https://github.com/user-attachments/assets/4d49ac9a-86e1-4713-9df5-68e13606e3b0


https://github.com/user-attachments/assets/1a0dcdc5-88ce-458f-a08b-72a1050202ab


## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- fix: Fixed parasite trap inconsistencies. They now stun for less (2.5->2.0 seconds) but parasites will now no longer do a doafter and will instant leap/infect anyone in their radius after 1.5 seconds
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
