### PR TITLE
Misc shells, m4spr, mataba parity fixes

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Revolvers/mateba.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Revolvers/mateba.yml
@@ -127,6 +127,9 @@
         Piercing: 60
   - type: CMArmorPiercing
     amount: 20
+  - type: RMCStunOnHit
+    maxRange: 4.5
+    stunTime: 1
   - type: RMCProjectileAccuracy
     accuracy: 90
 

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Revolvers/mateba.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Revolvers/mateba.yml
@@ -127,9 +127,6 @@
         Piercing: 60
   - type: CMArmorPiercing
     amount: 20
-  - type: RMCStunOnHit
-    maxRange: 4.5
-    stunTime: 1
   - type: RMCProjectileAccuracy
     accuracy: 90
 

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m4spr_scout_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m4spr_scout_rifle.yml
@@ -280,7 +280,7 @@
   - type: CMArmorPiercing
     amount: 25
   - type: RMCProjectileAccuracy
-    accuracy: 95
+    accuracy: 105
   - type: IgniteOnProjectileHit
 
 - type: Tag

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/shotgun_pellets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/shotgun_pellets.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   abstract: true
   parent: CMBulletBase
   id: CMPelletShotgunBase
@@ -26,6 +26,8 @@
     damage:
       types:
         Piercing: 65
+  - type: CMArmorPiercing
+    amount: 5
   - type: ProjectileSpread
     proto: CMPelletShotgunBuckshot
     count: 4
@@ -86,6 +88,8 @@
     damage:
       types:
         Heat: 55
+  - type: CMArmorPiercing
+    amount: 5
   - type: RMCProjectileDamageFalloff
     thresholds:
     - range: 12


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adjusted the stats of some projectiles to be more in line with parity.

~removed the stuns from the normal mateba .454, since it  doesn't have stuns in cm13, its the HI version that has stuns.~
![image](https://github.com/user-attachments/assets/fd4a5ef6-bfa6-4408-86b1-e349a1860a6f)

## Why / Balance
Parity

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed M4SPR A19 incendiary rounds having 95 accuracy instead of 105.
- fix: Fixed incendiary slugs having 20 AP instead of 5, and regular buckshot having 0 AP instead of 5.