### PR TITLE
Add new vendor content and change names

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/command.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/command.yml
@@ -131,7 +131,7 @@
       - id: CMBeltUtilityFilled
         name: M276 pattern toolbelt rig (Full)
       - id: CMBeltMedicBagFilled
-        name: M276 lifesaver bag (Full)
+        name: M276 pattern lifesaver bag (Full)
       - id: CMBeltMedicalFilled
         name: M276 medical storage rig (Full)
       - id: RMCBeltHolsterSMGPouch
@@ -435,9 +435,10 @@
       - id: RMCBeltUtilityGeneral
         recommended: true
       - id: CMBeltSecurityMPFilled
+        name: M276 pattern security rig (Full)
         recommended: true
       - id: CMBeltMedicBagFilled
-        recommended: true
+        name: M276 pattern lifesaver bag (Full)
       - id: CMBeltMarine
         recommended: true
       - id: CMBeltUtilityCombat
@@ -661,8 +662,10 @@
       - id: RMCBeltUtilityGeneral
         recommended: true
       - id: CMBeltSecurityMPFilled
+        name: M276 pattern security rig (Full)
         recommended: true
       - id: CMBeltMedicBagFilled
+        name: M276 pattern lifesaver bag (Full)
         recommended: true
       - id: CMBeltMarine
         recommended: true

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/medical.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/medical.yml
@@ -71,7 +71,9 @@
       choices: { CMBelt: 1 }
       entries:
       - id: CMBeltMedicBagFilled
+        name: M276 pattern lifesaver bag (Full)
       - id: CMBeltMedicalFilled
+        name: M276 pattern medical storage rig (Full)
     - name: Backpack
       choices: { CMBackpack: 1 }
       entries:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/pilot.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/pilot.yml
@@ -41,8 +41,10 @@
       - id: RMCBeltUtilityGeneral
       - id: CMBeltMarine
       - id: CMBeltMedicBagFilled
+        name: M276 pattern lifesaver bag (Full)
         recommended: true
       - id: CMBeltMedicalFilled
+        name: M276 pattern medical storage rig (Full)
         recommended: true
       - id: RMCBeltHolsterSMGPouch
       - id: RMCBeltHolsterPistol
@@ -63,6 +65,7 @@
         recommended: true
       - id: RMCPouchFirstResponder
       - id: RMCPouchFlareFilled
+        name: flare pouch (Full)
       - id: RMCPouchGeneralLarge
       - id: RMCPouchMagazineLarge
       - id: RMCPouchMagazinePistolLarge
@@ -150,6 +153,7 @@
       #- id: RMCMacheteScabbard # TODO RMC14 Machete Back Scabbard
       #  points: 10
       - id: RMCPouchMacheteFilled
+        name: machete pouch (Full)
         points: 15
       - id: RMCMotionDetector
         points: 15

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/pilot.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/pilot.yml
@@ -150,8 +150,9 @@
         points: 15
       - id: RMCPouchMagazineLarge
         points: 15
-      #- id: RMCMacheteScabbard # TODO RMC14 Machete Back Scabbard
-      #  points: 10
+      - id: RMCScabbardMacheteFilled
+        name: machete scabbard (Full)
+        points: 10
       - id: RMCPouchMacheteFilled
         name: machete pouch (Full)
         points: 15

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
@@ -175,12 +175,14 @@
       - id: RMCPouchExplosive
         amount: 2
       - id: RMCPouchFlareFilled
+        name: flare pouch (Full)
         amount: 5
       - id: RMCPouchDocument
         amount: 2
       #- id: RMCPouchSling
       #  amount: 2
       - id: RMCPouchMacheteFilled
+        name: machete pouch (Full)
         amount: 1
       - id: RMCPouchBayonet
         name: Bayonet Sheath (Full)

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/senior_enlisted_advisor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/senior_enlisted_advisor.yml
@@ -31,8 +31,11 @@
       entries:
       - id: RMCBeltUtilityGeneral
       - id: CMBeltUtilityFilled
+        name: M276 pattern toolbelt rig (Full)
       - id: CMBeltMedicBagFilled
+        name: M276 pattern lifesaver bag (Full)
       - id: CMBeltUtilityCombatFilled
+        name: M276 pattern combat toolbelt rig (Full)
     - name: Pouches
       choices: { CMPouches: 2 }
       entries:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/engineer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/engineer.yml
@@ -125,8 +125,10 @@
     - name: Clothing Items
       entries:
       - id: RMCScabbardMacheteFilled
+        name: machete scabbard (Full)
         points: 6
       - id: RMCPouchMacheteFilled
+        name: machete pouch (Full)
         points: 8
       - id: RMCBackpackRTO
         points: 15
@@ -210,6 +212,7 @@
       choices: { CMBackpack: 1 }
       entries:
       - id: RMCScabbardMacheteFilled
+        name: machete scabbard (Full)
       - id: CMBackpackMarineTech
       - id: CMSatchelMarineTech
       - id: CMBackpackWelder
