### PR TITLE
Make rotary phones emote when ringing

### DIFF
--- a/Content.Server/_RMC14/Telephone/RMCTelephoneSystem.cs
+++ b/Content.Server/_RMC14/Telephone/RMCTelephoneSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.Hands.Systems;
 using Content.Server.Popups;
 using Content.Server.Radio;
 using Content.Server.Speech;
+using Content.Server.Chat.Systems;
 using Content.Server.Speech.Components;
 using Content.Shared._RMC14.Communications;
 using Content.Shared._RMC14.Hands;
@@ -26,6 +27,7 @@ public sealed class RMCTelephoneSystem : SharedRMCTelephoneSystem
     [Dependency] private readonly HandsSystem _hands = default!;
     [Dependency] private readonly CMHandsSystem _rmcHands = default!;
     [Dependency] private readonly RMCPlanetSystem _rmcPlanet = default!;
+    [Dependency] private readonly ChatSystem _chat = default!;
 
     public override void Initialize()
     {
@@ -35,6 +37,7 @@ public sealed class RMCTelephoneSystem : SharedRMCTelephoneSystem
         SubscribeLocalEvent<RadioReceiveAttemptEvent>(OnRadioReceiveAttempt);
 
         SubscribeLocalEvent<RMCTelephoneComponent, ListenEvent>(OnListen);
+        SubscribeLocalEvent<RMCTelephoneRingEvent>(OnTelephoneRing);
     }
 
     private void OnRadioSendAttempt(ref RadioSendAttemptEvent ev)
@@ -111,5 +114,16 @@ public sealed class RMCTelephoneSystem : SharedRMCTelephoneSystem
     {
         base.PickupPhone(rotary, telephone, user);
         EnsureComp<ActiveListenerComponent>(telephone);
+    }
+
+    private void OnTelephoneRing(ref RMCTelephoneRingEvent ev)
+    {
+        if (TryComp<RotaryPhoneBackpackComponent>(ev.Receiving, out var comp))
+        {
+            _chat.TrySendInGameICMessage(ev.Receiving, "rings vigorously!", InGameICChatType.Emote, false, ignoreActionBlocker: true);
+        }else
+        {
+            _chat.TrySendInGameICMessage(ev.Receiving, "phone rings vigorously!", InGameICChatType.Emote, false, ignoreActionBlocker: true);
+        }
     }
 }

--- a/Content.Shared/_RMC14/Telephone/RMCTelephoneRingEvent.cs
+++ b/Content.Shared/_RMC14/Telephone/RMCTelephoneRingEvent.cs
@@ -1,0 +1,7 @@
+namespace Content.Shared._RMC14.Telephone;
+
+/// <summary>
+///     Raised when playing rotary telephone ring sound.
+/// </summary>
+[ByRefEvent]
+public readonly record struct RMCTelephoneRingEvent(EntityUid Receiving);

--- a/Content.Shared/_RMC14/Telephone/SharedRMCTelephoneSystem.cs
+++ b/Content.Shared/_RMC14/Telephone/SharedRMCTelephoneSystem.cs
@@ -213,6 +213,8 @@ public abstract class SharedRMCTelephoneSystem : EntitySystem
                 _ambientSound.SetSound(target, receivingSound, otherSound);
                 _ambientSound.SetRange(target, 16, otherSound);
                 _ambientSound.SetVolume(target, receivingSound.Params.Volume, otherSound);
+                var ev = new RMCTelephoneRingEvent(target);
+                RaiseLocalEvent<RMCTelephoneRingEvent>(ref ev);
             }
         }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Parity disparity

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
OW console users being deaf to telephone calls is not parity, so we can afford to make this an exception for not porting 13 action text. Also allows phone pack users to quickly discern whose phone is ringing. Text is parity as well.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://github.com/user-attachments/assets/325d7c2c-a2d5-4771-a73d-34253f7c9502


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: Made rotary phones emote when ringing
