### PR TITLE
Hotfix: Defib draining

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Medical/defib.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Medical/defib.yml
@@ -78,6 +78,7 @@
   suffix: RMC14
   components:
   - type: PowerCellDraw
+    enabled: false
     useRate: 100
 
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Disabled passive power draw on defib, it still correctly drains power when being used on dead bodies.

## Why / Balance
Bug

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- fix: Defibrillators no longer passively drain power at all.

