### PR TITLE
Make Food, Engineering and Medical vendors pullable.

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/base.yml
@@ -56,3 +56,15 @@
     blacklist:
       components:
       - Xeno
+
+- type: entity
+  abstract: true
+  parent: ColMarTechBase
+  id: ColMarTechBaseAnchorable
+  components:
+  - type: Transform
+    anchored: true
+  - type: Anchorable
+  - type: Pullable
+  - type: Physics
+    bodyType: Dynamic

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/engineering.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/engineering.yml
@@ -2,41 +2,63 @@
 
 # Tools
 - type: entity
-  parent: CMVendor
+  parent: ColMarTechBaseAnchorable
   id: CMVendorTool
   name: tool storage machine
   description: A large storage machine containing various tools and devices for general repair.
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/tool.rsi
-  - type: VendingMachine
-    pack: CMVendorTool
-    denyState: deny-unshaded
-    ejectState: eject-unshaded
+    layers:
+    - state: "off"
+      map: [ "enum.VendingMachineVisualLayers.Base" ]
+    - state: "normal-unshaded"
+      map: [ "enum.VendingMachineVisualLayers.BaseUnshaded" ]
+      shader: unshaded
   - type: AccessReader
     access: [["CMAccessCombatTechPrep"], ["CMAccessEngineering"], ["CMAccessColonyEngineering"]]
-
-- type: vendingMachineInventory
-  id: CMVendorTool
-  startingInventory:
-    RMCFlashlight: 4 #TODO combat variant?
-    RMCHardhatBlue: 4
-    CMHandsInsulated: 4
-    CMBeltUtility: 4
-    ClothingEyesGlassesMeson: 4
-    ClothingHeadHatWelding: 4
-    RMCEngineerKit: 2
-    #Atmos scanner
-    #Demo scanner
-    #Meson scanner
-    #Reagent scanner
-    trayScanner: 4
-    CMCrowbar: 8
-    CMWelder: 8
-    CMWelderSmall: 4
-    CMScrewdriver: 8
-    CMWirecutter: 8
-    CMWrench: 8
+  - type: CMAutomatedVendor
+    sections:    
+    - name: Equipment
+      entries:
+      - id: RMCFlashlight
+        amount: 15
+      - id: RMCFlashlight
+        amount: 4
+      - id: RMCHardhatBlue
+        amount: 4
+      - id: CMHandsInsulated
+        amount: 4
+      - id: CMBeltUtility
+        amount: 4
+      - id: ClothingEyesGlassesMeson
+        amount: 4
+      - id: ClothingHeadHatWelding
+        amount: 4
+      - id: RMCEngineerKit
+        amount: 2
+    - name: Scanners
+      entries:
+      #Atmos scanner
+      #Demo scanner
+      #Meson scanner
+      #Reagent scanner
+      - id: trayScanner
+        amount: 4
+    - name: Tools
+      entries:
+      - id: CMCrowbar
+        amount: 8
+      - id: CMWelder
+        amount: 8
+      - id: CMWelderSmall
+        amount: 4
+      - id: CMScrewdriver
+        amount: 8
+      - id: CMWirecutter
+        amount: 8
+      - id: CMWrench
+        amount: 8
 
 
 # Circuits
@@ -48,29 +70,36 @@
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/robotics.rsi
-  - type: VendingMachine
-    pack: CMVendorCircuits
-
-- type: vendingMachineInventory
-  id: CMVendorCircuits
-  startingInventory:
-    FireAlarmElectronics: 5
-    CMAPCElectronics: 6
-#    CMAutolatheMachineCircuitboard: 2 # TODO RMC14
-    TelecomServerCircuitboard: 1
-    CrewMonitoringComputerCircuitboard: 2
-    IDComputerCircuitboard: 2
-    StationRecordsComputerCircuitboard: 2
-# Supply ordering console
-# Reserach data terminal
-#    CMPortableGeneratorPacmanMachineCircuitBoard: 5
-    CMSMESMachineCircuitboard: 2
-# Air alarm
-# security camera monitor
-# television set
-# station alerts
-# arcade
-# atmospheric monitor
+  - type: CMAutomatedVendor
+    sections:    
+    - name: Circuitboards
+      entries:
+      - id: FireAlarmElectronics
+        amount: 5
+      - id: CMAPCElectronics
+        amount: 6
+#      - id: CMAutolatheMachineCircuitboard
+#        amount: 2 # TODO RMC14
+      - id: TelecomServerCircuitboard
+        amount: 1
+      - id: CrewMonitoringComputerCircuitboard
+        amount: 2
+      - id: IDComputerCircuitboard
+        amount: 2
+      - id: StationRecordsComputerCircuitboard
+        amount: 2
+#     - id: Supply ordering console
+#     - id: Reserach data terminal
+#     - id: CMPortableGeneratorPacmanMachineCircuitBoard
+#       amount: 5
+      - id: CMSMESMachineCircuitboard
+        amount: 2
+#     - id: Air alarm
+#     - id: security camera monitor
+#     - id: television set
+#     - id: station alerts
+#     - id: arcade
+#     - id: atmospheric monitor
 
 
 # Electronics
