### PR TITLE
Add some more parity starting gear

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Engineering/maint_tech.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Engineering/maint_tech.yml
@@ -36,10 +36,7 @@
   equipment:
     jumpsuit: CMJumpsuitMaintTech
     shoes: CMBootsBlack
-    gloves: CMHandsInsulated
     id: CMIDCardMaintTech
-    #    belt: TODO RMC14 M276 Pattern General Pistol Holster Rig Filled
-    pocket2: RMCPouchGeneralMedium
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/mess_tech.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/mess_tech.yml
@@ -41,7 +41,7 @@
     shoes: CMBootsBlack
     id: CMIDCardMessTech
     ears: CMHeadsetChef
-#    belt: TODO RMC14 M276 Pattern General Pistol Holster Rig Filled
+    belt: RMCM1984BeltFilled
     pocket1: RMCPouchGeneralMedium
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Requisitions/cargo_tech.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Requisitions/cargo_tech.yml
@@ -40,7 +40,7 @@
     ears: CMHeadsetRequisition
     pocket1: RMCPouchGeneralMedium
     pocket2: CMStampApproved
-#    belt: TODO RMC14 M276 Pattern General Pistol Holster Rig Filled
+    belt: RMCM1984BeltFilled
 
 - type: entity
   parent: CMSpawnPointJobBase


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Made roles start with the gear they're intended to
Mess techs and cargo techs now spawn with M1984 magazines
Maint techs no longer spawn with insuls or pouches

- https://github.com/cmss13-devs/cmss13/blob/2acbb144aa12fe41e131f2012f73c280dae91cfa/code/modules/gear_presets/uscm_ship.dm#L322

:cl:
- fix: Fixed cargo technicians not spawning with a M1984 belt.
- fix: Fixed maint techs spawning with insulated gloves and pouches.
