### PR TITLE
Fix no melee damage sound not working

### DIFF
--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -537,7 +537,8 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
 
         }
 
-        _meleeSound.PlayHitSound(target.Value, user, GetHighestDamageSound(modifiedDamage, _protoManager), hitEvent.HitSoundOverride, component);
+        if (damageResult != null)
+        _meleeSound.PlayHitSound(target.Value, user, GetHighestDamageSound(damageResult, _protoManager), hitEvent.HitSoundOverride, component);
 
         if (damageResult?.GetTotal() > FixedPoint2.Zero)
         {
@@ -735,9 +736,6 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         {
             return groups.Keys.First();
         }
-
-        if (modifiedDamage.GetTotal() == FixedPoint2.Zero)
-            return null;
 
         var highestDamage = FixedPoint2.Zero;
         string? highestDamageType = null;

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -736,6 +736,9 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
             return groups.Keys.First();
         }
 
+        if (modifiedDamage.GetTotal() == FixedPoint2.Zero)
+            return null;
+
         var highestDamage = FixedPoint2.Zero;
         string? highestDamageType = null;
 


### PR DESCRIPTION
before, melee weapons would make the hit sound even if the damage didn't do anything
this was broken because melee weapons used the modifiedDamage instead of the applied damage, which is never zero

this should be fixed because it can be confusing to hear the hit sound when you aren't doing any damage, especially with things like xeno claw sharpness where you don't know that you're doing damage unless you look in the code