### PR TITLE
Fix glass shards from blocking doors closing

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Materials/shards.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Materials/shards.yml
@@ -1,8 +1,9 @@
 ﻿- type: entity
-  parent: ShardBase
+  parent: BaseItem
   id: CMShardBase
   abstract: true
   components:
+  - type: Sharp
   - type: Sprite
     layers:
       - sprite: _RMC14/Objects/Materials/shards.rsi
@@ -16,6 +17,33 @@
         medium: ""
         small: ""
         tiny: ""
+  - type: Item
+    sprite: Objects/Materials/Shards/shard.rsi
+    size: Tiny
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 2
+  - type: Tag
+    tags:
+    - Trash
+  - type: SpaceGarbage
+  - type: Damageable
+    damageContainer: Inorganic
+    damageModifierSet: Glass
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: MeleeWeapon
+    attackRate: 1
+    damage:
+      types:
+        Slash: 3.5
 
 - type: entity
   parent: CMShardBase


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed glass shards blocking doors closing

## Why / Balance
It's not supposed to do that

## Technical details
Change parent to BaseItem and transfer anything from upstream glass shard that is maybe desirable, while removing undesirable aspects (tripping people, having an evil fixture, etc)

## Media

https://github.com/user-attachments/assets/94065c02-2bd0-483f-a4d2-83236bd754c7


https://github.com/user-attachments/assets/eecd8ba1-bd79-4b95-8b25-126dca84f2cd

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- fix: Glass Shards no longer prevent doors and resin doors closing.