### PR TITLE
Make phones make a popup when starting a call

### DIFF
--- a/Content.Shared/_RMC14/Telephone/SharedTelephoneSystem.cs
+++ b/Content.Shared/_RMC14/Telephone/SharedTelephoneSystem.cs
@@ -180,9 +180,9 @@ public abstract class SharedTelephoneSystem : EntitySystem
 
         // Emit the popup on a successful call.
         // Check for the marine component cause we don't want walls calling phones.
-        if (TryComp<MarineComponent>(user, out var marine) && TryComp(user, out MetaDataComponent? meta))
+        if (TryComp<MarineComponent>(user, out var marine) && TryComp(user, out MetaDataComponent? marinemeta) && TryComp(ent, out MetaDataComponent? phonemeta))
         {
-            _popup.PopupEntity($"{meta.EntityName} dials a number on the rotary phone.", ent);
+            _popup.PopupEntity($"{marinemeta.EntityName} dials a number on the {phonemeta.EntityName}.", ent);
         }
 
         ent.Comp.Idle = false;

--- a/Content.Shared/_RMC14/Telephone/SharedTelephoneSystem.cs
+++ b/Content.Shared/_RMC14/Telephone/SharedTelephoneSystem.cs
@@ -178,6 +178,13 @@ public abstract class SharedTelephoneSystem : EntitySystem
             return;
         }
 
+        // Emit the popup on a successful call.
+        // Check for the marine component cause we don't want walls calling phones.
+        if (TryComp<MarineComponent>(user, out var marine) && TryComp<MetaDataComponent>(user, out var meta))
+        {
+            _popup.PopupEntity($"{meta.EntityName} dials a number on the rotary phone.", ent);
+        }
+
         ent.Comp.Idle = false;
         ent.Comp.LastCall = time;
         Dirty(ent);

--- a/Content.Shared/_RMC14/Telephone/SharedTelephoneSystem.cs
+++ b/Content.Shared/_RMC14/Telephone/SharedTelephoneSystem.cs
@@ -180,7 +180,7 @@ public abstract class SharedTelephoneSystem : EntitySystem
 
         // Emit the popup on a successful call.
         // Check for the marine component cause we don't want walls calling phones.
-        if (TryComp<MarineComponent>(user, out var marine) && TryComp<MetaDataComponent>(user, out var meta))
+        if (TryComp<MarineComponent>(user, out var marine) && TryComp(user, out MetaDataComponent? meta))
         {
             _popup.PopupEntity($"{meta.EntityName} dials a number on the rotary phone.", ent);
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Phones now make a popup including the name of who's calling.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Cause I've had it with the briefing phone spam.

## Technical details
<!-- Summary of code changes for easier review. -->

Literally a six line change.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

![image](https://github.com/user-attachments/assets/746212f0-8a0d-496b-a28d-8ab3adbd33c0)
![image](https://github.com/user-attachments/assets/f173c6a1-9972-4a37-aa5b-879881aef449)
(Image slightly outdated, it now fills in the phone being used to make the call correctly.)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- add: Phones now make a popup including the name of who initiated the call.
