### PR TITLE
Grenade yml cleanup and fix molotov fitting in GL 

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -27,7 +27,19 @@
   - type: ChangeItemSizeOnTimerTrigger
 
 - type: entity
-  parent: CMGrenadeBase
+  abstract: true
+  id: RMCM40DPTags
+  components:
+  - type: Tag
+    tags:
+    - Grenade
+    - LauncherCompatibleGrenade
+    - RMCGrenadeM40
+
+- type: entity
+  parent:
+  - CMGrenadeBase
+  - RMCM40DPTags 
   id: CMGrenadeHighExplosive
   name: M40 HEDP grenade
   description: High-Explosive Dual-Purpose. A small, but deceptively strong blast grenade that has been phasing out the M15 HE grenades alongside the M40 HEFA. Capable of being loaded in grenade launchers, or thrown by hand.
@@ -40,18 +52,15 @@
     intensitySlope: 6
     totalIntensity: 200
     canCreateVacuum: false
-  - type: Tag
-    tags:
-    - Grenade
-    - LauncherCompatibleGrenade
-    - RMCGrenadeM40
   - type: Ammo
   - type: CMExplosionEffect
   - type: CMVocalizeTrigger
   - type: RMCScorchEffect
 
 - type: entity
-  parent: CMGrenadeBase
+  parent:
+  - CMGrenadeBase
+  - RMCM40DPTags 
   id: CMGrenadeSmoke
   name: M40 HSDP smoke grenade
   description: The M40 HSDP is a small, but powerful smoke grenade. Based off the same platform as the M40 HEDP. It is set to detonate in 2 seconds.
@@ -121,11 +130,6 @@
   - type: ContainerContainer
     containers:
       cluster-payload: !type:Container
-  - type: Tag
-    tags:
-    - Grenade
-    - LauncherCompatibleGrenade
-    - RMCGrenadeM40
   - type: Ammo
   - type: ClusterLimitHits
   - type: CMExplosionEffect
@@ -183,7 +187,9 @@
   - type: Ammo
 
 - type: entity
-  parent: CMGrenadeBase
+  parent:
+  - CMGrenadeBase
+  - RMCM40DPTags
   id: RMCGrenadeIncendiary
   name: M40 HIDP incendiary grenade
   description: The M40 HIDP is a small, but deceptively strong incendiary grenade designed to disrupt enemy mobility with long-lasting Type B napalm. It is set to detonate in 4 seconds.
@@ -192,9 +198,6 @@
     sprite: _RMC14/Objects/Weapons/Grenades/m40hidp.rsi
   - type: OnUseTimerTrigger
     beepSound: null
-  - type: Tag
-    tags:
-    - Grenade
   - type: CMVocalizeTrigger
   - type: TileFireOnTrigger
     spawn: RMCTileFireGreen
@@ -214,6 +217,9 @@
     max: 4
   - type: TileFireOnTrigger
     spawn: RMCTileFire
+  - type: Tag
+    tags:
+    - Grenade
 
 - type: entity
   id: CMExplosionEffectGrenade
@@ -275,4 +281,3 @@
 
 - type: Tag
   id: RMCGrenadeTraining
-


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
attempted to cleanup the yml a little, made an abstract entity with the Grenade, LauncherCompatibleGrenade and RMCGrenadeM40 tags, then got all of the M40 ##DP grenades to parent from that, to reduce the amount of repeated lines

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
