### PR TITLE
Make pickup dropped items hotkey smarter

### DIFF
--- a/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
+++ b/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
@@ -288,7 +288,13 @@ public abstract class SharedCMInventorySystem : EntitySystem
         if (!_pickupDroppedItemsQuery.TryComp(user, out var pickupDroppedItems))
             return;
 
-        foreach (var item in pickupDroppedItems.DroppedItems.Distinct().ToList())
+        // Sort items by importance
+        var sortedItems = pickupDroppedItems.DroppedItems
+            .OrderByDescending(item => HasComp<GunComponent>(item))
+            .ThenByDescending(item => HasComp<MeleeWeaponComponent>(item))
+            .ToList();
+
+        foreach (var item in sortedItems.Distinct())
         {
             if (!_container.IsEntityInContainer(item) && _interaction.InRangeUnobstructed(user, item))
             {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Now it sorts based on if the item is a gun or melee weapon, so important items (like guns) are picked up first rather than useless things like flares


https://github.com/user-attachments/assets/91b85df7-a268-4f78-af81-897a6f0bac55



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

:cl:
- tweak: Pickup dropped items hotkey now picks up important items (like guns and melee) before other items.
