### PR TITLE
First Sergeant Prefix Tweak (1Sgt -> 1st Sgt)

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Ranks/UNMC/enlisted.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Ranks/UNMC/enlisted.yml
@@ -13,7 +13,7 @@
 - type: rank
   id: RMCRankFirstSergeant
   name: First Sergeant
-  prefix: 1Sgt.
+  prefix: 1st Sgt.
   paygrade: E8E
 
 - type: rank

--- a/Resources/Prototypes/_RMC14/Roles/Ranks/UNMC/enlisted.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Ranks/UNMC/enlisted.yml
@@ -13,7 +13,7 @@
 - type: rank
   id: RMCRankFirstSergeant
   name: First Sergeant
-  prefix: 1st Sgt.
+  prefix: 1stSgt.
   paygrade: E8E
 
 - type: rank


### PR DESCRIPTION
## About the PR
1Sgt -> 1st Sgt

## Why / Balance
Now consistent with 1st LT and 2nd LT. I did add a space for sake of readability, 1st LT and 2nd LT do not have this space.

## Technical details
YAML

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
- tweak: The First Sergeant rank prefix has changed to be more consistent with other ranks. (1Sgt -> 1stSgt)
