### PR TITLE
make the clues in the intel window readable

### DIFF
--- a/Content.Client/_RMC14/Intel/ViewIntelObjectivesWindow.xaml
+++ b/Content.Client/_RMC14/Intel/ViewIntelObjectivesWindow.xaml
@@ -3,7 +3,7 @@
     xmlns:controls="clr-namespace:Content.Client._RMC14.Intel"
     xmlns:ui="clr-namespace:Content.Client._RMC14.UserInterface"
     Title="Marine Tech Tree Objectives"
-    MinSize="600 300">
+    MinSize="600 450">
     <BoxContainer Orientation="Vertical">
         <RichTextLabel Text="[bold]Tech Points[/bold]" />
         <ui:BlueHorizontalSeparator />
@@ -50,8 +50,8 @@
             <RichTextLabel Text="[color=#5B88B0]Colony power:[/color]" MinWidth="200" />
             <Label Name="ColonyPowerLabel" Access="Public" />
         </BoxContainer>
-        <RichTextLabel Text="[bold]Objectives[/bold]" Margin="0 15 0 0" />
+        <RichTextLabel Text="[bold]Clues[/bold]" Margin="0 15 0 0" />
         <ui:BlueHorizontalSeparator />
-        <TabContainer Name="CluesContainer" Access="Public" />
+        <TabContainer Name="CluesContainer" Access="Public" VerticalExpand="True" MinHeight="100" />
     </BoxContainer>
 </controls:ViewIntelObjectivesWindow>


### PR DESCRIPTION
## About the PR

This PR changes the marine tech tree window to actually show the collected clues.

## Why / Balance

The container holding the clues had a height of 0, making the collected clues it displays unreadable.

## Technical details

- made the tabcontainer that holds clues expand and gave it a minimum height
- adjusted the minimum height of the window accordingly

## Media

![image](https://github.com/user-attachments/assets/4c3016d4-b02f-4685-a7a9-2d3273c9baa2)

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: You can now actually read your collected clues inside the tech tree window.
