### PR TITLE
SADAR Assisted Reload

### DIFF
--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
@@ -91,30 +91,36 @@ public abstract partial class SharedGunSystem
         if (args.Handled)
             return;
 
-        if (_whitelistSystem.IsWhitelistFailOrNull(component.Whitelist, args.Used))
-            return;
+        TryAmmoInsert(uid, component, args.Used, args.User, args.Target, component.InsertDelay);
+        args.Handled = true;
+    }
+
+    public bool TryAmmoInsert(EntityUid uid, BallisticAmmoProviderComponent component, EntityUid ammo, EntityUid loader, EntityUid weapon, double insertDelay)
+    {
+        if (_whitelistSystem.IsWhitelistFailOrNull(component.Whitelist, ammo))
+            return false;
 
         //Prevent primed grenades or other primed ordanance from being loaded into weapons.
-        if (HasComp<ActiveTimerTriggerComponent>(args.Used))
+        if (HasComp<ActiveTimerTriggerComponent>(ammo))
         {
             Popup(
                 Loc.GetString("gun-ballistic-transfer-primed",
-                    ("ammoEntity", args.Used)),
+                    ("ammoEntity", ammo)),
                 uid,
-                args.User);
+                loader);
 
-            return;
+            return false;
         }
 
         if (GetBallisticShots(component) >= component.Capacity)
-            return;
+            return false;
 
         TimeSpan insertDelayConverted;
 
-        if (component.InsertDelay > 0)
+        if (insertDelay > 0)
         {
-            insertDelayConverted = TimeSpan.FromSeconds(component.InsertDelay);
-            _doAfter.TryStartDoAfter(new DoAfterArgs(EntityManager, args.User, insertDelayConverted, new DelayedAmmoInsertDoAfterEvent(), used: args.Used, target: args.Target, eventTarget: uid)
+            insertDelayConverted = TimeSpan.FromSeconds(insertDelay);
+            _doAfter.TryStartDoAfter(new DoAfterArgs(EntityManager, loader, insertDelayConverted, new DelayedAmmoInsertDoAfterEvent(), used: ammo, target: weapon, eventTarget: uid)
             {
                 BreakOnMove = true,
                 BreakOnDamage = false,
@@ -123,9 +129,10 @@ public abstract partial class SharedGunSystem
         }
         else // If there's no custom InsertDelay on this component, immediately load the ammo in. Shotguns and mag-filling.
         {
-            ManualLoad(uid, component, args.Used, args.User);
+            ManualLoad(uid, component, ammo, loader);
         }
-        args.Handled = true;
+        
+        return true;
     }
 
     /// <summary>

--- a/Content.Shared/_RMC14/Weapons/Ranged/AssistedReloadAmmoComponent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/AssistedReloadAmmoComponent.cs
@@ -1,0 +1,11 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Weapons.Ranged;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(CMGunSystem))]
+public sealed partial class AssistedReloadAmmoComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public double InsertDelay = 3.0;
+}

--- a/Content.Shared/_RMC14/Weapons/Ranged/AssistedReloadReceiverComponent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/AssistedReloadReceiverComponent.cs
@@ -1,0 +1,13 @@
+using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Weapons.Ranged;
+
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(CMGunSystem))]
+public sealed partial class AssistedReloadReceiverComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public EntityUid? Weapon;
+}

--- a/Content.Shared/_RMC14/Weapons/Ranged/AssistedReloadWeaponComponent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/AssistedReloadWeaponComponent.cs
@@ -1,0 +1,7 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Weapons.Ranged;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(CMGunSystem))]
+public sealed partial class AssistedReloadWeaponComponent : Component;

--- a/Resources/Locale/en-US/_RMC14/weapons/guns.ftl
+++ b/Resources/Locale/en-US/_RMC14/weapons/guns.ftl
@@ -26,3 +26,9 @@ rmc-examine-text-iff = [color=cyan]This gun will ignore and shoot past friendlie
 rmc-gun-rack-examine = [bold]Press your [color=cyan]unique action[/color] keybind (Spacebar by default) to rack before shooting.[/bold]
 rmc-gun-rack-first-with = You need to rack the gun with {$key} first!
 rmc-gun-rack-first = You need to rack the gun first!
+
+rmc-assisted-reload-fail-angle = You must be standing behind {$target} in order to reload {POSS-ADJ($target)} weapon!
+rmc-assisted-reload-fail-full = {CAPITALIZE(POSS-ADJ($target))} {$weapon} is already loaded.
+rmc-assisted-reload-fail-mismatch = The {$ammo} can't be loaded into a {$weapon}!
+rmc-assisted-reload-start-user = You begin reloading {$target}'s {$weapon}! Hold still...
+rmc-assisted-reload-start-target = {$reloader} begins reloading your {$weapon} with the {$ammo}! Hold still...

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m5_atl_rocket_launcher.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m5_atl_rocket_launcher.yml
@@ -65,6 +65,7 @@
       rmc-aslot-rail: -0.057, 0.162
   - type: IgnorePredictionHide
   - type: GunIgnorePrediction
+  - type: AssistedReloadWeapon
 
 # 84mm HE
 - type: entity
@@ -91,6 +92,7 @@
     state: m5_84mm_he
     suffix: false
   - type: IgnorePredictionHide
+  - type: AssistedReloadAmmo
 
 - type: entity
   id: RMCProjectileRocket84mm


### PR DESCRIPTION

## About the PR
Ports the SADAR's assisted reload from CM13. When wielding the M5-ATL, another marine can quickly load a rocket into your weapon if they are standing behind you. This takes 3 seconds, as opposed to the standard 6 second self-load.

## Technical details
Creates 3 components, an Ammo, Weapon, and Receiver component. The Ammo component stores the amount of time it takes to load (for flexibility), the Receiver component is attached to the player wielding the rocket and lets the player be interacted with, and it stores the Uid of the relevant weapon. The Weapon component adds and removes the Receiver component to the player wielding and unwielding it.

CMGunSystem handles everything about assisted reloading besides actually inserting the ammunition (which can't be detached from SharedGunSystem). Event handlers handle the components and interactions between the in-hand ammo and the receiver.

TryAssistedReload() is called to attempt an assisted reload with an assisted reload eligible item. It will fail if the required components are not present, the reload fails, or if IsBehindTarget() fails, which grabs the angle of the 2 players, and compares them with the target's facing direction to ensure the loader is within 90 degrees of their backside.

There is an additional whitelisting check that would otherwise be handled by the reloading process itself, in order to give feedback to the player if they attempt to insert the ammo into the wrong type of weapon. As is, this should never trigger, as only the M5-ATL has the components for assisted reload currently, but is established now for the future if other such weapons were to be made, especially for other HvH factions.

One upstream file is minorly changed: SharedGunSystem.Ballistic.cs. All that was changed about this is that the behavior for ammo inserting was made a generic function TryAmmoInsert(), rather than being hard coded into a single event handler. It has also been changed to output a bool, true on success, false on fail, so that Assisted Reload may receive feedback on whether it worked or not. These changes do not affect standard reloading in any way, there should be no behavioral difference between this and live.

## Media

Loader POV

https://github.com/user-attachments/assets/d0500449-0e95-45d8-bb94-6e6467062797

Shooter POV

https://github.com/user-attachments/assets/6aaceccf-09a7-4729-a72c-ee4120ebf9f2

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- add: Added the Assisted Reload mechanic. You can now perform an assisted reload on a SADAR (M5-ATL) by clicking on a player that is actively wielding a SADAR while you are behind them. This will load the SADAR in just 3 seconds, as opposed to the 6 second self-load time.
