### PR TITLE
fix m96s sniper rifle spawning as classic on jungle maps

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Snipers/m96s_sniper.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Snipers/m96s_sniper.yml
@@ -77,7 +77,7 @@
       rmc-aslot-underbarrel: 0.21875, -0.343
   - type: ItemCamouflage
     camouflageVariations:
-      Jungle:  _RMC14/Objects/Weapons/Guns/Snipers/m96s/classic.rsi
+      Jungle:  _RMC14/Objects/Weapons/Guns/Snipers/m96s/jungle.rsi
       Desert:  _RMC14/Objects/Weapons/Guns/Snipers/m96s/desert.rsi
       Snow:  _RMC14/Objects/Weapons/Guns/Snipers/m96s/snow.rsi
       Classic:  _RMC14/Objects/Weapons/Guns/Snipers/m96s/classic.rsi


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
single yaml line, fixed the m96s sniper rifle spawning with the classic skin on jungle maps
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
the m96s sniper spawns with the classic skin on jungle maps
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
