### PR TITLE
Add combat technician's small tool webbing and construction rig

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
@@ -120,7 +120,7 @@
   parent: CMBeltUtility
   id: RMCBeltConstruction
   name: M277 pattern construction rig
-  description: The M277 is a common rig used by Combat Technicians to carry around materials and other supplies. It consists of a modular belt with various clips. This version sarafices storage space for specialized material loading clips.
+  description: The M277 is a common rig used by Combat Technicians to carry around materials and other supplies. It consists of a modular belt with various clips. This version sacrifices storage space for specialized material loading clips.
   components:
   - type: Storage
     grid:

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
@@ -118,6 +118,50 @@
 
 - type: entity
   parent: CMBeltUtility
+  id: RMCBeltConstruction
+  name: M277 pattern construction rig
+  description: The M277 is a common rig used by Combat Technicians to carry around materials and other supplies. It consists of a modular belt with various clips. This version sarafices storage space for specialized material loading clips.
+  components:
+  - type: Storage
+    grid:
+    - 0,0,11,1 # 6 slots
+    whitelist:
+      tags:
+      - Crowbar
+      - Screwdriver
+      - Wirecutter
+      - Wrench
+      - CableCoil
+      - Multitool
+      - Flashlight
+      - PowerCell
+      - CMFireExtinguisherPortable
+      - RMCExplosiveBreachingCharge
+#     - # TODO nailgun, circuit board, plastic explosives, stock parts
+      components:
+      - Welder
+      - PowerCell
+      - TrayScanner
+      - GasAnalyzer
+      - LightReplacer
+      - EntrenchingTool
+      - BarbedWire
+      - Material
+      - Sentry
+      - EmptySandbag
+      - FullSandbag
+  - type: IgnoreContentsSize
+    items:
+      components:
+      - EntrenchingTool
+      - LightReplacer
+      - Material
+      - Sentry
+      - FullSandbag
+  - type: FixedItemSizeStorage
+
+- type: entity
+  parent: CMBeltUtility
   id: CMBeltUtilityCombat
   name: M276 pattern combat toolbelt rig
   description: The M276 pattern combat toolbelt rig is an alternative load-bearing equipment of the UNMC for engineers conducting repairs within combat zones. It consists of a modular belt with various clips and pouches for tools along with a holster for a sidearm. Due to the bulk of the sidearm, it is unable to hold as many tools as its standard counterpart.

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
@@ -158,7 +158,6 @@
       - Material
       - Sentry
       - FullSandbag
-  - type: FixedItemSizeStorage
 
 - type: entity
   parent: CMBeltUtility

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/webbing.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/webbing.yml
@@ -277,3 +277,76 @@
     - type: ExplosionResistance
       damageCoefficient: 0
       worn: false
+
+- type: entity
+  parent: CMWebbing
+  id: RMCToolWebbingSmall
+  name: small tool webbing
+  description: A brown synthcotton webbing that is similar in function to civilian tool aprons, but is more durable for field usage. This is the small low-budget version.
+  components:
+  - type: Storage
+    grid:
+    - 0,0,11,1 #6 slots
+    whitelist:
+      tags:
+      - Crowbar
+      - Screwdriver
+      - Wirecutter
+      - Wrench
+      - CableCoil
+      - Multitool
+      - PowerCell
+      # TODO nailgun
+      components:
+      - Welder
+      - PowerCell
+      - EntrenchingTool
+  - type: FixedItemSizeStorage
+  - type: IgnoreContentsSize
+    items:
+      components:
+      - EntrenchingTool
+      - LightReplacer
+  - type: Webbing
+    components:
+    - type: Storage
+      maxItemSize: Small
+      grid:
+      - 0,0,11,1 #6 slots
+      whitelist:
+        tags:
+        - Crowbar
+        - Screwdriver
+        - Wirecutter
+        - Wrench
+        - CableCoil
+        - Multitool
+        - PowerCell
+        # TODO nailgun
+        components:
+        - Welder
+        - PowerCell
+        - EntrenchingTool
+    - type: FixedItemSizeStorage
+    - type: IgnoreContentsSize
+      items:
+        components:
+        - EntrenchingTool
+        - LightReplacer
+    - type: ExplosionResistance
+      damageCoefficient: 0
+      worn: false
+
+- type: entity
+  parent: RMCToolWebbingSmall
+  id: RMCToolWebbingSmallFilled
+  suffix: Filled
+  components:
+  - type: StorageFill
+    contents:
+    - id: CMScrewdriver
+    - id: CMWrench
+    - id: CMWelder
+    - id: CMCrowbar
+    - id: CMWirecutter
+    - id: CMMultitool

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/engineer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/engineer.yml
@@ -249,8 +249,8 @@
       - id: RMCPouchFirstAidPills
         name: first-aid pouch (pills)
         recommended: true
