### PR TITLE
Fix Acid Traps detection around open corners

### DIFF
--- a/Content.Server/_RMC14/Xenonids/Construction/ResinHole/XenoResinHoleSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Construction/ResinHole/XenoResinHoleSystem.cs
@@ -532,7 +532,7 @@ public sealed class XenoResinHoleSystem : SharedXenoResinHoleSystem
                 if (ent != tripper.Owner)
                     continue;
 
-                if (!_interaction.InRangeUnobstructed(resinHole, ent, 1.5f))
+                if (!IsVisibleToTrap(resinHole, ent))
                     continue;
 
                 ActivateTrap((resinHole, holeComponent));
@@ -549,6 +549,45 @@ public sealed class XenoResinHoleSystem : SharedXenoResinHoleSystem
 
         if (stoodUp || tripper.Comp.HoleList.Count == 0)
             RemCompDeferred<InResinHoleRangeComponent>(tripper);
+    }
+
+    public bool IsVisibleToTrap(EntityUid resinHole, EntityUid ent)
+    {
+        //Basic case, can see each other clearly, open LoS
+        if (_interaction.InRangeUnobstructed(resinHole, ent, 1.5f))
+            return true;
+
+        //Advanced case, checks if any point 1 tile away in any cardinal direction is capable of seeing the target.
+        //Allows slipping around open passages, but NOT through encasing walls, as offset check fails if the origin coordinate is inside a wall.
+        var holeCoordinates = _transform.GetMapCoordinates(resinHole);
+        var offsetCoordinates = holeCoordinates;
+
+        for (int i = 0; i < 4; i++)
+        {
+            switch (i)
+            {
+                case 0:
+                    offsetCoordinates = holeCoordinates.Offset(1, 0);
+                    break;
+                case 1:
+                    offsetCoordinates = holeCoordinates.Offset(-1, 0);
+                    break;
+                case 2:
+                    offsetCoordinates = holeCoordinates.Offset(0, 1);
+                    break;
+                case 3:
+                    offsetCoordinates = holeCoordinates.Offset(0, -1);
+                    break;
+                default:
+                    break;
+            }
+
+            //Trigger Range is preserved by the ContactingEntities check in the parent function, this just checks vision
+            if (_interaction.InRangeUnobstructed(offsetCoordinates, ent, 1.5f))
+                return true;
+        }
+
+        return false;
     }
 
     public override void Update(float frameTime)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Acid Traps now correctly trigger when walking into their radius around an open corner specifically. They will NOT trigger through solid walls still.

## Technical details
Check if the resin hole can see directly first, then check if any tile straight to the north, east, south, and west can see the target. If nothing can see the player, the trap does not trigger. If the offset tile is inside a wall, the trigger automatically fails. Each offset vision check is 1.5f to maintain desired behavior + the vision range check does not run regardless if you are not in range to trigger it.

## Media

https://github.com/user-attachments/assets/b0e8b35a-3731-4c62-8436-ab732ea81453

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- fix: Fixed Acid Resin Traps not triggering around open corners. (Traps will still not trigger if they are entirely obstructed)
