### PR TITLE
Add mutiny system and commands

### DIFF
--- a/Content.Server/_RMC14/Antag/MutinyCommand.cs
+++ b/Content.Server/_RMC14/Antag/MutinyCommand.cs
@@ -7,10 +7,10 @@ using Robust.Shared.Toolshed;
 
 namespace Content.Server._RMC14.Antag;
 
-[ToolshedCommand, AdminCommand(AdminFlags.VarEdit)]
+[ToolshedCommand, AdminCommand(AdminFlags.Admin)]
 public sealed class MutinyCommand : ToolshedCommand
 {
-    [CommandImplementation("end")]
+    [CommandImplementation("end"), AdminCommand(AdminFlags.Fun)]
     public void EndMutiny([CommandInvocationContext] IInvocationContext ctx)
     {
         var mutineers = EntityManager.EntityQueryEnumerator<MutineerComponent>();
@@ -53,7 +53,7 @@ public sealed class MutinyCommand : ToolshedCommand
         return HasComp<MutineerComponent>(marine) ? "Yes" : "No";
     }
 
-    [CommandImplementation("makemutineer")]
+    [CommandImplementation("makemutineer"), AdminCommand(AdminFlags.Fun)]
     public EntityUid MakeMutineer([CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] EntityUid marine)
     {
@@ -62,14 +62,14 @@ public sealed class MutinyCommand : ToolshedCommand
         return marine;
     }
 
-    [CommandImplementation("makemutineer")]
+    [CommandImplementation("makemutineer"), AdminCommand(AdminFlags.Fun)]
     public IEnumerable<EntityUid> MakeMutineer([CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] IEnumerable<EntityUid> marines)
     {
         return marines.Select(marine => MakeMutineer(ctx, marine));
     }
 
-    [CommandImplementation("removemutineer")]
+    [CommandImplementation("removemutineer"), AdminCommand(AdminFlags.Fun)]
     public EntityUid RemoveMutineer([CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] EntityUid marine)
     {
@@ -78,7 +78,7 @@ public sealed class MutinyCommand : ToolshedCommand
         return marine;
     }
 
-    [CommandImplementation("removemutineer")]
+    [CommandImplementation("removemutineer"), AdminCommand(AdminFlags.Fun)]
     public IEnumerable<EntityUid> RemoveMutineer([CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] IEnumerable<EntityUid> marines)
     {

--- a/Content.Server/_RMC14/Antag/MutinyCommand.cs
+++ b/Content.Server/_RMC14/Antag/MutinyCommand.cs
@@ -1,0 +1,87 @@
+using System.Linq;
+using Content.Server.Administration;
+using Content.Shared._RMC14.Antag.Components;
+using Content.Shared.Administration;
+using Robust.Shared.Player;
+using Robust.Shared.Toolshed;
+
+namespace Content.Server._RMC14.Antag;
+
+[ToolshedCommand, AdminCommand(AdminFlags.VarEdit)]
+public sealed class MutinyCommand : ToolshedCommand
+{
+    [CommandImplementation("end")]
+    public void EndMutiny([CommandInvocationContext] IInvocationContext ctx)
+    {
+        var mutineers = EntityManager.EntityQueryEnumerator<MutineerComponent>();
+
+        int numMutineers = 0;
+        int numNonPlayerMutineers = 0;
+
+        while (mutineers.MoveNext(out var mutineer, out var comp))
+        {
+            RemComp<MutineerComponent>(mutineer);
+            numMutineers++;
+            if (!HasComp<ActorComponent>(mutineer))
+                numNonPlayerMutineers++;
+        }
+
+        ctx.WriteLine($"Set {numMutineers} mutineer players to be non-mutineers, of which {numNonPlayerMutineers} had no player attached.");
+    }
+
+    [CommandImplementation("list")]
+    public void ListMutineers([CommandInvocationContext] IInvocationContext ctx)
+    {
+        var mutineers = EntityManager.EntityQueryEnumerator<MutineerComponent>();
+
+        while (mutineers.MoveNext(out var mutineer, out var comp))
+        {
+            if (TryComp<ActorComponent>(mutineer, out var actorComponent))
+            {
+                ctx.WriteLine($"- Player {actorComponent.PlayerSession.Name} in entity {mutineer}");
+            }
+            else
+            {
+                ctx.WriteLine($"- Entity {mutineer}, with no player attached.");
+            }
+        }
+    }
+
+    [CommandImplementation("ismutineer")]
+    public String IsMutineer([PipedArgument] EntityUid marine)
+    {
+        return HasComp<MutineerComponent>(marine) ? "Yes" : "No";
+    }
+
+    [CommandImplementation("makemutineer")]
+    public EntityUid MakeMutineer([CommandInvocationContext] IInvocationContext ctx,
+        [PipedArgument] EntityUid marine)
+    {
+        EnsureComp<MutineerComponent>(marine);
+
+        return marine;
+    }
+
+    [CommandImplementation("makemutineer")]
+    public IEnumerable<EntityUid> MakeMutineer([CommandInvocationContext] IInvocationContext ctx,
+        [PipedArgument] IEnumerable<EntityUid> marines)
+    {
+        return marines.Select(marine => MakeMutineer(ctx, marine));
+    }
+
+    [CommandImplementation("removemutineer")]
+    public EntityUid RemoveMutineer([CommandInvocationContext] IInvocationContext ctx,
+        [PipedArgument] EntityUid marine)
+    {
+        RemComp<MutineerComponent>(marine);
+
+        return marine;
+    }
+
+    [CommandImplementation("removemutineer")]
+    public IEnumerable<EntityUid> RemoveMutineer([CommandInvocationContext] IInvocationContext ctx,
+        [PipedArgument] IEnumerable<EntityUid> marines)
+    {
+        return marines.Select(marine => RemoveMutineer(ctx, marine));
+    }
+}

--- a/Content.Server/_RMC14/Antag/MutinySystem.cs
+++ b/Content.Server/_RMC14/Antag/MutinySystem.cs
@@ -49,7 +49,7 @@ public sealed class MutinySystem : EntitySystem
 
                 Verb mutineer = new()
                 {
-                    Text = Loc.GetString("admin-verb-text-make-mutineer"),
+                    Text = "Make mutineer",
                     Category = VerbCategory.Antag,
                     Icon = new SpriteSpecifier.Rsi(new ResPath("/Textures/_RMC14/Interface/cm_job_icons.rsi"),
                         "hudmutineer"),
@@ -58,7 +58,7 @@ public sealed class MutinySystem : EntitySystem
                         MakeMutineer(args.Target);
                     },
                     Impact = LogImpact.High,
-                    Message = Loc.GetString("admin-verb-make-traitor"),
+                    Message = "Make mutineer",
                 };
                 args.Verbs.Add(mutineer);
             }

