### PR TITLE
Fixed bug that allowed laser designation on the warship

### DIFF
--- a/Content.Shared/_RMC14/Rangefinder/RangefinderComponent.cs
+++ b/Content.Shared/_RMC14/Rangefinder/RangefinderComponent.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Shared._RMC14.Marines.Skills;
+using Content.Shared.DoAfter;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
@@ -30,6 +31,9 @@ public sealed partial class RangefinderComponent : Component
 
     [DataField, AutoNetworkedField]
     public TimeSpan SwitchModeDelay = TimeSpan.FromSeconds(0.5);
+
+    [DataField, AutoNetworkedField]
+    public DoAfter.DoAfter? DoAfter;
 
     [DataField, AutoNetworkedField]
     public TimeSpan Delay = TimeSpan.FromSeconds(10);

--- a/Content.Shared/_RMC14/Rangefinder/RangefinderSystem.cs
+++ b/Content.Shared/_RMC14/Rangefinder/RangefinderSystem.cs
@@ -283,6 +283,9 @@ public sealed class RangefinderSystem : EntitySystem
             _useDelay.TryResetDelay(rangefinder, component: useDelay, id: delay);
         }
 
+        if (rangefinder.Comp.DoAfter != null && _doAfter.IsRunning(rangefinder.Comp.DoAfter.Id))
+            _doAfter.Cancel(rangefinder.Comp.DoAfter.Id);
+
         rangefinder.Comp.Mode = mode;
         Dirty(rangefinder);
         UpdateAppearance(rangefinder);
@@ -322,6 +325,8 @@ public sealed class RangefinderSystem : EntitySystem
             var msg = Loc.GetString("rmc-laser-designator-start");
             _popup.PopupClient(msg, coordinates, user, PopupType.Medium);
             _audio.PlayPredicted(rangefinder.Comp.TargetSound, rangefinder, user);
+
+            rangefinder.Comp.DoAfter = ev.DoAfter;
         }
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- You used to be able to laser designate tiles on the drop/gun/warship if you simply switched modes while range finding.
- Now the do-after is immediately cancelled when switching modes.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #4627

## Technical details
<!-- Summary of code changes for easier review. -->
The shared `RangefinderComponent` now stores the DoAfter created in `TryTarget()`. This DoAfter is cancelled in `ChangeDesignatorMode()`.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed bug that allowed laser designation on the warship.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
