### PR TITLE
Add mortar knocking over

### DIFF
--- a/Content.Shared/_RMC14/Mortar/MortarComponent.cs
+++ b/Content.Shared/_RMC14/Mortar/MortarComponent.cs
@@ -1,6 +1,7 @@
-﻿using Content.Shared._RMC14.Marines.Skills;
+using Content.Shared._RMC14.Marines.Skills;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared._RMC14.Mortar;
@@ -80,4 +81,7 @@ public sealed partial class MortarComponent : Component
 
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
     public TimeSpan LastFiredAt;
+
+    [DataField, AutoNetworkedField]
+    public EntProtoId Drop = "RMCMortarKit";
 }

--- a/Content.Shared/_RMC14/Mortar/SharedMortarSystem.cs
+++ b/Content.Shared/_RMC14/Mortar/SharedMortarSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared._RMC14.Areas;
+using Content.Shared._RMC14.Areas;
 using Content.Shared._RMC14.Camera;
 using Content.Shared._RMC14.Chat;
 using Content.Shared._RMC14.Explosion;
@@ -11,6 +11,7 @@ using Content.Shared.Chat;
 using Content.Shared.Construction.Components;
 using Content.Shared.Coordinates;
 using Content.Shared.Database;
+using Content.Shared.Destructible;
 using Content.Shared.DoAfter;
 using Content.Shared.Examine;
 using Content.Shared.Interaction;
@@ -69,6 +70,7 @@ public abstract class SharedMortarSystem : EntitySystem
         SubscribeLocalEvent<MortarComponent, ExaminedEvent>(OnMortarExamined);
         SubscribeLocalEvent<MortarComponent, ActivatableUIOpenAttemptEvent>(OnMortarActivatableUIOpenAttempt);
         SubscribeLocalEvent<MortarComponent, CombatModeShouldHandInteractEvent>(OnMortarShouldInteract);
+        SubscribeLocalEvent<MortarComponent, DestructionEventArgs>(OnMortarDestruction);
 
         SubscribeLocalEvent<MortarCameraShellComponent, MortarShellLandEvent>(OnMortarCameraShellLand);
 
@@ -79,6 +81,14 @@ public abstract class SharedMortarSystem : EntitySystem
                 subs.Event<MortarDialBuiMsg>(OnMortarDialBui);
                 subs.Event<MortarViewCamerasMsg>(OnMortarViewCameras);
             });
+    }
+
+    private void OnMortarDestruction(Entity<MortarComponent> mortar, ref DestructionEventArgs args)
+    {
+        if (!mortar.Comp.Deployed || _net.IsClient)
+            return;
+
+        SpawnAtPosition(mortar.Comp.Drop, mortar.Owner.ToCoordinates());
     }
 
     private void OnMortarUseInHand(Entity<MortarComponent> mortar, ref UseInHandEvent args)

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/mortars.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/mortars.yml
@@ -51,11 +51,6 @@
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
-      - !type:SpawnEntitiesBehavior
-            spawn:
-              RMCMortarKit:
-                min: 1
-                max: 1
   - type: UserInterface
     interfaces:
       enum.MortarUiKey.Key:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/mortars.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/mortars.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   parent: BaseItem
   id: RMCMortarKit
   name: M402 mortar portable kit
@@ -47,10 +47,15 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 500
+        damage: 100
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
+      - !type:SpawnEntitiesBehavior
+            spawn:
+              RMCMortarKit:
+                min: 1
+                max: 1
   - type: UserInterface
     interfaces:
       enum.MortarUiKey.Key:
@@ -89,6 +94,10 @@
       Snow: _RMC14/Objects/Weapons/mortar/snow.rsi
       Classic: _RMC14/Objects/Weapons/mortar/classic.rsi
       Urban: _RMC14/Objects/Weapons/mortar/urban.rsi
+  - type: ReceiverXenoClaws
+    maxHealth: 100
+    hitsToDestroy: 1
+    minimumClawStrength: Normal
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/mortars.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/mortars.yml
@@ -98,6 +98,11 @@
     maxHealth: 100
     hitsToDestroy: 1
     minimumClawStrength: Normal
+  - type: MeleeSound
+    soundGroups:
+      Brute:
+        path:
+          "/Audio/_RMC14/Structures/metalhit.ogg"
 
 - type: entity
   abstract: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title. Mortar now drops as an item if a xeno hits it. Only 1 hit is needed.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity. On destruction from a non-xeno it shouldn't drop, and it should be invulnerable when firing, but this is just doing the drop parity for now.

## Technical details
<!-- Summary of code changes for easier review. -->
MortarComp has a destruction event if deployed, drops an item. The item being a mortar kit. Yea.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed xenos being able to destroy mortars. They now make them drop the kit on the floor. Mortar health reverted back, and xenos now knock them over in 1 hit.
