### PR TITLE
Fix xeno abilities that move a target not breaking all pulls

### DIFF
--- a/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
+++ b/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
@@ -283,6 +283,17 @@ public sealed class RMCPullingSystem : EntitySystem
         _pulling.TryStopPull(puller.Pulling.Value, pullable, user);
     }
 
+    public void TryStopAllPullsIfBeingPulled(EntityUid pulled)
+    {
+       if (!TryComp<PullableComponent>(pulled, out var pullable) ||
+            pullable.Puller == null)
+        {
+            return;
+        }
+
+        _pulling.TryStopPull(pulled, pullable);
+    }
+
     private void OnPullAnimation(Entity<PullableComponent> ent, ref PullStartedMessage args)
     {
         if (args.PulledUid != ent.Owner)

--- a/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
+++ b/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
@@ -283,15 +283,28 @@ public sealed class RMCPullingSystem : EntitySystem
         _pulling.TryStopPull(puller.Pulling.Value, pullable, user);
     }
 
-    public void TryStopAllPullsIfBeingPulled(EntityUid pulled)
+    public void TryStopPullsOn(EntityUid puller)
     {
-       if (!TryComp<PullableComponent>(pulled, out var pullable) ||
-            pullable.Puller == null)
+        if (!TryComp<PullableComponent>(puller, out var pullable) ||
+             pullable.Puller == null)
         {
             return;
         }
 
-        _pulling.TryStopPull(pulled, pullable);
+        _pulling.TryStopPull(puller, pullable);
+    }
+
+    public void TryStopAllPullsFromAndOn(EntityUid pullie)
+    {
+        TryStopPullsOn(pullie);
+
+       if (TryComp(pullie, out PullerComponent? puller) &&
+            puller.Pulling != null &&
+            TryComp(puller.Pulling, out PullableComponent? pullable2))
+        {
+            _pulling.TryStopPull(puller.Pulling.Value, pullable2, pullie);
+            return;
+        }
     }
 
     private void OnPullAnimation(Entity<PullableComponent> ent, ref PullStartedMessage args)

--- a/Content.Shared/_RMC14/Stun/RMCSizeStunSystem.cs
+++ b/Content.Shared/_RMC14/Stun/RMCSizeStunSystem.cs
@@ -1,4 +1,5 @@
 ﻿using System.Numerics;
+using Content.Shared._RMC14.Pulling;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Damage.Systems;
 using Content.Shared.Movement.Systems;
