### PR TITLE
Fix max item size of a few med pouches + fix rig having ointment

### DIFF
--- a/Resources/Prototypes/_RMC14/Catalog/Fills/Clothing/belt.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Fills/Clothing/belt.yml
@@ -75,7 +75,7 @@
     - id: CMPillCanisterInaprovaline
       amount: 1
     # TODO RMC14 tramadol and perixadon pills, splint
-    - id: CMOintment10
+    - id: CMBurnKit10
       amount: 1
     - id: CMTraumaKit10
       amount: 1

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Pouches/medical.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Pouches/medical.yml
@@ -240,6 +240,7 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Pouches/frt_med.rsi
   - type: Storage
+    maxItemSize: Large
     grid:
     - 0,0,7,1 #4 slots
     whitelist:
@@ -440,6 +441,7 @@
   - type: Storage
     grid:
     - 0,0,13,1 #7 slots
+    maxItemSize: Large
     whitelist:
       tags:
       - DiscreteHealthAnalyzer


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Few of them couldn't hold pill canisters due to the size limit, just buffed them like the medical pouch. Also the rig is supposed to have burn kits in it like the medical bag.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed a few medical pouches not being able to store pill bottles
- fix: Fixed medical rig starting with ointment and not burn kits