--- a/Content.Server/_RMC14/Antag/MutinySystem.cs
+++ b/Content.Server/_RMC14/Antag/MutinySystem.cs
@@ -1,0 +1,122 @@
+using Content.Server.Administration.Managers;
+using Content.Server.Chat.Managers;
+using Content.Shared._RMC14.Antag.Components;
+using Content.Shared._RMC14.Marines;
+using Content.Shared.Administration;
+using Content.Shared.Database;
+using Content.Shared.Mind.Components;
+using Content.Shared.Verbs;
+using Robust.Shared.Player;
+using Robust.Shared.Utility;
+
+namespace Content.Server._RMC14.Antag;
+
+public sealed class MutinySystem : EntitySystem
+{
+    [Dependency] private readonly IAdminManager _adminManager = default!;
+    [Dependency] private readonly SharedMarineSystem _marineSystem = default!;
+    [Dependency] private readonly IChatManager _chatManager = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<GetVerbsEvent<Verb>>(AddMakeMutineerVerb);
+        SubscribeLocalEvent<MutineerComponent, ComponentAdd>(MutineerAdded);
+        SubscribeLocalEvent<MutineerComponent, ComponentRemove>(MutineerRemoved);
+    }
+
+    private void AddMakeMutineerVerb(GetVerbsEvent<Verb> args)
+    {
+        // To the reader. I am sorry for the abhorrent mess that is this method.
+        if (!TryComp<ActorComponent>(args.User, out var actor))
+            return;
+
+        var player = actor.PlayerSession;
+
+        // Upstream's permission for making antags.
+        if (!_adminManager.HasAdminFlag(player, AdminFlags.Fun))
+            return;
+
+        // More boilerplate....
+        if (!HasComp<MindContainerComponent>(args.Target) || !TryComp<ActorComponent>(args.Target, out var targetActor))
+            return;
+
+        if (TryComp<MarineComponent>(args.Target, out var marine))
+        {
+            // Must be a marine.
+            if (!HasComp<MutineerComponent>(args.Target))
+            {
+                // Must not already be a mutineer.
+
+                Verb mutineer = new()
+                {
+                    Text = Loc.GetString("admin-verb-text-make-mutineer"),
+                    Category = VerbCategory.Antag,
+                    Icon = new SpriteSpecifier.Rsi(new ResPath("/Textures/_RMC14/Interface/cm_job_icons.rsi"),
+                        "hudmutineer"),
+                    Act = () =>
+                    {
+                        MakeMutineer(args.Target);
+                    },
+                    Impact = LogImpact.High,
+                    Message = Loc.GetString("admin-verb-make-traitor"),
+                };
+                args.Verbs.Add(mutineer);
+            }
+        }
+    }
+
+    private void MutineerAdded(Entity<MutineerComponent> ent, ref ComponentAdd args)
+    {
+        if (!MakeMutineer(ent))
+            RemComp<MutineerComponent>(ent);
+    }
+
+    public bool MakeMutineer(EntityUid mutineer)
+    {
+        if (!TryComp<MarineComponent>(mutineer, out var marineComponent))
+            return false;
+        if (!TryComp<ActorComponent>(mutineer, out var actorComponent))
+            return false;
+        EnsureComp<MutineerComponent>(mutineer, out var mutineerComp);
+
+        mutineerComp.OldIcon = marineComponent.Icon;
+        mutineerComp.IsValid = true;
+
+        _marineSystem.SetMarineIcon(mutineer,
+            new SpriteSpecifier.Rsi(
+                new ResPath("/Textures/_RMC14/Interface/cm_job_icons.rsi"),
+                "hudmutineer")
+        );
+
+        _chatManager.DispatchServerMessage(actorComponent.PlayerSession, "You have been made a mutineer by a Game Admin. You may now participate in the ongoing mutiny.");
+        _chatManager.SendAdminAnnouncement($"Player {actorComponent.PlayerSession.Name} was made a mutineer.");
+
+        return true;
+    }
+
+    private void MutineerRemoved(Entity<MutineerComponent> ent, ref ComponentRemove args)
+    {
+        if (!TryComp<MarineComponent>(ent, out var marineComponent))
+            return;
+
+        if (ent.Comp.OldIcon == null)
+        {
+            _marineSystem.ClearMarineIcon(ent);
+        }
+        else
+        {
+            _marineSystem.SetMarineIcon(ent, ent.Comp.OldIcon);
+        }
+
+        if (TryComp<ActorComponent>(ent, out var actorComponent))
+        {
+            _chatManager.DispatchServerMessage(actorComponent.PlayerSession, "The mutiny you were a part of has ended. You are no longer permitted to participate in mutiny activity.");
+            _chatManager.SendAdminAnnouncement($"Player {actorComponent.PlayerSession.Name} is no longer a mutineer.");
+        }
+        else
+        {
+            if (ent.Comp.IsValid) // Only if the component was added through MakeMutineer and passed its checks.
+                _chatManager.SendAdminAnnouncement($"Entity {ent} is no longer a mutineer, but had no players attached.");
+        }
+    }
+}

