### PR TITLE
Fixes xeno free slots + fix devolve identifiers

### DIFF
--- a/Content.Server/_RMC14/NameIdentifier/RMCNameIdentifierSystem.cs
+++ b/Content.Server/_RMC14/NameIdentifier/RMCNameIdentifierSystem.cs
@@ -14,10 +14,22 @@ public sealed class RMCNameIdentifierSystem : EntitySystem
     public override void Initialize()
     {
         SubscribeLocalEvent<NameIdentifierComponent, NewXenoEvolvedEvent>(OnNewXenoEvolved);
+        SubscribeLocalEvent<NameIdentifierComponent, XenoDevolvedEvent>(OnXenoDevolved);
         SubscribeLocalEvent<TransferNameIdentifierComponent, AfterNewXenoEvolvedEvent>(OnAfterNewXenoEvolved);
     }
 
     private void OnNewXenoEvolved(Entity<NameIdentifierComponent> ent, ref NewXenoEvolvedEvent args)
+    {
+        if (!TryComp(args.OldXeno, out NameIdentifierComponent? nameIdentifier))
+            return;
+
+        var transfer = EnsureComp<TransferNameIdentifierComponent>(ent);
+        transfer.FullIdentifier = nameIdentifier.FullIdentifier;
+        transfer.Identifier = nameIdentifier.Identifier;
+        transfer.Group = nameIdentifier.Group;
+    }
+
+    private void OnXenoDevolved(Entity<NameIdentifierComponent> ent, ref XenoDevolvedEvent args)
     {
         if (!TryComp(args.OldXeno, out NameIdentifierComponent? nameIdentifier))
             return;

--- a/Content.Server/_RMC14/NameIdentifier/RMCNameIdentifierSystem.cs
+++ b/Content.Server/_RMC14/NameIdentifier/RMCNameIdentifierSystem.cs
@@ -14,22 +14,10 @@ public sealed class RMCNameIdentifierSystem : EntitySystem
     public override void Initialize()
     {
         SubscribeLocalEvent<NameIdentifierComponent, NewXenoEvolvedEvent>(OnNewXenoEvolved);
-        SubscribeLocalEvent<NameIdentifierComponent, XenoDevolvedEvent>(OnXenoDevolved);
         SubscribeLocalEvent<TransferNameIdentifierComponent, AfterNewXenoEvolvedEvent>(OnAfterNewXenoEvolved);
     }
 
     private void OnNewXenoEvolved(Entity<NameIdentifierComponent> ent, ref NewXenoEvolvedEvent args)
-    {
-        if (!TryComp(args.OldXeno, out NameIdentifierComponent? nameIdentifier))
-            return;
-
-        var transfer = EnsureComp<TransferNameIdentifierComponent>(ent);
-        transfer.FullIdentifier = nameIdentifier.FullIdentifier;
-        transfer.Identifier = nameIdentifier.Identifier;
-        transfer.Group = nameIdentifier.Group;
-    }
-
-    private void OnXenoDevolved(Entity<NameIdentifierComponent> ent, ref XenoDevolvedEvent args)
     {
         if (!TryComp(args.OldXeno, out NameIdentifierComponent? nameIdentifier))
             return;

--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
@@ -227,11 +227,11 @@ public sealed class XenoEvolutionSystem : EntitySystem
 
         Del(xeno.Owner);
 
-        _popup.PopupEntity(Loc.GetString("rmc-xeno-evolution-devolve", ("xeno", newXeno)), newXeno, newXeno, PopupType.LargeCaution);
+                var afterEv = new AfterNewXenoEvolvedEvent();
+        RaiseLocalEvent(newXeno, ref afterEv);
 
-		var afterEv = new AfterNewXenoEvolvedEvent();
-		RaiseLocalEvent(newXeno, ref afterEv);
-	}
+        _popup.PopupEntity(Loc.GetString("rmc-xeno-evolution-devolve", ("xeno", newXeno)), newXeno, newXeno, PopupType.LargeCaution);
+    }
 
     private void OnXenoEvolveDoAfter(Entity<XenoEvolutionComponent> xeno, ref XenoEvolutionDoAfterEvent args)
     {

--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
@@ -401,10 +401,7 @@ public sealed class XenoEvolutionSystem : EntitySystem
                 existing++;
             }
 
-            if (_xenoHive.TryGetFreeSlots((oldHive, oldHive.Comp), newXeno, out var freeSlots))
-                existing -= freeSlots;
-
-            if (total != 0 && existing / (float) total >= limit)
+            if (total != 0 && existing / (float) total >= limit && !HasFreeSlotsAvailible(newXeno, oldHive))
             {
                 if (doPopup)
                 {
@@ -421,6 +418,15 @@ public sealed class XenoEvolutionSystem : EntitySystem
         }
 
         return true;
+    }
+
+    private bool HasFreeSlotsAvailible(EntProtoId caste, Entity<HiveComponent> hive)
+    {
+        if (!_xenoHive.TryGetFreeSlots((hive, hive.Comp), caste, out var freeSlots))
+            return false;
+
+        //Returns true if we have less than that caste for the slot (Assuming role Id = caste defined here, which it should)
+        return !HasLiving<XenoComponent>(freeSlots, e => e.Comp.Role.Id == caste);
     }
 
     private bool CanEvolveAny(Entity<XenoEvolutionComponent> xeno)

