### PR TITLE
Fix chemistry chem metabolisms + parity hunger

### DIFF
--- a/Resources/Prototypes/Reagents/Consumable/Food/food.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/food.yml
@@ -6,16 +6,23 @@
   desc: reagent-desc-nutriment
   physicalDesc: reagent-physical-desc-opaque
   flavor: nutriment
-  color: "#24591F"
+  color: "#664330"
   metabolisms:
     Food:
+      metabolismRate: 0.1
       effects:
       - !type:SatiateHunger
-  plantMetabolism:
-  - !type:PlantAdjustNutrition
-    amount: 1.5
-  - !type:PlantAdjustHealth
-    amount: 0.75
+        factor: 30
+      - !type:ModifyBloodLevel
+        conditions:
+        - !type:Hunger
+          min: 400 #Should be 200 but just to make it so you only get blood when pretty full
+        amount: 0.5
+      - !type:SatiateHunger # Really need a property to track blood level so we don't just loss free nutrition
+        conditions:
+        - !type:Hunger
+          min: 400
+        factor: -5
   pricePerUnit: 2
 
 - type: reagent

--- a/Resources/Prototypes/Reagents/Consumable/Food/food.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/food.yml
@@ -12,16 +12,16 @@
       metabolismRate: 0.1
       effects:
       - !type:SatiateHunger
-        factor: 30
+        factor: 35
       - !type:ModifyBloodLevel
         conditions:
         - !type:Hunger
-          min: 400 #Should be 200 but just to make it so you only get blood when pretty full
+          min: 200
         amount: 0.5
-      - !type:SatiateHunger # Really need a property to track blood level so we don't just loss free nutrition
+      - !type:SatiateHunger
         conditions:
         - !type:Hunger
-          min: 400
+          min: 200
         factor: -5
   pricePerUnit: 2
 

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
@@ -73,7 +73,7 @@
   - type: RMCSuitLight
   - type: HolocardState
   - type: Hunger
-    baseDecayRate: 0.5
+    baseDecayRate: 0.025
     thresholds:
       Overfed: 550
       Okay: 400

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
@@ -73,6 +73,19 @@
   - type: RMCSuitLight
   - type: HolocardState
   - type: Hunger
+    baseDecayRate: 0.5
+    thresholds:
+      Overfed: 550
+      Okay: 400
+      Peckish: 250
+      Starving: 50
+      Dead: 0
+    hungerThresholdDecayModifiers:
+      Overfed: 1
+      Okay: 1
+      Peckish: 1
+      Starving: 1
+      Dead: 0
   - type: Thirst
     baseDecayRate: 0.01666666666
   - type: Body

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Food/MRE/mre_dessert.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Food/MRE/mre_dessert.yml
@@ -83,7 +83,7 @@
         reagents:
         - ReagentId: Nutriment
           Quantity: 2
-        - ReagentId: Sugar
+        - ReagentId: RMCSugar
           Quantity: 2
         - ReagentId: Theobromine
           Quantity: 1

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Food/MRE/mre_main.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Food/MRE/mre_main.yml
@@ -65,7 +65,7 @@
   id: CMMREFoodMain
   components:
   - type: Food
-    transferAmount: 5
+    transferAmount: 4
   - type: SolutionContainerManager
     solutions:
       food:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Food/MRE/mre_side.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Food/MRE/mre_side.yml
@@ -55,7 +55,7 @@
   id: CMMREFoodSide
   components:
   - type: Food
-    transferAmount: 4
+    transferAmount: 1.6
   - type: SolutionContainerManager
     solutions:
       food:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Food/MRE/mre_snack.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Food/MRE/mre_snack.yml
@@ -75,7 +75,7 @@
   id: CMMREFoodSnack
   components:
   - type: Food
-    transferAmount: 1
+    transferAmount: 1.2
   - type: SolutionContainerManager
     solutions:
       food:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Food/prepared.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Food/prepared.yml
@@ -12,8 +12,6 @@
         reagents:
         - ReagentId: Nutriment
           Quantity: 20
-        - ReagentId: Vitamin
-          Quantity: 5
   - type: Item
     size: Small
     sprite: _RMC14/Objects/Consumable/Food/prepared.rsi
@@ -29,6 +27,15 @@
   components:
   - type: Sprite
     state: cornbread
+  - type: Food
+    transferAmount: 3
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 9
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 9
 
 - type: entity
   parent: CMMarinePreparedMealBase
@@ -38,6 +45,15 @@
   components:
   - type: Sprite
     state: chicken
+  - type: Food
+    transferAmount: 3.33
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 10
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 10
 
 - type: entity
   parent: CMMarinePreparedMealBase
@@ -47,6 +63,15 @@
   components:
   - type: Sprite
     state: pasta
+  - type: Food
+    transferAmount: 3
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 9
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 9
 
 - type: entity
   parent: CMMarinePreparedMealBase
@@ -56,6 +81,15 @@
   components:
   - type: Sprite
     state: pizza
+  - type: Food
+    transferAmount: 8
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 8
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 8
 
 - type: entity
   parent: CMMarinePreparedMealBase
@@ -65,6 +99,15 @@
   components:
   - type: Sprite
     state: pork
