### PR TITLE
Fix lizard snouts not being hidden by gas masks

### DIFF
--- a/Content.Shared/Clothing/EntitySystems/ClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/ClothingSystem.cs
@@ -109,18 +109,19 @@ public abstract class ClothingSystem : EntitySystem
                                 if (clothing.EquippedPrefix != mask.EquippedPrefix)
                                 {
                                     shouldLayerShow = false;
-                                    break;
+                                    continue;
                                 }
                             }
                             else
                             {
                                 shouldLayerShow = false;
-                                break;
+                                continue;
                             }
                         }
                     }
                 }
             }
+
             _humanoidSystem.SetLayerVisibility(equipee, layer, shouldLayerShow);
         }
     }

--- a/Content.Shared/Clothing/EntitySystems/ClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/ClothingSystem.cs
@@ -101,7 +101,7 @@ public abstract class ClothingSystem : EntitySystem
                 {
                     if (comp.Slots.Contains(layer))
                     {
-                        if (TryComp(item, out ClothingComponent? clothing) && clothing.Slots == slot.SlotFlags)
+                        if (TryComp(item, out ClothingComponent? clothing) && clothing.InSlot == slot.Name)
                         {
                             //Checks for mask toggling. TODO: Make a generic system for this
                             if (comp.HideOnToggle && TryComp(item, out MaskComponent? mask))

--- a/Content.Shared/Clothing/EntitySystems/ClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/ClothingSystem.cs
@@ -121,7 +121,6 @@ public abstract class ClothingSystem : EntitySystem
                     }
                 }
             }
-
             _humanoidSystem.SetLayerVisibility(equipee, layer, shouldLayerShow);
         }
     }

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Masks/masks.yml
@@ -19,8 +19,8 @@
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/Mask/gas.rsi
     slots:
-    - Suitstorage
     - Mask
+    - Suitstorage
   - type: Item
     size: Small
   - type: Tag

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Masks/masks.yml
@@ -19,8 +19,8 @@
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/Mask/gas.rsi
     slots:
-    - Mask
     - Suitstorage
+    - Mask
   - type: Item
     size: Small
   - type: Tag
@@ -68,6 +68,12 @@
     coverage: MOUTH
   - type: Item
     storedRotation: -90
+  - type: HideLayerClothing # TODO port pulled down sprite from SS13
+    slots:
+    - Hair
+    - Snout
+    - HeadTop
+    - HeadSide
 
 - type: entity
   parent: CMBaseMask


### PR DESCRIPTION
hide layer clothing system bulldozes the other layers because it breaks instead of continuing

hide layer clothing system also decides to check a SlotDefinition with SlotFlags, which causes the check to fail if the clothing item has more than one equipable slot (in this case, gas masks can fit on both suit storage and on mask slot)

also made coif hide humanoid layers because cm13 hides it too

resolves #4415

