### PR TITLE
Fix idle outgoing telephone sound not playing

### DIFF
--- a/Content.Shared/_RMC14/Telephone/SharedTelephoneSystem.cs
+++ b/Content.Shared/_RMC14/Telephone/SharedTelephoneSystem.cs
@@ -474,22 +474,19 @@ public abstract class SharedTelephoneSystem : EntitySystem
             if (phone.Idle)
                 continue;
 
-            phone.Idle = true;
-            Dirty(uid, phone);
-
             if (dialing.Other is not { } other)
                 continue;
 
-            if (!HasComp<RotaryPhoneDialingComponent>(other) ||
-                !HasComp<RotaryPhoneReceivingComponent>(other))
-            {
+            if (!HasComp<RotaryPhoneReceivingComponent>(other))
                 continue;
-            }
 
             if (!HasPickedUp(other) &&
                 time > phone.LastCall + phone.DialingIdleDelay &&
                 phone.DialingIdleSound is { } sound)
             {
+                phone.Idle = true;
+                Dirty(uid, phone);
+
                 _ambientSound.SetSound(uid, sound);
                 _ambientSound.SetVolume(uid, sound.Params.Volume);
             }


### PR DESCRIPTION
Before, the idle telephone sound would constantly play the dialing sound, instead of playing the idle outgoing noise after 3 seconds

The reason this happened is because ``RotaryPhoneDialingComponent`` wasn't present on the receiving telephone, but an if statement continued if it didn't have ``RotaryPhoneDialingComponent``

this removes the check and fixes another one