### PR TITLE
Removes the MOU and M42A2 having burst fire

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/m357_sawn_off_shotgun.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/m357_sawn_off_shotgun.yml
@@ -1,5 +1,5 @@
 ﻿- type: entity
-  parent: [ RMCBaseBreechloader, RMCBaseAttachableHolder ]
+  parent: [ WeaponShotgunM357, RMCBaseAttachableHolder ]
   name: Sawn-Off M357 Rival
   id: WeaponShotgunM357Sawn
   description: A double barrel shotgun produced by Aegis. Archaic, sturdy, affordable. It has been artificially shortened to reduce range but increase damage and spread.

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/mou53_shotgun.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/mou53_shotgun.yml
@@ -14,7 +14,6 @@
   - type: RMCSelectiveFire
     baseFireModes:
     - SemiAuto
-    - Burst
     recoilWielded: 2
     recoilUnwielded: 4
     scatterWielded: 9

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/pump_shotgun.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/pump_shotgun.yml
@@ -14,7 +14,6 @@
   - type: RMCSelectiveFire
     baseFireModes:
     - SemiAuto
-    - Burst
     recoilWielded: 2
     recoilUnwielded: 4
     scatterWielded: 10


### PR DESCRIPTION
## About the PR
See title. Apparently, I'm the one who added this. Probably copied the selective fire component from somewhere else before editing the different parts and forgetting to get rid of burst.

The double-barrels are both supposed to have burst.

## Why / Balance
Bug.

## Technical details
YAML.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None.

**Changelog**

:cl: Sigil
- fix: Fixed The MOU and the M42A2 having burst fire.
- fix: The sawn-off double-barrel shotgun now has a 2-round burst, same as the normal double-barrel shotgun.
