### PR TITLE
Various Thermal cloak / ghillie suit fixes

### DIFF
--- a/Content.Server/_RMC14/Marines/Armor/RMCSuitLightSystem.cs
+++ b/Content.Server/_RMC14/Marines/Armor/RMCSuitLightSystem.cs
@@ -21,9 +21,9 @@ public sealed class RMCSuitLightSystem : EntitySystem
     public override void Initialize()
     {
         SubscribeLocalEvent<RMCSuitLightComponent, ClothingGotUnequippedEvent>(OnUnequip);
-        SubscribeLocalEvent<MobStateChangedEvent>(OnMobStateChanged);
-        SubscribeLocalEvent<VictimInfectedComponent, ComponentStartup>(OnComponentStartup);
-        SubscribeLocalEvent<MarineComponent, XenoDevouredEvent>(OnDevour);
+        SubscribeLocalEvent<RMCSuitLightComponent, MobStateChangedEvent>(OnMobStateChanged);
+        SubscribeLocalEvent<RMCSuitLightComponent, XenoParasiteInfectEvent>(OnParasiteInfect);
+        SubscribeLocalEvent<RMCSuitLightComponent, XenoDevouredEvent>(OnDevour);
     }
 
     private void OnUnequip(Entity<RMCSuitLightComponent> ent, ref ClothingGotUnequippedEvent args)
@@ -31,35 +31,30 @@ public sealed class RMCSuitLightSystem : EntitySystem
         ShortLights(ent.Owner, args.Wearer);
     }
 
-    private void OnMobStateChanged(MobStateChangedEvent args)
+    private void OnMobStateChanged(Entity<RMCSuitLightComponent> ent, ref MobStateChangedEvent args)
     {
-        var uid = args.Target;
-
         if (args.NewMobState != MobState.Dead)
             return;
 
-        var suit = FindSuit(uid);
-
-        if (suit != null)
-            ShortLights(suit.Value.Owner, uid);
+        TryShortLights(ent.Owner);
     }
 
-    private void OnComponentStartup(Entity<VictimInfectedComponent> ent, ref ComponentStartup args)
+    private void OnParasiteInfect(Entity<RMCSuitLightComponent> ent, ref XenoParasiteInfectEvent args)
     {
-        var uid = ent.Owner;
-        var suit = FindSuit(uid);
-
-        if (suit != null)
-            ShortLights(suit.Value.Owner, uid);
+        TryShortLights(ent.Owner);
     }
 
-    private void OnDevour(Entity<MarineComponent> ent, ref XenoDevouredEvent args)
+    private void OnDevour(Entity<RMCSuitLightComponent> ent, ref XenoDevouredEvent args)
     {
-        var uid = ent.Owner;
-        var suit = FindSuit(uid);
+        TryShortLights(ent.Owner);
+    }
+
+    public void TryShortLights(EntityUid user)
+    {
+        var suit = FindSuit(user);
 
         if (suit != null)
-            ShortLights(suit.Value.Owner, uid);
+            ShortLights(suit.Value.Owner, user);
     }
 
     public void ShortLights(EntityUid armor, EntityUid user)

--- a/Content.Shared/_RMC14/Armor/Ghillie/SharedGhillieSuitSystem.cs
+++ b/Content.Shared/_RMC14/Armor/Ghillie/SharedGhillieSuitSystem.cs
@@ -17,6 +17,7 @@ using Content.Shared._RMC14.Chemistry;
 using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Coordinates;
 using Robust.Shared.Network;
+using Content.Shared._RMC14.Armor.ThermalCloak;
 
 namespace Content.Shared._RMC14.Armor.Ghillie;
 
@@ -31,6 +32,7 @@ public sealed class SharedGhillieSuitSystem : EntitySystem
     [Dependency] private readonly InventorySystem _inventory = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly ThermalCloakSystem _thermalCloak = default!;
 
     public override void Initialize()
     {
@@ -171,8 +173,7 @@ public sealed class SharedGhillieSuitSystem : EntitySystem
             EnsureComp<EntityIFFComponent>(user);
             RemCompDeferred<RMCNightVisionVisibleComponent>(user);
 
-            if (_net.IsServer)
-                SpawnAttachedTo(comp.CloakEffect, user.ToCoordinates());
+            _thermalCloak.SpawnCloakEffects(user, comp.CloakEffect);
         }
 
         if (!enabling && TryComp<EntityActiveInvisibleComponent>(user, out var invisible))
@@ -228,6 +229,9 @@ public sealed class SharedGhillieSuitSystem : EntitySystem
 
     private void OnMove(Entity<RMCPassiveStealthComponent> ent, ref MoveInputEvent args)
     {
+        if (!args.HasDirectionalMovement)
+            return;
+
         TryToggleInvisibility(ent.Owner, false);
     }
 

