### PR TITLE
Add Pressured Canister Chem Dispensers + HM vendor decluttering

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Science/Dispensers/chem.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Science/Dispensers/chem.yml
@@ -147,3 +147,53 @@
   components:
   - type: RMCChemicalStorage
     network: RMCChemStorageResearch
+
+- type: entity
+  parent: RMCChemDispenserBase
+  id: RMCChemDispenserCorpsmanBase
+  name: pressurized chemical dispenser
+  description: A more basic chemical dispenser, designed for use with pressurized reagent canisters. A We-Ya product.
+  abstract: true
+  components:
+  - type: RequiresSkill
+    skills:
+      RMCSkillMedical: 2
+  - type: ItemSlots
+    slots:
+      chemical_dispenser_slot:
+        name: Chemical Dispenser
+        whitelist:
+          tags:
+          - PressurizedCanister
+  - type: Sprite
+    sprite: _RMC14/Structures/Machines/Science/chem_master.rsi
+    layers:
+    - state: mixer_empty
+    - state: mixer_screen
+      shader: unshaded
+      map: ["enum.PowerDeviceVisualLayers.Powered"]
+    snapCardinals: true
+  - type: GenericVisualizer
+    visuals:
+      enum.PowerDeviceVisuals.Powered:
+        enum.PowerDeviceVisualLayers.Powered:
+          True: { visible: true }
+  - type: RMCChemicalDispenser
+    reagents:
+      - CMBicaridine
+      - CMKelotane
+      - CMDylovene
+      - CMDexalin
+      - CMInaprovaline
+      - CMEpinephrine
+      # TODO RMC-14 Peridaxon and tramadol
+      - CMTricordrazine
+
+- type: entity
+  parent: RMCChemDispenserCorpsmanBase
+  id: RMCChemDispenserCorpsmanMedbay
+  suffix: Medbay
+  components:
+  - type: RMCChemicalDispenser
+    network: RMCChemStorageMedbay
+

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/medic.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/medic.yml
@@ -29,10 +29,6 @@
 #        recommended: true
     #    CMMedicalSplints: 1P
 #        recommended: true
-      - id: CMGauze10
-        points: 1
-      - id: CMOintment10
-        points: 1
       - id: CMBloodPackFull # TODO RMC14 O-
         name: blood bag (O-)
         points: 4
@@ -51,24 +47,6 @@
         points: 6
 #      - id: #    CMRadiationFirstaidKit # TODO RMC14
 #        points: 6
-    - name: Autoinjectors
-      entries:
-      - id: CMBicaridineAutoInjector
-        points: 1
-      - id: CMDexalinPlusAutoInjector
-        points: 1
-      - id: CMEpinephrineAutoInjector
-        points: 2
-      - id: CMInaprovalineAutoInjector
-        points: 1
-      - id: CMKelotaneAutoInjector
-        points: 1
-#      - id: CMAutoinjectorOxycodone
-#        points: 2
-#      - id: CMAutoinjectorTramadol
-#        points: 1
-      - id: CMTricordrazineAutoInjector
-        points: 1
     - name: Pill Bottles
       entries:
       - id: CMPillCanisterBicaridine
@@ -88,18 +66,34 @@
 #      - id: CMPillCanisterTramadol
 #        points: 5
 #        recommended: true
+    - name: Autoinjectors
+      entries:
+      - id: CMBicaridineAutoInjector
+        points: 1
+      - id: CMDexalinPlusAutoInjector
+        points: 1
+      - id: CMEpinephrineAutoInjector
+        points: 2
+      - id: CMInaprovalineAutoInjector
+        points: 1
+      - id: CMKelotaneAutoInjector
+        points: 1
+#      - id: CMAutoinjectorOxycodone
+#        points: 2
+#      - id: CMAutoinjectorTramadol
+#        points: 1
+      - id: CMTricordrazineAutoInjector
+        points: 1
     - name: Medical Utilities
       entries:
-      - id: CMHealthAnalyzer
-        points: 4
+     #    CMMS11SmartRefillTank: 6P
+     # FixOVien: 7P
       - id: CMRollerBedSpawnFolded
+        points: 4
+      - id: CMHealthAnalyzer
         points: 4
       - id: CMStasisBagFolded
         points: 6
-    #    CMPressurizedReagentCanisterPouchEMPTY: 3P
-      - id: RMCBeltUtilityGeneral
-        points: 15
-    #    CMMS11SmartRefillTank: 6P
     - name: Explosives
       entries:
       - id: CMPacketGrenadeHighExplosiveFilled
@@ -147,12 +141,9 @@
         points: 12
     - name: Clothing Items
       entries:
-      - id: RMCScabbardMacheteFilled
-        points: 6
       - id: RMCPouchMacheteFilled
         points: 8
     #    CMMarineRadioTelephonePack: 15P
-    #    CMFuelTankStrapPouch: 4P
     #    CMWeldingGoggles: 3P
     - name: Utilities
       entries:
@@ -175,8 +166,6 @@
     #    CMWeldingVisor: 5P
     - name: Pamphlets
       entries:
