### PR TITLE
Fix XM88's Gun Stacks System

### DIFF
--- a/Content.Shared/_RMC14/Weapons/Ranged/Stacks/GunStacksActiveComponent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/Stacks/GunStacksActiveComponent.cs
@@ -1,0 +1,18 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Shared._RMC14.Weapons.Ranged.Stacks;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
+[Access(typeof(GunStacksSystem))]
+public sealed partial class GunStacksActiveComponent : Component
+{
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
+    public TimeSpan ExpireAt;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan StacksExpire = TimeSpan.FromSeconds(2);
+
+    [DataField, AutoNetworkedField]
+    public int Hits = 0;
+}

--- a/Content.Shared/_RMC14/Weapons/Ranged/Stacks/GunStacksComponent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/Stacks/GunStacksComponent.cs
@@ -1,10 +1,9 @@
 using Content.Shared.FixedPoint;
 using Robust.Shared.GameStates;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared._RMC14.Weapons.Ranged.Stacks;
 
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 [Access(typeof(GunStacksSystem))]
 public sealed partial class GunStacksComponent : Component
 {
@@ -19,13 +18,4 @@ public sealed partial class GunStacksComponent : Component
 
     [DataField, AutoNetworkedField]
     public float SetFireRate = 1.4285f;
-
-    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
-    public TimeSpan LastHitAt;
-
-    [DataField, AutoNetworkedField]
-    public TimeSpan StacksExpire = TimeSpan.FromSeconds(2);
-
-    [DataField, AutoNetworkedField]
-    public int Hits;
 }

--- a/Content.Shared/_RMC14/Weapons/Ranged/Stacks/GunStacksSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/Stacks/GunStacksSystem.cs
@@ -30,35 +30,17 @@ public sealed class GunStacksSystem : EntitySystem
         _selectiveFireQuery = GetEntityQuery<RMCSelectiveFireComponent>();
         _xenoQuery = GetEntityQuery<XenoComponent>();
 
-        SubscribeLocalEvent<GunStacksComponent, GetGunDamageModifierEvent>(OnStacksGetGunDamageModifier);
-        SubscribeLocalEvent<GunStacksComponent, GunGetFireRateEvent>(OnStacksGetGunFireRate);
         SubscribeLocalEvent<GunStacksComponent, AmmoShotEvent>(OnStacksAmmoShot);
-        SubscribeLocalEvent<GunStacksComponent, DroppedEvent>(OnStacksDropped);
+
+        SubscribeLocalEvent<GunStacksActiveComponent, GetGunDamageModifierEvent>(OnStacksActiveGetGunDamageModifier);
+        SubscribeLocalEvent<GunStacksActiveComponent, GunGetFireRateEvent>(OnStacksActiveGetGunFireRate);
+        SubscribeLocalEvent<GunStacksActiveComponent, DroppedEvent>(OnStacksActiveDropped);
 
         SubscribeLocalEvent<GunStacksProjectileComponent, ProjectileHitEvent>(OnStacksProjectileHit);
     }
 
-    private void OnStacksGetGunDamageModifier(Entity<GunStacksComponent> ent, ref GetGunDamageModifierEvent args)
-    {
-        if (ent.Comp.Hits > 0)
-            args.Multiplier += ent.Comp.DamageIncrease;
-    }
-
-    private void OnStacksGetGunFireRate(Entity<GunStacksComponent> ent, ref GunGetFireRateEvent args)
-    {
-        if (ent.Comp.Hits > 0)
-            args.FireRate = ent.Comp.SetFireRate;
-    }
-
     private void OnStacksAmmoShot(Entity<GunStacksComponent> ent, ref AmmoShotEvent args)
     {
-        var time = _timing.CurTime;
-        if (ent.Comp.Hits > 0 && time >= ent.Comp.LastHitAt + ent.Comp.StacksExpire)
-        {
-            ent.Comp.Hits = 0;
-            Dirty(ent);
-        }
-
         foreach (var bullet in args.FiredProjectiles)
         {
             var stacks = EnsureComp<GunStacksProjectileComponent>(bullet);
@@ -66,19 +48,45 @@ public sealed class GunStacksSystem : EntitySystem
             Dirty(bullet, stacks);
 
             var piercing = EnsureComp<CMArmorPiercingComponent>(bullet);
-            var ap = Math.Min(ent.Comp.MaxAP, ent.Comp.IncreaseAP * ent.Comp.Hits);
+            var shotsHit = 0;
+
+            if (TryComp<GunStacksActiveComponent>(ent, out var active))
+                shotsHit = active.Hits;
+
+            var ap = Math.Min(ent.Comp.MaxAP, ent.Comp.IncreaseAP * shotsHit);
             _rmcArmor.SetArmorPiercing((bullet, piercing), ap);
         }
     }
 
