### PR TITLE
takeOne field for vendor sections

### DIFF
--- a/Content.Client/_RMC14/Vendors/CMAutomatedVendorBui.cs
+++ b/Content.Client/_RMC14/Vendors/CMAutomatedVendorBui.cs
@@ -92,7 +92,7 @@ public sealed class CMAutomatedVendorBui : BoundUserInterface
                         var color = CMAutomatedVendorPanel.DefaultColor;
                         var borderColor = CMAutomatedVendorPanel.DefaultBorderColor;
                         var hoverColor = CMAutomatedVendorPanel.DefaultBorderColor;
-                        if (section.TakeAll != null)
+                        if (section.TakeAll != null || section.TakeOne != null)
                         {
                             name = $"Mandatory: {name}";
                             color = Color.FromHex("#251A0C");
@@ -220,6 +220,12 @@ public sealed class CMAutomatedVendorBui : BoundUserInterface
                     if (takeAll != null && takeAll.Contains((takeAllId, entry.Id)))
                         disabled = true;
                 }
+                if (section.TakeOne is { } takeOneId)
+                {
+                    var takeOne = user?.TakeOne;
+                    if (takeOne != null && takeOne.Contains(takeOneId))
+                        disabled = true;
+                }
 
                 if (entry.Points != null)
                 {
@@ -302,7 +308,14 @@ public sealed class CMAutomatedVendorBui : BoundUserInterface
                 }
             }
         }
-
+        else if (section.TakeOne != null)
+        {
+            var takeOne = user?.TakeOne;
+            if (takeOne == null || !takeOne.Contains(section.TakeOne))
+            {
+                name.AddText(" (TAKE ONE)");
+            }
+        }
         else if (section.Choices is { } choices)
         {
             if (user == null)

--- a/Content.Shared/_RMC14/Vendors/CMVendorSection.cs
+++ b/Content.Shared/_RMC14/Vendors/CMVendorSection.cs
@@ -17,6 +17,9 @@ public sealed partial class CMVendorSection
     [DataField]
     public string? TakeAll;
 
+    [DataField]
+    public string? TakeOne;
+
     [DataField(required: true)]
     public List<CMVendorEntry> Entries = new();
 

--- a/Content.Shared/_RMC14/Vendors/CMVendorUserComponent.cs
+++ b/Content.Shared/_RMC14/Vendors/CMVendorUserComponent.cs
@@ -14,6 +14,9 @@ public sealed partial class CMVendorUserComponent : Component
     public HashSet<(string Category, EntProtoId Ent)> TakeAll = new();
 
     [DataField, AutoNetworkedField]
+    public HashSet<string> TakeOne = new();
+
+    [DataField, AutoNetworkedField]
     public int Points;
 
     [DataField, AutoNetworkedField]

--- a/Content.Shared/_RMC14/Vendors/SharedCMAutomatedVendorSystem.cs
+++ b/Content.Shared/_RMC14/Vendors/SharedCMAutomatedVendorSystem.cs
@@ -217,6 +217,17 @@ public abstract class SharedCMAutomatedVendorSystem : EntitySystem
 
             Dirty(actor, user);
         }
+        if (section.TakeOne is { } takeOne)
+        {
+            user = EnsureComp<CMVendorUserComponent>(actor);
+            if (!user.TakeOne.Add(takeOne))
+            {
+                Log.Error($"{ToPrettyString(actor)} tried to buy too many take-ones.");
+                return;
+            }
+
+            Dirty(actor, user);
+        }
 
         var validJob = true;
         if (_mind.TryGetMind(args.Actor, out var mindId, out _))
@@ -267,6 +278,8 @@ public abstract class SharedCMAutomatedVendorSystem : EntitySystem
         {
             if (section.Choices is { } choices && user != null)
                 user.Choices[choices.Id]--;
+            if (section.TakeOne is { } takeOne && user != null)
+                user.TakeOne.Remove(takeOne);
         }
 
         if (section.SharedSpecLimit is { } globalLimit)

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/command.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/command.yml
@@ -115,12 +115,10 @@
       - id: RMCGlassesAviators
       - id: RMCM5Bayonet
     - name: Specialisation Kit
-      choices: { CMBundle: 1 }
+      takeOne: CMBundle
       entries:
       - id: CMVendorBundleCombatTechnicianEssentials
-        recommended: true
       - id: CMVendorBundleSquadMedicalEssentials
