### PR TITLE
Sentinel buff parity

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Paralyzing/XenoParalyzingSlashComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Paralyzing/XenoParalyzingSlashComponent.cs
@@ -14,8 +14,8 @@ public sealed partial class XenoParalyzingSlashComponent : Component
     public TimeSpan ActiveDuration = TimeSpan.FromSeconds(5);
 
     [DataField, AutoNetworkedField]
-    public TimeSpan StunDelay = TimeSpan.FromSeconds(4);
+    public TimeSpan StunDelay = TimeSpan.FromSeconds(3);
 
     [DataField, AutoNetworkedField]
-    public TimeSpan StunDuration = TimeSpan.FromSeconds(4);
+    public TimeSpan StunDuration = TimeSpan.FromSeconds(5);
 }

--- a/Content.Shared/_RMC14/Xenonids/Projectile/Spit/Scattered/XenoScatteredSpitComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/Spit/Scattered/XenoScatteredSpitComponent.cs
@@ -25,5 +25,5 @@ public sealed partial class XenoScatteredSpitComponent : Component
     public int MaxProjectiles = 5;
 
     [DataField, AutoNetworkedField]
-    public Angle MaxDeviation = Angle.FromDegrees(60);
+    public Angle MaxDeviation = Angle.FromDegrees(45);
 }

--- a/Content.Shared/_RMC14/Xenonids/Projectile/Spit/Slowing/XenoSlowingSpitProjectileComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/Spit/Slowing/XenoSlowingSpitProjectileComponent.cs
@@ -7,7 +7,7 @@ namespace Content.Shared._RMC14.Xenonids.Projectile.Spit.Slowing;
 public sealed partial class XenoSlowingSpitProjectileComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public TimeSpan Slow = TimeSpan.FromSeconds(5);
+    public TimeSpan Slow = TimeSpan.FromSeconds(8);
 
     [DataField, AutoNetworkedField]
     public TimeSpan Paralyze = TimeSpan.FromSeconds(3.5);

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
@@ -185,7 +185,7 @@
       sprite: _RMC14/Actions/xeno_actions.rsi
       state: xeno_spit
     event: !type:XenoSlowingSpitActionEvent
-    useDelay: 1.5
+    useDelay: 2
     range: 15
     checkCanAccess: false
   - type: ActionBlockIfResting
@@ -202,7 +202,7 @@
       sprite: _RMC14/Actions/xeno_actions.rsi
       state: acid_shotgun
     event: !type:XenoScatteredSpitActionEvent
-    useDelay: 8
+    useDelay: 6
     range: 15
     checkCanAccess: false
   - type: ActionBlockIfResting


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title. 

paralyzing slash kicks in 3 secs instead of 4, and stuns for 5 instead of 4 seconds
slowing spit slows for 8 instead of 5 seconds
max scatter spit angle decreased from 60 to 45
slowing spit cooldown increased from 1.5 to 2
scatter spit cooldown decreased from 8 to 6

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
paritoo not biased against sentinel at all.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Sentinel's paralyzing slash now kicks in 1 second faster, and stuns for an additional second
- tweak: Slowing spit now last 8 seconds
- tweak: Scatter spit's max scatter decreased from 60 to 45
- tweak: Slowing spit's cooldown increased to 2 seconds, Scatter spit's cooldown decreased to 6