### PR TITLE
Fix pump action shotgun sound

### DIFF
--- a/Content.Shared/_RMC14/Weapons/Ranged/SharedPumpActionSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/SharedPumpActionSystem.cs
@@ -5,11 +5,13 @@ using Content.Shared.Weapons.Ranged.Events;
 using Content.Shared.Weapons.Ranged.Systems;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
+using Robust.Shared.Network;
 
 namespace Content.Shared._RMC14.Weapons.Ranged;
 
 public abstract class SharedPumpActionSystem : EntitySystem
 {
+    [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
 
@@ -66,7 +68,8 @@ public abstract class SharedPumpActionSystem : EntitySystem
 
         args.Handled = true;
 
-        _audio.PlayPredicted(ent.Comp.Sound, ent, args.UserUid);
+        if (_net.IsServer)
+            _audio.PlayPvs(ent.Comp.Sound, args.User);
     }
 
     private void OnEntRemovedFromContainer(Entity<PumpActionComponent> ent, ref EntRemovedFromContainerMessage args)

--- a/Content.Shared/_RMC14/Weapons/Ranged/SharedPumpActionSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/SharedPumpActionSystem.cs
@@ -69,7 +69,7 @@ public abstract class SharedPumpActionSystem : EntitySystem
         args.Handled = true;
 
         if (_net.IsServer)
-            _audio.PlayPvs(ent.Comp.Sound, args.User);
+            _audio.PlayPvs(ent.Comp.Sound, args.UserUid);
     }
 
     private void OnEntRemovedFromContainer(Entity<PumpActionComponent> ent, ref EntRemovedFromContainerMessage args)


### PR DESCRIPTION
## About the PR
This unpredicts the sound, but fixes a bug where if you spam the unique action button, the sound sometimes wouldnt play
resolves #5120

:cl:
- fix: Fixed the shotgun pump or XM88 cycle sound not playing when you spam the unique action button.