### PR TITLE
Fix resin traps draw depth

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_resin_hole.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_resin_hole.yml
@@ -44,7 +44,7 @@
         Heat: 3
   - type: Sprite
     sprite: _RMC14/Structures/Xenos/xeno_resin_trap.rsi
-    drawdepth: FloorTiles
+    drawdepth: FloorObjects
     layers:
     - state: trap
       map: [ "enum.XenoResinHoleLayers.Base" ]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Bug fix, draw the resin holes above the weeds

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Fixed a case where resin traps would not be shown above weeds if the weeds they are on are removed and then built back again.
