### PR TITLE
Medical reactives parity change

### DIFF
--- a/Resources/Prototypes/_RMC14/Reagents/medicine.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/medicine.yml
@@ -133,7 +133,7 @@
   overdose: 15
   metabolisms:
     Medicine:
-      metabolismRate: 0.025
+      metabolismRate: 0.03
       effects:
       - !type:EqualHealthChange
         damage:

--- a/Resources/Prototypes/_RMC14/Reagents/medicine.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/medicine.yml
@@ -343,9 +343,9 @@
         conditions:
         - !type:RecentlyDefibrillated
         damage:
-        - Brute: -40
-        - Burn: -40
-        - Toxin: -40
+        - Brute: -20
+        - Burn: -20
+        - Toxin: -20
       - !type:AdjustReagent
         conditions:
         - !type:RecentlyDefibrillated

--- a/Resources/Prototypes/_RMC14/Reagents/medicine.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/medicine.yml
@@ -311,7 +311,12 @@
         - Brute: -16
         - Burn: -16
         - Toxin: -16
-        - Asphyxiation: -16
+      - !type:HealthChange
+        conditions:
+        - !type:RecentlyDefibrillated
+        damage:
+          types:
+            Asphyxiation: -16
       - !type:AdjustReagent
         conditions:
         - !type:RecentlyDefibrillated
@@ -325,8 +330,7 @@
         - !type:ReagentThreshold
           min: 20
         damage:
-          types:
-            Brute: 1
+          Brute: 1
 
 # TODO RMC14 other effects
 # TODO RMC14 allow breathing in crit instead of reducing asphyxiation

--- a/Resources/Prototypes/_RMC14/Reagents/medicine.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/medicine.yml
@@ -8,18 +8,27 @@
   overdose: 30
   metabolisms:
     Medicine:
-      metabolismRate: 0.1
+      metabolismRate: 0.2
       effects:
       - !type:EqualHealthChange
         damage:
-        - Toxin: -1
+        - Toxin: -2
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           min: 30
         damage:
           groups:
+            Brute: 1 # TODO: change to eye damage
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 50
+        damage:
+          groups:
             Brute: 1
+            Burn: 1
+            Toxin: 2
       - !type:Jitter
         conditions:
         - !type:ReagentThreshold
@@ -51,26 +60,29 @@
   overdose: 30
   metabolisms:
     Medicine:
-      metabolismRate: 0.1
+      metabolismRate: 0.2
       effects:
       - !type:GenericStatusEffect
         key: Drunk
-        time: 1.5
+        time: 3
         type: Remove
+      - !type:AdjustReagent # TODO add another alcohols to decrease
+        reagent: RMCEthanol
+        amount: -3
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           min: 30
         damage:
           groups:
-            Toxin: 0.75
+            Toxin: 1.5
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           min: 50
         damage:
           groups:
-            Toxin: 2.25
+            Toxin: 6
 
 # TODO RMC14 other effects
 - type: reagent
@@ -79,29 +91,40 @@
   name: reagent-name-cmarithrazine
   desc: reagent-desc-cmarithrazine
   color: "#3c8529"
-  overdose: 7.5
+  overdose: 15
   metabolisms:
     Medicine:
-      metabolismRate: 0.03
+      metabolismRate: 0.05
       effects:
       - !type:EqualHealthChange
         damage:
-        - Toxin: -0.5
+        - Toxin: -1
+      - !type:HealthChange
+        damage:
+          groups:
+            Brute: 1
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 7.5
+          min: 15
         damage:
           groups:
-            Brute: 0.5
+            Brute: 3 # TODO: change to 1 eye damage + 2 brute damage
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 25
+        damage:
+          groups:
+            Brute: 4
       - !type:Jitter
         conditions:
         - !type:ReagentThreshold
-          min: 12.5
+          min: 25
       - !type:PopupMessage
         conditions:
         - !type:ReagentThreshold
-          min: 12.5
+          min: 25
         type: Local
         visualType: Medium
         messages: [ "generic-reagent-effect-nauseous" ]
@@ -109,29 +132,11 @@
       - !type:GenericStatusEffect
         conditions:
         - !type:ReagentThreshold
-          min: 12.5
+          min: 25
         key: Drunk
         component: Drunk
         time: 30
         type: Add
-      - !type:HealthChange
-        damage:
-          groups:
-            Brute: 0.12
-      - !type:HealthChange
-        conditions:
-        - !type:ReagentThreshold
-          min: 7.5
-        damage:
-          groups:
-            Brute: 0.25
-      - !type:HealthChange
-        conditions:
-        - !type:ReagentThreshold
-          min: 12.5
-        damage:
-          groups:
-            Brute: 0.62
 
 # TODO RMC14 other effects
 - type: reagent
