### PR TITLE
Lurker attack reset

### DIFF
--- a/Content.Shared/_RMC14/Weapons/Melee/MeleeResetComponent.cs
+++ b/Content.Shared/_RMC14/Weapons/Melee/MeleeResetComponent.cs
@@ -1,0 +1,11 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Weapons.Melee;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(SharedRMCMeleeWeaponSystem))]
+public sealed partial class MeleeResetComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public TimeSpan OriginalTime;
+}

--- a/Content.Shared/_RMC14/Weapons/Melee/SharedRMCMeleeWeaponSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Melee/SharedRMCMeleeWeaponSystem.cs
@@ -16,7 +16,6 @@ public abstract class SharedRMCMeleeWeaponSystem : EntitySystem
     [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
     [Dependency] private readonly SharedMeleeWeaponSystem _melee = default!;
 
-
     private EntityQuery<MeleeWeaponComponent> _meleeWeaponQuery;
     private EntityQuery<XenoComponent> _xenoQuery;
 

--- a/Content.Shared/_RMC14/Weapons/Melee/SharedRMCMeleeWeaponSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Melee/SharedRMCMeleeWeaponSystem.cs
@@ -44,9 +44,6 @@ public abstract class SharedRMCMeleeWeaponSystem : EntitySystem
     //Call this whenever you add MeleeResetComponent to anything
     public void MeleeResetInit(Entity<MeleeResetComponent> ent)
     {
-        if (!_timing.IsFirstTimePredicted)
-            return;
-
         if (!TryComp<MeleeWeaponComponent>(ent, out var weapon))
         {
             RemComp<MeleeResetComponent>(ent);

--- a/Content.Shared/_RMC14/Xenonids/Crippling/XenoCripplingStrikeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Crippling/XenoCripplingStrikeSystem.cs
@@ -18,6 +18,7 @@ public sealed class XenoCripplingStrikeSystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly XenoSystem _xeno = default!;
+    [Dependency] private readonly SharedRMCMeleeWeaponSystem _rmcMelee = default!;
     [Dependency] private readonly XenoPlasmaSystem _xenoPlasma = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
 
@@ -39,7 +40,8 @@ public sealed class XenoCripplingStrikeSystem : EntitySystem
 
         args.Handled = true;
         var active = EnsureComp<XenoActiveCripplingStrikeComponent>(xeno);
-        EnsureComp<MeleeResetComponent>(xeno);
+        var reset = EnsureComp<MeleeResetComponent>(xeno);
+        _rmcMelee.MeleeResetInit((xeno.Owner, reset));
 
         active.ExpireAt = _timing.CurTime + xeno.Comp.ActiveDuration;
         active.SpeedMultiplier = xeno.Comp.SpeedMultiplier;

--- a/Content.Shared/_RMC14/Xenonids/Crippling/XenoCripplingStrikeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Crippling/XenoCripplingStrikeSystem.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Shared._RMC14.Armor;
 using Content.Shared._RMC14.Xenonids.Plasma;
+using Content.Shared._RMC14.Weapons.Melee;
 using Content.Shared.Coordinates;
 using Content.Shared.Damage;
 using Content.Shared.Movement.Systems;
@@ -38,6 +39,7 @@ public sealed class XenoCripplingStrikeSystem : EntitySystem
 
         args.Handled = true;
         var active = EnsureComp<XenoActiveCripplingStrikeComponent>(xeno);
+        EnsureComp<MeleeResetComponent>(xeno);
 
         active.ExpireAt = _timing.CurTime + xeno.Comp.ActiveDuration;
         active.SpeedMultiplier = xeno.Comp.SpeedMultiplier;
@@ -122,6 +124,7 @@ public sealed class XenoCripplingStrikeSystem : EntitySystem
                     continue;
 
                 RemCompDeferred<XenoActiveCripplingStrikeComponent>(uid);
+                RemCompDeferred<MeleeResetComponent>(uid);
 
                 _popup.PopupEntity(Loc.GetString("cm-xeno-crippling-strike-expire"), uid, uid, PopupType.SmallCaution);
             }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Ports Lurker's melee attack reset when activating Crippling Strike.

## Why / Balance
CM13 Parity.

## Technical details
Adds a Component named MeleeResetComponent, currently only used in XenoCripplingStrikeSystem.

Subscribes SharedRMCMeleeWeaponSystem to all 3 attack events, running before the upstream version.
MeleeResetInit() is a function called externally on startup (request of Smug), it readies your melee's attack immediately once called, and stores the original time you would've been able to next melee for the purpose of disarm (you are not allowed to use your reset for tackling).

TryMeleeReset() removes the comp so that the melee reset is consumed when attacking, and if a disarm is attempted, it prevents you from using your reset on disarming by reverting the reset timer.

## Media
https://github.com/user-attachments/assets/128e2361-68e7-468c-9003-e4ad7741bcf6

https://github.com/user-attachments/assets/77963e98-d04f-4584-88a7-b64d99626a12

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- add: Ported Lurker's Crippling Strike Attack Reset from CM13. Whenever the Crippling Strike ability is used, you can melee attack again instantly, regardless of when you last meleed. This lets you melee twice in quick succession.

