### PR TITLE
fix accents that weren't intended to be added

### DIFF
--- a/Content.Server/Speech/Components/MobsterAccentComponent.cs
+++ b/Content.Server/Speech/Components/MobsterAccentComponent.cs
@@ -12,4 +12,10 @@ public sealed partial class MobsterAccentComponent : Component
     /// </summary>
     [DataField("isBoss")]
     public bool IsBoss = true;
+
+    [DataField]
+    public float PrefixChance = 0.15f;
+
+    [DataField]
+    public float SuffixChance = 0.4f;
 }

--- a/Content.Server/Speech/EntitySystems/MobsterAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/MobsterAccentSystem.cs
@@ -46,46 +46,48 @@ public sealed class MobsterAccentSystem : EntitySystem
         msg = RegexUpperAr.Replace(msg, "AH");
 
         // Prefix
-        if (_random.Prob(0.15f))
-        {
-            //Checks if the first word of the sentence is all caps
-            //So the prefix can be allcapped and to not resanitize the captial
-            var firstWordAllCaps = !RegexFirstWord.Match(msg).Value.Any(char.IsLower);
-            var pick = _random.Next(1, 2);
-
-            // Reverse sanitize capital
-            var prefix = Loc.GetString($"accent-mobster-prefix-{pick}");
-            if (!firstWordAllCaps)
-                msg = msg[0].ToString().ToLower() + msg.Remove(0, 1);
-            else
-                prefix = prefix.ToUpper();
-            msg = prefix + " " + msg;
-        }
+        // Removed for RMC
+        // if (_random.Prob(0.15f))
+        // {
+        //     //Checks if the first word of the sentence is all caps
+        //     //So the prefix can be allcapped and to not resanitize the captial
+        //     var firstWordAllCaps = !RegexFirstWord.Match(msg).Value.Any(char.IsLower);
+        //     var pick = _random.Next(1, 2);
+        //
+        //     // Reverse sanitize capital
+        //     var prefix = Loc.GetString($"accent-mobster-prefix-{pick}");
+        //     if (!firstWordAllCaps)
+        //         msg = msg[0].ToString().ToLower() + msg.Remove(0, 1);
+        //     else
+        //         prefix = prefix.ToUpper();
+        //     msg = prefix + " " + msg;
+        // }
 
         // Sanitize capital again, in case we substituted a word that should be capitalized
         msg = msg[0].ToString().ToUpper() + msg.Remove(0, 1);
 
         // Suffixes
-        if (_random.Prob(0.4f))
-        {
-            //Checks if the last word of the sentence is all caps
-            //So the suffix can be allcapped
-            var lastWordAllCaps = !RegexLastWord.Match(msg).Value.Any(char.IsLower);
-            var suffix = "";
-            if (component.IsBoss)
-            {
-                var pick = _random.Next(1, 4);
-                suffix = Loc.GetString($"accent-mobster-suffix-boss-{pick}");
-            }
-            else
-            {
-                var pick = _random.Next(1, 3);
-                suffix = Loc.GetString($"accent-mobster-suffix-minion-{pick}");
-            }
-            if (lastWordAllCaps)
-                suffix = suffix.ToUpper();
-            msg += suffix;
-        }
+        // removed for RMC
+        // if (_random.Prob(0.4f))
+        // {
+        //     //Checks if the last word of the sentence is all caps
+        //     //So the suffix can be allcapped
+        //     var lastWordAllCaps = !RegexLastWord.Match(msg).Value.Any(char.IsLower);
+        //     var suffix = "";
+        //     if (component.IsBoss)
+        //     {
+        //         var pick = _random.Next(1, 4);
+        //         suffix = Loc.GetString($"accent-mobster-suffix-boss-{pick}");
+        //     }
+        //     else
+        //     {
+        //         var pick = _random.Next(1, 3);
+        //         suffix = Loc.GetString($"accent-mobster-suffix-minion-{pick}");
+        //     }
+        //     if (lastWordAllCaps)
+        //         suffix = suffix.ToUpper();
+        //     msg += suffix;
+        // }
 
         return msg;
     }