@@ -143,26 +148,26 @@
   overdose: 30
   metabolisms:
     Medicine:
-      metabolismRate: 0.1
+      metabolismRate: 0.2
       effects:
       - !type:EqualHealthChange
         damage:
-        - Brute: -0.5
+        - Brute: -1
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           min: 30
         damage:
           groups:
-            Burn: 0.25
+            Burn: 1
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           min: 50
         damage:
           groups:
-            Burn: 2.5
-            Toxin: 1
+            Burn: 6
+            Toxin: 2
 
 # TODO RMC14 other effects (remove toxic reagents)
 - type: reagent
@@ -173,16 +178,16 @@
   color: "#4acaca"
   metabolisms:
     Medicine:
-      metabolismRate: 0.1
+      metabolismRate: 0.2
       effects:
       - !type:EqualHealthChange
         conditions:
         - !type:Temperature
           max: 170
         damage:
-        - Brute: -1.5
-        - Burn: -1
-        - Toxin: -1.5
+        - Brute: -3
+        - Burn: -3
+        - Toxin: -3
       - !type:HealthChange
         conditions:
         - !type:Temperature
@@ -190,7 +195,7 @@
         damage:
           types:
             Asphyxiation: -1
-            Cellular: -0.12
+            Cellular: -3
 
 # TODO RMC14 other effects
 - type: reagent
@@ -202,27 +207,27 @@
   overdose: 15
   metabolisms:
     Medicine:
-      metabolismRate: 0.1
+      metabolismRate: 0.2
       effects:
       - !type:EqualHealthChange
         damage:
-        - Burn: -0.75
+        - Burn: -1.5
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           min: 15
         damage:
           groups:
-            Burn: 0.37
-            Toxin: 0.37
+            Burn: 1.5
+            Toxin: 1.5
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           min: 25
         damage:
           groups:
-            Burn: 0.88
-            Toxin: 0.88
+            Burn: 9
+            Toxin: 9
 
 # TODO RMC14 other effects
 - type: reagent
@@ -234,26 +239,26 @@
   overdose: 30
   metabolisms:
     Medicine:
-      metabolismRate: 0.1
+      metabolismRate: 0.2
       effects:
       - !type:EqualHealthChange
         damage:
-        - Airloss: -1
+        - Airloss: -4
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           min: 30
         damage:
           groups:
-            Toxin: 0.5
+            Toxin: 2
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           min: 50
         damage:
           groups:
-            Brute: 1
-            Toxin: 2
+            Brute: 4
+            Toxin: 8
 
 # TODO RMC14 other effects
 - type: reagent
@@ -265,7 +270,7 @@
   overdose: 15
   metabolisms:
     Medicine:
-      metabolismRate: 0.1
+      metabolismRate: 0.2
       effects:
       - !type:RemoveDamage
         group: Airloss
@@ -275,15 +280,15 @@
           min: 15
         damage:
           groups:
-            Toxin: 0.75
+            Toxin: 1.5
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           min: 25
         damage:
           groups:
-            Brute: 1.5
-            Toxin: 3
+            Brute: 3
+            Toxin: 7.5
 
 # TODO RMC14 other effects (pain)
 # TODO RMC14 injected only
@@ -297,15 +302,16 @@
   worksOnTheDead: true
   metabolisms:
     Medicine:
-      metabolismRate: 0.2
+      metabolismRate: 0.4
       effects:
       - !type:EqualHealthChange
         conditions:
         - !type:RecentlyDefibrillated
         damage:
-        - Brute: -20
-        - Burn: -20
-        - Toxin: -20
+        - Brute: -16
+        - Burn: -16
+        - Toxin: -16
+        - Asphyxiation: -16
       - !type:AdjustReagent
         conditions:
         - !type:RecentlyDefibrillated
@@ -317,17 +323,10 @@
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 10.5
-        damage:
-          groups:
-            Toxin: 0.19
-      - !type:HealthChange
-        conditions:
-        - !type:ReagentThreshold
           min: 20
         damage:
           types:
-            Asphyxiation: 1.5
+            Brute: 1
 
 # TODO RMC14 other effects
 # TODO RMC14 allow breathing in crit instead of reducing asphyxiation
@@ -340,7 +339,7 @@
   overdose: 60
   metabolisms:
     Medicine:
-      metabolismRate: 0.1
+      metabolismRate: 0.2
       effects:
       - !type:HealthChange
         conditions:
@@ -388,27 +387,27 @@
   overdose: 30
   metabolisms:
     Medicine:
-      metabolismRate: 0.1
+      metabolismRate: 0.2
       effects:
       - !type:EqualHealthChange
         damage:
-        - Burn: -0.5
+        - Burn: -1
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           min: 30
         damage:
           groups:
-            Brute: 0.3
-            Toxin: 0.3
+            Brute: 1
+            Toxin: 1
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           min: 50
         damage:
           groups:
-            Brute: 2.5
-            Toxin: 2.5
+            Brute: 5.5
+            Toxin: 5.5
 
 # TODO RMC14 other effects
 - type: reagent
@@ -420,7 +419,7 @@
   overdose: 30
   metabolisms:
     Medicine:
-      metabolismRate: 0.1
+      metabolismRate: 0.2
       effects:
       - !type:StabilizeTemperature
         stable: 310
@@ -460,12 +459,12 @@
   overdose: 30
   metabolisms:
     Medicine:
-      metabolismRate: 0.1
+      metabolismRate: 0.2
       effects:
       - !type:EqualHealthChange
         damage:
-        - Brute: -0.25
-        - Burn: -0.25
+        - Brute: -0.5
+        - Burn: -0.5
         - Toxin: -0.5
       - !type:HealthChange
         damage:
@@ -477,18 +476,18 @@
           min: 30
         damage:
           groups:
-            Brute: 0.13
-            Burn: 0.26
-            Toxin: 0.26
+            Brute: 1 # TODO: change to 0.5 eye damage + 0.5 brute damage
+            Burn: 0.5
+            Toxin: 0.25
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           min: 50
         damage:
           groups:
-            Brute: 1.5
-            Burn: 1.25
-            Toxin: 2.25
+            Brute: 2.5
+            Burn: 2.5
+            Toxin: 4
       - !type:GenericStatusEffect
         conditions:
         - !type:ReagentThreshold
@@ -508,26 +507,26 @@
   overdose: 15
   metabolisms:
     Medicine:
-      metabolismRate: 0.1
+      metabolismRate: 0.2
       effects:
       - !type:EqualHealthChange
         damage:
-        - Brute: -0.75
+        - Brute: -1.5
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           min: 15
         damage:
           groups:
-            Burn: 0.375
+            Burn: 1.5
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           min: 25
         damage:
           groups:
-            Burn: 3.75
-            Toxin: 1.5
+            Burn: 9
+            Toxin: 3
 
 # TODO RMC14 other effects
 # TODO RMC14 progressive eye healing
@@ -541,7 +540,7 @@
   overdose: 30
   metabolisms:
     Medicine:
-      metabolismRate: 0.1
+      metabolismRate: 0.2
       effects:
       - !type:ChemHealEyeDamage
       - !type:HealthChange
@@ -550,16 +549,16 @@
           min: 30
         damage:
           groups:
-            Toxin: 0.5
+            Toxin: 1
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           min: 50
         damage:
           groups:
-            Brute: 0.5
-            Burn: 0.5
-            Toxin: 2
+            Brute: 1
+            Burn: 1
+            Toxin: 4
 
 # TODO RMC14 other effects
 # TODO RMC14 heal cloneloss
@@ -571,13 +570,20 @@
   color: "#51b4db"
   metabolisms:
     Medicine:
-      metabolismRate: 0.1
+      metabolismRate: 0.2
       effects:
       - !type:EqualHealthChange
         conditions:
         - !type:Temperature
           max: 170
         damage:
-        - Toxin: -3.75
-        - Brute: -2.25
-        - Burn: -3
+        - Toxin: -6
+        - Brute: -6
+        - Burn: -6
+      - !type:HealthChange
+        conditions:
+        - !type:Temperature
+          max: 170
+        damage:
+          types:
+            Cellular: -6

--- a/Resources/Prototypes/_RMC14/Reagents/medicine.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/medicine.yml
@@ -7,16 +7,29 @@
   overdose: 30
   metabolisms:
     Medicine:
-      metabolismRate: 0.2
+      metabolismRate: 0.1
       effects:
       - !type:EqualHealthChange
         damage:
         - Toxin: -2
+      - !type:GenericStatusEffect
+        key: SeeingRainbows
+        component: SeeingRainbows
+        type: Remove
+        time: 20
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
+        damage:
+          groups:
+            Toxin: 0.5
       - !type:ChemHealEyeDamage
         conditions:
         - !type:ReagentThreshold
           min: 30
         amount: 1
+        probability: 0.5
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
@@ -25,27 +38,15 @@
           groups:
             Brute: 1
             Burn: 1