-        recommended: true
     - name: Belt
       choices: { CMBelt: 1 }
       entries:
@@ -232,8 +230,7 @@
     - CMExecutiveOfficer
     sections:
     - name: Captain's Primary
-      choices: { CMPrimary: 1 }
-      takeAll: CMStandard
+      takeOne: CMPrimary
       entries:
       - id: RMCM54CMK1CaseAP
         name: M54C MK1 assault rifle
@@ -253,7 +250,7 @@
       - id: RMCBoxShotgunFlechette
         points: 20
     - name: Specilisation Kit
-      choices: { CMBundle: 1 }
+      takeOne: CMBundle
       entries:
       - id: CMVendorBundleSquadMedicalEssentials
       - id: CMVendorBundleCombatTechnicianEssentials
@@ -484,14 +481,12 @@
     - CMCommandingOfficer
     sections:
     - name: Commander's Primary
-      choices: { CMProtagGun: 1 }
+      takeOne: CMProtagGun
       entries:
       - id: WeaponRifleM59A
         name: M59A Prototype Rifle
-        recommended: true # TODO RMC14 Make choices: colour the options brown
       - id: CMSmartGunOperatorEquipmentCaseBelt
         name: Commander's Smartgun
-        recommended: true # TODO RMC14 Make choices: colour the options brown
     - name: Primary Ammunition
       entries:
       - id: CMMagazineRifleM54CMK1

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/intel.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/intel.yml
@@ -124,10 +124,10 @@
       - id: CMHeadsetIntel
       - id: CMMRE
     - name: Armor
-      choices: { CMArmor: 1 }
-      takeAll: RMCIntelArmor
+      choices: { CMArmor: 1}
       entries:
       - id: RMCArmorXM4
+        recommended: true
       - id: CMArmorM3Light
       - id: CMCoatOfficer
     - name: Backpack

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/intel.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/intel.yml
@@ -124,10 +124,9 @@
       - id: CMHeadsetIntel
       - id: CMMRE
     - name: Armor
-      choices: { CMArmor: 1 }
+      takeOne: CMArmor
       entries:
       - id: RMCArmorXM4
-        recommended: true
       - id: CMArmorM3Light
       - id: CMCoatOfficer
     - name: Backpack

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/intel.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/intel.yml
@@ -124,7 +124,7 @@
       - id: CMHeadsetIntel
       - id: CMMRE
     - name: Armor
-      choices: { CMArmor: 1}
+      choices: { CMArmor: 1 }
       entries:
       - id: RMCArmorXM4
         recommended: true

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/engineer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/engineer.yml
@@ -20,7 +20,7 @@
       entries:
       - id: CMVendorBundleCombatTechnicianEssentials
     - name: Handheld Defense
-      choices: { CMHandheldDefense: 1 }
+      takeOne: CMHandheldDefense
       entries:
     #    CM21STeslaCoil
     #    CMJIMAPlantedFlag

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/leader.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/leader.yml
@@ -19,8 +19,8 @@
       takeAll: CMStandard
       entries:
       - id: RMCVendorBundleCrewLeader
-    - name: Squad Kit (CHOOSE 1, for yourself or your squad)
-      choices: { RMCSquadKit: 1 }
+    - name: Squad Kit (for yourself or your squad)
+      takeOne: RMCSquadKit
       entries:
       - id: RMCKitRifleM4SPR
       - id: RMCKitCM54C

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/specialist.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/specialist.yml
@@ -18,7 +18,7 @@
     pointsType: Specialist
     sections:
     - name: Weapons Specialist Sets
-      choices: { SquadSpecKit: 1 }
+      takeOne: SquadSpecKit
       sharedSpecLimit: 2 # 2 as requested until Pyro is added
       entries:
       - id: RMCDemoSpecEquipmentCase


### PR DESCRIPTION
## About the PR

This PR adds a "takeOne" field to vendors.

## Why / Balance

There where a bunch of "takeAll" + "choices: 1" that can lead to confusion, as the title would say to take everything but you where only able to take one.

## Technical details

CMVendorSection and CMVendorUserComponent now have a new "TakeOne" field that tracks singular mandatory selections.

## Media

![Screenshot From 2025-02-10 20-55-57](https://github.com/user-attachments/assets/7728b539-230b-4298-b6ad-e1c92ebf63ee)

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

No cl.