### PR TITLE
Resin surge fixes + weed layering revert

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/ResinSurge/ResinSurgeReinforcableComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/ResinSurge/ResinSurgeReinforcableComponent.cs
@@ -1,0 +1,6 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.ResinSurge;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ResinSurgeReinforcableComponent : Component;

--- a/Content.Shared/_RMC14/Xenonids/ResinSurge/SharedXenoResinSurgeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/ResinSurge/SharedXenoResinSurgeSystem.cs
@@ -8,6 +8,7 @@ using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared._RMC14.Xenonids.Spray;
 using Content.Shared._RMC14.Xenonids.Weeds;
 using Content.Shared.Actions;
+using Content.Shared.Coordinates;
 using Content.Shared.Coordinates.Helpers;
 using Content.Shared.DoAfter;
 using Content.Shared.Maps;
@@ -34,6 +35,7 @@ public sealed class SharedXenoResinSurgeSystem : EntitySystem
     [Dependency] private readonly TurfSystem _turf = default!;
     [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
     [Dependency] private readonly SharedRMCMapSystem _rmcMap = default!;
+    [Dependency] private readonly SharedXenoWeedsSystem _weeds = default!;
 
     public override void Initialize()
     {
@@ -110,10 +112,10 @@ public sealed class SharedXenoResinSurgeSystem : EntitySystem
         if (xeno.Comp.ResinDoafter != null || !_xenoPlasma.TryRemovePlasmaPopup((xeno.Owner, null), args.PlasmaCost))
             return;
 
-        if (args.Entity is { } entity && _hive.FromSameHive(xeno.Owner, entity))
+        if (args.Entity is { } entity)
         {
             // Check if target is xeno wall or door
-            if (TryComp(entity, out XenoConstructComponent? construct))
+            if (TryComp(entity, out ResinSurgeReinforcableComponent? construct) && _hive.FromSameHive(xeno.Owner, entity))
             {
                 // Check if target is already buffed
                 if (HasComp<XenoConstructReinforceComponent>(entity))
@@ -136,7 +138,7 @@ public sealed class SharedXenoResinSurgeSystem : EntitySystem
             }
 
             // Check if target is fruit
-            if (TryComp(entity, out XenoFruitComponent? fruit))
+            if (TryComp(entity, out XenoFruitComponent? fruit) && _hive.FromSameHive(xeno.Owner, entity))
             {
                 // Check if fruit mature, try to fasten its growth if not
                 if (!_xenoFruit.TrySpeedupGrowth((entity, fruit), xeno.Comp.FruitGrowth))
@@ -153,14 +155,28 @@ public sealed class SharedXenoResinSurgeSystem : EntitySystem
             }
 
             // Check if target is on weeds
-            if (TryComp(entity, out XenoWeedsComponent? weeds))
+            if (TryComp(entity, out XenoWeedsComponent? weeds) || _weeds.IsOnWeeds(entity))
             {
-                var popupSelf = Loc.GetString("rmc-xeno-resin-surge-wall-self");
-                var popupOthers = Loc.GetString("rmc-xeno-resin-surge-wall-others", ("xeno", xeno));
-                _popup.PopupPredicted(popupSelf, popupOthers, xeno, xeno);
+                EntityUid weedEnt = entity;
+                if (weeds == null)
+                {
+                    var weedTempEnt = _weeds.GetWeedsOnFloor((gridId, grid), entity.ToCoordinates());
+                    if (weedTempEnt != null)
+                    {
+                        weedEnt = weedTempEnt.Value;
+                        TryComp(weedEnt, out weeds);
+                    }
+                }
 
-                SurgeUnstableWall(xeno, target);
-                return;
+                if (weeds != null && _hive.FromSameHive(xeno.Owner, weedEnt))
+                {
+                    var popupSelf = Loc.GetString("rmc-xeno-resin-surge-wall-self");
+                    var popupOthers = Loc.GetString("rmc-xeno-resin-surge-wall-others", ("xeno", xeno));
+                    _popup.PopupPredicted(popupSelf, popupOthers, xeno, xeno);
+
+                    SurgeUnstableWall(xeno, target);
+                    return;
+                }
             }
         }
 

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Base/base_structure.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Base/base_structure.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   parent: BaseStructure
   id: CMBaseStructure
   abstract: true
@@ -157,6 +157,7 @@
     flags:
     - Turf
     - Xeno
+  - type: ResinSurgeReinforcable
 
 # Invisible Wall
 

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_weeds.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_weeds.yml
@@ -1,4 +1,4 @@
-﻿- type: entity # TODO RMC14 sound
+- type: entity # TODO RMC14 sound
   id: XenoWeeds
   name: weeds
   description: Weird black weeds...
@@ -113,6 +113,7 @@
     drawdepth: DeadMobs
     layers:
     - state: weed0
+      drawdepth: FloorTiles
     - state: constructionnode
   - type: Destructible
     thresholds:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_weeds.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_weeds.yml
@@ -110,7 +110,7 @@
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Xenos/xeno_weeds.rsi
-    drawdepth: FloorObjects
+    drawdepth: FloorTiles
     layers:
     - state: weed0
     - state: constructionnode

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_weeds.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_weeds.yml
@@ -110,10 +110,9 @@
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Xenos/xeno_weeds.rsi
-    drawdepth: DeadMobs
+    drawdepth: FloorObjects
     layers:
     - state: weed0
-      drawdepth: FloorTiles
     - state: constructionnode
   - type: Destructible
     thresholds:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title. Resin surge can no longer reinforce sticky/fast resins, and no longer makes sticky resin if there are ever hive-member weeds under the target (if a fruit or wall wasn't chosen).

Layering for weeds is uh...not good right now. Xenos can't destroy them under nodes and marines can't see them under nodes. Until weeds are changed to have the weed tile be seperate but still connected someway, the older style should work for now. You can still hit a node on a tile with sticky, its just a lil harder to see.


## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity, and lesser of two evils.

## Technical details
<!-- Summary of code changes for easier review. -->
New comp for reinforce resin surge. Moved some stuff around so the hive check can be done later for weeds.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed resin surge reinforcing non-walls and doors
- fix: Fixed resin surge making sticky weeds if a non-wall non-fruit entity was targeted on weeds (it now makes a wall as intended)
- tweak: Reverted weed node layering changes for now.
