### PR TITLE
Xeno Build Buttons work when clicked instead of when you stop clicking

### DIFF
--- a/Content.Client/_RMC14/Xenonids/Construction/XenoChooseStructureBui.cs
+++ b/Content.Client/_RMC14/Xenonids/Construction/XenoChooseStructureBui.cs
@@ -42,6 +42,7 @@ public sealed class XenoChooseStructureBui : BoundUserInterface
 
                 var control = new XenoChoiceControl();
                 control.Button.Group = group;
+                control.Button.Mode = 0;
 
                 var name = structure.Name;
                 if (_xenoConstruction.GetStructurePlasmaCost(structureId) is { } cost)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed the button mode of choosing structures to occur when the button is pressed, instead of when the button is released (you let go of the mouse button).

## Why / Balance
QoL. The choose resin structure window is something that is constantly cycled between the in-game space and the buttons, when building and choosing different structures very quickly sometimes your option may not actually select if you're too fast, or your game client is lagging.

## Technical details
Button.Mode = 0 instead of 1

## Media
Video Demonstration

https://github.com/user-attachments/assets/dc7aac3b-ae91-452b-b180-ca484973d30c

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- tweak: The buttons for choosing resin structures for Drone castes are now much more responsive. It will now immediately select the option you click on, instead of cancelling if you drag your mouse away before letting go of the mouse button.

