### PR TITLE
removes DumpableSolution from chemmaster :trollface: 

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Science/chem_master.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Science/chem_master.yml
@@ -92,6 +92,8 @@
   - type: RequiresSkill
     skills:
       RMCSkillMedical: 3
+  - type: ApcPowerReceiver
+    needsPower: false # TOOD RMC14 power
   - type: ActivatableUIBlacklist
     blacklist:
       components:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Science/chem_master.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Science/chem_master.yml
@@ -1,8 +1,10 @@
 - type: entity
-  parent: ChemMaster
   id: CMChemMaster
+  parent: [ BaseMachinePowered, ConstructibleMachine ]
   name: ChemMaster 3000
   description: An industrial grade chemical manipulator with pill and bottle production included.
+  placement:
+    mode: SnapgridCenter
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Machines/Science/chem_master.rsi
@@ -14,13 +16,82 @@
   - type: Icon
     sprite: _RMC14/Structures/Machines/Science/chem_master.rsi
     state: mixer_loaded
+  - type: ChemMaster
+    pillDosageLimit: 20
+  - type: Physics
+    bodyType: Static
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.25,-0.4,0.25,0.4"
+        density: 190
+        mask:
+        - MachineMask
+        layer:
+        - MachineLayer
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 50
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalGlassBreak
+      - !type:ChangeConstructionNodeBehavior
+        node: machineFrame
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: ActivatableUI
+    key: enum.ChemMasterUiKey.Key
+  - type: ActivatableUIRequiresPower
+  - type: UserInterface
+    interfaces:
+      enum.ChemMasterUiKey.Key:
+        type: ChemMasterBoundUserInterface
+  - type: ApcPowerReceiver
+    powerLoad: 250
+    needsPower: false # TODO RMC14 power
+  - type: Appearance
+  - type: GenericVisualizer
+    visuals:
+      enum.PowerDeviceVisuals.Powered:
+        enum.PowerDeviceVisualLayers.Powered:
+          True: { visible: true }
+          False: { visible: false }
+  - type: WiresPanel
   - type: Machine
     board: CMCircuitboardChemMaster
+  - type: ContainerContainer
+    containers:
+      beakerSlot: !type:ContainerSlot
+      outputSlot: !type:ContainerSlot
+      machine_board: !type:Container
+      machine_parts: !type:Container
+  - type: ItemSlots
+    slots:
+      beakerSlot:
+        whitelist:
+          components:
+          - FitsInDispenser
+      outputSlot:
+        whitelistFailPopup: chem-master-component-cannot-put-entity-message
+        whitelist:
+          tags:
+          - Bottle
+          - PillCanister
+  - type: SolutionContainerManager
+    solutions:
+      buffer: {}
+  - type: GuideHelp
+    guides:
+    - Chemicals
+    - Chemist
   - type: RequiresSkill
     skills:
       RMCSkillMedical: 3
-  - type: ApcPowerReceiver
-    needsPower: false # TOOD RMC14 power
   - type: ActivatableUIBlacklist
     blacklist:
       components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Semi parity as the chemmaster on cm13 can't even be used as a storage
Anyways you can't dump shit in the chemmaster anymore
## Technical details
<!-- Summary of code changes for easier review. -->
I had to merge both chemmaster ymls to remove it's first parent, I tested it and seems fine I hope I didn't break something 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- remove: Removed the ability to drag and drop containers into the chem master
