### PR TITLE
Status display mission time 

### DIFF
--- a/Content.Client/_RMC14/AlertLevel/RMCAlertLevelDisplayVisualizerSystem.cs
+++ b/Content.Client/_RMC14/AlertLevel/RMCAlertLevelDisplayVisualizerSystem.cs
@@ -1,0 +1,57 @@
+using System.Linq;
+using System.Numerics;
+using Content.Shared._RMC14.AlertLevel;
+using Content.Shared.Clock;
+using Content.Shared.GameTicking;
+using Robust.Client.GameObjects;
+
+namespace Content.Client._RMC14.AlertLevel;
+
+public sealed class RMCAlertLevelDisplayVisualizerSystem : EntitySystem
+{
+
+    [Dependency] private readonly SharedGameTicker _ticker = default!;
+    [Dependency] private readonly RMCAlertLevelSystem _alertLevel = default!;
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var current = _alertLevel.Get();
+
+        if (current > RMCAlertLevels.Green)
+            return;
+
+        var query = EntityQueryEnumerator<RMCAlertLevelDisplayComponent, SpriteComponent>();
+        while (query.MoveNext(out var uid, out var comp, out var sprite))
+        {
+            if (!sprite.LayerMapTryGet(RMCAlertLevelDisplayVisualLayers.HourTens, out var hourTensLayer) ||
+                !sprite.LayerMapTryGet(RMCAlertLevelDisplayVisualLayers.HourOnes, out var hourOnesLayer) ||
+                !sprite.LayerMapTryGet(RMCAlertLevelDisplayVisualLayers.Separator, out var separatorLayer) ||
+                !sprite.LayerMapTryGet(RMCAlertLevelDisplayVisualLayers.MinuteTens, out var minuteTensLayer) ||
+                !sprite.LayerMapTryGet(RMCAlertLevelDisplayVisualLayers.MinuteOnes, out var minuteOnesLayer)
+                )
+                continue;
+
+            var worldTime = (EntityQuery<GlobalTimeManagerComponent>().FirstOrDefault()?.TimeOffset ?? TimeSpan.Zero) + _ticker.RoundDuration();
+            var timeString = worldTime.ToString(@"hh\:mm");
+            var hourTensState = $"{timeString[0]}";
+            var hourOnesState = $"{timeString[1]}";
+            var separatorState = "~";
+            var minuteTensState = $"{timeString[3]}";
+            var minuteOnesState = $"{timeString[4]}";
+
+            sprite.LayerSetOffset(hourTensLayer, new Vector2(0.11f, -0.4375f));
+            sprite.LayerSetOffset(hourOnesLayer, new Vector2(0.28f, -0.4375f));
+            sprite.LayerSetOffset(separatorLayer, new Vector2(0.406f, -0.4375f));
+            sprite.LayerSetOffset(minuteTensLayer, new Vector2(0.56f, -0.4375f));
+            sprite.LayerSetOffset(minuteOnesLayer, new Vector2(0.73f, -0.4375f));
+
+            sprite.LayerSetState(hourTensLayer, hourTensState);
+            sprite.LayerSetState(hourOnesLayer, hourOnesState);
+            sprite.LayerSetState(separatorLayer, separatorState);
+            sprite.LayerSetState(minuteTensLayer, minuteTensState);
+            sprite.LayerSetState(minuteOnesLayer, minuteOnesState);
+        }
+    }
+}

--- a/Content.Shared/_RMC14/AlertLevel/RMCAlertLevelDisplayComponent.cs
+++ b/Content.Shared/_RMC14/AlertLevel/RMCAlertLevelDisplayComponent.cs
@@ -1,7 +1,18 @@
 ﻿using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
 
 namespace Content.Shared._RMC14.AlertLevel;
 
 [RegisterComponent, NetworkedComponent]
 [Access(typeof(RMCAlertLevelSystem))]
 public sealed partial class RMCAlertLevelDisplayComponent : Component;
+
+[Serializable, NetSerializable]
+public enum RMCAlertLevelDisplayVisualLayers : byte
+{
+    MinuteOnes,
+    MinuteTens,
+    Separator,
+    HourOnes,
+    HourTens
+}

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/status_display.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/status_display.yml
@@ -15,6 +15,11 @@
     - map: [ "screen" ]
       state: bluealert
       visible: false
+    - map: [ "enum.RMCAlertLevelDisplayVisualLayers.HourTens" ]
+    - map: [ "enum.RMCAlertLevelDisplayVisualLayers.HourOnes" ]
+    - map: [ "enum.RMCAlertLevelDisplayVisualLayers.Separator" ]
+    - map: [ "enum.RMCAlertLevelDisplayVisualLayers.MinuteTens" ]
+    - map: [ "enum.RMCAlertLevelDisplayVisualLayers.MinuteOnes" ]
   - type: Appearance
   - type: GenericVisualizer
     visuals:
@@ -24,4 +29,29 @@
           Blue: { state: bluealert, visible: true }
           Red: { state: redalert, visible: true }
           Delta: { state: evac, visible: true }
+        enum.RMCAlertLevelDisplayVisualLayers.HourTens:
+          Green: { visible: true }
+          Blue: { visible: false }
+          Red: { visible: false }
+          Delta: { visible: false }
+        enum.RMCAlertLevelDisplayVisualLayers.HourOnes:
+          Green: { visible: true }
+          Blue: { visible: false }
+          Red: { visible: false }
+          Delta: { visible: false }
+        enum.RMCAlertLevelDisplayVisualLayers.Separator:
+          Green: { visible: true }
+          Blue: { visible: false }
+          Red: { visible: false }
+          Delta: { visible: false }
+        enum.RMCAlertLevelDisplayVisualLayers.MinuteTens:
+          Green: { visible: true }
+          Blue: { visible: false }
+          Red: { visible: false }
+          Delta: { visible: false }
+        enum.RMCAlertLevelDisplayVisualLayers.MinuteOnes:
+          Green: { visible: true }
+          Blue: { visible: false }
+          Red: { visible: false }
+          Delta: { visible: false }
   - type: RMCAlertLevelDisplay


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Whenever the station is in green alert, the status displays show station time

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
More ways for marines to know the time for rp, and it's more useful than a static logo/blank screen

## Technical details
<!-- Summary of code changes for easier review. -->
Overall similar to how hours/minutes hands are handled on the upstream wristwatch. Each number is a separate sprite layer, updating is handled by the client.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![Screenshot 2025-01-28 144542](https://github.com/user-attachments/assets/8a7bdc93-e9ce-424d-aba6-99f8610cfc85)
![Screenshot 2025-01-28 144507](https://github.com/user-attachments/assets/72b9c167-153a-45db-a1a9-76c16b606a5a)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added time display to status screens when on green alert.