### PR TITLE
Un-predict Shove, Tail Stab, Paralyzing Slash, and Crippling Strike popups

### DIFF
--- a/Content.Shared/_RMC14/Tackle/TackleSystem.cs
+++ b/Content.Shared/_RMC14/Tackle/TackleSystem.cs
@@ -51,7 +51,9 @@ public sealed class TackleSystem : EntitySystem
         if (recently.Current < tackle.Threshold)
         {
             _adminLog.Add(LogType.RMCTackle, $"{ToPrettyString(user)} tried to tackle {ToPrettyString(target)}.");
-            _popup.PopupClient(Loc.GetString("cm-tackle-try-self", ("target", target.Owner)), user, user);
+
+            if (_net.IsServer)
+                _popup.PopupEntity(Loc.GetString("cm-tackle-try-self", ("target", target.Owner)), user, user);
 
             foreach (var session in Filter.PvsExcept(user).Recipients)
             {

--- a/Content.Shared/_RMC14/Xenonids/Crippling/XenoCripplingStrikeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Crippling/XenoCripplingStrikeSystem.cs
@@ -74,10 +74,13 @@ public sealed class XenoCripplingStrikeSystem : EntitySystem
             _movementSpeed.RefreshMovementSpeedModifiers(entity);
 
             var message = Loc.GetString("cm-xeno-crippling-strike-hit", ("target", entity));
-            _popup.PopupClient(message, entity, xeno);
+            
 
             if (_net.IsServer)
+            {
+                _popup.PopupEntity(message, entity, xeno);
                 SpawnAttachedTo(xeno.Comp.Effect, entity.ToCoordinates());
+            }
 
             RemCompDeferred<XenoActiveCripplingStrikeComponent>(xeno);
             break;

--- a/Content.Shared/_RMC14/Xenonids/Paralyzing/XenoParalyzingSlashSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Paralyzing/XenoParalyzingSlashSystem.cs
@@ -61,7 +61,9 @@ public sealed class XenoParalyzingSlashSystem : EntitySystem
             Dirty(entity, victim);
 
             var message = Loc.GetString("cm-xeno-paralyzing-slash-hit", ("target", entity));
-            _popup.PopupClient(message, entity, xeno);
+
+            if (_net.IsServer)
+                _popup.PopupEntity(message, entity, xeno);
 
             RemCompDeferred<XenoActiveParalyzingSlashComponent>(xeno);
             break;

--- a/Content.Shared/_RMC14/Xenonids/Stab/SharedXenoTailStabSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Stab/SharedXenoTailStabSystem.cs
@@ -19,6 +19,7 @@ using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Configuration;
 using Robust.Shared.Map;
+using Robust.Shared.Network;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Player;
@@ -38,6 +39,8 @@ public abstract class SharedXenoTailStabSystem : EntitySystem
     [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
     [Dependency] private readonly SharedInteractionSystem _interaction = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly INetManager _net = default!;
+
     [Dependency] private readonly SharedSolutionContainerSystem _solutionContainer = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
@@ -208,7 +211,8 @@ public abstract class SharedXenoTailStabSystem : EntitySystem
                     }
 
                     var msg = Loc.GetString("rmc-xeno-tail-stab-self", ("target", hit));
-                    _popup.PopupClient(msg, stab, stab);
+                    if (_net.IsServer)
+                        _popup.PopupEntity(msg, stab, stab);
 
                     msg = Loc.GetString("rmc-xeno-tail-stab-target", ("user", stab));
                     _popup.PopupEntity(msg, stab, hit, PopupType.MediumCaution);
@@ -228,7 +232,8 @@ public abstract class SharedXenoTailStabSystem : EntitySystem
         DoLunge((stab, stab, transform), localPos, "WeaponArcThrust");
 
         var sound = actualResults.Count > 0 ? stab.Comp.SoundHit : stab.Comp.SoundMiss;
-        _audio.PlayPredicted(sound, stab, stab);
+        if (_net.IsServer)
+            _audio.PlayPvs(sound, stab);
 
         var attackEv = new MeleeAttackEvent(stab);
         RaiseLocalEvent(stab, ref attackEv);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Makes the pop-ups for paralyzing slash, tail stab, tackling, and crippling strike run only on the server to prevent mis-predictions.

## Why / Balance
Melee/Shove prediction is broken and the client can't be trusted with giving you information. Having a mis-predicted popup can cause very negative consequences (mis-predicted shoving on Runner can cause you to drop a grab, mis-predicted Para Slash can cause you to not go for another that will actually work or play more passive as you wait for the stun, only for it to never come out). The cooldown for Tail Stab is already not predicted and it also frequently lies so did the same for it with the sound and the popup

## Technical details
Convert the 4 relevant PopupClient()s to a server-only PopupEntity().
Convert Tail Stab's sound from PlayPredicted() to a server-only PlayPvs().

## Media
Shove, Paralyzing Slash, Crippling Strike

https://github.com/user-attachments/assets/5b6fda94-c85f-40ca-a3b9-2e4b73f2a2a1

Tail Stab

https://github.com/user-attachments/assets/99a89e44-681b-4c91-a2f1-ec05ad3ac7a9


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- fix: Popups for Shoving, Tail Stab, Sentinel Paralyzing Slash, and Lurker Crippling Strike are no longer predicted. This means the message will no longer mispredict and lie to you about their effects happening, but will appear later than they used to on successes.
- The sound for Tail Stab is no longer predicted, the correct hit or miss sound will now always play, but may play delayed depending on your ping.
