### PR TITLE
Fix Shotgun + Grenade Launcher ammo counters not updating when loaded

### DIFF
--- a/Content.Client/Weapons/Ranged/Systems/GunSystem.AmmoCounter.cs
+++ b/Content.Client/Weapons/Ranged/Systems/GunSystem.AmmoCounter.cs
@@ -45,20 +45,21 @@ public sealed partial class GunSystem
         UpdateAmmoCount(uid, component);
     }
 
-    private void UpdateAmmoCount(EntityUid uid, AmmoCounterComponent component)
+    private void UpdateAmmoCount(EntityUid uid, AmmoCounterComponent component, int artificialIncrease = 0)
     {
         if (component.Control == null)
             return;
 
         var ev = new UpdateAmmoCounterEvent()
         {
-            Control = component.Control
+            Control = component.Control,
+            ArtificialIncrease = artificialIncrease
         };
 
         RaiseLocalEvent(uid, ev, false);
     }
 
-    protected override void UpdateAmmoCount(EntityUid uid, bool prediction = true)
+    protected override void UpdateAmmoCount(EntityUid uid, bool prediction = true, int artificialIncrease = 0)
     {
         // Don't use resolves because the method is shared and there's no compref and I'm trying to
         // share as much code as possible
@@ -68,7 +69,7 @@ public sealed partial class GunSystem
             return;
         }
 
-        UpdateAmmoCount(uid, clientComp);
+        UpdateAmmoCount(uid, clientComp, artificialIncrease);
     }
 
     /// <summary>
@@ -85,6 +86,7 @@ public sealed partial class GunSystem
     public sealed class UpdateAmmoCounterEvent : HandledEntityEventArgs
     {
         public Control Control = default!;
+        public int ArtificialIncrease = 0;
     }
 
     #region Controls

--- a/Content.Client/Weapons/Ranged/Systems/GunSystem.Ballistic.cs
+++ b/Content.Client/Weapons/Ranged/Systems/GunSystem.Ballistic.cs
@@ -19,7 +19,7 @@ public sealed partial class GunSystem
     {
         if (args.Control is DefaultStatusControl control)
         {
-            control.Update(GetBallisticShots(component), component.Capacity);
+            control.Update(GetBallisticShots(component) + args.ArtificialIncrease, component.Capacity);
         }
     }
 

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
@@ -290,6 +290,8 @@ public abstract partial class SharedGunSystem
             if (CompOrNull<CartridgeAmmoComponent>(used)?.SoundInsert is { } sound)
                 Audio.PlayPredicted(sound, uid, user);
 
+            UpdateAmmoCount(uid, artificialIncrease: 1);
+
             if (_netManager.IsClient)
                 return;
         }
@@ -297,9 +299,11 @@ public abstract partial class SharedGunSystem
         // Reused function moved here.
         component.Entities.Add(used);
         Containers.Insert(used, component.Container);
+        Dirty(uid, component);
         // Not predicted so
         Audio.PlayPredicted(component.SoundInsert, uid, user);
         UpdateBallisticAppearance(uid, component);
+        UpdateAmmoCount(uid);
         Dirty(uid, component);
         return;
     }

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -933,7 +933,7 @@ public abstract partial class SharedGunSystem : EntitySystem
     /// <summary>
     /// Call this whenever the ammo count for a gun changes.
     /// </summary>
-    protected virtual void UpdateAmmoCount(EntityUid uid, bool prediction = true) {}
+    protected virtual void UpdateAmmoCount(EntityUid uid, bool prediction = true, int artificialIncrease = 0) {}
 
     protected void SetCartridgeSpent(EntityUid uid, CartridgeAmmoComponent cartridge, bool spent)
     {


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Fixes the ammo counter for Grenade Launchers, Shotguns, and other non-magazine fed ballistic weapons to update when ammo is manually inserted.

## Why / Balance
Bug fix, it doesn't do anything at all currently when being loaded, only when being taken out or shot.

## Technical details
Grenade Launchers are fixed by a simple UpdateAmmoCounter call

Shotguns had to be more involved, since Handfuls completely deprive the client of information regarding how much ammo is loaded until after the ammo is already inserted, due to returning if the client reaches it. The ammo counter is entirely client sided so the server does nothing, and you can't make the loading un-client-sided without introducing entirely different bugs (it causes the handful to disappear when loading, spam swapping your weapon hand if loading too quickly)

To circumvent this I added an int field named ArtificialIncrease to UpdateAmmoCounter that allows us to spoof ammo being loaded since its all in the client, even if it hasn't been loaded yet. This is helpful in this specific use case as we know the amount of ammo we load from a handful will always be exactly one, so we can just tell it we are loading one shell and it works very well, while still letting you load the shotgun fast.

## Media
Video Demonstration

https://github.com/user-attachments/assets/775eb26a-7dc7-4ca4-b82a-290f6f56a9d9

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**

:cl:
- fix: Shotguns and Grenade Launchers now correctly display ammo when being loaded.

