### PR TITLE
Make marines in lockers count as dead, remove xenos seeing through lockers

### DIFF
--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
@@ -732,7 +732,6 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
             {
                 distress.Hijack = true;
                 distress.AbandonedAt ??= time + distress.AbandonedDelay;
-                _hive.SetSeeThroughContainers(distress.Hive, true);
             }
 
             _almayerMaps.Clear();
@@ -772,6 +771,9 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
                 {
                     continue;
                 }
+
+                if (_containers.IsEntityInContainer(marineId))
+                    continue;
 
                 if (_mobState.IsAlive(marineId, mobState) &&
                     (distress.AbandonedAt == null ||


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
CM13 parity
Marines in lockers don't count for the round end condition anymore, remove ability for xenos to see through containers in hijack

:cl:
- tweak: Xenos can no longer see through containers during hijack.
- tweak: Marines in lockers are now considered as escaped and no longer count towards the xeno major condition.
