### PR TITLE
Make xenos unable to see ID/dogtag examines

### DIFF
--- a/Content.Shared/_RMC14/Examine/BlockIdExamineComponent.cs
+++ b/Content.Shared/_RMC14/Examine/BlockIdExamineComponent.cs
@@ -1,0 +1,7 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Examine;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(CMExamineSystem))]
+public sealed partial class BlockIdExamineComponent : Component {}

--- a/Content.Shared/_RMC14/Examine/CMExamineSystem.cs
+++ b/Content.Shared/_RMC14/Examine/CMExamineSystem.cs
@@ -31,6 +31,9 @@ public sealed class CMExamineSystem : EntitySystem
 
     private void OnIdExamined(Entity<IdExaminableComponent> ent, ref ExaminedEvent args)
     {
+        if (HasComp<BlockIdExamineComponent>(args.Examiner))
+            return;
+
         using (args.PushGroup(nameof(CMExamineSystem), 1))
         {
             if (_idExaminable.GetInfo(ent) is { } info)

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
@@ -287,6 +287,7 @@
     blacklist:
       components:
       - Marine
+  - type: BlockIdExamine
 
 - type: entity
   abstract: true


### PR DESCRIPTION
CM13 Parity


:cl:
- fix: Fixed xenos being able to see ID card / dogtag names by examining.