### PR TITLE
Remove acid from dancer praetorian

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/praetorian.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/praetorian.yml
@@ -221,7 +221,6 @@
     - ActionXenoRegurgitate
     - ActionXenoWatch
     - ActionXenoTailStab
-    - ActionXenoAcidNormal
     - ActionXenoImpale
     - ActionXenoDodge
     - ActionXenoTailTrip


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Parity: https://github.com/cmss13-devs/cmss13/pull/7765?notification_referrer_id=NT_kwDOArOWa7QxMzc1MTQzNTUxNjo0NTMyMzg4Mw#event-15949746356

Basically getting killed by this xeno, whos a master at 1v1 and then having all ur shit melted is not fun

:cl:
- tweak: Removed Dancer Praetorian's corrosive acid