@@ -26,6 +27,7 @@ public sealed class RMCSizeStunSystem : EntitySystem
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly SharedStunSystem _stun = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+    [Dependency] private readonly RMCPullingSystem _rmcPulling = default!;
 
     public override void Initialize()
     {
@@ -101,6 +103,7 @@ public sealed class RMCSizeStunSystem : EntitySystem
             var vec = _transform.GetMoverCoordinates(args.Target).Position - bullet.Comp.ShotFrom.Value.Position;
             if (vec.Length() != 0)
             {
+                _rmcPulling.TryStopAllPullsIfBeingPulled(args.Target);
                 var direction = vec.Normalized();
                 _throwing.TryThrow(args.Target, direction, 1, animated: false, playSound: false, doSpin: false);
                 // RMC-14 TODO Thrown into obstacle mechanics

--- a/Content.Shared/_RMC14/Stun/RMCSizeStunSystem.cs
+++ b/Content.Shared/_RMC14/Stun/RMCSizeStunSystem.cs
@@ -103,7 +103,7 @@ public sealed class RMCSizeStunSystem : EntitySystem
             var vec = _transform.GetMoverCoordinates(args.Target).Position - bullet.Comp.ShotFrom.Value.Position;
             if (vec.Length() != 0)
             {
-                _rmcPulling.TryStopAllPullsIfBeingPulled(args.Target);
+                _rmcPulling.TryStopPullsOn(args.Target);
                 var direction = vec.Normalized();
                 _throwing.TryThrow(args.Target, direction, 1, animated: false, playSound: false, doSpin: false);
                 // RMC-14 TODO Thrown into obstacle mechanics

--- a/Content.Shared/_RMC14/Xenonids/Charge/XenoChargeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Charge/XenoChargeSystem.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Shared._RMC14.Marines;
+using Content.Shared._RMC14.Pulling;
 using Content.Shared._RMC14.Xenonids.Animation;
 using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared.Coordinates;
@@ -31,6 +32,7 @@ public sealed class XenoChargeSystem : EntitySystem
     [Dependency] private readonly XenoAnimationsSystem _xenoAnimations = default!;
     [Dependency] private readonly XenoSystem _xeno = default!;
     [Dependency] private readonly XenoPlasmaSystem _xenoPlasma = default!;
+    [Dependency] private readonly RMCPullingSystem _rmcPulling = default!;
 
     private EntityQuery<PhysicsComponent> _physicsQuery;
     private EntityQuery<ThrownItemComponent> _thrownItemQuery;
@@ -119,11 +121,13 @@ public sealed class XenoChargeSystem : EntitySystem
             _colorFlash.RaiseEffect(Color.Red, new List<EntityUid> { targetId }, filter);
         }
 
+        _rmcPulling.TryStopAllPullsIfBeingPulled(targetId);
+
         var origin = _transform.GetMapCoordinates(xeno);
         var target = _transform.GetMapCoordinates(targetId);
         var diff = target.Position - origin.Position;
         var length = diff.Length();
-        diff *= xeno.Comp.Range / 3 / length;
+        diff = diff.Normalized() * xeno.Comp.Range;
 
         _stun.TryParalyze(targetId, xeno.Comp.StunTime, true);
         _throwing.TryThrow(targetId, diff, 10);

--- a/Content.Shared/_RMC14/Xenonids/Charge/XenoChargeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Charge/XenoChargeSystem.cs
@@ -79,11 +79,13 @@ public sealed class XenoChargeSystem : EntitySystem
         if (args.Cancelled)
             return;
 
+        _rmcPulling.TryStopAllPullsFromAndOn(xeno);
+
         var coordinates = GetCoordinates(args.Coordinates);
         var origin = _transform.GetMapCoordinates(xeno);
         var diff = _transform.ToMapCoordinates(coordinates).Position - origin.Position;
         var length = diff.Length();
-        diff *= xeno.Comp.Range / length;
+        diff = diff.Normalized() * xeno.Comp.Range;
 
         xeno.Comp.Charge = diff;
         Dirty(xeno);
@@ -121,7 +123,7 @@ public sealed class XenoChargeSystem : EntitySystem
             _colorFlash.RaiseEffect(Color.Red, new List<EntityUid> { targetId }, filter);
         }
 
-        _rmcPulling.TryStopAllPullsIfBeingPulled(targetId);
+        _rmcPulling.TryStopAllPullsFromAndOn(targetId);
 
         var origin = _transform.GetMapCoordinates(xeno);
         var target = _transform.GetMapCoordinates(targetId);

--- a/Content.Shared/_RMC14/Xenonids/Charge/XenoChargeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Charge/XenoChargeSystem.cs
@@ -84,7 +84,6 @@ public sealed class XenoChargeSystem : EntitySystem
         var coordinates = GetCoordinates(args.Coordinates);
         var origin = _transform.GetMapCoordinates(xeno);
         var diff = _transform.ToMapCoordinates(coordinates).Position - origin.Position;
-        var length = diff.Length();
         diff = diff.Normalized() * xeno.Comp.Range;
 
         xeno.Comp.Charge = diff;
@@ -128,7 +127,6 @@ public sealed class XenoChargeSystem : EntitySystem
         var origin = _transform.GetMapCoordinates(xeno);
         var target = _transform.GetMapCoordinates(targetId);
         var diff = target.Position - origin.Position;
-        var length = diff.Length();
         diff = diff.Normalized() * xeno.Comp.Range;
 
         _stun.TryParalyze(targetId, xeno.Comp.StunTime, true);

--- a/Content.Shared/_RMC14/Xenonids/Cleave/XenoCleaveSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Cleave/XenoCleaveSystem.cs
@@ -57,7 +57,6 @@ public sealed class XenoCleaveSystem : EntitySystem
             var origin = _transform.GetMapCoordinates(xeno);
             var target = _transform.GetMapCoordinates(args.Target);
             var diff = target.Position - origin.Position;
-            var length = diff.Length();
             diff = diff.Normalized() * flingRange;
 
             if (_net.IsServer)

--- a/Content.Shared/_RMC14/Xenonids/Cleave/XenoCleaveSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Cleave/XenoCleaveSystem.cs
@@ -51,7 +51,7 @@ public sealed class XenoCleaveSystem : EntitySystem
         if (xeno.Comp.Flings)
         {
             var flingRange = buffed ? xeno.Comp.FlingDistanceBuffed : xeno.Comp.FlingDistance;
-            _rmcPulling.TryStopAllPullsIfBeingPulled(args.Target);
+            _rmcPulling.TryStopAllPullsFromAndOn(args.Target);
 
             //From fling
             var origin = _transform.GetMapCoordinates(xeno);

--- a/Content.Shared/_RMC14/Xenonids/Cleave/XenoCleaveSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Cleave/XenoCleaveSystem.cs
@@ -19,7 +19,7 @@ public sealed class XenoCleaveSystem : EntitySystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly VanguardShieldSystem _vanguard = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
-    [Dependency] private readonly RMCPullingSystem _rmcpulling = default!;
+    [Dependency] private readonly RMCPullingSystem _rmcPulling = default!;
     [Dependency] private readonly ThrowingSystem _throwing = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly MovementSpeedModifierSystem _speed = default!;
@@ -51,7 +51,7 @@ public sealed class XenoCleaveSystem : EntitySystem
         if (xeno.Comp.Flings)
         {
             var flingRange = buffed ? xeno.Comp.FlingDistanceBuffed : xeno.Comp.FlingDistance;
-            _rmcpulling.TryStopUserPullIfPulling(xeno, args.Target);
+            _rmcPulling.TryStopAllPullsIfBeingPulled(args.Target);
 
             //From fling
             var origin = _transform.GetMapCoordinates(xeno);

--- a/Content.Shared/_RMC14/Xenonids/Fling/XenoFlingSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Fling/XenoFlingSystem.cs
@@ -48,10 +48,10 @@ public sealed class XenoFlingSystem : EntitySystem
             args.Handled = true;
             _audio.PlayPvs(xeno.Comp.Sound, xeno);
         }
-            
+
 
         var targetId = args.Target;
-        _rmcPulling.TryStopUserPullIfPulling(xeno, targetId);
+        _rmcPulling.TryStopAllPullsIfBeingPulled(targetId);
 
         var damage = _damageable.TryChangeDamage(targetId, xeno.Comp.Damage);
         if (damage?.GetTotal() > FixedPoint2.Zero)
@@ -66,7 +66,7 @@ public sealed class XenoFlingSystem : EntitySystem
         var length = diff.Length();
         diff = diff.Normalized() * xeno.Comp.Range;
 
-		if (_net.IsServer)
+        if (_net.IsServer)
         {
             _stun.TryParalyze(targetId, xeno.Comp.ParalyzeTime, true);
             _throwing.TryThrow(targetId, diff, 10);

--- a/Content.Shared/_RMC14/Xenonids/Fling/XenoFlingSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Fling/XenoFlingSystem.cs
@@ -63,7 +63,6 @@ public sealed class XenoFlingSystem : EntitySystem
         var origin = _transform.GetMapCoordinates(xeno);
         var target = _transform.GetMapCoordinates(targetId);
         var diff = target.Position - origin.Position;
-        var length = diff.Length();
         diff = diff.Normalized() * xeno.Comp.Range;
 
         if (_net.IsServer)

--- a/Content.Shared/_RMC14/Xenonids/Fling/XenoFlingSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Fling/XenoFlingSystem.cs
@@ -51,7 +51,7 @@ public sealed class XenoFlingSystem : EntitySystem
 
 
         var targetId = args.Target;
-        _rmcPulling.TryStopAllPullsIfBeingPulled(targetId);
+        _rmcPulling.TryStopAllPullsFromAndOn(targetId);
 
         var damage = _damageable.TryChangeDamage(targetId, xeno.Comp.Damage);
         if (damage?.GetTotal() > FixedPoint2.Zero)

--- a/Content.Shared/_RMC14/Xenonids/Headbutt/XenoHeadbuttSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Headbutt/XenoHeadbuttSystem.cs
@@ -62,7 +62,7 @@ public sealed class XenoHeadbuttSystem : EntitySystem
         if (!_xenoPlasma.TryRemovePlasmaPopup(xeno.Owner, xeno.Comp.PlasmaCost))
             return;
 
-        _rmcPulling.TryStopAllPullsIfBeingPulled(args.Target);
+        _rmcPulling.TryStopAllPullsFromAndOn(xeno);
 
         args.Handled = true;
 
@@ -107,6 +107,8 @@ public sealed class XenoHeadbuttSystem : EntitySystem
             var filter = Filter.Pvs(targetId, entityManager: EntityManager).RemoveWhereAttachedEntity(o => o == xeno.Owner);
             _colorFlash.RaiseEffect(Color.Red, new List<EntityUid> { targetId }, filter);
         }
+
+        _rmcPulling.TryStopAllPullsFromAndOn(targetId);
 
         var origin = _transform.GetMapCoordinates(xeno);
         var target = _transform.GetMapCoordinates(targetId);

--- a/Content.Shared/_RMC14/Xenonids/Headbutt/XenoHeadbuttSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Headbutt/XenoHeadbuttSystem.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared._RMC14.Xenonids.Animation;
+﻿using Content.Shared._RMC14.Pulling;
+using Content.Shared._RMC14.Xenonids.Animation;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared.Coordinates;
@@ -24,7 +25,7 @@ public sealed class XenoHeadbuttSystem : EntitySystem
     [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly ThrowingSystem _throwing = default!;
-    [Dependency] private readonly PullingSystem _pulling = default!;
+    [Dependency] private readonly RMCPullingSystem _rmcPulling = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly ThrownItemSystem _thrownItem = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
@@ -61,8 +62,7 @@ public sealed class XenoHeadbuttSystem : EntitySystem
         if (!_xenoPlasma.TryRemovePlasmaPopup(xeno.Owner, xeno.Comp.PlasmaCost))
             return;
 
-        if (TryComp(xeno, out PullerComponent? puller) && TryComp(puller.Pulling, out PullableComponent? pullable))
-            _pulling.TryStopPull(puller.Pulling.Value, pullable, xeno);
+        _rmcPulling.TryStopAllPullsIfBeingPulled(args.Target);
 
         args.Handled = true;
 

--- a/Content.Shared/_RMC14/Xenonids/Leap/XenoLeapSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Leap/XenoLeapSystem.cs
@@ -1,4 +1,5 @@
 ﻿using System.Numerics;
+using Content.Shared._RMC14.Pulling;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Invisibility;
 using Content.Shared._RMC14.Xenonids.Plasma;
@@ -40,7 +41,7 @@ public sealed class XenoLeapSystem : EntitySystem
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
-    [Dependency] private readonly PullingSystem _pulling = default!;
+    [Dependency] private readonly RMCPullingSystem _rmcPulling = default!;
     [Dependency] private readonly StandingStateSystem _standing = default!;
     [Dependency] private readonly SharedStunSystem _stun = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
@@ -123,8 +124,7 @@ public sealed class XenoLeapSystem : EntitySystem
             return;
         }
 
-        if (TryComp(xeno, out PullerComponent? puller) && TryComp(puller.Pulling, out PullableComponent? pullable))
-            _pulling.TryStopPull(puller.Pulling.Value, pullable, xeno);
+        _rmcPulling.TryStopAllPullsFromAndOn(xeno);
 
         var origin = _transform.GetMapCoordinates(xeno);
         var target = _transform.ToMapCoordinates(args.Coordinates);

--- a/Content.Shared/_RMC14/Xenonids/Lunge/XenoLungeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Lunge/XenoLungeSystem.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Shared._RMC14.Marines;
-﻿using Content.Shared._RMC14.Xenonids.Hive;
+using Content.Shared._RMC14.Pulling;
+using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared.Coordinates;
 using Content.Shared.Movement.Pulling.Events;
 using Content.Shared.Movement.Pulling.Systems;
@@ -26,6 +27,7 @@ public sealed class XenoLungeSystem : EntitySystem
     [Dependency] private readonly SharedStunSystem _stun = default!;
     [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
     [Dependency] private readonly XenoSystem _xeno = default!;
+    [Dependency] private readonly RMCPullingSystem _rmcPulling = default!;
 
     private EntityQuery<PhysicsComponent> _physicsQuery;
     private EntityQuery<ThrownItemComponent> _thrownItemQuery;
@@ -57,11 +59,12 @@ public sealed class XenoLungeSystem : EntitySystem
 
         args.Handled = true;
 
+        _rmcPulling.TryStopAllPullsFromAndOn(xeno);
+
         var origin = _transform.GetMapCoordinates(xeno);
         var target = _transform.GetMapCoordinates(args.Target);
         var diff = target.Position - origin.Position;
-        var length = diff.Length();
-        diff *= xeno.Comp.Range / length;
+        diff = diff.Normalized() * xeno.Comp.Range;
 
         xeno.Comp.Charge = diff;
         Dirty(xeno);

--- a/Content.Shared/_RMC14/Xenonids/Neurotoxin/SharedNeurotoxinSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Neurotoxin/SharedNeurotoxinSystem.cs
@@ -22,6 +22,7 @@ using Robust.Shared.Physics.Systems;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 using Content.Shared.Projectiles;
+using Content.Shared._RMC14.Pulling;
 
 namespace Content.Shared._RMC14.Xenonids.Neurotoxin;
 
@@ -43,6 +44,7 @@ public abstract class SharedNeurotoxinSystem : EntitySystem
     [Dependency] private readonly ActionBlockerSystem _blocker = default!;
     [Dependency] private readonly MovementSpeedModifierSystem _movementSpeed = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+    [Dependency] private readonly RMCPullingSystem _rmcPulling = default!;
 
     private readonly HashSet<Entity<MarineComponent>> _marines = new();
     public override void Initialize()
@@ -178,6 +180,7 @@ public abstract class SharedNeurotoxinSystem : EntitySystem
                 // This is how we randomly move them - by throwing
                 if (_blocker.CanMove(uid))
                 {
+                    _rmcPulling.TryStopAllPullsIfBeingPulled(uid);
                     _physics.SetLinearVelocity(uid, Vector2.Zero);
                     _physics.SetAngularVelocity(uid, 0f);
                     _throwing.TryThrow(uid, _random.NextAngle().ToVec().Normalized(), 1, animated: false, playSound: false, doSpin: false);

--- a/Content.Shared/_RMC14/Xenonids/Neurotoxin/SharedNeurotoxinSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Neurotoxin/SharedNeurotoxinSystem.cs
@@ -180,7 +180,7 @@ public abstract class SharedNeurotoxinSystem : EntitySystem
                 // This is how we randomly move them - by throwing
                 if (_blocker.CanMove(uid))
                 {
-                    _rmcPulling.TryStopAllPullsIfBeingPulled(uid);
+                    _rmcPulling.TryStopPullsOn(uid);
                     _physics.SetLinearVelocity(uid, Vector2.Zero);
                     _physics.SetAngularVelocity(uid, 0f);
                     _throwing.TryThrow(uid, _random.NextAngle().ToVec().Normalized(), 1, animated: false, playSound: false, doSpin: false);

--- a/Content.Shared/_RMC14/Xenonids/Punch/XenoPunchSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Punch/XenoPunchSystem.cs
@@ -68,7 +68,6 @@ public sealed class XenoPunchSystem : EntitySystem
         var origin = _transform.GetMapCoordinates(xeno);
         var target = _transform.GetMapCoordinates(targetId);
         var diff = target.Position - origin.Position;
-        var length = diff.Length();
         diff = diff.Normalized() * xeno.Comp.Range;
 
         _throwing.TryThrow(targetId, diff, 10);

--- a/Content.Shared/_RMC14/Xenonids/Punch/XenoPunchSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Punch/XenoPunchSystem.cs
@@ -56,7 +56,7 @@ public sealed class XenoPunchSystem : EntitySystem
             _audio.PlayPvs(xeno.Comp.Sound, xeno);
 
         var targetId = args.Target;
-        _rmcPulling.TryStopAllPullsIfBeingPulled(targetId);
+        _rmcPulling.TryStopAllPullsFromAndOn(targetId);
 
         var damage = _damageable.TryChangeDamage(targetId, xeno.Comp.Damage);
         if (damage?.GetTotal() > FixedPoint2.Zero)

--- a/Content.Shared/_RMC14/Xenonids/Punch/XenoPunchSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Punch/XenoPunchSystem.cs
@@ -56,7 +56,7 @@ public sealed class XenoPunchSystem : EntitySystem
             _audio.PlayPvs(xeno.Comp.Sound, xeno);
 
         var targetId = args.Target;
-        _rmcPulling.TryStopUserPullIfPulling(xeno, targetId);
+        _rmcPulling.TryStopAllPullsIfBeingPulled(targetId);
 
         var damage = _damageable.TryChangeDamage(targetId, xeno.Comp.Damage);
         if (damage?.GetTotal() > FixedPoint2.Zero)

--- a/Content.Shared/_RMC14/Xenonids/Retrieve/XenoRetrieveSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Retrieve/XenoRetrieveSystem.cs
@@ -2,6 +2,7 @@
 using Content.Shared._RMC14.Actions;
 using Content.Shared._RMC14.Emote;
 using Content.Shared._RMC14.Line;
+using Content.Shared._RMC14.Pulling;
 using Content.Shared._RMC14.Stun;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Rest;
@@ -35,6 +36,7 @@ public sealed class XenoRetrieveSystem : EntitySystem
     [Dependency] private readonly StandingStateSystem _standing = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly RMCPullingSystem _rmcPulling = default!;
 
     public override void Initialize()
     {
@@ -155,6 +157,8 @@ public sealed class XenoRetrieveSystem : EntitySystem
 
         if (!_rmcActions.TryUseAction(xeno, action.Value))
             return;
+
+        _rmcPulling.TryStopAllPullsIfBeingPulled(target);
 
         var length = direction.Length();
         var distance = Math.Clamp(length, 0.1f, xeno.Comp.Range);

--- a/Content.Shared/_RMC14/Xenonids/Retrieve/XenoRetrieveSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Retrieve/XenoRetrieveSystem.cs
@@ -158,7 +158,7 @@ public sealed class XenoRetrieveSystem : EntitySystem
         if (!_rmcActions.TryUseAction(xeno, action.Value))
             return;
 
-        _rmcPulling.TryStopAllPullsIfBeingPulled(target);
+        _rmcPulling.TryStopAllPullsFromAndOn(target);
 
         var length = direction.Length();
         var distance = Math.Clamp(length, 0.1f, xeno.Comp.Range);

--- a/Content.Shared/_RMC14/Xenonids/Sweep/XenoTailSweepSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Sweep/XenoTailSweepSystem.cs
@@ -69,7 +69,7 @@ public sealed class XenoTailSweepSystem : EntitySystem
             if (!_xeno.CanAbilityAttackTarget(xeno, marine))
                 return;
 
-            _rmcPulling.TryStopAllPullsIfBeingPulled(marine);
+            _rmcPulling.TryStopAllPullsFromAndOn(marine);
 
             var marineCoords = _transform.GetMapCoordinates(marine);
             var diff = marineCoords.Position - origin.Position;

--- a/Content.Shared/_RMC14/Xenonids/Sweep/XenoTailSweepSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Sweep/XenoTailSweepSystem.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Shared._RMC14.Marines;
+using Content.Shared._RMC14.Pulling;
 using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared.Coordinates;
 using Content.Shared.Damage;
@@ -27,6 +28,7 @@ public sealed class XenoTailSweepSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly XenoSystem _xeno = default!;
     [Dependency] private readonly XenoPlasmaSystem _xenoPlasma = default!;
+    [Dependency] private readonly RMCPullingSystem _rmcPulling = default!;
 
     private readonly HashSet<Entity<MarineComponent>> _hit = new();
 
@@ -67,9 +69,11 @@ public sealed class XenoTailSweepSystem : EntitySystem
             if (!_xeno.CanAbilityAttackTarget(xeno, marine))
                 return;
 
+            _rmcPulling.TryStopAllPullsIfBeingPulled(marine);
+
             var marineCoords = _transform.GetMapCoordinates(marine);
             var diff = marineCoords.Position - origin.Position;
-            diff *= xeno.Comp.Range / 3;
+            diff = diff.Normalized() * xeno.Comp.Range;
 
             if (xeno.Comp.Damage is { } damage)
                 _damageable.TryChangeDamage(marine, damage);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity, all the moves I tested that move you just break anyones pull on you in CM. Fixes a few discord bugs

## Technical details
<!-- Summary of code changes for easier review. -->
New func in the RMC pulling system to try to call to break any pulls on a target, put it everywhere that's relevant. Also a seperate function to run both this and the previous function. In CM when an ability moves you it breaks every pull on your and every pull your doing. For the fake movement stuff it only breaks pulling from others as it's like your moving.

Also went through and fixed up a few remaining distance calc things.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/5ac92cb6-9c79-41fd-a767-c9bacce95baf



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed xeno abilities that move a target not breaking pulls.
