### PR TITLE
Add M1984 AP ammo to Rifleman vendor. Move m77 ammo from m1984 file

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/m1984_pistol.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/m1984_pistol.yml
@@ -132,30 +132,6 @@
 
 #9mmAP
 - type: entity
-  parent: CMBulletBase
-  id: CMBulletPistolM77AP
-  name: bullet (9mm AP)
-  components:
-  - type: Projectile
-    damage:
-      types:
-        Piercing: 25
-  - type: CMArmorPiercing
-    amount: 40
-
-- type: entity
-  id: CMCartridgePistolM77AP
-  name: cartridge (9mm AP)
-  parent: CMCartridgePistolBase
-  components:
-  - type: Tag
-    tags:
-    - Cartridge
-    - CMCartridgePistol9mmAP
-  - type: CartridgeAmmo
-    proto: CMBulletPistolM77AP
-
-- type: entity
   parent: CMMagazinePistolM1984
   id: RMCMagazinePistolM1984AP
   name: M1984 AP magazine (9mm)

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/m77_pistol.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/m77_pistol.yml
@@ -123,5 +123,29 @@
   - type: MagazineVisuals
     magState: base_ap
 
+- type: entity
+  parent: CMBulletBase
+  id: CMBulletPistolM77AP
+  name: bullet (9mm AP)
+  components:
+  - type: Projectile
+    damage:
+      types:
+        Piercing: 25
+  - type: CMArmorPiercing
+    amount: 40
+
+- type: entity
+  id: CMCartridgePistolM77AP
+  name: cartridge (9mm AP)
+  parent: CMCartridgePistolBase
+  components:
+  - type: Tag
+    tags:
+    - Cartridge
+    - CMCartridgePistol9mmAP
+  - type: CartridgeAmmo
+    proto: CMBulletPistolM77AP
+
 - type: Tag
   id: CMMagazinePistolM77AP

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/rifleman.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/rifleman.yml
@@ -137,8 +137,14 @@
         points: 10
     - name: Sidearm Ammunition
       entries:
+      #- id: M44 Heavy Speedloader
+      #  points: 10
       - id: RMCSpeedLoader44Marksman
         points: 10
+      #- id: M1984 Hollow Point magazine
+      #  points: 5
+      - id: RMCMagazinePistolM1984AP
+        points: 5
       - id: CMMagazinePistolMK80
         points: 5
       - id: RMCMagazinePistolSU6
@@ -187,8 +193,6 @@
         points: 5
       - id: RMCMotionDetector
         points: 15
-    #- id: CMMotionDetector
-    #  points: 15
     #- id: CMDataDetector
     #  points: 15
       - id: RMCWhistle


### PR DESCRIPTION
## About the PR

Parity.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

:cl:
- fix: Fixed Riflemen not being able to buy M1984 AP ammo in their vendor.