-            Toxin: 2
-      - !type:Jitter
-        conditions:
-        - !type:ReagentThreshold
-          min: 50
-      - !type:PopupMessage
-        conditions:
-        - !type:ReagentThreshold
-          min: 50
-        type: Local
-        visualType: Medium
-        messages: [ "generic-reagent-effect-nauseous" ]
-        probability: 0.2
+            Toxin: 3
       - !type:GenericStatusEffect
         conditions:
         - !type:ReagentThreshold
           min: 50
         key: ForcedSleep
         component: ForcedSleeping
-        time: 2
-        refresh: false
+        time: 30
+        refresh: true
         type: Add
 
 # TODO add another alcohols to decrease
@@ -58,10 +59,30 @@
   overdose: 30
   metabolisms:
     Medicine:
-      metabolismRate: 0.2
+      metabolismRate: 0.1
       effects:
       - !type:GenericStatusEffect
         key: Drunk
+        time: 3
+        type: Remove
+      - !type:GenericStatusEffect
+        key: Jitter
+        time: 3
+        type: Remove
+      - !type:GenericStatusEffect
+        key: ForcedSleep
+        time: 3
+        type: Remove
+      - !type:GenericStatusEffect
+        key: Stutter
+        time: 3
+        type: Remove
+      - !type:GenericStatusEffect
+        key: SlurredSpeech
+        time: 3
+        type: Remove
+      - !type:GenericStatusEffect
+        key: Drowsiness
         time: 3
         type: Remove
       - !type:AdjustReagent
@@ -101,7 +122,7 @@
           min: 50
         damage:
           groups:
-            Toxin: 6
+            Toxin: 4.5
 
 - type: reagent
   parent: [ CMReagentMedicine, Arithrazine ]
@@ -112,7 +133,7 @@
   overdose: 15
   metabolisms:
     Medicine:
-      metabolismRate: 0.05
+      metabolismRate: 0.025
       effects:
       - !type:EqualHealthChange
         damage:
@@ -120,46 +141,35 @@
       - !type:HealthChange
         damage:
           groups:
-            Brute: 1
+            Brute: 0.25
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           min: 15
         damage:
           groups:
-            Brute: 2
+            Brute: 1
       - !type:ChemHealEyeDamage
         conditions:
         - !type:ReagentThreshold
           min: 15
         amount: 1
+        probability: 0.25
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           min: 25
         damage:
           groups:
-            Brute: 4
-      - !type:Jitter
-        conditions:
-        - !type:ReagentThreshold
-          min: 25
-      - !type:PopupMessage
-        conditions:
-        - !type:ReagentThreshold
-          min: 25
-        type: Local
-        visualType: Medium
-        messages: [ "generic-reagent-effect-nauseous" ]
-        probability: 0.2
+            Brute: 2.5
       - !type:GenericStatusEffect
         conditions:
         - !type:ReagentThreshold
           min: 25
         key: ForcedSleep
         component: ForcedSleeping
-        refresh: false
-        time: 2
+        refresh: true
+        time: 30
         type: Add
 
 - type: reagent
@@ -171,7 +181,7 @@
   overdose: 30
   metabolisms:
     Medicine:
-      metabolismRate: 0.2
+      metabolismRate: 0.1
       effects:
       - !type:EqualHealthChange
         damage:
@@ -182,14 +192,14 @@
           min: 30
         damage:
           groups:
-            Burn: 1
+            Burn: 0.5
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           min: 50
         damage:
           groups:
-            Burn: 6
+            Burn: 5
             Toxin: 2
 
 # TODO RMC14 other effects (remove toxic reagents)
@@ -201,24 +211,23 @@
   color: "#4acaca"
   metabolisms:
     Medicine:
-      metabolismRate: 0.2
+      metabolismRate: 0.1
       effects:
       - !type:EqualHealthChange
         conditions:
         - !type:Temperature
           max: 170
         damage:
-        - Brute: -3
-        - Burn: -3
-        - Toxin: -3
+        - Brute: -3.5
+        - Burn: -3.5
+        - Toxin: -6
       - !type:HealthChange
         conditions:
         - !type:Temperature
           max: 170
         damage:
           types:
-            Asphyxiation: -1
-            Cellular: -3
+            Cellular: -2.25
 
 - type: reagent
   parent: [ CMReagentMedicine, Dermaline ]
@@ -229,7 +238,7 @@
   overdose: 15
   metabolisms:
     Medicine:
-      metabolismRate: 0.2
+      metabolismRate: 0.1
       effects:
       - !type:EqualHealthChange
         damage:
@@ -240,17 +249,19 @@
           min: 15
         damage:
           groups:
-            Burn: 1.5
-            Toxin: 1.5
+            Burn: 0.75
+            Toxin: 0.75
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           min: 25
         damage:
           groups:
-            Burn: 9
-            Toxin: 9
+            Burn: 7.5
+            Toxin: 7.5
 
