### PR TITLE
colored fire lights!

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Tiles/tile_fire.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Tiles/tile_fire.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   id: RMCTileFire
   name: fire
   placement:
@@ -29,6 +29,8 @@
   - type: InteractionOutline
   - type: PointLight
     radius: 2
+    energy: 2
+    color: "#FFBF00"
   - type: EffectVisuals
   - type: Tag
     tags:
@@ -64,6 +66,8 @@
     layers:
     - map: [ "base" ]
       state: green_4
+  - type: PointLight
+    color: "#00cf5a"
   - type: RMCIgniteOnCollide
     maxStacks: 10
     tileDamage:
@@ -98,6 +102,8 @@
     layers:
     - map: [ "base" ]
       state: white_4
+  - type: PointLight
+    color: "#C8FFFF"
   - type: RMCIgniteOnCollide
     intensity: 80
     duration: 70

--- a/Resources/Prototypes/_RMC14/Entities/Tiles/tile_fire.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Tiles/tile_fire.yml
@@ -28,9 +28,8 @@
   - type: Clickable
   - type: InteractionOutline
   - type: PointLight
-    radius: 2
-    energy: 2
-    color: "#FFBF00"
+    radius: 4.75
+    color: "#bfa902"
   - type: EffectVisuals
   - type: Tag
     tags:
@@ -67,7 +66,7 @@
     - map: [ "base" ]
       state: green_4
   - type: PointLight
-    color: "#00cf5a"
+    color: "#069420"
   - type: RMCIgniteOnCollide
     maxStacks: 10
     tileDamage:
@@ -103,7 +102,7 @@
     - map: [ "base" ]
       state: white_4
   - type: PointLight
-    color: "#C8FFFF"
+    color: "#8fcbeb"
   - type: RMCIgniteOnCollide
     intensity: 80
     duration: 70

--- a/Resources/Prototypes/_RMC14/Entities/Tiles/tile_fire.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Tiles/tile_fire.yml
@@ -28,8 +28,8 @@
   - type: Clickable
   - type: InteractionOutline
   - type: PointLight
-    radius: 4.75
-    color: "#bfa902"
+    radius: 5
+    color: "#bf6d02"
   - type: EffectVisuals
   - type: Tag
     tags:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
changed the Hex code of molotov, HIDP and OB fires light, couldn't get the colors 1:1, but i think the out come was good.
also increased the light radius closer to parity.

## Why / Balance
resolves #5011

## Media
![image](https://github.com/user-attachments/assets/1d5f4347-dc8c-4a15-a480-d6f6abc6d3f9)
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: Basic, green and white fires, no longer emit a basic white light, they emit their own unique color of light. 


