### PR TITLE
Fix phone busy sound

### DIFF
--- a/Content.Shared/_RMC14/Telephone/SharedTelephoneSystem.cs
+++ b/Content.Shared/_RMC14/Telephone/SharedTelephoneSystem.cs
@@ -428,6 +428,7 @@ public abstract class SharedTelephoneSystem : EntitySystem
 
         RemCompDeferred<RotaryPhoneDialingComponent>(ent);
         ReturnPhone(ent.Owner, phone, user);
+        StopSound(ent.Owner);
 
         if (ent.Comp.Other is { } other)
         {


### PR DESCRIPTION
Last PR which fixed phone voicemail accidentally introduced a new bug, basically when the receiving end hung up it set the dialing's other to null as intended, but then once the dialing end hung up, the busy sound wouldn't stop as the code which stops the sounds doesn't run because other is null

this pr fixes that