+# TODO implement CMLexorin
+# TODO Dexalin should remove 2 lexorin
 - type: reagent
   parent: [ CMReagentMedicine, Dexalin ]
   id: CMDexalin
@@ -260,27 +271,29 @@
   overdose: 30
   metabolisms:
     Medicine:
-      metabolismRate: 0.2
+      metabolismRate: 0.1
       effects:
       - !type:EqualHealthChange
         damage:
-        - Airloss: -4
+        - Airloss: -2
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           min: 30
         damage:
           groups:
-            Toxin: 2
+            Toxin: 1
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           min: 50
         damage:
           groups:
-            Brute: 4
-            Toxin: 8
+            Brute: 2
+            Toxin: 4
 
+# TODO implement CMLexorin
+# TODO DexalinPlus should remove 3 lexorin
 - type: reagent
   parent: [ CMReagentMedicine, DexalinPlus ]
   id: CMDexalinPlus
@@ -290,7 +303,7 @@
   overdose: 15
   metabolisms:
     Medicine:
-      metabolismRate: 0.2
+      metabolismRate: 0.1
       effects:
       - !type:RemoveDamage
         group: Airloss
@@ -307,11 +320,13 @@
           min: 25
         damage:
           groups:
-            Brute: 3
-            Toxin: 7.5
+            Brute: 2
+            Toxin: 6
 
 # TODO RMC14 other effects (pain)
 # TODO RMC14 injected only
+# TODO implement opiate receptor deficency
+# TODO CMEpinephrine should deal liver and brain damage over 20u
 - type: reagent
   parent: [ CMReagentMedicine, Epinephrine ]
   id: CMEpinephrine
@@ -322,21 +337,15 @@
   worksOnTheDead: true
   metabolisms:
     Medicine:
-      metabolismRate: 0.4
+      metabolismRate: 0.2
       effects:
       - !type:EqualHealthChange
         conditions:
         - !type:RecentlyDefibrillated
         damage:
-        - Brute: -16
-        - Burn: -16
-        - Toxin: -16
-      - !type:HealthChange
-        conditions:
-        - !type:RecentlyDefibrillated
-        damage:
-          types:
-            Asphyxiation: -16
+        - Brute: -40
+        - Burn: -40
+        - Toxin: -40
       - !type:AdjustReagent
         conditions:
         - !type:RecentlyDefibrillated
@@ -348,10 +357,28 @@
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
+          min: 10.5
+        damage:
+          groups:
+            Toxin: 0.75
+      - !type:GenericStatusEffect
+        conditions:
+        - !type:ReagentThreshold
+          min: 10.5
+        key: SeeingRainbows # TODO change to hallucinations
+        component: SeeingRainbows
+        type: Add
+        time: 60
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
           min: 20
         damage:
-          Brute: 1
+          groups:
+            Airloss: 2
 
+# TODO pain related effects
+# TODO heart damage over 100u
 # TODO RMC14 allow breathing in crit instead of reducing asphyxiation
 - type: reagent
   parent: [ CMReagentMedicine, Inaprovaline ]
@@ -362,7 +389,7 @@
   overdose: 60
   metabolisms:
     Medicine:
-      metabolismRate: 0.2
+      metabolismRate: 0.1
       effects:
       - !type:HealthChange
         conditions:
@@ -375,29 +402,20 @@
         conditions:
         - !type:ReagentThreshold
           min: 60
-      - !type:GenericStatusEffect
+        time: 5
+      - !type:Paralyze
         conditions:
         - !type:ReagentThreshold
           min: 60
-        key: Stun
-        component: Stunned
-        time: 40
-        type: Add
-      - !type:GenericStatusEffect
-        conditions:
-        - !type:ReagentThreshold
-          min: 60
-        key: KnockedDown
-        component: KnockedDown
-        time: 40
-        type: Add
+        paralyzeTime: 30
       - !type:GenericStatusEffect
         conditions:
         - !type:ReagentThreshold
           min: 100
-        key: Drunk
-        component: Drunk
-        time: 40
+        key: ForcedSleep
+        component: ForcedSleeping
+        time: 20
+        refresh: true
         type: Add
 
 - type: reagent
@@ -409,7 +427,7 @@
   overdose: 30
   metabolisms:
     Medicine:
-      metabolismRate: 0.2
+      metabolismRate: 0.1
       effects:
       - !type:EqualHealthChange
         damage:
@@ -420,16 +438,16 @@
           min: 30
         damage:
           groups:
-            Brute: 1
-            Toxin: 1
+            Brute: 0.5
+            Toxin: 0.5
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           min: 50
         damage:
           groups:
