### PR TITLE
surgery audio fixes part 2

### DIFF
--- a/Content.Shared/_RMC14/Medical/Surgery/SharedCMSurgerySystem.Steps.cs
+++ b/Content.Shared/_RMC14/Medical/Surgery/SharedCMSurgerySystem.Steps.cs
@@ -209,9 +209,9 @@ public abstract partial class SharedCMSurgerySystem
             foreach (var tool in validTools)
             {
                 if (TryComp(tool, out CMSurgeryToolComponent? toolComp) &&
-                    toolComp.EndSound != null)
+                    toolComp.StartSound != null)
                 {
-                    _audio.PlayEntity(toolComp.StartSound, user, tool);
+                    _audio.PlayPvs(toolComp.StartSound, tool);
                 }
             }
         }


### PR DESCRIPTION
part 2 of #4463

oversights, makes the start sound play for everyone, before it played for only the user
changes a broken check