### PR TITLE
Fix xenos having the wrong map backgrounds

### DIFF
--- a/Content.Server/_RMC14/TacticalMap/TacticalMapSystem.cs
+++ b/Content.Server/_RMC14/TacticalMap/TacticalMapSystem.cs
@@ -386,6 +386,7 @@ public sealed class TacticalMapSystem : SharedTacticalMapSystem
         if (_tacticalMapIconQuery.TryComp(tracked, out var iconComp))
         {
             tracked.Comp.Icon = iconComp.Icon;
+            tracked.Comp.Background = iconComp.Background;
             return;
         }
 

--- a/Content.Shared/_RMC14/TacticalMap/TacticalMapIconComponent.cs
+++ b/Content.Shared/_RMC14/TacticalMap/TacticalMapIconComponent.cs
@@ -9,4 +9,7 @@ public sealed partial class TacticalMapIconComponent : Component
 {
     [DataField(required: true), AutoNetworkedField]
     public SpriteSpecifier.Rsi? Icon;
+
+    [DataField, AutoNetworkedField]
+    public SpriteSpecifier.Rsi? Background;
 }

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
@@ -272,6 +272,13 @@
   - type: TacticalMapLiveUpdateOnOvi
     enabled: true
   - type: MotionDetectorTracked
+  - type: TacticalMapIcon
+    icon:
+      sprite: _RMC14/Interface/map_blips.rsi
+      state: xeno
+    background:
+      sprite: _RMC14/Interface/map_blips.rsi
+      state: background_xeno
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
@@ -189,6 +189,9 @@
     icon:
       sprite: _RMC14/Interface/map_blips.rsi
       state: xenoqueen
+    background:
+      sprite: _RMC14/Interface/map_blips.rsi
+      state: xeno_ruler
   - type: AcidTrap
   - type: TacticalMapLiveUpdateOnOvi
     enabled: false


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
They uh, didn't inherit it from jobs.

## Technical details
<!-- Summary of code changes for easier review. -->
Adds a background field to tacticalmapicon, updated it for base xeno and queen

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
