### PR TITLE
Fix xenos not rotating when pulling an object

### DIFF
--- a/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
+++ b/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
@@ -49,8 +49,12 @@ public sealed class RMCPullingSystem : EntitySystem
 
     private const string PullEffect = "CMEffectGrab";
 
+    private EntityQuery<FiremanCarriableComponent> _firemanQuery;
+
     public override void Initialize()
     {
+        _firemanQuery = GetEntityQuery<FiremanCarriableComponent>();
+
         SubscribeLocalEvent<ParalyzeOnPullAttemptComponent, PullAttemptEvent>(OnParalyzeOnPullAttempt);
         SubscribeLocalEvent<InfectOnPullAttemptComponent, PullAttemptEvent>(OnInfectOnPullAttempt);
 
@@ -381,15 +385,15 @@ public sealed class RMCPullingSystem : EntitySystem
             _pulling.TryStopPull(uid, pullable);
         }
 
-        var pullableQuery = EntityQueryEnumerator<BeingPulledComponent, PullableComponent, FiremanCarriableComponent>();
-        while (pullableQuery.MoveNext(out var uid, out _, out var pullable, out var firemanCarry))
+        var pullableQuery = EntityQueryEnumerator<BeingPulledComponent, PullableComponent>();
+        while (pullableQuery.MoveNext(out var uid, out _, out var pullable))
         {
             if (pullable.Puller == null)
                 continue;
 
             var puller = pullable.Puller.Value;
 
-            if (firemanCarry.BeingCarried)
+            if (_firemanQuery.TryComp(uid, out var fireman) && fireman.BeingCarried)
                 continue;
 
             if (HasComp<MouseRotatorComponent>(puller))


### PR DESCRIPTION
Gets fireman query, only continues if the fireman component actually exists