### PR TITLE
Barricade welding parity

### DIFF
--- a/Content.Shared/_RMC14/Repairable/RMCRepairableComponent.cs
+++ b/Content.Shared/_RMC14/Repairable/RMCRepairableComponent.cs
@@ -25,4 +25,7 @@ public sealed partial class RMCRepairableComponent : Component
 
     [DataField, AutoNetworkedField]
     public ProtoId<ToolQualityPrototype> Quality = "Welding";
+
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 FuelUsed = FixedPoint2.New(0);
 }

--- a/Content.Shared/_RMC14/Repairable/RMCRepairableSystem.cs
+++ b/Content.Shared/_RMC14/Repairable/RMCRepairableSystem.cs
@@ -1,12 +1,16 @@
 ﻿using Content.Shared._RMC14.Damage;
 using Content.Shared._RMC14.Marines.Skills;
+using Content.Shared.Chemistry.Components.SolutionManager;
+using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Damage;
 using Content.Shared.DoAfter;
 using Content.Shared.FixedPoint;
 using Content.Shared.Interaction;
+using Content.Shared.Item.ItemToggle.Components;
 using Content.Shared.Popups;
 using Content.Shared.Tools.Systems;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Network;
 
 namespace Content.Shared._RMC14.Repairable;
 
@@ -19,6 +23,11 @@ public sealed class RMCRepairableSystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SkillsSystem _skills = default!;
     [Dependency] private readonly SharedToolSystem _tool = default!;
+    [Dependency] private readonly SharedSolutionContainerSystem _solution = default!;
+    [Dependency] private readonly INetManager _net = default!;
+
+    const string SOLUTION_WELDER = "Welder";
+    const string REAGANT_WELDER = "WeldingFuel";
 
     public override void Initialize()
     {
@@ -50,10 +59,13 @@ public sealed class RMCRepairableSystem : EntitySystem
             return;
         }
 
+        if (!UseFuel(args.Used, args.User, repairable.Comp.FuelUsed, true))
+            return;
+
         var delay = repairable.Comp.Delay * _skills.GetSkillDelayMultiplier(args.User, repairable.Comp.Skill);
 
         var ev = new RMCRepairableDoAfterEvent();
-        var doAfter = new DoAfterArgs(EntityManager, user, delay, ev, repairable)
+        var doAfter = new DoAfterArgs(EntityManager, user, delay, ev, repairable, used: args.Used)
         {
             BreakOnMove = true,
             BlockDuplicate = true,
@@ -75,6 +87,9 @@ public sealed class RMCRepairableSystem : EntitySystem
 
         args.Handled = true;
 
+        if (args.Used == null || !UseFuel(args.Used.Value, args.User, repairable.Comp.FuelUsed))
+            return;
+
         var heal = _rmcDamageable.DistributeTypes(repairable.Owner, repairable.Comp.Heal);
         _damageable.TryChangeDamage(repairable, heal);
 
@@ -83,5 +98,34 @@ public sealed class RMCRepairableSystem : EntitySystem
         var othersMsg = Loc.GetString("rmc-repairable-finish-others", ("user", user), ("target", repairable));
         _popup.PopupPredicted(selfMsg, othersMsg, user, user);
         _audio.PlayPredicted(repairable.Comp.Sound, repairable, user);
+    }
+
+    public bool UseFuel(EntityUid tool, EntityUid user, FixedPoint2 fuelUsed, bool attempt = false)
+    {
+        if (!TryComp<SolutionContainerManagerComponent>(tool, out var welderCon))
+            return false;
+
+        if (!TryComp<ItemToggleComponent>(tool, out var toggle) || !toggle.Activated)
+        {
+            _popup.PopupClient(Loc.GetString("welder-component-welder-not-lit-message"), user, PopupType.SmallCaution);
+            return false;
+        }
+
+        if (!_solution.TryGetSolution((tool, welderCon), SOLUTION_WELDER, out var solutionComp, out var solution))
+            return false;
+
+        if (solution.GetTotalPrototypeQuantity(REAGANT_WELDER) == 0 || solution.GetTotalPrototypeQuantity(REAGANT_WELDER) < fuelUsed)
+        {
+            _popup.PopupClient(Loc.GetString("welder-component-no-fuel-message"), user, PopupType.SmallCaution);
+            return false;
+        }
+
+        if (!attempt && _net.IsServer)
+        {
+            _solution.RemoveReagent(solutionComp.Value, REAGANT_WELDER, fuelUsed);
+            Dirty(solutionComp.Value);
+        }
+
+        return true;
     }
 }