+  - type: Food
+    transferAmount: 4.5
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 9
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 9
 
 - type: entity
   parent: CMMarinePreparedMealBase
@@ -74,6 +117,15 @@
   components:
   - type: Sprite
     state: tofu
+  - type: Food
+    transferAmount: 2
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 2
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 2
 
 # Empty Tray
 

--- a/Resources/Prototypes/_RMC14/Reagents/elements.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/elements.yml
@@ -18,7 +18,7 @@
   color: "#1C1300"
   metabolisms:
     Medicine:
-      metabolismRate: 0.005 # 1 every 200 seconds?
+      metabolismRate: 0.01 # 1 every 200 seconds in CM?
       effects:
       - !type:ChemVomit
         probability: 0
@@ -64,7 +64,7 @@
   color: "#6E3B08"
   metabolisms:
     Medicine:
-      metabolismRate: 0.005 # 1 every 200 seconds?
+      metabolismRate: 0.01 # 1 every 200 seconds in CM?
       effects:
       - !type:ChemVomit
         probability: 0
@@ -121,7 +121,7 @@
   color: "#808080"
   metabolisms:
     Medicine:
-      metabolismRate: 0.005 # 1 every 200 seconds?
+      metabolismRate: 0.01 # 1 every 200 seconds in CM?
       effects:
       - !type:ChemVomit
         probability: 0
@@ -217,7 +217,7 @@
   color: "#A0A0A0"
   metabolisms:
     Medicine:
-      metabolismRate: 0.005 # 1 every 200 seconds?
+      metabolismRate: 0.01 # 1 every 200 seconds in CM?
       effects:
       - !type:ChemVomit
         probability: 0
@@ -232,7 +232,7 @@
   color: "#832828"
   metabolisms:
     Medicine:
-      metabolismRate: 0.005 # 1 every 200 seconds?
+      metabolismRate: 0.01 # 1 every 200 seconds in CM?
       effects:
       - !type:ChemVomit
         probability: 0
@@ -297,7 +297,7 @@
   color: "#BF8C00"
   metabolisms:
     Medicine:
-      metabolismRate: 0.005 # 1 every 200 seconds?
+      metabolismRate: 0.01 # 1 every 200 seconds in CM?
       effects:
       - !type:ChemVomit
         probability: 0
@@ -312,7 +312,7 @@
   color: "#808080"
   metabolisms:
     Medicine:
-      metabolismRate: 0.005 # 1 every 200 seconds?
+      metabolismRate: 0.01 # 1 every 200 seconds in CM?
       effects:
       - !type:ChemVomit
         probability: 0
@@ -356,7 +356,7 @@
   color: "#808080"
   metabolisms:
     Medicine:
-      metabolismRate: 0.005 # 1 every 200 seconds?
+      metabolismRate: 0.01 # 1 every 200 seconds in CM?
       effects:
       - !type:ChemVomit
         probability: 0
@@ -370,7 +370,7 @@
   color: "#808080"
   metabolisms:
     Medicine:
-      metabolismRate: 0.005 # 1 every 200 seconds?
+      metabolismRate: 0.01 # 1 every 200 seconds in CM?
       effects:
       - !type:ChemVomit
         probability: 0

--- a/Resources/Prototypes/_RMC14/Reagents/elements.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/elements.yml
@@ -159,13 +159,13 @@
       - !type:ModifyBloodLevel
         conditions:
         - !type:Hunger
-          min: 72 # Note in CM it starts at 200+ nutrition, with max nutrition being 550, this is just converted to work with 200 max
+          min: 200
         amount: 1.5
       - !type:SatiateHunger
         conditions:
         - !type:Hunger
-          min: 72 # Ditto
-        factor: -6 #Note both scaled up because of metabolism rate
+          min: 200
+        factor: -15
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
@@ -177,7 +177,7 @@
         conditions:
         - !type:ReagentThreshold
           min: 50
-        factor: -27 #Unscaled to max -7.5 on CM with their 550 max hunger
+        factor: -75
 
 - type: reagent
   id: RMCLithium
@@ -442,7 +442,7 @@
         damage:
           groups:
             Toxin: 0.625
-            Oxygen: 1.25
+            Airloss: 1.25
       - !type:ChemVomit
         conditions:
         - !type:ReagentThreshold
@@ -460,7 +460,7 @@
         damage:
           groups:
             Toxin: 1.2
-            Oxygen: 2.5
+            Airloss: 2.5
       - !type:ChemVomit
         conditions:
         - !type:ReagentThreshold
@@ -485,7 +485,7 @@
         - !type:ReagentThreshold #It needs it's thing to have some kinda food level to work
           reagent: Nutriment
           min: 0.1
-        factor: 0.18 #Scaled with current hunger values
+        factor: 1 #Scaled with current hunger values
   metamorphicSprite:
     sprite: Objects/Consumable/Drinks/sugarglass.rsi
     state: icon_empty

--- a/Resources/Prototypes/_RMC14/Reagents/elements.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/elements.yml
@@ -19,6 +19,9 @@
   metabolisms:
     Medicine:
       metabolismRate: 0.005 # 1 every 200 seconds?
+      effects:
+      - !type:ChemVomit
+        probability: 0
 
 - type: reagent
   id: RMCChlorine
