### PR TITLE
Use squad color for chat names

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -17,6 +17,7 @@ using Content.Client.Stylesheets;
 using Content.Client.UserInterface.Screens;
 using Content.Client.UserInterface.Systems.Chat.Widgets;
 using Content.Client.UserInterface.Systems.Gameplay;
+using Content.Shared._RMC14.Marines.Squads;
 using Content.Shared.Administration;
 using Content.Shared.CCVar;
 using Content.Shared.Chat;
@@ -857,7 +858,13 @@ public sealed class ChatUIController : UIController
         {
             var grammar = _ent.GetComponentOrNull<GrammarComponent>(_ent.GetEntity(msg.SenderEntity));
             if (grammar != null && grammar.ProperNoun == true)
-                msg.WrappedMessage = SharedChatSystem.InjectTagInsideTag(msg, "Name", "color", GetNameColor(SharedChatSystem.GetStringInsideTag(msg, "Name")));
+            {
+                // RMC change to color the chat message name by the squad they're in, otherwise use the default.
+                var squad = _ent.GetComponentOrNull<SquadMemberComponent>(_ent.GetEntity(msg.SenderEntity));
+                string color = squad?.BackgroundColor.ToHex() ?? GetNameColor(SharedChatSystem.GetStringInsideTag(msg, "Name"));
+
+                msg.WrappedMessage = SharedChatSystem.InjectTagInsideTag(msg, "Name", "color", color);
+            }
         }
 
         // Color any codewords for minds that have roles that use them


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
When a squad member speaks, it uses their squad color for their chat name.


## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/b07e9a2f-bb13-48bb-aee1-3569d1b3bf26)


## Technical details
<!-- Summary of code changes for easier review. -->
- *Modifies upstream file in a non-intrusive way, but still modifies it and will need to be fixed if this upstream code is refactored. (But only the part where name color is applied.)
- Checks for squad component, then pulls the squad color and uses that instead of the randomly assigned color.
- Tested and works with squad transfers (tested with RMC admin ui but not in game mechanic), and any new squads with a color.
- Did not test the lack of a squad color if a squad is found, and I think the code doesn't account for a squad not having a color.


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl: Whisper
- add: Marines in squads now speak with their squad color.
