### PR TITLE
Add item mapper for command pouch

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Pouches/storage.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Pouches/storage.yml
@@ -157,14 +157,30 @@
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Pouches/command.rsi
-    layers: # TODO RMC14 on sprite binoculars and tablet
+    layers:
     - state: cmateba
       map: [ "enum.CMHolsterLayers.Fill" ]
       visible: false
       offset: -0.19, 0
     - state: icon
+    - state: command_pouch_binos
+      map: ["command_pouch_binos"]
+      visible: false
+    - state: command_pouch_tablet
+      map: ["command_pouch_tablet"]
+      visible: false
     - state: closed
       map: [ "closedLayer" ]
+  - type: ItemMapper
+    mapLayers:
+      command_pouch_binos:
+        whitelist:
+          tags:
+          - Binoculars
+      command_pouch_tablet:
+        whitelist:
+          tags:
+          - CommandTablet
   - type: Storage
     maxItemSize: Normal
     grid:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds display of the commander officer's tablet sprites when binoculars or a tablet are present.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
CM13 parity

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/2d0411d1-80cf-4f1b-8c18-1b1508985160)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
