### PR TITLE
RTO/breaching shell vendor fixes, underbarrel shotgun fixes, command tablet fixes, other fixes

### DIFF
--- a/Content.Client/_RMC14/Marines/Announce/MarineCommunicationsComputerBui.cs
+++ b/Content.Client/_RMC14/Marines/Announce/MarineCommunicationsComputerBui.cs
@@ -1,4 +1,6 @@
 ﻿using Content.Shared._RMC14.Marines.Announce;
+using Content.Shared._RMC14.Overwatch;
+using Content.Shared._RMC14.TacticalMap;
 using JetBrains.Annotations;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Utility;
@@ -17,8 +19,17 @@ public sealed class MarineCommunicationsComputerBui(EntityUid owner, Enum uiKey)
             return;
 
         _window = new MarineCommunicationsComputerWindow();
-        _window.TacticalMapButton.OnPressed += _ => SendPredictedMessage(new MarineCommunicationsOpenMapMsg());
-        _window.OverwatchButton.OnPressed += _ => SendPredictedMessage(new MarineCommunicationsOverwatchMsg());
+
+        if (EntMan.HasComponent<TacticalMapComputerComponent>(Owner))
+            _window.TacticalMapButton.OnPressed += _ => SendPredictedMessage(new MarineCommunicationsOpenMapMsg());
+        else
+            _window.TacticalMapButton.Visible = false;
+
+        if (EntMan.HasComponent<OverwatchConsoleComponent>(Owner))
+            _window.OverwatchButton.OnPressed += _ => SendPredictedMessage(new MarineCommunicationsOverwatchMsg());
+        else
+            _window.OverwatchButton.Visible = false;
+
         _window.Send.OnPressed += _ => SendPredictedMessage(new MarineCommunicationsComputerMsg( Rope.Collapse(_window.Text.TextRope)));
         OnStateUpdate();
 

--- a/Content.Shared/_RMC14/Marines/Announce/SharedMarineAnnounceSystem.cs
+++ b/Content.Shared/_RMC14/Marines/Announce/SharedMarineAnnounceSystem.cs
@@ -34,7 +34,7 @@ public abstract class SharedMarineAnnounceSystem : EntitySystem
     {
         if (!_skills.HasSkill(args.Actor, ent.Comp.OverwatchSkill, ent.Comp.OverwatchSkillLevel))
         {
-            _popup.PopupCursor("You are not trained in overwatch!", args.Actor, PopupType.LargeCaution);
+            _popup.PopupClient("You are not trained in overwatch!", args.Actor, PopupType.LargeCaution);
             return;
         }
 

--- a/Content.Shared/_RMC14/NightVision/NightVisionItemComponent.cs
+++ b/Content.Shared/_RMC14/NightVision/NightVisionItemComponent.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared.Inventory;
+﻿using Content.Shared._RMC14.Marines.Skills;
+using Content.Shared.Inventory;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 
@@ -23,4 +24,7 @@ public sealed partial class NightVisionItemComponent : Component
     // Only allows for a single slotflag right now because some code uses strings and some code uses enums to determine slots :(
     [DataField, AutoNetworkedField]
     public SlotFlags SlotFlags { get; set; } = SlotFlags.EYES;
+
+    [DataField, AutoNetworkedField]
+    public Dictionary<EntProtoId<SkillDefinitionComponent>, int>? Skills;
 }

--- a/Content.Shared/_RMC14/NightVision/SharedNightVisionSystem.cs
+++ b/Content.Shared/_RMC14/NightVision/SharedNightVisionSystem.cs
@@ -1,6 +1,8 @@
-﻿using Content.Shared.Actions;
+﻿using Content.Shared._RMC14.Marines.Skills;
+using Content.Shared.Actions;
 using Content.Shared.Alert;
 using Content.Shared.Inventory.Events;
+using Content.Shared.Popups;
 using Content.Shared.Rounding;
 using Content.Shared.Toggleable;
 using Robust.Shared.Timing;
@@ -12,6 +14,8 @@ public abstract class SharedNightVisionSystem : EntitySystem
     [Dependency] private readonly SharedActionsSystem _actions = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly AlertsSystem _alerts = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SkillsSystem _skills = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
 
     public override void Initialize()
