### PR TITLE
M59 Attachment Fixes

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m59a_prototype_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m59a_prototype_rifle.yml
@@ -113,8 +113,8 @@
           #TODO RMC: add underbarrel flamer (and adv underbarrel flamer) and underbarrel extinguisher here when they are added
   - type: AttachableHolderVisuals
     offsets:
-      rmc-aslot-barrel: 0.75, 0.00
-      rmc-aslot-rail: 0.1, 0.16
+      rmc-aslot-barrel: 0.8125, 0.03125
+      rmc-aslot-rail: 0.1, 0.09375
       rmc-aslot-stock: -0.78, 0.0325
       rmc-aslot-underbarrel: 0.35, -0.343
   - type: ItemCamouflage


### PR DESCRIPTION

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
> Tweaked the Barrel Attachment point to be in line with the actual gun barrel
> Fixes the Rail Attachment point to prevent floating rail attachments

## Why / Balance
Magnetic Harness was floating cuz the attachment offset wasn't in line with the item sprite, fixed it

## Technical details
> Tweaked the attachment coords for both barrel and rail for stylistic reasons

## Media
Before:
![image](https://github.com/user-attachments/assets/14dd59ba-8ce4-4c99-add8-997a873fa772)

After:
![image](https://github.com/user-attachments/assets/7f9b7575-3399-4c2c-9610-11150d7ce6b4)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Made the attachment points for the M59 better match with the sprite. No more floating magnetic harnesses.

