### PR TITLE
Fix Boiler glob going through xeno walls/membrane

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
@@ -50,7 +50,7 @@ public sealed class XenoProjectileSystem : EntitySystem
         if (args.Cancelled || ent.Comp.DeleteOnFriendlyXeno)
             return;
 
-        if (_hive.FromSameHive(ent.Owner, args.OtherEntity))
+        if (_hive.FromSameHive(ent.Owner, args.OtherEntity) && HasComp<XenoComponent>(args.OtherEntity))
             args.Cancelled = true;
     }
 

--- a/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
@@ -50,7 +50,8 @@ public sealed class XenoProjectileSystem : EntitySystem
         if (args.Cancelled || ent.Comp.DeleteOnFriendlyXeno)
             return;
 
-        if (_hive.FromSameHive(ent.Owner, args.OtherEntity) && HasComp<XenoComponent>(args.OtherEntity))
+        if (_hive.FromSameHive(ent.Owner, args.OtherEntity) && 
+            (HasComp<XenoComponent>(args.OtherEntity) || HasComp<HiveCoreComponent>(args.OtherEntity)))
             args.Cancelled = true;
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Resin Whisperer PR made xeno structures have hive member tags, but that allowed Boilers to shoot through them. Boiler globs now explicitly make sure they only go through Xeno mobs to prevent this.

## Why / Balance
Evil bug

## Technical details
Check for XenoComponent/HiveCoreComponent in XenoProjectileSystem

## Media

https://github.com/user-attachments/assets/4babf121-ae0f-446c-9a6b-081152067872

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- fix: Fixed Boiler globs phasing through resin walls, membranes, and doors.
