### PR TITLE
revert color change of Almayer channel

### DIFF
--- a/Resources/Prototypes/_RMC14/radio_channels.yml
+++ b/Resources/Prototypes/_RMC14/radio_channels.yml
@@ -13,7 +13,7 @@
   name: chat-radio-marine-common
   keycode: "g" #; and g in cm13
   frequency: 1480
-  color: "#B4B4B4"
+  color: "#6FD08C"
   longRange: true
   tower: true
   planet: false


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Revert the changes to the Almayer channel color, as a result of [accessibility feedback](https://discord.com/channels/1168210010233376858/1302544720874045520)* 
(*after the chatbox was shaded to be darker)

**Changelog**

:cl: Whisper

- tweak: Reverted color change of Almayer channel.

