### PR TITLE
Fix intelligence officer uniform not being foldable

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/marines.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/marines.yml
@@ -259,13 +259,16 @@
 # Auxiliary
 # IO
 - type: entity
-  parent: RMCMarineUniformBase
+  parent: [RMCMarineUniformBase, RMCFoldableUniformBase]
   id: RMCUniformIntel
   name: marine intelligence officer uniform
   description: Tighter than a vice. Slicker than beard oil. Covered from head to toe in pouches, pockets, bags, straps, and belts. Clearly, you are not only the most intelligent of intelligence officers, but the most fashionable as well. This suit took an entire R&D team five days to develop. It is more expensive than the entire Almayer... probably.
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Uniforms/intel/jungle.rsi
+  - type: Foldable
+    unfoldVerbText: rmc-sleeves-verb-unfold
+    foldVerbText: rmc-sleeves-verb-fold
   - type: ItemCamouflage
     camouflageVariations:
       Jungle: _RMC14/Objects/Clothing/Uniforms/intel/jungle.rsi

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/intel.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/intel.yml
@@ -125,6 +125,7 @@
       - id: CMMRE
     - name: Armor
       choices: { CMArmor: 1 }
+      takeAll: RMCIntelArmor
       entries:
       - id: RMCArmorXM4
       - id: CMArmorM3Light


### PR DESCRIPTION
It didn't inherit from foldable uniforms

+ mark armor in intel vendor as mandatory