### PR TITLE
Add selectable sounds system

### DIFF
--- a/Content.Shared/_RMC14/SelectableSounds/RMCSelectableSoundsComponent.cs
+++ b/Content.Shared/_RMC14/SelectableSounds/RMCSelectableSoundsComponent.cs
@@ -10,5 +10,5 @@ namespace Content.Shared._RMC14.SelectableSounds;
 public sealed partial class RMCSelectableSoundsComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public Dictionary<string, SoundSpecifier> Sounds = new();
+    public Dictionary<LocId, SoundSpecifier> Sounds = new();
 }

--- a/Content.Shared/_RMC14/SelectableSounds/RMCSelectableSoundsComponent.cs
+++ b/Content.Shared/_RMC14/SelectableSounds/RMCSelectableSoundsComponent.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Audio;
+
+namespace Content.Shared._RMC14.SelectableSounds;
+
+/// <summary>
+/// A component which lets you toggle sounds on things like an EmitSoundOnUseComponent with a verb
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class RMCSelectableSoundsComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public Dictionary<string, SoundSpecifier> Sounds = new();
+}

--- a/Content.Shared/_RMC14/SelectableSounds/RMCSelectableSoundsSystem.cs
+++ b/Content.Shared/_RMC14/SelectableSounds/RMCSelectableSoundsSystem.cs
@@ -23,15 +23,11 @@ public sealed class RMCSelectableSoundsSystem : EntitySystem
             return;
 
         var user = args.User;
-
-        if (!TryComp<EmitSoundOnUseComponent>(ent.Owner, out var use))
-            return;
-
         var verbs = new ValueList<AlternativeVerb>();
 
         foreach (var soundEntry in ent.Comp.Sounds)
         {
-            var name = soundEntry.Key;
+            var name = Loc.GetString(soundEntry.Key);
             var sound = soundEntry.Value;
 
             var newVerb = new AlternativeVerb()
@@ -41,7 +37,8 @@ public sealed class RMCSelectableSoundsSystem : EntitySystem
                 Category = VerbCategory.SelectType,
                 Act = () =>
                 {
-                    use.Sound = sound;
+                    if (TryComp<EmitSoundOnUseComponent>(ent.Owner, out var use))
+                        use.Sound = sound;
 
                     if (TryComp<EmitSoundOnActionComponent>(ent.Owner, out var action))
                         action.Sound = sound;

--- a/Content.Shared/_RMC14/SelectableSounds/RMCSelectableSoundsSystem.cs
+++ b/Content.Shared/_RMC14/SelectableSounds/RMCSelectableSoundsSystem.cs
@@ -1,0 +1,59 @@
+﻿using Content.Shared._RMC14.Sound;
+using Content.Shared.Popups;
+using Content.Shared.Sound.Components;
+using Content.Shared.Verbs;
+using Robust.Shared.Collections;
+
+namespace Content.Shared._RMC14.SelectableSounds;
+
+public sealed class RMCSelectableSoundsSystem : EntitySystem
+{
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<RMCSelectableSoundsComponent, GetVerbsEvent<AlternativeVerb>>(OnGetAltVerbs);
+    }
+
+    private void OnGetAltVerbs(Entity<RMCSelectableSoundsComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
+    {
+        if (!args.CanAccess || !args.CanInteract || args.Hands == null)
+            return;
+
+        var user = args.User;
+
+        if (!TryComp<EmitSoundOnUseComponent>(ent.Owner, out var use))
+            return;
+
+        var verbs = new ValueList<AlternativeVerb>();
+
+        foreach (var soundEntry in ent.Comp.Sounds)
+        {
+            var name = soundEntry.Key;
+            var sound = soundEntry.Value;
+
+            var newVerb = new AlternativeVerb()
+            {
+                Text = name,
+                IconEntity = GetNetEntity(ent.Owner),
+                Category = VerbCategory.SelectType,
+                Act = () =>
+                {
+                    use.Sound = sound;
+
+                    if (TryComp<EmitSoundOnActionComponent>(ent.Owner, out var action))
+                        action.Sound = sound;
+
+                    var msg = Loc.GetString("rmc-sound-select", ("sound", name));
+                    _popup.PopupClient(msg, user, user);
+                },
+            };
+
+            verbs.Add(newVerb);
+        }
+
+        args.Verbs.UnionWith(verbs);
+    }
+}

--- a/Resources/Locale/en-US/_RMC14/selectable_sounds.ftl
+++ b/Resources/Locale/en-US/_RMC14/selectable_sounds.ftl
@@ -1,1 +1,5 @@
 ﻿rmc-sound-select = Changed sound to: {$sound}
+
+rmc-sound-select-whistle = Trench Whistle
+rmc-sound-select-crowbar = Crowbar
+rmc-sound-select-detector = Motion Detector

--- a/Resources/Locale/en-US/_RMC14/selectable_sounds.ftl
+++ b/Resources/Locale/en-US/_RMC14/selectable_sounds.ftl
@@ -1,0 +1,1 @@
+﻿rmc-sound-select = Changed sound to: {$sound}

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Fun/misc.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Fun/misc.yml
@@ -1,0 +1,19 @@
+- type: entity
+  parent: RMCWhistle
+  id: RMCDebugSoundDevice
+  name: unknown device
+  description: "???"
+  suffix: DO NOT MAP
+  components:
+  - type: Sprite
+    sprite: Objects/Devices/declaration_of_war.rsi
+    state: declarator
+    color: Blue
+  - type: RMCSelectableSounds
+    sounds:
+      Whistle:
+        collection: TrenchWhistle
+      Crowbar:
+        path: /Audio/_RMC14/Handling/crowbar_pickup.ogg
+      Detector:
+        path: /Audio/_RMC14/Effects/motion_detector.ogg

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Fun/misc.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Fun/misc.yml
@@ -11,9 +11,9 @@
     color: Blue
   - type: RMCSelectableSounds
     sounds:
-      Whistle:
+      rmc-sound-select-whistle: # Loc ID
         collection: TrenchWhistle
-      Crowbar:
+      rmc-sound-select-crowbar:
         path: /Audio/_RMC14/Handling/crowbar_pickup.ogg
-      Detector:
+      rmc-sound-select-detector:
         path: /Audio/_RMC14/Effects/motion_detector.ogg


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR


https://github.com/user-attachments/assets/8b4ef752-453e-4a39-9b03-09b0f1644216




adds generic system for  making a ``EmitSoundOnUse`` object have selectable sounds
need this for another pr
adds debug item