### PR TITLE
Update Essential Maintenance Set

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/engineer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/engineer.yml
@@ -99,6 +99,6 @@
     bundle:
     - CMLightReplacer
     # demo scanner
-    # trash bag
-    # mechanical toolbox
+    - TrashBag
+    - RMCToolboxMechanicalFilled
     - RMCFlashlight


### PR DESCRIPTION
## About the PR

"Uncommented" trash bag and mechanical toolbox in MT essential set.
Reason: Parity.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:
- add: Added trash bag in Maintenance Technician set.