--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
@@ -227,7 +227,7 @@ public sealed class XenoEvolutionSystem : EntitySystem
 
         Del(xeno.Owner);
 
-                var afterEv = new AfterNewXenoEvolvedEvent();
+        var afterEv = new AfterNewXenoEvolvedEvent();
         RaiseLocalEvent(newXeno, ref afterEv);
 
         _popup.PopupEntity(Loc.GetString("rmc-xeno-evolution-devolve", ("xeno", newXeno)), newXeno, newXeno, PopupType.LargeCaution);

--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
@@ -228,7 +228,10 @@ public sealed class XenoEvolutionSystem : EntitySystem
         Del(xeno.Owner);
 
         _popup.PopupEntity(Loc.GetString("rmc-xeno-evolution-devolve", ("xeno", newXeno)), newXeno, newXeno, PopupType.LargeCaution);
-    }
+
+		var afterEv = new AfterNewXenoEvolvedEvent();
+		RaiseLocalEvent(newXeno, ref afterEv);
+	}
 
     private void OnXenoEvolveDoAfter(Entity<XenoEvolutionComponent> xeno, ref XenoEvolutionDoAfterEvent args)
     {
@@ -399,13 +402,13 @@ public sealed class XenoEvolutionSystem : EntitySystem
                 if (existingComp.Tier < newXenoComp.Tier)
                     continue;
 
-                if (slotCount.ContainsKey(newXeno) && slotCount[newXeno] > 0)
-                    slotCount[newXeno] -= 1;
+                if (slotCount.ContainsKey(existingComp.Role.Id) && slotCount[existingComp.Role.Id] > 0)
+                    slotCount[existingComp.Role.Id] -= 1;
                 else
                     existing++;
             }
 
-            if (total != 0 && existing / (float) total >= limit && !HasFreeSlotsAvailible(newXeno, oldHive))
+            if (total != 0 && existing / (float) total >= limit && (!slotCount.ContainsKey(newXeno) || slotCount[newXeno] <= 0))
             {
                 if (doPopup)
                 {
@@ -422,15 +425,6 @@ public sealed class XenoEvolutionSystem : EntitySystem
         }
 
         return true;
-    }
-
-    private bool HasFreeSlotsAvailible(EntProtoId caste, Entity<HiveComponent> hive)
-    {
-        if (!_xenoHive.TryGetFreeSlots((hive, hive.Comp), caste, out var freeSlots))
-            return false;
-
-        //Returns true if we have less than that caste for the slot (Assuming role Id = caste defined here, which it should)
-        return !HasLiving<XenoComponent>(freeSlots, e => e.Comp.Role.Id == caste);
     }
 
     private bool CanEvolveAny(Entity<XenoEvolutionComponent> xeno)

--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
@@ -388,6 +388,7 @@ public sealed class XenoEvolutionSystem : EntitySystem
             var existing = 0;
             var total = 0;
             var current = EntityQueryEnumerator<XenoComponent, HiveMemberComponent>();
+            var slotCount = oldHive.Comp.FreeSlots.ToDictionary();
             while (current.MoveNext(out var existingComp, out var member))
             {
                 if (member.Hive != oldHive.Owner || !existingComp.CountedInSlots)
@@ -398,7 +399,10 @@ public sealed class XenoEvolutionSystem : EntitySystem
                 if (existingComp.Tier < newXenoComp.Tier)
                     continue;
 
-                existing++;
+                if (slotCount.ContainsKey(newXeno) && slotCount[newXeno] > 0)
+                    slotCount[newXeno] -= 1;
+                else
+                    existing++;
             }
 
             if (total != 0 && existing / (float) total >= limit && !HasFreeSlotsAvailible(newXeno, oldHive))


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Title.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
It was bugged! Since it only minused from the existing tiers and only if you tried to evolve into that caste, it ran into weird issues. This should make it more inline with parity.

Fixes #4492 and fixes #4290

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
When checking for evos, a copy of the free slots dictionary is made. If it runs into a xeno who's Role Id matches the free slot and the free slots value is more than 0, it instead minuses from the free slot, making them not count towards existing t2s.

Instead of using the get free slots func, the dictionary that was used prior is used to check if the current caste we're going into has any free slots in it left, and won't return false if we do have more than 0.

The name identity fix just adds the evolve after event to devolving and also has the name identifier system for rmc subscribe to said devolve event.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

https://github.com/user-attachments/assets/75dc504b-6653-49e7-82f7-27a7623b53aa


https://github.com/user-attachments/assets/b5276729-9986-4ec4-a817-af7a0d654371


## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- fix: Fix identifiers not being preserved on devolve
- fix: Fix free slots not being 100% free. They will no longer count towards existing tier counts and will always be available no matter how many xenos of that tier are roaming about.