### PR TITLE
Give XO service peaked cap in loadout

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Command/executive_officer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Command/executive_officer.yml
@@ -58,7 +58,7 @@
   equipment:
     jumpsuit: CMJumpsuitBO
     shoes: RMCShoesLaceup
-    head: RMCHeadCapFlippable
+    head: CMHeadCapPeakedService
     outerClothing: RMCCoatService
     id: CMIDCardExecutiveOfficer
     ears: CMHeadsetSeniorCommand


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
cm13

:cl:
- fix: Fixed Executive Officer not starting with a marine service peaked cap.