### PR TITLE
Add gauze and scar markings to Vulpkanin

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/gauze.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/gauze.yml
@@ -3,7 +3,7 @@
   id: GauzeLefteyePatch
   bodyPart: Eyes
   markingCategory: Overlay
-  speciesRestriction: [Dwarf, Human, Arachnid, Felinid]
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin]
   coloring:
     default:
       type:
@@ -17,7 +17,7 @@
   id: GauzeLefteyePad
   bodyPart: Eyes
   markingCategory: Overlay
-  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, Felinid]
+  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, Felinid, Vulpkanin]
   coloring:
     default:
       type:
@@ -31,7 +31,7 @@
   id: GauzeRighteyePatch
   bodyPart: Eyes
   markingCategory: Overlay
-  speciesRestriction: [Dwarf, Human, Arachnid, Felinid]
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin]
   coloring:
     default:
       type:
@@ -45,7 +45,7 @@
   id: GauzeRighteyePad
   bodyPart: Eyes
   markingCategory: Overlay
-  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, Felinid]
+  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, Felinid, Vulpkanin]
   coloring:
     default:
       type:
@@ -59,7 +59,7 @@
   id: GauzeBlindfold
   bodyPart: Eyes
   markingCategory: Overlay
-  speciesRestriction: [Dwarf, Human, Arachnid, Felinid]
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin]
   coloring:
     default:
       type:
@@ -73,7 +73,7 @@
   id: GauzeShoulder
   bodyPart: Chest
   markingCategory: Overlay
-  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, Felinid]
+  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, Felinid, Vulpkanin]
   coloring:
     default:
       type:
@@ -87,7 +87,7 @@
   id: GauzeStomach
   bodyPart: Chest
   markingCategory: Overlay
-  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, Felinid]
+  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, Felinid, Vulpkanin]
   coloring:
     default:
       type:
@@ -101,7 +101,7 @@
   id: GauzeUpperArmRight
   bodyPart: RArm
   markingCategory: Overlay
-  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, Felinid]
+  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, Felinid, Vulpkanin]
   coloring:
     default:
       type:
@@ -115,7 +115,7 @@
   id: GauzeLowerArmRight
   bodyPart: RArm, RHand
   markingCategory: Overlay
-  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, Felinid]
+  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, Felinid, Vulpkanin]
   coloring:
     default:
       type:
@@ -129,7 +129,7 @@
   id: GauzeLeftArm
   bodyPart: LArm, LHand
   markingCategory: Overlay
-  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, Felinid]
+  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, Felinid, Vulpkanin]
   coloring:
     default:
       type:
@@ -143,7 +143,7 @@
   id: GauzeLowerLegLeft
   bodyPart: LFoot
   markingCategory: Overlay
-  speciesRestriction: [Dwarf, Human, Arachnid, Felinid]
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin]
   coloring:
     default:
       type:
@@ -157,7 +157,7 @@
   id: GauzeUpperLegLeft
   bodyPart: LLeg
   markingCategory: Overlay
-  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, Felinid]
+  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, Felinid, Vulpkanin]
   coloring:
     default:
       type:
@@ -171,7 +171,7 @@
   id: GauzeUpperLegRight
   bodyPart: RLeg
   markingCategory: Overlay
-  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, Felinid]
+  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, Felinid, Vulpkanin]
   coloring:
     default:
       type:
@@ -185,7 +185,7 @@
   id: GauzeLowerLegRight
   bodyPart: RFoot
   markingCategory: Overlay
-  speciesRestriction: [Dwarf, Human, Arachnid, Felinid]
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin]
   coloring:
     default:
       type:
@@ -199,7 +199,7 @@
   id: GauzeBoxerWrapRight
   bodyPart: RHand
   markingCategory: Overlay
-  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, Felinid]
+  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, Felinid, Vulpkanin]
   coloring:
     default:
       type:
@@ -213,7 +213,7 @@
   id: GauzeBoxerWrapLeft
   bodyPart: LHand
   markingCategory: Overlay
-  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, Felinid]
+  speciesRestriction: [Dwarf, Human, Reptilian, Arachnid, Felinid, Vulpkanin]
   coloring:
     default:
       type:

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/scars.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/scars.yml
@@ -2,7 +2,7 @@
   id: ScarEyeRight
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Human, Dwarf, Felinid]
+  speciesRestriction: [Human, Dwarf, Felinid, Vulpkanin]
   followSkinColor: true
   sprites:
   - sprite: Mobs/Customization/scars.rsi
@@ -12,7 +12,7 @@
   id: ScarEyeLeft
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Human, Dwarf, Felinid]
+  speciesRestriction: [Human, Dwarf, Felinid, Vulpkanin]
   followSkinColor: true
   sprites:
   - sprite: Mobs/Customization/scars.rsi
@@ -22,7 +22,7 @@
   id: ScarTopSurgeryShort
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Human, Dwarf, Felinid]
+  speciesRestriction: [Human, Dwarf, Felinid, Vulpkanin]
   sexRestriction: [Male]
   followSkinColor: true
   sprites:
@@ -33,7 +33,7 @@
   id: ScarTopSurgeryLong
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Human, Dwarf, Felinid]
+  speciesRestriction: [Human, Dwarf, Felinid, Vulpkanin]
   sexRestriction: [Male]
   followSkinColor: true
   sprites:
@@ -44,7 +44,7 @@
   id: ScarChest
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Human, Dwarf, Felinid]
+  speciesRestriction: [Human, Dwarf, Felinid, Vulpkanin]
   followSkinColor: true
   sprites:
   - sprite: Mobs/Customization/scars.rsi

--- a/Resources/Prototypes/_RMC14/Species/vulpkanin.yml
+++ b/Resources/Prototypes/_RMC14/Species/vulpkanin.yml
@@ -75,9 +75,6 @@
       points: 1
       required: true
       defaultMarkings: [ VulpEar ]
-    Overlay:
-      points: 2
-      required: false
 
 - type: humanoidBaseSprite
   id: MobVulpkaninHead


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Made Vulpkanin compatible with gauze/scar markings

## Why 

More customisation!

## Technical details
Just added Vulpkanin to the whitelist for existing gauze/scar markings

## Media
![image](https://github.com/user-attachments/assets/93d24bc9-ce6d-4cc9-8887-364391ccd939)



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->



:cl:
- add: Allowed Vulpkanin to use gauze/scar markings