--- a/Content.Server/Speech/EntitySystems/MobsterAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/MobsterAccentSystem.cs
@@ -46,48 +46,52 @@ public sealed class MobsterAccentSystem : EntitySystem
         msg = RegexUpperAr.Replace(msg, "AH");
 
         // Prefix
-        // Removed for RMC
-        // if (_random.Prob(0.15f))
-        // {
-        //     //Checks if the first word of the sentence is all caps
-        //     //So the prefix can be allcapped and to not resanitize the captial
-        //     var firstWordAllCaps = !RegexFirstWord.Match(msg).Value.Any(char.IsLower);
-        //     var pick = _random.Next(1, 2);
-        //
-        //     // Reverse sanitize capital
-        //     var prefix = Loc.GetString($"accent-mobster-prefix-{pick}");
-        //     if (!firstWordAllCaps)
-        //         msg = msg[0].ToString().ToLower() + msg.Remove(0, 1);
-        //     else
-        //         prefix = prefix.ToUpper();
-        //     msg = prefix + " " + msg;
-        // }
+        if (_random.Prob(component.PrefixChance))
+        {
+            //Checks if the first word of the sentence is all caps
+            //So the prefix can be allcapped and to not resanitize the captial
+            var firstWordAllCaps = !RegexFirstWord.Match(msg).Value.Any(char.IsLower);
+            var pick = _random.Next(1, 2);
+
+            // Reverse sanitize capital
+            var prefix = Loc.GetString($"accent-mobster-prefix-{pick}");
+            if (!firstWordAllCaps)
+                msg = msg[0].ToString().ToLower() + msg.Remove(0, 1);
+            else
+                prefix = prefix.ToUpper();
+            msg = prefix + " " + msg;
+        }
 
         // Sanitize capital again, in case we substituted a word that should be capitalized
         msg = msg[0].ToString().ToUpper() + msg.Remove(0, 1);
 
         // Suffixes
-        // removed for RMC
-        // if (_random.Prob(0.4f))
-        // {
-        //     //Checks if the last word of the sentence is all caps
-        //     //So the suffix can be allcapped
-        //     var lastWordAllCaps = !RegexLastWord.Match(msg).Value.Any(char.IsLower);
-        //     var suffix = "";
-        //     if (component.IsBoss)
-        //     {
-        //         var pick = _random.Next(1, 4);
-        //         suffix = Loc.GetString($"accent-mobster-suffix-boss-{pick}");
-        //     }
-        //     else
-        //     {
-        //         var pick = _random.Next(1, 3);
-        //         suffix = Loc.GetString($"accent-mobster-suffix-minion-{pick}");
-        //     }
-        //     if (lastWordAllCaps)
-        //         suffix = suffix.ToUpper();
-        //     msg += suffix;
-        // }
+        if (_random.Prob(component.SuffixChance))
+        {
+            //Checks if the last word of the sentence is all caps
+            //So the suffix can be allcapped
+            var lastWordAllCaps = !RegexLastWord.Match(msg).Value.Any(char.IsLower);
+            var suffix = "";
+            if (component.IsBoss)
+            {
+                var pick = _random.Next(1, 4);
+                suffix = Loc.GetString($"accent-mobster-suffix-boss-{pick}");
+            }
+            else
+            {
+                var pick = _random.Next(1, 3);
+                suffix = Loc.GetString($"accent-mobster-suffix-minion-{pick}");
+            }
+            if (lastWordAllCaps)
+                suffix = suffix.ToUpper();
+
+            if (msg.EndsWith("..."))
+                suffix = suffix[1..];
+            else if (msg.EndsWith("."))
+                msg = msg[..^1];
+
+            msg += suffix;
+        }
 
         return msg;
     }

