### PR TITLE
Fixed RMC Actions menu transforming into strain instead of base xenonid

### DIFF
--- a/Content.Client/_RMC14/Admin/RMCAdminEui.cs
+++ b/Content.Client/_RMC14/Admin/RMCAdminEui.cs
@@ -4,6 +4,7 @@ using Content.Shared._RMC14.Admin;
 using Content.Shared._RMC14.Marines.Squads;
 using Content.Shared._RMC14.Vendors;
 using Content.Shared._RMC14.Xenonids;
+using Content.Shared._RMC14.Xenonids.Strain;
 using Content.Shared.Eui;
 using Content.Shared.Humanoid.Prototypes;
 using JetBrains.Annotations;
@@ -64,6 +65,9 @@ public sealed class RMCAdminEui : BaseEui
         foreach (var entity in _prototypes.EnumeratePrototypes<EntityPrototype>())
         {
             if (entity.Abstract || !entity.TryGetComponent(out XenoComponent? xeno, _compFactory))
+                continue;
+
+            if (entity.TryGetComponent(out XenoStrainComponent? strain, _compFactory))
                 continue;
 
             if (!tiers.TryGetValue(xeno.Tier, out var xenos))


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The RMC Actions menu transforms you into a strain instead of the base xenonid
This happens with both the praetorian and drone
This PR fixes that

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug-fix

## Technical details
<!-- Summary of code changes for easier review. -->
Just a check for XenoStrainComponent

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Fixed RMC Actions menu transforming into strain instead of base xenonid.
