### PR TITLE
Clock Date Fix

### DIFF
--- a/Content.Server/Clock/ClockSystem.cs
+++ b/Content.Server/Clock/ClockSystem.cs
@@ -30,6 +30,7 @@ public sealed class ClockSystem : SharedClockSystem
     private void OnMapInit(Entity<GlobalTimeManagerComponent> ent, ref MapInitEvent args)
     {
         ent.Comp.TimeOffset = TimeSpan.FromHours(_robustRandom.NextFloat(0, 24));
+        ent.Comp.DateOffset = DateTime.Today.AddYears(100);
         _pvsOverride.AddGlobalOverride(ent);
         Dirty(ent);
     }

--- a/Content.Shared/Clock/GlobalTimeManagerComponent.cs
+++ b/Content.Shared/Clock/GlobalTimeManagerComponent.cs
@@ -13,4 +13,7 @@ public sealed partial class GlobalTimeManagerComponent : Component
     /// </summary>
     [DataField, AutoPausedField, AutoNetworkedField]
     public TimeSpan TimeOffset;
+
+    [DataField, AutoNetworkedField]
+    public DateTime DateOffset;
 }

--- a/Content.Shared/_RMC14/RMCClock/RMCClockSystem.cs
+++ b/Content.Shared/_RMC14/RMCClock/RMCClockSystem.cs
@@ -17,10 +17,11 @@ public sealed class RMCClockSystem : EntitySystem
     private void OnExamined(Entity<RMCClockComponent> ent, ref ExaminedEvent args)
     {
         var owner = ent.Owner;
-        var date = DateTime.Now.AddYears(100).ToString("dd MMMM, yyyy");
         var worldTime = (EntityQuery<GlobalTimeManagerComponent>().FirstOrDefault()?.TimeOffset ?? TimeSpan.Zero) + _ticker.RoundDuration();
-        var time = worldTime.ToString(@"hh\:mm");
+        var worldDate = (EntityQuery<GlobalTimeManagerComponent>().FirstOrDefault()?.DateOffset ?? DateTime.Today.AddYears(100))
+                        + worldTime;
+        var time = worldDate.ToString("dd MMMM, yyyy - HH:mm");
 
-        args.PushMarkup(Loc.GetString("rmc-clock-examine", ("device", owner), ("date", date), ("time", time)));
+        args.PushMarkup(Loc.GetString("rmc-clock-examine", ("device", owner), ("time", time)));
     }
 }

--- a/Resources/Locale/en-US/_RMC14/devices/clock.ftl
+++ b/Resources/Locale/en-US/_RMC14/devices/clock.ftl
@@ -1,1 +1,1 @@
-rmc-clock-examine = The {$device} reads: [color=white]{$date} - {$time}[/color]
+rmc-clock-examine = The {$device} reads: [color=white]{$time}[/color]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Digital clock now displays the date from the server, rather than the client.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes: 
- clients may see different dates on the same clock
- no proper date rollover if clock goes past midnight.

## Technical details
<!-- Summary of code changes for easier review. -->
Add DateOffset value to the GlobalTimeManagerComponent. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed digital clock showing proper date from the server.