-      - id: RMCPouchElectronicsFill
-        name: electronics pouch (Full)
+      # - id: RMCPouchElectronicsFill
+        # name: electronics pouch (Full)
       - id: RMCPouchExplosive
       - id: RMCPouchFlareFilled
         name: Flare pouch (Full)

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/engineer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/engineer.yml
@@ -230,6 +230,7 @@
       - id: RMCM276ShotgunShellLoadingRig
       - id: CMBeltMortar
       - id: CMBeltUtilityFilled
+        name: M276 pattern toolbelt rig (Full)
         # mandatory: true, TODO allow vendors to mark entries as mandatory
       - id: RMCBeltGrenade
       - id: RMCBeltConstruction

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/engineer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/engineer.yml
@@ -231,9 +231,9 @@
       - id: CMBeltMortar
       - id: CMBeltUtilityFilled
         # mandatory: true, TODO allow vendors to mark entries as mandatory
+      - id: RMCBeltGrenade
       - id: RMCBeltConstruction
         recommended: true
-      - id: RMCBeltGrenade
     - name: Pouches
       choices: { RMCPouch: 2 }
       entries:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/engineer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/engineer.yml
@@ -230,6 +230,8 @@
       - id: RMCM276ShotgunShellLoadingRig
       - id: CMBeltMortar
       - id: CMBeltUtilityFilled
+        # mandatory: true, TODO allow vendors to mark entries as mandatory
+      - id: RMCBeltConstruction
         recommended: true
       - id: RMCBeltGrenade
     - name: Pouches
@@ -246,7 +248,8 @@
       - id: RMCPouchFirstAidPills
         name: first-aid pouch (pills)
         recommended: true
-      #- id: CMElectronicsPouchFull
+      - id: RMCPouchElectronicsFill
+        name: electronics pouch (Full)
       - id: RMCPouchExplosive
       - id: RMCPouchFlareFilled
         name: Flare pouch (Full)
@@ -256,7 +259,7 @@
       - id: RMCPouchGeneralMedium
       - id: RMCPouchPistol
       - id: RMCPouchToolsFill
-        name: Tools pouch (Filled)
+        name: Tools pouch (Full)
     - name: Accessories
       choices: { CMAccessories: 1 }
       entries:
@@ -266,6 +269,8 @@
       - id: CMWebbing
       - id: CMWebbingPouch
       - id: CMWebbingHolster
+      - id: RMCToolWebbingSmallFilled
+        name: small tool webbing (Full)
     - name: Mask
       choices: { CMMask: 1 }
       entries:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added the small tool webbing and the M277 pattern construction rig from CM13

Construction rig carries various CT equipment
Small tool webbing is just a webbing but it carries tools
Both have 6 slots

## Media
Small Tool Webbing
![image](https://github.com/user-attachments/assets/48ad325e-f769-4c04-9582-0f4f122902c1)

Construction Rig
![image](https://github.com/user-attachments/assets/a9770cbf-ecbe-48cc-ad5c-36cb4ef23fea)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

:cl:
- add: Added the M277 pattern construction rig; it can carry materials, sentries, sandbags, and various tools. You can get it from the combat technician vendor.
- add: Added the small tool webbing to the combat technician vendor, it is a webbing that carries tools. It has 6 slots.
