### PR TITLE
Dollars are now UN minted and not US.

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Devices/portable_vendor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Devices/portable_vendor.yml
@@ -46,7 +46,7 @@
       #- id: /obj/item/trash/ceramic_plate
       #  points: 10
       - id: RMCSpaceCash1000 # TODO RMC14 counterfiet
-        name: $1000 USD, unmarked bills
+        name: $1000 UND, unmarked bills
         points: 5
       - id: CMEncryptionKeyWEYA
         points: 5

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Misc/spacecash.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Misc/spacecash.yml
@@ -38,7 +38,7 @@
   parent: RMCSpaceCash
   id: RMCSpaceCash1
   name: 1 dollar bill
-  description: A single UN Government minted one dollar bill. It has a picture of George Washington printed on it. Makes most people of English origin cry, but isn't worth very much. Could probably get you half a hot-dog in some systems.
+  description: A single one-dollar bill, minted by the United Nations Treasury. Its design features the image of a long-forgotten figure from a bygone era, a leader whose legacy now means little to the galactic populace. While it holds sentimental value for those from certain worlds, its actual worth is minimal. In most systems, it might fetch you half a hot-dog or a similar low-value snack.
 
 - type: material
   id: Dollar

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Misc/spacecash.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Misc/spacecash.yml
@@ -2,7 +2,7 @@
   parent: SpaceCash
   id: RMCSpaceCash
   name: dollars
-  description: Ten US Government minted hundred-dollar bills. Every single damn one of them has Ben Fucking Franklin on them. The court of Bens sit impatiently, as if each one thought they alone belonged to you. This coven of angry Bens have all since learned about your relations with the other Bens, and they want answers.
+  description: Ten UN Government minted hundred-dollar bills. Every single damn one of them has Ben Fucking Franklin on them. The court of Bens sit impatiently, as if each one thought they alone belonged to you. This coven of angry Bens have all since learned about your relations with the other Bens, and they want answers.
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Misc/spacecash.rsi
@@ -38,7 +38,7 @@
   parent: RMCSpaceCash
   id: RMCSpaceCash1
   name: 1 dollar bill
-  description: A single US Government minted one dollar bill. It has a picture of George Washington printed on it. Makes most people of English origin cry, but isn't worth very much. Could probably get you half a hot-dog in some systems.
+  description: A single UN Government minted one dollar bill. It has a picture of George Washington printed on it. Makes most people of English origin cry, but isn't worth very much. Could probably get you half a hot-dog in some systems.
 
 - type: material
   id: Dollar

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Misc/spacecash.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Misc/spacecash.yml
@@ -2,7 +2,7 @@
   parent: SpaceCash
   id: RMCSpaceCash
   name: dollars
-  description: Ten UN Government minted hundred-dollar bills. Every single damn one of them has Ben Fucking Franklin on them. The court of Bens sit impatiently, as if each one thought they alone belonged to you. This coven of angry Bens have all since learned about your relations with the other Bens, and they want answers.
+  description: Ten hundred-dollar bills, minted by the United Nations Treasury. Each are adorned with the face of a long-forgotten diplomat of a once-powerful planet. These bills are more than mere currency, they feel alive, as though they carry the weight of ancient history and the judgments of those who once controlled vast empires. The faces on each bill seem to watch you with silent intensity, as if each one believes it alone should be in your possession..
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Misc/spacecash.rsi


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Changed description for $1 and $10 bills to reflect current government.

Would close #5598
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Space dollars are now legal UN tender.