### PR TITLE
Adjust XM88  Hit stack stats

### DIFF
--- a/Content.Shared/_RMC14/Weapons/Ranged/Stacks/GunStacksComponent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/Stacks/GunStacksComponent.cs
@@ -15,7 +15,7 @@ public sealed partial class GunStacksComponent : Component
     public int MaxAP = 50;
 
     [DataField, AutoNetworkedField]
-    public FixedPoint2 DamageIncrease = FixedPoint2.New(0.5);
+    public FixedPoint2 DamageIncrease = FixedPoint2.New(0.2);
 
     [DataField, AutoNetworkedField]
     public float SetFireRate = 1.4285f;
@@ -24,7 +24,7 @@ public sealed partial class GunStacksComponent : Component
     public TimeSpan LastHitAt;
 
     [DataField, AutoNetworkedField]
-    public TimeSpan StacksExpire = TimeSpan.FromSeconds(4);
+    public TimeSpan StacksExpire = TimeSpan.FromSeconds(2);
 
     [DataField, AutoNetworkedField]
     public int Hits;

--- a/Content.Shared/_RMC14/Weapons/Ranged/Stacks/GunStacksComponent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/Stacks/GunStacksComponent.cs
@@ -18,7 +18,7 @@ public sealed partial class GunStacksComponent : Component
     public FixedPoint2 DamageIncrease = FixedPoint2.New(0.2);
 
     [DataField, AutoNetworkedField]
-    public float SetFireRate = 1.4285f;
+    public float SetFireRate = 0.7692f;
 
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
     public TimeSpan LastHitAt;

--- a/Content.Shared/_RMC14/Weapons/Ranged/Stacks/GunStacksComponent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/Stacks/GunStacksComponent.cs
@@ -18,7 +18,7 @@ public sealed partial class GunStacksComponent : Component
     public FixedPoint2 DamageIncrease = FixedPoint2.New(0.2);
 
     [DataField, AutoNetworkedField]
-    public float SetFireRate = 1.11f;
+    public float SetFireRate = 1.4285f;
 
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
     public TimeSpan LastHitAt;

--- a/Content.Shared/_RMC14/Weapons/Ranged/Stacks/GunStacksComponent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/Stacks/GunStacksComponent.cs
@@ -18,7 +18,7 @@ public sealed partial class GunStacksComponent : Component
     public FixedPoint2 DamageIncrease = FixedPoint2.New(0.2);
 
     [DataField, AutoNetworkedField]
-    public float SetFireRate = 0.7692f;
+    public float SetFireRate = 1.11f;
 
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
     public TimeSpan LastHitAt;

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/xm88_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/xm88_rifle.yml
@@ -13,7 +13,7 @@
   - type: Clothing
     sprite: _RMC14/Objects/Weapons/Guns/Rifles/xm88/desert.rsi
   - type: Gun
-    fireRate: 0.8
+    fireRate: 0.6896
     shotsPerBurst: 1
     selectedMode: SemiAuto
     availableModes:
@@ -27,7 +27,7 @@
     recoilUnwielded: 5
     scatterWielded: 6
     scatterUnwielded: 20
-    baseFireRate: 0.8
+    baseFireRate: 0.6896
   - type: RMCWeaponAccuracy
     accuracyMultiplier: 1.1
     accuracyMultiplierUnwielded: 0.5

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/xm88_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/xm88_rifle.yml
@@ -13,7 +13,7 @@
   - type: Clothing
     sprite: _RMC14/Objects/Weapons/Guns/Rifles/xm88/desert.rsi
   - type: Gun
-    fireRate: 0.6896
+    fireRate: 0.8
     shotsPerBurst: 1
     selectedMode: SemiAuto
     availableModes:
@@ -27,7 +27,7 @@
     recoilUnwielded: 5
     scatterWielded: 6
     scatterUnwielded: 20
-    baseFireRate: 0.6896
+    baseFireRate: 0.8
   - type: RMCWeaponAccuracy
     accuracyMultiplier: 1.1
     accuracyMultiplierUnwielded: 0.5


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
changes the stats to parity
## Why / Balance
Parity

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed the XM88's damage increase on hit being higher than intended (50% > 20%) and the duration until its combo stacks expire being higher than intended (4 > 2).
