### PR TITLE
Vendor fixes and XO sidearm belts.

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
@@ -787,8 +787,52 @@
   - type: StorageFill
     contents:
     - id: RMCSpeedLoaderMateba
-      amount: 5
+      amount: 6
     - id: RMCWeaponRevolverMateba
+
+- type: entity
+  parent: RMCBeltHolsterPistol
+  id: RMCMK80BeltFilled
+  suffix: Filled
+  components:
+  - type: StorageFill
+    contents:
+    - id: CMMagazinePistolMK80
+      amount: 6
+    - id: CMWeaponPistolMK80
+
+- type: entity
+  parent: RMCBeltHolsterPistol
+  id: RMCM1984BeltFilled
+  suffix: Filled
+  components:
+  - type: StorageFill
+    contents:
+    - id: CMMagazinePistolM1984
+      amount: 6
+    - id: CMWeaponPistolM1984
+
+- type: entity
+  parent: RMCBeltHolsterPistol
+  id: CMM77BeltFilled
+  suffix: Filled
+  components:
+  - type: StorageFill
+    contents:
+    - id: CMMagazinePistolM77AP
+      amount: 6
+    - id: CMWeaponPistolM77
+
+- type: entity
+  parent: RMCBeltHolsterRevolver
+  id: RMCM44BeltFilled
+  suffix: Filled
+  components:
+  - type: StorageFill
+    contents:
+    - id: RMCSpeedLoaderM44
+      amount: 6
+    - id: RMCWeaponRevolverM44
 
 - type: entity
   parent: CMBeltBaseStorage

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
@@ -787,7 +787,7 @@
   - type: StorageFill
     contents:
     - id: RMCSpeedLoaderMateba
-      amount: 6
+      amount: 5
     - id: RMCWeaponRevolverMateba
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/auxiliary.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/auxiliary.yml
@@ -53,10 +53,13 @@
       choices: { CMPouches: 2 }
       entries:
       - id: RMCPouchFirstAidInjectors
+        name: first-aid pouch (refillable injectors)
         recommended: true
       - id: RMCPouchFirstAidSplintsGauzeOintment
+        name: first-aid pouch (gauze, ointment)
         recommended: true
       - id: RMCPouchFirstAidPills
+        name: first-aid pouch (pills)
         recommended: true
       - id: RMCPouchFirstResponder
       - id: RMCPouchFlareFilled

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/command.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/command.yml
@@ -494,11 +494,11 @@
       #   points: 20
       - id: RMCMagazineSmartGun
         points: 20
-    # - name: Sidearm Ammunition # TODO RMC14 Port CO Sidearm
-    #   entries:
-    #   - id: CMMagazineMateba
-    #     points: 15
-    #   - id: CMMagazineMatebaAP
+    - name: Sidearm Ammunition
+      entries:
+      - id: RMCSpeedLoaderMateba
+        points: 15
+    #   - id: CMMagazineMatebaAP  # TODO RMC14 Port More Sidearm Ammo
     #     points: 20
     #   - id: CMMagazineDesertEagle
     #     points: 15
@@ -595,11 +595,15 @@
     - name: Personal Weapon
       choices: { CMWeapon: 1 }
       entries:
-      - id: CMWeaponPistolMK80  # These all come inside belts; but these don't exist so...
-        recommended: true       # TODO RMC14 Pistol Belt Fills
-      - id: CMWeaponPistolM1984
-      - id: CMWeaponPistolM77
-      - id: RMCWeaponRevolverM44
+      - id: RMCMK80BeltFilled
+        name: MK80 Pistol
+        recommended: true
+      - id: RMCM1984BeltFilled
+        name: M1984 Pistol
+      - id: CMM77BeltFilled
+        name: M77 Pistol
+      - id: RMCM44BeltFilled
+        name: M44 Revolver
     - name: Belt
       choices: { CMBelt: 1 }
       entries:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/team_leader.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/team_leader.yml
@@ -188,6 +188,7 @@
         recommended: true
       - id: RMCPouchFirstAidPills
         name: first-aid pouch (pills)
+        recommended: true
       - id: RMCPouchFirstResponder
       - id: RMCPouchFlareFilled
         name: Flare pouch (Full)

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/team_leader.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/team_leader.yml
@@ -188,7 +188,6 @@
         recommended: true
       - id: RMCPouchFirstAidPills
         name: first-aid pouch (pills)
-        recommended: true
       - id: RMCPouchFirstResponder
       - id: RMCPouchFlareFilled
         name: Flare pouch (Full)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Various changes to various Vendors.
- Gave Mateba Belt one more speedloader that it was missing(Unsure if parity or not)
- Changed the MK80, M1984, M44 and M77 in XO vendor to come with belts and ammunition. 
- Added descriptions to the DDC vendor first-aid pouches.
- Adding the sidearm ammunition tab to CO vendor which currently only has Mateba speedloader.
- Made the pill packet first aid pouch of FTL recommended, just like how it is everywhere else.

## Why / Balance
Parity

## Technical details
YAML, mostly just moving things around.

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
There is a weird thing I couldn't exactly replicate where if you pick up the new pistol belts as an admin ghost, it becomes a 4 item big container filled with shotgun slugs. I am not sure what causes it, but only seems to happen as an admin ghost.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed the MK80, M1984, M44 and M77 sidearms in XO vendor to come with belts and ammunition. 
- fix: Fixed fun!
-->
:cl:
- add: Changed the MK80, M1984, M44 and M77 sidearms in XO vendor to come with belts and ammunition. 
- fix: Added descriptions to the DDC vendor first-aid pouches.
- fix: Adding the sidearm ammunition tab to CO vendor which currently only has Mateba speedloader.