--- a/Resources/Prototypes/Entities/skills.yml
+++ b/Resources/Prototypes/Entities/skills.yml
@@ -13,6 +13,10 @@
   parent: RMCSkillBase
   id: RMCSkillConstruction
   name: Construction
+  components:
+  - type: SkillDefinition
+    delayMultipliers: [1, 1, 0.5]
+# Based on barricade weld times, 1 and 0 are full second, 2 is half
 
 - type: entity
   parent: RMCSkillBase

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Walls/barricade_metal.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Walls/barricade_metal.yml
@@ -245,7 +245,7 @@
     - type: Physics
     - type: RMCRepairable
       heal: -200
-      skills: RMCSkillConstruction
+      skill: RMCSkillConstruction
       delay: 10
       fuelUsed: 2
     - type: Damageable

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Walls/barricade_metal.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Walls/barricade_metal.yml
@@ -73,7 +73,11 @@
     messagePerceivedByOthers: fence-rattle-success
     interactSuccessSound:
       collection: FenceRattle
-  - type: Repairable
+  - type: RMCRepairable
+    heal: -200
+    skill: RMCSkillConstruction
+    delay: 10
+    fuelUsed: 2
   - type: Destructible
     thresholds:
     - trigger:
@@ -239,7 +243,11 @@
       - state: handrail_a_0
       - map: [ "acided" ]
     - type: Physics
-    - type: Repairable
+    - type: RMCRepairable
+      heal: -200
+      skills: RMCSkillConstruction
+      delay: 10
+      fuelUsed: 2
     - type: Damageable
       damageContainer: Inorganic
     - type: Destructible
@@ -338,7 +346,11 @@
       map: ["enum.DoorVisualLayers.Base"]
     - map: [ "acided" ]
     drawdepth: WallTops
-  - type: Repairable
+  - type: RMCRepairable
+    heal: -200
+    skill: RMCSkillConstruction
+    delay: 10
+    fuelUsed: 2
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Walls/barricade_plasteel.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Walls/barricade_plasteel.yml
@@ -37,7 +37,11 @@
     messagePerceivedByOthers: fence-rattle-success
     interactSuccessSound:
       collection: FenceRattle
-  - type: Repairable
+  - type: RMCRepairable
+    heal: -200
+    skill: RMCSkillConstruction
+    delay: 10
+    fuelUsed: 2
   - type: Destructible
     thresholds:
     - trigger:
@@ -156,7 +160,11 @@
       map: ["enum.DoorVisualLayers.Base"]
     - map: [ "acided" ]
     drawdepth: WallTops
-  - type: Repairable
+  - type: RMCRepairable
+    heal: -200
+    skill: RMCSkillConstruction
+    delay: 10
+    fuelUsed: 2
   - type: Destructible
     thresholds:
     - trigger:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Barricades now use the RMCRepairableSystem, which has been worked on to include what they need:
They take 5 seconds with 2 construction skill and 10 with anything lower.
They use 2 fuel on repair.
They heal only 200 health.
You can only weld 1 at once.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
parity! Fixes #3437, addresses parts of #4460. Boilers can't be avoided with a single ComTech :p

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Added fuel support to RMCRepairableSystem. Comp has it at 0 as alot of things in CM check it for if a welder is on and has ANY fuel.

Added skill defs for construction as that's whats used for barricade welding.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


https://github.com/user-attachments/assets/258e98a4-756b-4a8a-9857-33e716683002


https://github.com/user-attachments/assets/1f56f0ca-13a1-4f3e-9bda-2e17afaadbb0

(First is with con skill 2 and second is with none)
## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- fix: Fix being able to repair multiple cades at once. Welders also use the proper amount of fuel for this, and isn't canceled by damage.
- fix: Cades now heal 200 health on weld instead of all their health. They also now take 5 seconds to weld with construction skill 2 and 10 with 1 or 0 skill.
- fix: You can no longer weld sentries with a turned off or empty welder.
