### PR TITLE
Ghost Warp Refactor

### DIFF
--- a/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml.cs
@@ -38,7 +38,7 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls
                     ? Loc.GetString("ghost-target-window-current-button", ("name", warp.DisplayName))
                     : warp.DisplayName;
 
-                _categories[warp.CategoryName].Add((warpName, warp.Entity, warp.CategoryColor));
+                _categories[warp.CategoryName].Add((warpName, warp.Entity, warp.WarpColor));
             }
         }
 

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -371,15 +371,15 @@ namespace Content.Server.Ghost
                 if (_jobs.MindTryGetJob(mind?.Mind, out var jobProto)) {
                     var playerInfo = $"{Comp<MetaDataComponent>(attached).EntityName} ({jobName})";
                     if (_jobs.TryGetPrimaryDepartment(jobProto.ID, out var departmentProto)) {
-                        var categoryColor = departmentProto.Color;
+                        var warpColor = departmentProto.Color;
                         if (TryComp(attached, out SquadMemberComponent? member)) // if they are in a squad, we use the squad colors instead.
                         {
                             if (TryComp(member.Squad, out SquadTeamComponent? squadComp))
                             {
-                                categoryColor = squadComp.Color;
+                                warpColor = squadComp.Color;
                             }
                         }
-                        yield return new GhostWarp(GetNetEntity(attached), playerInfo, false, departmentProto.CustomName ?? Loc.GetString(departmentProto.Name), categoryColor.ToHex());
+                        yield return new GhostWarp(GetNetEntity(attached), playerInfo, false, departmentProto.CustomName ?? Loc.GetString(departmentProto.Name), warpColor.ToHex());
                     } else {
                         yield return new GhostWarp(GetNetEntity(attached), playerInfo, false, null, null); // no department was found, i'm probably going to need to create more departments, pmc and such.
                     }

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -368,9 +368,11 @@ namespace Content.Server.Ghost
                 if(!_mobState.IsAlive(attached) && !_mobState.IsCritical(attached)) continue;
 
                 var jobName = _jobs.MindTryGetJobName(mind?.Mind);
-                if (_jobs.MindTryGetJob(mind?.Mind, out var jobProto)) {
+                if (_jobs.MindTryGetJob(mind?.Mind, out var jobProto)) 
+                {
                     var playerInfo = $"{Comp<MetaDataComponent>(attached).EntityName} ({jobName})";
-                    if (_jobs.TryGetPrimaryDepartment(jobProto.ID, out var departmentProto)) {
+                    if (_jobs.TryGetPrimaryDepartment(jobProto.ID, out var departmentProto)) 
+                    {
                         var warpColor = departmentProto.Color;
                         if (TryComp(attached, out SquadMemberComponent? member)) // if they are in a squad, we use the squad colors instead.
                         {

--- a/Content.Shared/Ghost/SharedGhostSystem.cs
+++ b/Content.Shared/Ghost/SharedGhostSystem.cs
@@ -75,11 +75,13 @@ namespace Content.Shared.Ghost
     [Serializable, NetSerializable]
     public struct GhostWarp
     {
-        public GhostWarp(NetEntity entity, string displayName, bool isWarpPoint)
+        public GhostWarp(NetEntity entity, string displayName, bool isWarpPoint, string? categoryName, string? categoryColor)
         {
             Entity = entity;
             DisplayName = displayName;
             IsWarpPoint = isWarpPoint;
+            CategoryName = categoryName ?? "Other";
+            CategoryColor = categoryColor ?? "#D3D3D3"; // light grey
         }
 
         /// <summary>
@@ -96,7 +98,17 @@ namespace Content.Shared.Ghost
         /// <summary>
         /// Whether this warp represents a warp point or a player
         /// </summary>
-        public bool IsWarpPoint { get;  }
+        public bool IsWarpPoint { get; }
+
+        /// <summary>
+        /// The name of the category to which the warp belongs to, for mobs it's just the department.
+        /// </summary>
+        public string CategoryName { get; }
+
+        /// <summary>
+        /// The color of the category label, should match the color of the department.
+        /// </summary>
+        public string CategoryColor { get; }
     }
 
     /// <summary>

--- a/Content.Shared/Ghost/SharedGhostSystem.cs
+++ b/Content.Shared/Ghost/SharedGhostSystem.cs
@@ -75,13 +75,13 @@ namespace Content.Shared.Ghost
     [Serializable, NetSerializable]
     public struct GhostWarp
     {
-        public GhostWarp(NetEntity entity, string displayName, bool isWarpPoint, string? categoryName, string? categoryColor)
+        public GhostWarp(NetEntity entity, string displayName, bool isWarpPoint, string? categoryName, string? warpColor)
         {
             Entity = entity;
             DisplayName = displayName;
             IsWarpPoint = isWarpPoint;
             CategoryName = categoryName ?? "Other";
-            CategoryColor = categoryColor ?? "#D3D3D3"; // light grey
+            WarpColor = warpColor ?? "#D3D3D3"; // light grey
         }
 
         /// <summary>
@@ -108,7 +108,7 @@ namespace Content.Shared.Ghost
         /// <summary>
         /// The color of each button in the category, should match the color of the department or a squad.
         /// </summary>
-        public string CategoryColor { get; }
+        public string WarpColor { get; }
     }
 
     /// <summary>

--- a/Content.Shared/Ghost/SharedGhostSystem.cs
+++ b/Content.Shared/Ghost/SharedGhostSystem.cs
@@ -106,7 +106,7 @@ namespace Content.Shared.Ghost
         public string CategoryName { get; }
 
         /// <summary>
-        /// The color of the category label, should match the color of the department.
+        /// The color of each button in the category, should match the color of the department or a squad.
         /// </summary>
         public string CategoryColor { get; }
     }

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Departments/marine_department.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Departments/marine_department.yml
@@ -3,7 +3,7 @@
   id: CMSquad
   name: department-CMSquad
   description: cm-department-Marine-description
-  color: "#DE3A3A"
+  color: "#01B5EE"
   roles:
   - CMRifleman
   - CMSquadLeader


### PR DESCRIPTION
## About the PR
Refactors the ghost warp menu to be more intuitive and user friendly.

## Why / Balance
CM13 parity 

## Technical details
- WIP, obvious changes still need to be made to clean this implementation up. Future iterations should include a category for groundside & shipside players as well as for those who have evacuated. 

- Currently, the department colors and names are the defined categories, the only exception for this are for the players who are in a squad. They will still fall under the department category, but their ghost warp button on the menu will be the same color as their squad, so for example Charlie will be under the marines category, but all the members will be seen in purple, Bravo - orange, Delta - blue etc... anything that doesn't have a department goes under the "other" category.

## Media
<img width="778" alt="warp" src="https://github.com/user-attachments/assets/036cc72d-e3e7-4909-8b0c-b9470d248061">

Edit: This diagram shows what I plan on implementing.
<img width="1028" alt="Screen Shot 2024-11-26 at 10 48 05 PM" src="https://github.com/user-attachments/assets/2f85964c-1c48-4a26-a6c3-8aba3b1a6b13">

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl:
- tweak: refactors ghost warp menu
