### PR TITLE
Fix Xenos no longer burn them self on lights

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Lighting/lighting.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Lighting/lighting.yml
@@ -1,4 +1,4 @@
-﻿# Light Tubes
+# Light Tubes
 
 # Light Tube, Always Powered
 - type: entity
@@ -32,6 +32,10 @@
     graph: CMLightFixture
     node: tubeLight
   - type: RMCBreakLightOnAttack
+  - type: InteractedBlacklist
+    blacklist:
+      components:
+      - Xeno
 
 - type: entity
   parent: CMLightFixtureAlwaysPowered


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
prevents xenos from burning them self on lights

## Why / Balance
fixes #4497

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Xenos can't burn them self on lights anymore.

