### PR TITLE
Nerf Frenzy Pulling boost by ~50%

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Pheromones/SharedXenoPheromonesSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Pheromones/SharedXenoPheromonesSystem.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using Content.Shared._RMC14.Pulling;
 using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared.Actions;
 using Content.Shared.Coordinates;
@@ -7,6 +8,7 @@ using Content.Shared.FixedPoint;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
+using Content.Shared.Movement.Pulling.Events;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Popups;
 using Content.Shared.Weapons.Melee.Events;
@@ -66,6 +68,9 @@ public abstract class SharedXenoPheromonesSystem : EntitySystem
         SubscribeLocalEvent<XenoFrenzyPheromonesComponent, ComponentRemove>(OnFrenzyRemove);
         SubscribeLocalEvent<XenoFrenzyPheromonesComponent, GetMeleeDamageEvent>(OnFrenzyGetMeleeDamage);
         SubscribeLocalEvent<XenoFrenzyPheromonesComponent, RefreshMovementSpeedModifiersEvent>(OnFrenzyMovementSpeedModifiers);
+        SubscribeLocalEvent<XenoFrenzyPheromonesComponent, PullStartedMessage>(OnFrenzyPullStarted, after: [typeof(RMCPullingSystem)] );
+        SubscribeLocalEvent<XenoFrenzyPheromonesComponent, PullStoppedMessage>(OnFrenzyPullStopped, after: [typeof(RMCPullingSystem)] );
+
 
         SubscribeLocalEvent<XenoActivePheromonesComponent, MobStateChangedEvent>(OnActiveMobStateChanged);
 
@@ -176,7 +181,20 @@ public abstract class SharedXenoPheromonesSystem : EntitySystem
     private void OnFrenzyMovementSpeedModifiers(Entity<XenoFrenzyPheromonesComponent> frenzy, ref RefreshMovementSpeedModifiersEvent args)
     {
         var speed = 1 + (frenzy.Comp.MovementSpeedModifier * frenzy.Comp.Multiplier).Float();
+        if (HasComp<PullingSlowedComponent>(frenzy.Owner))
+            speed = 1 + (frenzy.Comp.PullMovementSpeedModifier * frenzy.Comp.Multiplier).Float();
+        
         args.ModifySpeed(speed, speed);
+    }
+
+    private void OnFrenzyPullStarted(Entity<XenoFrenzyPheromonesComponent> frenzy, ref PullStartedMessage args)
+    {
+        _movementSpeed.RefreshMovementSpeedModifiers(args.PullerUid);
+    }
+
+    private void OnFrenzyPullStopped(Entity<XenoFrenzyPheromonesComponent> frenzy, ref PullStoppedMessage args)
+    {
+        _movementSpeed.RefreshMovementSpeedModifiers(args.PullerUid);
     }
 
     private void AssignMaxMultiplier(ref FixedPoint2 a, FixedPoint2 b)

--- a/Content.Shared/_RMC14/Xenonids/Pheromones/XenoFrenzyPheromonesComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Pheromones/XenoFrenzyPheromonesComponent.cs
@@ -24,5 +24,8 @@ public sealed partial class XenoFrenzyPheromonesComponent : Component
     public FixedPoint2 MovementSpeedModifier = 0.06;
 
     [DataField, AutoNetworkedField]
+    public FixedPoint2 PullMovementSpeedModifier = 0.03;
+
+    [DataField, AutoNetworkedField]
     public List<ProtoId<DamageTypePrototype>> DamageTypes = new() { "Blunt", "Slash", "Piercing" };
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
If you are a xeno with frenzy and pulling, your frenzy boost gets halved. Far closer to CM13 Parity.

## Why / Balance
It Brings Lurker frenzy pulling into Parity primarily Lurker was travelling at 2.47 TPS whe pulling with T4 Queen Frenzy when it was supposed to be travelling at ~2.23 TPS. Making the modifier 0.03 instead of 0.06 specifically when pulling reaches this breakpoint. Other Xenos may not reach their exact breakpoints but this is the one everyone was attacking me over so this is the one that I used.

## Technical details
Add pulling speed modifier field, set to 0.03, used when pulling, as opposed to the standard 0.06.

SharedXenoPheromoneSystem now calculates speed based on whether or not you are pulling. 2 new events were added to this system to refresh your movement speed modifiers when you start and stop pulling, specifically happening after RMCPullingSystem has handled the events so that the PullingSlowedComponent can be correctly added or removed.

## Media

https://github.com/user-attachments/assets/03d9ebde-2c3b-4a22-999d-5e60a11e226d

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- fix: Halved the speed bonus Frenzy gives while pulling to more closely match CM13. This means overall pulling speeds are reduced by ~10% total.
