### PR TITLE
Make colorblind mode change Almayer radio message color

### DIFF
--- a/Content.Shared/_RMC14/Radio/RadioChannelPrototype.cs
+++ b/Content.Shared/_RMC14/Radio/RadioChannelPrototype.cs
@@ -1,0 +1,9 @@
+﻿// ReSharper disable CheckNamespace
+
+namespace Content.Shared.Radio;
+
+public sealed partial class RadioChannelPrototype
+{
+    [DataField]
+    public Color? ColorblindColor;
+}

--- a/Resources/Prototypes/_RMC14/radio_channels.yml
+++ b/Resources/Prototypes/_RMC14/radio_channels.yml
@@ -14,6 +14,7 @@
   keycode: "g" #; and g in cm13
   frequency: 1480
   color: "#B4B4B4"
+  colorblindColor: "#6FD08C"
   longRange: true
   tower: true
   planet: false


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
https://github.com/user-attachments/assets/44f1bd62-308b-4703-be19-cc1caabf9b07

<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- add: Colorblind friendly mode (in Escape > Options > Accessibility) now changes the color of Almayer radio messages from gray to green.
