### PR TITLE
Add more visual effects to xeno abilities

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Cleave/XenoCleaveSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Cleave/XenoCleaveSystem.cs
@@ -1,9 +1,8 @@
 ﻿using Content.Shared._RMC14.Pulling;
 using Content.Shared._RMC14.Shields;
-using Content.Shared.Actions;
+using Content.Shared._RMC14.Weapons.Melee;
 using Content.Shared.Coordinates;
 using Content.Shared.Movement.Systems;
-using Content.Shared.Popups;
 using Content.Shared.Throwing;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Network;
@@ -13,7 +12,6 @@ namespace Content.Shared._RMC14.Xenonids.Cleave;
 
 public sealed class XenoCleaveSystem : EntitySystem
 {
-    [Dependency] private readonly SharedActionsSystem _actions = default!;
     [Dependency] private readonly XenoSystem _xeno = default!;
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
@@ -23,7 +21,7 @@ public sealed class XenoCleaveSystem : EntitySystem
     [Dependency] private readonly ThrowingSystem _throwing = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly MovementSpeedModifierSystem _speed = default!;
-    [Dependency] private readonly SharedPopupSystem _popups = default!;
+    [Dependency] private readonly SharedRMCMeleeWeaponSystem _rmcMelee = default!;
     public override void Initialize()
     {
         SubscribeLocalEvent<XenoCleaveComponent, XenoCleaveActionEvent>(OnCleaveAction);
@@ -46,6 +44,8 @@ public sealed class XenoCleaveSystem : EntitySystem
         var buffed = _vanguard.ShieldBuff(xeno);
 
         args.Handled = true;
+
+        _rmcMelee.DoLunge(xeno, args.Target);
 
         if (args.Flings)
         {

--- a/Content.Shared/_RMC14/Xenonids/Fling/XenoFlingSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Fling/XenoFlingSystem.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Shared._RMC14.Pulling;
+using Content.Shared._RMC14.Weapons.Melee;
 using Content.Shared.Coordinates;
 using Content.Shared.Damage;
 using Content.Shared.Effects;
@@ -23,6 +24,7 @@ public sealed class XenoFlingSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedStunSystem _stun = default!;
     [Dependency] private readonly XenoSystem _xeno = default!;
+    [Dependency] private readonly SharedRMCMeleeWeaponSystem _rmcMelee = default!;
 
     public override void Initialize()
     {
@@ -64,6 +66,9 @@ public sealed class XenoFlingSystem : EntitySystem
         var target = _transform.GetMapCoordinates(targetId);
         var diff = target.Position - origin.Position;
         diff = diff.Normalized() * xeno.Comp.Range;
+
+        _rmcMelee.DoLunge(xeno, targetId);
+
 
         if (_net.IsServer)
         {

--- a/Content.Shared/_RMC14/Xenonids/Heal/SharedXenoHealSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Heal/SharedXenoHealSystem.cs
@@ -14,12 +14,14 @@ using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.FixedPoint;
 using Content.Shared.Interaction;
+using Content.Shared.Jittering;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Popups;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
+using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
@@ -45,6 +47,8 @@ public abstract class SharedXenoHealSystem : EntitySystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedXenoAnnounceSystem _xenoAnnounce = default!;
+    [Dependency] private readonly SharedJitteringSystem _jitter = default!;
+    [Dependency] private readonly INetManager _net = default!;
 
     private static readonly ProtoId<DamageGroupPrototype> BruteGroup = "Brute";
     private static readonly ProtoId<DamageGroupPrototype> BurnGroup = "Burn";
@@ -107,7 +111,8 @@ public abstract class SharedXenoHealSystem : EntitySystem
 
             heal.HealStacks.Add(healStack);
 
-            SpawnAttachedTo(ent.Comp.HealEffect, xeno.Owner.ToCoordinates());
+            if (_net.IsServer)
+                SpawnAttachedTo(ent.Comp.HealEffect, xeno.Owner.ToCoordinates());
         }
     }
 
@@ -192,7 +197,10 @@ public abstract class SharedXenoHealSystem : EntitySystem
         var salved = EnsureComp<RecentlySalvedComponent>(ent);
         salved.ExpiresAt = _timing.CurTime + args.TotalHealDuration;
 
-        SpawnAttachedTo(args.HealEffect, target.ToCoordinates());
+        if(_net.IsServer)
+            SpawnAttachedTo(args.HealEffect, target.ToCoordinates());
+
+        _jitter.DoJitter(target, TimeSpan.FromSeconds(1), true, 80, 8, true);
 
         _audio.PlayPredicted(args.HealSound, target.ToCoordinates(), ent);
 
@@ -295,7 +303,10 @@ public abstract class SharedXenoHealSystem : EntitySystem
 
         Heal(target, healAmount);
 
-        SpawnAttachedTo(args.HealEffect, target.ToCoordinates());
+        _jitter.DoJitter(target, TimeSpan.FromSeconds(1), true, 80, 8, true);
+
+        if(_net.IsServer)
+         SpawnAttachedTo(args.HealEffect, target.ToCoordinates());
 
         var corpsePosition = _transform.GetMoverCoordinates(ent);
 

--- a/Content.Shared/_RMC14/Xenonids/Heal/XenoApplySalveActionEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Heal/XenoApplySalveActionEvent.cs
@@ -40,7 +40,7 @@ public sealed partial class XenoApplySalveActionEvent : EntityTargetActionEvent
     public TimeSpan TotalHealDuration = TimeSpan.FromSeconds(5);
 
     [DataField]
-    public EntProtoId HealEffect = "RMCEffectHeal";
+    public EntProtoId HealEffect = "RMCEffectHealHealer";
 
     [DataField]
     public SoundSpecifier HealSound = new SoundPathSpecifier("/Audio/_RMC14/Xeno/alien_drool1.ogg");

--- a/Content.Shared/_RMC14/Xenonids/Heal/XenoSacrificeHealActionEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Heal/XenoSacrificeHealActionEvent.cs
@@ -22,5 +22,5 @@ public sealed partial class XenoSacrificeHealActionEvent : EntityTargetActionEve
     public TimeSpan RespawnDelay = TimeSpan.FromSeconds(0.5);
 
     [DataField]
-    public EntProtoId HealEffect = "RMCEffectHeal";
+    public EntProtoId HealEffect = "RMCEffectHealSacrifice";
 }

--- a/Content.Shared/_RMC14/Xenonids/Impale/XenoImpaleSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Impale/XenoImpaleSystem.cs
@@ -6,12 +6,12 @@ using Content.Shared.FixedPoint;
 using Content.Shared.Coordinates;
 using Robust.Shared.Timing;
 using Content.Shared._RMC14.Xenonids.Plasma;
-using Content.Shared.Popups;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
+using Content.Shared._RMC14.Weapons.Melee;
 
 namespace Content.Shared._RMC14.Xenonids.Impale;
 
@@ -25,7 +25,7 @@ public sealed class XenoImpaleSystem : EntitySystem
     [Dependency] private readonly DamageableSystem _damage = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly XenoPlasmaSystem _plasma = default!;
-    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedRMCMeleeWeaponSystem _rmcMelee = default!;
 
 
     public override void Initialize()
@@ -74,6 +74,8 @@ public sealed class XenoImpaleSystem : EntitySystem
             var filter = Filter.Pvs(target, entityManager: EntityManager).RemoveWhereAttachedEntity(o => o == xeno);
             _flash.RaiseEffect(Color.Red, new List<EntityUid> { target }, filter);
         }
+
+        _rmcMelee.DoLunge(xeno, target);
 
         if (_net.IsClient)
             return;

--- a/Content.Shared/_RMC14/Xenonids/Pierce/XenoPierceSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Pierce/XenoPierceSystem.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Shared._RMC14.Emote;
 using Content.Shared._RMC14.Shields;
+using Content.Shared._RMC14.Weapons.Melee;
 using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared.Coordinates;
 using Content.Shared.Damage;
@@ -7,6 +8,7 @@ using Content.Shared.Effects;
 using Content.Shared.FixedPoint;
 using Content.Shared.Interaction;
 using Content.Shared.Physics;
+using Content.Shared.Weapons.Melee;
 using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
@@ -14,7 +16,6 @@ using Robust.Shared.Network;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Player;
-using Robust.Shared.Timing;
 using System.Linq;
 using System.Numerics;
 
@@ -33,7 +34,7 @@ public sealed class XenoPierceSystem : EntitySystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly VanguardShieldSystem _vanguard = default!;
-    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SharedRMCMeleeWeaponSystem _rmcMelee = default!;
 
     private const int AttackMask = (int)(CollisionGroup.MobMask | CollisionGroup.Opaque);
 
@@ -113,10 +114,13 @@ public sealed class XenoPierceSystem : EntitySystem
                 SpawnAttachedTo(xeno.Comp.AttackEffect, hit.ToCoordinates());
         }
 
