### PR TITLE
[Fix] Extinguisher spray will no longer go into disposal 

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Tools/fire_extinguisher.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Tools/fire_extinguisher.yml
@@ -11,6 +11,7 @@
     sprite: _RMC14/Objects/fire_extinguisher.rsi
   - type: Spray
     transferAmount: 5
+    sprayedPrototype: RMCExtinguisherSpray
   - type: SolutionContainerManager
     solutions:
       spray:
@@ -71,3 +72,10 @@
     - CMFireExtinguisherPortable
   - type: Clothing
     sprite: _RMC14/Objects/fire_extinguisher_mini.rsi
+
+- type: entity
+  parent: ExtinguisherSpray
+  id: RMCExtinguisherSpray
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Undisposable


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Extinguisher spray will no longer go into disposal

## Why / Balance
fixes #5113

## Technical details
made a new entity "RMCExtinguisherSpray" which parents from "ExtinguisherSpray", and gave the new entity the Undisposable component, and gave the RMC extinguishers the new spray

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Fixed extinguisher spray going into disposal.
