### PR TITLE
Makes xenos more tech illiterate

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
@@ -263,6 +263,7 @@
     keys:
     - enum.VendingMachineUiKey.Key
     - enum.PaperUiKey.Key
+    - enum.RMCCameraUiKey.Key 
   - type: ActiveInputMover
   - type: HiveTracker
   - type: RequireProjectileTarget

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Science/Dispensers/booze.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Science/Dispensers/booze.yml
@@ -15,6 +15,10 @@
     pack: CMDispenserBoozeInventory
   - type: Machine
     board: CMCircuitboardDispenserBooze
+  - type: InteractedBlacklist
+    blacklist:
+      components:
+      - Xeno
   - type: ApcPowerReceiver
     needsPower: false
 

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/reagent_grinder.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/reagent_grinder.yml
@@ -23,3 +23,7 @@
     idleLoad: 5
     activeLoad: 100
     channel: Equipment
+  - type: InteractedBlacklist
+    blacklist:
+      components:
+      - Xeno


### PR DESCRIPTION
## About the PR
Made xenos unable to use the all-in-one grinder, booze dispenser and security camera.

## Why / Balance
resolves #3940, consistency and because they shouldn't be able to.

## Media

https://github.com/user-attachments/assets/cb60e205-36e1-47cb-8ca1-bef83ad1156e



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Xenos can no longer be bartenders 😭
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Xenos are now more tech illiterate.
- fix: Fixed Xenos being able to use security cameras, the all-in-one grinder, and the booze dispenser.