-            Brute: 5.5
-            Toxin: 5.5
+            Brute: 5
+            Toxin: 5
 
 - type: reagent
   parent: [ CMReagentMedicine, Leporazine ]
@@ -440,35 +458,24 @@
   overdose: 30
   metabolisms:
     Medicine:
-      metabolismRate: 0.2
+      metabolismRate: 0.1
       effects:
       - !type:StabilizeTemperature
         stable: 310
-        change: 60
-      - !type:GenericStatusEffect
+        change: 30
+      - !type:Paralyze
         conditions:
         - !type:ReagentThreshold
           min: 30
-        key: KnockedDown
-        component: KnockedDown
-        time: 40
-        type: Add
-      - !type:GenericStatusEffect
-        conditions:
-        - !type:ReagentThreshold
-          min: 30
-        key: Stun
-        component: Stunned
-        time: 40
-        type: Add
+        paralyzeTime: 30
       - !type:GenericStatusEffect
         conditions:
         - !type:ReagentThreshold
           min: 50
         key: ForcedSleep
         component: ForcedSleeping
-        time: 2
-        refresh: false
+        time: 30
+        refresh: true
         type: Add
 
 - type: reagent
@@ -480,49 +487,48 @@
   overdose: 30
   metabolisms:
     Medicine:
-      metabolismRate: 0.2
+      metabolismRate: 0.1
       effects:
       - !type:EqualHealthChange
         damage:
         - Brute: -0.5
         - Burn: -0.5
-        - Toxin: -0.5
+        - Toxin: -1
       - !type:HealthChange
         damage:
-          types:
-            Asphyxiation: -0.5
+          Airloss: -0.5
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           min: 30
         damage:
           groups:
-            Brute: 0.5
-            Burn: 0.5
-            Toxin: 0.25
+            Brute: 0.25
+            Burn: 0.25
+            Toxin: 0.5
       - !type:ChemHealEyeDamage
         conditions:
         - !type:ReagentThreshold
           min: 30
-        amount: 1 # can't make 0.5 eye damage because of int value
-        probability: 0.5
+        amount: 1 # can't make 0.25 eye damage because of int value
+        probability: 0.25
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           min: 50
         damage:
           groups:
-            Brute: 2.5
+            Brute: 3
             Burn: 2.5
-            Toxin: 4
+            Toxin: 4.5
       - !type:GenericStatusEffect
         conditions:
         - !type:ReagentThreshold
           min: 50
         key: ForcedSleep
         component: ForcedSleeping
-        time: 2
-        refresh: false
+        time: 30
+        refresh: true
         type: Add
 
 - type: reagent
@@ -534,7 +540,7 @@
   overdose: 15
   metabolisms:
     Medicine:
-      metabolismRate: 0.2
+      metabolismRate: 0.1
       effects:
       - !type:EqualHealthChange
         damage:
@@ -545,18 +551,19 @@
           min: 15
         damage:
           groups:
-            Burn: 1.5
+            Burn: 0.75
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           min: 25
         damage:
           groups:
-            Burn: 9
+            Burn: 7.5
             Toxin: 3
 
 # TODO RMC14 progressive eye healing ??? (for chemical eye damage healing is alrealdy progressive)
 # TODO RMC14 brain damage over 50u
+# TODO implement blindness and blurness separetly from eye damage
 - type: reagent
   parent: [ CMReagentMedicine, CMDylovene ]
   id: CMImidazoline
@@ -566,7 +573,7 @@
   overdose: 30
   metabolisms:
     Medicine:
-      metabolismRate: 0.2
+      metabolismRate: 0.1
       effects:
       - !type:ChemHealEyeDamage
       - !type:HealthChange
@@ -584,10 +591,8 @@
           groups:
             Brute: 1
             Burn: 1
-            Toxin: 4
+            Toxin: 3
 
-# TODO RMC14 other effects
-# TODO RMC14 heal cloneloss
 - type: reagent
   parent: [ CMReagentMedicine, CMCryoxadone ]
   id: CMClonexadone
@@ -596,20 +601,20 @@
   color: "#51b4db"
   metabolisms:
     Medicine:
-      metabolismRate: 0.2
+      metabolismRate: 0.1
       effects:
       - !type:EqualHealthChange
         conditions:
         - !type:Temperature
           max: 170
         damage:
-        - Toxin: -6
-        - Brute: -6
-        - Burn: -6
+        - Toxin: -11.25
+        - Brute: -11.25
+        - Burn: -15
       - !type:HealthChange
         conditions:
         - !type:Temperature
           max: 170
         damage:
           types:
-            Cellular: -6
+            Cellular: -3.75

--- a/Resources/Prototypes/_RMC14/Reagents/medicine.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/medicine.yml
@@ -66,7 +66,7 @@
         type: Remove
       - !type:AdjustReagent
         reagent: RMCEthanol
