### PR TITLE
allow saved survivors to pick up documents

### DIFF
--- a/Content.Shared/_RMC14/Intel/IntelSystem.cs
+++ b/Content.Shared/_RMC14/Intel/IntelSystem.cs
@@ -242,7 +242,7 @@ public sealed class IntelSystem : EntitySystem
 
         if (HasComp<IntelRescueSurvivorObjectiveComponent>(user))
         {
-            _popup.PopupClient($"You have no need to read the {Name(ent)}.", ent, user);
+            _popup.PopupClient(Loc.GetString("rmc-intel-survivor-read", ("thing", Name(ent))), ent, user);
             return;
         }
 
@@ -261,7 +261,7 @@ public sealed class IntelSystem : EntitySystem
         if (HasComp<IntelRescueSurvivorObjectiveComponent>(user))
         {
             args.Cancel();
-            _popup.PopupClient($"You have no use for the {Name(ent)}.", ent, user);
+            _popup.PopupClient(Loc.GetString("rmc-intel-survivor-pickup", ("thing", Name(ent))), ent, user);
             return;
         }
 
@@ -273,7 +273,7 @@ public sealed class IntelSystem : EntitySystem
         if (HasComp<IntelRescueSurvivorObjectiveComponent>(user))
         {
             args.Cancelled = true;
-            _popup.PopupClient($"You have no use for the {Name(ent)}.", user, user);
+            _popup.PopupClient(Loc.GetString("rmc-intel-survivor-pickup", ("thing", Name(ent))), ent, user);
         }
     }
 

--- a/Content.Shared/_RMC14/Intel/IntelSystem.cs
+++ b/Content.Shared/_RMC14/Intel/IntelSystem.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
-using System.Net;
 using Content.Shared._RMC14.Areas;
 using Content.Shared._RMC14.ARES;
 using Content.Shared._RMC14.CCVar;
@@ -10,7 +9,6 @@ using Content.Shared._RMC14.Intel.Tech;
 using Content.Shared._RMC14.Marines.Announce;
 using Content.Shared._RMC14.Marines.Skills;
 using Content.Shared._RMC14.Power;
-using Content.Shared._RMC14.Survivor;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared.Actions;
 using Content.Shared.DoAfter;
@@ -242,7 +240,7 @@ public sealed class IntelSystem : EntitySystem
     {
         var user = args.User;
 
-        if (HasComp<SurvivorComponent>(user))
+        if (HasComp<IntelRescueSurvivorObjectiveComponent>(user))
         {
             _popup.PopupClient($"You have no need to read the {Name(ent)}.", ent, user);
             return;
@@ -260,7 +258,7 @@ public sealed class IntelSystem : EntitySystem
         ContainerGettingInsertedAttemptEvent args)
     {
         var user = args.Container.Owner;
-        if (HasComp<SurvivorComponent>(user))
+        if (HasComp<IntelRescueSurvivorObjectiveComponent>(user))
         {
             args.Cancel();
             _popup.PopupClient($"You have no use for the {Name(ent)}.", ent, user);
@@ -272,7 +270,7 @@ public sealed class IntelSystem : EntitySystem
     private void OnIntelPullAttempt(Entity<IntelRetrieveItemObjectiveComponent> ent, ref PullAttemptEvent args)
     {
         var user = args.PullerUid;
-        if (HasComp<SurvivorComponent>(user))
+        if (HasComp<IntelRescueSurvivorObjectiveComponent>(user))
         {
             args.Cancelled = true;
             _popup.PopupClient($"You have no use for the {Name(ent)}.", user, user);

--- a/Resources/Locale/en-US/_RMC14/intel.ftl
+++ b/Resources/Locale/en-US/_RMC14/intel.ftl
@@ -13,3 +13,7 @@ rmc-intel-clue-folder = A {$intel} in {$area}.
 rmc-intel-clue-technical-manual = {$intel} in {$area}.
 rmc-intel-clue-experimental-device = Retrieve {$intel} in {$area}.
 rmc-intel-not-intel-jumpsuit = You cannot wear this without wearing a marine intelligence officer uniform.
+rmc-intel-survivor-pickup = You have no use for the {$thing}.
+    Focus on getting out alive first.
+rmc-intel-survivor-read = You have no need to read the {$thing}.
+    Focus on getting out alive first.


### PR DESCRIPTION
## About the PR

As discussed in #5583 I feel like survivors should be allowed to pick up documents AFTER they had visited the warship.

## Why / Balance

Allows survivors to collect intel AFTER being rescued.
A survivor that wants to help the marines should be able to do so without this limitation.

## Technical details

Instead of checking for the SurvivorComponent, we check for the IntelRescueSurvivorObjectiveComponent.

## Media


https://github.com/user-attachments/assets/37cda1e0-d8bc-478d-9cbb-96999ea38105



## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- tweak: Survivors can handle intel after being rescued.
