### PR TITLE
Fix humanoids being too slow + fix xeno slow amounts

### DIFF
--- a/Content.Shared/_RMC14/Clothing/NoClothingSlowdownComponent.cs
+++ b/Content.Shared/_RMC14/Clothing/NoClothingSlowdownComponent.cs
@@ -10,10 +10,10 @@ public sealed partial class NoClothingSlowdownComponent : Component
     public string Slot = "shoes";
 
     [DataField, AutoNetworkedField]
-    public float WalkModifier = 0.68f;
+    public float WalkModifier = 0.62f;
 
     [DataField, AutoNetworkedField]
-    public float SprintModifier = 0.68f;
+    public float SprintModifier = 0.62f;
 
     [DataField, AutoNetworkedField]
     public bool Active = false;

--- a/Content.Shared/_RMC14/Xenonids/Crippling/XenoCripplingStrikeComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Crippling/XenoCripplingStrikeComponent.cs
@@ -18,7 +18,7 @@ public sealed partial class XenoCripplingStrikeComponent : Component
     public TimeSpan ActiveDuration = TimeSpan.FromSeconds(5);
 
     [DataField, AutoNetworkedField]
-    public FixedPoint2 SpeedMultiplier = FixedPoint2.New(0.75);
+    public FixedPoint2 SpeedMultiplier = FixedPoint2.New(0.33);
 
     [DataField, AutoNetworkedField]
     public TimeSpan SlowDuration = TimeSpan.FromSeconds(5);

--- a/Content.Shared/_RMC14/Xenonids/MeleeSlow/XenoMeleeSlowComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/MeleeSlow/XenoMeleeSlowComponent.cs
@@ -15,7 +15,7 @@ public sealed partial class XenoMeleeSlowComponent : Component
     public bool RequiresKnockDown = false;
 
     [DataField, AutoNetworkedField]
-    public FixedPoint2 SpeedMultiplier = FixedPoint2.New(0.55);
+    public FixedPoint2 SpeedMultiplier = FixedPoint2.New(0.66);
 
     [DataField, AutoNetworkedField]
     public EntProtoId Effect = "RMCEffectLurkerSlow";

--- a/Content.Shared/_RMC14/Xenonids/MeleeSlow/XenoMeleeSlowComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/MeleeSlow/XenoMeleeSlowComponent.cs
@@ -15,7 +15,7 @@ public sealed partial class XenoMeleeSlowComponent : Component
     public bool RequiresKnockDown = false;
 
     [DataField, AutoNetworkedField]
-    public FixedPoint2 SpeedMultiplier = FixedPoint2.New(0.87);
+    public FixedPoint2 SpeedMultiplier = FixedPoint2.New(0.55);
 
     [DataField, AutoNetworkedField]
     public EntProtoId Effect = "RMCEffectLurkerSlow";

--- a/Content.Shared/_RMC14/Xenonids/Neurotoxin/CoughedBloodComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Neurotoxin/CoughedBloodComponent.cs
@@ -7,7 +7,7 @@ namespace Content.Shared._RMC14.Xenonids.GasToggle;
 public sealed partial class CoughedBloodComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public FixedPoint2 SlowMultiplier = FixedPoint2.New(0.55);
+    public FixedPoint2 SlowMultiplier = FixedPoint2.New(0.66);
 
     [DataField, AutoNetworkedField]
     public TimeSpan ExpireTime;

--- a/Content.Shared/_RMC14/Xenonids/Neurotoxin/CoughedBloodComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Neurotoxin/CoughedBloodComponent.cs
@@ -7,7 +7,7 @@ namespace Content.Shared._RMC14.Xenonids.GasToggle;
 public sealed partial class CoughedBloodComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public FixedPoint2 SlowMultiplier = FixedPoint2.New(0.87);
+    public FixedPoint2 SlowMultiplier = FixedPoint2.New(0.55);
 
     [DataField, AutoNetworkedField]
     public TimeSpan ExpireTime;

