### PR TITLE
Fix medic autoinjectors not having a lock

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Medical/auto_injectors.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Medical/auto_injectors.yml
@@ -1,7 +1,7 @@
 ﻿- type: entity
   abstract: true
   parent: ChemicalMedipen
-  id: CMAutoInjectorBase
+  id: CMAutoInjector
   name: autoinjector
   description: An autoinjector.
   categories: [ HideSpawnMenu ]
@@ -38,19 +38,12 @@
   - type: Tag
     tags:
     - CMAutoInjector
+  - type: MedicallyUnskilledDoAfter
   - type: UseDelay
     delay: 0.333
   - type: IconLabel
     textColor: White
     storedOffset: 0, 12
-
-- type: entity
-  abstract: true
-  parent: CMAutoInjectorBase
-  id: CMAutoInjector
-  categories: [ HideSpawnMenu ]
-  components:
-  - type: MedicallyUnskilledDoAfter
 
 - type: entity
   parent: CMAutoInjector
@@ -243,7 +236,7 @@
     labelTextLocId: rmc-epinephrine-container-label-text
 
 - type: entity
-  parent: CMAutoInjectorBase
+  parent: CMAutoInjector
   id: RMCMedicAutoInjector
   name: medic autoinjector (M-M)
   description: A custom-made professional injector, likely from research. Has a similar lock to pill bottles, and fits up to 6 injections.

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Medical/auto_injectors.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Medical/auto_injectors.yml
@@ -1,7 +1,7 @@
 ﻿- type: entity
   abstract: true
   parent: ChemicalMedipen
-  id: CMAutoInjector
+  id: CMAutoInjectorBase
   name: autoinjector
   description: An autoinjector.
   categories: [ HideSpawnMenu ]
@@ -38,12 +38,19 @@
   - type: Tag
     tags:
     - CMAutoInjector
-  - type: MedicallyUnskilledDoAfter
   - type: UseDelay
     delay: 0.333
   - type: IconLabel
     textColor: White
     storedOffset: 0, 12
+
+- type: entity
+  abstract: true
+  parent: CMAutoInjectorBase
+  id: CMAutoInjector
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: MedicallyUnskilledDoAfter
 
 - type: entity
   parent: CMAutoInjector
@@ -236,7 +243,7 @@
     labelTextLocId: rmc-epinephrine-container-label-text
 
 - type: entity
-  parent: CMAutoInjector
+  parent: CMAutoInjectorBase
   id: RMCMedicAutoInjector
   name: medic autoinjector (M-M)
   description: A custom-made professional injector, likely from research. Has a similar lock to pill bottles, and fits up to 6 injections.
@@ -254,6 +261,9 @@
     - RMCAutoInjectorMedical
   - type: RefillableSolution
     solution: pen
+  - type: RequiresSkill
+    skills:
+      RMCSkillMedical: 2
 
 - type: entity
   parent: RMCMedicAutoInjector


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity. Only those with medical 2 can use them at ALL.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fix Medic Autoinjectors not requiring medical 2 to use
