### PR TITLE
Fix all instances of scout's M4SPR name

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/specialist_loadouts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/specialist_loadouts.yml
@@ -105,7 +105,7 @@
   id: RMCScoutSpecEquipmentCase
   name: scout equipment case
   suffix: Jungle
-  description: "A large case containing an M4RA battle rifle, M3-S light armor and helmet, M4RA battle sight, M68 thermal cloak, V3 reactive thermal tarp, ammunition and additional pieces of equipment.\nNOTE: You cannot put items back inside this case."
+  description: "A large case containing an M4SPR custom battle rifle, M3-S light armor and helmet, M4SPR battle sight, M68 thermal cloak, V3 reactive thermal tarp, ammunition and additional pieces of equipment.\nNOTE: You cannot put items back inside this case."
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m4spr_scout_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m4spr_scout_rifle.yml
@@ -208,7 +208,7 @@
   parent: RMCMagazineRifleM4SPRA19
   id: RMCMagazineRifleM4SPRA19Impact
   name: "A19 HV high impact magazine (10x24mm)"
-  description: "A magazine of A19 HV high impact rounds for use in the M4RA battle rifle. The M4RA battle rifle is the only gun that can chamber these rounds."
+  description: "A magazine of A19 HV high impact rounds for use in the M4SPR custom battle rifle. The M4SPR custom battle rifle is the only gun that can chamber these rounds."
   components:
   - type: Tag
     tags:
@@ -233,7 +233,7 @@
   parent: RMCMagazineRifleM4SPRA19
   id: RMCMagazineRifleM4SPRA19Incendiary
   name: "A19 HV incendiary magazine (10x24mm)"
-  description: "A magazine of A19 HV incendiary rounds for use in the M4RA battle rifle. The M4RA battle rifle is the only gun that can chamber these rounds."
+  description: "A magazine of A19 HV incendiary rounds for use in the M4SPR custom battle rifle. The M4SPR custom battle rifle is the only gun that can chamber these rounds."
   components:
   - type: Tag
     tags:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
M4RA -> M4SPR custom in all locations where it is still referred to as such.

## Why / Balance
It is not an M4RA, we can not use that word

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
![image](https://github.com/user-attachments/assets/9a404c50-e2c8-4252-b2a6-47edd85b4456)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- fix: Fixed the Scout's M4SPR custom battle rifle being referred to by the wrong name in the WS vendor and equipment case.

