### PR TITLE
Fix mini sentry not being spit hittable + fix sentry deploy/undeploy times

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Sentries/sentries.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Sentries/sentries.yml
@@ -321,7 +321,6 @@
         11.0
   - type: Sentry
     deployDelay: 2
-    undeployDelay: 2
     upgrades: null
   - type: RMCWeaponAccuracy
     accuracyMultiplier: 4
@@ -429,6 +428,7 @@
       AggroVisionRadius: !type:Single
         4.0
   - type: Sentry
+    undeployDelay: 1.5
     upgrades: null
     startingMagazine: RMCMagazineSentryShotgun
     magazineTag: RMCMagazineSentryShotgun

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Sentries/sentries.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Sentries/sentries.yml
@@ -242,11 +242,29 @@
         acts: [ "Destruction" ]
   - type: GunDamageModifier
     multiplier: 0.4
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.25,-0.25,0.25,0.25"
+        density: 20
+        mask:
+        - ItemMask
+        restitution: 0.3
+        friction: 0.2
+      sentry:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.49,-0.49,0.49,0.49"
+        density: 20
+        layer: 
+        - BulletImpassable
+        hard: false
   - type: Sentry
     deployDelay: 0.75
     undeployDelay: 0.75
     upgrades: null
-    deployFixture: null
 
 - type: entity
   parent: RMCSentry
@@ -302,6 +320,8 @@
       AggroVisionRadius: !type:Single
         11.0
   - type: Sentry
+    deployDelay: 2
+    undeployDelay: 2
     upgrades: null
   - type: RMCWeaponAccuracy
     accuracyMultiplier: 4


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity.

## Technical details
<!-- Summary of code changes for easier review. -->
remove the null deploy fixture, copy the normal sentry fixtures and remove the mini's mask and only keep it's layer so it can be hit by spits but still walked over.

Also snipers deploy a second faster apparently. The more you know.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed mini sentries being unable to be hit with spit
- fix: Fixed sniper sentries not having a slightly faster deploy time and shotgun sentries not having a faster undeploy time.
