### PR TITLE
SEA Vendor Update

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/senior_enlisted_advisor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/senior_enlisted_advisor.yml
@@ -104,4 +104,3 @@
       - id: RMCAttachmentS5RedDotSight
       - id: RMCAttachmentS6ReflexSight
       - id: RMCAttachmentRailFlashlight
-      - id: RMCAttachmentBipod

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/senior_enlisted_advisor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/senior_enlisted_advisor.yml
@@ -105,7 +105,6 @@
         points: 8
       - id: RMCBoxShotgunSlugs
         points: 8
-      - id:
     - name: Gun Attachments
       choices: { CMAttachments: 1 }
       entries:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/senior_enlisted_advisor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/senior_enlisted_advisor.yml
@@ -97,12 +97,6 @@
       entries:
       - id: CMMagazineRifleM54C
         points: 9
-      - id: CMMagazineSMGM63
-        points: 9
-      - id: RMCBoxShotgunBuckshot
-        points: 8
-      - id: RMCBoxShotgunSlugs
-        points: 8
     - name: Gun Attachments
       choices: { CMAttachments: 1 }
       entries:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/senior_enlisted_advisor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/senior_enlisted_advisor.yml
@@ -41,7 +41,7 @@
       - id: RMCPouchMagazineLarge
       - id: RMCPouchMagazinePistolLarge
       - id: RMCPouchShotgunLarge
-      #Medical Kit Pouch
+      - id: RMCPouchMedkit
       - id: RMCPouchPistol
       - id: RMCPouchSling
     - name: Armor
@@ -50,7 +50,7 @@
       - id: CMArmorM3VLBallistics
       - id: CMArmorM3Light
       - id: CMArmorM3Medium
-      #Bulletproof Vest
+      - id: CMArmorM3VLBallistics
       - id: CMCoatOfficer
     - name: Eyewear
       choices: { CMEyewear: 1 }

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/senior_enlisted_advisor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/senior_enlisted_advisor.yml
@@ -94,9 +94,12 @@
       entries:
       - id: WeaponRifleM54C
       - id: WeaponShotgunM42A2
+      - id: WeaponSMGM63
     - name: Ammunition
       entries:
       - id: CMMagazineRifleM54C
+        points: 9
+      - id: CMMagazineSMGM63
         points: 9
       - id: RMCBoxShotgunBuckshot
         points: 8
@@ -107,6 +110,7 @@
       choices: { CMAttachments: 1 }
       entries:
       - id: RMCAttachmentLaserSight
-      #Red-Dot Sight
+      - id: RMCAttachmentS5RedDotSight
       - id: RMCAttachmentS6ReflexSight
       - id: RMCAttachmentRailFlashlight
+      - id: RMCAttachmentBipod

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/senior_enlisted_advisor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/senior_enlisted_advisor.yml
@@ -92,9 +92,7 @@
     - name: Personal Primary
       choices: { CMPrimary: 1 }
       entries:
-      - id: WeaponRifleM54C
-      - id: WeaponSMGM63
-      - id: WeaponShotgunM42A2
+      - id: WeaponRifleM54C # TODO rmc14 this should be MK1 WeaponRifleM54CMK1
     - name: Ammunition
       entries:
       - id: CMMagazineRifleM54C

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/senior_enlisted_advisor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/senior_enlisted_advisor.yml
@@ -93,8 +93,8 @@
       choices: { CMPrimary: 1 }
       entries:
       - id: WeaponRifleM54C
-      - id: WeaponShotgunM42A2
       - id: WeaponSMGM63
+      - id: WeaponShotgunM42A2
     - name: Ammunition
       entries:
       - id: CMMagazineRifleM54C

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/senior_enlisted_advisor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/senior_enlisted_advisor.yml
@@ -51,7 +51,7 @@
       - id: CMArmorM3Light
       - id: CMArmorM3Medium
       #Bulletproof Vest
-      #UNMC Service Jacket
+      - id: CMCoatOfficer
     - name: Eyewear
       choices: { CMEyewear: 1 }
       entries:
@@ -93,10 +93,16 @@
       choices: { CMPrimary: 1 }
       entries:
       - id: WeaponRifleM54C
+      - id: WeaponShotgunM42A2
     - name: Ammunition
       entries:
       - id: CMMagazineRifleM54C
         points: 9
+      - id: RMCBoxShotgunBuckshot
+        points: 8
+      - id: RMCBoxShotgunSlugs
+        points: 8
+      - id:
     - name: Gun Attachments
       choices: { CMAttachments: 1 }
       entries:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/vending_machines.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/vending_machines.yml
@@ -288,6 +288,7 @@
     #rifle rubber ammo 20
     #m4spr rubber ammo 20
     #shotgun beanbag 20
+    RMCGrenadeTraining: 6
     CMFirstAidKitFilled: 2
     CMBurnAidKitFilled: 2 #firstaid fire 2
     #MedkitRadiationFilled: 1 #firstaid rad 1

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/vending_machines.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/vending_machines.yml
@@ -288,7 +288,6 @@
     #rifle rubber ammo 20
     #m4spr rubber ammo 20
     #shotgun beanbag 20
-    RMCGrenadeTraining: 6
     CMFirstAidKitFilled: 2
     CMBurnAidKitFilled: 2 #firstaid fire 2
     #MedkitRadiationFilled: 1 #firstaid rad 1


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The SEA uniform vendor now has the option for the service jacket, ballistics vest, medkit pouch.
The SEA Weapon Vendor now has the reddot sight.

## Why / Balance

## Technical details
YAML Updating.

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: The SEA vendors have been updated to include new items and equipment: Service Jackets, medkit pouch, reddot sight.
