### PR TITLE
Show Parasite Ghost Cooldown Timer

### DIFF
--- a/Content.Server/_RMC14/Xenonids/Parasite/XenoParasiteRoleSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Parasite/XenoParasiteRoleSystem.cs
@@ -80,10 +80,12 @@ public sealed class XenoEggRoleSystem : EntitySystem
         if (!TryComp(user, out GhostComponent? ghostComp))
             return false;
 
+        var timeSinceDeath = _gameTiming.CurTime.Subtract(ghostComp.TimeOfDeath);
+
         // Must have been dead for 3 minutes
-        if (_gameTiming.CurTime.Subtract(ghostComp.TimeOfDeath) < TimeSpan.FromMinutes(3))
+        if (timeSinceDeath < TimeSpan.FromMinutes(3))
         {
-            _popup.PopupEntity(Loc.GetString("rmc-xeno-egg-ghost-need-time"), user, user, PopupType.MediumCaution);
+            _popup.PopupEntity(Loc.GetString("rmc-xeno-egg-ghost-need-time", ("seconds", 180 - (int)timeSinceDeath.TotalSeconds)), user, user, PopupType.MediumCaution);
             return false;
         }
 

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-eggs.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-eggs.ftl
@@ -16,7 +16,7 @@ rmc-xeno-egg-return-self = {CAPITALIZE($parasite)} crawls back into the egg.
 rmc-xeno-egg-return = {CAPITALIZE($user)} slides {$parasite} back into the egg.
 
 rmc-xeno-egg-ghost-verb = Become parasite
-rmc-xeno-egg-ghost-need-time = You ghosted too recently. You cannot become a parasite until 3 minutes have passed.
+rmc-xeno-egg-ghost-need-time = You ghosted too recently. You cannot become a parasite until 3 minutes have passed ({$seconds} seconds remaining).
 rmc-xeno-egg-ghost-confirm = Are you sure you want to become a parasite?
 
 rmc-xeno-egg-throw-xeno = Throwing the egg would break it!


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Shows the time until you can take a Parasite ghost role from an Egg/Carrier in seconds. Displayed in raw seconds instead of minutes/seconds because CM13 does it this way and also the popup message is already incredibly long as is.

## Why / Balance
CM13 Parity. You should not have to run an external timer or check your system clock to know when you can play parasite again.

Resolves #4484 

## Media
![image](https://github.com/user-attachments/assets/834c329e-c9f2-4824-aa33-444cf89f80c8)

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**

:cl:
- add: The remaining time until you are allowed to become a Parasite is now told to the player when attempting to take a Parasite ghost role from an Egg/Carrier.