@@ -82,18 +111,26 @@
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/engivend.rsi
-  - type: VendingMachine
-    pack: CMVendorElectronics
-
-- type: vendingMachineInventory
-  id: CMVendorElectronics
-  startingInventory:
-    RMCCableCoil: 6
-    CMMultitool: 6
-    DoorElectronics: 8
-    CMAPCElectronics: 8
-    RMCPowerCellHigh: 6
-    RMCPowerCell: 14
+  - type: CMAutomatedVendor
+    sections:    
+    - name: Tools
+      entries:
+      - id: RMCCableCoil
+        amount: 6
+      - id: CMMultitool
+        amount: 6
+    - name: Circuitboards
+      entries:
+      - id: DoorElectronics
+        amount: 8
+      - id: CMAPCElectronics
+        amount: 8
+    - name: Batteries
+      entries:
+      - id: RMCPowerCellHigh
+        amount: 6
+      - id: RMCPowerCell
+        amount: 14
 
 
 # Components
@@ -105,49 +142,72 @@
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/engi.rsi
-  - type: VendingMachine
-    pack: CMVendorComponent
-
-- type: vendingMachineInventory
-  id: CMVendorComponent
-  startingInventory:
-    Igniter: 8
-    TimerTrigger: 4
-    ProximitySensor: 4
-    RemoteSignaller: 4
-    RMCBucket: 6
-    CMBucketMop: 2
-    CMStockPartMatterBin: 8
-    CMStockPartManipulatorMicro: 8
-    CMStockPartCapacitor: 8
+  - type: CMAutomatedVendor
+    sections:    
+    - name: Assembly Components
+      entries:
+      - id: Igniter
+        amount: 8
+      - id: TimerTrigger
+        amount: 4
+      - id: ProximitySensor
+        amount: 4
+      - id: RemoteSignaller
+        amount: 4
+    - name: Container
+      entries:
+      - id: RMCBucket
+        amount: 6
+      - id: CMBucketMop
+        amount: 2
+    - name: Stock Parts
+      entries:
+      - id: CMStockPartMatterBin
+        amount: 8
+      - id: CMStockPartManipulatorMicro
+        amount: 8
+      - id: CMStockPartCapacitor
+        amount: 8
     #TODO Console screen, scanning module
 
 
 # Science
 - type: entity
-  parent: CMVendor
+  parent: ColMarTechBaseAnchorable
   id: CMVendorScience
   name: We-Ya SciVend
   description: Vendor containing basic equipment for your experiments.
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/robotics.rsi
-  - type: VendingMachine
-    pack: CMVendorScience
-    denyState: deny-unshaded
-    ejectState: eject-unshaded
+    layers:
+    - state: "off"
+      map: [ "enum.VendingMachineVisualLayers.Base" ]
+    - state: "normal-unshaded"
+      map: [ "enum.VendingMachineVisualLayers.BaseUnshaded" ]
+      shader: unshaded
   - type: AccessReader
     access: [["CMAccessResearch"]]
-
-- type: vendingMachineInventory
-  id: CMVendorScience
-  startingInventory:
-    ClothingHeadHatHoodBioScientist: 2
-    ClothingOuterBioScientist: 2
-    CMJumpsuitResearch: 2
-    Igniter: 8
-    ProximitySensor: 4
-    RemoteSignaller: 4
+  - type: CMAutomatedVendor
+    sections:    
+    - name: Equipment
+      entries:
+      - id: ClothingHeadHatHoodBioScientist
+        amount: 2
+      - id: ClothingOuterBioScientist
+        amount: 2
+      - id: CMJumpsuitResearch
+        amount: 2
+    - name: Assembly Components
+      entries:
+      - id: Igniter
+        amount: 8
+      - id: ProximitySensor
+        amount: 4
+      - id: RemoteSignaller
+        amount: 4
+      # Tank transfer valve
+      # Timer
 
 
 # Robotics
@@ -157,20 +217,39 @@
   name: Robotech Deluxe
   description: All the tools you need to create your own robot army.
   components:
-  - type: VendingMachine
-    pack: CMVendorRobotics
-
-- type: vendingMachineInventory
-  id: CMVendorRobotics
-  startingInventory:
-    RMCCableCoil: 4
-    SawElectric: 2
-    CMCrowbar: 2
-    CMScalpel: 2
-    CMScrewdriver: 2
-    CMFlash: 4
-    RMCPowerCellHigh: 4
-    ProximitySensor: 4
-    RemoteSignaller: 4
-    CMHealthAnalyzer: 2
-    NitrousOxideTankFilled: 2
+  - type: CMAutomatedVendor
+    sections:    
+    - name: Equipment
+      entries:
+      # Labcoat
+      - id: CMMaskGasMedical
+        amount: 2
+      # Roboticist Jumpsuit
+    - name: Tools
+      entries:
+      - id: RMCCableCoil
+        amount: 4
+      - id: SawElectric
+        amount: 2
+      - id: CMCrowbar
+        amount: 2
+      - id: CMScalpel
+        amount: 2
+      - id: CMScrewdriver
+        amount: 2
+    - name: Assembly Components
+      entries:
+      - id: CMFlash
+        amount: 4
+      - id: RMCPowerCellHigh
+        amount: 4
+      - id: ProximitySensor
+        amount: 4
+      - id: RemoteSignaller
+        amount: 4
+    - name: Miscellaneous
+      entries:
+      - id: NitrousOxideTankFilled
+        amount: 2
+      - id: CMHealthAnalyzer
+        amount: 2

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/food.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/food.yml
@@ -1,7 +1,7 @@
 # FOOD
 
 - type: entity
-  parent: ColMarTechBase
+  parent: ColMarTechBaseAnchorable
   id: ColMarTechFood
   name: ColMarTech food vendor
   description: Marine Food Vendor, containing standard military Prepared Meals.
@@ -51,7 +51,7 @@
         amount: 5
 
 - type: entity
-  parent: ColMarTechBase
+  parent: ColMarTechBaseAnchorable
   id: CMVendorBooze
   name: Booze-O-Mat
   description: A technological marvel, supposedly able to mix just the mixture you'd like to drink the moment you ask for one.
@@ -127,7 +127,7 @@
         amount: 5
 
 - type: entity
-  parent: ColMarTechBase
+  parent: ColMarTechBaseAnchorable
   id: CMVendorChess
   name: Chess-o-mat
   description: In 2143 Red Star Drinks, a SPP-CA (Colony Administration) affiliated corporation ran a promotional sweepstakes for drinkers who had found special codes on the inside of the caps of a limited run of Red Star Vodka, shipping them a Chess-O-Mat with unlimited refills.

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/general.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/general.yml
@@ -1,7 +1,7 @@
 # GENERAL
 
 - type: entity
-  parent: ColMarTechBase
+  parent: ColMarTechBaseAnchorable
   id: CMVendorWalkman
   name: Rec-Vend
   description: Contains We-Ya approved recreational items, like Walkmans and Cards.

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/medical.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/medical.yml
@@ -17,13 +17,11 @@
 
 
 - type: entity
-  parent: ColMarTechBase
+  parent: ColMarTechBaseAnchorable
   id: CMVendorMedical
   name: We-Ya-Med Plus
   description: Medical pharmaceutical dispenser. Provided by We-Ya Pharmaceuticals Division(TM).
   components:
-  - type: Transform
-    anchored: true
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/med.rsi
     layers:
@@ -148,8 +146,6 @@
   name: We-Ya-Chem Plus
   description: Medical chemistry dispenser. Provided by We-Ya Pharmaceuticals Division(TM).
   components:
-  - type: Transform
-    anchored: true
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/chem.rsi
     layers:
@@ -200,13 +196,11 @@
 
 
 - type: entity
-  parent: ColMarTechBase
+  parent: ColMarTechBaseAnchorable
   id: ColMarTechMarineMedical
   name: ColMarTech MarineMed
   description: Medical Pharmaceutical dispenser with basic medical supplies for marines.
   components:
-  - type: Transform
-    anchored: true
   - type: Fixtures
     fixtures:
       fix1:
@@ -259,7 +253,7 @@
 #        amount: 7
 
 - type: entity
-  parent: ColMarTechBase
+  parent: ColMarTechBaseAnchorable
   id: RMCNanoMed
   name: NanoMed
   description: A wall-mounted medical equipment dispenser.
@@ -313,7 +307,7 @@
         amount: 3
 
 - type: entity
-  parent: ColMarTechBase
+  parent: ColMarTechBaseAnchorable
   id: CMVendorBlood
   name: MM Blood Dispenser
   description: The Marine Med Brand Blood Pack Dispensary is the premier, top-of-the-line blood dispenser of 2105! Get yours today! #dont update year, that`s a joke from cm13


### PR DESCRIPTION
## About the PR

Addresses [Discord Issue: Medvendors and Booze vendors should be unwrenchable.](https://discord.com/channels/1168210010233376858/1330686538237087744)

- Adds new abstract entity: ColMarTechBaseAnchorable for unwrenchable vendors
- Changes Medical vendors parent from ColMarTechBase to ColMarTechAnchorable (parity)
- Changes Food vendors parent from ColMarTechBase to ColMarTechAnchorable (parity)
- Engi vendors now use CMAutomatedVendor (parity)

## Media

![image](https://github.com/user-attachments/assets/b6d4a11c-94a2-4095-b9c5-74a4fd1b7c59)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- fix: Fixed not being able to unwrench and pull medical vendors, food vendors, booze-o-mats, chess-o-mats, and rec-vends.