### PR TITLE
Sentinels drain med chems on hit + parity fixes

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Projectile/DrainOnHitComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/DrainOnHitComponent.cs
@@ -1,0 +1,18 @@
+﻿using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.Projectile;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+
+public sealed partial class DrainOnHitComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 DrainAmount = FixedPoint2.New(1.75);
+
+    [DataField]
+    public string TargetSolution = "chemicals";
+
+    [DataField]
+    public string DrainGroup = "Medicine";
+}

--- a/Content.Shared/_RMC14/Xenonids/Projectile/Spit/Slowing/SlowedBySpitComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/Spit/Slowing/SlowedBySpitComponent.cs
@@ -8,7 +8,7 @@ namespace Content.Shared._RMC14.Xenonids.Projectile.Spit.Slowing;
 public sealed partial class SlowedBySpitComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public float Multiplier = 0.5f;
+    public float Multiplier = 0.75f;
 
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
     public TimeSpan ExpiresAt;

--- a/Content.Shared/_RMC14/Xenonids/Projectile/Spit/Slowing/XenoSlowingSpitProjectileComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/Spit/Slowing/XenoSlowingSpitProjectileComponent.cs
@@ -7,10 +7,10 @@ namespace Content.Shared._RMC14.Xenonids.Projectile.Spit.Slowing;
 public sealed partial class XenoSlowingSpitProjectileComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public TimeSpan Slow = TimeSpan.FromSeconds(3);
+    public TimeSpan Slow = TimeSpan.FromSeconds(5);
 
     [DataField, AutoNetworkedField]
-    public TimeSpan Paralyze = TimeSpan.FromSeconds(2);
+    public TimeSpan Paralyze = TimeSpan.FromSeconds(3.5);
 
     [DataField, AutoNetworkedField]
     public bool ArmorResistsKnockdown = true;

--- a/Content.Shared/_RMC14/Xenonids/Projectile/Spit/XenoSpitSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/Spit/XenoSpitSystem.cs
@@ -13,6 +13,7 @@ using Content.Shared._RMC14.Xenonids.Projectile.Spit.Slowing;
 using Content.Shared._RMC14.Xenonids.Projectile.Spit.Stacks;
 using Content.Shared._RMC14.Xenonids.Projectile.Spit.Standard;
 using Content.Shared.ActionBlocker;
+using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Coordinates;
 using Content.Shared.Damage;
 using Content.Shared.DoAfter;
@@ -26,6 +27,7 @@ using Content.Shared.Stunnable;
 using Content.Shared.Whitelist;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
 namespace Content.Shared._RMC14.Xenonids.Projectile.Spit;
@@ -50,6 +52,8 @@ public sealed class XenoSpitSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly XenoProjectileSystem _xenoProjectile = default!;
     [Dependency] private readonly XenoShieldSystem _xenoShield = default!;
+    [Dependency] private readonly SharedSolutionContainerSystem _solution = default!;
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
 
     private EntityQuery<ProjectileComponent> _projectileQuery;
 
@@ -85,6 +89,8 @@ public sealed class XenoSpitSystem : EntitySystem
         SubscribeLocalEvent<UserAcidedComponent, ShowFireAlertEvent>(OnUserAcidedShowFireAlert);
 
         SubscribeLocalEvent<InventoryComponent, HitBySlowingSpitEvent>(_inventory.RelayEvent);
+
+        SubscribeLocalEvent<DrainOnHitComponent, ProjectileHitEvent>(OnDrainOnHitProjectileHit, after: [typeof(CMClusterGrenadeSystem)]);
     }
 
     private void OnActiveChargingSpitRemove(Entity<XenoActiveChargingSpitComponent> ent, ref ComponentRemove args)
@@ -392,6 +398,27 @@ public sealed class XenoSpitSystem : EntitySystem
             RemCompDeferred<VictimXenoAcidStacksComponent>(target);
         }
     }
