### PR TITLE
Fix broken area sprites on chances

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Areas/areas_chances.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Areas/areas_chances.yml
@@ -3,7 +3,7 @@
   id: RMCAreaLv522
   components:
   - type: Sprite
-    state: lv-626
+    state: unknown
   - type: Area
     buildSpecial: true
     powerNet: ground
@@ -962,7 +962,7 @@
   name: Atmospheric Processor
   components:
   - type: Sprite
-    state: engineering
+    state: unknown
   - type: Area
     CAS: false
     fulton: false


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Broken sprites were causing YAML failures. This is actually parity because these sprites are broken in cm13, but since they're not meant to be placed directly, made them go to Unknown sprite instead.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fix YAML failure.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

