### PR TITLE
Fix intel light armor appearing as medium armor

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/intel.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/intel.yml
@@ -127,7 +127,7 @@
       takeOne: CMArmor
       entries:
       - id: RMCArmorXM4
-      - id: CMArmorM3Light
+      - id: RMCArmorM3LightVariants
       - id: CMCoatOfficer
     - name: Backpack
       choices: { CMBag: 1 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
It appears as medium armor because the prototype it's using is the base light armor
Padded light armor or the variants is the way to go

:cl:
- fix: Fixed light armor chosen from the intel vendor appearing as medium armor
