### PR TITLE
Give healer their own custom alert text, fix warden's popup text

### DIFF
--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
@@ -5,6 +5,10 @@ cm-xeno-not-enough-plasma = You don't have enough plasma!
 rmc-xeno-not-enough-energy = Your energy reserves are insufficient!
 rmc-xeno-energy-increase-user = You feel your internal energy reserves increase!
 
+# Energy
+rmc-xeno-not-enough-internal-health = Your health reserves are insufficient!
+rmc-xeno-internal-health-increase-user = You feel your internal health reserves increase!
+
 # Acid reserves
 rmc-xeno-not-enough-acid = Your don't have enough acid built up!
 rmc-xeno-acid-increase-user = You feel your acid reserves increase!

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
@@ -5,7 +5,7 @@ cm-xeno-not-enough-plasma = You don't have enough plasma!
 rmc-xeno-not-enough-energy = Your energy reserves are insufficient!
 rmc-xeno-energy-increase-user = You feel your internal energy reserves increase!
 
-# Energy
+# Internal Health
 rmc-xeno-not-enough-internal-health = Your health reserves are insufficient!
 rmc-xeno-internal-health-increase-user = You feel your internal health reserves increase!
 

--- a/Resources/Prototypes/_RMC14/Alerts/Xeno/xeno_energy_alerts.yml
+++ b/Resources/Prototypes/_RMC14/Alerts/Xeno/xeno_energy_alerts.yml
@@ -55,3 +55,9 @@
   id: XenoEnergyWarden
   name: Health reserves
   description: Your stored health. Used by different abilities.
+
+- type: alert
+  parent: XenoEnergyBase
+  id: XenoEnergyHealer
+  name: Amount healed
+  description: Your total healing done. If full you'll revive after using sacrifice.

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/drone.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/drone.yml
@@ -225,6 +225,7 @@
     stunMax: 4
     chance: 0.30
   - type: XenoEnergy
+    alert: XenoEnergyHealer
     max: 7500
     gain: 0
     gainAttack: 0

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/praetorian.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/praetorian.yml
@@ -174,6 +174,8 @@
     projectileId: XenoSpitProjectilePraetorianWarden
   - type: XenoEnergy
     alert: XenoEnergyWarden
+    popupGain: rmc-xeno-internal-health-increase-user
+    popupNotEnough: rmc-xeno-not-enough-internal-health
   - type: XenoRetrieve
   - type: XenoAid
   - type: XenoSprayAcid


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title. Warden's has been referring to generic energy for a bit now. For healer their alert refers to it has Amount healed.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Better matches what it represents.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
no cl kinda smol