### PR TITLE
Fix xeno AOE abilities hitting devoured marines

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared._RMC14.Medical.Scanner;
 using Content.Shared._RMC14.NightVision;
 using Content.Shared._RMC14.Vendors;
 using Content.Shared._RMC14.Xenonids.Construction.Nest;
+using Content.Shared._RMC14.Xenonids.Devour;
 using Content.Shared._RMC14.Xenonids.Evolution;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Parasite;
@@ -334,6 +335,9 @@ public sealed class XenoSystem : EntitySystem
             return false;
 
         if (_mobState.IsDead(target))
+            return false;
+
+        if (HasComp<DevouredComponent>(target))
             return false;
 
         if (_xenoNestedQuery.HasComp(target))


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Unintentional with AOEs to hit marines currently devoured. This doesn't stop them from hitting people in containers in general which I think is fine?

## Technical details
<!-- Summary of code changes for easier review. -->
xeno system check.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed xeno AOE abilities hitting devoured marines