@@ -62,6 +65,9 @@
   metabolisms:
     Medicine:
       metabolismRate: 0.005 # 1 every 200 seconds?
+      effects:
+      - !type:ChemVomit
+        probability: 0
 
 - type: reagent
   id: RMCFluorine
@@ -116,6 +122,9 @@
   metabolisms:
     Medicine:
       metabolismRate: 0.005 # 1 every 200 seconds?
+      effects:
+      - !type:ChemVomit
+        probability: 0
 
 - type: reagent #TODO if over blood limit take limb damage, oxy damage, move slower
   id: RMCIron
@@ -209,6 +218,9 @@
   metabolisms:
     Medicine:
       metabolismRate: 0.005 # 1 every 200 seconds?
+      effects:
+      - !type:ChemVomit
+        probability: 0
 
 - type: reagent
   id: RMCPhosphorus
@@ -221,6 +233,9 @@
   metabolisms:
     Medicine:
       metabolismRate: 0.005 # 1 every 200 seconds?
+      effects:
+      - !type:ChemVomit
+        probability: 0
 
 - type: reagent
   id: RMCRadium
@@ -283,6 +298,9 @@
   metabolisms:
     Medicine:
       metabolismRate: 0.005 # 1 every 200 seconds?
+      effects:
+      - !type:ChemVomit
+        probability: 0
 
 - type: reagent
   id: RMCSodium
@@ -295,6 +313,9 @@
   metabolisms:
     Medicine:
       metabolismRate: 0.005 # 1 every 200 seconds?
+      effects:
+      - !type:ChemVomit
+        probability: 0
 
 - type: reagent
   id: RMCUranium
@@ -336,6 +357,9 @@
   metabolisms:
     Medicine:
       metabolismRate: 0.005 # 1 every 200 seconds?
+      effects:
+      - !type:ChemVomit
+        probability: 0
 
 - type: reagent
   id: RMCNitrogen
@@ -347,6 +371,9 @@
   metabolisms:
     Medicine:
       metabolismRate: 0.005 # 1 every 200 seconds?
+      effects:
+      - !type:ChemVomit
+        probability: 0
 
 - type: reagent
   id: RMCEthanol

--- a/Resources/Prototypes/_RMC14/Reagents/elements.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/elements.yml
@@ -38,6 +38,7 @@
   physicalDesc: reagent-physical-desc-gaseous
   flavor: bitter
   color: "#808080"
+  overdose: 30
   metabolisms:
     Poison:
       metabolismRate: 0.1
@@ -84,6 +85,7 @@
   physicalDesc: reagent-physical-desc-gaseous
   flavor: bitter
   color: "#808080"
+  overdose: 30
   metabolisms:
     Poison:
       metabolismRate: 0.1
@@ -147,8 +149,7 @@
   physicalDesc: reagent-physical-desc-metallic
   flavor: metallic
   color: "#434b4d"
-  boilingPoint: 2862.0
-  meltingPoint: 1538.0
+  overdose: 30
   metabolisms:
     Medicine:
       metabolismRate: 0.1
@@ -162,7 +163,7 @@
         conditions:
         - !type:Hunger
           min: 72 # Ditto
-        factor: -0.6
+        factor: -6 #Note both scaled up because of metabolism rate
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
@@ -174,7 +175,7 @@
         conditions:
         - !type:ReagentThreshold
           min: 50
-        factor: -2.7 #Unscaled to max -7.5 on CM with their 550 max hunger
+        factor: -27 #Unscaled to max -7.5 on CM with their 550 max hunger
 
 - type: reagent
   id: RMCLithium
@@ -259,6 +260,7 @@
   physicalDesc: reagent-physical-desc-glowing
   flavor: metallic
   color: "#C7C7C7"
+  overdose: 30
   metabolisms:
     Poison:
       effects:
@@ -350,6 +352,7 @@
   physicalDesc: reagent-physical-desc-metallic
   flavor: metallic
   color: "#B8B8C0"
+  overdose: 30
   metabolisms:
     Poison:
       effects:
@@ -409,8 +412,6 @@
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: alcohol
   color: "#404030"
-  boilingPoint: 78.2
-  meltingPoint: -114.1
   metabolisms:
     Alcohol:
       effects:
@@ -456,6 +457,7 @@
   flavor: acid
   color: "#DB5008"
   recognizable: true
+  overdose: 30
   metabolisms:
     Poison:
       metabolismRate: 0.1

--- a/Resources/Prototypes/_RMC14/Reagents/elements.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/elements.yml
@@ -426,15 +426,46 @@
   color: "#404030"
   metabolisms:
     Alcohol:
+      metabolismRate: 0.1
       effects:
-      - !type:ChemVomit
-        probability: 0.04
+      - !type:Drunk
+        boozePower: 6.38
+      - !type:Drunk
         conditions:
         - !type:ReagentThreshold
-          reagent: Ethanol
-          min: 12
+          min: 60
+        boozePower: 9.69
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 60
+        damage:
+          groups:
+            Toxin: 0.625
+            Oxygen: 1.25
+      - !type:ChemVomit
+        conditions:
+        - !type:ReagentThreshold
+          min: 60
+        probability: 0.12
       - !type:Drunk
