### PR TITLE
Dodge no longer counts downed marines for it's double speed boost

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Dodge/XenoDodgeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Dodge/XenoDodgeSystem.cs
@@ -2,6 +2,7 @@
 using Content.Shared.Mobs.Components;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Popups;
+using Content.Shared.Standing;
 using Robust.Shared.Network;
 using Robust.Shared.Timing;
 
@@ -16,6 +17,7 @@ public sealed class XenoDodgeSystem : EntitySystem
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
     [Dependency] private readonly XenoSystem _xeno = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly StandingStateSystem _standing = default!;
 
     private readonly HashSet<Entity<MobStateComponent>> _crowd = new();
     public override void Initialize()
@@ -30,10 +32,10 @@ public sealed class XenoDodgeSystem : EntitySystem
 
     private void OnXenoActionDodge(Entity<XenoDodgeComponent> xeno, ref XenoDodgeActionEvent args)
     {
-		if (args.Handled)
-			return;
+        if (args.Handled)
+            return;
 
-		if (!_plasma.TryRemovePlasmaPopup(xeno.Owner, xeno.Comp.PlasmaCost))
+        if (!_plasma.TryRemovePlasmaPopup(xeno.Owner, xeno.Comp.PlasmaCost))
             return;
 
         args.Handled = true;
@@ -84,7 +86,7 @@ public sealed class XenoDodgeSystem : EntitySystem
             bool crowd = false;
             foreach (var mob in _crowd)
             {
-                if (_xeno.CanAbilityAttackTarget(uid, mob))
+                if (_xeno.CanAbilityAttackTarget(uid, mob) && !_standing.IsDown(mob))
                 {
                     crowd = true;
                     break;

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_self_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_self_actions.yml
@@ -243,7 +243,7 @@
   id: ActionXenoDodge
   parent: ActionXenoBase
   name: Dodge (200)
-  description: Gain a speed boost for 7 seconds. Your speed is doubled near enemies.
+  description: Gain a speed boost for 7 seconds. Your speed is doubled near standing enemies.
   components:
   - type: InstantAction
     itemIconStyle: NoItem


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Few reasons:
1. You aren't supposed to be able to much drag faster
2. The extra boost is made to replicate the ease of movement a dancer has in a marine crowd in CM with dodge, but when someone is downed in CM you could already move freely though them.

## Technical details
<!-- Summary of code changes for easier review. -->
checks for down seperately now

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed Dancer Praetorian's dodge double speed buff counting downed marines.
