### PR TITLE
Fix arm brace breaking the holster

### DIFF
--- a/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
+++ b/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
@@ -422,11 +422,11 @@ public abstract class SharedCMInventorySystem : EntitySystem
             if (slot.ItemSlot == null &&
                 TryComp(slot.Ent, out StorageComponent? storage) &&
                 TryComp(slot.Ent, out CMHolsterComponent? holster) &&
-                !holster.Contents.Contains(item))
+                !holster.Contents.Contains(item) &&
+                _hands.TryDrop(user, item) &&
+                _storage.Insert(slot.Ent, item, out _, user, storage, playSound: false))
             {
                 holster.Contents.Add(item);
-                _hands.TryDrop(user, item);
-                _storage.Insert(slot.Ent, item, out _, user, storage, playSound: false);
                 _audio.PlayPredicted(holster.InsertSound, item, user);
                 _adminLog.Add(LogType.RMCHolster, $"{ToPrettyString(user)} holstered {ToPrettyString(item)}");
                 return;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Attempting to holster the M63 with its brace extended breaks the holster.
This PR fixes it

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug-fix

## Technical details
<!-- Summary of code changes for easier review. -->
Added a check if the gun has been holstered successfully before counting as part of the holster's contents.
(Or rather, moved parts of the existing behaviour _inside_ the check before adding it to the holster's internal list.)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- Attempting to holster the M63 with its brace extended no longer breaks its pouched holster belt.
