### PR TITLE
Make pickup dropped items hotkey more accurate

### DIFF
--- a/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
+++ b/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
@@ -288,7 +288,7 @@ public abstract class SharedCMInventorySystem : EntitySystem
         if (!_pickupDroppedItemsQuery.TryComp(user, out var pickupDroppedItems))
             return;
 
-        foreach (var item in pickupDroppedItems.DroppedItems.Distinct().Reverse())
+        foreach (var item in pickupDroppedItems.DroppedItems.Distinct().ToList())
         {
             if (!_container.IsEntityInContainer(item) && _interaction.InRangeUnobstructed(user, item))
             {


### PR DESCRIPTION
Makes it pick up the first dropped item instead of the last
It's somewhat annoying to drop your gun and pick up a random flare, so this fixes it by making it so the first item is picked up before the others

:cl:
- tweak: Made picking up dropped items hotkey pick up the first dropped item, instead of the last.