### PR TITLE
Fix dropship weapons/ammo always being insertable

### DIFF
--- a/Content.Shared/_RMC14/PowerLoader/Events/GetAttachementSlotEvent.cs
+++ b/Content.Shared/_RMC14/PowerLoader/Events/GetAttachementSlotEvent.cs
@@ -28,6 +28,9 @@ public sealed partial class GetAttachementSlotEvent : EntityEventArgs
 
     public string SlotId = "";
 
+    //If the slot returned is able to have something placed/be removed depending on the mode
+    public bool CanUse = true;
+
     public GetAttachementSlotEvent(NetEntity user, NetEntity? used)
     {
         User = user;

--- a/Content.Shared/_RMC14/PowerLoader/PowerLoaderSystem.cs
+++ b/Content.Shared/_RMC14/PowerLoader/PowerLoaderSystem.cs
@@ -444,6 +444,8 @@ public sealed class PowerLoaderSystem : EntitySystem
         var containedEntity = EntityManager.GetEntity(args.ContainedEntity);
 
         var slot = _container.GetContainer(containerEntity, args.SlotId);
+        if (slot.ContainedEntities.Count > 0)
+            return;
         _container.Insert(containedEntity, slot);
 
         if (user.Comp != null)
@@ -477,6 +479,8 @@ public sealed class PowerLoaderSystem : EntitySystem
         }
 
         var slot = _container.GetContainer(containerEntity, args.SlotId);
+        if (slot.ContainedEntities.Count > 0)
+            return;
         _container.Insert(containedEntity, slot);
 
         if (user.Comp != null)

--- a/Content.Shared/_RMC14/PowerLoader/PowerLoaderSystem.cs
+++ b/Content.Shared/_RMC14/PowerLoader/PowerLoaderSystem.cs
@@ -389,9 +389,9 @@ public sealed class PowerLoaderSystem : EntitySystem
 
         ContainerSlot? slot = null;
         if (args.BeingAttached)
-            CanAttachPopup(ref user, ent, used.Value, out slot);
+            args.CanUse = CanAttachPopup(ref user, ent, used.Value, out slot);
         else
-            CanDetachPopup(ref user, ent, out slot);
+            args.CanUse = CanDetachPopup(ref user, ent, out slot);
 
         if (slot is null)
         {
@@ -584,7 +584,7 @@ public sealed class PowerLoaderSystem : EntitySystem
         RaiseLocalEvent(target, slotEv);
         var slot = _container.EnsureContainer<ContainerSlot>(target, slotEv.SlotId);
 
-        if (slot is null)
+        if (slot is null || !slotEv.CanUse)
         {
             return;
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title. You could still insert stuff while they already had stuff (so try to attach another gau while there's a gau or try to put in another ammo box when there's already an ammo box)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug.

## Technical details
<!-- Summary of code changes for easier review. -->
Probably not the best solution, couldn't really tell where I should put CanAttach so I just made teh get slots event return whether it was successful or not and use that before before range interact. Also made the doafters check if the slot is empty before trying to insert.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/fc97f40c-c984-46e1-a62d-b8c7b69ffaeb



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed being able to attach a weapon/insert ammo on a dropship weapon point when it already had a weapon/ammo in it.
