### PR TITLE
Devour nongrounded victims

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Devour/XenoDevourSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Devour/XenoDevourSystem.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using Content.Shared._RMC14.Armor;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Buckle.Components;
@@ -363,16 +363,6 @@ public sealed class XenoDevourSystem : EntitySystem
 
             if (popup)
                 _popup.PopupClient(Loc.GetString("cm-xeno-devour-failed-stomach-full"), victim, xeno, PopupType.SmallCaution);
-
-            return false;
-        }
-
-        if (!_standing.IsDown(victim))
-        {
-            if (popup)
-            {
-                _popup.PopupClient(Loc.GetString("cm-xeno-devour-failed-target-resisting", ("target", victim)), victim, xeno, PopupType.MediumCaution);
-            }
 
             return false;
         }


### PR DESCRIPTION
## About the PR
Allows nongrounded victims to be devoured

## Why / Balance
resolves #4885
## Media

https://github.com/user-attachments/assets/7901f595-7a31-4859-bb60-cb89ae17286f


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed Xenos not being able to devour standing victims that aren't moving.

