### PR TITLE
Fixes Xm51 ammo changing into buckshot ammo under certain circumstances.

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/shotgun_handfuls.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/shotgun_handfuls.yml
@@ -27,6 +27,13 @@
     - RMCShellShotgun
     - RMCShellShotgunBuckshot
 
+- type: stack
+  id: RMCShellShotgunBuckshot
+  name: handful of buckshot shells
+  icon: { sprite: /Textures/_RMC14/Objects/Weapons/Guns/Ammunition/Handfuls/shotgun_handfuls.rsi, state: buckshot_shell_1 }
+  spawn: CMShellShotgunBuckshot
+  maxCount: 5
+
 - type: entity
   parent: CMShellShotgunBase
   id: RMCShellShotgunBreaching
@@ -41,7 +48,7 @@
     proto: RMCPelletShotgunBreaching
   - type: Stack
     count: 6
-    stackType: RMCShellShotgunBuckshot
+    stackType: RMCShellShotgunBreaching
     baseLayer: base
     layerStates:
     - breaching_shell_1
@@ -58,11 +65,11 @@
     - RMCShellShotgunBreaching
 
 - type: stack
-  id: RMCShellShotgunBuckshot
-  name: handful of buckshot shell
-  icon: { sprite: /Textures/_RMC14/Objects/Weapons/Guns/Ammunition/Handfuls/shotgun_handfuls.rsi, state: buckshot_shell_1 }
-  spawn: CMShellShotgunBuckshot
-  maxCount: 5
+  id: RMCShellShotgunBreaching
+  name: handful of breaching shells
+  icon: { sprite: /Textures/_RMC14/Objects/Weapons/Guns/Ammunition/Handfuls/shotgun_handfuls.rsi, state: breaching_shell_1 }
+  spawn: RMCShellShotgunBreaching
+  maxCount: 6
 
 - type: entity
   parent: CMShellShotgunBase


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The XM51's breaching shell prototype had the stacktype incorrectly defined as buckshot shells, which caused the shells to transform into buckshot shells when split or taken out of a mag. Also, pluralized "handful of buckshot shells" somewhere, to make it fit the rest. 
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug.
https://discord.com/channels/1168210010233376858/1305038016061902899
https://discord.com/channels/1168210010233376858/1304607677141483632
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/97f7fa04-3e1b-4a35-8a3d-e544aafbfcfc


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Fixed the breaching shells reverting to buckshot shells under certain circumstances. 