### PR TITLE
Fix boiler death cloud spawning clientside

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Deathcloud/XenoDeathcloudSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Deathcloud/XenoDeathcloudSystem.cs
@@ -1,10 +1,12 @@
 ﻿using Content.Shared.Coordinates;
 using Content.Shared.Mobs;
+using Robust.Shared.Network;
 
 namespace Content.Shared._RMC14.Xenonids.Deathcloud;
 
 public sealed class XenoDeathcloudSystem : EntitySystem
 {
+    [Dependency] private readonly INetManager _net = default!; 
     public override void Initialize()
     {
         SubscribeLocalEvent<XenoDeathcloudComponent, MobStateChangedEvent>(OnStateChanged);
@@ -12,6 +14,9 @@ public sealed class XenoDeathcloudSystem : EntitySystem
 
     private void OnStateChanged(Entity<XenoDeathcloudComponent> xeno, ref MobStateChangedEvent args)
     {
+        if (_net.IsClient)
+            return;
+
         if (args.NewMobState != MobState.Dead)
             return;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Would cause clouds to pop in as observer, probably in general. Anyway spawning clientside bad.

## Technical details
<!-- Summary of code changes for easier review. -->
INetworkManager wins again

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
no cl
