### PR TITLE
Stop dead people triggering para traps

### DIFF
--- a/Content.Server/_RMC14/Xenonids/Construction/ResinHole/XenoResinHoleSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Construction/ResinHole/XenoResinHoleSystem.cs
@@ -375,6 +375,9 @@ public sealed class XenoResinHoleSystem : SharedXenoResinHoleSystem
 
     private void OnXenoResinHoleStepTriggered(Entity<XenoResinHoleComponent> resinHole, ref StepTriggeredOffEvent args)
     {
+        if (_mobState.IsDead(args.Tripper))
+            return;
+
         if (resinHole.Comp.TrapPrototype == XenoResinHoleComponent.ParasitePrototype)
         {
             _stun.TryParalyze(args.Tripper, resinHole.Comp.StepStunDuration, true);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Prevents dead bodies from triggering resin hole traps (parasite most relevant) via step trigger.

## Why / Balance
They're not supposed to do that

CM13 Test Video from Ammoniacres

https://github.com/user-attachments/assets/0b5f971f-26a9-4a28-a8c4-02f73cb1cb74

## Technical details
Simply checks if they are dead.

## Media

https://github.com/user-attachments/assets/498c50aa-ef96-44c1-bcd1-854b24ea3649

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- fix: Dragging dead bodies that are on top of Parasite traps no longer triggers the trap.
