### PR TITLE
Actually fix duplicate m5-atl for real

### DIFF
--- a/Content.Shared/_RMC14/Item/ItemCamouflageComponent.cs
+++ b/Content.Shared/_RMC14/Item/ItemCamouflageComponent.cs
@@ -10,6 +10,10 @@ public sealed partial class ItemCamouflageComponent : Component
     //you have to add a prototype for each camo type.
     [DataField(required: true), AutoNetworkedField]
     public Dictionary<CamouflageType, EntProtoId> CamouflageVariations = new();
+
+    //for weapon spec boxes, to prevent two M5-ATLs
+    [DataField, AutoNetworkedField]
+    public bool OverrideStorageReplace = false;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/_RMC14/Item/ItemCamouflageEvent.cs
+++ b/Content.Shared/_RMC14/Item/ItemCamouflageEvent.cs
@@ -1,4 +1,4 @@
-﻿namespace Content.Shared._RMC14.Item;
+namespace Content.Shared._RMC14.Item;
 
 [ByRefEvent]
-public readonly record struct ItemCamouflageEvent(EntityUid Old, EntityUid New);
+public readonly record struct ItemCamouflageEvent(EntityUid Old, EntityUid New, bool ReplaceOverride = false);

--- a/Content.Shared/_RMC14/Item/ItemCamouflageSystem.cs
+++ b/Content.Shared/_RMC14/Item/ItemCamouflageSystem.cs
@@ -100,7 +100,7 @@ public sealed class ItemCamouflageSystem : EntitySystem
             newEnt = SpawnNextToOrDrop(ent.Comp.CamouflageVariations[type], ent.Owner);
         }
 
-        var ev = new ItemCamouflageEvent(ent, newEnt);
+        var ev = new ItemCamouflageEvent(ent, newEnt, ent.Comp.OverrideStorageReplace);
         RaiseLocalEvent(ent, ref ev);
 
         QueueDel(ent.Owner);
@@ -108,6 +108,9 @@ public sealed class ItemCamouflageSystem : EntitySystem
 
     private void OnItemCamoflage(Entity<StorageComponent> ent, ref ItemCamouflageEvent args)
     {
+        if (args.ReplaceOverride)
+            return;
+
         var oldItem = args.Old;
         var newItem = args.New;
 

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/smartgunner_loadouts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/smartgunner_loadouts.yml
@@ -113,6 +113,7 @@
   suffix: Camo Replace
   components:
   - type: ItemCamouflage
+    overrideStorageReplace: true
     camouflageVariations:
       Jungle: CMSmartGunOperatorEquipmentCaseBelt
       Snow: RMCSGOEquipmentCaseBeltSnow
@@ -128,6 +129,7 @@
   suffix: Camo Replace
   components:
   - type: ItemCamouflage
+    overrideStorageReplace: true
     camouflageVariations:
       Jungle: CMSmartGunOperatorEquipmentCase
       Snow: RMCSGOEquipmentCaseSnow

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/spec_camos.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/spec_camos.yml
@@ -5,6 +5,7 @@
   suffix: Camo Replace
   components:
   - type: ItemCamouflage
+    overrideStorageReplace: true
     camouflageVariations:
       Jungle: CMSniperEquipmentCase
       Desert: RMCSniperEquipmentCaseDesert
@@ -18,6 +19,7 @@
   suffix: Camo Replace
   components:
   - type: ItemCamouflage
+    overrideStorageReplace: true
     camouflageVariations:
       Jungle: RMCGrenadeSpecEquipmentCase
       Desert: RMCGrenadeSpecEquipmentCaseDesert
@@ -31,6 +33,7 @@
   suffix: Camo Replace
   components:
   - type: ItemCamouflage
+    overrideStorageReplace: true
     camouflageVariations:
       Jungle: RMCDemoSpecEquipmentCase
       Desert: RMCDemoSpecEquipmentCaseDesert
@@ -44,6 +47,7 @@
   suffix: Camo Replace
   components:
   - type: ItemCamouflage
+    overrideStorageReplace: true
     camouflageVariations:
       Jungle: RMCScoutSpecEquipmentCase
       Desert: RMCScoutSpecEquipmentCaseDesert


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes the duplicate m5-atl that demo specs get, without implementing any extra bugs, hopefully.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfix
## Technical details
<!-- Summary of code changes for easier review. -->
adds a boolean to the ItemCamouflageComponent that if true will prevent the storage transfer between the spawned entity and the replaced entity. It is false by default so it doesn't interfere with loadouts.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Demolition specialists no longer get two M5-ATLs