### PR TITLE
Downed players can't be pulled over tables/window frames, restores Runner window travel, fix the game not compiling

### DIFF
--- a/Content.Server/_RMC14/Dropship/Weapon/DropshipWeaponSystem.cs
+++ b/Content.Server/_RMC14/Dropship/Weapon/DropshipWeaponSystem.cs
@@ -1,6 +1,5 @@
 using Content.Shared._RMC14.Dropship.Weapon;
 using Content.Shared.Decals;
-using JetBrains.FormatRipper.Elf;
 using Robust.Server.GameObjects;
 using Robust.Shared.Player;
 using System.Numerics;

--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -384,7 +384,7 @@ public abstract partial class SharedBuckleSystem
                 _standing.Stand(buckle, force: true);
                 break;
             case StrapPosition.Down:
-                _standing.Down(buckle, false, false, force: true);
+                _standing.Down(buckle, false, false, force: true, changeCollision: true);
                 break;
         }
 
@@ -482,7 +482,7 @@ public abstract partial class SharedBuckleSystem
         Appearance.SetData(buckle, BuckleVisuals.Buckled, false);
 
         if (HasComp<KnockedDownComponent>(buckle) || _mobState.IsIncapacitated(buckle))
-            _standing.Down(buckle, playSound: false);
+            _standing.Down(buckle, playSound: false, changeCollision: true);
         else
             _standing.Stand(buckle);
 

--- a/Content.Shared/Standing/StandingStateSystem.cs
+++ b/Content.Shared/Standing/StandingStateSystem.cs
@@ -29,6 +29,7 @@ namespace Content.Shared.Standing
             bool playSound = true,
             bool dropHeldItems = true,
             bool force = false,
+            bool changeCollision = false,
             StandingStateComponent? standingState = null,
             AppearanceComponent? appearance = null,
             HandsComponent? hands = null)
@@ -69,7 +70,7 @@ namespace Content.Shared.Standing
             _appearance.SetData(uid, RotationVisuals.RotationState, RotationState.Horizontal, appearance);
 
             // Change collision masks to allow going under certain entities like flaps and tables
-            if (TryComp(uid, out FixturesComponent? fixtureComponent))
+            if (changeCollision && TryComp(uid, out FixturesComponent? fixtureComponent))
             {
                 foreach (var (key, fixture) in fixtureComponent.Fixtures)
                 {

--- a/Content.Shared/_RMC14/Fireman/FiremanCarrySystem.cs
+++ b/Content.Shared/_RMC14/Fireman/FiremanCarrySystem.cs
@@ -117,7 +117,7 @@ public sealed class FiremanCarrySystem : EntitySystem
 
         _transform.SetParent(ent, user);
         _transform.SetLocalPosition(ent, Vector2.Zero);
-        _standing.Down(ent);
+        _standing.Down(ent, changeCollision: true);
 
         _movementSpeed.RefreshMovementSpeedModifiers(user);
         _rmcSprite.SetRenderOrder(user, 1);
@@ -248,7 +248,7 @@ public sealed class FiremanCarrySystem : EntitySystem
             puller.Pulling is { } pulling)
         {
             _actionBlocker.UpdateCanMove(pulling);
-            _standing.Down(pulling);
+            _standing.Down(pulling, changeCollision: true);
             _rmcPulling.PlayPullEffect(ent, pulling);
 
             var selfMsg = Loc.GetString("rmc-pull-aggressive-self", ("pulled", pulling));

--- a/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestSystem.cs
@@ -151,7 +151,7 @@ public sealed class XenoNestSystem : EntitySystem
 
         // TODO RMC14
         if (HasComp<KnockedDownComponent>(ent) || _mobState.IsIncapacitated(ent))
-            _standing.Down(ent);
+            _standing.Down(ent, changeCollision: true);
     }
 
     private void OnSurfaceDoAfterAttempt(Entity<XenoNestSurfaceComponent> ent, ref DoAfterAttemptEvent<XenoNestDoAfterEvent> args)

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Windows/frames.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Windows/frames.yml
@@ -31,7 +31,7 @@
         mask:
         - MachineMask
         layer:
-        - HalfWallLayer
+        - MidImpassable
   - type: Destructible
     thresholds:
       - trigger:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Made being knocked down not allowing you to pass through tables, window frames, flaps, etc.

Restored Runner/Larva/Parasite running over window frames as the former was making this way too broken before, but it now works properly.

## Why / Balance
CM13 Parity. Needed for Runner traveling over window frames. Removes currently existing Runner table cheese.

Also I think prevents a Marine-only out of bounds bug for New Varadero (there are flaps that exit the map) in advance.

## Technical details
Added a new arg "changeCollision" to Down() in StandingStateSystem that is set to false by default, setting it to true lets you pass objects like before, but by default your collision will not change, as in CM13.

Added changeCollision: true to everything that needs it (I tested every .Down() call myself), that being Fireman Carry (so you can carry over objects when you are able to), Xeno nesting (prevents weird stuff happening with nesting over tables), and Buckle system. Everything else works correctly being set to false.

Restores MidImpassible to window frames now that the collision mask doesn't change

Removed erroneous FormatRipper inclusion in DropshipWeaponSystem so the game compiles. (Smug said to include this)

## Media
[Video Demonstration including edge cases](https://cdn.discordapp.com/attachments/1168210011823026270/1302077952577634345/2024-11-01_21-00-16.mp4?ex=6726ce17&is=67257c97&hm=858fd2ed1adb0cb4f68188e40b20f42a2ace180ad5bd82d4740ee7cbf1e0d78f&)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Changes default behavior for .Down(), but all cases should be okay as I've set the problem ones to the original behavior.

**Changelog**

:cl:
- tweak: Mobs that are knocked down can no longer be dragged through tables, window frames, and flaps without manually vaulting them.
- tweak: Runners, Larvae, and Parasites can now travel on top of window frames without vaulting once again.

