### PR TITLE
Fix Strains consuming points when turned into

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Evolution/NewXenoEvolvedEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/NewXenoEvolvedEvent.cs
@@ -1,4 +1,4 @@
 ﻿namespace Content.Shared._RMC14.Xenonids.Evolution;
 
 [ByRefEvent]
-public readonly record struct NewXenoEvolvedEvent(Entity<XenoEvolutionComponent> OldXeno, EntityUid NewXeno);
+public readonly record struct NewXenoEvolvedEvent(Entity<XenoEvolutionComponent> OldXeno, EntityUid NewXeno, bool SubtractPoints);

--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
@@ -206,7 +206,7 @@ public sealed class XenoEvolutionSystem : EntitySystem
             return;
 
         var newXeno = TransferXeno(xeno, args.Choice);
-        var ev = new NewXenoEvolvedEvent(xeno, newXeno);
+        var ev = new NewXenoEvolvedEvent(xeno, newXeno, false);
         RaiseLocalEvent(newXeno, ref ev, true);
 
         _adminLog.Add(LogType.RMCEvolve, $"Xenonid {ToPrettyString(xeno)} chose strain {ToPrettyString(newXeno)}");
@@ -237,7 +237,7 @@ public sealed class XenoEvolutionSystem : EntitySystem
         args.Handled = true;
 
         var newXeno = TransferXeno(xeno, args.Choice);
-        var ev = new NewXenoEvolvedEvent(xeno, newXeno);
+        var ev = new NewXenoEvolvedEvent(xeno, newXeno, true);
         RaiseLocalEvent(newXeno, ref ev, true);
 
         _adminLog.Add(LogType.RMCEvolve, $"Xenonid {ToPrettyString(xeno)} evolved into {ToPrettyString(newXeno)}");
@@ -252,7 +252,7 @@ public sealed class XenoEvolutionSystem : EntitySystem
 
     private void OnXenoEvolutionNewEvolved(Entity<XenoEvolutionComponent> xeno, ref NewXenoEvolvedEvent args)
     {
-        TransferPoints((args.OldXeno, args.OldXeno), xeno, true);
+        TransferPoints((args.OldXeno, args.OldXeno), xeno, args.SubtractPoints);
         _jitter.DoJitter(xeno, xeno.Comp.EvolutionJitterDuration, true, 80, 8, true);
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed Strains subtracting the T2/T3 evolve price when attempting to become one.

CM13 Parity. Strains don't use evolution points.

## Technical details
Added a bool to the evolution event that says whether to subtract points. Evolution sets it to true. Becoming a strain sets it to false.

## Media

https://github.com/user-attachments/assets/2cc76952-5b1b-4a16-94c0-9b7a2572626a


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:
- fix: Turning into a Xeno strain no longer consumes points.

