### PR TITLE
Fix Magazine Bullet Transfer

### DIFF
--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
@@ -91,8 +91,8 @@ public abstract partial class SharedGunSystem
         if (args.Handled)
             return;
 
-        TryAmmoInsert(uid, component, args.Used, args.User, args.Target, component.InsertDelay);
-        args.Handled = true;
+        if (TryAmmoInsert(uid, component, args.Used, args.User, args.Target, component.InsertDelay))
+            args.Handled = true;
     }
 
     public bool TryAmmoInsert(EntityUid uid, BallisticAmmoProviderComponent component, EntityUid ammo, EntityUid loader, EntityUid weapon, double insertDelay)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed Magazine Bullet Transferring not working

## Technical details
Handles the argument for InteractUsingEvent only if TryAmmoInsert returns true. Despite being entirely different events, handling an InteractUsingEvent also seems to handle AfterInteractEvent, which prevented OnBallisticAfterInteract() from running. This got missed in the genericization since the comment says "OnBallisticAfterInteract takes precendence", when what actually happens is OnBallisticInteractUsing gives up and OnBallisticAfterInteract takes over after.

## Media

https://github.com/user-attachments/assets/5924b398-adb1-4034-9a96-8565b2ab8f15

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- fix: Transferring ammo between magazines now functions again.

