### PR TITLE
Changed tail stab damage to be parity

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/boiler.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/boiler.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   parent:
   - CMXenoDeveloped
   - CMXenoTail
@@ -64,6 +64,9 @@
     toggle: true
     inject:
       RMCMolecularAcid: 1 # TODO RMC14 6
+    tailDamage:
+      groups:
+        Brute: 27
   - type: XenoSprayAcid
     acid: XenoAcidSprayStrong
     barricadeDamage:
@@ -72,7 +75,7 @@
   - type: MeleeWeapon
     damage:
       groups:
-        Brute: 22.5
+        Brute: 22.5 
   - type: Tackle # min: 2, max: 6
     threshold: 5
     stun: 7

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/boiler.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/boiler.yml
@@ -75,7 +75,7 @@
   - type: MeleeWeapon
     damage:
       groups:
-        Brute: 22.5 
+        Brute: 22.5
   - type: Tackle # min: 2, max: 6
     threshold: 5
     stun: 7

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/boiler.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/boiler.yml
@@ -66,7 +66,7 @@
       RMCMolecularAcid: 1 # TODO RMC14 6
     tailDamage:
       groups:
-        Brute: 27
+        Brute: 30
   - type: XenoSprayAcid
     acid: XenoAcidSprayStrong
     barricadeDamage:

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/burrower.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/burrower.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   parent:
   - CMXenoDeveloped
   - CMXenoTail
@@ -58,6 +58,10 @@
     damage:
       groups:
         Brute: 27.5
+  - type: XenoTailStab
+    tailDamage:
+      groups:
+        Brute: 33
   - type: Tackle # min: 3, max: 5
     threshold: 4
     stun: 9

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/burrower.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/burrower.yml
@@ -61,7 +61,7 @@
   - type: XenoTailStab
     tailDamage:
       groups:
-        Brute: 33
+        Brute: 36
   - type: Tackle # min: 3, max: 5
     threshold: 4
     stun: 9

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/carrier.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/carrier.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   parent:
   - CMXenoDeveloped
   - CMXenoTail
@@ -73,6 +73,10 @@
     damage:
       groups:
         Brute: 27.5
+  - type: XenoTailStab
+    tailDamage:
+      groups:
+        Brute: 33
   - type: Tackle # min: 2, max: 4
     threshold: 4
     stun: 9

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/carrier.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/carrier.yml
@@ -76,7 +76,7 @@
   - type: XenoTailStab
     tailDamage:
       groups:
-        Brute: 33
+        Brute: 42
   - type: Tackle # min: 2, max: 4
     threshold: 4
     stun: 9

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/crusher.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/crusher.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   parent:
   - CMXenoDeveloped
   - CMXenoTail
@@ -64,6 +64,10 @@
     damage:
       groups:
         Brute: 40
+  - type: XenoTailStab
+    tailDamage:
+      groups:
+        Brute: 48
   - type: CrusherShield
   - type: XenoShield
   - type: XenoMeleeSlow

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/defender.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/defender.yml
@@ -69,6 +69,10 @@
     damage:
       groups:
         Brute: 27.5
+  - type: XenoTailStab
+    tailDamage:
+      groups:
+        Brute: 33
   - type: Tackle # min: 2, max: 4
     threshold: 4
     stun: 5

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/defender.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/defender.yml
@@ -72,7 +72,7 @@
   - type: XenoTailStab
     tailDamage:
       groups:
-        Brute: 33
+        Brute: 36
   - type: Tackle # min: 2, max: 4
     threshold: 4
     stun: 5

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/drone.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/drone.yml
@@ -28,7 +28,7 @@
   - type: XenoTailStab
     tailDamage:
       groups:
-        Brute: 27
+        Brute: 30
   - type: Xeno
     role: CMXenoDrone
     hudOffset: 0,0.15

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/drone.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/drone.yml
@@ -25,6 +25,10 @@
     damage:
       groups:
         Brute: 22.5
+  - type: XenoTailStab
+    tailDamage:
+      groups:
+        Brute: 27
   - type: Xeno
     role: CMXenoDrone
     hudOffset: 0,0.15

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/hivelord.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/hivelord.yml
@@ -72,7 +72,7 @@
   - type: XenoTailStab
     tailDamage:
       groups:
-        Brute: 27
+        Brute: 30
   - type: Tackle # min: 2, max: 4
     threshold: 4
     stun: 9

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/hivelord.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/hivelord.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   parent:
   - CMXenoDeveloped
   - CMXenoTail
@@ -69,6 +69,10 @@
     damage:
       groups:
         Brute: 22.5
+  - type: XenoTailStab
+    tailDamage:
+      groups:
+        Brute: 27
   - type: Tackle # min: 2, max: 4
     threshold: 4
     stun: 9

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lesser_drone.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lesser_drone.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   parent:
   - CMXenoDeveloped
   - CMXenoTail
@@ -59,6 +59,10 @@
     damage:
       groups:
         Brute: 20
