### PR TITLE
fix IO not being able to pick armor AND backback

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/intel.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/intel.yml
@@ -130,7 +130,7 @@
       - id: CMArmorM3Light
       - id: CMCoatOfficer
     - name: Backpack
-      choices: { CMArmor: 1 }
+      choices: { CMBag: 1 }
       entries:
       - id: CMSatchelMarineIntel
         recommended: true
@@ -188,7 +188,7 @@
       - id: CMWebbingHolster
       - id: CMWebbing
       - id: CMWebbingPouch
-    - name: Accessories
+    - name: Mask
       choices: { CMMask: 1 }
       entries:
       - id: CMMaskGas


### PR DESCRIPTION
## About the PR

This PR gives ColMarTechIntelEquipment the correct choice group for backpacks.

## Why / Balance

- Fixes #5558

## Technical details

Someone copy-pasted the IO equipment and forgot the change the choice group. Same for the mask group-name but that was just cosmetic.

## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- fix: IO can now pick up armor and a backpack from their equipment vendor.
