### PR TITLE
Add stun when leaving an entity storage

### DIFF
--- a/Content.Shared/_RMC14/Storage/RMCStorageSystem.cs
+++ b/Content.Shared/_RMC14/Storage/RMCStorageSystem.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared._RMC14.Marines.Skills;
+﻿using Content.Shared._RMC14.Marines;
+using Content.Shared._RMC14.Marines.Skills;
 using Content.Shared._RMC14.Prototypes;
 using Content.Shared.DoAfter;
 using Content.Shared.Hands.EntitySystems;
@@ -9,7 +10,9 @@ using Content.Shared.Popups;
 using Content.Shared.Storage;
 using Content.Shared.Storage.Components;
 using Content.Shared.Storage.EntitySystems;
+using Content.Shared.Stunnable;
 using Content.Shared.Whitelist;
+using Robust.Shared.Containers;
 using Robust.Shared.Timing;
 using static Content.Shared.Storage.StorageComponent;
 
@@ -29,11 +32,13 @@ public sealed class RMCStorageSystem : EntitySystem
     [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
     [Dependency] private readonly SharedHandsSystem _hands = default!;
     [Dependency] private readonly InventorySystem _inventory = default!;
+    [Dependency] private readonly SharedStunSystem _stun = default!;
 
     private readonly List<EntityUid> _toRemove = new();
 
     private EntityQuery<StorageComponent> _storageQuery;
 
+    private readonly TimeSpan STUN_STORAGE = TimeSpan.FromSeconds(4);
     public override void Initialize()
     {
         _storageQuery = GetEntityQuery<StorageComponent>();
@@ -48,6 +53,7 @@ public sealed class RMCStorageSystem : EntitySystem
         SubscribeLocalEvent<StorageCloseOnMoveComponent, GotEquippedEvent>(OnStorageEquip);
 
         SubscribeLocalEvent<BlockEntityStorageComponent, InsertIntoEntityStorageAttemptEvent>(OnBlockInsertIntoEntityStorageAttempt);
+        SubscribeLocalEvent<MarineComponent, EntGotRemovedFromContainerMessage>(OnRemovedMarineFromContainer);
 
         Subs.BuiEvents<StorageCloseOnMoveComponent>(StorageUiKey.Key, subs =>
         {
@@ -186,6 +192,12 @@ public sealed class RMCStorageSystem : EntitySystem
     {
         if (_entityWhitelist.IsWhitelistPassOrNull(ent.Comp.Whitelist, args.Container))
             args.Cancelled = true;
+    }
+
+    private void OnRemovedMarineFromContainer(Entity<MarineComponent> ent, ref EntGotRemovedFromContainerMessage args)
+    {
+        if (_timing.IsFirstTimePredicted)
+            _stun.TryStun(ent, STUN_STORAGE, true);
     }
 
     private void OnCloseOnMoveUIClosed(Entity<StorageOpenComponent> ent, ref BoundUIClosedEvent args)

--- a/Content.Shared/_RMC14/Storage/RMCStorageSystem.cs
+++ b/Content.Shared/_RMC14/Storage/RMCStorageSystem.cs
@@ -13,6 +13,7 @@ using Content.Shared.Storage.EntitySystems;
 using Content.Shared.Stunnable;
 using Content.Shared.Whitelist;
 using Robust.Shared.Timing;
+using Robust.Shared.Containers;
 using static Content.Shared.Storage.StorageComponent;
 
 namespace Content.Shared._RMC14.Storage;

--- a/Content.Shared/_RMC14/Storage/RMCStorageSystem.cs
+++ b/Content.Shared/_RMC14/Storage/RMCStorageSystem.cs
@@ -12,7 +12,6 @@ using Content.Shared.Storage.Components;
 using Content.Shared.Storage.EntitySystems;
 using Content.Shared.Stunnable;
 using Content.Shared.Whitelist;
-using Robust.Shared.Containers;
 using Robust.Shared.Timing;
 using static Content.Shared.Storage.StorageComponent;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
parity, fixes #4840. No cheeze

## Technical details
<!-- Summary of code changes for easier review. -->
EntGotRemovedFromContainerMessage on the marine comp (I tried to use the general inside ent container function but it never triggered...) Mispredicts on move but otherwise fine.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Leaving a container stuns you for 4 seconds