### PR TITLE
allow gun melee weapons to be used while devoured

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Devour/GunUsableWhileDevouredComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Devour/GunUsableWhileDevouredComponent.cs
@@ -1,0 +1,12 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.Devour;
+
+/// <summary>
+/// For use on an entity with a <see cref="GunComponent"/>. This allows a gun to be usable when the parent entity is devoured.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(XenoDevourSystem))]
+public sealed partial class GunUsableWhileDevouredComponent : Component
+{
+}

--- a/Content.Shared/_RMC14/Xenonids/Devour/UsableWhileDevouredComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Devour/UsableWhileDevouredComponent.cs
@@ -12,4 +12,7 @@ public sealed partial class UsableWhileDevouredComponent : Component
 
     [DataField, AutoNetworkedField]
     public float AttackRateMultiplier = 0.55f;
+
+    [DataField, AutoNetworkedField]
+    public bool CanUnequip = false;
 }

--- a/Content.Shared/_RMC14/Xenonids/Devour/XenoDevourSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Devour/XenoDevourSystem.cs
@@ -21,6 +21,7 @@ using Content.Shared.Standing;
 using Content.Shared.Stunnable;
 using Content.Shared.Throwing;
 using Content.Shared.Weapons.Melee.Events;
+using Content.Shared.Weapons.Ranged.Events;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Network;
@@ -67,6 +68,7 @@ public sealed class XenoDevourSystem : EntitySystem
         SubscribeLocalEvent<DevouredComponent, IsEquippingAttemptEvent>(OnDevouredIsEquippingAttempt);
         SubscribeLocalEvent<DevouredComponent, IsUnequippingAttemptEvent>(OnDevouredIsUnequippingAttempt);
         SubscribeLocalEvent<DevouredComponent, AttackAttemptEvent>(OnDevouredAttackAttempt);
+        SubscribeLocalEvent<DevouredComponent, ShotAttemptedEvent>(OnDevouredShotAttempted);
 
         SubscribeLocalEvent<XenoDevourComponent, CanDropTargetEvent>(OnXenoCanDropTarget);
         SubscribeLocalEvent<XenoDevourComponent, ActivateInWorldEvent>(OnXenoActivate);
@@ -173,8 +175,16 @@ public sealed class XenoDevourSystem : EntitySystem
 
     private void OnDevouredIsUnequippingAttempt(Entity<DevouredComponent> devoured, ref IsUnequippingAttemptEvent args)
     {
-        // if (!HasComp<UsableWhileDevouredComponent>(args.Equipment))
+        if (TryComp<UsableWhileDevouredComponent>(args.Equipment, out var usableDevoured) && usableDevoured.CanUnequip)
+            return;
+
         args.Cancel();
+    }
+
+    private void OnDevouredShotAttempted(Entity<DevouredComponent> devoured, ref ShotAttemptedEvent args)
+    {
+        if (!HasComp<GunUsableWhileDevouredComponent>(args.Used))
+            args.Cancel();
     }
 
     private void OnXenoCanDropTarget(Entity<XenoDevourComponent> xeno, ref CanDropTargetEvent args)

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/cm_base_gun.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/cm_base_gun.yml
@@ -3,6 +3,8 @@
   parent: RMCBaseMeleeWeapon
   id: CMBaseWeaponGun
   components:
+  - type: UsableWhileDevoured
+    canUnequip: true
   - type: GunUnskilledPenalty
   - type: GunIFF
     enabled: false


### PR DESCRIPTION
## Why / Balance
CM13

## Technical details
adds ``GunUsableWhileDevouredComponent`` for guns that can be shot while devoured
adds ``CanUnequip`` bool to ``UsableWhileDevouredComponent``


https://github.com/user-attachments/assets/2de8b22b-f8e0-4931-8f2c-5906280d28ec



## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


:cl:
- tweak: Gun bayonets can now be used while devoured by a xenonid. You cannot shoot the gun, however.