### PR TITLE
M4SPR Barrel Attachment Tweak

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m4spr_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m4spr_rifle.yml
@@ -85,7 +85,7 @@
           - RMCAttachmentVerticalGrip
   - type: AttachableHolderVisuals
     offsets:
-      rmc-aslot-barrel: 1.18, 0.0
+      rmc-aslot-barrel: 1.12, 0.0
       rmc-aslot-rail: 0.225, 0.125
       rmc-aslot-underbarrel: 0.62, -0.31
   - type: ItemCamouflage


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adjusts the x-axis barrel attachment node for both M4SPR and M4SPR Custom to 1.12 instead of 1.18 to remove the gap between the gun frame and the bayonet attachment for stylistic reasons.

## Why / Balance
Minor visual tweak for sake of style!

## Technical details
changed the x-axis coord for the M4SPR barrel attachment from 1.18 to 1.12.

## Media
Before:
![image](https://github.com/user-attachments/assets/28386d2d-e50f-417b-ade9-5afb1ef275e1)

After:
![image](https://github.com/user-attachments/assets/59bd08d6-6ff4-4906-b1e4-7c80daed0b16)

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--

-->
:cl:
- tweak: Tweaked the M4SPR's barrel attachment point to look better with the bayonet.
