### PR TITLE
Predict armor light verb!

### DIFF
--- a/Content.Client/Light/HandheldLightSystem.cs
+++ b/Content.Client/Light/HandheldLightSystem.cs
@@ -21,6 +21,22 @@ public sealed class HandheldLightSystem : SharedHandheldLightSystem
         SubscribeLocalEvent<HandheldLightComponent, AppearanceChangeEvent>(OnAppearanceChange);
     }
 
+    /// <remarks>
+    ///     TODO: Not properly predicted yet. Don't call this function if you want a the actual return value!
+    /// </remarks>
+    public override bool TurnOff(Entity<HandheldLightComponent> ent, bool makeNoise = true)
+    {
+        return true;
+    }
+
+    /// <remarks>
+    ///     TODO: Not properly predicted yet. Don't call this function if you want a the actual return value!
+    /// </remarks>
+    public override bool TurnOn(EntityUid user, Entity<HandheldLightComponent> uid)
+    {
+        return true;
+    }
+
     private void OnAppearanceChange(EntityUid uid, HandheldLightComponent? component, ref AppearanceChangeEvent args)
     {
         if (!Resolve(uid, ref component))

--- a/Content.Server/Light/EntitySystems/HandheldLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/HandheldLightSystem.cs
@@ -9,7 +9,6 @@ using Content.Shared.Light;
 using Content.Shared.Light.Components;
 using Content.Shared.Rounding;
 using Content.Shared.Toggleable;
-using Content.Shared.Verbs;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
@@ -46,7 +45,6 @@ namespace Content.Server.Light.EntitySystems
             SubscribeLocalEvent<HandheldLightComponent, ComponentShutdown>(OnShutdown);
 
             SubscribeLocalEvent<HandheldLightComponent, ExaminedEvent>(OnExamine);
-            SubscribeLocalEvent<HandheldLightComponent, GetVerbsEvent<ActivationVerb>>(AddToggleLightVerb);
 
             SubscribeLocalEvent<HandheldLightComponent, ActivateInWorldEvent>(OnActivate);
 
@@ -179,25 +177,7 @@ namespace Content.Server.Light.EntitySystems
             }
         }
 
-        private void AddToggleLightVerb(Entity<HandheldLightComponent> ent, ref GetVerbsEvent<ActivationVerb> args)
-        {
-            if (!args.CanAccess || !args.CanInteract || !ent.Comp.ToggleOnInteract)
-                return;
-
-            var @event = args;
-            ActivationVerb verb = new()
-            {
-                Text = Loc.GetString("verb-common-toggle-light"),
-                Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/VerbIcons/light.svg.192dpi.png")),
-                Act = ent.Comp.Activated
-                    ? () => TurnOff(ent)
-                    : () => TurnOn(@event.User, ent)
-            };
-
-            args.Verbs.Add(verb);
-        }
-
-        public bool TurnOff(Entity<HandheldLightComponent> ent, bool makeNoise = true)
+        public override bool TurnOff(Entity<HandheldLightComponent> ent, bool makeNoise = true)
         {
             if (!ent.Comp.Activated || !_lights.TryGetLight(ent, out var pointLightComponent))
             {
@@ -211,7 +191,7 @@ namespace Content.Server.Light.EntitySystems
             return true;
         }
 
-        public bool TurnOn(EntityUid user, Entity<HandheldLightComponent> uid)
+        public override bool TurnOn(EntityUid user, Entity<HandheldLightComponent> uid)
         {
             var component = uid.Comp;
             if (component.Activated || !_lights.TryGetLight(uid, out var pointLightComponent))

--- a/Content.Shared/Light/SharedHandheldLightSystem.cs
+++ b/Content.Shared/Light/SharedHandheldLightSystem.cs
@@ -3,9 +3,11 @@ using Content.Shared.Clothing.EntitySystems;
 using Content.Shared.Item;
 using Content.Shared.Light.Components;
 using Content.Shared.Toggleable;
+using Content.Shared.Verbs;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.GameStates;
+using Robust.Shared.Utility;
 
 namespace Content.Shared.Light;
 
@@ -22,6 +24,8 @@ public abstract class SharedHandheldLightSystem : EntitySystem
         base.Initialize();
         SubscribeLocalEvent<HandheldLightComponent, ComponentInit>(OnInit);
         SubscribeLocalEvent<HandheldLightComponent, ComponentHandleState>(OnHandleState);
+
+        SubscribeLocalEvent<HandheldLightComponent, GetVerbsEvent<ActivationVerb>>(AddToggleLightVerb);
     }
 
     private void OnInit(EntityUid uid, HandheldLightComponent component, ComponentInit args)
@@ -78,4 +82,25 @@ public abstract class SharedHandheldLightSystem : EntitySystem
 
         _appearance.SetData(uid, ToggleableLightVisuals.Enabled, component.Activated, appearance);
     }
+
+    private void AddToggleLightVerb(Entity<HandheldLightComponent> ent, ref GetVerbsEvent<ActivationVerb> args)
+    {
+        if (!args.CanAccess || !args.CanInteract || !ent.Comp.ToggleOnInteract)
+            return;
+
+        var @event = args;
+        ActivationVerb verb = new()
+        {
+            Text = Loc.GetString("verb-common-toggle-light"),
+            Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/VerbIcons/light.svg.192dpi.png")),
+            Act = ent.Comp.Activated
+                ? () => TurnOff(ent)
+                : () => TurnOn(@event.User, ent)
+        };
+
+        args.Verbs.Add(verb);
+    }
+
+    public abstract bool TurnOff(Entity<HandheldLightComponent> ent, bool makeNoise = true);
+    public abstract bool TurnOn(EntityUid user, Entity<HandheldLightComponent> uid);
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Moved some stuff to shared so the verb is correctly predicted! I'm going to be PRing this to upstream soon as well.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This was killing me in game... The lag was making me constantly turn my light on or off when I didn't mean to

## Technical details
<!-- Summary of code changes for easier review. -->
Moved the verb function to shared, made the on and off functions overridable so they can be "predicted" on the client side (Its fake but they need the definitions).

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://github.com/user-attachments/assets/a9f1a77d-2b15-4b38-b1cd-f8ba0e3e0835


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Body armor lights are now predicted. Yay!

