### PR TITLE
Make stasis bags run out of stasis time

### DIFF
--- a/Content.Shared/_RMC14/Medical/Stasis/CMStasisBagComponent.cs
+++ b/Content.Shared/_RMC14/Medical/Stasis/CMStasisBagComponent.cs
@@ -1,4 +1,5 @@
 ﻿using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared._RMC14.Medical.Stasis;
 
@@ -9,4 +10,13 @@ public sealed partial class CMStasisBagComponent : Component
     // TODO RMC14 make upstream metabolism modifiers not shit, this just makes metabolism 1000 times slower instead of stopping it
     [DataField, AutoNetworkedField]
     public int MetabolismMultiplier = 1000;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan StasisMaxTime = TimeSpan.FromMinutes(15);
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan StasisLeft = TimeSpan.FromMinutes(15);
+
+    [DataField, AutoNetworkedField]
+    public EntProtoId UsedBag = "RMCStasisBagUsed";
 }

--- a/Content.Shared/_RMC14/Medical/Stasis/CMStasisBagSystem.cs
+++ b/Content.Shared/_RMC14/Medical/Stasis/CMStasisBagSystem.cs
@@ -1,6 +1,11 @@
 ﻿using Content.Shared._RMC14.Medical.Wounds;
 using Content.Shared._RMC14.Xenonids.Parasite;
 using Content.Shared.Body.Organ;
+using Content.Shared.Coordinates;
+using Content.Shared.Examine;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.Popups;
+using Content.Shared.Storage.EntitySystems;
 using Robust.Shared.Containers;
 
 namespace Content.Shared._RMC14.Medical.Stasis;
@@ -8,6 +13,10 @@ namespace Content.Shared._RMC14.Medical.Stasis;
 public sealed class CMStasisBagSystem : EntitySystem
 {
     [Dependency] private readonly SharedXenoParasiteSystem _parasite = default!;
+    [Dependency] private readonly SharedContainerSystem _container = default!;
+    [Dependency] private readonly MobStateSystem _mobstate = default!;
+    [Dependency] private readonly SharedEntityStorageSystem _entStorage = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
 
     private EntityQuery<OrganComponent> _organQuery;
 
@@ -19,6 +28,7 @@ public sealed class CMStasisBagSystem : EntitySystem
 
         SubscribeLocalEvent<CMStasisBagComponent, ContainerIsInsertingAttemptEvent>(OnStasisInsert);
         SubscribeLocalEvent<CMStasisBagComponent, ContainerIsRemovingAttemptEvent>(OnStasisRemove);
+        SubscribeLocalEvent<CMStasisBagComponent, ExaminedEvent>(OnStasisExamine);
 
         SubscribeLocalEvent<CMInStasisComponent, CMMetabolizeAttemptEvent>(OnBloodstreamMetabolizeAttempt);
         SubscribeLocalEvent<CMInStasisComponent, MapInitEvent>(OnInStasisMapInit);
@@ -35,6 +45,19 @@ public sealed class CMStasisBagSystem : EntitySystem
     private void OnStasisRemove(Entity<CMStasisBagComponent> ent, ref ContainerIsRemovingAttemptEvent args)
     {
         OnRemove(ent, args.EntityUid);
+    }
+
+    private void OnStasisExamine(Entity<CMStasisBagComponent> ent, ref ExaminedEvent args)
+    {
+        string msg = "rmc-stasis-new";
+
+        if (ent.Comp.StasisLeft / ent.Comp.StasisMaxTime < 0.33f)
+            msg = "rmc-stasis-very-used";
+        else if (ent.Comp.StasisLeft / ent.Comp.StasisMaxTime < 0.66f)
+            msg = "rmc-stasis-used";
+
+        args.PushMarkup(Loc.GetString(msg));
+
     }
 
     private void OnBloodstreamMetabolizeAttempt(Entity<CMInStasisComponent> ent, ref CMMetabolizeAttemptEvent args)
@@ -78,6 +101,46 @@ public sealed class CMStasisBagSystem : EntitySystem
     private void OnRemove(Entity<CMStasisBagComponent> bag, EntityUid target)
     {
         RemCompDeferred<CMInStasisComponent>(target);
+    }
+
+    public override void Update(float frameTime)
+    {
+        var stasisQuery = EntityQueryEnumerator<CMStasisBagComponent>();
+
+        while (stasisQuery.MoveNext(out var uid, out var bag))
+        {
+            if (!_container.TryGetContainer(uid, "entity_storage", out var container))
+                return;
+
+            if (container.ContainedEntities.Count <= 0)
+                return;
+
+            bool inStasis = false;
+            foreach (var ent in container.ContainedEntities)
+            {
+                if(_mobstate.IsDead(ent))
+                {
+                    _entStorage.OpenStorage(uid);
+                    _popup.PopupEntity(Loc.GetString("rmc-stasis-reject-dead"), uid, PopupType.SmallCaution);
+                    return;
+                }
+
+                if (HasComp<CMInStasisComponent>(ent))
+                    inStasis = true;
+            }
+
+            if (!inStasis)
+                return;
+
+            bag.StasisLeft -= TimeSpan.FromSeconds(frameTime);
+
+            if(bag.StasisLeft <= TimeSpan.Zero)
+            {
+                _entStorage.EmptyContents(uid);
+                SpawnAtPosition(bag.UsedBag, uid.ToCoordinates());
+                QueueDel(uid);
+            }
+        }
     }
 
     public bool CanBodyMetabolize(EntityUid body)

--- a/Resources/Locale/en-US/_RMC14/medical/stasisbag.ftl
+++ b/Resources/Locale/en-US/_RMC14/medical/stasisbag.ftl
@@ -1,0 +1,4 @@
+﻿rmc-stasis-reject-dead = The stasis bag rejects the corpse.
+rmc-stasis-new = It looks new.
+rmc-stasis-used = It looks a bit used.
+rmc-stasis-very-used = It looks really used.

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Medical/bodybags.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Medical/bodybags.yml
@@ -136,6 +136,23 @@
     folded: true
 
 - type: entity
+  parent: BaseItem
+  id: RMCStasisBagUsed
+  name: used stasis bag
+  description: It's been ripped open. You will need to find a machine capable of recycling it.
+  suffix: trash
+  components:
+  - type: Item
+    size: Small
+  - type: Sprite
+    sprite: _RMC14/Objects/Medical/stasisbag.rsi
+    state: bodybag_used
+  - type: Tag
+    tags:
+    - Trash
+  
+
+- type: entity
   parent: CMBodyBag
   id: RMCThermalTarp # TODO RMC14 This needs to halt infected timers or something
   name: V3 reactive thermal tarp


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title. Stasis bags now have 15 minutes of stasis. Once they run out they eject their contents and turn into used bags. Also they can't hold the dead.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity. Fixes #2846

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/c7763e5c-c09f-4fba-98b0-0f96dc8d015a



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed stasis bags being able to hold corpses
- fix: Fix stasis bags lasting forever. They now have 15 minutes of stasis per bag that goes down as someone is kept inside. Once they run out they turned into trash.