### PR TITLE
Fix voicemail sometimes appearing when it shouldn't

### DIFF
--- a/Content.Shared/_RMC14/Telephone/SharedTelephoneSystem.cs
+++ b/Content.Shared/_RMC14/Telephone/SharedTelephoneSystem.cs
@@ -266,9 +266,6 @@ public abstract class SharedTelephoneSystem : EntitySystem
             return;
         }
 
-        rotaryPhone.Other = null;
-        Dirty(rotary, rotaryPhone);
-
         if (user != null)
         {
             if (_hands.TryDropIntoContainer(user.Value, telephone, container))
@@ -460,6 +457,12 @@ public abstract class SharedTelephoneSystem : EntitySystem
 
         if (ent.Comp.Other is { } other)
         {
+            if (TryComp<RotaryPhoneDialingComponent>(other, out var dialing))
+            {
+                dialing.Other = null;
+                Dirty(other, dialing);
+            }
+
             HangUp(ent, other);
 
             if (!HasPickedUp(other))

--- a/Content.Shared/_RMC14/Telephone/SharedTelephoneSystem.cs
+++ b/Content.Shared/_RMC14/Telephone/SharedTelephoneSystem.cs
@@ -514,7 +514,7 @@ public abstract class SharedTelephoneSystem : EntitySystem
             {
                 if (time > phone.LastCall + phone.VoicemailDelay && !dialing.DidVoicemail)
                 {
-                    if (HangUpReceiving((other, receiving), receivingPhone.Phone.Value, null));
+                    if (HangUpReceiving((other, receiving), receivingPhone.Phone.Value, null))
                     {
                         StopSound(other);
                         StopSound(uid);

--- a/Content.Shared/_RMC14/Telephone/SharedTelephoneSystem.cs
+++ b/Content.Shared/_RMC14/Telephone/SharedTelephoneSystem.cs
@@ -266,6 +266,9 @@ public abstract class SharedTelephoneSystem : EntitySystem
             return;
         }
 
+        rotaryPhone.Other = null;
+        Dirty(rotary, rotaryPhone);
+
         if (user != null)
         {
             if (_hands.TryDropIntoContainer(user.Value, telephone, container))


### PR DESCRIPTION
When the receiving end hangs up on the dialing end and then another line calls the receiving end, then the voicemail SFX will play on the dialing end because the dialing end still thinks the receiving phone is 'ringing', even though they already hung up

this PR sets the ``Other`` data field to null whenever the phone hangs up, so this issue shouldn't occur