### PR TITLE
make undeployed mortars un-damagable

### DIFF
--- a/Content.Shared/_RMC14/Mortar/SharedMortarSystem.cs
+++ b/Content.Shared/_RMC14/Mortar/SharedMortarSystem.cs
@@ -10,6 +10,7 @@ using Content.Shared.Administration.Logs;
 using Content.Shared.Chat;
 using Content.Shared.Construction.Components;
 using Content.Shared.Coordinates;
+using Content.Shared.Damage;
 using Content.Shared.Database;
 using Content.Shared.Destructible;
 using Content.Shared.DoAfter;
@@ -37,6 +38,7 @@ public abstract class SharedMortarSystem : EntitySystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedContainerSystem _container = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
+    [Dependency] private readonly IEntityManager _entity = default!;
     [Dependency] private readonly FixtureSystem _fixture = default!;
     [Dependency] private readonly MetaDataSystem _metaData = default!;
     [Dependency] private readonly INetManager _net = default!;
@@ -111,6 +113,7 @@ public abstract class SharedMortarSystem : EntitySystem
             return;
 
         mortar.Comp.Deployed = true;
+        _entity.AddComponent<DamageableComponent>(mortar);
         Dirty(mortar);
 
         if (_fixture.GetFixtureOrNull(mortar, mortar.Comp.FixtureId) is { } fixture)
@@ -281,6 +284,7 @@ public abstract class SharedMortarSystem : EntitySystem
             return;
 
         mortar.Comp.Deployed = false;
+        _entity.RemoveComponent<DamageableComponent>(mortar);
         Dirty(mortar);
 
         if (_fixture.GetFixtureOrNull(mortar, mortar.Comp.FixtureId) is { } fixture)

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/mortars.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/mortars.yml
@@ -41,6 +41,7 @@
   - type: Corrodible
     isCorrodible: false
   - type: Mortar
+  - type: Damageable
     damageContainer: Inorganic
   - type: Destructible
     thresholds:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/mortars.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/mortars.yml
@@ -41,7 +41,6 @@
   - type: Corrodible
     isCorrodible: false
   - type: Mortar
-  - type: Damageable
     damageContainer: Inorganic
   - type: Destructible
     thresholds:


### PR DESCRIPTION
## About the PR

Mortars should only take damage when deployed as they are not supposed to get completely destroyed, just knocked over.

## Why / Balance

Fixes #5584.

## Technical details

Add/Remove the "Damageable" component from the mortar depending on deployment status.

## Media

https://github.com/user-attachments/assets/d8f1aa48-ef30-4e61-9e9d-a6e15d704873


## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- fix: Undeployed mortars can no longer be destroyed.
