### PR TITLE
Instant chair deconstruction

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Furniture/chairs.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Furniture/chairs.yml
@@ -22,7 +22,6 @@
     anchored: false
   - type: Physics
     bodyType: Static
-  - type: Anchorable
   - type: Construction
     graph: CMSeat
     node: chair
@@ -59,7 +58,6 @@
     anchored: true
   - type: Physics
     bodyType: Static
-  - type: Anchorable
   - type: Construction
     graph: CMSeat
     node: chairComfy

--- a/Resources/Prototypes/_RMC14/Recipes/Construction/Graphs/furniture/seats.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Construction/Graphs/furniture/seats.yml
@@ -42,7 +42,7 @@
               prototype: CMSheetMetal1
           steps:
             - tool: Screwing
-              doAfter: 1
+              doAfter: 0
 
     - node: stool
       entity: RMCStool
@@ -53,7 +53,7 @@
               prototype: CMSheetMetal1
           steps:
             - tool: Screwing
-              doAfter: 1
+              doAfter: 0
 
     - node: chairComfy
       entity: CMChairComfy
@@ -64,7 +64,7 @@
               prototype: CMSheetMetal1
           steps:
             - tool: Screwing
-              doAfter: 1
+              doAfter: 0
 
     - node: chairOfficeDark
       entity: CMChairOfficeDark
@@ -75,7 +75,7 @@
               prototype: CMSheetMetal1
           steps:
             - tool: Screwing
-              doAfter: 1
+              doAfter: 0
 
     - node: chairOfficeWhite
       entity: CMChairOfficeWhite
@@ -86,4 +86,4 @@
               prototype: CMSheetMetal1
           steps:
             - tool: Screwing
-              doAfter: 1
+              doAfter: 0

--- a/Resources/Prototypes/_RMC14/Recipes/Construction/Graphs/furniture/seats.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Construction/Graphs/furniture/seats.yml
@@ -41,7 +41,7 @@
             - !type:SpawnPrototype
               prototype: CMSheetMetal1
           steps:
-            - tool: Screwing
+            - tool: Anchoring
               doAfter: 0
 
     - node: stool
@@ -52,7 +52,7 @@
             - !type:SpawnPrototype
               prototype: CMSheetMetal1
           steps:
-            - tool: Screwing
+            - tool: Anchoring
               doAfter: 0
 
     - node: chairComfy
@@ -63,7 +63,7 @@
             - !type:SpawnPrototype
               prototype: CMSheetMetal1
           steps:
-            - tool: Screwing
+            - tool: Anchoring
               doAfter: 0
 
     - node: chairOfficeDark
@@ -74,7 +74,7 @@
             - !type:SpawnPrototype
               prototype: CMSheetMetal1
           steps:
-            - tool: Screwing
+            - tool: Anchoring
               doAfter: 0
 
     - node: chairOfficeWhite
@@ -85,5 +85,5 @@
             - !type:SpawnPrototype
               prototype: CMSheetMetal1
           steps:
-            - tool: Screwing
+            - tool: Anchoring
               doAfter: 0


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Chair deconstruction doafter removed.
Chair deconstruction tool changed from screwdriver to wrench.
Resolves #5451 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Dygon
- tweak: Chair are now instantly deconstructed with a wrench, instead of a screwdriver.