@@ -155,6 +159,12 @@ public abstract class SharedNightVisionSystem : EntitySystem
     {
         DisableNightVisionItem(item, item.Comp.User);
 
+        if (item.Comp.Skills != null && !_skills.HasAllSkills(user, item.Comp.Skills))
+        {
+            _popup.PopupClient(Loc.GetString("rmc-skills-hud-toggle"), user, user, PopupType.MediumCaution);
+            return;
+        }
+
         item.Comp.User = user;
         Dirty(item);
 
@@ -178,7 +188,7 @@ public abstract class SharedNightVisionSystem : EntitySystem
     {
     }
 
-    protected void DisableNightVisionItem(Entity<NightVisionItemComponent> item, EntityUid? user)
+    public void DisableNightVisionItem(Entity<NightVisionItemComponent> item, EntityUid? user)
     {
         _actions.SetToggled(item.Comp.Action, false);
 

--- a/Content.Shared/_RMC14/Power/SharedRMCPowerSystem.cs
+++ b/Content.Shared/_RMC14/Power/SharedRMCPowerSystem.cs
@@ -13,6 +13,7 @@ using Content.Shared.Interaction;
 using Content.Shared.Popups;
 using Content.Shared.Tools.Systems;
 using Content.Shared.UserInterface;
+using Content.Shared.Weapons.Melee;
 using Robust.Shared.Containers;
 using Robust.Shared.Network;
 using Robust.Shared.Random;
@@ -353,7 +354,7 @@ public abstract class SharedRMCPowerSystem : EntitySystem
     private void OnFusionReactorInteractHand(Entity<RMCFusionReactorComponent> ent, ref InteractHandEvent args)
     {
         var user = args.User;
-        if (!HasComp<XenoComponent>(user))
+        if (!HasComp<XenoComponent>(user) || !HasComp<MeleeWeaponComponent>(user))
             return;
 
         if (ent.Comp.State == RMCFusionReactorState.Weld)

--- a/Content.Shared/_RMC14/Pulling/BeingPulledComponent.cs
+++ b/Content.Shared/_RMC14/Pulling/BeingPulledComponent.cs
@@ -1,0 +1,7 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Pulling;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(RMCPullingSystem))]
+public sealed partial class BeingPulledComponent : Component;

--- a/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
@@ -203,6 +203,9 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
             upgradeable.Comp.To is { } to &&
             _prototype.HasIndex(to))
         {
+            if (!_interaction.InRangeUnobstructed(xeno.Owner, upgradeable.Owner, popup: true))
+                return;
+
             var cost = upgradeable.Comp.Cost;
             if (!_xenoPlasma.TryRemovePlasmaPopup(xeno.Owner, cost))
                 return;

--- a/Content.Shared/_RMC14/Xenonids/Hive/SharedXenoHiveSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hive/SharedXenoHiveSystem.cs
@@ -317,7 +317,7 @@ public abstract class SharedXenoHiveSystem : EntitySystem
             if (!_mind.TryGetMind(actor.PlayerSession.UserId, out var mind))
                 mind = _mind.CreateMind(actor.PlayerSession.UserId);
 
-            _mind.TransferTo(mind.Value, spawned);
+            _mind.TransferTo(mind.Value, spawned, ghostCheckOverride: true);
         }
 
         _adminLog.Add(LogType.RMCBurrowedLarva, $"{ToPrettyString(user):player} took a burrowed larva from hive {ToPrettyString(hive):hive}.");

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Eyes/glasses.yml
@@ -73,6 +73,8 @@
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/Eyes/Glasses/ml66a_sight.rsi
   - type: NightVisionItem
+    skills:
+      RMCSkillSmartGun: 1
   - type: ClothingRequireEquipped
     whitelist:
       components:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Devices/command_tablet.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Devices/command_tablet.yml
@@ -21,6 +21,7 @@
       enum.TacticalMapComputerUi.Key:
         type: TacticalMapComputerBui
   - type: MarineCommunicationsComputer
+  - type: TacticalMapComputer
   - type: Tag
     tags:
     - CommandTablet

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/under_attachments.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/under_attachments.yml
@@ -282,7 +282,7 @@
       tags:
       - RMCShellShotgunBuckshot
     capacity: 5
-    proto: null
+    proto: CMShellShotgunBuckshot
     soundInsert:
       path: /Audio/_RMC14/Weapons/Guns/Reload/m42a2.ogg
   - type: GunDamageMultipliers

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/under_attachments.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/under_attachments.yml
@@ -289,8 +289,6 @@
     multipliers:
       Turf: 5
       Breaching: 10.8
