### PR TITLE
Assorted Barrel Attachment Fix

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Revolvers/m44_revolver.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Revolvers/m44_revolver.yml
@@ -47,7 +47,7 @@
           - RMCAttachmentLaserSight
   - type: AttachableHolderVisuals
     offsets:
-      rmc-aslot-barrel: 0.715, 0.125
+      rmc-aslot-barrel: 0.6875, 0.125
       rmc-aslot-rail: 0, 0.185
       rmc-aslot-stock: -0.59375, 0.09375
       rmc-aslot-underbarrel: 0.375, -0.155

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m54c_heavy_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m54c_heavy_rifle.yml
@@ -93,7 +93,7 @@
           - RMCAttachmentVerticalGrip
   - type: AttachableHolderVisuals # CHANGE THESE WHEN THIS THING GETS ITS OWN SPRITE
     offsets:
-      rmc-aslot-barrel: 0.81, 0.029
+      rmc-aslot-barrel: 0.75, 0.03125
       rmc-aslot-rail: 0.125, 0.185
       rmc-aslot-stock: -0.875, 0.0325
       rmc-aslot-underbarrel: 0.35, -0.4

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/m63_smg.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/m63_smg.yml
@@ -91,7 +91,7 @@
           - RMCAttachmentVerticalGrip
   - type: AttachableHolderVisuals
     offsets:
-      rmc-aslot-barrel: 0.715, 0.092
+      rmc-aslot-barrel: 0.71875, 0.03125
       rmc-aslot-rail: 0.032, 0.155
       rmc-aslot-stock: -0.81, 0.032
       rmc-aslot-underbarrel: 0.25, -0.25


### PR DESCRIPTION


<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixes the barrel attachment points on the M44, M54CE2, and M63 guns because they were a bit wonky looking.

## Why / Balance
Visual style mostly.

## Technical details
> Adjusted the attachment coords for the barrel attachments

## Media
![image](https://github.com/user-attachments/assets/8f9dd60b-8e55-437b-9c10-a6503e4e76c8)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Tweaked the barrel attachment node for the M44, M63, and M54CE2 to better fit the weapon sprites.

