### PR TITLE
Adds press armor light

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
@@ -544,7 +544,7 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/press.rsi
   - type: ItemCamouflage # this is needed, otherwise it looks like M3MediumArmor
-    camouflageVariations:
+    camouflageVariations: { }
 
 - type: Tag
   id: RMCScoutArmor

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
@@ -536,28 +536,15 @@
       Urban: _RMC14/Objects/Clothing/OuterClothing/Armor/m3/light/smooth/urban.rsi
 
 - type: entity
-  parent: RMCBaseMarineArmorLight
+  parent: CMArmorM3Light
   id: CMArmorPress
   name: press body armor
   description: Body armor used by war correspondents in battles and wars across the universe.
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/press.rsi
-  - type: CMArmor
-    armor: 15
-    bio: 15
-    explosionArmor: 20
-  - type: RMCArmorSpeedTier
-    speedTier: light
-  - type: ClothingSpeedModifier
-    walkModifier: .725
-    sprintModifier: .725
-  - type: Storage
-    grid:
-    - 0,0,3,1 # 2 slots
-  - type: ExplosionResistance
-    damageCoefficient: 0
-    worn: false
+  - type: ItemCamouflage # this is needed, otherwise it looks like M3MediumArmor
+    camouflageVariations:
 
 - type: Tag
   id: RMCScoutArmor

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
@@ -536,7 +536,7 @@
       Urban: _RMC14/Objects/Clothing/OuterClothing/Armor/m3/light/smooth/urban.rsi
 
 - type: entity
-  parent: RMCBaseMarineArmor
+  parent: RMCBaseMarineArmorLight
   id: CMArmorPress
   name: press body armor
   description: Body armor used by war correspondents in battles and wars across the universe.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
gave the press armor a light

## Why / Balance
resolves #4331

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Press armor now has a light.
