### PR TITLE
Fix welder backpacks not refueling welders by just clicking on them

### DIFF
--- a/Content.Shared/Tools/Systems/SharedToolSystem.Welder.cs
+++ b/Content.Shared/Tools/Systems/SharedToolSystem.Welder.cs
@@ -15,7 +15,7 @@ public abstract partial class SharedToolSystem
     public void InitializeWelder()
     {
         SubscribeLocalEvent<WelderComponent, ExaminedEvent>(OnWelderExamine);
-        SubscribeLocalEvent<WelderComponent, AfterInteractEvent>(OnWelderAfterInteract);
+        // RMC14 SubscribeLocalEvent<WelderComponent, AfterInteractEvent>(OnWelderAfterInteract);
 
         SubscribeLocalEvent<WelderComponent, ToolUseAttemptEvent>((uid, comp, ev) => {
             CanCancelWelderUse((uid, comp), ev.User, ev.Fuel, ev);
@@ -92,7 +92,7 @@ public abstract partial class SharedToolSystem
             }
         }
     }
-
+    /* RMC14 comment out, see RMCRepairableSystem
     private void OnWelderAfterInteract(Entity<WelderComponent> entity, ref AfterInteractEvent args)
     {
         if (args.Handled)
@@ -126,7 +126,7 @@ public abstract partial class SharedToolSystem
             args.Handled = true;
         }
     }
-
+    */
     private void CanCancelWelderUse(Entity<WelderComponent> entity, EntityUid user, float requiredFuel, CancellableEntityEventArgs ev)
     {
         if (!ItemToggle.IsActivated(entity.Owner))

--- a/Content.Shared/_RMC14/Chemistry/SharedRMCChemistrySystem.cs
+++ b/Content.Shared/_RMC14/Chemistry/SharedRMCChemistrySystem.cs
@@ -5,13 +5,8 @@ using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Examine;
 using Content.Shared.FixedPoint;
-using Content.Shared.Interaction;
 using Content.Shared.Popups;
-using Content.Shared.Storage.EntitySystems;
-using Content.Shared.Tools.Components;
 using Content.Shared.Verbs;
-using Content.Shared.Whitelist;
-using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
 using Robust.Shared.Network;
@@ -23,14 +18,12 @@ namespace Content.Shared._RMC14.Chemistry;
 public abstract class SharedRMCChemistrySystem : EntitySystem
 {
     [Dependency] private readonly SharedContainerSystem _container = default!;
-    [Dependency] private readonly EntityWhitelistSystem _entityWhitelist = default!;
     [Dependency] private readonly ItemSlotsSystem _itemSlots = default!;
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly IPrototypeManager _prototypes = default!;
     [Dependency] private readonly SharedSolutionContainerSystem _solution = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
-    [Dependency] private readonly SharedAudioSystem _audio = default!;
 
     private readonly List<Entity<RMCChemicalDispenserComponent>> _dispensers = new();
 
@@ -45,8 +38,6 @@ public abstract class SharedRMCChemistrySystem : EntitySystem
 
         SubscribeLocalEvent<RMCToggleableSolutionTransferComponent, MapInitEvent>(OnToggleableSolutionTransferMapInit);
         SubscribeLocalEvent<RMCToggleableSolutionTransferComponent, GetVerbsEvent<AlternativeVerb>>(OnToggleableSolutionTransferVerbs);
-
-        SubscribeLocalEvent<RMCSolutionTransferWhitelistComponent, SolutionTransferAttemptEvent>(OnTransferWhitelistAttempt);
 
         Subs.BuiEvents<RMCChemicalDispenserComponent>(RMCChemicalDispenserUi.Key,
             subs =>
@@ -142,13 +133,6 @@ public abstract class SharedRMCChemistrySystem : EntitySystem
                 }
             },
         });
-    }
-
-    private void OnTransferWhitelistAttempt(Entity<RMCSolutionTransferWhitelistComponent> ent, ref SolutionTransferAttemptEvent args)
-    {
-        var other = ent.Owner == args.From ? args.To : args.From;
-        if (_entityWhitelist.IsWhitelistFail(ent.Comp.Whitelist, other))
-            args.Cancel(Loc.GetString(ent.Comp.Popup));
     }
 
     private void OnChemicalDispenserSettingMsg(Entity<RMCChemicalDispenserComponent> ent, ref RMCChemicalDispenserDispenseSettingBuiMsg args)

