### PR TITLE
Port Bipod 90 degree turning radius

### DIFF
--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -381,7 +381,7 @@ public abstract partial class SharedGunSystem : EntitySystem
 
         // Shoot confirmed - sounds also played here in case it's invalid (e.g. cartridge already spent).
         var projectiles = Shoot(gunUid, gun, ev.Ammo, fromCoordinates, toCoordinates.Value, out var userImpulse, user, throwItems: attemptEv.ThrowItems, predictedProjectiles, userSession);
-        var shotEv = new GunShotEvent(user, ev.Ammo);
+        var shotEv = new GunShotEvent(user, ev.Ammo, fromCoordinates, toCoordinates.Value);
         RaiseLocalEvent(gunUid, ref shotEv);
 
         if (userImpulse && TryComp<PhysicsComponent>(user, out var userPhysics))
@@ -1079,7 +1079,7 @@ public record struct AttemptShootEvent(EntityUid User, string? Message, bool Can
 /// </summary>
 /// <param name="User">The user that fired this gun.</param>
 [ByRefEvent]
-public record struct GunShotEvent(EntityUid User, List<(EntityUid? Uid, IShootable Shootable)> Ammo);
+public record struct GunShotEvent(EntityUid User, List<(EntityUid? Uid, IShootable Shootable)> Ammo, EntityCoordinates FromCoordinates, EntityCoordinates ToCoordinates);
 
 public enum EffectLayers : byte
 {

--- a/Content.Shared/_RMC14/Attachable/Components/AttachableSideLockedComponent.cs
+++ b/Content.Shared/_RMC14/Attachable/Components/AttachableSideLockedComponent.cs
@@ -1,0 +1,18 @@
+using Content.Shared._RMC14.Attachable.Systems;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Attachable.Components;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(AttachableToggleableSystem))]
+public sealed partial class AttachableSideLockedComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public List<EntityUid> AttachableList = new();
+
+    /// <summary>
+    /// The cardinal direction the attachments are locked into. In this case, direction is counted as a full 180 degrees, rather than 90.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public Direction? LockedDirection;
+}

--- a/Content.Shared/_RMC14/Attachable/Components/AttachableToggleableComponent.cs
+++ b/Content.Shared/_RMC14/Attachable/Components/AttachableToggleableComponent.cs
@@ -41,6 +41,12 @@ public sealed partial class AttachableToggleableComponent : Component
     public bool BreakOnRotate = false;
 
     /// <summary>
+    /// If set to true, the attachment will deactivate upon rotating 180 degrees away from the one it was activated in.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool BreakOnFullRotate = false;
+
+    /// <summary>
     /// If set to true, the attachment can only be toggled when the holder is wielded.
     /// </summary>
     [DataField, AutoNetworkedField]

--- a/Content.Shared/_RMC14/Attachable/Components/AttachableToggleableComponent.cs
+++ b/Content.Shared/_RMC14/Attachable/Components/AttachableToggleableComponent.cs
@@ -41,7 +41,7 @@ public sealed partial class AttachableToggleableComponent : Component
     public bool BreakOnRotate = false;
 
     /// <summary>
-    /// If set to true, the attachment will deactivate upon rotating 180 degrees away from the one it was activated in.
+    /// If set to true, the attachment will deactivate upon rotating 90 degrees away from the one it was activated in.
     /// </summary>
     [DataField, AutoNetworkedField]
     public bool BreakOnFullRotate = false;

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/under_attachments.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/under_attachments.yml
@@ -51,7 +51,7 @@
     doInterrupt: true
     attachedOnly: true
     breakOnMove: true
-    breakOnRotate: true
+    breakOnFullRotate: true
     doAfter: 1.5
     deactivateDoAfter: 0
     instantToggle: Brace


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Ports the correct firing cone for the Bipod from CM13, increased from 45 degrees to a full 90 degrees in each direction, giving you a firing cone of 180 degrees total before your Bipod dismounts itself. The checks for this are similar but entirely separate from the other checks for scopes, which are correct at 45 degrees, and you can have your scope aimed one direction and your bipod aimed another direction without them all incorrectly cancelling each other.

## Why / Balance
CM Parity. 

Resolves #4590 

## Technical details
Adds CheckUserBreakOnFullRotate() to AttachableToggleableSystem. This functions similar to CheckUserBreakOnRotate() takes in the player's and target's position as arguments, and uses these arguments to calculate a difference in angle between your initial mount angle and the angle that you just shot. There is some funky looking math to account for angle wrap-around, because angles represent a circle, you have to add +540, modulo 360, and then take away 180 afterward to get this number. If the difference in angle is 90 degrees or more in either direction, the Bipod will dismount.

Adds a field BreakOnFullRotate to AttachableTogglableComponent, and assigns it to the Bipod in YML.

Adds a new component AttachableSideLockedComponent to pair with BreakOnFullRotate, it functions similarly to AttachableDirectionLockedComponent and its pair BreakOnRotate. They have to be separate despite how similar the code is because their functions are separate and have no gameplay relation to each other, they act independently.

In SharedGunSystem, GunShotEvent now passes the coordinates of the user and the gun shot, so that event listeners can use the data. In this case, the Bipod needs to know this information to determine the World Angle of the gunshot, which it has no way of knowing otherwise.

## Media
Video Demonstration
https://github.com/user-attachments/assets/4b1e9913-c999-4be9-8edc-11f47b632ef1

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- fix: The Bipod can now correctly turn 90 degrees in either direction before automatically dismounting, up from 45 degrees.