--- a/Content.Server/Speech/EntitySystems/RussianAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/RussianAccentSystem.cs
@@ -15,28 +15,30 @@ public sealed class RussianAccentSystem : EntitySystem
     {
         var accentedMessage = new StringBuilder(_replacement.ApplyReplacements(message, "russian"));
 
-        for (var i = 0; i < accentedMessage.Length; i++)
-        {
-            var c = accentedMessage[i];
+        // RMC CHANGE Removed the letter swaps for accessibility. Accent still contains word swaps like yes and no.
 
-            accentedMessage[i] = c switch
-            {
-                'b' => 'в',
-                'N' => 'И',
-                'n' => 'и',
-                'K' => 'К',
-                'k' => 'к',
-                'm' => 'м',
-                'h' => 'н',
-                't' => 'т',
-                'R' => 'Я',
-                'r' => 'я',
-                'Y' => 'У',
-                'W' => 'Ш',
-                'w' => 'ш',
-                _ => accentedMessage[i]
-            };
-        }
+        // for (var i = 0; i < accentedMessage.Length; i++)
+        // {
+        //     var c = accentedMessage[i];
+        //
+        //     accentedMessage[i] = c switch
+        //     {
+        //         'b' => 'в',
+        //         'N' => 'И',
+        //         'n' => 'и',
+        //         'K' => 'К',
+        //         'k' => 'к',
+        //         'm' => 'м',
+        //         'h' => 'н',
+        //         't' => 'т',
+        //         'R' => 'Я',
+        //         'r' => 'я',
+        //         'Y' => 'У',
+        //         'W' => 'Ш',
+        //         'w' => 'ш',
+        //         _ => accentedMessage[i]
+        //     };
+        // }
 
         return accentedMessage.ToString();
     }

--- a/Resources/IgnoredPrototypes/cm_ignoredPrototypes.yml
+++ b/Resources/IgnoredPrototypes/cm_ignoredPrototypes.yml
@@ -1,4 +1,5 @@
 - /Prototypes/lobbyscreens.yml
-- /Prototypes/Traits/neutral.yml
+- /Prototypes/Traits/speech.yml
+- /Prototypes/Traits/quirks.yml
 - /Prototypes/Traits/disabilities.yml
 - /Prototypes/game_presets.yml

--- a/Resources/Prototypes/Accents/word_replacements.yml
+++ b/Resources/Prototypes/Accents/word_replacements.yml
@@ -4,6 +4,7 @@
 # i guess you could just specify the prefix ('mobster') and count and let the system fill it
 - type: accent
   id: mobster
+  replacementChance: 0.2
   wordReplacements:
     accent-mobster-words-1: accent-mobster-words-replace-1
     accent-mobster-words-2: accent-mobster-words-replace-2
@@ -230,6 +231,7 @@
 
 - type: accent
   id: pirate
+  replacementChance: 0.2
   wordReplacements:
     accent-pirate-replaced-1: accent-pirate-replacement-1
     accent-pirate-replaced-2: accent-pirate-replacement-2
@@ -266,6 +268,7 @@
 
 - type: accent
   id: cowboy
+  replacementChance: 0.2
   wordReplacements:
     accent-cowboy-words-1: accent-cowboy-replacement-1
     accent-cowboy-words-2: accent-cowboy-replacement-2

--- a/Resources/Prototypes/Traits/quirks.yml
+++ b/Resources/Prototypes/Traits/quirks.yml
@@ -1,16 +1,16 @@
-- type: trait
-  id: LightweightDrunk
-  name: trait-lightweight-name
-  description: trait-lightweight-desc
-  category: Quirks
-  components:
-  - type: LightweightDrunk
-    boozeStrengthMultiplier: 2
-
-- type: trait
-  id: Snoring
-  name: trait-snoring-name
-  description: trait-snoring-desc
-  category: Quirks
-  components:
-  - type: Snoring
+#- type: trait
+#  id: LightweightDrunk
+#  name: trait-lightweight-name
+#  description: trait-lightweight-desc
+#  category: Quirks
+#  components:
+#  - type: LightweightDrunk
+#    boozeStrengthMultiplier: 2
+#
+#- type: trait
+#  id: Snoring
+#  name: trait-snoring-name
+#  description: trait-snoring-desc
+#  category: Quirks
+#  components:
+#  - type: Snoring

