### PR TITLE
Sentinel neuro drains 2u instead of 1.75u on hit

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Projectile/DrainOnHitComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/DrainOnHitComponent.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.FixedPoint;
+using Content.Shared.FixedPoint;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared._RMC14.Xenonids.Projectile;
@@ -8,7 +8,7 @@ namespace Content.Shared._RMC14.Xenonids.Projectile;
 public sealed partial class DrainOnHitComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public FixedPoint2 DrainAmount = FixedPoint2.New(1.75);
+    public FixedPoint2 DrainAmount = FixedPoint2.New(2);
 
     [DataField]
     public string TargetSolution = "chemicals";


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity increased it.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed Sentinel Neurospit draining fewer units of chemicals than intended, it now drains 0.25 more units on hit (1.75u -> 2u)
