### PR TITLE
Allow switching hands while using the Bipod

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/under_attachments.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/under_attachments.yml
@@ -45,7 +45,6 @@
     - RMCAttachmentUnderbarrel
     - RMCAttachmentBipod
   - type: AttachableToggleable
-    needHand: true
     heldOnlyActivate: true
     userOnly: true
     doInterrupt: true

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/under_attachments.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/under_attachments.yml
@@ -53,6 +53,7 @@
     breakOnFullRotate: true
     doAfter: 1.5
     deactivateDoAfter: 0
+    doAfterNeedHand: false
     instantToggle: Brace
     useDelay: 0.5
     activatePopupText: attachable-popup-activate-deploy-on-ground


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Allowed you to switch hands while deploying the Bipod and while having the Bipod deployed, CM13 Parity.

## Why / Balance
It is parity, we love parity!

https://github.com/user-attachments/assets/9f9d512a-2e37-484b-9b6b-adcb4e5db4f1

## Media

https://github.com/user-attachments/assets/22ae14ed-25bc-4881-b403-11732e97caa4


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- tweak: You can now freely switch hands and wield/unwield while deploying and using a Bipod.
