### PR TITLE
Boiler gas explosion on death

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Deathcloud/XenoDeathcloudComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Deathcloud/XenoDeathcloudComponent.cs
@@ -1,0 +1,12 @@
+﻿using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._RMC14.Xenonids.Deathcloud;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(XenoDeathcloudSystem))]
+public sealed partial class XenoDeathcloudComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public EntProtoId Spawn = "RMCSmokeAcidDeathcloud";
+}

--- a/Content.Shared/_RMC14/Xenonids/Deathcloud/XenoDeathcloudSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Deathcloud/XenoDeathcloudSystem.cs
@@ -1,0 +1,20 @@
+﻿using Content.Shared.Coordinates;
+using Content.Shared.Mobs;
+
+namespace Content.Shared._RMC14.Xenonids.Deathcloud;
+
+public sealed class XenoDeathcloudSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<XenoDeathcloudComponent, MobStateChangedEvent>(OnStateChanged);
+    }
+
+    private void OnStateChanged(Entity<XenoDeathcloudComponent> xeno, ref MobStateChangedEvent args)
+    {
+        if (args.NewMobState != MobState.Dead)
+            return;
+
+        SpawnAtPosition(xeno.Comp.Spawn, xeno.Owner.ToCoordinates());
+    }
+}

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/boiler.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/boiler.yml
@@ -101,6 +101,7 @@
     autoRot: true
   - type: RMCSize
     size: Big
+  - type: XenoDeathcloud
   - type: NeurotoxinInjector
     neuroPerSecond: 16
     injectInContact: false

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_smoke.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_smoke.yml
@@ -130,6 +130,16 @@
     spawn: RMCSmokeNeurotoxinShroud
     range: 1
 
+- type: entity
+  parent: RMCSmokeAcid
+  id: RMCSmokeAcidDeathcloud
+  name: acid gas
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: EvenSmoke
+    spawn: RMCSmokeAcidDeathcloud
+    range: 2
+
 - type: edgeSpreader
   id: RMCSmokeAcid
   updatesPerSecond: 2


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity, Fixes #4812.

## Technical details
<!-- Summary of code changes for easier review. -->
System and Comp, comp stores the proto to spawn. System triggers on death and spawns cloud. Thats it. In CM I think the cloud starts spreaded but messing around with that is kinda troublesome so I simply just left the spreading logic alone. It only spreads 2 tiles so it's probably fast enough...

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/d4d3ca5e-7d66-452d-bcfa-01070ef7de9a



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Fixed Boilers not exploding into acid gas on death.