--- a/Resources/Prototypes/Traits/speech.yml
+++ b/Resources/Prototypes/Traits/speech.yml
@@ -1,116 +1,116 @@
-## Free
-#
-#- type: trait
-#  id: Accentless
-#  name: trait-accentless-name
-#  description: trait-accentless-desc
-#  category: SpeechTraits
-#  cost: 2
-#  components:
-#  - type: Accentless
-#    removes:
-#    - type: LizardAccent
-#    - type: MothAccent
-#    - type: ReplacementAccent
-#      accent: dwarf
-#
-## 1 Cost
-#
-#- type: trait
-#  id: SouthernAccent
-#  name: trait-southern-name
-#  description: trait-southern-desc
-#  category: SpeechTraits
-#  cost: 1
-#  components:
-#  - type: SouthernAccent
-#
-#- type: trait
-#  id: PirateAccent
-#  name: trait-pirate-accent-name
-#  description: trait-pirate-accent-desc
-#  category: SpeechTraits
-#  cost: 1
-#  components:
-#  - type: PirateAccent
-#
-#- type: trait
-#  id: CowboyAccent
-#  name: trait-cowboy-name
-#  description: trait-cowboy-desc
-#  category: SpeechTraits
-#  cost: 1
-#  components:
-#  - type: ReplacementAccent
-#    accent: cowboy
-#
-#- type: trait
-#  id: GermanAccent
-#  name: trait-german-name
-#  description: trait-german-desc
-#  category: SpeechTraits
-#  cost: 1
-#  components:
-#  - type: GermanAccent
-#
-#- type: trait
-#  id: ItalianAccent
-#  name: trait-italian-name
-#  description: trait-italian-desc
-#  category: SpeechTraits
-#  cost: 1
-#  components:
-#  - type: ReplacementAccent
-#    accent: italian
-#
-#- type: trait
-#  id: FrenchAccent
-#  name: trait-french-name
-#  description: trait-french-desc
-#  category: SpeechTraits
-#  cost: 1
-#  components:
-#  - type: FrenchAccent
-#
-#- type: trait
-#  id: SpanishAccent
-#  name: trait-spanish-name
-#  description: trait-spanish-desc
-#  category: SpeechTraits
-#  cost: 1
-#  components:
-#  - type: SpanishAccent
-#
-#- type: trait
-#  id: Liar
-#  name: trait-liar-name
-#  description: trait-liar-desc
-#  category: SpeechTraits
-#  cost: 1
-#  components:
-#  - type: ReplacementAccent
-#    accent: liar
-#
-## 2 Cost
-#
-#- type: trait
-#  id: SocialAnxiety
-#  name: trait-socialanxiety-name
-#  description: trait-socialanxiety-desc
-#  category: SpeechTraits
-#  cost: 2
-#  components:
-#  - type: StutteringAccent
-#    matchRandomProb: 0.1
-#    fourRandomProb: 0
-#    threeRandomProb: 0
-#    cutRandomProb: 0
-#
-#- type: trait
-#  id: FrontalLisp
-#  name: trait-frontal-lisp-name
-#  description: trait-frontal-lisp-desc
-#  category: SpeechTraits
-#  cost: 2
-#  components:
-#  - type: FrontalLisp
+# Free
+
+- type: trait
+  id: Accentless
+  name: trait-accentless-name
+  description: trait-accentless-desc
+  category: SpeechTraits
+  cost: 2
+  components:
+  - type: Accentless
+    removes:
+    - type: LizardAccent
+    - type: MothAccent
+    - type: ReplacementAccent
+      accent: dwarf
+
+# 1 Cost
+
+- type: trait
+  id: SouthernAccent
+  name: trait-southern-name
+  description: trait-southern-desc
+  category: SpeechTraits
+  cost: 1
+  components:
+  - type: SouthernAccent
+
+- type: trait
+  id: PirateAccent
+  name: trait-pirate-accent-name
+  description: trait-pirate-accent-desc
+  category: SpeechTraits
+  cost: 1
+  components:
+  - type: PirateAccent
+
+- type: trait
+  id: CowboyAccent
+  name: trait-cowboy-name
+  description: trait-cowboy-desc
+  category: SpeechTraits
+  cost: 1
+  components:
+  - type: ReplacementAccent
+    accent: cowboy
+
+- type: trait
+  id: GermanAccent
+  name: trait-german-name
+  description: trait-german-desc
+  category: SpeechTraits
+  cost: 1
+  components:
+  - type: GermanAccent
+
+- type: trait
+  id: ItalianAccent
+  name: trait-italian-name
+  description: trait-italian-desc
+  category: SpeechTraits
+  cost: 1
+  components:
+  - type: ReplacementAccent
+    accent: italian
+
+- type: trait
+  id: FrenchAccent
+  name: trait-french-name
+  description: trait-french-desc
+  category: SpeechTraits
+  cost: 1
+  components:
+  - type: FrenchAccent
+
+- type: trait
+  id: SpanishAccent
+  name: trait-spanish-name
+  description: trait-spanish-desc
+  category: SpeechTraits
+  cost: 1
+  components:
+  - type: SpanishAccent
+
+- type: trait
+  id: Liar
+  name: trait-liar-name
+  description: trait-liar-desc
+  category: SpeechTraits
+  cost: 1
+  components:
+  - type: ReplacementAccent
+    accent: liar
+
+# 2 Cost
+
+- type: trait
+  id: SocialAnxiety
+  name: trait-socialanxiety-name
+  description: trait-socialanxiety-desc
+  category: SpeechTraits
+  cost: 2
+  components:
+  - type: StutteringAccent
+    matchRandomProb: 0.1
+    fourRandomProb: 0
+    threeRandomProb: 0
+    cutRandomProb: 0
+
+- type: trait
+  id: FrontalLisp
+  name: trait-frontal-lisp-name
+  description: trait-frontal-lisp-desc
+  category: SpeechTraits
+  cost: 2
+  components:
+  - type: FrontalLisp

