### PR TITLE
Make xeno jobs appear as xeno instead of naked character in the editor

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Xeno/queen.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Xeno/queen.yml
@@ -26,6 +26,7 @@
   minimapBackground:
    sprite: _RMC14/Interface/map_blips.rsi
    state: xeno_ruler
+  jobEntity: CMXenoQueen
 
 - type: playTimeTracker
   id: CMJobXenoQueen

--- a/Resources/Prototypes/_RMC14/Roles/Xeno/selectable.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Xeno/selectable.yml
@@ -4,6 +4,7 @@
   name: cm-job-name-selectable-xenonid
   playTimeTracker: CMJobSelectableXeno
   hidden: false
+  jobEntity: CMXenoLarva
 
 - type: playTimeTracker
   id: CMJobSelectableXeno


### PR DESCRIPTION
Just adds the ``JobEntity`` field to the queen and selectable xeno jobs, like a cyborg and station AI