-    private void OnStacksDropped(Entity<GunStacksComponent> ent, ref DroppedEvent args)
+    private void OnStacksActiveGetGunDamageModifier(Entity<GunStacksActiveComponent> ent, ref GetGunDamageModifierEvent args)
+    {
+        if (!TryComp<GunStacksComponent>(ent, out var gunStacks))
+            return;
+
+        if (ent.Comp.Hits > 0)
+            args.Multiplier += gunStacks.DamageIncrease;
+    }
+
+    private void OnStacksActiveGetGunFireRate(Entity<GunStacksActiveComponent> ent, ref GunGetFireRateEvent args)
+    {
+        if (!TryComp<GunStacksComponent>(ent, out var gunStacks))
+            return;
+
+        if (ent.Comp.Hits > 0)
+            args.FireRate = gunStacks.SetFireRate;
+    }
+
+    private void OnStacksActiveDropped(Entity<GunStacksActiveComponent> ent, ref DroppedEvent args)
     {
         Reset(ent);
     }
 
     private void OnStacksProjectileHit(Entity<GunStacksProjectileComponent> ent, ref ProjectileHitEvent args)
     {
-        if (!_gunStacksQuery.TryComp(ent.Comp.Gun, out var gun))
+        if (ent.Comp.Gun == null)
+            return;
+
+        if (!_gunStacksQuery.HasComp(ent.Comp.Gun))
             return;
 
         if (TryComp(ent, out ProjectileComponent? projectile) &&
@@ -90,39 +98,55 @@ public sealed class GunStacksSystem : EntitySystem
         var target = args.Target;
         if (_xenoQuery.HasComp(target) && !_mobState.IsDead(target))
         {
+            if (!TryComp<GunStacksActiveComponent>(ent.Comp.Gun, out var gun))
+                gun = EnsureComp<GunStacksActiveComponent>(ent.Comp.Gun.Value);
+
             gun.Hits++;
-            gun.LastHitAt = _timing.CurTime;
+            gun.ExpireAt = _timing.CurTime + gun.StacksExpire;
             if (args.Shooter is { } shooter &&
                 _net.IsServer)
             {
-                var msg = gun.Hits == 1 ? "Bullseye!" : $"Bullseye! {gun.Hits} hits in a row!";
+                var msg = gun.Hits == 1 ? Loc.GetString("rmc-gun-stacks-hit-single") : Loc.GetString("rmc-gun-stacks-hit-multiple", ("hits", gun.Hits));
                 _popup.PopupEntity(msg, shooter, shooter);
             }
         }
-        else
-        {
-            if (gun.Hits > 0 &&
-                args.Shooter is { } shooter &&
-                _net.IsServer)
-            {
-                var msg = $"The {Name(ent.Comp.Gun.Value)} beeps as it loses its targeting data, and returns to normal firing procedures.";
-                _popup.PopupEntity(msg, shooter, shooter);
-            }
 
-            gun.Hits = 0;
-        }
-
-        _rmcGun.RefreshGunDamageMultiplier(ent.Owner);
-
-        if (_selectiveFireQuery.TryComp(ent.Comp.Gun, out var selective))
-            _rmcSelectiveFire.RefreshFireModeGunValues((ent.Comp.Gun.Value, selective));
+        RefreshGunStats(ent.Comp.Gun.Value);
 
         Dirty(ent);
     }
 
-    private void Reset(Entity<GunStacksComponent> gun)
+    private void Reset(Entity<GunStacksActiveComponent> gun)
     {
-        gun.Comp.Hits = 0;
-        Dirty(gun);
+        RemComp<GunStacksActiveComponent>(gun.Owner);
+        if (_net.IsServer)
+            _popup.PopupEntity(Loc.GetString("rmc-gun-stacks-reset", ("weapon", gun.Owner)), gun, PopupType.SmallCaution);
+
+        RefreshGunStats(gun.Owner);
+    }
+
+    private void RefreshGunStats(EntityUid gun)
+    {
+        _rmcGun.RefreshGunDamageMultiplier(gun);
+
+        if (_selectiveFireQuery.TryComp(gun, out var selective))
+        {
+            _rmcSelectiveFire.RefreshFireModeGunValues((gun, selective));
+            Dirty(gun, selective);
+        }
+    }
+
+    public override void Update(float frameTime)
+    {
+        var time = _timing.CurTime;
+
+        var gunStackQuery = EntityQueryEnumerator<GunStacksActiveComponent>();
+        while (gunStackQuery.MoveNext(out var uid, out var active))
+        {
+            if (active.ExpireAt > time)
+                continue;
+
+            Reset((uid, active));
+        }
     }
 }

--- a/Resources/Locale/en-US/_RMC14/weapons/guns.ftl
+++ b/Resources/Locale/en-US/_RMC14/weapons/guns.ftl
@@ -52,3 +52,7 @@ rmc-assisted-reload-fail-full = {CAPITALIZE(POSS-ADJ($target))} {$weapon} is alr
 rmc-assisted-reload-fail-mismatch = The {$ammo} can't be loaded into a {$weapon}!
 rmc-assisted-reload-start-user = You begin reloading {$target}'s {$weapon}! Hold still...
 rmc-assisted-reload-start-target = {$reloader} begins reloading your {$weapon} with the {$ammo}! Hold still...
+
+rmc-gun-stacks-hit-single = Bullseye!
+rmc-gun-stacks-hit-multiple = Bullseye! {$hits} hits in a row!
+rmc-gun-stacks-reset = The {$weapon} beeps as it loses its targeting data, and returns to normal firing procedures.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Rewrote XM88's stack system to properly update damage and reset stacks correctly, as well as added ftl localization.

## Technical details
Split GunStacksComponent into itself + GunStacksActiveComponent. The active version tracks the shots hit and the expire time, this needed to be done so that an Update() loop can be implemented without being expensive to run to properly reset the stacks after 2 seconds.

Removed the condition that resets your stacks when you miss, it is only supposed to reset after the timer runs out.

Added helper functions to manage the stack reset process, as well as updating the gun stats.

The code no longer tries to refresh the gun damage multiplier of the bullet, and instead now correctly updates the gun.

## Media
Video Demonstration available on Discord at https://discord.com/channels/1168210010233376858/1168210011823026270/1326725713113518194

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- fix: Fixed the XM88 not increasing its damage on a successful hit.
- fix: Fixed the XM88 getting stuck at maximum damage for extended periods of time.
- fix: Fixed XM88 stacks not resetting once the timer runs out.
- fix: Fixed XM88 stacks resetting when hitting something that is not an alive Xeno, it now only resets after the timer runs out.
- fix: Fixed the XM88 not consistently giving a popup that its stacks have reset.
