### PR TITLE
Fix armor variants not being patreon named

### DIFF
--- a/Content.Server/_RMC14/Armor/RMCArmorSystem.cs
+++ b/Content.Server/_RMC14/Armor/RMCArmorSystem.cs
@@ -44,6 +44,9 @@ public sealed class RMCArmorSystem : EntitySystem
         var equipmentEntity = Spawn(equipmentEntityID, _transform.GetMapCoordinates(ent));
         InventorySystem.TryEquip(ent, equipmentEntity, "outerClothing", force: true, predicted: false);
 
+        var ev = new RMCArmorVariantCreatedEvent(ent, equipmentEntity);
+        RaiseLocalEvent(ent, ref ev);
+
         QueueDel(args.Item);
     }
 }

--- a/Content.Server/_RMC14/NamedItems/RMCNamedItemSystem.cs
+++ b/Content.Server/_RMC14/NamedItems/RMCNamedItemSystem.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using Content.Server._RMC14.LinkAccount;
 using Content.Server.Administration.Logs;
+using Content.Shared._RMC14.Armor;
 using Content.Shared._RMC14.NamedItems;
 using Content.Shared._RMC14.Sentry;
 using Content.Shared._RMC14.Vendors;
@@ -28,6 +29,7 @@ public sealed class RMCNamedItemSystem : EntitySystem
         SubscribeLocalEvent<RMCUserNamedItemsComponent, RMCAutomatedVendedUserEvent>(OnAutomatedVenderUser);
         SubscribeLocalEvent<RMCNameItemOnVendComponent, SentryUpgradedEvent>(OnSentryUpgraded);
 
+        SubscribeLocalEvent<RMCNamedItemComponent, RMCArmorVariantCreatedEvent>(OnArmorVariantCreated);
         SubscribeLocalEvent<RMCNamedItemComponent, RefreshNameModifiersEvent>(OnItemRefreshNameModifiers);
     }
 
@@ -70,6 +72,17 @@ public sealed class RMCNamedItemSystem : EntitySystem
         var newNameComp = EnsureComp<RMCNameItemOnVendComponent>(args.NewSentry);
         newNameComp.Name = name;
         NameItem(args.User, args.NewSentry, name);
+    }
+
+    private void OnArmorVariantCreated(Entity<RMCNamedItemComponent> ent, ref RMCArmorVariantCreatedEvent args)
+    {
+        if (!TryComp(args.Old, out RMCNamedItemComponent? old))
+            return;
+
+        var namedNew = EnsureComp<RMCNamedItemComponent>(args.New);
+        namedNew.Name = old.Name;
+
+        _nameModifier.RefreshNameModifiers(args.New);
     }
 
     private void OnItemRefreshNameModifiers(Entity<RMCNamedItemComponent> ent, ref RefreshNameModifiersEvent args)

--- a/Content.Shared/_RMC14/Armor/RMCArmorVariantCreatedEvent.cs
+++ b/Content.Shared/_RMC14/Armor/RMCArmorVariantCreatedEvent.cs
@@ -1,0 +1,4 @@
+﻿namespace Content.Shared._RMC14.Armor;
+
+[ByRefEvent]
+public readonly record struct RMCArmorVariantCreatedEvent(EntityUid Old, EntityUid New);


### PR DESCRIPTION
Title

**Changelog**
:cl:
fix: Fixed armor variants not being patreon named.