--- a/Resources/Prototypes/Traits/speech.yml
+++ b/Resources/Prototypes/Traits/speech.yml
@@ -33,6 +33,7 @@
   cost: 1
   components:
   - type: PirateAccent
+    yarrChance: 0.1
 
 - type: trait
   id: CowboyAccent

--- a/Resources/Prototypes/Traits/speech.yml
+++ b/Resources/Prototypes/Traits/speech.yml
@@ -1,116 +1,116 @@
-# Free
-
-- type: trait
-  id: Accentless
-  name: trait-accentless-name
-  description: trait-accentless-desc
-  category: SpeechTraits
-  cost: 2
-  components:
-  - type: Accentless
-    removes:
-    - type: LizardAccent
-    - type: MothAccent
-    - type: ReplacementAccent
-      accent: dwarf
-
-# 1 Cost
-
-- type: trait
-  id: SouthernAccent
-  name: trait-southern-name
-  description: trait-southern-desc
-  category: SpeechTraits
-  cost: 1
-  components:
-  - type: SouthernAccent
-
-- type: trait
-  id: PirateAccent
-  name: trait-pirate-accent-name
-  description: trait-pirate-accent-desc
-  category: SpeechTraits
-  cost: 1
-  components:
-  - type: PirateAccent
-
-- type: trait
-  id: CowboyAccent
-  name: trait-cowboy-name
-  description: trait-cowboy-desc
-  category: SpeechTraits
-  cost: 1
-  components:
-  - type: ReplacementAccent
-    accent: cowboy
-
-- type: trait
-  id: GermanAccent
-  name: trait-german-name
-  description: trait-german-desc
-  category: SpeechTraits
-  cost: 1
-  components:
-  - type: GermanAccent
-
-- type: trait
-  id: ItalianAccent
-  name: trait-italian-name
-  description: trait-italian-desc
-  category: SpeechTraits
-  cost: 1
-  components:
-  - type: ReplacementAccent
-    accent: italian
-
-- type: trait
-  id: FrenchAccent
-  name: trait-french-name
-  description: trait-french-desc
-  category: SpeechTraits
-  cost: 1
-  components:
-  - type: FrenchAccent
-
-- type: trait
-  id: SpanishAccent
-  name: trait-spanish-name
-  description: trait-spanish-desc
-  category: SpeechTraits
-  cost: 1
-  components:
-  - type: SpanishAccent
-
-- type: trait
-  id: Liar
-  name: trait-liar-name
-  description: trait-liar-desc
-  category: SpeechTraits
-  cost: 1
-  components:
-  - type: ReplacementAccent
-    accent: liar
-
-# 2 Cost
-
-- type: trait
-  id: SocialAnxiety
-  name: trait-socialanxiety-name
-  description: trait-socialanxiety-desc
-  category: SpeechTraits
-  cost: 2
-  components:
-  - type: StutteringAccent
-    matchRandomProb: 0.1
-    fourRandomProb: 0
-    threeRandomProb: 0
-    cutRandomProb: 0
-
-- type: trait
-  id: FrontalLisp
-  name: trait-frontal-lisp-name
-  description: trait-frontal-lisp-desc
-  category: SpeechTraits
-  cost: 2
-  components:
-  - type: FrontalLisp
+## Free
+#
+#- type: trait
+#  id: Accentless
+#  name: trait-accentless-name
+#  description: trait-accentless-desc
+#  category: SpeechTraits
+#  cost: 2
+#  components:
+#  - type: Accentless
+#    removes:
+#    - type: LizardAccent
+#    - type: MothAccent
+#    - type: ReplacementAccent
+#      accent: dwarf
+#
+## 1 Cost
+#
+#- type: trait
+#  id: SouthernAccent
+#  name: trait-southern-name
+#  description: trait-southern-desc
+#  category: SpeechTraits
+#  cost: 1
+#  components:
+#  - type: SouthernAccent
+#
+#- type: trait
+#  id: PirateAccent
+#  name: trait-pirate-accent-name
+#  description: trait-pirate-accent-desc
+#  category: SpeechTraits
+#  cost: 1
+#  components:
+#  - type: PirateAccent
+#
+#- type: trait
+#  id: CowboyAccent
+#  name: trait-cowboy-name
+#  description: trait-cowboy-desc
+#  category: SpeechTraits
+#  cost: 1
+#  components:
+#  - type: ReplacementAccent
+#    accent: cowboy
+#
+#- type: trait
+#  id: GermanAccent
+#  name: trait-german-name
+#  description: trait-german-desc
+#  category: SpeechTraits
+#  cost: 1
+#  components:
+#  - type: GermanAccent
+#
+#- type: trait
+#  id: ItalianAccent
+#  name: trait-italian-name
+#  description: trait-italian-desc
+#  category: SpeechTraits
+#  cost: 1
+#  components:
+#  - type: ReplacementAccent
+#    accent: italian
+#
+#- type: trait
+#  id: FrenchAccent
+#  name: trait-french-name
+#  description: trait-french-desc
+#  category: SpeechTraits
+#  cost: 1
+#  components:
+#  - type: FrenchAccent
+#
+#- type: trait
+#  id: SpanishAccent
+#  name: trait-spanish-name
+#  description: trait-spanish-desc
+#  category: SpeechTraits
+#  cost: 1
+#  components:
+#  - type: SpanishAccent
+#
+#- type: trait
+#  id: Liar
+#  name: trait-liar-name
+#  description: trait-liar-desc
+#  category: SpeechTraits
+#  cost: 1
+#  components:
+#  - type: ReplacementAccent
+#    accent: liar
+#
+## 2 Cost
+#
+#- type: trait
+#  id: SocialAnxiety
+#  name: trait-socialanxiety-name
+#  description: trait-socialanxiety-desc
+#  category: SpeechTraits
+#  cost: 2
+#  components:
+#  - type: StutteringAccent
+#    matchRandomProb: 0.1
+#    fourRandomProb: 0
+#    threeRandomProb: 0
+#    cutRandomProb: 0
+#
+#- type: trait
+#  id: FrontalLisp
+#  name: trait-frontal-lisp-name
+#  description: trait-frontal-lisp-desc
+#  category: SpeechTraits
+#  cost: 2
+#  components:
+#  - type: FrontalLisp