--- a/Content.Shared/_RMC14/Xenonids/Projectile/Bone/SlowedByBoneChipsComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/Bone/SlowedByBoneChipsComponent.cs
@@ -8,7 +8,7 @@ namespace Content.Shared._RMC14.Xenonids.Projectile.Bone;
 public sealed partial class SlowedByBoneChipsComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public float Multiplier = 0.5f;
+    public float Multiplier = 0.66f;
 
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
     public TimeSpan ExpiresAt;

--- a/Content.Shared/_RMC14/Xenonids/Projectile/Spit/Slowing/SlowedBySpitComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/Spit/Slowing/SlowedBySpitComponent.cs
@@ -8,7 +8,7 @@ namespace Content.Shared._RMC14.Xenonids.Projectile.Spit.Slowing;
 public sealed partial class SlowedBySpitComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public float Multiplier = 0.75f;
+    public float Multiplier = 0.33f;
 
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
     public TimeSpan ExpiresAt;

--- a/Content.Shared/_RMC14/Xenonids/Projectile/Spit/Slowing/SlowedBySpitComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/Spit/Slowing/SlowedBySpitComponent.cs
@@ -7,9 +7,15 @@ namespace Content.Shared._RMC14.Xenonids.Projectile.Spit.Slowing;
 [Access(typeof(XenoSpitSystem))]
 public sealed partial class SlowedBySpitComponent : Component
 {
-    [DataField, AutoNetworkedField]
-    public float Multiplier = 0.33f;
+	[DataField, AutoNetworkedField]
+	public bool SuperSlow = true;
 
-    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
+	[DataField, AutoNetworkedField]
+    public float SuperMultiplier = 0.33f;
+
+	[DataField, AutoNetworkedField]
+	public float Multiplier = 0.66f;
+
+	[DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
     public TimeSpan ExpiresAt;
 }

--- a/Content.Shared/_RMC14/Xenonids/Projectile/Spit/Slowing/XenoSlowingSpitProjectileComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/Spit/Slowing/XenoSlowingSpitProjectileComponent.cs
@@ -7,6 +7,9 @@ namespace Content.Shared._RMC14.Xenonids.Projectile.Spit.Slowing;
 public sealed partial class XenoSlowingSpitProjectileComponent : Component
 {
     [DataField, AutoNetworkedField]
+    public bool SuperSlow = true;
+
+    [DataField, AutoNetworkedField]
     public TimeSpan Slow = TimeSpan.FromSeconds(8);
 
     [DataField, AutoNetworkedField]

--- a/Content.Shared/_RMC14/Xenonids/Projectile/Spit/XenoSpitSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/Spit/XenoSpitSystem.cs
@@ -208,7 +208,9 @@ public sealed class XenoSpitSystem : EntitySystem
 
         if (spit.Comp.Slow > TimeSpan.Zero)
         {
-            EnsureComp<SlowedBySpitComponent>(target).ExpiresAt = _timing.CurTime + spit.Comp.Slow;
+            var slow = EnsureComp<SlowedBySpitComponent>(target);
+            slow.ExpiresAt = _timing.CurTime + spit.Comp.Slow;
+            slow.SuperSlow = spit.Comp.SuperSlow;
             _movementSpeed.RefreshMovementSpeedModifiers(target);
         }
 
@@ -308,7 +310,7 @@ public sealed class XenoSpitSystem : EntitySystem
     private void OnSlowedBySpitRefreshMovement(Entity<SlowedBySpitComponent> slowed, ref RefreshMovementSpeedModifiersEvent args)
     {
         if (slowed.Comp.ExpiresAt > _timing.CurTime)
-            args.ModifySpeed(slowed.Comp.Multiplier, slowed.Comp.Multiplier);
+            args.ModifySpeed( slowed.Comp.SuperSlow ? slowed.Comp.SuperMultiplier : slowed.Comp.Multiplier, slowed.Comp.Multiplier);
     }
 
     private void OnUserAcidedMapInit(Entity<UserAcidedComponent> ent, ref MapInitEvent args)

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Back/backpacks.yml
@@ -197,8 +197,8 @@
     - state: ammo_pack-0
       map: ["enum.StorageFillLayers.Fill"]
   - type: ClothingSpeedModifier
-    walkModifier: 0.7
-    sprintModifier: 0.7
+    walkModifier: 0.79225
+    sprintModifier: 0.79225
   - type: HeldSpeedModifier
   - type: StorageFillVisualizer
     fillBaseName: ammo_pack

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Back/backpacks.yml
@@ -197,8 +197,8 @@
     - state: ammo_pack-0
       map: ["enum.StorageFillLayers.Fill"]
   - type: ClothingSpeedModifier
-    walkModifier: 0.79225
-    sprintModifier: 0.79225
+    walkModifier: 0.710
+    sprintModifier: 0.710
   - type: HeldSpeedModifier
   - type: StorageFillVisualizer
     fillBaseName: ammo_pack

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/armored_vest.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/armored_vest.yml
@@ -7,8 +7,8 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/armored_vest.rsi
   - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.9
+    walkModifier: 0.725
+    sprintModifier: 0.725
   - type: CMArmor
     armor: 15 # TODO RMC14 20 bullet
     bio: 20

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/basic_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/basic_armor.yml
@@ -11,8 +11,8 @@
     equipDelay: 2
     unequipDelay: 2
   - type: ClothingSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.8
+    walkModifier: 0.725
+    sprintModifier: 0.725
   - type: CMArmor
     armor: 30
     explosionArmor: 10

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/detective_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/detective_armor.yml
@@ -7,8 +7,8 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/detective_armor.rsi
   - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.9
+    walkModifier: 0.725
+    sprintModifier: 0.725
   - type: CMArmor
     armor: 15 # TODO RMC14 20 bullet
     bio: 20

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/faction_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/faction_armor.yml
@@ -14,8 +14,8 @@
     bio: 15 # CLOTHING_ARMOR_MEDIUMLOW
     explosionArmor: 40 # CLOTHING_ARMOR_VERYHIGH
   - type: ClothingSpeedModifier # SLOWDOWN_ARMOR_LIGHT
-    walkModifier: 0.814
-    sprintModifier: 0.814
+    walkModifier: 0.725
+    sprintModifier: 0.725
   - type: Storage
     grid:
     - 0,0,7,1 # 4 slots
@@ -76,8 +76,8 @@
     bio: 20
     explosionArmor: 20 # CLOTHING_ARMOR_MEDIUM
   - type: ClothingSpeedModifier # SLOWDOWN_ARMOR_LIGHT
-    walkModifier: 0.814
-    sprintModifier: 0.814
+    walkModifier: 0.725
+    sprintModifier: 0.725
 
 # Freelancer
 - type: entity
@@ -93,8 +93,8 @@
     bio: 15
     explosionArmor: 20
   - type: ClothingSpeedModifier # SLOWDOWN_ARMOR_LIGHT
-    walkModifier: 0.814
-    sprintModifier: 0.814
+    walkModifier: 0.725
+    sprintModifier: 0.725
   - type: ExplosionResistance
     damageCoefficient: 0
     worn: false
@@ -119,8 +119,8 @@
     armor: 18 # CLOTHING_ARMOR_MEDIUM (melee); CLOTHING_ARMOR_MEDIUMLOW (bullets)
     explosionArmor: 20 # CLOTHING_ARMOR_MEDIUM
   - type: ClothingSpeedModifier # SLOWDOWN_ARMOR_LIGHT
-    walkModifier: 0.814
-    sprintModifier: 0.814
+    walkModifier: 0.725
+    sprintModifier: 0.725
   - type: WieldSlowdownCompensation
     walk: 0.12
     sprint: 0.198
@@ -194,8 +194,8 @@
     bio: 20
     explosionArmor: 20 # CLOTHING_ARMOR_MEDIUM
   - type: ClothingSpeedModifier # SLOWDOWN_ARMOR_LIGHT
-    walkModifier: 0.814
-    sprintModifier: 0.814
+    walkModifier: 0.725
+    sprintModifier: 0.725
   - type: Storage
     grid:
     - 0,0,3,1 # 2 slots
@@ -267,8 +267,8 @@
     bio: 20
     explosionArmor: 20 # CLOTHING_ARMOR_MEDIUM
   - type: ClothingSpeedModifier # SLOWDOWN_ARMOR_VERY_LIGHT
-    walkModifier: 0.897
-    sprintModifier: 0.897
+    walkModifier: 0.725
+    sprintModifier: 0.725
 
 - type: entity
   parent: RMCArmorPMCRiot
@@ -299,8 +299,8 @@
     explosionArmor: 20 # CLOTHING_ARMOR_MEDIUM
     bio: 10 # CLOTHING_ARMOR_LOW
   - type: ClothingSpeedModifier # SLOWDOWN_ARMOR_HEAVY
-    walkModifier: 0.68
-    sprintModifier: 0.68
+    walkModifier: 0.62
+    sprintModifier: 0.62
 
 - type: entity
   parent: RMCArmorCBRN

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
@@ -12,8 +12,8 @@
     bio: 20
     explosionArmor: 15
   - type: ClothingSpeedModifier
-    walkModifier: 0.727
-    sprintModifier: 0.727
+    walkModifier: 0.666
+    sprintModifier: 0.666
   - type: ExplosionResistance
     damageCoefficient: 0
     worn: false
@@ -112,8 +112,8 @@
     walk: 0.12
     sprint: 0.198
   - type: ClothingSpeedModifier
-    walkModifier: 0.68
-    sprintModifier: 0.68
+    walkModifier: 0.62
+    sprintModifier: 0.62
   - type: Storage
     grid:
     - 0,0,3,1 # 2 slots
@@ -223,8 +223,8 @@
   - type: CMArmor
     explosionArmor: 30
   - type: ClothingSpeedModifier # light armor speed
-    walkModifier: .814
-    sprintModifier: .814
+    walkModifier: .725
+    sprintModifier: .725
   - type: Corrodible
     isCorrodible: false
 
@@ -241,8 +241,8 @@
     bio: 15
     explosionArmor: 20
   - type: ClothingSpeedModifier
-    walkModifier: .814
-    sprintModifier: .814
+    walkModifier: .725
+    sprintModifier: .725
   - type: Storage
     grid:
     - 0,0,3,1 # 2 slots
@@ -319,8 +319,8 @@
     bio: 15
     explosionArmor: 20
   - type: ClothingSpeedModifier
-    walkModifier: .814
-    sprintModifier: .814
+    walkModifier: .725
+    sprintModifier: .725
   - type: Storage
     grid:
     - 0,0,3,1 # 2 slots
@@ -342,8 +342,8 @@
   - type: Corrodible
     isCorrodible: false
   - type: ClothingSpeedModifier # light armor speed
-    walkModifier: .814
-    sprintModifier: .814
+    walkModifier: .725
+    sprintModifier: .725
   - type: CMArmor
     armor: 25
   - type: Tag
@@ -442,8 +442,8 @@
   - type: Corrodible
     isCorrodible: false
   - type: ClothingSpeedModifier # light armor speed
-    walkModifier: .814
-    sprintModifier: .814
+    walkModifier: .725
+    sprintModifier: .725
   - type: GhillieSuit
     whitelist:
       components:
@@ -463,8 +463,8 @@
     grid:
     - 0,0,3,1 # 2 slots
   - type: ClothingSpeedModifier
-    walkModifier: .814
-    sprintModifier: .814
+    walkModifier: .725
+    sprintModifier: .725
   - type: ClothingBlockBackpack
   - type: SmartGunArmor
 
@@ -482,8 +482,8 @@
     bio: 15
     explosionArmor: 20
   - type: ClothingSpeedModifier
-    walkModifier: 0.814
-    sprintModifier: 0.814
+    walkModifier: 0.725
+    sprintModifier: 0.725
   - type: Storage
     maxItemSize: Small
     grid:

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/pmc.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/pmc.yml
@@ -12,8 +12,8 @@
     bio: 20 # CLOTHING_ARMOR_MEDIUM
     explosionArmor: 20 # CLOTHING_ARMOR_MEDIUM
   - type: ClothingSpeedModifier # SLOWDOWN_ARMOR_LIGHT
-    walkModifier: 0.814
-    sprintModifier: 0.814
+    walkModifier: 0.725
+    sprintModifier: 0.725
   - type: Storage
     grid:
     - 0,0,3,1 # 2 slots
@@ -43,8 +43,8 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/PMC/corporate.rsi
   - type: ClothingSpeedModifier # SLOWDOWN_ARMOR_LIGHT
-    walkModifier: 0.814
-    sprintModifier: 0.814
+    walkModifier: 0.725
+    sprintModifier: 0.725
 
 - type: entity
   parent: RMCArmorM4PMCCorporate
@@ -119,8 +119,8 @@
     walk: 0.24
     sprint: 0.384
   - type: ClothingSpeedModifier # SLOWDOWN_ARMOR_MEDIUM
-    walkModifier: 0.727
-    sprintModifier: 0.727
+    walkModifier: 0.666
+    sprintModifier: 0.666
   - type: Corrodible
     isCorrodible: false
 

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/provost.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/provost.yml
@@ -12,8 +12,8 @@
     bio: 15
     explosionArmor: 25 # CLOTHING_ARMOR_MEDIUMHIGH
   - type: ClothingSpeedModifier # SLOWDOWN_ARMOR_LIGHT
-    walkModifier: 0.814
-    sprintModifier: 0.814
+    walkModifier: 0.725
+    sprintModifier: 0.725
   - type: Storage
     grid:
     - 0,0,5,1 # 3 slots

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/royal.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/royal.yml
@@ -21,8 +21,8 @@
     bio: 20
     explosionArmor: 20 # CLOTHING_ARMOR_MEDIUM
   - type: ClothingSpeedModifier # SLOWDOWN_ARMOR_LIGHT
-    walkModifier: 0.814
-    sprintModifier: 0.814
+    walkModifier: 0.725
+    sprintModifier: 0.725
 
 - type: entity
   parent: RMCArmorRoyal
@@ -56,8 +56,8 @@
     explosionArmor: 35 # CLOTHING_ARMOR_HIGHPLUS
     bio: 20 # CLOTHING_ARMOR_MEDIUM
   - type: ClothingSpeedModifier # SLOWDOWN_ARMOR_LOWHEAVY
-    walkModifier: 0.68
-    sprintModifier: 0.68
+    walkModifier: 0.64
+    sprintModifier: 0.64
   - type: WieldSlowdownCompensation
     walk: 0.12
     sprint: 0.198

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/security_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/security_armor.yml
@@ -7,8 +7,8 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/security_armor.rsi
   - type: ClothingSpeedModifier
-    walkModifier: .814
-    sprintModifier: .814
+    walkModifier: .725
+    sprintModifier: .725
   - type: CMArmor
     armor: 15 # TODO RMC14 20 bullet
     bio: 20

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/spp.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/spp.yml
@@ -12,8 +12,8 @@
     bio: 15 # CLOTHING_ARMOR_MEDIUMLOW
     explosionArmor: 20 # CLOTHING_ARMOR_MEDIUM
   - type: ClothingSpeedModifier # SLOWDOWN_ARMOR_MEDIUM
-    walkModifier: 0.727
-    sprintModifier: 0.727
+    walkModifier: 0.666
+    sprintModifier: 0.666
   - type: Storage
     grid:
     - 0,0,1,1 # 1 slot
@@ -27,8 +27,8 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/SPP/support.rsi
   - type: ClothingSpeedModifier # SLOWDOWN_ARMOR_LIGHT
-    walkModifier: 0.814
-    sprintModifier: 0.814
+    walkModifier: 0.725
+    sprintModifier: 0.725
   - type: Storage
     grid:
     - 0,0,5,1 # 3 slots
@@ -59,8 +59,8 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/SPP/commando.rsi
   - type: ClothingSpeedModifier # SLOWDOWN_ARMOR_LIGHT
-    walkModifier: 0.814
-    sprintModifier: 0.814
+    walkModifier: 0.725
+    sprintModifier: 0.725
   - type: Storage
     grid:
     - 0,0,3,1 # 2 slots
@@ -74,8 +74,8 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/SPP/heavy.rsi
   - type: ClothingSpeedModifier # SLOWDOWN_ARMOR_HEAVY
-    walkModifier: 0.68
-    sprintModifier: 0.68
+    walkModifier: 0.62
+    sprintModifier: 0.62
   - type: CMArmor
     armor: 30 # CLOTHING_ARMOR_HIGHPLUS (bullets), CLOTHING_ARMOR_MEDIUMHIGH (melee); choosing an intermediate value until more damage types are implemented
     bio: 20 # CLOTHING_ARMOR_MEDIUM

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
@@ -188,18 +188,22 @@
     baseSprintSpeed: 5
   - type: SlowOnPull
     slowdowns:
-    - multiplier: 0.7575
+    - multiplier: 0.745
       whitelist:
         components:
         - Marine
-    - multiplier: 0.8725
+    - multiplier: 0.855
       whitelist:
         components:
         - XenoLight
-    - multiplier: 0.59
+    - multiplier: 0.5775
       whitelist:
         components:
         - XenoHeavy
+    - multiplier: 0.645
+      whitelist:
+        tags:
+        - Bodybag
   - type: MobThresholds
     thresholds:
       0: Alive

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
@@ -200,10 +200,10 @@
       whitelist:
         components:
         - XenoHeavy
-    - multiplier: 0.645
-      whitelist:
-        tags:
-        - Bodybag
+#    - multiplier: 0.645
+#      whitelist:
+#        tags:
+#        - Bodybag
   - type: MobThresholds
     thresholds:
       0: Alive

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
@@ -183,6 +183,9 @@
   - type: UserIFF
   - type: UserLimitHits
   - type: MovementIgnoreGravity
+  - type: MovementSpeedModifier
+    baseWalkSpeed: 2.7
+    baseSprintSpeed: 5
   - type: SlowOnPull
     slowdowns:
     - multiplier: 0.7575

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_projectiles.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_projectiles.yml
@@ -143,6 +143,7 @@
     - state: bonechips
       shader: unshaded
   - type: XenoSlowingSpitProjectile
+    superSlow: false
     slow: 5
     paralyze: 0
   - type: Projectile


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Should be parity. Humans in CM are as fast as a lurker wearing shoes armorless due to how it works. Slows on them however are much harsher (1 delay for slow, 4 for superslow).

This means that slow would bring them down to boiler speed, and superslow makes them slower than queen. The percents should be about 0.66 for slow and 0.33 for super slow.

Xeno slowdown from ammo is about right already I think (it's never going to be perfect due to how speed is handled in CM rn) so leaving it alone.

All these values should be easy to test (on account of being whole numbers) in CM. I don't trust myself with a stopwatch to get it exactly right though.

Edit: Pull speeds and armor speeds were updated based on some testing information.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/7b442b24-f393-46e8-b980-27b721054eab



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed Humanoids being slower than intended when unarmored. Armor speeds have mostly not changed.
- fix: Slowing effects caused by Xenos should slow marines more (they weren't slowing enough before).
- fix: Fixed IMP ammo rack slowing marines down more than intended.
- fix: Bodybags and stasis bags slow on drag.
- fix: Fix bonechips slowing the wrong amount.
