### PR TITLE
Fix crafted M1984 AP magazine boxes not fitting any mags

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magazine_boxes.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magazine_boxes.yml
@@ -521,6 +521,7 @@
   parent: RMCBoxMagazineBase
   id: RMCBoxMagazinePistolM1984APEmpty
   name: magazine box (AP M1984 x 16)
+  suffix: Empty
   components:
   - type: Construction
     graph: RMCBoxMagazine
@@ -536,18 +537,20 @@
       map: [ "lid" ]
     - state: lid_type_ap
       map: [ "lid_stripe" ]
-
-- type: entity
-  parent: RMCBoxMagazinePistolM1984APEmpty
-  id: RMCBoxMagazinePistolM1984AP
-  components:
   - type: CMItemSlots
-    startingItem: RMCMagazinePistolM1984AP
     count: 16
     slot:
       whitelist:
         tags:
         - RMCMagazinePistolM1984AP
+
+- type: entity
+  parent: RMCBoxMagazinePistolM1984APEmpty
+  id: RMCBoxMagazinePistolM1984AP
+  suffix: Filled
+  components:
+  - type: CMItemSlots
+    startingItem: RMCMagazinePistolM1984AP
 
 # M77
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed crafted M1984 AP magazine boxes not fitting any mags.