### PR TITLE
Fix Kutjevo areas

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Areas/areas_kutjevo.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Areas/areas_kutjevo.yml
@@ -413,7 +413,6 @@
     state: power
   - type: Area
     minimapColor: '#C19504E7'
-  - type: Area
     CAS: true
     fulton: true
     mortarPlacement: false
@@ -430,15 +429,6 @@
   components:
   - type: Sprite
     state: power
-  - type: Area
-    CAS: true
-    fulton: true
-    mortarPlacement: false
-    mortarFire: true
-    lasing: false
-    medevac: false
-    OB: true
-    supplyDrop: true
 
 - type: entity
   parent: RMCAreaKutjevoInterior

--- a/Resources/Prototypes/_RMC14/Entities/Areas/areas_kutjevo.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Areas/areas_kutjevo.yml
@@ -273,6 +273,15 @@
   components:
   - type: Sprite
     state: kutjevo
+  - type: Area
+    CAS: true
+    fulton: true
+    mortarPlacement: false
+    mortarFire: true
+    lasing: false
+    medevac: false
+    OB: true
+    supplyDrop: true
 
 - type: entity
   parent: RMCAreaKutjevoInteriorComplex
@@ -404,6 +413,15 @@
     state: power
   - type: Area
     minimapColor: '#C19504E7'
+  - type: Area
+    CAS: true
+    fulton: true
+    mortarPlacement: false
+    mortarFire: true
+    lasing: false
+    medevac: false
+    OB: true
+    supplyDrop: true
 
 - type: entity
   parent: RMCAreaKutjevoInteriorPower
@@ -412,6 +430,15 @@
   components:
   - type: Sprite
     state: power
+  - type: Area
+    CAS: true
+    fulton: true
+    mortarPlacement: false
+    mortarFire: true
+    lasing: false
+    medevac: false
+    OB: true
+    supplyDrop: true
 
 - type: entity
   parent: RMCAreaKutjevoInterior


### PR DESCRIPTION
## About the PR

Kutjevo Colony Buildings (like Hydro Dam, Medical and Botany) in cm-13 are mortarable, due to contributor error in RMC-14 they are **not**.

- Fixes Interior Complex
- Fixes Hydro Dams

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- fix: Fixed Kutjevo areas. Now you can mortar Colony and Hydro Dam buildings.
