### PR TITLE
Xeno Stun reduction fix

### DIFF
--- a/Content.Shared/_RMC14/StatusEffect/RMCStatusEffectSystem.cs
+++ b/Content.Shared/_RMC14/StatusEffect/RMCStatusEffectSystem.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Shared._RMC14.Marines.Skills;
+using Content.Shared._RMC14.Xenonids;
 using Content.Shared.StatusEffect;
 using Robust.Shared.Prototypes;
 
@@ -15,6 +16,7 @@ public sealed class RMCStatusEffectSystem : EntitySystem
     public override void Initialize()
     {
         SubscribeLocalEvent<SkillsComponent, RMCStatusEffectTimeEvent>(OnSkillsStatusEffectTime);
+        SubscribeLocalEvent<XenoComponent, RMCStatusEffectTimeEvent>(OnXenoStatusEffectTime);
     }
 
     private void OnSkillsStatusEffectTime(Entity<SkillsComponent> ent, ref RMCStatusEffectTimeEvent args)
@@ -29,5 +31,13 @@ public sealed class RMCStatusEffectSystem : EntitySystem
         var skill = (endurance - 1) * 0.08;
         var multiplier = 1 - skill; // TODO RMC14 hunter/synthetic/monkey/zombie/human hero multiplier
         args.Duration *= multiplier;
+    }
+
+    private void OnXenoStatusEffectTime(Entity<XenoComponent> ent, ref RMCStatusEffectTimeEvent args)
+    {
+        if (args.Key != Knockdown && args.Key != Stun)
+            return;
+
+        args.Duration *= 0.667;
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fix Xeno stuns not being multiplied by 2/3. This was missed because 13's xeno has interceptor functions for each form of CC that is not directly called anywhere, but still runs.

https://github.com/cmss13-devs/cmss13/blob/a635ff15336f0bd3c6749e259ecef718714f47d3/code/modules/mob/living/carbon/xenomorph/life.dm#L546

## Technical details
If Xeno multiply stun/knockdown by 0.667 (it throws a fit if you try to do 2 / 3 because ints)

## Media

https://github.com/user-attachments/assets/00084faf-0cc6-4edc-8dac-5c799e8f9aba

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- fix: Fixed Xenos being stunned by 50% longer than they were supposed to be.
