### PR TITLE
Add .5 range to buckshot, slug, mateba stuns

### DIFF
--- a/Content.Shared/_RMC14/Stun/RMCStunOnHitComponent.cs
+++ b/Content.Shared/_RMC14/Stun/RMCStunOnHitComponent.cs
@@ -10,7 +10,7 @@ public sealed partial class RMCStunOnHitComponent : Component
     public EntityCoordinates? ShotFrom;
 
     [DataField, AutoNetworkedField]
-    public float MaxRange = 2;
+    public float MaxRange = 2.5f;
 
     [DataField, AutoNetworkedField]
     public bool LosesEffectWithRange = false;

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Revolvers/mateba.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Revolvers/mateba.yml
@@ -120,7 +120,7 @@
   - type: CMArmorPiercing
     amount: 20
   - type: RMCStunOnHit
-    maxRange: 4
+    maxRange: 4.5
     stunTime: 1
   - type: RMCProjectileAccuracy
     accuracy: 90

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/shotgun_pellets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/shotgun_pellets.yml
@@ -67,7 +67,7 @@
   - type: CMArmorPiercing
     amount: 20
   - type: RMCStunOnHit
-    maxRange: 6
+    maxRange: 6.5
     stunTime: 1
     superSlowTime: 2
     slowTime: 6


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Ups the range of ammo stuns by .5 tiles to make them more consistent at ranges they should be going off

## Why / Balance
You could basically be at 2 tiles versus buckshot and not get stunned due to being a nanometer off, making engagements feel very inconsistent both mechanically and visually

Demonstration of live being weird

https://github.com/user-attachments/assets/7ed9e951-d0dc-4948-84fc-8b67cfaa3e71

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
Video Demonstration

https://github.com/user-attachments/assets/26b7ccbd-8859-4cdd-8fe1-77714f258ced

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- tweak: Buckshot, Slugs, and the Mateba will now stun from 0.5 tiles further away. Buckshot now stuns at 2.5 tiles, Slugs now stun at 6.5 tiles, and the Mateba now stuns at 4.5 tiles.