+        if (actualResults.Count > 0)
+            _rmcMelee.DoLunge(xeno, actualResults[0]);
+
         if (_net.IsServer)
             _audio.PlayPvs(xeno.Comp.Sound, xeno);
 
-		if (actualResults.Count >= xeno.Comp.RechargeTargetsRequired)
-			_vanguard.RegenShield(xeno);
-	}
+        if (actualResults.Count >= xeno.Comp.RechargeTargetsRequired)
+            _vanguard.RegenShield(xeno);
+    }
 }

--- a/Content.Shared/_RMC14/Xenonids/Plasma/XenoPlasmaSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Plasma/XenoPlasmaSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared._RMC14.Xenonids.Evolution;
 using Content.Shared.Alert;
 using Content.Shared.DoAfter;
 using Content.Shared.FixedPoint;
+using Content.Shared.Jittering;
 using Content.Shared.Popups;
 using Content.Shared.Rejuvenate;
 using Content.Shared.Rounding;
@@ -19,6 +20,7 @@ public sealed class XenoPlasmaSystem : EntitySystem
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedJitteringSystem _jitter = default!;
 
     private EntityQuery<XenoPlasmaComponent> _xenoPlasmaQuery;
 
@@ -83,7 +85,8 @@ public sealed class XenoPlasmaSystem : EntitySystem
         var doAfter = new DoAfterArgs(EntityManager, xeno, xeno.Comp.PlasmaTransferDelay, ev, xeno, args.Target)
         {
             BreakOnMove = true,
-            DistanceThreshold = args.Range
+            DistanceThreshold = args.Range,
+            TargetEffect = "RMCEffectHealBusy",
         };
 
         _doAfter.TryStartDoAfter(doAfter);
