### PR TITLE
fix dots in ids

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/holdout_pistol.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/holdout_pistol.yml
@@ -84,7 +84,7 @@
 
 - type: entity
   parent: CMBulletBase
-  id: CMBulletPistol.22mm
+  id: CMBulletPistol22mm
   name: bullet (.22)
   components:
   - type: Projectile
@@ -95,7 +95,7 @@
     amount: 10
 
 - type: entity
-  id: CMCartridgePistol.22mm
+  id: CMCartridgePistol22mm
   name: cartridge (.22)
   parent: CMCartridgePistolBase
   components:
@@ -104,7 +104,7 @@
     - Cartridge
     - CMCartridgePistol.22mm
   - type: CartridgeAmmo
-    proto: CMBulletPistol.22mm
+    proto: CMBulletPistol22mm
 
 
 - type: Tag

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/holdout_pistol.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/holdout_pistol.yml
@@ -72,7 +72,7 @@
     whitelist:
       tags:
       - CMCartridgePistol.22mm
-    proto: CMCartridgePistol.22mm
+    proto: CMCartridgePistol22mm
     capacity: 5
   - type: Sprite
     sprite: _RMC14/Objects/Weapons/Guns/Ammunition/Magazines/holdout.rsi

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m16_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m16_rifle.yml
@@ -159,11 +159,11 @@
     - Cartridge
     - RMCCartridgeRifleM16
   - type: CartridgeAmmo
-    proto: BulletRifle5.56x45mm
+    proto: BulletRifle556x45mm
 
 - type: entity
   parent: BulletRifle10x24mm
-  id: BulletRifle5.56x45mm
+  id: BulletRifle556x45mm
   components:
   - type: Projectile
     damage:

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -1069,3 +1069,8 @@ RMCCrateBoxMagazineM44RevolverMarksman: RMCCrateBoxMagazineRevolverM44Marksman
 
 # 2025-01-19
 RMCCrateM54C: RMCCrateM54CMK1
+
+# 2025-02-10
+BulletRifle5.56x45mm: BulletRifle556x45mm
+CMBulletPistol.22mm: CMBulletPistol22mm
+CMCartridgePistol.22mm: CMCartridgePistol22mm


### PR DESCRIPTION
remove dots from id datafields as they cannot support localization
i am asking you to not using dots in id please
```
  8 |ent-BulletRifle5.56x45mm = { ent-BulletRifle10x24mm }
  9 |
 10 |  .desc = { ent-BulletRifle10x24mm.desc }
                     ^ Expected a token starting with  "=" found "." instead Exception: 
```
