### PR TITLE
Improve Warrior Lunge Hit Reg, unpredict Fling + Lunge CC, Fling CD

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Fling/XenoFlingSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Fling/XenoFlingSystem.cs
@@ -43,10 +43,12 @@ public sealed class XenoFlingSystem : EntitySystem
         if (attempt.Cancelled)
             return;
 
-        args.Handled = true;
-
         if (_net.IsServer)
+        {
+            args.Handled = true;
             _audio.PlayPvs(xeno.Comp.Sound, xeno);
+        }
+            
 
         var targetId = args.Target;
         _rmcPulling.TryStopUserPullIfPulling(xeno, targetId);
@@ -64,10 +66,12 @@ public sealed class XenoFlingSystem : EntitySystem
         var length = diff.Length();
         diff *= xeno.Comp.Range / 3 / length;
 
-        _stun.TryParalyze(targetId, xeno.Comp.ParalyzeTime, true);
-        _throwing.TryThrow(targetId, diff, 10);
-
         if (_net.IsServer)
+        {
+            _stun.TryParalyze(targetId, xeno.Comp.ParalyzeTime, true);
+            _throwing.TryThrow(targetId, diff, 10);
+
             SpawnAttachedTo(xeno.Comp.Effect, targetId.ToCoordinates());
+        } 
     }
 }

--- a/Content.Shared/_RMC14/Xenonids/Lunge/XenoLungeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Lunge/XenoLungeSystem.cs
@@ -8,6 +8,7 @@ using Content.Shared.Stunnable;
 using Content.Shared.Throwing;
 using Robust.Shared.Network;
 using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Systems;
 using Robust.Shared.Timing;
 
 namespace Content.Shared._RMC14.Xenonids.Lunge;
@@ -19,6 +20,7 @@ public sealed class XenoLungeSystem : EntitySystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly ThrownItemSystem _thrownItem = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly PullingSystem _pulling = default!;
     [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
     [Dependency] private readonly SharedStunSystem _stun = default!;
@@ -65,12 +67,29 @@ public sealed class XenoLungeSystem : EntitySystem
         Dirty(xeno);
 
         _throwing.TryThrow(xeno, diff, 10, animated: false);
+
+        if (!_physicsQuery.TryGetComponent(xeno, out var physics))
+            return;
+
+        //Handle close-range or same-tile lunges
+        foreach (var ent in _physics.GetContactingEntities(xeno.Owner, physics))
+        {
+            if (ent != args.Target)
+                continue;
+
+            if (ApplyLungeHitEffects(xeno, ent))
+                return;
+        }
     }
 
     private void OnXenoLungeHit(Entity<XenoLungeComponent> xeno, ref ThrowDoHitEvent args)
     {
+        ApplyLungeHitEffects(xeno, args.Target);
+    }
+
+    private bool ApplyLungeHitEffects(Entity<XenoLungeComponent> xeno, EntityUid targetId)
+    {
         // TODO RMC14 lag compensation
-        var targetId = args.Target;
         if (_physicsQuery.TryGetComponent(xeno, out var physics) &&
             _thrownItemQuery.TryGetComponent(xeno, out var thrown))
         {
@@ -82,13 +101,17 @@ public sealed class XenoLungeSystem : EntitySystem
             xeno.Comp.Charge = null;
 
         if (_hive.FromSameHive(xeno.Owner, targetId))
-            return;
+            return true;
 
-        _stun.TryParalyze(targetId, xeno.Comp.StunTime, true);
 
-        var stunned = EnsureComp<XenoLungeStunnedComponent>(targetId);
-        stunned.ExpireAt = _timing.CurTime + xeno.Comp.StunTime;
-        Dirty(targetId, stunned);
+        if(_net.IsServer)
+        {
+            _stun.TryParalyze(targetId, xeno.Comp.StunTime, true);
+
+            var stunned = EnsureComp<XenoLungeStunnedComponent>(targetId);
+            stunned.ExpireAt = _timing.CurTime + xeno.Comp.StunTime;
+            Dirty(targetId, stunned);
+        }
 
         _pulling.TryStartPull(xeno, targetId);
 
@@ -97,6 +120,8 @@ public sealed class XenoLungeSystem : EntitySystem
         {
             SpawnAttachedTo(xeno.Comp.Effect, targetId.ToCoordinates());
         }
+
+        return true;
     }
 
     private void OnXenoLungeStunnedPullStopped(Entity<XenoLungeStunnedComponent> ent, ref PullStoppedMessage args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

* Improved Warrior's Lunge hit registration at close range, using similar code to #4529. Checks if the target you clicked on is close enough when starting the Lunge so that you don't just uselessly fly through them.

* Unpredicted Lunge stun. It will now appear to happen slightly later, but will never incorrectly show the stun visual. Prior to this it was VERY problematic, as if Lunge mis-predicted its stun then the person you used it on would appear to be knocked down for the rest of the game.

* Unpredicted basically the entirety of Fling for the following reasons/purpose:

1. The stun of Fling made the target appear to just fall over for half a second if mis-predicted, giving incorrect feedback to the Warrior player about hitting their ability.

2. The cooldown of Fling on high ping previously could mispredict itself to go on cooldown, and then not refund it when the server declines the fling. This made it to where your Fling cooldown could just be consumed entirely by nothing.

All of these mis-prediction issues are VERY common, even on incredibly low levels of ping.

## Media
Video Demonstration on various levels of lag (~average West Coast/EU connection for first half, ~375ms of lag for second half to showcase edge cases of insane lag)

https://cdn.discordapp.com/attachments/1168210011823026271/1304872256026972212/2024-11-09_13-06-01.mp4?ex=6730f87d&is=672fa6fd&hm=52bb37556f962a8b4dce90f60ac1349f7fb67a3dedcc47c06e94bb5409a4002f&

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Technical details
Make Lunge/Fling stuns and Fling's cooldown to only run on the server, not the client, using _net.IsServer checks.

Moved code in OnXenoLungeHit() to ApplyLungeHitEffects(), and calls it from there, so that this code can be re-used.

When using the Lunge ability, it now checks for targets very close to it using _physics.GetContactingEntities(), similar to how Runner, Lurker, and Parasite leaps now do. Unlike them, it only checks for the specific target, due to being a click-targetted ability.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- fix: Warrior Lunge will now register hits on Marines that are too close or sharing the same tile as them, instead of making the Warrior uselessly fly through them.
- fix: Warrior Lunge's knockdown and stun is no longer predicted. It will no longer lie about hitting when it actually missed, and no longer cause Marines to appear on the floor for the rest of the game when it fails, but will appear to happen slightly later on a successful hit.
- fix: Warrior Fling is no longer predicted. It will no longer consume it's cooldown on a mis-predicted hit, and will not appear to knock Marines down when the ability actually failed.
