### PR TITLE
Fixes Command tablet being corrodible

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Devices/command_tablet.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Devices/command_tablet.yml
@@ -25,6 +25,8 @@
   - type: Tag
     tags:
     - CommandTablet
+  - type: Corrodible
+    isCorrodible: false
 
 - type: Tag
   id: CommandTablet


### PR DESCRIPTION
## About the PR
Made the command tablet uncorrodible

## Why / Balance
marine agents forced me to fix this ✋😨🤚

parity
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Fixed being able to acid the command tablet.

