### PR TITLE
Fix auto punctuation breaking with sanitization

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -759,14 +759,14 @@ public sealed partial class ChatSystem : SharedChatSystem
         var newMessage = message.Trim();
         newMessage = SanitizeMessageReplaceWords(source, newMessage);
 
+        _sanitizer.TrySanitizeOutSmilies(newMessage, source, out newMessage, out emoteStr);
+
         if (capitalize)
             newMessage = SanitizeMessageCapital(newMessage);
         if (capitalizeTheWordI)
             newMessage = SanitizeMessageCapitalizeTheWordI(newMessage, "i");
         if (punctuate)
             newMessage = SanitizeMessagePeriod(newMessage);
-
-        _sanitizer.TrySanitizeOutSmilies(newMessage, source, out newMessage, out emoteStr);
 
         return newMessage;
     }


### PR DESCRIPTION
If you say "lol" with auto punctuation enabled, normally it will come out as "*laughs*", but instead it will come out as "Lol."

this is a simple pr, just makes the smilieys santize run before the message gets auto punctuated


:cl:
- fix: Fixed auto punctuation causing messages like "Lol" to not sanitize