### PR TITLE
Fix Client Crash on attachment forced-untoggle + Code Cleanup

### DIFF
--- a/Content.Shared/_RMC14/Attachable/Systems/AttachableToggleableSystem.cs
+++ b/Content.Shared/_RMC14/Attachable/Systems/AttachableToggleableSystem.cs
@@ -298,8 +298,9 @@ public sealed class AttachableToggleableSystem : EntitySystem
         if (!args.HasDirectionalMovement)
             return;
 
-        foreach (var attachableUid in user.Comp.AttachableList)
+        for (var i = user.Comp.AttachableList.Count - 1; i >= 0; i--)
         {
+            var attachableUid = user.Comp.AttachableList[i];
             if (!TryComp(attachableUid, out AttachableToggleableComponent? toggleableComponent) ||
                 !toggleableComponent.Active ||
                 !toggleableComponent.BreakOnMove)
@@ -309,8 +310,6 @@ public sealed class AttachableToggleableSystem : EntitySystem
 
             Toggle((attachableUid, toggleableComponent), user.Owner, toggleableComponent.DoInterrupt);
         }
-
-        RemCompDeferred<AttachableMovementLockedComponent>(user);
     }
 
     private void CheckUserBreakOnRotate(Entity<AttachableDirectionLockedComponent?> user)
@@ -326,8 +325,9 @@ public sealed class AttachableToggleableSystem : EntitySystem
         if (Transform(user.Owner).LocalRotation.GetCardinalDir() == user.Comp.LockedDirection)
             return;
 
-        foreach (EntityUid attachableUid in user.Comp.AttachableList)
+        for (var i = user.Comp.AttachableList.Count - 1; i >= 0; i--)
         {
+            var attachableUid = user.Comp.AttachableList[i];
             if (!TryComp(attachableUid, out AttachableToggleableComponent? toggleableComponent) ||
                 !toggleableComponent.Active ||
                 !toggleableComponent.BreakOnRotate)
@@ -337,8 +337,6 @@ public sealed class AttachableToggleableSystem : EntitySystem
 
             Toggle((attachableUid, toggleableComponent), user.Owner, toggleableComponent.DoInterrupt);
         }
-
-        RemCompDeferred<AttachableDirectionLockedComponent>(user);
     }
 
     private void CheckUserBreakOnFullRotate(Entity<AttachableSideLockedComponent?> user, EntityCoordinates playerPos, EntityCoordinates targetPos)
@@ -364,8 +362,9 @@ public sealed class AttachableToggleableSystem : EntitySystem
         if (differenceFromLockedAngle > -90 && differenceFromLockedAngle < 90)
             return;
 
-        foreach (EntityUid attachableUid in user.Comp.AttachableList)
+        for (var i = user.Comp.AttachableList.Count - 1; i >= 0; i--)
         {
+            var attachableUid = user.Comp.AttachableList[i];
             if (!TryComp(attachableUid, out AttachableToggleableComponent? toggleableComponent) ||
                 !toggleableComponent.Active ||
                 !toggleableComponent.BreakOnFullRotate)
@@ -375,8 +374,6 @@ public sealed class AttachableToggleableSystem : EntitySystem
 
             Toggle((attachableUid, toggleableComponent), user.Owner, toggleableComponent.DoInterrupt);
         }
-
-        RemCompDeferred<AttachableSideLockedComponent>(user);
     }
 #endregion
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed a client crash that occurs when being forced to untoggle an attachment by a fail condition (such as shooting the wrong way). 

## Why
This got missed in the last PR as the F5 build has had a bullet-prediction related DebugAssert for the Bipod when turning around while shooting ever since that was added. This crash was found when manually building instead.

## Technical details
Swaps the foreach check in all of the force un-toggles to a for loop that runs in reverse, as Toggle() is actively removing from the list it is iterating over. Foreach() doesn't really work unless it's read-only, which this isn't.

Removed the unneeded RemCompDeferred from each of the CheckUserBreakOns as Toggle() is now the one that handles all component removal.

## Media

https://github.com/user-attachments/assets/14c4b224-c529-49e1-b7fe-080585a33305

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

No CL
