### PR TITLE
Fix Resin Holes not triggering when Marines stand up in them

### DIFF
--- a/Content.Server/_RMC14/Xenonids/Construction/ResinHole/XenoResinHoleSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Construction/ResinHole/XenoResinHoleSystem.cs
@@ -24,12 +24,15 @@ using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Popups;
+using Content.Shared.Standing;
 using Content.Shared.StepTrigger.Systems;
 using Content.Shared.Stunnable;
 using Content.Shared.Tag;
 using Robust.Server.Audio;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Systems;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Player;
 using static Content.Shared.Physics.CollisionGroup;
@@ -60,14 +63,19 @@ public sealed partial class XenoResinHoleSystem : SharedXenoResinHoleSystem
     [Dependency] private readonly StandingStateSystem _standing = default!;
     [Dependency] private readonly SharedXenoConstructionSystem _xenoConstruct = default!;
     [Dependency] private readonly SharedMapSystem _mapSystem = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
 
     private static readonly ProtoId<TagPrototype> AirlockTag = "Airlock";
     private static readonly ProtoId<TagPrototype> StructureTag = "Structure";
 
     private static readonly EntProtoId ResinHolePrototype = "XenoResinHole";
+    private EntityQuery<PhysicsComponent> _physicsQuery;
+
     public override void Initialize()
     {
         base.Initialize();
+
+        _physicsQuery = GetEntityQuery<PhysicsComponent>();
 
         SubscribeLocalEvent<XenoComponent, XenoPlaceResinHoleActionEvent>(OnPlaceXenoResinHole);
         SubscribeLocalEvent<XenoComponent, XenoPlaceResinHoleDestroyWeedSourceDoAfterEvent>(OnCompleteRemoveWeedSource);
@@ -84,6 +92,7 @@ public sealed partial class XenoResinHoleSystem : SharedXenoResinHoleSystem
         SubscribeLocalEvent<XenoResinHoleComponent, StepTriggeredOffEvent>(OnXenoResinHoleStepTriggered);
         SubscribeLocalEvent<XenoResinHoleComponent, ExaminedEvent>(OnExamine);
 
+        SubscribeLocalEvent<InResinHoleRangeComponent, StoodEvent>(OnInRangeStand);
     }
 
     private void OnPlaceXenoResinHole(Entity<XenoComponent> xeno, ref XenoPlaceResinHoleActionEvent args)
@@ -370,6 +379,9 @@ public sealed partial class XenoResinHoleSystem : SharedXenoResinHoleSystem
         }
         else if (_mobState.IsDead(args.Tripper) || _standing.IsDown(args.Tripper))
         {
+            var inRange = EnsureComp<InResinHoleRangeComponent>(args.Tripper);
+            if (!inRange.HoleList.Contains(resinHole))
+                inRange.HoleList.Add(resinHole);
             args.Continue = false;
             return;
         }
@@ -384,6 +396,43 @@ public sealed partial class XenoResinHoleSystem : SharedXenoResinHoleSystem
             _stun.TryParalyze(args.Tripper, resinHole.Comp.StepStunDuration, true);
         }
         ActivateTrap(resinHole);
+    }
+
+    private void OnInRangeStand(Entity<InResinHoleRangeComponent> tripper, ref StoodEvent args)
+    {
+        for (var i  = tripper.Comp.HoleList.Count - 1; i >= 0; i--)
+        {
+            var resinHole = tripper.Comp.HoleList[i];
+
+            if (!TryComp<XenoResinHoleComponent>(resinHole, out var holeComponent))
+            {
+                tripper.Comp.HoleList.Remove(resinHole);
+                continue;
+            }
+
+            //Check if each Resin Hole is still colliding with tripper
+            if (!_physicsQuery.TryGetComponent(resinHole, out var physics))
+            {
+                tripper.Comp.HoleList.Remove(resinHole);
+                continue;
+            }
+
+            foreach (var ent in _physics.GetContactingEntities(resinHole, physics))
+            {
+                if (ent != tripper.Owner)
+                    continue;
+
+                ActivateTrap((resinHole, holeComponent));
+                tripper.Comp.HoleList.Remove(resinHole);
+
+                if (tripper.Comp.HoleList.Count == 0)
+                {
+                    RemCompDeferred<InResinHoleRangeComponent>(tripper);
+                }
+                //Only trigger one trap maximum per stand-up
+                return;
+            }
+        }
     }
 
     private bool CanPlaceResinHole(EntityUid user, EntityCoordinates coords)

--- a/Content.Server/_RMC14/Xenonids/Construction/ResinHole/XenoResinHoleSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Construction/ResinHole/XenoResinHoleSystem.cs
@@ -433,6 +433,8 @@ public sealed partial class XenoResinHoleSystem : SharedXenoResinHoleSystem
                 return;
             }
         }
+
+        RemCompDeferred<InResinHoleRangeComponent>(tripper);
     }
 
     private bool CanPlaceResinHole(EntityUid user, EntityCoordinates coords)

--- a/Content.Server/_RMC14/Xenonids/Construction/ResinHole/XenoResinHoleSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Construction/ResinHole/XenoResinHoleSystem.cs
@@ -410,6 +410,10 @@ public sealed partial class XenoResinHoleSystem : SharedXenoResinHoleSystem
                 continue;
             }
 
+            //Continue if trap has emptied or been replaced with a parasite
+            if (holeComponent.TrapPrototype is null || holeComponent.TrapPrototype == XenoResinHoleComponent.ParasitePrototype)
+                continue;
+
             //Check if each Resin Hole is still colliding with tripper
             if (!_physicsQuery.TryGetComponent(resinHole, out var physics))
             {

--- a/Content.Shared/_RMC14/Xenonids/Construction/ResinHole/InResinHoleRangeComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/ResinHole/InResinHoleRangeComponent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.Construction.ResinHole;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class InResinHoleRangeComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public List<EntityUid> HoleList = new();
+}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
When Marines stand up after being knocked down while inside of a Resin Trap, the trap will trigger.

CM13 Parity. Needed for Burrower to function correctly in combat.

## Technical details
Adds a component "InResinHoleRangeComponent" that tracks all of the Resin Holes a mob has come into contact with while on the knocked down on the floor (either while crit/dead or just plain knocked down).

On a StoodEvent from an entity with the InResinHoleRangeComponent, it will cycle over this list of holes and check each one to see if it is still contacting the mob. If it is still contacting the mob, the trap in question will trigger, it will be removed from the list of holes, and the function will return, never triggering more than 1 trap per stand up.

Removes the component if no traps are in range entirely, thus also clearing the list.

## Media

https://github.com/user-attachments/assets/61e1f560-16f7-4429-82cb-7f47a4726727

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- fix: Fixed Resin Hole Acid Traps not triggering when a Marine stands up after being dragged in.
