### PR TITLE
[Fix] Locker/Closet Modifier and HP reduction

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Storage/closets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Storage/closets.yml
@@ -32,6 +32,22 @@
   - type: Anchorable
     flags:
     - None
+  - type: Damageable
+    damageContainer: StructuralMarine
+    damageModifierSet: StructuralMarine
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
+          params:
+            volume: -6
 
 - type: entity
   parent: CMClosetBase


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
changed CMClosetBase to have the StructuralMarine damage container and modifier, and gave it 100 hp.

it also allows every xeno to dmg lockers/closets, since ther won't be a flat 10, blunt, slash and piercing damage reduction, which prevented anything with less melee dmg than +30 brute to damage lockers/closets
### old damage modifier
![image](https://github.com/user-attachments/assets/0b73e123-8c21-4771-9471-29143b99c866)

## Why / Balance
Parity.
fixes #3707

this also fixes lockers dropping upstream steel when broken, either i couldn't find it or there just isn't anything dropped, when broken in cm13.
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed lockers/closets having more HP than intended.
