### PR TITLE
MK80 Refinements

### DIFF
--- a/Resources/Prototypes/SoundCollections/gun_impacts.yml
+++ b/Resources/Prototypes/SoundCollections/gun_impacts.yml
@@ -27,3 +27,8 @@
   - "/Audio/Weapons/Guns/Hits/energy_metal1.ogg"
   - "/Audio/Weapons/Guns/Hits/energy_metal2.ogg"
 
+- type: soundCollection
+  id: ExplosiveBulletImpact # To do - change sound effects to closer match HESH - small explosion sounds are temporary
+  files:
+  - "Audio/Effects/explosion_small3.ogg"
+  - "Audio/Effects/explosion_small1.ogg"


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Increases the MK80s baseFirerate from 2.0 > 2.5
Decreases the burst fireDelay from 0.1665 > 0.1225
Increases the shotsPerBurst from 3 > 5 
Decreases maxScatterModifier from 10 > 7
Adds a "structural" damage component of 20
Adds a unique (explosive) soundCollection for the purposes of displaying the properties of the squash-head ammunition. 

**All in all** - increases the gun's firerate slightly when used alongside another weapon, and increases the effectiveness of the MK80 far more when used alone with full burst capabilities. It also hopefully makes it *sound* more satisfying in active combat. 

## Why / Balance
There's a discrepancy between the VP78 in CM13 and its equivalent in RMC. Colloquially the VP78 is understood as the best sidearm comparative to the other options, or the sidearm most capable of matching the damage output of a primary weapon. In RMC, however, the weapon is woefully underused and generally overlooked considering it's a restricted weapon that shares no ammunition type with anything else. This means that it is both incredibly hard to come by without investment, and requires constant financing in order to be used on the field. The only other gun available that shares this problem, the SU-16, makes up for its relative faults through full IFF capability. Non-restricted sidearms like the M77 and M44 have strong enough damage output (and AP) to compete with the MK80 outright despite not being restricted in terms of ammo, and are more modular than the MK80 as well. 

So why is the weapon considered far better in CM13? The most likely answer is that the VP78 is best used with burst fire to take advantage of its high base AP and damage output per bullet. Due to the way Byond works, burst damage output is generally far higher, primarily due to its accuracy as a single entity, whereas in RMC burst fire usually results in higher DPS in exchange for a total loss of accuracy. It doesn't help that for most marines the best way to make use of the increased burst-fire DPS the VP78 has to be used solo - pitting its viability against the primary, non-restricted weapons. All in all, a resounding "why buy?". 

The changes to the fire-rate and burst-fire-rate, audio rework, alongside the (unique) addition of structural damage will likely help make the gun stand out as both a primary and secondary option - bring it closer to parity with CM13 - and hopefully make it a worthy addition for specialists alongside the SU-16. 


## Technical details
**In mk80_pistol.yml:**

    shotsPerBurst: 3 >> 5
    
    baseFireRate: 2.0 >> 2.5
    
    fireDelay: 0.1665 >> 0.1225
    maxScatterModifier: 10 >> 7
    
    Added:
    Damage:
        Types:
            Structural: 20

**In Audio\Effects:**

Added:
RMC_MK80-Xenohit1.ogg
RMC_MK80-Xenohit2.ogg
RMC_MK80-Xenohit3.ogg

**In gun_impacts.yml**
Added:

- type: soundCollection
  id: ExplosiveBulletImpact
  files:
  - "/Audio/Effects/explosion_small3.ogg"
  - "/Audio/Effects/explosion_small1.ogg"
  - "/Audio/Effects/RMC_MK80-Xenohit1.ogg"
  - "/Audio/Effects/RMC_MK80-Xenohit3.ogg"
  - "/Audio/Weapons/Guns/Hits/bullet_hit.ogg"
  - "/Audio/Weapons/Guns/Hits/bullet_hit.ogg"
  - "/Audio/Weapons/Guns/Hits/bullet_hit.ogg"
  - "/Audio/Weapons/Guns/Hits/bullet_hit.ogg"
  - "/Audio/Weapons/Guns/Hits/bullet_hit.ogg"

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://github.com/user-attachments/assets/b6866b1a-e7aa-443b-8b4d-a4e68225f303

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- tweak: Increased the fire-rate and burst fire-rate of the MK80
- added: Added unique hit-sounds for the MK80
- added: Added structural damage component for the MK80, it will now deal (slightly) increased damage towards walls, hive walls and specific emplacements. 
-->
