### PR TITLE
Add night vision film grain

### DIFF
--- a/Resources/Textures/_RMC14/Shaders/night_vision.swsl
+++ b/Resources/Textures/_RMC14/Shaders/night_vision.swsl
@@ -2,5 +2,15 @@
 
 void fragment() {
     highp vec4 color = zTextureSpec(SCREEN_TEXTURE, UV);
-    COLOR = color * vec4(0.1, 0.75, 0.1, 1);
+
+    // Generate random noise for the film grain
+    highp float noise = (fract(sin(dot(UV * TIME, vec2(12.9898, 78.233))) * 43758.5453) - 0.5) * 2.0;
+
+    // Add noise
+    color.rgb += noise * 0.05; // Adjust intensity of the grain
+
+    // Apply the night vision green tint
+    color.rgb *= vec3(0.1, 0.75, 0.1);
+
+    COLOR = vec4(clamp(color.rgb, 0.0, 1.0), color.a);
 }


### PR DESCRIPTION
Cool effect from CM13

Split from #5387 because they weren't really related, see there for a video

:cl:
- tweak: Night vision visors now have their film grain overlay