### PR TITLE
Remove NVV comp from dead xenos

### DIFF
--- a/Content.Shared/_RMC14/NightVision/SharedNightVisionSystem.cs
+++ b/Content.Shared/_RMC14/NightVision/SharedNightVisionSystem.cs
@@ -1,11 +1,14 @@
-﻿using Content.Shared._RMC14.Marines.Skills;
+using Content.Shared._RMC14.Marines.Skills;
 using Content.Shared._RMC14.Scoping;
 using Content.Shared._RMC14.Visor;
+using Content.Shared._RMC14.Xenonids;
 using Content.Shared.Actions;
 using Content.Shared.Alert;
 using Content.Shared.IgnitionSource;
 using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Systems;
 using Content.Shared.Popups;
 using Content.Shared.Rounding;
 using Content.Shared.Toggleable;
@@ -25,6 +28,7 @@ public abstract class SharedNightVisionSystem : EntitySystem
     [Dependency] private readonly SkillsSystem _skills = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly VisorSystem _visor = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
 
     public override void Initialize()
     {
@@ -47,6 +51,8 @@ public abstract class SharedNightVisionSystem : EntitySystem
         SubscribeLocalEvent<NightVisionVisorComponent, VisorRelayedEvent<ScopedEvent>>(OnNightVisionScoped);
 
         SubscribeLocalEvent<RMCNightVisionVisibleOnIgniteComponent, IgnitionEvent>(OnNightVisionVisibleIgnition);
+
+        SubscribeLocalEvent<RMCNightVisionVisibleComponent, MobStateChangedEvent>(OnMobConditionChanged);
     }
 
     private void OnNightVisionStartup(Entity<NightVisionComponent> ent, ref ComponentStartup args)
@@ -306,6 +312,15 @@ public abstract class SharedNightVisionSystem : EntitySystem
             return;
 
         ent.Comp.SeeThroughContainers = see;
+        Dirty(ent);
+    }
+
+    private void OnMobConditionChanged(Entity<RMCNightVisionVisibleComponent> ent, ref MobStateChangedEvent args)
+    {
+        if (!_mobState.IsDead(ent) || !HasComp<XenoComponent>(ent))
+            return;
+
+        RemCompDeferred<RMCNightVisionVisibleComponent>(ent);
         Dirty(ent);
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
removes the nightVisionVisible component from dead xenos.
keeps the death icon visibile so xenos can still identify that there is a dead xeno there.

## Why / Balance
fixes the issues of marines appearing under dead xenos while in nightvision mode.
fixes the issue of barricades being under dead xenos while in nightvision mode.

## Technical details
added OnMobConditionChanged to SharedNightVisionSystem .
OnMobConditionChanged gets called when MobStateChangedEvent happens.

returns if they are not dead or doesn't have the Xeno component
`if (!_mobState.IsDead(ent) || !HasComp<XenoComponent>(ent))
            return;`
then it removes and dirty the entity
`RemCompDeferred<RMCNightVisionVisibleComponent>(ent);
        Dirty(ent);`
## Media

https://github.com/user-attachments/assets/477510b8-ef9b-46e4-8bf5-e37361b2a343



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Dead Xenonids no longer appear above barricades and mobs.