-        boozePower: 2
+        conditions:
+        - !type:ReagentThreshold
+          min: 100
+        boozePower: 13.125
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 100
+        damage:
+          groups:
+            Toxin: 1.2
+            Oxygen: 2.5
+      - !type:ChemVomit
+        conditions:
+        - !type:ReagentThreshold
+          min: 100
+        probability: 0.25 #TODO Liver damage
 
 - type: reagent
   id: RMCSugar #Candy and grains
@@ -447,13 +478,14 @@
   unknown: true # Yes a health analyzer can't detect sugar. How about that
   metabolisms:
     Food:
+      metabolismRate: 0.1
       effects:
       - !type:SatiateHunger
         conditions:
-        - !type:ReagentThreshold #Only satiates when eaten with nutriment
+        - !type:ReagentThreshold #It needs it's thing to have some kinda food level to work
           reagent: Nutriment
           min: 0.1
-        factor: 1
+        factor: 0.18
   metamorphicSprite:
     sprite: Objects/Consumable/Drinks/sugarglass.rsi
     state: icon_empty

--- a/Resources/Prototypes/_RMC14/Reagents/elements.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/elements.yml
@@ -485,7 +485,7 @@
         - !type:ReagentThreshold #It needs it's thing to have some kinda food level to work
           reagent: Nutriment
           min: 0.1
-        factor: 0.18
+        factor: 0.18 #Scaled with current hunger values
   metamorphicSprite:
     sprite: Objects/Consumable/Drinks/sugarglass.rsi
     state: icon_empty

--- a/Resources/Prototypes/_RMC14/Reagents/elements.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/elements.yml
@@ -7,8 +7,6 @@
   physicalDesc: reagent-physical-desc-metallic
   flavor: metallic
   color: "#A8A8A8"
-  boilingPoint: 2327.0
-  meltingPoint: 660.0
 
 - type: reagent
   id: RMCCarbon
@@ -18,8 +16,9 @@
   physicalDesc: reagent-physical-desc-crystalline
   flavor: bitter
   color: "#1C1300"
-  boilingPoint: 4200.0
-  meltingPoint: 3550.0
+  metabolisms:
+    Medicine:
+      metabolismRate: 0.005 # 1 every 200 seconds?
 
 - type: reagent
   id: RMCChlorine
@@ -29,24 +28,28 @@
   physicalDesc: reagent-physical-desc-gaseous
   flavor: bitter
   color: "#808080"
-  meltingPoint: -101.5
-  boilingPoint: -34.04
-  plantMetabolism:
-    - !type:PlantAdjustWater
-      amount: -0.5
-    - !type:PlantAdjustToxins
-      amount: 15
-    - !type:PlantAdjustWeeds
-      amount: -3
-    - !type:PlantAdjustHealth
-      amount: -1
   metabolisms:
     Poison:
+      metabolismRate: 0.1
       effects:
       - !type:HealthChange
         damage:
-          types:
-            Poison: 2
+          groups:
+            Brute: 0.25
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
+        damage:
+          groups:
+            Brute: 1
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 50
+        damage:
+          groups:
+            Brute: 2.5
 
 - type: reagent
   id: RMCCopper
@@ -56,28 +59,9 @@
   physicalDesc: reagent-physical-desc-metallic
   flavor: metallic
   color: "#6E3B08"
-  boilingPoint: 2595.0
-  meltingPoint: 1083.0
   metabolisms:
-    Poison:
-      metabolismRate: 0.1
-      effects:
-      - !type:HealthChange
-        conditions:
-        - !type:OrganType
-          type: Arachnid
-          shouldHave: false
-        damage:
-          types:
-            Poison: 0.1
     Medicine:
-      effects:
-      - !type:ModifyBloodLevel
-        conditions:
-        - !type:OrganType
-          type: Arachnid
-          shouldHave: true
-        amount: 0.4
+      metabolismRate: 0.005 # 1 every 200 seconds?
 
 - type: reagent
   id: RMCFluorine
@@ -87,25 +71,30 @@
   physicalDesc: reagent-physical-desc-gaseous
   flavor: bitter
   color: "#808080"
-  boilingPoint: -188.11
-  meltingPoint: -219.67
-  plantMetabolism:
-    - !type:PlantAdjustWater
-      amount: -0.5
-    - !type:PlantAdjustToxins
-      amount: 25
-    - !type:PlantAdjustWeeds
-      amount: -4
-    - !type:PlantAdjustHealth
-      amount: -2
   metabolisms:
     Poison:
+      metabolismRate: 0.1
       effects:
       - !type:HealthChange
         damage:
-          types:
-            Caustic: 0.5
-            Poison: 0.5
+          groups:
+            Burn: 0.5
+            Toxin: 0.5
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
+        damage:
+          groups:
+            Burn: 1
+            Toxin: 1.5
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 50
+        damage: #TODO liver damage on high
+          groups:
+            Toxin: 2.5
 
 - type: reagent
   id: RMCGold
@@ -115,8 +104,6 @@
   physicalDesc: reagent-physical-desc-metallic
   flavor: metallic
   color: "#F7C430"
-  boilingPoint: 2700.0
-  meltingPoint: 1064.76
 
 - type: reagent
   id: RMCHydrogen