@@ -249,8 +252,8 @@
       - id: RMCPouchFirstAidPills
         name: first-aid pouch (pills)
         recommended: true
-      # - id: RMCPouchElectronicsFill
-        # name: electronics pouch (Full)
+      - id: RMCPouchElectronicsFill
+        name: electronics pouch (Full)
       - id: RMCPouchExplosive
       - id: RMCPouchFlareFilled
         name: Flare pouch (Full)

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/leader.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/leader.yml
@@ -38,8 +38,10 @@
     - name: Clothing Items
       entries:
       - id: RMCScabbardMacheteFilled
+        name: machete scabbard (Full)
         points: 4
       - id: RMCPouchMacheteFilled
+        name: machete pouch (Full)
         points: 4
       - id: RMCBackpackRTO
         points: 5

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/medic.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/medic.yml
@@ -143,6 +143,7 @@
     - name: Clothing Items
       entries:
       - id: RMCPouchMacheteFilled
+        name: machete pouch (Full)
         points: 8
       - id: RMCBackpackRTO
         points: 15
@@ -249,6 +250,7 @@
       - id: RMCPouchReagentCanister
         name: Pressurized Reagent Canister Pouch\n(EMPTY)
       - id: RMCPouchVialFill
+        name: vial pouch (Full)
       - id: RMCPouchMedical
       - id: RMCPouchFirstAidInjectors
         name: first-aid pouch (refillable injectors)

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/prep.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/prep.yml
@@ -394,6 +394,7 @@
       - id: CMRollerBedSpawnFolded
         amount: 1
       - id: RMCScabbardMacheteFilled
+        name: machete scabbard (Full)
         amount: 5
       - id: RMCBinoculars
         amount: 1

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/rifleman.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/rifleman.yml
@@ -59,6 +59,7 @@
       choices: { RMCPouch: 2 }
       entries:
       - id: RMCPouchBayonetFill
+        name: bayonet sheath (Full)
       - id: RMCPouchFirstAidInjectors
         name: first-aid pouch (refillable injectors)
         recommended: true
@@ -161,8 +162,10 @@
       - id: CMWebbingHolster
         points: 15
       - id: RMCScabbardMacheteFilled
+        name: machete scabbard (Full)
         points: 15
       - id: RMCPouchMacheteFilled
+        name: machete pouch (Full)
         points: 15
       - id: RMCBackpackRTO
         points: 15

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/smart_gun_operator.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/smart_gun_operator.yml
@@ -156,6 +156,7 @@
       - id: RMCPouchGeneralMedium
       - id: RMCPouchPistol
       - id: RMCPouchMacheteFilled
+        name: machete pouch (Full)
     #- id: CMSlingPouch
     - name: Accessories
       choices: { CMAccessories: 1 }

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/specialist.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/specialist.yml
@@ -179,8 +179,10 @@
     - name: Clothing Items
       entries:
       - id: RMCScabbardMacheteFilled
+        name: machete scabbard (Full)
         points: 6
       - id: RMCPouchMacheteFilled
+        name: machete pouch (Full)
         points: 15
       - id: RMCBackpackRTO
         points: 15
@@ -191,6 +193,7 @@
       - id: CMBeltUtilityCombat
         points: 15
       - id: RMCPouchAutoinjectorFill
+        name: autoinjector pouch (Full)
         points: 15
     - name: Utilities
       entries:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/team_leader.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/team_leader.yml
@@ -78,16 +78,19 @@
     - name: Clothing Items
       entries:
       - id: RMCScabbardMacheteFilled
+        name: machete scabbard (Full)
         points: 5
       - id: RMCPouchMacheteFilled
+        name: machete pouch (Full)
         points: 15
       - id: RMCBackpackRTO
         points: 5
-    #- id: CMWeldingGoggles
-    #  points: 3
+      - id: RMCWeldingGoggles
+        points: 3
       - id: CMBeltUtilityCombat
         points: 15
       - id: RMCPouchAutoinjectorFill
+        name: autoinjector pouch (Full)
         points: 15
       - id: CMHandsInsulated
         points: 3
@@ -202,7 +205,7 @@
       - id: RMCPouchPistol
       - id: RMCPouchToolsFill
         recommended: true
-        name: Tools pouch (Filled)
+        name: Tools pouch (Full)
     - name: Accessories
       choices: { CMAccessories: 1 }
       entries:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/team_leader.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/team_leader.yml
@@ -85,8 +85,8 @@
         points: 15
       - id: RMCBackpackRTO
         points: 5
-      - id: RMCWeldingGoggles
-        points: 3
+      #- id: RMCWeldingGoggles
+      #  points: 3
       - id: CMBeltUtilityCombat
         points: 15
       - id: RMCPouchAutoinjectorFill


### PR DESCRIPTION
Marks some vendor content as filled as they're meant to

uncomments some vendor content, such as the combat tech's electronic pouch as battery swapping is in now

## Changelog
:cl:
- add: Added the electronics pouch to the combat technician equipment rack.
- add: Added the machete scabbard to the dropship crew equipment rack.