### PR TITLE
Bodybags down you on enter

### DIFF
--- a/Content.Shared/_RMC14/Standing/DownOnEnterComponent.cs
+++ b/Content.Shared/_RMC14/Standing/DownOnEnterComponent.cs
@@ -1,0 +1,6 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Standing;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class DownOnEnterComponent : Component;

--- a/Content.Shared/_RMC14/Standing/RMCStandingSystem.cs
+++ b/Content.Shared/_RMC14/Standing/RMCStandingSystem.cs
@@ -91,7 +91,7 @@ public sealed class RMCStandingSystem : EntitySystem
     private void OnLeaveDown(Entity<DownOnEnterComponent> mob, ref EntRemovedFromContainerMessage args)
     {
         if (HasComp<KnockedDownComponent>(args.Entity) || _mob.IsIncapacitated(args.Entity))
-            _standing.Down(args.Entity, false, false, true, true);
+            _standing.Down(args.Entity, false, true, true, true);
         else
             _standing.Stand(args.Entity);
     }

--- a/Content.Shared/_RMC14/Standing/RMCStandingSystem.cs
+++ b/Content.Shared/_RMC14/Standing/RMCStandingSystem.cs
@@ -3,7 +3,10 @@ using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Item;
+using Content.Shared.Mobs.Systems;
 using Content.Shared.Standing;
+using Content.Shared.Stunnable;
+using Robust.Shared.Containers;
 
 namespace Content.Shared._RMC14.Standing;
 
@@ -11,6 +14,7 @@ public sealed class RMCStandingSystem : EntitySystem
 {
     [Dependency] private readonly SharedHandsSystem _hands = default!;
     [Dependency] private readonly StandingStateSystem _standing = default!;
+    [Dependency] private readonly MobStateSystem _mob = default!;
 
     public override void Initialize()
     {
@@ -19,6 +23,10 @@ public sealed class RMCStandingSystem : EntitySystem
         SubscribeLocalEvent<DropItemsOnRestComponent, IsEquippingAttemptEvent>(OnDropIsEquippingAttempt);
         SubscribeLocalEvent<DropItemsOnRestComponent, IsUnequippingAttemptEvent>(OnDropIsUnequippingAttempt);
         SubscribeLocalEvent<DropItemsOnRestComponent, AttackAttemptEvent>(CancelIfResting);
+        SubscribeLocalEvent<DropItemsOnRestComponent, UseAttemptEvent>(CancelIfResting);
+
+        SubscribeLocalEvent<DownOnEnterComponent, EntInsertedIntoContainerMessage>(OnEnterDown);
+        SubscribeLocalEvent<DownOnEnterComponent, EntRemovedFromContainerMessage>(OnLeaveDown);
     }
 
     private void OnDropBuckled(Entity<DropItemsOnRestComponent> drop, ref BuckledEvent args)
@@ -73,5 +81,18 @@ public sealed class RMCStandingSystem : EntitySystem
         }
 
         return false;
+    }
+
+    private void OnEnterDown(Entity<DownOnEnterComponent> mob, ref EntInsertedIntoContainerMessage args)
+    {
+        _standing.Down(args.Entity, false, false, true, true);
+    }
+
+    private void OnLeaveDown(Entity<DownOnEnterComponent> mob, ref EntRemovedFromContainerMessage args)
+    {
+        if (HasComp<KnockedDownComponent>(args.Entity) || _mob.IsIncapacitated(args.Entity))
+            _standing.Down(args.Entity, false, false, true, true);
+        else
+            _standing.Stand(args.Entity);
     }
 }

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Medical/bodybags.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Medical/bodybags.yml
@@ -87,6 +87,7 @@
           False: {visible: true}
   - type: Pullable
   - type: ItemSlots
+  - type: DownOnEnter
   - type: ContainerContainer
     containers:
       entity_storage: !type:Container


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #4732. Not 100% parity. CM doesn't actually force you down when in a bodybag, it just preserves whatever state you were in. Which is a little silly, as it does mean you can just take everything off white "laying down" in a bodybag (how else would you fit)

I think it makes more sense this way, and makes a lil animation coming out of the bag to stand which is neat. To preserve some of CMs handling you don't drop items being put in the bag.

## Technical details
<!-- Summary of code changes for easier review. -->
Copied some bits from the buckle code to work with a new comp that downs on entering a container. Pretty simple.

Also made the comp block use attempts of items with the comp. Could be removed maybe, it just prevents some weird stuff like using a nade while resting and such (since resting you're supposed to drop everything but we aren't doing it here)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/d93271a6-e6e8-4148-aded-64d7e32b5c9c

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed Bodybags and Stasisbags letting you perform some actions by having them down you on enter (you still don't your drop held items)