@@ -104,6 +107,8 @@ public sealed class XenoPlasmaSystem : EntitySystem
 
         args.Handled = true;
         RegenPlasma(target, args.Amount);
+
+        _jitter.DoJitter(target, TimeSpan.FromSeconds(1), true, 80, 8, true);
 
         // for some reason the popup will sometimes not show for the predicting client here
         if (_net.IsClient)

--- a/Content.Shared/_RMC14/Xenonids/Punch/XenoPunchSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Punch/XenoPunchSystem.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Shared._RMC14.Pulling;
+using Content.Shared._RMC14.Weapons.Melee;
 using Content.Shared.Coordinates;
 using Content.Shared.Damage;
 using Content.Shared.Effects;
@@ -27,6 +28,7 @@ public sealed class XenoPunchSystem : EntitySystem
     [Dependency] private readonly XenoSystem _xeno = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly MovementSpeedModifierSystem _speed = default!;
+    [Dependency] private readonly SharedRMCMeleeWeaponSystem _rmcMelee = default!;
 
     public override void Initialize()
     {
@@ -69,6 +71,8 @@ public sealed class XenoPunchSystem : EntitySystem
         var target = _transform.GetMapCoordinates(targetId);
         var diff = target.Position - origin.Position;
         diff = diff.Normalized() * xeno.Comp.Range;
+
+        _rmcMelee.DoLunge(xeno, targetId);
 
         _throwing.TryThrow(targetId, diff, 10);
 

--- a/Resources/Prototypes/_RMC14/Effects/heal.yml
+++ b/Resources/Prototypes/_RMC14/Effects/heal.yml
@@ -28,6 +28,14 @@
 
 - type: entity
   parent: RMCEffectHeal
+  id: RMCEffectHealSacrifice
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    color: "#44253D"
+
+- type: entity
+  parent: RMCEffectHeal
   id: RMCEffectHealAilments
   categories: [ HideSpawnMenu ]
   components:

--- a/Resources/Prototypes/_RMC14/Effects/heal.yml
+++ b/Resources/Prototypes/_RMC14/Effects/heal.yml
@@ -28,6 +28,16 @@
 
 - type: entity
   parent: RMCEffectHeal
+  id: RMCEffectHealHealer
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: TimedDespawn
+    lifetime: 5
+  - type: Sprite
+    color: "#00BE6F"
+
+- type: entity
+  parent: RMCEffectHeal
   id: RMCEffectHealSacrifice
   categories: [ HideSpawnMenu ]
   components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title!

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity and game juice/soul/or something

## Technical details
<!-- Summary of code changes for easier review. -->
Transferplasma doafter has particles, makes the target xeno jitter on complete
Salve has a jitter on apply, animation is diff color and lasts longer
Sacrifice has a longer jitter on apply, color is diff
fling, punch, impale, pierce, and both cleaves now do a melee lunges


## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/f5fa02ec-49e7-4040-8eeb-60e23017353a


https://github.com/user-attachments/assets/84887039-9d06-4d8c-a1a0-426105733fff


https://github.com/user-attachments/assets/3d63fb7d-48a0-48fa-b527-02bd1dad9ee7




## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed visuals of some xeno abilities