### PR TITLE
M4SPR custom barrel fix

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m4spr_scout_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m4spr_scout_rifle.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   parent: WeaponRifleM4SPR
   name: M4SPR custom battle rifle
   id: WeaponRifleM4SPRCustom
@@ -13,7 +13,7 @@
     - sprite: _RMC14/Objects/Weapons/Guns/Attachments/barrel.rsi
       state: d_m4spr_custom_barrel
       offset: 0.65, 0
-      map: [ "enum.ItemCamouflageLayers.Layer" ]
+      map: [ "barrel" ]
     - state: mag-0
       map: [ "enum.GunVisualLayers.Mag" ]
   - type: RMCSelectiveFire
@@ -101,6 +101,13 @@
       Snow: _RMC14/Objects/Weapons/Guns/Rifles/m4spr_custom/snow.rsi
       Classic: _RMC14/Objects/Weapons/Guns/Rifles/m4spr_custom/classic.rsi
       Urban: _RMC14/Objects/Weapons/Guns/Rifles/m4spr_custom/urban.rsi
+    layers:
+      barrel:
+        Jungle: m4spr_custom_barrel
+        Desert: d_m4spr_custom_barrel
+        Snow: s_m4spr_custom_barrel
+        Classic: c_m4spr_custom_barrel
+        Urban: u_m4spr_custom_barrel
 
 - type: entity
   parent: CMMagazineRifleBase


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
its map for the barrel was looking at the wrong path, corrected it

## Why / Balance
fixes #5285

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/44da6110-545f-4d67-9c75-01100b6be2b0)
ignore the jungle one being the normal m4spr, it works, i just spawned the wrong one for that one
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