+
+    private void OnDrainOnHitProjectileHit(Entity<DrainOnHitComponent> spit, ref ProjectileHitEvent args)
+    {
+        if (_net.IsClient)
+            return;
+
+        var target = args.Target;
+        if (_hive.FromSameHive(spit.Owner, target) || _solution.TryGetSolution(target, spit.Comp.TargetSolution, out var solEnt, out var solu))
+            return;
+
+        if (solu == null || solEnt == null)
+            return;
+
+        //TODO RMC-14 resisting neuro should prevent medicine drain but not stim drain
+        foreach (var chemical in solu.GetReagentPrototypes(_prototypeManager).Keys)
+        {
+            if (chemical.Group == spit.Comp.DrainGroup)
+                _solution.RemoveReagent(solEnt.Value, chemical.ID, spit.Comp.DrainAmount);
+        }
+    }
+
 
     public override void Update(float frameTime)
     {

--- a/Content.Shared/_RMC14/Xenonids/Projectile/Spit/XenoSpitSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/Spit/XenoSpitSystem.cs
@@ -405,7 +405,7 @@ public sealed class XenoSpitSystem : EntitySystem
             return;
 
         var target = args.Target;
-        if (_hive.FromSameHive(spit.Owner, target) || _solution.TryGetSolution(target, spit.Comp.TargetSolution, out var solEnt, out var solu))
+        if (_hive.FromSameHive(spit.Owner, target) || !_solution.TryGetSolution(target, spit.Comp.TargetSolution, out var solEnt, out var solu))
             return;
 
         if (solu == null || solEnt == null)

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
@@ -177,7 +177,7 @@
   id: ActionXenoSlowingSpit
   parent: ActionXenoBase
   name: Slowing Spit (20) # TODO RMC14 proper plasma costs
-  description: Launches a damageless projectile that will slow the first enemy that it hits, and paralyze them if they have no armor.
+  description: Launches a damageless projectile that will slow the first enemy that it hits, and paralyze them if they have no armor. It'll also drain helpful substances from their body.
   components:
   - type: EntityWorldTargetAction
     itemIconStyle: NoItem

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_projectiles.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_projectiles.yml
@@ -105,6 +105,7 @@
     armorResistsKnockdown: true
   - type: XenoProjectile
     deleteOnFriendlyXeno: true
+  - type: DrainOnHit
 
 - type: entity
   id: XenoScatteredSpitProjectile

--- a/Resources/Prototypes/_RMC14/Reagents/base_reagent.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/base_reagent.yml
@@ -2,3 +2,9 @@
   abstract: true
   id: CMReagent
   isCM: true
+
+- type: reagent
+  abstract: true
+  parent: CMReagent
+  id: CMReagentMedicine
+  group: Medicine

--- a/Resources/Prototypes/_RMC14/Reagents/medicine.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/medicine.yml
@@ -1,6 +1,6 @@
 ﻿# TODO RMC14 other effects
 - type: reagent
-  parent: [ CMReagent, Dylovene ]
+  parent: [ CMReagentMedicine, Dylovene ]
   id: CMDylovene
   name: reagent-name-cmdylovene
   desc: reagent-desc-cmdylovene
@@ -43,7 +43,7 @@
 
 # TODO RMC14 other effects
 - type: reagent
-  parent: [ CMReagent, Ethylredoxrazine ]
+  parent: [ CMReagentMedicine, Ethylredoxrazine ]
   id: CMEthylredoxrazine
   name: reagent-name-cmethylredoxrazine
   desc: reagent-desc-cmethylredoxrazine
@@ -74,7 +74,7 @@
 
 # TODO RMC14 other effects
 - type: reagent
-  parent: [ CMReagent, Arithrazine ]
+  parent: [ CMReagentMedicine, Arithrazine ]
   id: CMArithrazine
   name: reagent-name-cmarithrazine
   desc: reagent-desc-cmarithrazine
@@ -135,7 +135,7 @@
 
 # TODO RMC14 other effects
 - type: reagent
-  parent: [ CMReagent, Bicaridine ]
+  parent: [ CMReagentMedicine, Bicaridine ]
   id: CMBicaridine
   name: reagent-name-cmbicaridine
   desc: reagent-desc-cmbicaridine
@@ -166,7 +166,7 @@
 
 # TODO RMC14 other effects (remove toxic reagents)
 - type: reagent
-  parent: [ CMReagent, Cryoxadone ]
+  parent: [ CMReagentMedicine, Cryoxadone ]
   id: CMCryoxadone
   name: reagent-name-cmcryoxadone
   desc: reagent-desc-cmcryoxadone
@@ -194,7 +194,7 @@
 
 # TODO RMC14 other effects
 - type: reagent
-  parent: [ CMReagent, Dermaline ]
+  parent: [ CMReagentMedicine, Dermaline ]
   id: CMDermaline
   name: reagent-name-cmdermaline
   desc: reagent-desc-cmdermaline
@@ -226,7 +226,7 @@
 
 # TODO RMC14 other effects
 - type: reagent
-  parent: [ CMReagent, Dexalin ]
+  parent: [ CMReagentMedicine, Dexalin ]
   id: CMDexalin
   name: reagent-name-cmdexalin
   desc: reagent-desc-cmdexalin
@@ -257,7 +257,7 @@
 
 # TODO RMC14 other effects
 - type: reagent
-  parent: [ CMReagent, DexalinPlus ]
+  parent: [ CMReagentMedicine, DexalinPlus ]
   id: CMDexalinPlus
   name: reagent-name-cmdexalinplus
   desc: reagent-desc-cmdexalinplus
@@ -288,7 +288,7 @@
 # TODO RMC14 other effects (pain)
 # TODO RMC14 injected only
 - type: reagent
-  parent: [ CMReagent, Epinephrine ]
+  parent: [ CMReagentMedicine, Epinephrine ]
   id: CMEpinephrine
   name: reagent-name-cmepinephrine
   desc: reagent-desc-cmepinephrine
@@ -332,7 +332,7 @@
 # TODO RMC14 other effects
 # TODO RMC14 allow breathing in crit instead of reducing asphyxiation
 - type: reagent
-  parent: [ CMReagent, Inaprovaline ]
+  parent: [ CMReagentMedicine, Inaprovaline ]
   id: CMInaprovaline
   name: reagent-name-cminaprovaline
   desc: reagent-desc-cminaprovaline
@@ -380,7 +380,7 @@
 
 # TODO RMC14 other effects
 - type: reagent
-  parent: [ CMReagent, Kelotane ]
+  parent: [ CMReagentMedicine, Kelotane ]
   id: CMKelotane
   name: reagent-name-cmkelotane
   desc: reagent-desc-cmkelotane
@@ -412,7 +412,7 @@
 
 # TODO RMC14 other effects
 - type: reagent
-  parent: [ CMReagent, Leporazine ]
+  parent: [ CMReagentMedicine, Leporazine ]
   id: CMLeporazine
   name: reagent-name-cmleporazine
   desc: reagent-desc-cmleporazine
@@ -452,7 +452,7 @@
 
 # TODO RMC14 other effects
 - type: reagent
-  parent: [ CMReagent, Tricordrazine ]
+  parent: [ CMReagentMedicine, Tricordrazine ]
   id: CMTricordrazine
   name: reagent-name-cmtricordrazine
   desc: reagent-desc-cmtricordrazine
@@ -500,7 +500,7 @@
 
 # TODO RMC14 other effects
 - type: reagent
-  parent: [ CMReagent, CMBicaridine ]
+  parent: [ CMReagentMedicine, CMBicaridine ]
   id: CMMeralyne
   name: reagent-name-cmmeralyne
   desc: reagent-desc-cmmeralyne
@@ -533,7 +533,7 @@
 # TODO RMC14 progressive eye healing
 # TODO RMC14 brain damage over 50u
 - type: reagent
-  parent: [ CMReagent, CMDylovene ]
+  parent: [ CMReagentMedicine, CMDylovene ]
   id: CMImidazoline
   name: reagent-name-cmimidazoline
   desc: reagent-desc-cmimidazoline
@@ -564,7 +564,7 @@
 # TODO RMC14 other effects
 # TODO RMC14 heal cloneloss
 - type: reagent
-  parent: [ CMReagent, CMCryoxadone ]
+  parent: [ CMReagentMedicine, CMCryoxadone ]
   id: CMClonexadone
   name: reagent-name-cmclonexadone
   desc: reagent-desc-cmclonexadone


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title!

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity.

## Technical details
<!-- Summary of code changes for easier review. -->
Sentinels now drain 1.75 chems on slowing spit hit. I also readjusted the values for slowing spit, as unlike most "superslows" they applied 0.5 instead of 0.75 slow. They also didn't last as long as they should've based on the CM values. I tested it in CM to make the values more accurate.

Anyway pretty simple, XenoProjectileSystem now subscribes to projectilehit for a new comp which stores the amount to drain, what the solution name is to target, and what group the chemical has to be apart of. If all that amtches it'll drain chems.

Because of the group being important I maded a medicine proto and applied it instead of CMReagent (which it inherits) to all the medicines so it works properly.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/f2c829d3-59ca-40a5-9629-ec3f0e03f59f



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Sentinel slowing spit now drains medicines in the target by 1.75 each on hit
- fix: Sentinel slowing spit now modifies speed the same as other 'superslow' moves
- fix: Sentinel slowing spit knockdown and slow last longer; their durations were too short before
