### PR TITLE
Make some headsets have disabled channels by default

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/ship_headsets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/ship_headsets.yml
@@ -52,6 +52,14 @@
       key_slots:
       - CMEncryptionKeyCommon
       - CMEncryptionKeyCE
+  - type: RMCRadioFilter
+    disabledChannels:
+    - MarineAlpha
+    - MarineBravo
+    - MarineCharlie
+    - MarineDelta
+    - MarineEcho
+    - MarineFoxtrot
 
 - type: entity
   parent: RMCHeadsetShip
@@ -66,6 +74,14 @@
       key_slots:
       - CMEncryptionKeyCommon
       - CMEncryptionKeyCMO
+  - type: RMCRadioFilter
+    disabledChannels:
+    - MarineAlpha
+    - MarineBravo
+    - MarineCharlie
+    - MarineDelta
+    - MarineEcho
+    - MarineFoxtrot
 
 - type: entity
   parent: RMCHeadsetShip
@@ -142,6 +158,15 @@
       key_slots:
       - CMEncryptionKeyCommon
       - RMCEncryptionKeyQuartermaster
+  - type: RMCRadioFilter
+    disabledChannels:
+    - MarineAlpha
+    - MarineBravo
+    - MarineCharlie
+    - MarineDelta
+    - MarineEcho
+    - MarineFoxtrot
+    - MarineMedical
 
 - type: entity
   parent: RMCHeadsetShip
@@ -170,6 +195,14 @@
       key_slots:
       - CMEncryptionKeyCommon
       - CMEncryptionKeyCMP
+  - type: RMCRadioFilter
+    disabledChannels:
+    - MarineAlpha
+    - MarineBravo
+    - MarineCharlie
+    - MarineDelta
+    - MarineEcho
+    - MarineFoxtrot
 
 - type: entity
   parent: RMCHeadsetShip
@@ -219,6 +252,14 @@
       key_slots:
       - CMEncryptionKeyIntel
       - CMEncryptionKeyIntelOfficer
+  - type: RMCRadioFilter
+    disabledChannels:
+    - MarineAlpha
+    - MarineBravo
+    - MarineCharlie
+    - MarineDelta
+    - MarineEcho
+    - MarineFoxtrot
 
 - type: entity
   parent: RMCHeadsetShip

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Devices/EncryptionKeys/ship.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Devices/EncryptionKeys/ship.yml
@@ -430,7 +430,7 @@
 - type: entity
   parent: CMEncryptionKey
   id: CMEncryptionKeyIntelOfficer
-  name: intel officer's encryption Key
+  name: intel officer's encryption key
   components:
   - type: EncryptionKey
     channels:
@@ -439,6 +439,12 @@
     - MarineEngineer
     - MarineJTAC
     - MarineMedical
+    - MarineAlpha
+    - MarineBravo
+    - MarineCharlie
+    - MarineDelta
+    - MarineEcho
+    - MarineFoxtrot
     defaultChannel: MarineCommon
   - type: Sprite
     state: cap_key


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
CM13 Parity

Department heads and IO has squad channels off by default

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

:cl:
- tweak: The CE's, CMO's, QM's, CMP's and IO's headsets now correctly start with some channels disabled by default. Right click the headset to configure them.