### PR TITLE
Update drop ship SFX volume

### DIFF
--- a/Content.Shared/_RMC14/Dropship/DropshipComponent.cs
+++ b/Content.Shared/_RMC14/Dropship/DropshipComponent.cs
@@ -49,10 +49,10 @@ public sealed partial class DropshipComponent : Component
     public SoundSpecifier CrashWarningSound = new SoundPathSpecifier("/Audio/_RMC14/Announcements/ARES/dropship_emergency.ogg", AudioParams.Default.WithVolume(-5));
 
     [DataField, AutoNetworkedField]
-    public SoundSpecifier CrashSound = new SoundPathSpecifier("/Audio/_RMC14/Dropship/dropship_crash.ogg", AudioParams.Default.WithVolume(-5));
+    public SoundSpecifier CrashSound = new SoundPathSpecifier("/Audio/_RMC14/Dropship/dropship_crash.ogg", AudioParams.Default.WithVolume(-1));
 
     [DataField, AutoNetworkedField]
-    public SoundSpecifier IncomingSound = new SoundPathSpecifier("/Audio/_RMC14/Dropship/dropship_incoming.ogg", AudioParams.Default.WithVolume(-5));
+    public SoundSpecifier IncomingSound = new SoundPathSpecifier("/Audio/_RMC14/Dropship/dropship_incoming.ogg", AudioParams.Default.WithVolume(-1));
 
     [DataField, AutoNetworkedField]
     public bool AnnouncedCrash;


### PR DESCRIPTION
Updated the dropship volume from -5 to -1

the volume was way too quiet and the actual explosion sound was louder than it

## Changelog
:cl:
- fix: Fixed the dropship incoming and crash sounds being too quiet compared to the explosion sound.