### PR TITLE
Flashbang Tweak

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -59,7 +59,9 @@
   - type: TimerTriggerVisuals
     primingSound:
       path: /Audio/Effects/countdown.ogg
-  - type: Tag
+  - type: RequiresSkill
+    skills:
+      RMCSkillPolice: 2
     tags:
     - RMCGrenadeRiot
     - Grenade

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -62,6 +62,7 @@
   - type: RequiresSkill
     skills:
       RMCSkillPolice: 2
+  - type: Tag
     tags:
     - RMCGrenadeRiot
     - Grenade


### PR DESCRIPTION
## About the PR
Flashbangs now require police skill level 2 for it to work

## Why / Balance
Parity, also better than making armory indestructible

## Technical details
Added RequiresSkill and RMCSkillPolice 2 to grenades.yml

## Media

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: Flashbangs are now made more complicated with rising amounts of CLF agents.