### PR TITLE
Make Resin Whisperer Remote Build LoS A LOT more permissive

### DIFF
--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-construction.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-construction.ftl
@@ -4,6 +4,7 @@ cm-xeno-construction-failed-cant-build = We can't build there!
 cm-xeno-construction-failed-select-structure = We need to select a structure to build first! Use the "Choose Resin Structure" action.
 cm-xeno-construction-failed-requires-support = {CAPITALIZE(MAKEPLURAL($choice))} need a wall or resin door next to them to stand up.
 
+rmc-xeno-construction-remote-failed-need-line-of-sight = We need direct line of sight to build!
 rmc-xeno-construction-remote-failed-need-on-weeds = We must be standing on weeds to establish a connection to the resin.
 rmc-xeno-construction-remote-construct = We focus our plasma into the weeds below us and force the weeds to secrete resin!
 rmc-xeno-construction-remote-open-door = We focus our connection to the resin and remotely open the resin door.


### PR DESCRIPTION
## About the PR
As long as you have Line of Sight to any part of the tile (either center or any of 4 corners/center of any 4 flat edges), you are allowed to remote build

## Why / Balance
CM13 is VERY permissive due to how sight works there (you can actually build without "direct" line of sight because your LoS wraps around corners by 45 degrees for whatever reason), so this makes it as close as possible to that. This is still more restrictive but it's the best we can get intuitively.

## Technical details
Check 9 different points on the tile to see if you can see it, if so, allow you to build (assuming other checks don't fail). First checks the center of a tile, then spirals outward in a clockwise motion.

## Media

https://github.com/user-attachments/assets/23f0ee03-0a86-417f-ac82-ff66582d7d0e

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- fix: Fixed the Hivelord Resin Whisperer's Remote Build being too restrictive on Line of Sight. You now only need to see any tiny part of a tile to remote build on it, similar to CM13.
