### PR TITLE
Make Armor Wield Compensation actually work

### DIFF
--- a/Content.Shared/_RMC14/Wieldable/RMCWieldableSystem.cs
+++ b/Content.Shared/_RMC14/Wieldable/RMCWieldableSystem.cs
@@ -42,13 +42,13 @@ public sealed class RMCWieldableSystem : EntitySystem
 
         SubscribeLocalEvent<WieldSlowdownCompensationComponent, GotEquippedEvent>(OnGotEquipped);
         SubscribeLocalEvent<WieldSlowdownCompensationComponent, GotUnequippedEvent>(OnGotUnequipped);
+        SubscribeLocalEvent<WieldSlowdownCompensationComponent, InventoryRelayedEvent<RefreshWieldSlowdownCompensationEvent>>(OnRefreshWieldSlowdownCompensation);
 
         SubscribeLocalEvent<WieldDelayComponent, GotEquippedHandEvent>(OnGotEquippedHand);
         SubscribeLocalEvent<WieldDelayComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<WieldDelayComponent, UseInHandEvent>(OnUseInHand);
         SubscribeLocalEvent<WieldDelayComponent, ShotAttemptedEvent>(OnShotAttempt);
         SubscribeLocalEvent<WieldDelayComponent, ItemWieldedEvent>(OnItemWieldedWithDelay);
-
 
         SubscribeLocalEvent<InventoryComponent, RefreshWieldSlowdownCompensationEvent>(_inventorySystem.RelayEvent);
     }
@@ -156,13 +156,13 @@ public sealed class RMCWieldableSystem : EntitySystem
         RaiseLocalEvent(user.Owner, ref ev);
 
         user.Comp.Walk = ev.Walk;
-        user.Comp.Walk = ev.Sprint;
+        user.Comp.Sprint = ev.Sprint;
     }
 
-    private void OnRefreshWieldSlowdownCompensation(Entity<WieldSlowdownCompensationComponent> armour, ref InventoryRelayedEvent<RefreshWieldSlowdownCompensationEvent> args)
+    private void OnRefreshWieldSlowdownCompensation(Entity<WieldSlowdownCompensationComponent> armor, ref InventoryRelayedEvent<RefreshWieldSlowdownCompensationEvent> args)
     {
-        args.Args.Walk += armour.Comp.Walk;
-        args.Args.Sprint += armour.Comp.Sprint;
+        args.Args.Walk += armor.Comp.Walk;
+        args.Args.Sprint += armor.Comp.Sprint;
     }
 #endregion
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
For exactly 6 months this has not worked because the event never even had a Subscriber + the Walk Speed was being set to the Sprint Speed and the Sprint Speed just never modified.

## Why / Balance
It didn't even run before

## Technical details
Actually subscribe to the inventory relayed event and tell it to actually run OnRefreshWieldSlowdownCompensation(). Actually set Sprint's value instead of setting Walk's value twice.

## Media
This is no longer 0 / 0

![image](https://github.com/user-attachments/assets/c5984e5a-af3f-47cc-ada7-7388d41a3e62)

You are no longer a snail

![image](https://github.com/user-attachments/assets/281d6474-7ec4-4242-a8f2-eae26c74ca0e)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- fix: Fixed armor not compensating your move speed when wielding a weapon. You will now move much faster when wielding a weapon while wearing armor.

