### PR TITLE
Fixes XO accidently using the wrong loadout

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Command/executive_officer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Command/executive_officer.yml
@@ -1,4 +1,4 @@
-﻿- type: job
+- type: job
   parent: CMJobBase
   id: CMExecutiveOfficer
   name: cm-job-name-executive-officer
@@ -9,7 +9,7 @@
     department: CMCommand
     time: 18000 # 5 hours
   weight: 5
-  startingGear: CMGearStaffOfficer
+  startingGear: CMGearExecutiveOfficer
   icon: "CMJobIconExecutiveOfficer"
   requireAdminNotify: true
   joinNotifyCrew: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
XO spawned with the SO loadout for some reason, looked to be accidental.

this also gives them some things they were missing, a jacket, senior command headset, MP comms, fancy satchle bag
## Why / Balance
fixes #4895 and gives XO their correct loadout.

## Media
XO loadout
![image](https://github.com/user-attachments/assets/07d1565a-96a8-4be7-b5e1-76f48838a0bb)
SO loadout
![image](https://github.com/user-attachments/assets/969d4858-7fad-4702-8c4d-330054b46e81)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
**Changelog**
:cl:
- add: XOs have been given a coat, senior command headset, Leather satchle, and the MP radio channel.
