### PR TITLE
Remove xenos ability to examine ranks

### DIFF
--- a/Content.Shared/_RMC14/Marines/Roles/Ranks/SharedRankSystem.cs
+++ b/Content.Shared/_RMC14/Marines/Roles/Ranks/SharedRankSystem.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared.Examine;
+﻿using Content.Shared._RMC14.Xenonids;
+using Content.Shared.Examine;
 using Content.Shared.Humanoid;
 using Robust.Shared.Enums;
 using Robust.Shared.Prototypes;
@@ -18,6 +19,9 @@ public abstract class SharedRankSystem : EntitySystem
 
     private void OnRankExamined(Entity<RankComponent> ent, ref ExaminedEvent args)
     {
+        if (HasComp<XenoComponent>(args.Examiner))
+            return;
+
         using (args.PushGroup(nameof(SharedRankSystem), 1))
         {
             var user = ent.Owner;


### PR DESCRIPTION
Basically invalidates the no ID examining, CM13 has it this way aswell

🆑

- fix: Fixed xenos being able to examine marine ranks