### PR TITLE
Fix fireaxe and pickaxe

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -13,15 +13,13 @@
       types:
         Blunt: 15
         Slash: 10
-        Structural: 10
     soundHit:
       collection: GenericHit
     wideAnimationRotation: 90
   - type: IncreaseDamageOnWield
     damage:
       types:
-        Slash: 15
-        Blunt: 15
-        Structural: 40
+        Slash: 10
+        Blunt: 10
   - type: Prying
     speedModifier: 100000

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Melee/pickaxe.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Melee/pickaxe.yml
@@ -23,7 +23,6 @@
       types:
         Slash: 15
         Blunt: 20
-        Structural: 20
     soundHit:
       path: /Audio/Weapons/bladeslice.ogg
   - type: Tag


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title. They don't do structural damage in CM.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Pretty silly that its better than machetes. also parity.

Note they still take out thick resin in 5 hits when it should be 7 (Least for fireaxe 1-handed). I assume this is something to do with the resin multiplier, dunno. But they don't do bonus damage that the machete doesn't already do.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed fireaxe and pickaxe doing structural damage.
