### PR TITLE
Fix M44 Marksman Speed Loader

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Revolvers/m44_revolver.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Revolvers/m44_revolver.yml
@@ -17,6 +17,7 @@
     whitelist:
       tags:
       - RMCSpeedLoaderM44
+      - RMCSpeedLoader44Marksman
       - RMCCartridgeRevolver44
     proto: RMCCartridgeRevolver44
     capacity: 7


### PR DESCRIPTION
## About the PR

Title. Marksman speedloader couldn't reload M44.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

:cl:
- fix: Fixed not being able to reload M44 revolvers with M44 marksman speedloaders.