### PR TITLE
Remove M54C MK1 camo

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/stock_attachments.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/stock_attachments.yml
@@ -385,6 +385,15 @@
       Urban: _RMC14/Objects/Weapons/Guns/Attachments/m54_stocks/urban.rsi
 
 - type: entity
+  parent: RMCAttachmentM54CStockCollapsible
+  id: RMCAttachmentM54CMK1StockCollapsible
+  suffix: Desert Camo
+  description: The standard back end of any gun starting with M54. Compatible with the M54C series, this stock reduces recoil and scatter, but at a reduction to handling and agility. Also enhances the thwacking of things with the stock-end of the rifle. Painted in a lovely desert camo.
+  components:
+  - type: ItemCamouflage
+    camouflageVariations: { }
+
+- type: entity
   parent: RMCStockAttachmentBase
   id: RMCAttachmentM16Stock
   name: M16 bump stock

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m54c_mk1_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m54c_mk1_rifle.yml
@@ -97,13 +97,6 @@
       rmc-aslot-rail: 0.1, 0.16
       rmc-aslot-stock: -0.78, 0.0325
       rmc-aslot-underbarrel: 0.35, -0.343
-  - type: ItemCamouflage
-    camouflageVariations:
-      Jungle: _RMC14/Objects/Weapons/Guns/Rifles/m54cmk1/jungle.rsi
-      Desert: _RMC14/Objects/Weapons/Guns/Rifles/m54cmk1/desert.rsi
-      Snow: _RMC14/Objects/Weapons/Guns/Rifles/m54cmk1/snow.rsi
-      Classic: _RMC14/Objects/Weapons/Guns/Rifles/m54cmk1/classic.rsi
-      Urban: _RMC14/Objects/Weapons/Guns/Rifles/m54cmk1/urban.rsi
   - type: Tag
     tags:
     - RMCWeaponRifleM54CMK1

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m54c_mk1_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m54c_mk1_rifle.yml
@@ -81,7 +81,7 @@
           - RMCAttachmentS5RedDotSight
           - RMCAttachmentS6ReflexSight
       rmc-aslot-stock:
-        startingAttachable: RMCAttachmentM54CStockCollapsible
+        startingAttachable: RMCAttachmentM54CMK1StockCollapsible
         whitelist:
           tags:
           - RMCAttachmentM54CStockCollapsible


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
It's supposed to have only desert camo, it's like this in CM13

A less-stocked older version of the M54C, so camo wasn't mass produced for it

![image](https://github.com/user-attachments/assets/46c59d23-ab92-4ba1-9d28-75161f5c99fe)
![image](https://github.com/user-attachments/assets/7e4dbf7e-ba68-4140-b38c-65698a64483c)
![image](https://github.com/user-attachments/assets/10ce8bd0-89bd-4c94-8c9f-aa7b447488fa)