--- a/Content.Shared/_RMC14/Antag/Components/MutineerComponent.cs
+++ b/Content.Shared/_RMC14/Antag/Components/MutineerComponent.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Utility;
+
+namespace Content.Shared._RMC14.Antag.Components;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class MutineerComponent : Component
+{
+    [DataField("oldIcon")]
+    public SpriteSpecifier? OldIcon = null!;
+
+    [DataField("isValid")]
+    public bool IsValid = false;
+}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Adds a system for admin-handling of mutinies.

Also adds the following toolshed commands:
- `mutiny:end`: Immediately makes all mutineers non-mutineers. No arguments.
- `mutiny:list`: Lists all active mutineers. No arguments.
- `mutiny:ismutineer`: Says Yes or No to the question "Is this entity a mutineer?". One piped argument of type single entity.
- `mutiny:makemutineer`: Makes valid piped entities into mutineers.
- `mutiny:removemutineer`: Does the opposite.

`mutiny:list` and `mutiny:ismutineer` can be run by any admin. For the other commands, the +FUN permission is required.

Admins with the +FUN permission can also make mutineers via the admin verb `Antag Control > Make mutineer`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Cause wawa.

## Technical details
<!-- Summary of code changes for easier review. -->

Okay so this is.... a lot.
- MutinySystem is responsible for making mutineers and sending the necessary messages to the players and admins.
- When the Mutineer component is added to *anything*, MakeMutineer is called by the MutinySystem.
- If MakeMutineer fails (i.e. there is no player attached to the body that had the component added or the entity isn't a marine), the component is removed. (No removal messages are triggered.)
- If MakeMutineer succeeds, a message is sent to the player and online admins. The player's marine icon is set to the mutiny icon.
- If the Mutineer component is removed, a message is sent to the attached player (if any) and online admins. Regardless of player being in the body or not, the icon is restored to what it was before the mutiny icon was set.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->


:cl:
ADMIN:
- add: Mutiny tooling.