-        amount: -3
+        amount: -1.5
       - !type:AdjustReagent
         conditions:
         - !type:ReagentThreshold

--- a/Resources/Prototypes/_RMC14/Reagents/medicine.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/medicine.yml
@@ -320,7 +320,7 @@
           min: 25
         damage:
           groups:
-            Brute: 2
+            Brute: 3
             Toxin: 6
 
 # TODO RMC14 other effects (pain)

--- a/Resources/Prototypes/_RMC14/Reagents/medicine.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/medicine.yml
@@ -13,13 +13,11 @@
       - !type:EqualHealthChange
         damage:
         - Toxin: -2
-      - !type:HealthChange
+      - !type:AdjustEyeDamage
         conditions:
         - !type:ReagentThreshold
           min: 30
-        damage:
-          groups:
-            Brute: 1 # TODO: change to eye damage
+        amount: 1
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
@@ -51,6 +49,7 @@
         type: Add
 
 # TODO RMC14 other effects
+# TODO add another alcohols to decrease
 - type: reagent
   parent: [ CMReagentMedicine, Ethylredoxrazine ]
   id: CMEthylredoxrazine
@@ -66,9 +65,30 @@
         key: Drunk
         time: 3
         type: Remove
-      - !type:AdjustReagent # TODO add another alcohols to decrease
+      - !type:AdjustReagent
         reagent: RMCEthanol
         amount: -3
+      - !type:AdjustReagent
+        conditions:
+        - !type:ReagentThreshold
+          reagent: RMCEthanol
+          min: 1
+        reagent: RMCEthanol
+        amount: -1
+      - !type:AdjustReagent
+        conditions:
+        - !type:ReagentThreshold
+          reagent: RMCEthanol
+          min: 1
+        reagent: CMEthylredoxrazine
+        amount: -1
+      - !type:AdjustReagent
+        conditions:
+        - !type:ReagentThreshold
+          reagent: RMCEthanol
+          min: 1
+        reagent: Water
+        amount: 2
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold

--- a/Resources/Prototypes/_RMC14/Reagents/medicine.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/medicine.yml
@@ -1,5 +1,4 @@
-﻿# TODO RMC14 other effects
-- type: reagent
+﻿- type: reagent
   parent: [ CMReagentMedicine, Dylovene ]
   id: CMDylovene
   name: reagent-name-cmdylovene
@@ -13,7 +12,7 @@
       - !type:EqualHealthChange
         damage:
         - Toxin: -2
-      - !type:AdjustEyeDamage
+      - !type:ChemHealEyeDamage
         conditions:
         - !type:ReagentThreshold
           min: 30
@@ -43,12 +42,12 @@
         conditions:
         - !type:ReagentThreshold
           min: 50
-        key: Drunk
-        component: Drunk
-        time: 60
+        key: ForcedSleep
+        component: ForcedSleeping
+        time: 2
+        refresh: false
         type: Add
 
-# TODO RMC14 other effects
 # TODO add another alcohols to decrease
 - type: reagent
   parent: [ CMReagentMedicine, Ethylredoxrazine ]
@@ -104,7 +103,6 @@
           groups:
             Toxin: 6
 
-# TODO RMC14 other effects
 - type: reagent
   parent: [ CMReagentMedicine, Arithrazine ]
   id: CMArithrazine
@@ -129,7 +127,12 @@
           min: 15
         damage:
           groups:
-            Brute: 3 # TODO: change to 1 eye damage + 2 brute damage
+            Brute: 2
+      - !type:ChemHealEyeDamage
+        conditions:
+        - !type:ReagentThreshold
+          min: 15
+        amount: 1
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
@@ -153,12 +156,11 @@
         conditions:
         - !type:ReagentThreshold
           min: 25
-        key: Drunk
-        component: Drunk
-        time: 30
+        key: ForcedSleep
+        component: ForcedSleeping
+        time: 2
         type: Add
 
-# TODO RMC14 other effects
 - type: reagent
   parent: [ CMReagentMedicine, Bicaridine ]
   id: CMBicaridine
@@ -217,7 +219,6 @@
             Asphyxiation: -1
             Cellular: -3
 
-# TODO RMC14 other effects
 - type: reagent
   parent: [ CMReagentMedicine, Dermaline ]
   id: CMDermaline
@@ -249,7 +250,6 @@
             Burn: 9
             Toxin: 9
 
-# TODO RMC14 other effects
 - type: reagent
   parent: [ CMReagentMedicine, Dexalin ]
   id: CMDexalin
@@ -280,7 +280,6 @@
             Brute: 4
             Toxin: 8
 
