### PR TITLE
Increase Outer Crusher Stomp Size

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Stomp/XenoStompComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Stomp/XenoStompComponent.cs
@@ -24,7 +24,7 @@ public sealed partial class XenoStompComponent : Component
     public float ShortRange = 0.5f;
 
     [DataField, AutoNetworkedField]
-    public float Range = 2;
+    public float Range = 2.82f;
 
     [DataField, AutoNetworkedField]
     public EntProtoId? SelfEffect;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Boosted the radius of Crusher Stomp from 2 to 2.82, giving it greater range to more closely match CM13.

## Why / Balance
2 was incorrect in the first place, as doing so would not make a 5x5 area, but rather a 4x4, if theoretically using squares (which we don't). Given we use circles, giving the circle a 2.82 radius roughly matches CM13's 25 tile area.

Graph pictured below, Red is RMC14 live range and Green is CM13's range. Red is very visibly much too small. Blue is this PR's range, a circle of the same radius as the green square.

![CrusherStomp](https://github.com/user-attachments/assets/f7c66d56-bbeb-49f5-833c-926fc9dd1973)

Video demonstration of live just being really really tiny

https://github.com/user-attachments/assets/f10a29b4-76d0-4512-9985-fb4af190bf53

## Media
Video Demo of this

https://github.com/user-attachments/assets/0f48952a-013e-499b-b033-cba4e2f4c2da

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Increased Crusher Stomp's outer radius, so it is no longer much smaller than it is supposed to be.
