### PR TITLE
[Fix] Combat engineering description spelling

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Misc/engineerkit.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Misc/engineerkit.yml
@@ -2,7 +2,7 @@
   parent: BaseStorageItem
   id: RMCEngineerKit
   name: engineer kit
-  description: An combat engineering toolkit intended to carry electrical and mechanical supplies into combat. With engineering training you can fit this in a backpack.
+  description: A combat engineering toolkit intended to carry electrical and mechanical supplies into combat. With engineering training you can fit this in a backpack.
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Misc/engineer_kit.rsi


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
An combat enginneering... -> A combat engineering...

## Why / Balance
spelling, issue is from cm13

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->