### PR TITLE
Leap now self-roots instead of self-stuns, Lurker Rework Part 2/3

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Leap/XenoLeapComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Leap/XenoLeapComponent.cs
@@ -32,4 +32,7 @@ public sealed partial class XenoLeapComponent : Component
 
     [DataField, AutoNetworkedField]
     public TimeSpan MoveDelayTime = TimeSpan.FromSeconds(.7);
+
+    [DataField, AutoNetworkedField]
+    public bool UnrootOnMelee = false;
 }

--- a/Content.Shared/_RMC14/Xenonids/Leap/XenoLeapSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Leap/XenoLeapSystem.cs
@@ -11,10 +11,12 @@ using Content.Shared.Mobs.Systems;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Events;
 using Content.Shared.Movement.Pulling.Systems;
+using Content.Shared.Movement.Systems;
 using Content.Shared.Popups;
 using Content.Shared.Pulling.Events;
 using Content.Shared.Standing;
 using Content.Shared.Stunnable;
+using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Network;
 using Robust.Shared.Physics;
@@ -34,6 +36,7 @@ public sealed class XenoLeapSystem : EntitySystem
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
+    [Dependency] private readonly MovementSpeedModifierSystem _movementSpeed = default!;
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
@@ -42,6 +45,7 @@ public sealed class XenoLeapSystem : EntitySystem
     [Dependency] private readonly SharedStunSystem _stun = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly XenoSystem _xeno = default!;
     [Dependency] private readonly XenoPlasmaSystem _xenoPlasma = default!;
 
     private EntityQuery<PhysicsComponent> _physicsQuery;
@@ -52,6 +56,7 @@ public sealed class XenoLeapSystem : EntitySystem
 
         SubscribeLocalEvent<XenoLeapComponent, XenoLeapActionEvent>(OnXenoLeapAction);
         SubscribeLocalEvent<XenoLeapComponent, XenoLeapDoAfterEvent>(OnXenoLeapDoAfter);
+        SubscribeLocalEvent<XenoLeapComponent, MeleeHitEvent>(OnXenoLeapMelee);
 
         SubscribeLocalEvent<XenoLeapingComponent, StartCollideEvent>(OnXenoLeapingDoHit);
         SubscribeLocalEvent<XenoLeapingComponent, ComponentRemove>(OnXenoLeapingRemove);
@@ -149,6 +154,28 @@ public sealed class XenoLeapSystem : EntitySystem
         }
     }
 
+    private void OnXenoLeapMelee(Entity<XenoLeapComponent> xeno, ref MeleeHitEvent args)
+    {
+        if (!xeno.Comp.UnrootOnMelee)
+            return;
+
+        if (!args.IsHit || args.HitEntities.Count == 0)
+            return;
+
+        foreach (var entity in args.HitEntities)
+        {
+            if (!_xeno.CanAbilityAttackTarget(xeno, entity))
+                return;
+        
+            if (TryComp<SlowedDownComponent>(xeno, out var root) && root.SprintSpeedModifier == 0f)
+            {
+                RemComp<SlowedDownComponent>(xeno);
+                _movementSpeed.RefreshMovementSpeedModifiers(xeno);
+            }
+            break;
+        }
+    }
+
     private void OnXenoLeapingDoHit(Entity<XenoLeapingComponent> xeno, ref StartCollideEvent args)
     {
         ApplyLeapingHitEffects(xeno, args.OtherEntity);
@@ -219,11 +246,12 @@ public sealed class XenoLeapSystem : EntitySystem
             victim.RecoverAt = _timing.CurTime + xeno.Comp.ParalyzeTime;
             Dirty(target, victim);
 
+            _stun.TrySlowdown(xeno, xeno.Comp.MoveDelayTime, true, 0f, 0f);
+
             if (_net.IsServer)
                 _stun.TryParalyze(target, xeno.Comp.ParalyzeTime, true);
         }
 
-        _stun.TryStun(xeno, xeno.Comp.MoveDelayTime, true);
         var ev = new XenoLeapHitEvent(xeno, target);
         RaiseLocalEvent(xeno, ref ev);
 

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lurker.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lurker.yml
@@ -54,9 +54,11 @@
   - type: XenoLeap
     plasmaCost: 20
     delay: 0
+    moveDelayTime: 1.5
     knockdownTime: 5
     leapSound: /Audio/_RMC14/Xeno/alien_pounce.ogg
     knockdownRequiresInvisibility: true
+    unrootOnMelee: true
   - type: XenoTurnInvisible
   - type: XenoCripplingStrike
   - type: XenoMeleeSlow


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
All Xeno Leaps now self-root instead of self-stun, keeping you stuck in place but still allowing you to attack, shove, and initiate grabs. This affects the Lurker and Runner, as they can now take actions while self-stunned. Parasites also are rooted, but don't have hands to do anything different with this, should be no change in behavior for them.

Lurker's self-root time has been largely increased to 1.5 seconds on an invisible leap (the ones that stun). Leaping as a Lurker while visible however, will not self-root at all.

Lurker now has its passive where if it attacks a Marine after leaping, it will instantly unroot itself, encouraging it to attack people instead of shove.

## Why / Balance
CM13 Parity

Resolves #4530 
Resolves #3968 

## Technical details
Converts TryStun() into TrySlowdown() with 0f/0f modifiers, similar to Crusher's Charge self-root.

Adds a new bool UnrootOnMelee and applies it to the Lurker. On attacking a valid target with melee, the Lurker will be unrooted if the SlowedComponent's multiplier is 0f. The 0f check is so that Lurkers don't unslow themselves when the Scout Weapons Specialist shoots them.

## Media
Video Demonstration
https://github.com/user-attachments/assets/1f0a0284-8ad3-493c-b758-781e0e007e60

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:
- fix: Fixed Leaps now self-stunning Xenos instead of self-rooting. This means Runners and Lurkers can attack, shove, and initiate grabs immediately after a leap without waiting, but still can not move.
- fix: Lurkers now self-root themselves for 1.5 seconds when leaping a Marine while invisible, up from 0.7 seconds.
- fix: Fixed Lurkers stunning themselves when leaping a marine while still visible.
- fix: Fixed Lurkers not un-rooting themselves when attacking Marines after a Leap.

