### PR TITLE
Fixes Devouring Already Nested Hosts

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Devour/XenoDevourSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Devour/XenoDevourSystem.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Content.Shared._RMC14.Armor;
+using Content.Shared._RMC14.Xenonids.Construction.Nest;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Buckle.Components;
 using Content.Shared.Coordinates;
@@ -17,7 +18,6 @@ using Content.Shared.Mobs.Systems;
 using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Popups;
-using Content.Shared.Standing;
 using Content.Shared.Stunnable;
 using Content.Shared.Throwing;
 using Content.Shared.Weapons.Melee.Events;
@@ -40,7 +40,6 @@ public sealed class XenoDevourSystem : EntitySystem
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
-    [Dependency] private readonly StandingStateSystem _standing = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedStunSystem _stun = default!;
     [Dependency] private readonly EntityManager _entManager = default!;
@@ -334,7 +333,8 @@ public sealed class XenoDevourSystem : EntitySystem
             return false;
         }
 
-        if (_mobState.IsIncapacitated(xeno))
+        if (_mobState.IsIncapacitated(xeno) ||
+            HasComp<XenoNestedComponent>(victim))
         {
             if (popup)
                 _popup.PopupClient(Loc.GetString("cm-xeno-devour-failed-cant-now"), victim, xeno);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Made is so you can't devour currently nested marines.
also cleans up XenoDevourSystem slightly
## Why / Balance
Fixes a bug that allowed you to devour already nested marines, which would keep them in a nested state.
## Media

https://github.com/user-attachments/assets/e829da66-91d0-4bb6-90ff-8eb4106d482e


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: You can no longer devour currently nested hosts.