-      - id: CMPamphletJTAC
-        points: 15
       - id: CMPamphletEngineer
         points: 15
     - name: Radio Keys
@@ -231,72 +220,60 @@
     - name: Belt
       choices: { CMBelt: 1 }
       entries:
-      - id: CMBeltMarine
-      #- id: CMM276GeneralPistolHolsterRig
       - id: CMBeltMedicBagFilled
         name: m276 lifesaver bag (full)
-        recommended: true
       - id: CMBeltMedicalFilled
         name: m276 medical storage rig (full)
-        recommended: true
-      - id: RMCBeltSmgMags
-      #- id: CMM276M44HolsterRig
-      #- id: CMM276M82FHolsterRig
-      - id: RMCM276ShotgunShellLoadingRig
-      - id: RMCBeltGrenade
     - name: Pouches
       choices: { RMCPouch: 2 }
       entries:
+      - id: RMCPouchReagentCanisterTricordrazineRevival
+        recommended: true
+     #- id: RMCPouchMedkit
+#       recommended: true
+        name: Pressurized Reagent Canister Pouch\n(Revival Mix - Tricordrazine)
       - id: RMCPouchAutoinjector
+      - id: RMCPouchFirstResponder
+      - id: RMCPouchReagentCanisterBicaridine
+        name: Pressurized Reagent Canister Pouch\n(Bicaridine)
+      - id: RMCPouchReagentCanisterKelotane
+        name: Pressurized Reagent Canister Pouch\n(Kelotane)
+      - id: RMCPouchReagentCanisterTricordrazine
+        name: Pressurized Reagent Canister Pouch\n(Tricordrazine)
+#     - id: CMPressurizedReagentCanisterPouchPeridaxonRevivalMix
+#       name: Pressurized Reagent Canister Pouch\n(Revival Mix - Peridaxon)
+      - id: RMCPouchReagentCanister
+        name: Pressurized Reagent Canister Pouch\n(EMPTY)
+      - id: RMCPouchVialFill
+      - id: RMCPouchMedical
+        recommended: true # TODO unrecommend when medkit pouch is real
       - id: RMCPouchFirstAidInjectors
         name: first-aid pouch (refillable injectors)
       - id: RMCPouchFirstAidSplintsGauzeOintment
         name: first-aid pouch (gauze, ointment) # TODO RMC14 splints comma
       - id: RMCPouchFirstAidPills
         name: first-aid pouch (pills)
-      - id: RMCPouchFirstResponder # TODO RMC14 test everything fits
       - id: RMCPouchFlareFilled
         name: Flare pouch (Full)
       - id: RMCPouchGeneralLarge
-      #- id: CMSlingPouch
+     #- id: CMSlingPouch
       - id: RMCPouchMagazinePistolLarge
       - id: RMCPouchMagazine
-      - id: RMCPouchShotgun
-      - id: RMCPouchMedical
-        recommended: true
-      #- id: RMCPouchMedkit
-#        recommended: true
-      - id: RMCPouchReagentCanisterBicaridine
-        recommended: true
-        name: Pressurized Reagent Canister Pouch\n(Bicaridine)
-      - id: RMCPouchReagentCanisterKelotane
-        recommended: true
-        name: Pressurized Reagent Canister Pouch\n(Kelotane)
-      - id: RMCPouchReagentCanisterTricordrazineRevival
-        recommended: true
-        name: Pressurized Reagent Canister Pouch\n(Revival Mix - Tricordrazine)
-#      - id: CMPressurizedReagentCanisterPouchPeridaxonRevivalMix
-#        recommended: true
-#        name: Pressurized Reagent Canister Pouch\n(Revival Mix - Peridaxon)
-      - id: RMCPouchReagentCanisterTricordrazine
-        recommended: true
-        name: Pressurized Reagent Canister Pouch\n(Tricordrazine)
-      - id: RMCPouchReagentCanister
-        name: Pressurized Reagent Canister Pouch\n(EMPTY)
+      - id: RMCPouchShotgun  
       - id: RMCPouchPistol
-      - id: RMCPouchVialFill
     - name: Accessories
       choices: { CMAccessories: 1 }
       entries:
       - id: CMWebbingBrown
         recommended: true
       - id: CMWebbingBlack
+        recommended: true
       #- id: CMShoulderHolster
       - id: CMWebbing
       - id: CMWebbingPouch
     - name: Mask
       choices: { CMMask: 1 }
       entries:
+      - id: CMMaskSterile
       - id: CMMaskGas
       - id: CMMaskCoif
-      - id: CMMaskSterile


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title. In short there's now dispensers usuable by corpsman with specific chems for filling their pressured canisters. There's supposed to be 1 mapped in each corpsman squad vend area and I think 2 mapped in medbay itself.

The decluttering reorganizes and removes some HM stuff from their vends, most notably changing recommendations around and removing all the belts but the med belts.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
parity

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added Pressurized Chemical Dispensers, which can be used by corpsman to make their own simple canister mixes.
- tweak: Corpsman vendors have been reorganized. A few items have been removed, most notably non-medical belts and the machete scabbard, as well as the JTAC pamphlet. You can also no longer pointbuy gauze or ointment from them.
