### PR TITLE
Replaces meson goggles with welding goggles

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/command.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/command.yml
@@ -828,7 +828,7 @@
       - id: CMHandsInsulated
       - id: CMHeadsetCE
       - id: CMBootsBlack
-      - id: ClothingEyesGlassesMeson # TODO change to CM13 engi goggles.
+      - id: RMCWeldingGoggles
       # TODO KN5500/2 PDA
       # TODO Compact nailgun
     - name: Uniform

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/engineering.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/engineering.yml
@@ -23,7 +23,7 @@
     RMCHardhatBlue: 4
     CMHandsInsulated: 4
     CMBeltUtility: 4
-    ClothingEyesGlassesMeson: 4
+    RMCWeldingGoggles: 4
     ClothingHeadHatWelding: 4
     #Engineer kit
     #Atmos scanner


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
switched out meson goggles with the welding goggles in the senior equipment vendor and tool vendor

## Why / Balance
resolves #5122

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: Welding goggles can now be found in the tool vendor, and in the CE's equipment rack.

