### PR TITLE
Add dummy IO starting gear

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/intel_officer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/intel_officer.yml
@@ -11,6 +11,7 @@
   ranks:
     RMCRankSecondLT: []
   startingGear: CMGearIntelOfficer
+  dummyStartingGear: RMCGearIntelOfficerEquipped
   icon: "CMJobIconIntelOfficer"
   joinNotifyCrew: false
   supervisors: cm-job-supervisors-aso
@@ -54,6 +55,23 @@
     jumpsuit: RMCUniformIntel
     shoes: CMBootsBlackFilled
     id: CMIDCardIntelOfficer
+
+- type: startingGear
+  id: RMCGearIntelOfficerEquipped
+  equipment:
+    jumpsuit: RMCUniformIntel
+    back: CMSatchelMarineIntel
+    shoes: CMBootsBlackFilled
+    head: RMCArmorHelmetM12Intel
+    outerClothing: RMCArmorXM4
+    gloves: CMHandsInsulated
+    id: CMIDCardIntelOfficer
+    ears: CMHeadsetIntel
+    belt: RMCMK80BeltFilled
+    pocket1: RMCPouchGeneralLarge
+    pocket2: RMCPouchDocument
+  inhand:
+    - RMCBinoculars
 
 - type: entity
   parent: CMSpawnPointJobBase


### PR DESCRIPTION
So admins can make easily equipped event intelligence officers, and for the lobby screen when you have intel officer on high

reference from CM:
![image](https://github.com/user-attachments/assets/5217bcc7-8d43-49b1-befe-87495ce488ae)