--- a/Resources/Prototypes/_RMC14/Traits/accents.yml
+++ b/Resources/Prototypes/_RMC14/Traits/accents.yml
@@ -14,7 +14,9 @@
   category: SpeechTraits
   cost: 1
   components:
-  - type: MobsterAccent
+    - type: MobsterAccent
+      prefixChance: 0.1
+      suffixChance: 0.2
 
 - type: trait
   id: FrenchAccent

--- a/Resources/Prototypes/_RMC14/Traits/accents.yml
+++ b/Resources/Prototypes/_RMC14/Traits/accents.yml
@@ -17,7 +17,7 @@
   - type: MobsterAccent
 
 - type: trait
-  id: French
+  id: FrenchAccent
   name: rmc-trait-french-accent-name
   description: rmc-trait-french-accent-desc
   category: SpeechTraits
@@ -26,7 +26,7 @@
     - type: FrenchAccent
 
 - type: trait
-  id: Spanish
+  id: SpanishAccent
   name: rmc-trait-spanish-accent-name
   description: rmc-trait-spanish-accent-desc
   category: SpeechTraits

--- a/Resources/Prototypes/_RMC14/Traits/accents.yml
+++ b/Resources/Prototypes/_RMC14/Traits/accents.yml
@@ -1,5 +1,5 @@
 - type: trait
