### PR TITLE
Survivors can no longer interact with intel

### DIFF
--- a/Content.Shared/_RMC14/Intel/IntelSystem.cs
+++ b/Content.Shared/_RMC14/Intel/IntelSystem.cs
@@ -242,7 +242,7 @@ public sealed class IntelSystem : EntitySystem
     {
         var user = args.User;
 
-        if (_ent.GetComponentOrNull<SurvivorComponent>(user) != null)
+        if (HasComp<SurvivorComponent>(user))
         {
             _popup.PopupClient($"You have no need to read the {Name(ent)}.", ent, user);
             return;
@@ -260,7 +260,7 @@ public sealed class IntelSystem : EntitySystem
         ContainerGettingInsertedAttemptEvent args)
     {
         var user = args.Container.Owner;
-        if (_ent.GetComponentOrNull<SurvivorComponent>(user) != null)
+        if (HasComp<SurvivorComponent>(user))
         {
             args.Cancel();
             _popup.PopupClient($"You have no use for the {Name(ent)}.", ent, user);
@@ -272,7 +272,7 @@ public sealed class IntelSystem : EntitySystem
     private void OnIntelPullAttempt(Entity<IntelRetrieveItemObjectiveComponent> ent, ref PullAttemptEvent args)
     {
         var user = args.PullerUid;
-        if (_ent.GetComponentOrNull<SurvivorComponent>(user) != null)
+        if (HasComp<SurvivorComponent>(user))
         {
             args.Cancelled = true;
             _popup.PopupClient($"You have no use for the {Name(ent)}.", user, user);

--- a/Resources/ServerInfo/Guidebook/_RMC14/Rules/RMCOverview.xml
+++ b/Resources/ServerInfo/Guidebook/_RMC14/Rules/RMCOverview.xml
@@ -7,7 +7,7 @@
 
   ## Recent Changes
   Read the relevant sections for the entire text.
-  - [textlink="[Survivor Roleplay]" link="RMCSurvivorRoleplay"]
+  - [textlink="(Survivor Roleplay)" link="RMCSurvivorRoleplay"] Survivors may no longer interact with intel objectives. See full text for exceptions.
   - Marine Law and SOP has been added. Command level roles including Squad Leaders must follow this.
   - Many sections of the rules have been changed in many places. It's recommended to read everything.
 

--- a/Resources/ServerInfo/Guidebook/_RMC14/Rules/RMCOverview.xml
+++ b/Resources/ServerInfo/Guidebook/_RMC14/Rules/RMCOverview.xml
@@ -7,6 +7,7 @@
 
   ## Recent Changes
   Read the relevant sections for the entire text.
+  - [textlink="[Survivor Roleplay]" link="RMCSurvivorRoleplay"]
   - Marine Law and SOP has been added. Command level roles including Squad Leaders must follow this.
   - Many sections of the rules have been changed in many places. It's recommended to read everything.
 

--- a/Resources/ServerInfo/Guidebook/_RMC14/Rules/Roleplay/RMCSurvivorRoleplay.xml
+++ b/Resources/ServerInfo/Guidebook/_RMC14/Rules/Roleplay/RMCSurvivorRoleplay.xml
@@ -6,4 +6,6 @@
   - Hostile Faction Survivors cannot attempt to harm other survivors.
   - [bold]Do not hunt, move, or secure monkeys to deny Xenonid captures. These monkeys lessen the amount of xenos at the start of the round, and make your life easier.[/bold]
   - Survivors should not engage or seek any xenonids before the roundstart xenos have had a chance to evolve (5 minutes). If a xenonid enters your vision, but you were not seeking them, you are free to attack them as they have forfeited their early round protection.
+  - Survivors may not attempt to secure intel unless they are assisted or have been enlisted into the marines.
+  - Survivors may pull and gather corpses of dead humanoids and xenonid corpses provided they are acting and speaking in character and not acting and speaking as if to secure intel.
 </Document>

--- a/Resources/ServerInfo/Guidebook/_RMC14/Rules/Roleplay/RMCSurvivorRoleplay.xml
+++ b/Resources/ServerInfo/Guidebook/_RMC14/Rules/Roleplay/RMCSurvivorRoleplay.xml
@@ -1,11 +1,15 @@
 ﻿<Document>
-  #Survivor Roleplay Standards
+  # Survivor Roleplay Standards
   - Survivors have more leeway than marines with mental stability due to trauma experienced during the xenonid attack. They may be suffering PTSD, paranoia or similar conditions for roleplaying purposes.\nDespite this, survivors should not become hostile or cause drastic issues for the marines, such as stealing their secure equipment.
   - Standard survivors are not hostile to the Marines.
   - If there is an exception due to faction it will be clear.
   - Hostile Faction Survivors cannot attempt to harm other survivors.
   - [bold]Do not hunt, move, or secure monkeys to deny Xenonid captures. These monkeys lessen the amount of xenos at the start of the round, and make your life easier.[/bold]
   - Survivors should not engage or seek any xenonids before the roundstart xenos have had a chance to evolve (5 minutes). If a xenonid enters your vision, but you were not seeking them, you are free to attack them as they have forfeited their early round protection.
+
+  ## Intel Objectives
+
   - Survivors may not attempt to secure intel unless they are assisted or have been enlisted into the marines.
   - Survivors may pull and gather corpses of dead humanoids and xenonid corpses provided they are acting and speaking in character and not acting and speaking as if to secure intel.
+
 </Document>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- Survivors can no longer mechanically interact with intel objectives, resulting in no accidental rulebreaks / ban bait.
- Survivors are forbidden to use any methods of picking up / moving intel objectives if discovered, by roleplay standards (excluding if supported by marines).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
- Prevents early game intel gathering for free by survivors, makes sure intel roles have more to do / actually engage with the intel mechanics.
- Roleplay Standards.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl: Whisper

- tweak: Survivors can no longer interact with intel objectives.
- tweak: Rules change; Survivors may not secure intel objectives without marine support.

