### PR TITLE
Add picked up dropped items hotkey

### DIFF
--- a/Content.Client/Input/ContentContexts.cs
+++ b/Content.Client/Input/ContentContexts.cs
@@ -144,6 +144,7 @@ namespace Content.Client.Input
             human.AddFunction(CMKeyFunctions.CMHolsterTertiary);
             human.AddFunction(CMKeyFunctions.CMHolsterQuaternary);
             human.AddFunction(CMKeyFunctions.CMXenoWideSwing);
+            human.AddFunction(CMKeyFunctions.RMCPickUpDroppedItems);
         }
     }
 }

--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
@@ -164,6 +164,7 @@ namespace Content.Client.Options.UI.Tabs
             AddButton(CMKeyFunctions.CMHolsterSecondary);
             AddButton(CMKeyFunctions.CMHolsterTertiary);
             AddButton(CMKeyFunctions.CMHolsterQuaternary);
+            AddButton(CMKeyFunctions.RMCPickUpDroppedItems);
 
             AddHeader("ui-options-header-general");
             AddCheckBox("ui-options-hotkey-keymap", _cfg.GetCVar(CVars.DisplayUSQWERTYHotkeys), HandleToggleUSQWERTYCheckbox);

--- a/Content.Shared/_RMC14/Input/CMKeyFunctions.cs
+++ b/Content.Shared/_RMC14/Input/CMKeyFunctions.cs
@@ -17,4 +17,5 @@ public sealed class CMKeyFunctions
     public static readonly BoundKeyFunction CMHolsterTertiary = "CMHolsterTertiary";
     public static readonly BoundKeyFunction CMHolsterQuaternary = "CMHolsterQuaternary";
     public static readonly BoundKeyFunction CMXenoWideSwing = "CMXenoWideSwing";
+    public static readonly BoundKeyFunction RMCPickUpDroppedItems = "RMCPickUpDroppedItems";
 }

--- a/Content.Shared/_RMC14/Inventory/RMCItemPickupComponent.cs
+++ b/Content.Shared/_RMC14/Inventory/RMCItemPickupComponent.cs
@@ -1,0 +1,10 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Inventory;
+
+/// <summary>
+/// Items that can be marked in a <see cref="RMCPickupDroppedItemsComponent"/>.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(SharedCMInventorySystem))]
+public sealed partial class RMCItemPickupComponent : Component {}

--- a/Content.Shared/_RMC14/Inventory/RMCPickupDroppedItems.cs
+++ b/Content.Shared/_RMC14/Inventory/RMCPickupDroppedItems.cs
@@ -1,0 +1,12 @@
+﻿using Robust.Shared.Collections;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Inventory;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(SharedCMInventorySystem))]
+public sealed partial class RMCPickupDroppedItems : Component
+{
+    [DataField, AutoNetworkedField]
+    public ValueList<EntityUid> DroppedItems = new();
+}

--- a/Content.Shared/_RMC14/Inventory/RMCPickupDroppedItemsComponent.cs
+++ b/Content.Shared/_RMC14/Inventory/RMCPickupDroppedItemsComponent.cs
@@ -5,7 +5,7 @@ namespace Content.Shared._RMC14.Inventory;
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 [Access(typeof(SharedCMInventorySystem))]
-public sealed partial class RMCPickupDroppedItems : Component
+public sealed partial class RMCPickupDroppedItemsComponent : Component
 {
     [DataField, AutoNetworkedField]
     public ValueList<EntityUid> DroppedItems = new();

--- a/Content.Shared/_RMC14/Inventory/RMCPickupDroppedItemsComponent.cs
+++ b/Content.Shared/_RMC14/Inventory/RMCPickupDroppedItemsComponent.cs
@@ -1,5 +1,4 @@
-﻿using Robust.Shared.Collections;
-using Robust.Shared.GameStates;
+﻿using Robust.Shared.GameStates;
 
 namespace Content.Shared._RMC14.Inventory;
 

--- a/Content.Shared/_RMC14/Inventory/RMCPickupDroppedItemsComponent.cs
+++ b/Content.Shared/_RMC14/Inventory/RMCPickupDroppedItemsComponent.cs
@@ -8,5 +8,5 @@ namespace Content.Shared._RMC14.Inventory;
 public sealed partial class RMCPickupDroppedItemsComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public ValueList<EntityUid> DroppedItems = new();
+    public List<EntityUid> DroppedItems = new();
 }

