### PR TITLE
Give me cigarettes and pens by the ears!

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/base_smokeables.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/base_smokeables.yml
@@ -36,6 +36,10 @@
         reagents:
           - ReagentId: Nicotine
             Quantity: 10
+  - type: Clothing
+    quickEquip: false
+    slots:
+    - Ears
 
 - type: entity
   parent: BaseSmokable

--- a/Resources/Prototypes/Entities/Objects/Misc/pen.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/pen.yml
@@ -26,6 +26,10 @@
         maxDistance: 2
   - type: UseDelay
     delay: 1.5
+  - type: Clothing
+    quickEquip: false
+    slots:
+    - Ears
 
 - type: entity
   parent: Pen


### PR DESCRIPTION
## About the PR
Smoked behind the school and forgot the cigarette behind your ear? No problem, no one cares in the army. Seriously though - why not, we'll have something to fill the slot.

## Why / Balance
For beauty and convenience, balance will not suffer.

## Technical details
Added clothing component to cigarettes and pen.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl: 
- add: Now you can put your cigarette/writing pen behind your ear.