--- a/Content.Shared/_RMC14/Chemistry/SharedRMCChemistrySystem.cs
+++ b/Content.Shared/_RMC14/Chemistry/SharedRMCChemistrySystem.cs
@@ -5,9 +5,13 @@ using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Examine;
 using Content.Shared.FixedPoint;
+using Content.Shared.Interaction;
 using Content.Shared.Popups;
+using Content.Shared.Storage.EntitySystems;
+using Content.Shared.Tools.Components;
 using Content.Shared.Verbs;
 using Content.Shared.Whitelist;
+using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
 using Robust.Shared.Network;
@@ -26,6 +30,7 @@ public abstract class SharedRMCChemistrySystem : EntitySystem
     [Dependency] private readonly IPrototypeManager _prototypes = default!;
     [Dependency] private readonly SharedSolutionContainerSystem _solution = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
 
     private readonly List<Entity<RMCChemicalDispenserComponent>> _dispensers = new();
 

--- a/Content.Shared/_RMC14/Repairable/RMCRepairableSystem.cs
+++ b/Content.Shared/_RMC14/Repairable/RMCRepairableSystem.cs
@@ -47,7 +47,7 @@ public sealed class RMCRepairableSystem : EntitySystem
         SubscribeLocalEvent<NailgunRepairableComponent, InteractUsingEvent>(OnNailgunRepairableInteractUsing);
         SubscribeLocalEvent<NailgunRepairableComponent, RMCNailgunRepairableDoAfterEvent>(OnNailgunRepairableDoAfter);
 
-        SubscribeLocalEvent<ReagentTankComponent, InteractUsingEvent>(OnWelderInteractUsing, before: [typeof(SharedStorageSystem)]);
+        SubscribeLocalEvent<ReagentTankComponent, InteractUsingEvent>(OnWelderInteractUsing);
     }
 
     private void OnRepairableInteractUsing(Entity<RMCRepairableComponent> repairable, ref InteractUsingEvent args)

--- a/Content.Shared/_RMC14/Repairable/RMCRepairableSystem.cs
+++ b/Content.Shared/_RMC14/Repairable/RMCRepairableSystem.cs
@@ -340,6 +340,12 @@ public sealed class RMCRepairableSystem : EntitySystem
             && _solution.TryGetDrainableSolution(target, out var targetSoln, out var targetSolution)
             && _solution.TryGetSolution(used, welder.FuelSolutionName, out var solutionComp, out var welderSolution))
         {
+            if (welder.Enabled)
+            {
+                _popup.PopupClient(Loc.GetString("rmc-welder-component-danger"), used, args.User, PopupType.MediumCaution);
+                return;
+            }
+
             var trans = FixedPoint2.Min(welderSolution.AvailableVolume, targetSolution.Volume);
             if (trans > 0)
             {

--- a/Content.Shared/_RMC14/Repairable/RMCRepairableSystem.cs
+++ b/Content.Shared/_RMC14/Repairable/RMCRepairableSystem.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Shared._RMC14.Damage;
 using Content.Shared._RMC14.Marines.Skills;
+using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Components.SolutionManager;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Damage;
@@ -10,6 +11,8 @@ using Content.Shared.Interaction;
 using Content.Shared.Item.ItemToggle.Components;
 using Content.Shared.Popups;
 using Content.Shared.Stacks;
+using Content.Shared.Storage.EntitySystems;
+using Content.Shared.Tools.Components;
 using Content.Shared.Tools.Systems;
 using Content.Shared.Weapons.Ranged;
 using Content.Shared.Weapons.Ranged.Events;
@@ -43,6 +46,8 @@ public sealed class RMCRepairableSystem : EntitySystem
 
         SubscribeLocalEvent<NailgunRepairableComponent, InteractUsingEvent>(OnNailgunRepairableInteractUsing);
         SubscribeLocalEvent<NailgunRepairableComponent, RMCNailgunRepairableDoAfterEvent>(OnNailgunRepairableDoAfter);
+
+        SubscribeLocalEvent<ReagentTankComponent, InteractUsingEvent>(OnWelderInteractUsing, before: new[] { typeof(SharedStorageSystem) });
     }
 
     private void OnRepairableInteractUsing(Entity<RMCRepairableComponent> repairable, ref InteractUsingEvent args)
@@ -318,5 +323,41 @@ public sealed class RMCRepairableSystem : EntitySystem
         }
 
         return repairValue;