@@ -126,39 +113,46 @@
   physicalDesc: reagent-physical-desc-gaseous
   flavor: bitter
   color: "#808080"
-  boilingPoint: -253.0
-  meltingPoint: -259.2
+  metabolisms:
+    Medicine:
+      metabolismRate: 0.005 # 1 every 200 seconds?
 
-- type: reagent
+- type: reagent #TODO if over blood limit take limb damage, oxy damage, move slower
   id: RMCIron
   name: reagent-name-iron
   group: Elements
   desc: reagent-desc-iron
   physicalDesc: reagent-physical-desc-metallic
   flavor: metallic
-  color: "#C8A5DC"
+  color: "#434b4d"
   boilingPoint: 2862.0
   meltingPoint: 1538.0
   metabolisms:
-    Poison:
-      metabolismRate: 0.1
-      effects:
-      - !type:HealthChange
-        conditions:
-        - !type:OrganType
-          type: Arachnid
-          shouldHave: true
-        damage:
-          types:
-            Poison: 0.1
     Medicine:
+      metabolismRate: 0.1
       effects:
       - !type:ModifyBloodLevel
         conditions:
-        - !type:OrganType
-          type: Arachnid
-          shouldHave: false
-        amount: 0.4
+        - !type:Hunger
+          min: 72 # Note in CM it starts at 200+ nutrition, with max nutrition being 550, this is just converted to work with 200 max
+        amount: 1.5
+      - !type:SatiateHunger
+        conditions:
+        - !type:Hunger
+          min: 72 # Ditto
+        factor: -0.6
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
+        damage:
+          groups:
+            Toxin: 1.5
+      - !type:SatiateHunger
+        conditions:
+        - !type:ReagentThreshold
+          min: 50
+        factor: -2.7 #Unscaled to max -7.5 on CM with their 550 max hunger
 
 - type: reagent
   id: RMCLithium
@@ -167,9 +161,7 @@
   desc: reagent-desc-lithium
   physicalDesc: reagent-physical-desc-shiny
   flavor: metallic
-  color: "#808080"
-  meltingPoint: 180.5
-  boilingPoint: 1330.0
+  color: "#ff356f"
   metabolisms:
     Poison:
       metabolismRate: 0.1
@@ -184,6 +176,7 @@
       - !type:Emote
         emote: Laugh
         probability: 0.05
+#TODO brain damage on OD and COD
 
 - type: reagent
   id: RMCMercury
@@ -193,18 +186,17 @@
   physicalDesc: reagent-physical-desc-shiny
   flavor: metallic
   color: "#484848"
-  meltingPoint: -38.83
-  boilingPoint: 356.73
   metabolisms:
     Poison:
+      metabolismRate: 0.1
       effects:
-      - !type:HealthChange
-        damage:
-          types:
-            Poison: 1
       - !type:GenericStatusEffect
         key: Stutter
         component: ScrambledAccent
+#TODO brain damage, OD more brain damage and jitter, COD applies neuro
+#Chance to paralyze/stun, lowers body temp on OD and brain damage on COD
+#Message on processing, brain damage on OD, paralyze on COD
+#Each diff property
 
 - type: reagent
   id: RMCPotassium
@@ -214,8 +206,9 @@
   physicalDesc: reagent-physical-desc-shiny
   flavor: metallic
   color: "#A0A0A0"
-  meltingPoint: 65.5
-  boilingPoint: 759.0
+  metabolisms:
+    Medicine:
+      metabolismRate: 0.005 # 1 every 200 seconds?
 
 - type: reagent
   id: RMCPhosphorus
@@ -225,15 +218,9 @@
   physicalDesc: reagent-physical-desc-powdery
   flavor: metallic
   color: "#832828"
-  meltingPoint: 44.2
-  boilingPoint: 280.5
-  plantMetabolism:
-    - !type:PlantAdjustNutrition
-      amount: 0.1
-    - !type:PlantAdjustWater
-      amount: -0.5
-    - !type:PlantAdjustWeeds
-      amount: -2
+  metabolisms:
+    Medicine:
+      metabolismRate: 0.005 # 1 every 200 seconds?
 
 - type: reagent
   id: RMCRadium
@@ -244,8 +231,28 @@
   physicalDesc: reagent-physical-desc-glowing
   flavor: metallic
   color: "#C7C7C7"
-  meltingPoint: 700.0
-  boilingPoint: 1737.0
+  metabolisms:
+    Poison:
+      effects:
+      - !type:HealthChange
+        damage:
+          types:
+            Genetic: 0.5
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
+        damage:
+          types:
+            Genetic: 2
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 50
+        damage:
+          types:
+            Brute: 2
+#TODO causes internal bleeding, OD organ damage, critical causes even more
 
 - type: reagent
   id: RMCSilicon
@@ -255,15 +262,6 @@
   physicalDesc: reagent-physical-desc-crystalline
   flavor: metallic
   color: "#A8A8A8"
-  boilingPoint: 3265.0
-  meltingPoint: 1414.0
-  metabolisms:
-    Poison:
-      effects:
-      - !type:HealthChange
-        damage:
-          types:
-            Poison: 1.5
 
 - type: reagent
   id: RMCSilver
