### PR TITLE
Add Fire patting popups for the receiver, and others

### DIFF
--- a/Content.Shared/_RMC14/Atmos/SharedRMCFlammableSystem.cs
+++ b/Content.Shared/_RMC14/Atmos/SharedRMCFlammableSystem.cs
@@ -29,6 +29,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Physics.Systems;
+using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
@@ -293,6 +294,11 @@ public abstract class SharedRMCFlammableSystem : EntitySystem
 
         _audio.PlayPredicted(patter.Sound, user, user);
         _popup.PopupClient($"You try to put out the fire on {Name(ent)}!", ent, user, PopupType.SmallCaution);
+        _popup.PopupEntity($"{Name(user)} tries to put out the fire on you!", ent, ent, PopupType.SmallCaution);
+
+        var others = Filter.PvsExcept(ent).RemoveWhereAttachedEntity(e => e == user || e == ent.Owner);
+        _popup.PopupEntity($"{Name(user)} tries to put out the fire on {Name(ent)}!", ent, others, true);
+
     }
 
     private void OnFlammableIgnite(Entity<FlammableComponent> ent, ref RMCIgniteEvent args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds more popups to patting out fire, adding a popup for when someone else pats you out, and a popup that shows everyone that you patted fire out on x person.

## Why / Balance
Better visual feedback for pats, credits the patter, and also passively teaches other xenos that patting is a mechanic that exists

## Technical details
PopupEntitys for both the case of receiving pats, and another for everyone else to see

## Media

https://github.com/user-attachments/assets/5666210d-b6d8-4dc8-8d87-e479e9ab569c

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- add: You now receive a popup when others pat out fire on you.
- add: Everyone else now receives a popup when a fire is patted out on others, too.
