### PR TITLE
Fix Burrower being able to acid and perform other do-afters while burrowing, fix Burrower not being able to unburrow

### DIFF
--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_self_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_self_actions.yml
@@ -267,5 +267,6 @@
     range: -1
     repeat: true
     deselectOnMiss: false
-    checkCanAccess : false
+    checkCanAccess: false
+    checkCanInteract: false
   - type: ActionBlockIfResting


### PR DESCRIPTION
## About the PR
Fixes #5022 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Fixed Burrower being able to acid and perform other do-afters while burrowing.
