### PR TITLE
Fix Hive Core Warp Point only being on the under-construction version and not the completed one

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_hive.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_hive.yml
@@ -49,6 +49,8 @@
   - type: RoofingEntity
     range: 10
   - type: EvolutionBonus
+  - type: WarpPoint
+    location: hive core
 
 - type: entity
   id: HiveCoreXenoConstructionNode


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Currently, the hive core only has a warp point when it is not fully completed, and it goes away when being built. This fixes that.

## Why / Balance
Bug fix!

## Media
![image](https://github.com/user-attachments/assets/51728040-421a-4021-97c4-94df51a0b2a7)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**


:cl:
- fix: Fixed Hive Cores having their ghost warp points removed upon being fully constructed.