--- a/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
+++ b/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
@@ -288,7 +288,7 @@ public abstract class SharedCMInventorySystem : EntitySystem
         if (!_pickupDroppedItemsQuery.TryComp(user, out var pickupDroppedItems))
             return;
 
-        foreach (var item in pickupDroppedItems.DroppedItems.Distinct().ToList())
+        foreach (var item in pickupDroppedItems.DroppedItems.Distinct().Reverse())
         {
             if (!_container.IsEntityInContainer(item) && _interaction.InRangeUnobstructed(user, item) && _hands.TryPickupAnyHand(user, item))
             {

--- a/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
+++ b/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
@@ -294,7 +294,10 @@ public abstract class SharedCMInventorySystem : EntitySystem
             if (!_container.IsEntityInContainer(item) && _interaction.InRangeUnobstructed(user, item))
             {
                 if (_hands.TryPickupAnyHand(user, item))
+                {
+                    pickupDroppedItems.DroppedItems.Remove(item);
                     break;
+                }
             }
         }
     }

--- a/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
+++ b/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
@@ -290,7 +290,7 @@ public abstract class SharedCMInventorySystem : EntitySystem
 
         foreach (var item in pickupDroppedItems.DroppedItems)
         {
-            if (_interaction.InRangeUnobstructed(user, item) && _hands.TryPickupAnyHand(user, item))
+            if (!_container.IsEntityInContainer(item) && _interaction.InRangeUnobstructed(user, item) && _hands.TryPickupAnyHand(user, item))
             {
                 pickupDroppedItems.DroppedItems.Remove(item);
                 break;

--- a/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
+++ b/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
@@ -285,10 +285,10 @@ public abstract class SharedCMInventorySystem : EntitySystem
         HandleDroppedItem(ent, args.User);
     }
 
-    protected void HandleDroppedItem(Entity<RMCItemPickupComponent> ent, EntityUid user)
+    protected void HandleDroppedItem(Entity<RMCItemPickupComponent> item, EntityUid user)
     {
         if (_pickupDroppedItemsQuery.TryComp(user, out var pickupDroppedItems))
-            pickupDroppedItems.DroppedItems.Add(ent.Owner);
+            pickupDroppedItems.DroppedItems.Add(item.Owner);
     }
 
     protected void TryPickupDroppedItems(EntityUid user)

--- a/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
+++ b/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
@@ -5,6 +5,7 @@ using Content.Shared.Administration.Logs;
 using Content.Shared.Clothing.Components;
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Database;
+using Content.Shared.Hands;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
@@ -89,6 +90,7 @@ public abstract class SharedCMInventorySystem : EntitySystem
 
         SubscribeLocalEvent<RMCItemPickupComponent, DroppedEvent>(OnItemDropped);
         SubscribeLocalEvent<RMCItemPickupComponent, RMCDroppedEvent>(OnItemDropped);
+        SubscribeLocalEvent<RMCItemPickupComponent, GotEquippedHandEvent>(OnItemEquipped);
 
         CommandBinds.Builder
             .Bind(CMKeyFunctions.CMHolsterPrimary,
@@ -265,6 +267,12 @@ public abstract class SharedCMInventorySystem : EntitySystem
         ent.Comp.Contents.Remove(item);
 
         ContentsUpdated(ent);
+    }
+
+    private void OnItemEquipped(Entity<RMCItemPickupComponent> ent, ref GotEquippedHandEvent args)
+    {
+        if (_pickupDroppedItemsQuery.TryComp(args.User, out var pickupDroppedItems))
+            pickupDroppedItems.DroppedItems.Remove(ent.Owner);
     }
 
     protected void OnItemDropped(Entity<RMCItemPickupComponent> ent, ref DroppedEvent args)

--- a/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
+++ b/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
@@ -290,7 +290,7 @@ public abstract class SharedCMInventorySystem : EntitySystem
 
         foreach (var item in pickupDroppedItems.DroppedItems)
         {
-            if (!_interaction.InRangeUnobstructed(user, item) && _hands.TryPickupAnyHand(user, item))
+            if (_interaction.InRangeUnobstructed(user, item) && _hands.TryPickupAnyHand(user, item))
             {
                 pickupDroppedItems.DroppedItems.Remove(item);
                 break;

--- a/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
+++ b/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
@@ -288,17 +288,13 @@ public abstract class SharedCMInventorySystem : EntitySystem
         if (!_pickupDroppedItemsQuery.TryComp(user, out var pickupDroppedItems))
             return;
 
-        foreach (var item in pickupDroppedItems.DroppedItems.ToList())
+        foreach (var item in pickupDroppedItems.DroppedItems)
         {
-            // Remove the item from the list, break the loop if the user can pickup the item.
-            // Otherwise, continue through the loop.
-            pickupDroppedItems.DroppedItems.Remove(item);
-
-            if (!_interaction.InRangeUnobstructed(user, item))
-                continue;
-
-            if (_hands.TryPickupAnyHand(user, item))
+            if (!_interaction.InRangeUnobstructed(user, item) && _hands.TryPickupAnyHand(user, item))
+            {
+                pickupDroppedItems.DroppedItems.Remove(item);
                 break;
+            }
         }
     }
 

--- a/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
+++ b/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
@@ -285,7 +285,8 @@ public abstract class SharedCMInventorySystem : EntitySystem
 
         foreach (var item in pickupDroppedItems.DroppedItems)
         {
-            // Remove the item from the list, break the loop if the user can pickup the item. Else, continue through the loop.
+            // Remove the item from the list, break the loop if the user can pickup the item.
+            // Otherwise, continue through the loop.
             pickupDroppedItems.DroppedItems.Remove(item);
 
             if (!_interaction.InRangeUnobstructed(user, item))

--- a/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
+++ b/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
@@ -87,8 +87,8 @@ public abstract class SharedCMInventorySystem : EntitySystem
         SubscribeLocalEvent<CMHolsterComponent, EntInsertedIntoContainerMessage>(OnHolsterEntInsertedIntoContainer);
         SubscribeLocalEvent<CMHolsterComponent, EntRemovedFromContainerMessage>(OnHolsterEntRemovedFromContainer);
 
-        SubscribeLocalEvent<RMCPickupDroppedItemsComponent, DroppedEvent>(OnItemDropped);
-        SubscribeLocalEvent<RMCPickupDroppedItemsComponent, RMCDroppedEvent>(OnItemDropped);
+        SubscribeLocalEvent<RMCItemPickupComponent, DroppedEvent>(OnItemDropped);
+        SubscribeLocalEvent<RMCItemPickupComponent, RMCDroppedEvent>(OnItemDropped);
 
         CommandBinds.Builder
             .Bind(CMKeyFunctions.CMHolsterPrimary,

--- a/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
+++ b/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
@@ -22,7 +22,6 @@ using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Input.Binding;
 using Robust.Shared.Timing;
-using Robust.Shared.Utility;
 
 namespace Content.Shared._RMC14.Inventory;
 
@@ -88,7 +87,8 @@ public abstract class SharedCMInventorySystem : EntitySystem
         SubscribeLocalEvent<CMHolsterComponent, EntInsertedIntoContainerMessage>(OnHolsterEntInsertedIntoContainer);
         SubscribeLocalEvent<CMHolsterComponent, EntRemovedFromContainerMessage>(OnHolsterEntRemovedFromContainer);
 
-        SubscribeLocalEvent<ItemComponent, RMCDroppedEvent>(OnItemDropped);
+        SubscribeLocalEvent<RMCPickupDroppedItemsComponent, DroppedEvent>(OnItemDropped);
+        SubscribeLocalEvent<RMCPickupDroppedItemsComponent, RMCDroppedEvent>(OnItemDropped);
 
         CommandBinds.Builder
             .Bind(CMKeyFunctions.CMHolsterPrimary,
@@ -267,12 +267,17 @@ public abstract class SharedCMInventorySystem : EntitySystem
         ContentsUpdated(ent);
     }
 
-    protected void OnItemDropped(Entity<ItemComponent> ent, ref RMCDroppedEvent args)
+    protected void OnItemDropped(Entity<RMCPickupDroppedItemsComponent> ent, ref DroppedEvent args)
     {
         HandleDroppedItem(ent, args.User);
     }
 
-    protected void HandleDroppedItem(Entity<ItemComponent> ent, EntityUid user)
+    protected void OnItemDropped(Entity<RMCPickupDroppedItemsComponent> ent, ref RMCDroppedEvent args)
+    {
+        HandleDroppedItem(ent, args.User);
+    }
+
+    protected void HandleDroppedItem(Entity<RMCPickupDroppedItemsComponent> ent, EntityUid user)
     {
         if (_pickupDroppedItemsQuery.TryComp(user, out var pickupDroppedItems))
             pickupDroppedItems.DroppedItems.Add(ent.Owner);

--- a/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
+++ b/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
@@ -8,6 +8,7 @@ using Content.Shared.Database;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
+using Content.Shared.Interaction.Events;
 using Content.Shared.Inventory;
 using Content.Shared.Item;
 using Content.Shared.Popups;
@@ -82,6 +83,7 @@ public abstract class SharedCMInventorySystem : EntitySystem
         SubscribeLocalEvent<CMHolsterComponent, EntInsertedIntoContainerMessage>(OnHolsterEntInsertedIntoContainer);
         SubscribeLocalEvent<CMHolsterComponent, EntRemovedFromContainerMessage>(OnHolsterEntRemovedFromContainer);
 
+        SubscribeLocalEvent<ItemComponent, DroppedEvent>(OnItemDropped);
         SubscribeLocalEvent<ItemComponent, RMCDroppedEvent>(OnItemDropped);
 
         CommandBinds.Builder
@@ -261,10 +263,18 @@ public abstract class SharedCMInventorySystem : EntitySystem
         ContentsUpdated(ent);
     }
 
+    protected void OnItemDropped(Entity<ItemComponent> ent, ref DroppedEvent args)
+    {
+        HandleDroppedItem(ent, args.User);
+    }
+
     protected void OnItemDropped(Entity<ItemComponent> ent, ref RMCDroppedEvent args)
     {
-        var user = args.User;
+        HandleDroppedItem(ent, args.User);
+    }
 
+    protected void HandleDroppedItem(Entity<ItemComponent> ent, EntityUid user)
+    {
         if (TryComp<RMCPickupDroppedItems>(user, out var pickupDroppedItems))
             pickupDroppedItems.DroppedItems.Add(ent.Owner);
     }

--- a/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
+++ b/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
@@ -275,13 +275,13 @@ public abstract class SharedCMInventorySystem : EntitySystem
 
     protected void HandleDroppedItem(Entity<ItemComponent> ent, EntityUid user)
     {
-        if (TryComp<RMCPickupDroppedItems>(user, out var pickupDroppedItems))
+        if (TryComp<RMCPickupDroppedItemsComponent>(user, out var pickupDroppedItems))
             pickupDroppedItems.DroppedItems.Add(ent.Owner);
     }
 
     protected void TryPickupDroppedItems(EntityUid user)
     {
-        if (!TryComp<RMCPickupDroppedItems>(user, out var pickupDroppedItems))
+        if (!TryComp<RMCPickupDroppedItemsComponent>(user, out var pickupDroppedItems))
             return;
 
         foreach (var item in pickupDroppedItems.DroppedItems)

--- a/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
+++ b/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
@@ -288,7 +288,7 @@ public abstract class SharedCMInventorySystem : EntitySystem
         if (!_pickupDroppedItemsQuery.TryComp(user, out var pickupDroppedItems))
             return;
 
-        foreach (var item in pickupDroppedItems.DroppedItems)
+        foreach (var item in pickupDroppedItems.DroppedItems.Distinct().ToList())
         {
             if (!_container.IsEntityInContainer(item) && _interaction.InRangeUnobstructed(user, item) && _hands.TryPickupAnyHand(user, item))
             {

--- a/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
+++ b/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
@@ -298,10 +298,10 @@ public abstract class SharedCMInventorySystem : EntitySystem
 
         foreach (var item in pickupDroppedItems.DroppedItems.Distinct().Reverse())
         {
-            if (!_container.IsEntityInContainer(item) && _interaction.InRangeUnobstructed(user, item) && _hands.TryPickupAnyHand(user, item))
+            if (!_container.IsEntityInContainer(item) && _interaction.InRangeUnobstructed(user, item))
             {
-                pickupDroppedItems.DroppedItems.Remove(item);
-                break;
+                if (_hands.TryPickupAnyHand(user, item))
+                    break;
             }
         }
     }

--- a/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
+++ b/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
@@ -267,17 +267,17 @@ public abstract class SharedCMInventorySystem : EntitySystem
         ContentsUpdated(ent);
     }
 
-    protected void OnItemDropped(Entity<RMCPickupDroppedItemsComponent> ent, ref DroppedEvent args)
+    protected void OnItemDropped(Entity<RMCItemPickupComponent> ent, ref DroppedEvent args)
     {
         HandleDroppedItem(ent, args.User);
     }
 
-    protected void OnItemDropped(Entity<RMCPickupDroppedItemsComponent> ent, ref RMCDroppedEvent args)
+    protected void OnItemDropped(Entity<RMCItemPickupComponent> ent, ref RMCDroppedEvent args)
     {
         HandleDroppedItem(ent, args.User);
     }
 
-    protected void HandleDroppedItem(Entity<RMCPickupDroppedItemsComponent> ent, EntityUid user)
+    protected void HandleDroppedItem(Entity<RMCItemPickupComponent> ent, EntityUid user)
     {
         if (_pickupDroppedItemsQuery.TryComp(user, out var pickupDroppedItems))
             pickupDroppedItems.DroppedItems.Add(ent.Owner);

--- a/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
+++ b/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
@@ -66,8 +66,12 @@ public abstract class SharedCMInventorySystem : EntitySystem
         SlotFlags.LEGS
     ];
 
+    private EntityQuery<RMCPickupDroppedItemsComponent> _pickupDroppedItemsQuery;
+
     public override void Initialize()
     {
+        _pickupDroppedItemsQuery = GetEntityQuery<RMCPickupDroppedItemsComponent>();
+
         SubscribeLocalEvent<GunComponent, IsUnholsterableEvent>(AllowUnholster);
         SubscribeLocalEvent<MeleeWeaponComponent, IsUnholsterableEvent>(AllowUnholster);
 
@@ -275,13 +279,13 @@ public abstract class SharedCMInventorySystem : EntitySystem
 
     protected void HandleDroppedItem(Entity<ItemComponent> ent, EntityUid user)
     {
-        if (TryComp<RMCPickupDroppedItemsComponent>(user, out var pickupDroppedItems))
+        if (_pickupDroppedItemsQuery.TryComp(user, out var pickupDroppedItems))
             pickupDroppedItems.DroppedItems.Add(ent.Owner);
     }
 
     protected void TryPickupDroppedItems(EntityUid user)
     {
-        if (!TryComp<RMCPickupDroppedItemsComponent>(user, out var pickupDroppedItems))
+        if (!_pickupDroppedItemsQuery.TryComp(user, out var pickupDroppedItems))
             return;
 
         foreach (var item in pickupDroppedItems.DroppedItems)

--- a/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
+++ b/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
@@ -90,7 +90,6 @@ public abstract class SharedCMInventorySystem : EntitySystem
 
         SubscribeLocalEvent<RMCItemPickupComponent, DroppedEvent>(OnItemDropped);
         SubscribeLocalEvent<RMCItemPickupComponent, RMCDroppedEvent>(OnItemDropped);
-        SubscribeLocalEvent<RMCItemPickupComponent, GotEquippedHandEvent>(OnItemEquipped);
 
         CommandBinds.Builder
             .Bind(CMKeyFunctions.CMHolsterPrimary,
@@ -267,12 +266,6 @@ public abstract class SharedCMInventorySystem : EntitySystem
         ent.Comp.Contents.Remove(item);
 
         ContentsUpdated(ent);
-    }
-
-    private void OnItemEquipped(Entity<RMCItemPickupComponent> ent, ref GotEquippedHandEvent args)
-    {
-        if (_pickupDroppedItemsQuery.TryComp(args.User, out var pickupDroppedItems))
-            pickupDroppedItems.DroppedItems.Remove(ent.Owner);
     }
 
     protected void OnItemDropped(Entity<RMCItemPickupComponent> ent, ref DroppedEvent args)

--- a/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
+++ b/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
@@ -288,7 +288,7 @@ public abstract class SharedCMInventorySystem : EntitySystem
         if (!_pickupDroppedItemsQuery.TryComp(user, out var pickupDroppedItems))
             return;
 
-        foreach (var item in pickupDroppedItems.DroppedItems)
+        foreach (var item in pickupDroppedItems.DroppedItems.ToList())
         {
             // Remove the item from the list, break the loop if the user can pickup the item.
             // Otherwise, continue through the loop.

--- a/Resources/Locale/en-US/_RMC14/escape-menu/options-menu.ftl
+++ b/Resources/Locale/en-US/_RMC14/escape-menu/options-menu.ftl
@@ -11,3 +11,4 @@ ui-options-function-cm-holster-primary = Unholster
 ui-options-function-cm-holster-secondary = Unholster secondary
 ui-options-function-cm-holster-tertiary = Unholster tertiary
 ui-options-function-cm-holster-quaternary = Unholster quaternary
+ui-options-function-rmc-pick-up-dropped-items = Pick up dropped items

--- a/Resources/Prototypes/Entities/Objects/base_item.yml
+++ b/Resources/Prototypes/Entities/Objects/base_item.yml
@@ -43,6 +43,7 @@
     noRot: false
   - type: Pullable
   - type: DamageExaminable
+  - type: RMCItemPickup
 
 - type: entity
   name: "storage item"

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
@@ -272,3 +272,4 @@
     blacklist:
       components:
       - Xeno
+  - type: RMCPickupDroppedItems

--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -625,3 +625,7 @@ binds:
 - function: CMXenoWideSwing
   type: State
   key: Space
+- function: RMCPickUpDroppedItems
+  type: State
+  key: E
+  mod1: Shift

--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -627,5 +627,4 @@ binds:
   key: Space
 - function: RMCPickUpDroppedItems
   type: State
-  key: E
-  mod1: Shift
+  key: R


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
A feature in CM13
automatically picks up items you dropped

## Media

https://github.com/user-attachments/assets/9798ad40-6eac-4dbe-9e30-1df4def5615a



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

:cl:
- add: Added a hotkey to pick up recently dropped items. The key is R by default.