### PR TITLE
Make correspondent microphone be not an instrument

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Devices/correspondent.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Devices/correspondent.yml
@@ -2,6 +2,7 @@
   parent: BaseItem
   id: RMCCorrespondentMicrophone
   name: microphone
+  suffix: RMC
   description: To report on the events where no other correspondent has gone before. Now with sound!
   components:
   - type: Sprite

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Devices/correspondent.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Devices/correspondent.yml
@@ -1,0 +1,12 @@
+- type: entity
+  parent: BaseItem
+  id: RMCCorrespondentMicrophone
+  name: microphone
+  description: To report on the events where no other correspondent has gone before. Now with sound!
+  components:
+  - type: Sprite
+    sprite: Objects/Fun/Instruments/microphone.rsi
+    state: icon
+  - type: Item
+    size: Small
+    sprite: Objects/Fun/Instruments/microphone.rsi

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/correspondent.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/correspondent.yml
@@ -42,7 +42,7 @@
     ears: CMHeadsetReporter
     #    belt: CMCamera TODO RMC14
     pocket1: RMCPouchGeneralLarge
-    pocket2: MicrophoneInstrument
+    pocket2: RMCCorrespondentMicrophone
 
 - type: entity
   parent: CMSpawnPointJobBase


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

New microphone prototype without its instrument components. Correspondent now spawns with this one instead.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Cause people generally only use it to be disruptive, and the cases where having MIDI's blared at your speakers is actually good roleplay or useful are very very limited in frequency.

Requested by @PolarTundraa .

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- remove: Correspondent microphone can no longer be used to play MIDI files.