-  id: Russian
+  id: RMCRussian
   name: rmc-trait-russian-accent-name
   description: rmc-trait-russian-accent-desc
   category: SpeechTraits
@@ -8,16 +8,7 @@
     - type: RussianAccent
 
 - type: trait
-  id: Mobster
-  name: rmc-trait-mobster-accent-name
-  description: rmc-trait-mobster-accent-desc
-  category: SpeechTraits
-  cost: 1
-  components:
-    - type: MobsterAccent
-
-- type: trait
-  id: French
+  id: RMCFrench
   name: rmc-trait-french-accent-name
   description: rmc-trait-french-accent-desc
   category: SpeechTraits
@@ -26,7 +17,7 @@
     - type: FrenchAccent
 
 - type: trait
-  id: Spanish
+  id: RMCSpanish
   name: rmc-trait-spanish-accent-name
   description: rmc-trait-spanish-accent-desc
   category: SpeechTraits
@@ -35,7 +26,7 @@
     - type: SpanishAccent
 
 - type: trait
-  id: ScottishAccent
+  id: RMCScottishAccent
   name: rmc-trait-scottish-accent-name
   description: rmc-trait-scottish-accent-desc
   category: SpeechTraits
@@ -43,3 +34,45 @@
   components:
   - type: ReplacementAccent
     accent: dwarf