-# TODO RMC14 other effects
 - type: reagent
   parent: [ CMReagentMedicine, DexalinPlus ]
   id: CMDexalinPlus
@@ -352,7 +351,6 @@
         damage:
           Brute: 1
 
-# TODO RMC14 other effects
 # TODO RMC14 allow breathing in crit instead of reducing asphyxiation
 - type: reagent
   parent: [ CMReagentMedicine, Inaprovaline ]
@@ -401,7 +399,6 @@
         time: 40
         type: Add
 
-# TODO RMC14 other effects
 - type: reagent
   parent: [ CMReagentMedicine, Kelotane ]
   id: CMKelotane
@@ -433,7 +430,6 @@
             Brute: 5.5
             Toxin: 5.5
 
-# TODO RMC14 other effects
 - type: reagent
   parent: [ CMReagentMedicine, Leporazine ]
   id: CMLeporazine
@@ -468,12 +464,12 @@
         conditions:
         - !type:ReagentThreshold
           min: 50
-        key: Drunk
-        component: Drunk
-        time: 30
+        key: ForcedSleep
+        component: ForcedSleeping
+        time: 2
+        refresh: false
         type: Add
 
-# TODO RMC14 other effects
 - type: reagent
   parent: [ CMReagentMedicine, Tricordrazine ]
   id: CMTricordrazine
@@ -500,9 +496,15 @@
           min: 30
         damage:
           groups:
-            Brute: 1 # TODO: change to 0.5 eye damage + 0.5 brute damage
+            Brute: 0.5
             Burn: 0.5
             Toxin: 0.25
+      - !type:ChemHealEyeDamage
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
+        amount: 1 # can't make 0.5 eye damage because of int value
+        probability: 0.5
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
@@ -516,12 +518,12 @@
         conditions:
         - !type:ReagentThreshold
           min: 50
-        key: Drunk
-        component: Drunk
-        time: 60
+        key: ForcedSleep
+        component: ForcedSleeping
+        time: 2
+        refresh: false
         type: Add
 
-# TODO RMC14 other effects
 - type: reagent
   parent: [ CMReagentMedicine, CMBicaridine ]
   id: CMMeralyne
@@ -552,8 +554,7 @@
             Burn: 9
             Toxin: 3
 
-# TODO RMC14 other effects
-# TODO RMC14 progressive eye healing
+# TODO RMC14 progressive eye healing ??? (for chemical eye damage healing is alrealdy progressive)
 # TODO RMC14 brain damage over 50u
 - type: reagent
   parent: [ CMReagentMedicine, CMDylovene ]

--- a/Resources/Prototypes/_RMC14/Reagents/medicine.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/medicine.yml
@@ -249,7 +249,7 @@
           min: 15
         damage:
           groups:
-            Burn: 0.75
+            Brute: 0.75
             Toxin: 0.75
       - !type:HealthChange
         conditions:
@@ -257,7 +257,7 @@
           min: 25
         damage:
           groups:
-            Burn: 7.5
+            Brute: 7.5
             Toxin: 7.5
 
 # TODO implement CMLexorin

--- a/Resources/Prototypes/_RMC14/Reagents/medicine.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/medicine.yml
@@ -158,6 +158,7 @@
           min: 25
         key: ForcedSleep
         component: ForcedSleeping
+        refresh: false
         time: 2
         type: Add
 

--- a/Resources/Prototypes/_RMC14/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Reactions/chemicals.yml
@@ -14,3 +14,13 @@
     intensityPerUnit: 0.5 # 50+50 reagent for maximum explosion
     intensitySlope: 4
     maxTotalIntensity: 100
+    
+- type: reaction
+  id: EthylredoxrazineOxidation
+  reactants:
+    RMCEthanol:
+      amount: 1
+    CMEthylredoxrazine:
+      amount: 1
+  products:
+    Water: 2


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Massive medicine reagents parity change. Overdoses are worse. Ethylredoxrazine removes ethanol.

## Why / Balance
Parity 

## Technical details
ChemHealEyeDamage have Amount field, if value is positive then deals damage to eye

## Media
Tricordrazine overdose blindness and Imidazoline heal

https://github.com/user-attachments/assets/20cdc90b-a781-4f55-88b4-767435d3bb77

Dylovene overdose sleepness

https://github.com/user-attachments/assets/d271c1ef-123e-411b-b3c2-4189af8d3319

Epinephrine overdose hallucinations and Dylovene hallucination removement

https://github.com/user-attachments/assets/64f4e4bd-74bb-4d40-9f9d-f55b837cced9

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Massive medicine reagents parity change. Medicines treat better. Overdoses are worse. Ethylredoxrazine removes ethanol.