--- a/Content.Shared/_RMC14/Armor/ThermalCloak/ThermalCloakSystem.cs
+++ b/Content.Shared/_RMC14/Armor/ThermalCloak/ThermalCloakSystem.cs
@@ -51,8 +51,7 @@ public sealed class ThermalCloakSystem : EntitySystem
         SubscribeLocalEvent<EntityActiveInvisibleComponent, VaporHitEvent>(OnVaporHit);
         SubscribeLocalEvent<EntityActiveInvisibleComponent, MobStateChangedEvent>(OnMobStateChanged);
         SubscribeLocalEvent<EntityActiveInvisibleComponent, XenoDevouredEvent>(OnDevour);
-
-        SubscribeLocalEvent<VictimInfectedComponent, ComponentStartup>(OnInfectedComponentStartup);
+        SubscribeLocalEvent<EntityActiveInvisibleComponent, XenoParasiteInfectEvent>(OnParasiteInfect);
 
         SubscribeLocalEvent<GunComponent, AttemptShootEvent>(OnAttemptShoot);
         SubscribeLocalEvent<ExplodeOnTriggerComponent, UseInHandEvent>(OnTimerUse);
@@ -262,7 +261,7 @@ public sealed class ThermalCloakSystem : EntitySystem
         TrySetInvisibility(ent.Owner, false, true);
     }
 
-    private void OnInfectedComponentStartup(Entity<VictimInfectedComponent> ent, ref ComponentStartup args)
+    private void OnParasiteInfect(Entity<EntityActiveInvisibleComponent> ent, ref XenoParasiteInfectEvent args)
     {
         TrySetInvisibility(ent.Owner, false, true);
     }

--- a/Content.Shared/_RMC14/Armor/ThermalCloak/ThermalCloakSystem.cs
+++ b/Content.Shared/_RMC14/Armor/ThermalCloak/ThermalCloakSystem.cs
@@ -208,7 +208,7 @@ public sealed class ThermalCloakSystem : EntitySystem
     {
         var cloak = FindWornCloak(uid);
         if (cloak.HasValue)
-            SetInvisibility(cloak.Value, uid, false, true);
+            SetInvisibility(cloak.Value, uid, enabling, forced);
     }
 
     private void OnAttemptShoot(Entity<GunComponent> ent, ref AttemptShootEvent args)

--- a/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
@@ -427,6 +427,9 @@ public abstract partial class SharedXenoParasiteSystem : EntitySystem
         unremovable.DeleteOnDrop = false;
         Dirty(parasite);
 
+        var ev = new XenoParasiteInfectEvent(victim, parasite.Owner);
+        RaiseLocalEvent(victim, ref ev, true);
+
         ParasiteLeapHit(parasite);
         return true;
     }
@@ -802,3 +805,11 @@ public abstract partial class SharedXenoParasiteSystem : EntitySystem
 public sealed partial class LarvaBurstDoAfterEvent : SimpleDoAfterEvent
 {
 }
+
+/// <summary>
+/// Event that is raised whenever a parasite infects a mob.
+/// </summary>
+/// <param name="Target">The Entity who was infected</param>
+/// <param name="Parasite">The Parasite who infected the Target</param>
+[ByRefEvent]
+public record struct XenoParasiteInfectEvent(EntityUid Target, EntityUid Parasite);

--- a/Resources/Prototypes/_RMC14/Effects/cloak.yml
+++ b/Resources/Prototypes/_RMC14/Effects/cloak.yml
@@ -20,7 +20,7 @@
   - type: Sprite
     state: cloak
   - type: TimedDespawn
-    lifetime: 0.8
+    lifetime: 0.75
 
 - type: entity
   parent: RMCEffectCloakBase
@@ -30,4 +30,4 @@
   - type: Sprite
     state: uncloak
   - type: TimedDespawn
-    lifetime: 0.7
+    lifetime: 0.65

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Back/satchels.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Back/satchels.yml
@@ -55,8 +55,14 @@
     whitelist:
       components:
       - ScoutWhitelist
-    cloakSound: /Audio/_RMC14/Effects/Cloak/cloak_scout_on.ogg
-    uncloakSound: /Audio/_RMC14/Effects/Cloak/cloak_scout_off.ogg
+    cloakSound:
+      path: /Audio/_RMC14/Effects/Cloak/cloak_scout_on.ogg
+      params:
+        variation: 0.09
+    uncloakSound:
+      path: /Audio/_RMC14/Effects/Cloak/cloak_scout_off.ogg
+      params:
+        variation: 0.09
   - type: Corrodible
     isCorrodible: false
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
resolves #4208

adds some variation to the uncloak and cloak sound

make the cloak effect not attached to your player, instead it spawns at where you first cloaked at, parity

fixes ghillie suit cloak breaking even if you dont move

## Technical details
adds ``XenoParasiteInfectEvent``

## Media

https://github.com/user-attachments/assets/e3032cc1-0e02-4851-a3dd-f76188b1d82d




:cl:
- tweak: Scouts now uncloak when they get infected by a parasite.
- fix: Fix ghillie suit cloak breaking when you press the walk button.