### PR TITLE
Carryover Voting

### DIFF
--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
@@ -1254,14 +1254,14 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
         if (!_config.GetCVar(RMCCVars.RMCPlanetMapVote))
             return;
 
-        if (!_useCarryoverVoting) {
-            foreach (var (planet, votes) in planets.Zip(args.Votes))
+        var planets = _planetMaps.Split(",").ToList();
+        if (!_useCarryoverVoting)
+        {
+            foreach (var planet in planets)
             {
                 _carryoverVotes[planet] = 0;
             }
         }
-
-        var planets = _planetMaps.Split(",").ToList();
         planets.RemoveAll(p => _lastPlanetMaps.Contains(p));
 
         var vote = new VoteOptions

--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
@@ -1254,6 +1254,13 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
         if (!_config.GetCVar(RMCCVars.RMCPlanetMapVote))
             return;
 
+        if (!_useCarryoverVoting) {
+            foreach (var (planet, votes) in planets.Zip(args.Votes))
+            {
+                _carryoverVotes[planet] = 0;
+            }
+        }
+
         var planets = _planetMaps.Split(",").ToList();
         planets.RemoveAll(p => _lastPlanetMaps.Contains(p));
 
@@ -1269,7 +1276,7 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
         handle.OnFinished += (_, args) =>
         {
             string picked;
-            
+
             var voteResult = planets.Zip(args.Votes);
             var adjustedVotes = voteResult.Select(p => (p.Item1, p.Item2 + _carryoverVotes[p.Item1])).ToList();
             var maxVotes = adjustedVotes.Max(v => v.Item2);

--- a/Content.Shared/_RMC14/CCVar/RMCCVars.cs
+++ b/Content.Shared/_RMC14/CCVar/RMCCVars.cs
@@ -184,6 +184,9 @@ public sealed class RMCCVars : CVars
     public static readonly CVarDef<int> RMCPlanetMapVoteExcludeLast =
         CVarDef.Create("rmc.planet_map_vote_exclude_last", 2, CVar.SERVER | CVar.SERVERONLY);
 
+    public static readonly CVarDef<bool> RMCUseCarryoverVoting =
+        CVarDef.Create("rmc.planet_map_vote_carryover", true, CVar.SERVER | CVar.SERVERONLY);
+
     public static readonly CVarDef<int> RMCTacticalMapAnnounceCooldownSeconds =
         CVarDef.Create("rmc.tactical_map_announce_cooldown_seconds", 240, CVar.SERVER | CVar.SERVERONLY);
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds the cm13 voting system, where votes carry over between rounds for maps that didn't win. Includes a cvar to disable/enable it.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
cm13 parity

## Technical details
<!-- Summary of code changes for easier review. -->
We store a dictionary of maps and carryover votes. 
When a vote happens, we get the vote counts from the voting handle and pick our own winners instead of using the built in Winner value. 
For each vote count, we add the carryover votes for that map from the dictionary, then pick the winner from the adjusted counts.
For all maps we use the adjusted votes as the new carryover value, and the map that won has the carryover votes set to 0.
IF carryover voting is disabled, all map carryovers are set to 0.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
2 clients vote for solaris ridge, 1 carryover vote for varadero:
![Voting2](https://github.com/user-attachments/assets/27e5946f-ed73-4177-bf6b-6c2a28d8478b)
![Voting3](https://github.com/user-attachments/assets/47252b01-f62d-4ebe-9c6d-d05e84ce50e1)
Next round solaris ridge has no carryover votes, since it won, varadero still has 1 because it had no additional votes:
![Voting4](https://github.com/user-attachments/assets/5b00e133-b54c-4dad-9a4a-c20fced0c6e0)
With no one else voting it wins most votes this round:
![Voting5](https://github.com/user-attachments/assets/15bf73ca-41b6-4129-b8c5-cbdb709d1bba)
Next round there are no carryover votes left:
![Voting6](https://github.com/user-attachments/assets/15d84a90-efb3-4d6a-8f78-a32251c7d5f2)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added carryover planet voting system from 13.