@@ -272,9 +270,7 @@
   desc: reagent-desc-silver
   physicalDesc: reagent-physical-desc-reasonably-metallic
   flavor: metallic
-  color: "#d0d0d0"
-  boilingPoint: 2212.0
-  meltingPoint: 960.5
+  color: "#D0D0D0"
 
 - type: reagent
   id: RMCSulfur
@@ -284,15 +280,9 @@
   physicalDesc: reagent-physical-desc-powdery
   flavor: bitter
   color: "#BF8C00"
-  boilingPoint: 445.0
-  meltingPoint: 120.0
   metabolisms:
-    Poison:
-      effects:
-      - !type:HealthChange
-        damage:
-          types:
-            Caustic: 0.1
+    Medicine:
+      metabolismRate: 0.005 # 1 every 200 seconds?
 
 - type: reagent
   id: RMCSodium
@@ -302,8 +292,9 @@
   physicalDesc: reagent-physical-desc-metallic
   flavor: bitter
   color: "#808080"
-  meltingPoint: 97.8
-  boilingPoint: 883.0
+  metabolisms:
+    Medicine:
+      metabolismRate: 0.005 # 1 every 200 seconds?
 
 - type: reagent
   id: RMCUranium
@@ -313,25 +304,27 @@
   physicalDesc: reagent-physical-desc-metallic
   flavor: metallic
   color: "#B8B8C0"
-  meltingPoint: 1133.0
-  boilingPoint: 4131.0
-  plantMetabolism:
-  - !type:PlantAdjustMutationLevel
-    amount: 0.6
-  - !type:PlantAdjustToxins
-    amount: 4
-  - !type:PlantAdjustHealth
-    amount: -1.5
-  - !type:PlantAdjustMutationMod
-    probability: 0.2
-    amount: 0.1
   metabolisms:
     Poison:
       effects:
       - !type:HealthChange
         damage:
           types:
-            Radiation: 2
+            Genetic: 0.5
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
+        damage:
+          types:
+            Genetic: 2
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 50
+        damage:
+          types:
+            Brute: 2
 
 - type: reagent
   id: RMCOxygen
@@ -340,27 +333,9 @@
   physicalDesc: reagent-physical-desc-gaseous
   flavor: bitter
   color: "#808080"
-  boilingPoint: -183.0
-  meltingPoint: -218.4
   metabolisms:
-    Gas:
-      effects:
-      - !type:Oxygenate
-        conditions:
-        - !type:OrganType
-          type: Human
-      - !type:Oxygenate
-        conditions:
-        - !type:OrganType
-          type: Animal
-      - !type:Oxygenate
-        conditions:
-        - !type:OrganType
-          type: Rat
-      - !type:Oxygenate
-        conditions:
-        - !type:OrganType
-          type: Plant
+    Medicine:
+      metabolismRate: 0.005 # 1 every 200 seconds?
 
 - type: reagent
   id: RMCNitrogen
@@ -369,15 +344,9 @@
   physicalDesc: reagent-physical-desc-gaseous
   flavor: bitter
   color: "#808080"
-  boilingPoint: -195.8
-  meltingPoint: -210.0
   metabolisms:
-    Poison:
-      effects:
-      - !type:HealthChange
-        damage:
-          types:
-            Cold: 1 # liquid nitrogen is cold
+    Medicine:
+      metabolismRate: 0.005 # 1 every 200 seconds?
 
 - type: reagent
   id: RMCEthanol
@@ -410,7 +379,6 @@
   physicalDesc: reagent-physical-desc-sweet
   flavor: sweet
   color: white
-  meltingPoint: 146.0
   metabolisms:
     Food:
       effects:
@@ -420,13 +388,6 @@
           reagent: Nutriment
           min: 0.1
         factor: 1
-  plantMetabolism:
-  - !type:PlantAdjustNutrition
-    amount: 0.1
-  - !type:PlantAdjustWeeds
-    amount: 2
-  - !type:PlantAdjustPests
-    amount: 2
   metamorphicSprite:
     sprite: Objects/Consumable/Drinks/sugarglass.rsi
     state: icon_empty
@@ -443,41 +404,28 @@
   flavor: acid
   color: "#DB5008"
   recognizable: true
-  boilingPoint: 337.0
-  meltingPoint: 10.31
-  plantMetabolism:
-  - !type:PlantAdjustToxins
-    amount: 10
-  - !type:PlantAdjustWeeds
-    amount: -2
-  - !type:PlantAdjustHealth
-    amount: -5
-  reactiveEffects:
-    Acidic:
-      methods: [ Touch ]
-      effects:
-      - !type:HealthChange
-        scaleByQuantity: true
-        ignoreResistances: false
-        damage:
-          types:
-            Caustic: 0.1
-      - !type:Emote
-        emote: Scream
-        probability: 0.1
   metabolisms:
     Poison:
-      metabolismRate: 3.00 # Okay damage, high metabolism rate. You need a lot of units to crit. Simulates acid burning through you fast.
+      metabolismRate: 0.1
       effects:
       - !type:HealthChange
         damage:
-          types:
-            Caustic: 5
-      - !type:PopupMessage
-        type: Local
-        visualType: Large
-        messages: [ "generic-reagent-effect-burning-insides" ]
-        probability: 0.33
-      - !type:Emote
-        emote: Scream
-        probability: 0.2
+          groups:
+            Burn: 0.75
+            Toxin: 0.25
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
+        damage:
+          groups:
+            Burn: 3
+            Toxin: 0.5
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 50
+        damage:
+          groups:
+            Burn: 7.5
+            Toxin: 2.5

--- a/Resources/Prototypes/_RMC14/Reagents/elements.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/elements.yml
@@ -7,6 +7,13 @@
   physicalDesc: reagent-physical-desc-metallic
   flavor: metallic
   color: "#A8A8A8"
+  metabolisms:
+    Medicine:
+      metabolismRate: 0.1
+      effects:
+      - !type:ChemVomit
+        probability: 0
+
 
 - type: reagent
   id: RMCCarbon
@@ -110,6 +117,12 @@
   physicalDesc: reagent-physical-desc-metallic
   flavor: metallic
   color: "#F7C430"
+  metabolisms:
+    Medicine:
+      metabolismRate: 0.1
+      effects:
+      - !type:ChemVomit
+        probability: 0
 
 - type: reagent
   id: RMCHydrogen
@@ -277,6 +290,12 @@
   physicalDesc: reagent-physical-desc-crystalline
   flavor: metallic
   color: "#A8A8A8"
+  metabolisms:
+    Medicine:
+      metabolismRate: 0.1
+      effects:
+      - !type:ChemVomit
+        probability: 0
 
 - type: reagent
   id: RMCSilver
@@ -286,6 +305,12 @@
   physicalDesc: reagent-physical-desc-reasonably-metallic
   flavor: metallic
   color: "#D0D0D0"
+  metabolisms:
+    Medicine:
+      metabolismRate: 0.1
+      effects:
+      - !type:ChemVomit
+        probability: 0
 
 - type: reagent
   id: RMCSulfur

--- a/Resources/Prototypes/_RMC14/Reagents/elements.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/elements.yml
@@ -481,11 +481,7 @@
       metabolismRate: 0.1
       effects:
       - !type:SatiateHunger
-        conditions:
-        - !type:ReagentThreshold #It needs it's thing to have some kinda food level to work
-          reagent: Nutriment
-          min: 0.1
-        factor: 15 #Based off nutriments value
+        factor: 5
   metamorphicSprite:
     sprite: Objects/Consumable/Drinks/sugarglass.rsi
     state: icon_empty

--- a/Resources/Prototypes/_RMC14/Reagents/elements.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/elements.yml
@@ -269,6 +269,7 @@
   unknown: true
   metabolisms:
     Poison:
+      metabolismRate: 0.1
       effects:
       - !type:HealthChange
         damage:
@@ -365,6 +366,7 @@
   unknown: true
   metabolisms:
     Poison:
+      metabolismRate: 0.1
       effects:
       - !type:HealthChange
         damage:

--- a/Resources/Prototypes/_RMC14/Reagents/elements.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/elements.yml
@@ -7,6 +7,7 @@
   physicalDesc: reagent-physical-desc-metallic
   flavor: metallic
   color: "#A8A8A8"
+  unknown: true
   metabolisms:
     Medicine:
       metabolismRate: 0.1
@@ -23,9 +24,10 @@
   physicalDesc: reagent-physical-desc-crystalline
   flavor: bitter
   color: "#1C1300"
+  unknown: true
   metabolisms:
     Medicine:
-      metabolismRate: 0.01 # 1 every 200 seconds in CM?
+      metabolismRate: 0.01 # 1 every 200 seconds in CM? 0.005 would be right but impossible because fixed point 2
       effects:
       - !type:ChemVomit
         probability: 0
@@ -38,7 +40,7 @@
   physicalDesc: reagent-physical-desc-gaseous
   flavor: bitter
   color: "#808080"
-  overdose: 30
+  unknown: true
   metabolisms:
     Poison:
       metabolismRate: 0.1
@@ -148,7 +150,7 @@
   desc: reagent-desc-iron
   physicalDesc: reagent-physical-desc-metallic
   flavor: metallic
-  color: "#434b4d"
+  color: "#C8A5DC"
   overdose: 30
   metabolisms:
     Medicine:
@@ -184,7 +186,8 @@
   desc: reagent-desc-lithium
   physicalDesc: reagent-physical-desc-shiny
   flavor: metallic
-  color: "#ff356f"
+  color: "#808080"
+  unknown: true
   metabolisms:
     Poison:
       metabolismRate: 0.1
@@ -209,6 +212,7 @@
   physicalDesc: reagent-physical-desc-shiny
   flavor: metallic
   color: "#484848"
+  unknown: true
   metabolisms:
     Poison:
       metabolismRate: 0.1
@@ -229,6 +233,7 @@
   physicalDesc: reagent-physical-desc-shiny
   flavor: metallic
   color: "#A0A0A0"
+  unknown: true
   metabolisms:
     Medicine:
       metabolismRate: 0.01 # 1 every 200 seconds in CM?
@@ -244,6 +249,7 @@
   physicalDesc: reagent-physical-desc-powdery
   flavor: metallic
   color: "#832828"
+  unknown: true
   metabolisms:
     Medicine:
       metabolismRate: 0.01 # 1 every 200 seconds in CM?
