### PR TITLE
Fix button system

### DIFF
--- a/Content.Shared/_RMC14/Doors/CMDoorSystem.cs
+++ b/Content.Shared/_RMC14/Doors/CMDoorSystem.cs
@@ -13,6 +13,8 @@ using Robust.Shared.Map.Enumerators;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Timing;
+using Content.Shared._RMC14.Survivor;
+using Content.Shared._RMC14.Marines;
 
 namespace Content.Shared._RMC14.Doors;
 
@@ -58,7 +60,7 @@ public sealed class CMDoorSystem : EntitySystem
     private void OnButtonActivateInWorld(Entity<RMCDoorButtonComponent> button, ref ActivateInWorldEvent args)
     {
         var user = args.User;
-        if (HasComp<XenoComponent>(user))
+        if (!HasComp<MarineComponent>(user) || !HasComp<SurvivorComponent>(user))
             return;
 
         if (!_accessReader.IsAllowed(user, button))


### PR DESCRIPTION
Now only entities with a SurvivorComponent or MarineComponent can press buttons

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? --> Content.Shared/_RMC14/Doors/CMDoorSystem.cs

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. --> bug fixes

## Technical details
<!-- Summary of code changes for easier review. --> added check for SurvivorComponent and MarineComponent
