### PR TITLE
Fix every Xeno Ghost Name bug

### DIFF
--- a/Content.Server/_RMC14/Name/XenoNameSystem.cs
+++ b/Content.Server/_RMC14/Name/XenoNameSystem.cs
@@ -1,7 +1,6 @@
 ﻿using Content.Server.GameTicking;
 using Content.Shared._RMC14.Xenonids.Name;
 using Content.Shared.GameTicking;
-using Content.Shared.Mind;
 using Content.Shared.NameModifier.EntitySystems;
 using Robust.Shared.Player;
 using Robust.Shared.Random;

--- a/Content.Server/_RMC14/Name/XenoNameSystem.cs
+++ b/Content.Server/_RMC14/Name/XenoNameSystem.cs
@@ -11,7 +11,6 @@ namespace Content.Server._RMC14.Name;
 public sealed class XenoNameSystem : SharedXenoNameSystem
 {
     [Dependency] private readonly GameTicker _gameTicker = default!;
-    [Dependency] private readonly SharedMindSystem _mind = default!;
     [Dependency] private readonly NameModifierSystem _nameModifier = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
 
@@ -49,9 +48,6 @@ public sealed class XenoNameSystem : SharedXenoNameSystem
             name.Postfix = profile.XenoPostfix;
             _nameModifier.RefreshNameModifiers(xeno);
             RemCompDeferred<AssignXenoNameComponent>(xeno);
-
-            if (_mind.TryGetMind(xeno, out var _, out var mind) && TryComp<MetaDataComponent>(xeno, out var xenoMetaData))
-                mind.CharacterName = xenoMetaData.EntityName;
         }
         catch (Exception e)
         {

--- a/Content.Server/_RMC14/Xenonids/XenoRoleSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/XenoRoleSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Maturing;
+using Content.Shared._RMC14.Xenonids.Name;
 using Content.Shared._RMC14.Xenonids.Rank;
 using Content.Shared.GameTicking;
 using Content.Shared.NameModifier.EntitySystems;
@@ -51,7 +52,7 @@ public sealed class XenoRoleSystem : EntitySystem
 
         SubscribeLocalEvent<ActorComponent, HiveChangedEvent>(OnHiveChanged);
 
-        SubscribeLocalEvent<XenoRankComponent, RefreshNameModifiersEvent>(OnRankRefreshName);
+        SubscribeLocalEvent<XenoRankComponent, RefreshNameModifiersEvent>(OnRankRefreshName, before: new[] { typeof(SharedXenoNameSystem) });
 
         Subs.CVar(_config, RMCCVars.RMCPlaytimeBronzeMedalTimeHours, v => _rankTwoTime = TimeSpan.FromHours(v), true);
         Subs.CVar(_config, RMCCVars.RMCPlaytimeSilverMedalTimeHours, v => _rankThreeTime = TimeSpan.FromHours(v), true);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixes various bugs relating to Xeno Ghost Names.

## Technical details
Converted the handler for PlayerAttachedEvent into one for MindAddedMessage. PlayerAttachedEvent has inconsistent behavior in interactions with ghost roles, in that it will run after the mind is added if it is a fresh ghost role, but run BEFORE the mind is added if the entity has been a ghost role in the past, which caused it to be unable to perform any actions relating to the mind on subsequent ghost roles (causing you to steal the previous name). It functions exactly the same otherwise, just more consistently.

Stopped handling name changes in hard-coded places and instead condensed it into one handling inside OnRefreshNameModifiers() so that it catches name changes generically, allowing it to catch more easily overlooked changes like the Queen maturing.

Made XenoRoleSystem handle the RefreshNameModifiersEvent before SharedXenoNameSystem, as otherwise XenoNameSystem has no clue what Rank you are when assigning your ghost name. This has to be a before call and not an after call, because the handler in shared can not interact with the server-only handler in XenoRoleSystem.

## Media
Main Fix Demonstration on Discord, channel link below

https://discord.com/channels/1168210010233376858/1168210011823026271/1321408086602158081

Additional Distress Signal round initialization test

https://github.com/user-attachments/assets/9a76b9c6-0412-4e93-949b-99c3bfcc77f6

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- fix: Taking a Xeno ghost role that previously belonged to someone else no longer causes your ghost to commit identity theft.
- fix: Fixed the Queen's ghost staying immature forever. It will now update correctly to change into the playtime rank when she matures.
