### PR TITLE
UGL Parity

### DIFF
--- a/Content.Server/_RMC14/Trigger/OnShootTriggerAmmoTimerComponent.cs
+++ b/Content.Server/_RMC14/Trigger/OnShootTriggerAmmoTimerComponent.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.Audio;
+using Robust.Shared.Audio;
 
 namespace Content.Server._RMC14.Trigger;
 
@@ -17,4 +17,13 @@ public sealed partial class OnShootTriggerAmmoTimerComponent : Component
 
     [DataField]
     public SoundSpecifier? BeepSound;
+
+    [DataField]
+    public Enum TimerStart = TimerStartMode.OnShoot;
 }
+
+public enum TimerStartMode : byte
+{
+    OnShoot,
+    OnHitGround
+};

--- a/Content.Server/_RMC14/Trigger/TriggerOnThrowEndComponent.cs
+++ b/Content.Server/_RMC14/Trigger/TriggerOnThrowEndComponent.cs
@@ -1,0 +1,9 @@
+namespace Content.Server._RMC14.Trigger;
+
+[RegisterComponent]
+[Access(typeof(RMCTriggerSystem))]
+public sealed partial class TriggerOnThrowEndComponent : Component
+{
+    [DataField]
+    public TimeSpan Delay;
+}

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/under_attachments.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/under_attachments.yml
@@ -356,13 +356,14 @@
       params:
         volume: -2
   - type: OnShootTriggerAmmoTimer
-    delay: 1
+    delay: 1.5
     beepInterval: 2
     initialBeepDelay: 0
     beepSound:
       path: "/Audio/Effects/beep1.ogg"
       params:
         volume: 5
+    timerStart: enum.TimerStartMode.OnHitGround
   - type: ShootAtFixedPoint
     maxFixedRange: 7
   - type: UniqueAction


### PR DESCRIPTION

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

CM13 Parity

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Current:

https://github.com/user-attachments/assets/a5d740fc-e69b-4187-869c-103f27cd509d

Revised:

https://github.com/user-attachments/assets/e9d5e45b-0315-4ec1-8336-c25ecf5d78bd


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl: blueDev2
- add: UGL launched grenades timer starts on landing.
- add: Timer is extended to 1.5 seconds.

<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--

-->