-  - type: UniqueAction
-  - type: PumpAction
   - type: UseDelay
   - type: AttachableToggleable
     userOnly: true

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/base_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/base_rifle.yml
@@ -1,7 +1,7 @@
 ﻿- type: entity
   abstract: true
   parent: [ CMBaseWeaponGun, BaseItem, RMCBaseAttachableHolder ]
-  id: CMBaseWeaponRifle
+  id: CMBaseWeaponRifleNoDualWieldPenalty
   components:
   - type: Gun
     shotsPerBurst: 3
@@ -60,6 +60,11 @@
   - type: Appearance
   - type: RMCNameItemOnVend
     item: PrimaryGun
+
+- type: entity
+  parent: CMBaseWeaponRifleNoDualWieldPenalty
+  id: CMBaseWeaponRifle
+  components:
   - type: GunGroupSpreadPenalty
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/xm51_shotgun.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/xm51_shotgun.yml
@@ -1,5 +1,5 @@
 ﻿- type: entity
-  parent: [ CMBaseWeaponRifle, RMCBaseAttachableHolder ]
+  parent: [ CMBaseWeaponRifleNoDualWieldPenalty, RMCBaseAttachableHolder ]
   name: XM51 breaching scattergun
   id: RMCWeaponShotgunXM51
   description: An experimental shotgun model going through testing trials in the UNMC. Based on the original civilian and CMB version, the XM51 is a mag-fed, pump-action shotgun. It utilizes special 16-gauge breaching rounds which are effective at breaching walls and doors. Users are advised not to employ the weapon against soft or armored targets due to low performance of the shells.

--- a/Resources/Prototypes/_RMC14/Entities/Objects/vines.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/vines.yml
@@ -112,3 +112,4 @@
         heavy_4: ""
         heavy_5: ""
         heavy_6: ""
+  - type: Occluder

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/command.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/command.yml
@@ -180,8 +180,8 @@
       #   points: 5
       - id: RMCAttachmentMagneticHarness
         points: 12
-      #- id: RMCBackpackRadioTelephone # TODO RMC14 Radio Telephone Pack (RTO FTL Pack)
-      #  points: 15
+      - id: RMCBackpackRTO
+        points: 15
       - id: RMCBinoculars
         points: 5
       - id: RMCRangefinder

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/prep.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/prep.yml
@@ -321,8 +321,8 @@
       #  amount: 2
       #- id: CMMagazineBoxM2C
       #  amount: 2
-      #- id: Box of Breaching Shells (16g)
-      #  amount: 2
+      - id: RMCBoxShotgunBreaching
+        amount: 2
       #- id: CMBatonSlugsHIRR
       #  amount: 6
       #- id: CMStarShellN74AGMS

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/medical.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/medical.yml
@@ -275,6 +275,7 @@
         layer:
         - MachineLayer
         density: 200
+        hard: false
   - type: Sprite
     drawdepth: WallMountedItems
     sprite: _RMC14/Structures/Machines/VendingMachines/nanomed.rsi

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Storage/reagent_tank.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Storage/reagent_tank.yml
@@ -45,6 +45,3 @@
     solutions:
       tank:
         maxVol: 1000
-  - type: Anchorable
-    flags:
-    - None

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_walls.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_walls.yml
@@ -172,3 +172,5 @@
     destroyWeeds: false
   - type: TimedDespawn
     lifetime: 5.0
+  - type: XenoStructureUpgradeable
+    to: null


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Fixed getting pulled stopping your movement until you tap a movement key again.
- fix: Fixed joining as burrowed larva sometimes leaving behind a catatonic larva.
- fix: Fixed non-smart gun operators being able to use a smart gun operator's night vision sight.
- fix: Fixed staff officers not being able to buy a radio telephone pack for 15 points in their vendor.
- fix: Fixed the automated munition squad vendor not having 2 boxes of breaching shells.
- fix: Fixed the underbarrel shotgun needing to be pumped and it not starting loaded with 5 buckshot shells.
- fix: Fixed the command tablet's tactical map button not working and it incorrectly having an overwatch button.
- fix: Fixed the nanomed blocking movement.
- fix: Fixed the reagent tank not being able to be anchored.
- fix: Fixed weak resin walls being upgradeable by hivelords.
- fix: Fixed hivelords being able to upgrade resin structures from infinite range.
- fix: Fixed parasites and larva being able to destroy fusion reactors and geothermal generators.
- fix: Fixed the XM51 breaching scattergun getting dual-wield penalties.
- fix: Fixed thick vines in LV not occluding vision.