### PR TITLE
Xeno Ghost Names

### DIFF
--- a/Content.Server/_RMC14/Name/XenoNameSystem.cs
+++ b/Content.Server/_RMC14/Name/XenoNameSystem.cs
@@ -1,6 +1,7 @@
 ﻿using Content.Server.GameTicking;
 using Content.Shared._RMC14.Xenonids.Name;
 using Content.Shared.GameTicking;
+using Content.Shared.Mind;
 using Content.Shared.NameModifier.EntitySystems;
 using Robust.Shared.Player;
 using Robust.Shared.Random;
@@ -10,6 +11,7 @@ namespace Content.Server._RMC14.Name;
 public sealed class XenoNameSystem : SharedXenoNameSystem
 {
     [Dependency] private readonly GameTicker _gameTicker = default!;
+    [Dependency] private readonly SharedMindSystem _mind = default!;
     [Dependency] private readonly NameModifierSystem _nameModifier = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
 
@@ -47,6 +49,9 @@ public sealed class XenoNameSystem : SharedXenoNameSystem
             name.Postfix = profile.XenoPostfix;
             _nameModifier.RefreshNameModifiers(xeno);
             RemCompDeferred<AssignXenoNameComponent>(xeno);
+
+            if (_mind.TryGetMind(xeno, out var _, out var mind) && TryComp<MetaDataComponent>(xeno, out var xenoMetaData))
+                mind.CharacterName = xenoMetaData.EntityName;
         }
         catch (Exception e)
         {

--- a/Content.Shared/_RMC14/Xenonids/Name/SharedXenoNameSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Name/SharedXenoNameSystem.cs
@@ -1,6 +1,7 @@
 ﻿using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Xenonids.Evolution;
 using Content.Shared._RMC14.Xenonids.Maturing;
+using Content.Shared.Mind;
 using Content.Shared.NameModifier.EntitySystems;
 using Content.Shared.Players.PlayTimeTracking;
 using Robust.Shared.Configuration;
@@ -13,6 +14,7 @@ namespace Content.Shared._RMC14.Xenonids.Name;
 public abstract class SharedXenoNameSystem : EntitySystem
 {
     [Dependency] private readonly IConfigurationManager _config = default!;
+    [Dependency] private readonly SharedMindSystem _mind = default!;
     [Dependency] private readonly NameModifierSystem _nameModifier = default!;
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly ISharedPlaytimeManager _playtime = default!;
@@ -127,6 +129,9 @@ public abstract class SharedXenoNameSystem : EntitySystem
         RemComp<AssignXenoNameComponent>(newXeno);
 
         _nameModifier.RefreshNameModifiers(newXeno);
+        
+        if (_mind.TryGetMind(newXeno, out var _, out var mind) && TryComp<MetaDataComponent>(newXeno, out var xenoMetaData))
+            mind.CharacterName = xenoMetaData.EntityName;
     }
 
     public virtual void SetupName(EntityUid xeno)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Ghosts that were Xenos now get their xeno names assigned instead of everyone just being "Larva" and "Parasite".

## Technical details
Sets the player's mind's character name whenever a Xeno name is assigned or edited. (Being taken by a ghost, evolution, and devolution)

## Media

https://github.com/user-attachments/assets/83b472cd-4cf4-4cc9-b578-803c72ac13e6

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- fix: Xeno ghosts will now retain their full xeno names, including rank, caste, letters, and number ID.
