### PR TITLE
parasite_observer(fixed)

### DIFF
--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-strains.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-strains.ftl
@@ -67,3 +67,11 @@ rmc-xeno-steelcrest-description = You trade your tail sweep and a small amount o
    - Headbutt while fortified. Headbutt doesn't lose damage and keeps it's higher range with high knockback.
    - Soak in damage for 6 seconds for a small heal that also refreshes your tail slam.
 rmc-xeno-steelcrest-popup = This one, like my will, is indomitable. It will become my steel crest against all that defy me.
+
+rmc-xeno-observer-name = Observer
+rmc-xeno-observer-description = You lose your ability to hide, but will be able to to see further into the distance. Stalk your prey for the best opportunity to infect or coordinate an ambush with your sisters.
+  You gain:
+  - An ability to Zoom out your field of view, like a Runner
+  You lose:
+  - Your ability to Hide
+rmc-xeno-observer-popup = This one will stalk prey from a distance, with a greater sight.

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/parasite.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/parasite.yml
@@ -2,7 +2,7 @@
   parent:
   - CMXenoUndeveloped
   - CMXenoFlammable
-  id: CMXenoParasite # TODO RMC14 slowly die off weeds
+  id: CMXenoParasiteBase 
   name: Parasite
   components:
   - type: GhostRole
@@ -23,7 +23,6 @@
     actionIds:
     - ActionXenoRest
     - ActionXenoWatch
-    - ActionXenoHide
     - ActionXenoLeap
     tier: 0
     hudOffset: -0.1,0.1
@@ -104,3 +103,37 @@
     downSound: null
   - type: XenoInhandSprite
     stateName: parasite
+
+
+
+- type: entity
+  parent: CMXenoParasiteBase
+  id: CMXenoParasite
+  components:
+  - type: Xeno
+    actionIds:
+    - ActionXenoRest
+    - ActionXenoWatch
+    - ActionXenoHide
+    - ActionXenoLeap
+  - type: XenoHide
+  - type: XenoEvolution
+    strains:
+    - RMCXenoParasiteObserver
+
+- type: entity
+  parent: CMXenoParasiteBase
+  id: RMCXenoParasiteObserver # Observer Strain
+  suffix: Observer
+  components:
+  - type: Xeno
+    actionIds:
+    - ActionXenoRest
+    - ActionXenoWatch
+    - ActionXenoLeap
+    - ActionXenoZoom 
+  - type: XenoZoom
+  - type: XenoStrain
+    name: rmc-xeno-observer-name
+    description: rmc-xeno-observer-description
+    popup: rmc-xeno-observer-popup


### PR DESCRIPTION
About the PR
Added New Xeno Strain - Parasite Observer

Why / Balance
Contributes to making more playable strains with the update

Technical details
This one wasn't hard, I just took major components of parasite and made them into Parasite Base, from which Normal (Has Hiding) and Observer (No hiding, but runner's Zoom) paras separated. The Parasite has its own Strain description too.

Requirements
 I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
 I have added screenshots/videos to this PR showcasing its changes ingame, or this PR does not require an ingame showcase


Changelog

🆑

add: Added Parasite Observer Strain!