+
+- type: trait
+  id: RMCAccentless
+  name: trait-accentless-name
+  description: trait-accentless-desc
+  category: SpeechTraits
+  cost: 2
+  components:
+  - type: Accentless
+    removes:
+    - type: LizardAccent
+    - type: MothAccent
+    - type: ReplacementAccent
+      accent: dwarf
+
+- type: trait
+  id: RMCSouthernAccent
+  name: trait-southern-name
+  description: trait-southern-desc
+  category: SpeechTraits
+  cost: 1
+  components:
+  - type: SouthernAccent
+
+- type: trait
+  id: RMCGermanAccent
+  name: trait-german-name
+  description: trait-german-desc
+  category: SpeechTraits
+  cost: 1
+  components:
+  - type: GermanAccent
+
+- type: trait
+  id: RMCItalianAccent
+  name: trait-italian-name
+  description: trait-italian-desc
+  category: SpeechTraits
+  cost: 1
+  components:
+  - type: ReplacementAccent
+    accent: italian

--- a/Resources/Prototypes/_RMC14/Traits/accents.yml
+++ b/Resources/Prototypes/_RMC14/Traits/accents.yml
@@ -1,5 +1,5 @@
 - type: trait
-  id: RMCRussian
+  id: Russian
   name: rmc-trait-russian-accent-name
   description: rmc-trait-russian-accent-desc
   category: SpeechTraits
@@ -8,7 +8,16 @@
     - type: RussianAccent
 
 - type: trait
-  id: RMCFrench
+  id: Mobster
+  name: rmc-trait-mobster-accent-name
+  description: rmc-trait-mobster-accent-desc
+  category: SpeechTraits
+  cost: 1
+  components:
+  - type: MobsterAccent
+
+- type: trait
+  id: French
   name: rmc-trait-french-accent-name
   description: rmc-trait-french-accent-desc
   category: SpeechTraits
@@ -17,7 +26,7 @@
     - type: FrenchAccent
 
 - type: trait
-  id: RMCSpanish
+  id: Spanish
   name: rmc-trait-spanish-accent-name
   description: rmc-trait-spanish-accent-desc
   category: SpeechTraits
@@ -26,7 +35,7 @@
     - type: SpanishAccent
 
 - type: trait
-  id: RMCScottishAccent
+  id: ScottishAccent
   name: rmc-trait-scottish-accent-name
   description: rmc-trait-scottish-accent-desc
   category: SpeechTraits
@@ -36,7 +45,7 @@
     accent: dwarf
 
 - type: trait
-  id: RMCAccentless
+  id: Accentless
   name: trait-accentless-name
   description: trait-accentless-desc
   category: SpeechTraits
@@ -50,7 +59,7 @@
       accent: dwarf
 
 - type: trait
-  id: RMCSouthernAccent
+  id: SouthernAccent
   name: trait-southern-name
   description: trait-southern-desc
   category: SpeechTraits
@@ -59,7 +68,7 @@
   - type: SouthernAccent
 
 - type: trait
-  id: RMCGermanAccent
+  id: GermanAccent
   name: trait-german-name
   description: trait-german-desc
   category: SpeechTraits
@@ -68,7 +77,7 @@
   - type: GermanAccent
 
 - type: trait
-  id: RMCItalianAccent
+  id: ItalianAccent
   name: trait-italian-name
   description: trait-italian-desc
   category: SpeechTraits

--- a/Resources/Prototypes/_RMC14/Traits/inconveniences.yml
+++ b/Resources/Prototypes/_RMC14/Traits/inconveniences.yml
@@ -1,7 +1,16 @@
 - type: trait
-  id: CMSnoring
+  id: Snoring
   name: trait-snoring-name
   description: trait-snoring-desc
-  category: RMCInconveniences
+  category: Quirks
   components:
-    - type: Snoring
+  - type: Snoring
+
+- type: trait
+  id: LightweightDrunk
+  name: trait-lightweight-name
+  description: trait-lightweight-desc
+  category: Quirks
+  components:
+  - type: LightweightDrunk
+    boozeStrengthMultiplier: 2


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
During an upstream merge, trait files were renamed and not being ignored anymore, resulting in duplicate traits and traits we did not intend to be selectable.

Also part of #4783 reasoning

**Changelog**

:cl: Whisper

- fix: Fixed duplicated traits and traits not intended to be selectable, and lowered the frequency of replacements for some accents.

