### PR TITLE
Fix the extra M5-ATL that demo specs get

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/spec_camos.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/spec_camos.yml
@@ -1,6 +1,6 @@
 ﻿#definers
 - type: entity
-  parent: CMSniperEquipmentCase
+  parent: RMCBaseEquipmentCase
   id: RMCSniperEquipmentCaseCamo
   suffix: Camo Replace
   components:
@@ -13,7 +13,7 @@
       Urban: RMCSniperEquipmentCaseUrban
 
 - type: entity
-  parent: RMCGrenadeSpecEquipmentCase
+  parent: RMCBaseEquipmentCase
   id: RMCGrenadeSpecEquipmentCaseCamo
   suffix: Camo Replace
   components:
@@ -26,7 +26,7 @@
       Urban: RMCGrenadeSpecEquipmentCaseUrban
 
 - type: entity
-  parent: RMCDemoSpecEquipmentCase
+  parent: RMCBaseEquipmentCase
   id: RMCDemoSpecEquipmentCaseCamo
   suffix: Camo Replace
   components:
@@ -39,7 +39,7 @@
       Urban: RMCDemoSpecEquipmentCaseUrban
 
 - type: entity
-  parent: RMCScoutSpecEquipmentCase
+  parent: RMCBaseEquipmentCase
   id: RMCScoutSpecEquipmentCaseCamo
   suffix: Camo Replace
   components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Made it so that the demo specs don't get a second M5-ATL
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
bug fix
fixes #5136 
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Demo specialists no longer spawn with two rocket launchers.