### PR TITLE
Fixes UGL unloading

### DIFF
--- a/Content.Shared/_RMC14/Attachable/Systems/AttachableToggleableSystem.cs
+++ b/Content.Shared/_RMC14/Attachable/Systems/AttachableToggleableSystem.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using Content.Shared._RMC14.Attachable.Components;
 using Content.Shared._RMC14.Attachable.Events;
+using Content.Shared._RMC14.Weapons.Ranged;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared.Actions;
 using Content.Shared.Actions.Events;
@@ -47,7 +48,8 @@ public sealed class AttachableToggleableSystem : EntitySystem
 
     public override void Initialize()
     {
-        SubscribeLocalEvent<AttachableToggleableComponent, ActivateInWorldEvent>(OnActivateInWorld);
+        SubscribeLocalEvent<AttachableToggleableComponent, ActivateInWorldEvent>(OnActivateInWorld,
+            after: new[] { typeof(CMGunSystem) });
         SubscribeLocalEvent<AttachableToggleableComponent, AttachableAlteredEvent>(OnAttachableAltered,
             after: new[] { typeof(AttachableModifiersSystem) });
         SubscribeLocalEvent<AttachableToggleableComponent, AttachableToggleableInterruptEvent>(OnAttachableToggleableInterrupt);

--- a/Content.Shared/_RMC14/Weapons/Ranged/BreechLoadedSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/BreechLoadedSystem.cs
@@ -23,6 +23,7 @@ public sealed class BreechLoadedSystem : EntitySystem
     {
         SubscribeLocalEvent<BreechLoadedComponent, AttemptShootEvent>(OnAttemptShoot);
         SubscribeLocalEvent<BreechLoadedComponent, GunShotEvent>(OnGunShot);
+        SubscribeLocalEvent<BreechLoadedComponent, RMCTryAmmoEjectEvent>(OnTryAmmoEject);
         SubscribeLocalEvent<BreechLoadedComponent, UniqueActionEvent>(OnUniqueAction);
         SubscribeLocalEvent<BreechLoadedComponent, InteractUsingEvent>(OnInteractUsing,
             before: new[] { typeof(SharedGunSystem) });
@@ -49,6 +50,15 @@ public sealed class BreechLoadedSystem : EntitySystem
         Dirty(gun);
     }
 
+    private void OnTryAmmoEject(Entity<BreechLoadedComponent> gun, ref RMCTryAmmoEjectEvent args)
+    {
+        if (gun.Comp.Open)
+            return;
+
+        _popupSystem.PopupClient(Loc.GetString("rmc-breech-loaded-closed-extract-attempt"), args.User, args.User);
+        args.Cancelled = true;
+    }
+
     private void OnUniqueAction(Entity<BreechLoadedComponent> gun, ref UniqueActionEvent args)
     {
         if (args.Handled)
@@ -69,7 +79,7 @@ public sealed class BreechLoadedSystem : EntitySystem
         //_audioSystem.PlayPredicted(sound, gun, args.UserUid, sound.Params);
         _audioSystem.PlayPredicted(sound, gun, args.UserUid);
     }
-    
+
     private void OnInteractUsing(Entity<BreechLoadedComponent> gun, ref InteractUsingEvent args)
     {
         if (gun.Comp.Open ||
@@ -78,7 +88,7 @@ public sealed class BreechLoadedSystem : EntitySystem
             ammoProviderComponent.Whitelist.Tags == null ||
             !_tagSystem.HasAnyTag(args.Used, ammoProviderComponent.Whitelist.Tags))
             return;
-        
+
         _popupSystem.PopupClient(Loc.GetString("rmc-breech-loaded-closed-load-attempt"), args.User, args.User);
         args.Handled = true;
     }

--- a/Content.Shared/_RMC14/Weapons/Ranged/CMGunSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/CMGunSystem.cs
@@ -438,6 +438,12 @@ public sealed class CMGunSystem : EntitySystem
             return;
         }
 
+        var cancelEvent = new RMCTryAmmoEjectEvent(args.User, false);
+        RaiseLocalEvent(gun.Owner, ref cancelEvent);
+
+        if (cancelEvent.Cancelled)
+            return;
+
         args.Handled = true;
 
         var ejectedAmmo = container.ContainedEntities[0];

--- a/Content.Shared/_RMC14/Weapons/Ranged/RMCTryAmmoEjectEvent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/RMCTryAmmoEjectEvent.cs
@@ -1,0 +1,8 @@
+
+namespace Content.Shared._RMC14.Weapons.Ranged;
+
+[ByRefEvent]
+public record struct RMCTryAmmoEjectEvent(
+    EntityUid User,
+    bool Cancelled
+);

--- a/Resources/Locale/en-US/_RMC14/weapons/guns.ftl
+++ b/Resources/Locale/en-US/_RMC14/weapons/guns.ftl
@@ -8,6 +8,7 @@ cm-gun-pump-first = You need to pump the gun first!
 rmc-breech-loaded-open-shoot-attempt = You need to close the breech first!
 rmc-breech-loaded-not-ready-to-shoot = You need to open and close the breech first!
 rmc-breech-loaded-closed-load-attempt = You need to open the breech first!
+rmc-breech-loaded-closed-extract-attempt = You need to open the breech first!
 
 rmc-wield-use-delay = You need to wait {$seconds} seconds before wielding {THE($wieldable)}!
 rmc-shoot-use-delay = You need to wait {$seconds} seconds before shooting {THE($wieldable)}!


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Makes it so you can extract grenades from the UGL when it's not attached to a gun. Makes it so you can't extract ammo from breechloaders when the breech is closed.

## Why / Balance
Bug.

## Technical details
The MOU and several other guns have a similar issue where you can't extract the ammo they spawn with through RMCAmmoEject. This is because BallisticAmmoProvider is a pile of shit. I can probably work around it without editing upstream files, but it'll be obnoxious because I'll need to figure out how to get it to not have weird interactions with shell handfuls. Leaving it for later.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None.

**Changelog**

:cl: Sigil
- fix: You can now extract grenades from the UGL even when it's not attached to a gun.
- fix: You can no longer extract grenades from the UGL when the breech is closed.
