### PR TITLE
Give APC a warning stripe for the lock label

### DIFF
--- a/Content.Client/_RMC14/Power/RMCApcWindow.xaml
+++ b/Content.Client/_RMC14/Power/RMCApcWindow.xaml
@@ -2,11 +2,12 @@
     xmlns="https://spacestation14.io"
     xmlns:controls="clr-namespace:Content.Client._RMC14.Power"
     xmlns:ui="clr-namespace:Content.Client._RMC14.UserInterface"
+    xmlns:s="clr-namespace:Content.Client.UserInterface.Controls"
     Title="APC" MinSize="450 450">
     <BoxContainer Orientation="Vertical">
-        <controls:StripeBack>
+        <s:StripeBack>
             <RichTextLabel Name="LockedLabel" Access="Public" Visible="True" />
-        </controls:StripeBack>
+        </s:StripeBack>
         <RichTextLabel Name="PowerStatusLabel" Access="Public" Margin="0 10 0 0" />
         <ui:BlueHorizontalSeparator />
         <BoxContainer Orientation="Horizontal" Visible="False">


### PR DESCRIPTION
Looks better
![image](https://github.com/user-attachments/assets/89499f29-ef3d-4661-aead-092ab678afc1)
