### PR TITLE
Xeno wideswing keybind option

### DIFF
--- a/Content.Client/Input/ContentContexts.cs
+++ b/Content.Client/Input/ContentContexts.cs
@@ -143,8 +143,10 @@ namespace Content.Client.Input
             human.AddFunction(CMKeyFunctions.CMHolsterSecondary);
             human.AddFunction(CMKeyFunctions.CMHolsterTertiary);
             human.AddFunction(CMKeyFunctions.CMHolsterQuaternary);
-            human.AddFunction(CMKeyFunctions.CMXenoWideSwing);
             human.AddFunction(CMKeyFunctions.RMCPickUpDroppedItems);
+
+            //Xeno
+            human.AddFunction(CMKeyFunctions.CMXenoWideSwing);
         }
     }
 }

--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
@@ -164,6 +164,7 @@ namespace Content.Client.Options.UI.Tabs
             AddButton(CMKeyFunctions.CMHolsterSecondary);
             AddButton(CMKeyFunctions.CMHolsterTertiary);
             AddButton(CMKeyFunctions.CMHolsterQuaternary);
+            AddButton(CMKeyFunctions.CMXenoWideSwing);
             AddButton(CMKeyFunctions.RMCPickUpDroppedItems);
 
             AddHeader("ui-options-header-general");

--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
@@ -164,8 +164,10 @@ namespace Content.Client.Options.UI.Tabs
             AddButton(CMKeyFunctions.CMHolsterSecondary);
             AddButton(CMKeyFunctions.CMHolsterTertiary);
             AddButton(CMKeyFunctions.CMHolsterQuaternary);
-            AddButton(CMKeyFunctions.CMXenoWideSwing);
             AddButton(CMKeyFunctions.RMCPickUpDroppedItems);
+
+            AddHeader("ui-options-header-rmc-xeno");
+            AddButton(CMKeyFunctions.CMXenoWideSwing);
 
             AddHeader("ui-options-header-general");
             AddCheckBox("ui-options-hotkey-keymap", _cfg.GetCVar(CVars.DisplayUSQWERTYHotkeys), HandleToggleUSQWERTYCheckbox);

--- a/Content.Shared/_RMC14/Input/CMKeyFunctions.cs
+++ b/Content.Shared/_RMC14/Input/CMKeyFunctions.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.Input;
+using Robust.Shared.Input;
 
 namespace Content.Shared._RMC14.Input;
 
@@ -16,7 +16,9 @@ public sealed class CMKeyFunctions
     public static readonly BoundKeyFunction CMHolsterSecondary = "CMHolsterSecondary";
     public static readonly BoundKeyFunction CMHolsterTertiary = "CMHolsterTertiary";
     public static readonly BoundKeyFunction CMHolsterQuaternary = "CMHolsterQuaternary";
-    public static readonly BoundKeyFunction CMXenoWideSwing = "CMXenoWideSwing";
     public static readonly BoundKeyFunction RMCPickUpDroppedItems = "RMCPickUpDroppedItems";
     public static readonly BoundKeyFunction RMCFocusMentorChat = "RMCFocusMentorChat";
+
+    //Xeno
+    public static readonly BoundKeyFunction CMXenoWideSwing = "CMXenoWideSwing";
 }

--- a/Resources/Locale/en-US/_RMC14/escape-menu/options-menu.ftl
+++ b/Resources/Locale/en-US/_RMC14/escape-menu/options-menu.ftl
@@ -11,5 +11,8 @@ ui-options-function-cm-holster-primary = Unholster
 ui-options-function-cm-holster-secondary = Unholster secondary
 ui-options-function-cm-holster-tertiary = Unholster tertiary
 ui-options-function-cm-holster-quaternary = Unholster quaternary
-ui-options-function-cm-xeno-wide-swing = Xeno wide swing
 ui-options-function-rmc-pick-up-dropped-items = Pick up dropped items
+
+ui-options-header-rmc-xeno = Xeno
+
+ui-options-function-cm-xeno-wide-swing = Xeno wide swing

--- a/Resources/Locale/en-US/_RMC14/escape-menu/options-menu.ftl
+++ b/Resources/Locale/en-US/_RMC14/escape-menu/options-menu.ftl
@@ -1,4 +1,4 @@
-﻿ui-options-header-rmc = RMC14
+ui-options-header-rmc = RMC14
 
 ui-options-function-rmc-activate-attachable-barrel = Activate barrel attachment
 ui-options-function-rmc-activate-attachable-rail = Activate rail attachment
@@ -11,4 +11,5 @@ ui-options-function-cm-holster-primary = Unholster
 ui-options-function-cm-holster-secondary = Unholster secondary
 ui-options-function-cm-holster-tertiary = Unholster tertiary
 ui-options-function-cm-holster-quaternary = Unholster quaternary
+ui-options-function-cm-xeno-wide-swing = Xeno wide swing
 ui-options-function-rmc-pick-up-dropped-items = Pick up dropped items


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
adds the option for players to change their xeno wide swing keybind in the options.
also added a xeno section in the controls menu, very bare for now, but its there for when we get other xeno keybinds.

## Why / Balance
QoL

## Media
![image](https://github.com/user-attachments/assets/ae6c5bf2-6bcb-4a4a-8933-a56c5d809588)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Added the ability to change the xeno wide swing keybind, in the options.
