### PR TITLE
Broken fences

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/fence.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/fence.yml
@@ -23,13 +23,61 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 50
+        damage: 600
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
+        damage: 50
+      behaviors:
+        - !type:PlaySoundBehavior
+          sound:
+            path: /Audio/Items/wirecutter.ogg
+        - !type:ChangeConstructionNodeBehavior
+          node: rmcFenceBroken
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
   - type: Construction
     graph: CMFence
     node: fenceMetal
   - type: RMCDropshipBlocked
   - type: MinimapColor
     color: "#8d2294ad"
+
+- type: entity
+  parent: CMBaseStructureCorrodible
+  id: RMCFenceBroken
+  name: broken fence
+  description: A mess of broken wire strewn between two poles, it's not blocking anyone's way through.
+  components:
+  - type: Transform
+    anchored: true
+  - type: Sprite
+    sprite: _RMC14/Structures/fences.rsi
+    state: brokenfence0
+  - type: PlacementReplacement
+    key: walls
+  - type: IconSmooth
+    key: walls
+    base: brokenfence
+    mode: CardinalFlags
+  - type: Physics
+    canCollide: false
+  - type: Damageable
+    damageContainer: StructuralMarine
+    damageModifierSet: StructuralMarine
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 600
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: RMCDropshipBlocked
+  - type: MinimapColor
+    color: "#8d2294ad"
+  - type: Construction
+    graph: CMFence
+    node: rmcFenceBroken

--- a/Resources/Prototypes/_RMC14/Recipes/Construction/Graphs/structures/fence.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Construction/Graphs/structures/fence.yml
@@ -4,15 +4,40 @@
   start: start
   graph:
   - node: start
+    actions:
+    - !type:DeleteEntity
+    edges:
+    - to: fenceMetal
+      completed:
+      - !type:SnapToGrid
+        southRotation: true
+      steps:
+      - material: CMRodMetal
+        amount: 10
+        doAfter: 2.0
+  
   - node: fenceMetal
     entity: CMFence
     edges:
-    - to: start #TODO RMC14: Missing an inbetween cutting step for full 1:1
+    - to: rmcFenceBroken
+      steps:
+      - tool: Cutting
+        doAfter: 1.0
+
+  - node: rmcFenceBroken
+    entity: RMCFenceBroken
+    edges:
+    - to: start      
       completed:
       - !type:SpawnPrototype
         prototype: CMRodMetal1
         amount: 10
-      - !type:DeleteEntity {}
+      - !type:DeleteEntity
       steps:
       - tool: Cutting
-        doAfter: 8.0
+        doAfter: 5.0
+    - to: fenceMetal
+      steps:
+      - material: BarbedWire
+        amount: 2
+        doAfter: 3.0

--- a/Resources/Prototypes/_RMC14/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Construction/structures.yml
@@ -419,3 +419,23 @@
   conditions:
     - !type:TileNotBlocked
       failIfSpace: false
+
+- type: construction
+  parent: RMC
+  id: CMFence
+  name: fence
+  graph: CMFence
+  startNode: start
+  targetNode: fenceMetal
+  category: construction-category-cm-structures
+  description: A weak mesh fence.
+  icon:
+    sprite: _RMC14/Structures/fences.rsi
+    state: fence0
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canRotate: false
+  canBuildInImpassable: false
+  conditions:
+    - !type:TileNotBlocked
+      failIfSpace: false


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Made fences breakable, constructable, and deconstructable in line with cm13.
Fences leave behind a broken fence when damaged or cut with wirecutters.
Broken fences can be cut with wirecutters to get 10 rods, or repaired into regular fences with 2 barbed wire.
New fences can be constructed with 10 rods.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/caab72e4-82fa-492e-98df-ad9abb91529c

https://github.com/user-attachments/assets/0deaa87b-ed4e-4957-b20a-6e66cd6b55c8

![Screenshot 2025-01-05 162816](https://github.com/user-attachments/assets/a5758468-f91f-480e-9375-393d62fb92d3)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added breakable fences.
