### PR TITLE
Fix shield fruit not applying the first time it's used

### DIFF
--- a/Content.Shared/_RMC14/Shields/XenoShieldSystem.cs
+++ b/Content.Shared/_RMC14/Shields/XenoShieldSystem.cs
@@ -82,8 +82,7 @@ public sealed partial class XenoShieldSystem : EntitySystem
     public void ApplyShield(EntityUid uid, ShieldType type, FixedPoint2 amount, TimeSpan? duration = null,
         double decay = 0, bool addShield = false, double maxShield = 200)
     {
-        if (!EnsureComp<XenoShieldComponent>(uid, out var shieldComp))
-            return;
+        EnsureComp<XenoShieldComponent>(uid, out var shieldComp);
 
         if (shieldComp.Active && shieldComp.Shield == type)
         {

--- a/Content.Shared/_RMC14/Shields/XenoShieldSystem.cs
+++ b/Content.Shared/_RMC14/Shields/XenoShieldSystem.cs
@@ -82,7 +82,7 @@ public sealed partial class XenoShieldSystem : EntitySystem
     public void ApplyShield(EntityUid uid, ShieldType type, FixedPoint2 amount, TimeSpan? duration = null,
         double decay = 0, bool addShield = false, double maxShield = 200)
     {
-        EnsureComp<XenoShieldComponent>(uid, out var shieldComp);
+        var shieldComp = EnsureComp<XenoShieldComponent>(uid);
 
         if (shieldComp.Active && shieldComp.Shield == type)
         {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug.

## Technical details
<!-- Summary of code changes for easier review. -->
So I If'd an ensurecomp...so if a xeno didn't have a shield comp the function would just, return. But next time it'd run it'd work fine. Whoops.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed shield fruit not applying the first time it's used
