### PR TITLE
Fix attempting to unholster gun while stunned breaking the holster

### DIFF
--- a/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
+++ b/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
@@ -592,7 +592,9 @@ public abstract class SharedCMInventorySystem : EntitySystem
             if (TryComp(item, out StorageComponent? storage) &&
                 TryGetLastInserted((item, holster), out var weapon))
             {
-                _hands.TryPickup(user, weapon);
+                if (!_hands.TryPickup(user, weapon))
+                    return false;
+
                 holster.Contents.Remove(weapon);
                 _audio.PlayPredicted(holster.EjectSound, item, user);
                 stop = true;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Currently, attempting to unholster gun while stunned breaks the holster; the gun has to be taken out manually and reinserted for the holster to work again.
This PR fixes that

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfix

## Technical details
<!-- Summary of code changes for easier review. -->
Added a check to make sure gun has successfully been removed from storage before "removing" it from the holster

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Attempting to unholster a gun from a belt holster while unable to interact with inventory items no longer breaks the holster.
