### PR TITLE
Fix Burrowed Larva not appearing on end card

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Hive/SharedXenoHiveSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hive/SharedXenoHiveSystem.cs
@@ -281,7 +281,7 @@ public abstract class SharedXenoHiveSystem : EntitySystem
         if (hive.Comp.BurrowedLarva <= 0)
             return;
 
-        EntityUid? spawned = null;
+        EntityUid? larva = null;
 
         bool TrySpawnAt<T>() where T : Component
         {
@@ -295,7 +295,7 @@ public abstract class SharedXenoHiveSystem : EntitySystem
                     continue;
 
                 var position = _transform.GetMoverCoordinates(uid);
-                spawned = SpawnAtPosition(hive.Comp.BurrowedLarvaId, position);
+                larva = SpawnAtPosition(hive.Comp.BurrowedLarvaId, position);
                 return true;
             }
 
@@ -309,21 +309,20 @@ public abstract class SharedXenoHiveSystem : EntitySystem
             return;
         }
 
-        if (spawned == null)
+        if (larva == null)
             return;
 
         hive.Comp.BurrowedLarva--;
         Dirty(hive);
 
-        _xeno.MakeXeno(spawned.Value);
-        _hive.SetHive(spawned.Value, hive);
+        _xeno.MakeXeno(larva.Value);
+        _hive.SetHive(larva.Value, hive);
 
         if (TryComp(user, out ActorComponent? actor))
         {
-            if (!_mind.TryGetMind(actor.PlayerSession.UserId, out var mind))
-                mind = _mind.CreateMind(actor.PlayerSession.UserId);
+            var newMind = _mind.CreateMind(actor.PlayerSession.UserId, EntityManager.GetComponent<MetaDataComponent>(larva.Value).EntityName);
 
-            _mind.TransferTo(mind.Value, spawned, ghostCheckOverride: true);
+            _mind.TransferTo(newMind, larva, ghostCheckOverride: true);
         }
 
         _adminLog.Add(LogType.RMCBurrowedLarva, $"{ToPrettyString(user):player} took a burrowed larva from hive {ToPrettyString(hive):hive}.");


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed Burrowed Larva not making a new mind, and instead reusing the last mind used (initial observer, Marine, etc)

## Why / Balance
Fixium

## Technical details
Always create a new mind for burrowed larva, like how ghost roles do, so they don't overwrite your previous mind.

Also renamed spawned to larva for code readability.

## Media

https://github.com/user-attachments/assets/12d28704-1b43-4218-820c-6638d7974baf

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- fix: Fixed Burrowed Larva not registering as a new entity on the round end summary.