+  - type: XenoTailStab
+    tailDamage:
+      groups:
+        Brute: 24
   - type: Tackle  # min: 4, max: 5
     threshold: 5
     stun: 5

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lurker.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lurker.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   parent:
   - CMXenoDeveloped
   - CMXenoTail
@@ -70,6 +70,10 @@
     damage:
       groups:
         Brute: 35
+  - type: XenoTailStab
+    tailDamage:
+      groups:
+        Brute: 42
   - type: Tackle # min: 2, max: 6
     threshold: 4
     stun: 5

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/praetorian.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/praetorian.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   abstract: true
   parent:
   - CMXenoDeveloped
@@ -57,6 +57,10 @@
     damage:
       groups:
         Brute: 40
+  - type: XenoTailStab
+    tailDamage:
+      groups:
+        Brute: 48
   - type: Tackle # min: 2, max: 5
     threshold: 4
     stun: 5
@@ -179,6 +183,10 @@
     damage:
       groups:
         Brute: 30
+  - type: XenoTailStab
+    tailDamage:
+      groups:
+        Brute: 36
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.2
     baseSprintSpeed: 3.4

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
@@ -90,7 +90,7 @@
   - type: XenoTailStab
     tailDamage:
       groups:
-        Brute: 48
+        Brute: 54
   - type: XenoOvipositorCapable
   - type: Tackle # min: 2, max: 6
     threshold: 4

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   parent:
   - CMXenoDeveloped
   - CMXenoTail
@@ -87,6 +87,10 @@
     damage:
       groups:
         Brute: 40
+  - type: XenoTailStab
+    tailDamage:
+      groups:
+        Brute: 48
   - type: XenoOvipositorCapable
   - type: Tackle # min: 2, max: 6
     threshold: 4

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/ravager.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/ravager.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   parent:
   - CMXenoDeveloped
   - CMXenoTail
@@ -56,6 +56,10 @@
     damage:
       groups:
         Brute: 45
+  - type: XenoTailStab
+    tailDamage:
+      groups:
+        Brute: 54
   - type: Tackle # min: 2, max: 5
     threshold: 4
     stun: 9

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/runner.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/runner.yml
@@ -89,7 +89,7 @@
   - type: XenoTailStab
     tailDamage:
       groups:
-        Brute: 27
+        Brute: 30
   - type: Tackle # min: 4, max: 5
     threshold: 5
     stun: 8

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/runner.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/runner.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   parent:
   - CMXenoDeveloped
   - CMXenoTail
@@ -86,6 +86,10 @@
     damage:
       groups:
         Brute: 22.5
+  - type: XenoTailStab
+    tailDamage:
+      groups:
+        Brute: 27
   - type: Tackle # min: 4, max: 5
     threshold: 5
     stun: 8

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/sentinel.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/sentinel.yml
@@ -64,7 +64,7 @@
   - type: XenoTailStab
     tailDamage:
       groups:
-        Brute: 27
+        Brute: 30
   - type: Tackle # min: 4, max: 4
     threshold: 4
     stun: 8

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/sentinel.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/sentinel.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   parent:
   - CMXenoDeveloped
   - CMXenoTail
@@ -61,6 +61,10 @@
     damage:
       groups:
         Brute: 22.5
+  - type: XenoTailStab
+    tailDamage:
+      groups:
+        Brute: 27
   - type: Tackle # min: 4, max: 4
     threshold: 4
     stun: 8

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/spitter.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/spitter.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   parent:
   - CMXenoDeveloped
   - CMXenoTail
@@ -62,6 +62,9 @@
   - type: XenoTailStab
     inject:
       RMCMolecularAcid: 1 # TODO RMC14 2
+    tailDamage:
+      groups:
+        Brute: 30
   - type: CMArmor
     armor: 15
     explosionArmor: 20

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/spitter.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/spitter.yml
@@ -64,7 +64,7 @@
       RMCMolecularAcid: 1 # TODO RMC14 2
     tailDamage:
       groups:
-        Brute: 30
+        Brute: 36
   - type: CMArmor
     armor: 15
     explosionArmor: 20

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/warrior.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/warrior.yml
@@ -68,7 +68,7 @@
   - type: XenoTailStab
     tailDamage:
       groups:
-        Brute: 42
+        Brute: 48
   - type: Tackle # min: 2, max: 4
     threshold: 4
     stun: 5

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/warrior.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/warrior.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   parent:
   - CMXenoDeveloped
   - CMXenoTail
@@ -65,6 +65,10 @@
     damage:
       groups:
         Brute: 35
+  - type: XenoTailStab
+    tailDamage:
+      groups:
+        Brute: 42
   - type: Tackle # min: 2, max: 4
     threshold: 4
     stun: 5


### PR DESCRIPTION
## About the PR

changed tailstab damage to be parity damage for each xeno caste
## Why / Balance
parity
## Technical details
yaml
## Media
https://github.com/user-attachments/assets/1ccd74b5-d873-4518-b542-f110eefcd73c
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.




:cl:
- tweak: Adjusted tail stab damage to be parity
