### PR TITLE
Make pulls rotate the puller

### DIFF
--- a/Content.Shared/_RMC14/Fireman/FiremanCarrySystem.cs
+++ b/Content.Shared/_RMC14/Fireman/FiremanCarrySystem.cs
@@ -115,8 +115,8 @@ public sealed class FiremanCarrySystem : EntitySystem
         carrier.Carrying = ent;
         Dirty(user, carrier);
 
-        if (!_timing.ApplyingState && !HasComp<MouseRotatorComponent>(ent))
-            RemCompDeferred<NoRotateOnMoveComponent>(ent);
+        if (!_timing.ApplyingState && !HasComp<MouseRotatorComponent>(user))
+            RemCompDeferred<NoRotateOnMoveComponent>(user);
 
         args.Handled = true;
 

--- a/Content.Shared/_RMC14/Fireman/FiremanCarrySystem.cs
+++ b/Content.Shared/_RMC14/Fireman/FiremanCarrySystem.cs
@@ -6,6 +6,8 @@ using Content.Shared.ActionBlocker;
 using Content.Shared.DoAfter;
 using Content.Shared.DragDrop;
 using Content.Shared.Mobs;
+using Content.Shared.MouseRotator;
+using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Events;
@@ -112,6 +114,9 @@ public sealed class FiremanCarrySystem : EntitySystem
 
         carrier.Carrying = ent;
         Dirty(user, carrier);
+
+        if (!_timing.ApplyingState && !HasComp<MouseRotatorComponent>(ent))
+            RemCompDeferred<NoRotateOnMoveComponent>(ent);
 
         args.Handled = true;
 

--- a/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
+++ b/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
@@ -1,8 +1,10 @@
 ﻿using System.Numerics;
 using Content.Shared._RMC14.Xenonids.Parasite;
 using Content.Shared.Coordinates;
+using Content.Shared.Interaction;
 using Content.Shared.Interaction.Components;
 using Content.Shared.Mobs.Systems;
+using Content.Shared.MouseRotator;
 using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Events;
@@ -37,6 +39,7 @@ public sealed class RMCPullingSystem : EntitySystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
+    [Dependency] private readonly RotateToFaceSystem _rotateTo = default!;
 
     private readonly SoundSpecifier _pullSound = new SoundPathSpecifier("/Audio/Effects/thudswoosh.ogg")
     {
@@ -66,6 +69,8 @@ public sealed class RMCPullingSystem : EntitySystem
         SubscribeLocalEvent<PreventPulledWhileAliveComponent, PullStoppedMessage>(OnPreventPulledWhileAliveStop);
 
         SubscribeLocalEvent<PullableComponent, PullStartedMessage>(OnPullAnimation);
+
+        SubscribeLocalEvent<PullerComponent, PullStoppedMessage>(OnPullerPullStopped);
 
         SubscribeLocalEvent<BeingPulledComponent, PullStoppedMessage>(OnBeingPulledPullStopped);
     }
@@ -293,6 +298,15 @@ public sealed class RMCPullingSystem : EntitySystem
         RemCompDeferred<BeingPulledComponent>(ent);
     }
 
+    private void OnPullerPullStopped(Entity<PullerComponent> ent, ref PullStoppedMessage args)
+    {
+        if (args.PulledUid == ent.Owner)
+            return;
+
+        if (!_timing.ApplyingState && !HasComp<MouseRotatorComponent>(ent))
+            RemCompDeferred<NoRotateOnMoveComponent>(ent);
+    }
+
     public bool IsPulling(Entity<PullerComponent?> user, Entity<PullableComponent?> target)
     {
         if (!Resolve(user, ref user.Comp, false) ||
@@ -364,6 +378,25 @@ public sealed class RMCPullingSystem : EntitySystem
                 continue;
 
             _pulling.TryStopPull(uid, pullable);
+        }
+
+        var pullerQuery = EntityQueryEnumerator<PullerComponent, TransformComponent>();
+        while (pullerQuery.MoveNext(out var uid, out var puller, out var xform))
+        {
+            if (HasComp<MouseRotatorComponent>(uid))
+                continue;
+
+            if (puller.Pulling == null)
+                continue;
+
+            if (!_timing.ApplyingState)
+                EnsureComp<NoRotateOnMoveComponent>(uid);
+
+            var pulledCoords = _transform.GetMapCoordinates(puller.Pulling.Value).Position;
+            var pullerCoords = _transform.GetMapCoordinates(uid, xform: xform).Position;
+
+            var angle = (pulledCoords - pullerCoords).ToWorldAngle().GetCardinalDir().ToAngle();
+            _rotateTo.TryFaceAngle(uid, angle, xform);
         }
     }
 }

--- a/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
+++ b/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
@@ -1,4 +1,5 @@
 ﻿using System.Numerics;
+using Content.Shared._RMC14.Fireman;
 using Content.Shared._RMC14.Xenonids.Parasite;
 using Content.Shared.Coordinates;
 using Content.Shared.Interaction;
@@ -380,13 +381,16 @@ public sealed class RMCPullingSystem : EntitySystem
             _pulling.TryStopPull(uid, pullable);
         }
 
-        var pullerQuery = EntityQueryEnumerator<PullerComponent, TransformComponent>();
-        while (pullerQuery.MoveNext(out var uid, out var puller, out var xform))
+        var pullerQuery = EntityQueryEnumerator<PullerComponent, TransformComponent, CanFiremanCarryComponent>();
+        while (pullerQuery.MoveNext(out var uid, out var puller, out var xform, out var firemanCarry))
         {
             if (HasComp<MouseRotatorComponent>(uid))
                 continue;
 
             if (puller.Pulling == null)
+                continue;
+
+            if (firemanCarry.Carrying != null)
                 continue;
 
             if (!_timing.ApplyingState)

--- a/Resources/Prototypes/_RMC14/Effects/attack.yml
+++ b/Resources/Prototypes/_RMC14/Effects/attack.yml
@@ -20,7 +20,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: TimedDespawn
-    lifetime: 1.6
+    lifetime: 1
   - type: Sprite
     sprite: _RMC14/Effects/attacks.rsi
     noRot: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Makes the pull effects despawn shorter ( they don't last that long in CM, and if you spam pull it can get clouded)
Make entities auto rotate when they're pulling an object, it rotates to face towards the object

## Why / Balance
Parity , more immersion

## Media

https://github.com/user-attachments/assets/9153311e-f091-42c4-84db-e4794a7aceb4



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->