+    }
+
+    private void OnWelderInteractUsing(Entity<ReagentTankComponent> ent, ref InteractUsingEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        var used = args.Used;
+        var target = args.Target;
+
+        if (!TryComp<WelderComponent>(used, out var welder))
+            return;
+
+        if (ent.Comp.TankType == ReagentTankType.Fuel
+            && _solution.TryGetDrainableSolution(target, out var targetSoln, out var targetSolution)
+            && _solution.TryGetSolution(used, welder.FuelSolutionName, out var solutionComp, out var welderSolution))
+        {
+            var trans = FixedPoint2.Min(welderSolution.AvailableVolume, targetSolution.Volume);
+            if (trans > 0)
+            {
+                var drained = _solution.Drain(target, targetSoln.Value, trans);
+                _solution.TryAddSolution(solutionComp.Value, drained);
+                _audio.PlayPredicted(welder.WelderRefill, used, user: args.User);
+                _popup.PopupClient(Loc.GetString("welder-component-after-interact-refueled-message"), used, args.User);
+            }
+            else if (welderSolution.AvailableVolume <= 0)
+            {
+                _popup.PopupClient(Loc.GetString("welder-component-already-full"), used, args.User);
+            }
+            else
+            {
+                _popup.PopupClient(Loc.GetString("welder-component-no-fuel-in-tank", ("owner", args.Target)), used, args.User);
+            }
+
+            args.Handled = true;
+        }
     }
 }

--- a/Content.Shared/_RMC14/Repairable/RMCRepairableSystem.cs
+++ b/Content.Shared/_RMC14/Repairable/RMCRepairableSystem.cs
@@ -47,7 +47,7 @@ public sealed class RMCRepairableSystem : EntitySystem
         SubscribeLocalEvent<NailgunRepairableComponent, InteractUsingEvent>(OnNailgunRepairableInteractUsing);
         SubscribeLocalEvent<NailgunRepairableComponent, RMCNailgunRepairableDoAfterEvent>(OnNailgunRepairableDoAfter);
 
-        SubscribeLocalEvent<ReagentTankComponent, InteractUsingEvent>(OnWelderInteractUsing, before: new[] { typeof(SharedStorageSystem) });
+        SubscribeLocalEvent<ReagentTankComponent, InteractUsingEvent>(OnWelderInteractUsing, before: [typeof(SharedStorageSystem)]);
     }
 
     private void OnRepairableInteractUsing(Entity<RMCRepairableComponent> repairable, ref InteractUsingEvent args)

--- a/Content.Shared/_RMC14/Repairable/RMCRepairableSystem.cs
+++ b/Content.Shared/_RMC14/Repairable/RMCRepairableSystem.cs
@@ -340,14 +340,13 @@ public sealed class RMCRepairableSystem : EntitySystem
             && _solution.TryGetDrainableSolution(target, out var targetSoln, out var targetSolution)
             && _solution.TryGetSolution(used, welder.FuelSolutionName, out var solutionComp, out var welderSolution))
         {
+            var trans = FixedPoint2.Min(welderSolution.AvailableVolume, targetSolution.Volume);
+
             if (welder.Enabled)
             {
                 _popup.PopupClient(Loc.GetString("rmc-welder-component-danger"), used, args.User, PopupType.MediumCaution);
-                return;
             }
-
-            var trans = FixedPoint2.Min(welderSolution.AvailableVolume, targetSolution.Volume);
-            if (trans > 0)
+            else if (trans > 0)
             {
                 var drained = _solution.Drain(target, targetSoln.Value, trans);
                 _solution.TryAddSolution(solutionComp.Value, drained);

--- a/Resources/Locale/en-US/_RMC14/tools/welder-component.ftl
+++ b/Resources/Locale/en-US/_RMC14/tools/welder-component.ftl
@@ -1,0 +1,1 @@
+﻿rmc-welder-component-danger = That was close! However, you realized you had the welder on and prevented disaster.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
now it's more intuitive to refuel welders with a backpack welder tank
cm13 has it like this

## Media

https://github.com/user-attachments/assets/5944a1af-22a6-4d6a-9585-77acf1070c67



## Technical details
Removes the upstream event and replaces it with a ``InteractUsingEvent`` that runs before storage

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

:cl:
- fix: Fixed welder packs not refueling by just clicking on them.
