### PR TITLE
Fix info tag collection range + QOL

### DIFF
--- a/Content.Shared/_RMC14/Marines/Dogtags/DogtagsSystem.cs
+++ b/Content.Shared/_RMC14/Marines/Dogtags/DogtagsSystem.cs
@@ -1,8 +1,9 @@
-﻿using Content.Shared._RMC14.Marines.Skills;
+﻿using Content.Shared._RMC14.Medical.Defibrillator;
+using Content.Shared._RMC14.Marines.Skills;
 using Content.Shared._RMC14.Xenonids;
+using Content.Shared._RMC14.Xenonids.Parasite;
 using Content.Shared.Access.Components;
 using Content.Shared.Atmos.Rotting;
-using Content.Shared.Disposal;
 using Content.Shared.Examine;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
@@ -10,12 +11,9 @@ using Content.Shared.Inventory;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Popups;
 using Content.Shared.Verbs;
-using Content.Shared.Interaction;
 using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
-using Content.Shared._RMC14.Medical.Defibrillator;
-using Content.Shared._RMC14.Xenonids.Parasite;
 
 namespace Content.Shared._RMC14.Marines.Dogtags;
 

--- a/Content.Shared/_RMC14/Marines/Dogtags/DogtagsSystem.cs
+++ b/Content.Shared/_RMC14/Marines/Dogtags/DogtagsSystem.cs
@@ -160,8 +160,9 @@ public sealed class DogtagsSystem : EntitySystem
             return;
 
         var tag = SpawnNextToOrDrop(tags.Comp.InfoTag, wearer);
+		Dirty(tags);
 
-        var comp = EnsureComp<InformationTagsComponent>(tag);
+		var comp = EnsureComp<InformationTagsComponent>(tag);
         GetTagInformation(tags, out var name, out var job, out var blood);
         InfoTagInfo tagInfo = new InfoTagInfo()
         {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
You can now also take tags from bursted and suicided corpses. Kinda weird that CM doesn't allow you to immediately take tags from the bursted or those who can't be revived.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug and QOL. Fixes #5005, fixes a discord issue.

## Technical details
<!-- Summary of code changes for easier review. -->
Lil function that checks all these things.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/abdffbda-e08c-4461-b9ff-7c552e8a1285



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fix range at which info tags are collectable
- tweak: Info tags can now also be collected unskilled from recently bursted or suicided humanoids.