@@ -260,7 +266,7 @@
   physicalDesc: reagent-physical-desc-glowing
   flavor: metallic
   color: "#C7C7C7"
-  overdose: 30
+  unknown: true
   metabolisms:
     Poison:
       effects:
@@ -292,6 +298,7 @@
   physicalDesc: reagent-physical-desc-crystalline
   flavor: metallic
   color: "#A8A8A8"
+  unknown: true
   metabolisms:
     Medicine:
       metabolismRate: 0.1
@@ -307,6 +314,7 @@
   physicalDesc: reagent-physical-desc-reasonably-metallic
   flavor: metallic
   color: "#D0D0D0"
+  unknown: true
   metabolisms:
     Medicine:
       metabolismRate: 0.1
@@ -322,6 +330,7 @@
   physicalDesc: reagent-physical-desc-powdery
   flavor: bitter
   color: "#BF8C00"
+  unknown: true
   metabolisms:
     Medicine:
       metabolismRate: 0.01 # 1 every 200 seconds in CM?
@@ -337,6 +346,7 @@
   physicalDesc: reagent-physical-desc-metallic
   flavor: bitter
   color: "#808080"
+  unknown: true
   metabolisms:
     Medicine:
       metabolismRate: 0.01 # 1 every 200 seconds in CM?
@@ -352,7 +362,7 @@
   physicalDesc: reagent-physical-desc-metallic
   flavor: metallic
   color: "#B8B8C0"
-  overdose: 30
+  unknown: true
   metabolisms:
     Poison:
       effects:
@@ -382,6 +392,7 @@
   physicalDesc: reagent-physical-desc-gaseous
   flavor: bitter
   color: "#808080"
+  unknown: true
   metabolisms:
     Medicine:
       metabolismRate: 0.01 # 1 every 200 seconds in CM?
@@ -396,6 +407,7 @@
   physicalDesc: reagent-physical-desc-gaseous
   flavor: bitter
   color: "#808080"
+  unknown: true
   metabolisms:
     Medicine:
       metabolismRate: 0.01 # 1 every 200 seconds in CM?
@@ -432,6 +444,7 @@
   physicalDesc: reagent-physical-desc-sweet
   flavor: sweet
   color: white
+  unknown: true # Yes a health analyzer can't detect sugar. How about that
   metabolisms:
     Food:
       effects:
@@ -456,8 +469,7 @@
   physicalDesc: reagent-physical-desc-oily
   flavor: acid
   color: "#DB5008"
-  recognizable: true
-  overdose: 30
+  unknown: true
   metabolisms:
     Poison:
       metabolismRate: 0.1

--- a/Resources/Prototypes/_RMC14/Reagents/elements.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/elements.yml
@@ -252,14 +252,14 @@
       - !type:HealthChange
         damage:
           types:
-            Genetic: 0.5
+            Cellular: 0.5
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           min: 30
         damage:
           types:
-            Genetic: 2
+            Cellular: 2
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
@@ -331,14 +331,14 @@
       - !type:HealthChange
         damage:
           types:
-            Genetic: 0.5
+            Cellular: 0.5
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           min: 30
         damage:
           types:
-            Genetic: 2
+            Cellular: 2
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold

--- a/Resources/Prototypes/_RMC14/Reagents/elements.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/elements.yml
@@ -485,7 +485,7 @@
         - !type:ReagentThreshold #It needs it's thing to have some kinda food level to work
           reagent: Nutriment
           min: 0.1
-        factor: 1 #Scaled with current hunger values
+        factor: 15 #Based off nutriments value
   metamorphicSprite:
     sprite: Objects/Consumable/Drinks/sugarglass.rsi
     state: icon_empty

--- a/Resources/Prototypes/_RMC14/Reagents/elements.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/elements.yml
@@ -265,7 +265,7 @@
         - !type:ReagentThreshold
           min: 50
         damage:
-          types:
+          groups:
             Brute: 2
 #TODO causes internal bleeding, OD organ damage, critical causes even more
 
@@ -344,7 +344,7 @@
         - !type:ReagentThreshold
           min: 50
         damage:
-          types:
+          groups:
             Brute: 2
 
 - type: reagent


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Changed all the basic chems metabolisms to match their effects and colors on CM, if they had any, and removed any upstream fluff that wasn't nessary.

Also changed humanoids to use hunger values from CM, and modified nutriment to match CM in how much it gives.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity.

## Technical details
<!-- Summary of code changes for easier review. -->
The most suspect is the nutrition drain of iron. I saw that the code scales satiate with metabolism rate, so not only is it scaled with our max hunger, it's also x10 to match the metabolism rate. Testing in CM the conversion matches for blood and nutrition.

All damage rates are 1/2 like the medicines so they can process over 0.1 secs correctly.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![color](https://github.com/user-attachments/assets/71badf93-8c47-47e4-b213-65bd9cc17326)
(Note iron and lithium fixed later, got their colors confused with their fire colors)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed metabolism rate and properties of basic dispenser chems. Most dispenser chems are shown as unknown on the health analyzer.
- fix: Iron correctly heals more blood but also requires nutrition and drains it as it processes.
- fix: Nutriment heals blood if you're not hungry
- fix: Modified Prepared MRES and components to intended values
