### PR TITLE
Boot storage - Mask storage

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Shoes/boots.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Shoes/boots.yml
@@ -23,6 +23,9 @@
           tags:
           - Knife
           - Holdout
+          - RMCScrewdriver
+          - RMCScalpel
+          - ThrowingKnife
         startingItem: RMCM5Bayonet
   - type: CMItemSlots
     startingItem: RMCM5Bayonet
@@ -56,6 +59,8 @@
           tags:
           - Knife
           - Holdout
+          - RMCScrewdriver
+          - RMCScalpel
   - type: Matchbox
   - type: CMHolster
   - type: CMItemSlots

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Medical/surgery.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Medical/surgery.yml
@@ -172,6 +172,9 @@
     soundHit:
       path: /Audio/Weapons/bladeslice.ogg
   - type: CMScalpel
+  - type: Tag
+    tags:
+    - RMCScalpel
 
 # - Predator
 - type: entity

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Tools/tools.yml
@@ -23,6 +23,10 @@
     slots:
     - Ears
     - Suitstorage
+    - mask
+  - type: Tag
+    tags:
+    - RMCScrewdriver
 
 - type: entity
   parent: Wirecutter

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/holdout_pistol.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/holdout_pistol.yml
@@ -29,7 +29,6 @@
         priority: 2
         whitelist:
           tags:
-          - Holdout
           - RMCMagazinePistolHoldout
   - type: AttachableHolder
     slots:
@@ -52,6 +51,9 @@
       rmc-aslot-barrel: 0.71, 0.095
       rmc-aslot-rail: -0.065, 0.125
       rmc-aslot-underbarrel: 0.312, -0.25
+  - type: Tag
+    tags:
+    - Holdout
 
 - type: entity
   parent: CMBaseMagazinePistol

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Melee/knife.yml
@@ -97,9 +97,6 @@
     tags:
     - ThrowingKnife
 
-- type: Tag
-  id: ThrowingKnife
-
 - type: entity
   parent: [ RMCBaseMeleeWeapon, BaseKnife]
   id: CMM2132Machete

--- a/Resources/Prototypes/_RMC14/tags.yml
+++ b/Resources/Prototypes/_RMC14/tags.yml
@@ -108,3 +108,12 @@
 
 - type: Tag
   id: RMCG8Pouch
+
+- type: Tag
+  id: RMCScalpel
+
+- type: Tag
+  id: RMCScrewdriver
+
+- type: Tag
+  id: ThrowingKnife


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Boots can now hold more things

## Why / Balance
#4803
Parity

**Changelog**
:cl:
- fix: Boots can now hold: Screwdriver, Scalpel, ThrowingKnife & Holdout Pistol.
- fix: Mouth slot can now hold: Screwdriver.
