### PR TITLE
adjust clothing size when webbing is attached

### DIFF
--- a/Content.Shared/_RMC14/Webbing/SharedWebbingSystem.cs
+++ b/Content.Shared/_RMC14/Webbing/SharedWebbingSystem.cs
@@ -175,7 +175,9 @@ public abstract class SharedWebbingSystem : EntitySystem
         handled = false;
         if (!TryComp(webbing, out WebbingComponent? webbingComp) ||
             HasComp<StorageComponent>(clothing) ||
-            !HasComp<StorageComponent>(webbing))
+            !HasComp<StorageComponent>(webbing) ||
+            !TryComp(clothing, out ItemComponent? clothingItem) ||
+            !TryComp(webbing, out ItemComponent? webbingItem))
         {
             return false;
         }
@@ -206,6 +208,9 @@ public abstract class SharedWebbingSystem : EntitySystem
         comp.Transfer = TransferType.ToClothing;
         Dirty(webbing, comp);
 
+        clothing.Comp.UnequippedSize = clothingItem.Size;
+        _item.SetSize(clothing, webbingItem.Size);
+
         handled = true;
         return true;
     }
@@ -227,6 +232,12 @@ public abstract class SharedWebbingSystem : EntitySystem
         comp.Clothing = clothing;
         comp.Transfer = TransferType.ToWebbing;
         Dirty(webbing, comp);
+
+        if (clothing.Comp.UnequippedSize is { } size)
+        {
+            clothing.Comp.UnequippedSize = null;
+            _item.SetSize(clothing, size);
+        }
     }
 
     public override void Update(float frameTime)

--- a/Content.Shared/_RMC14/Webbing/WebbingClothingComponent.cs
+++ b/Content.Shared/_RMC14/Webbing/WebbingClothingComponent.cs
@@ -1,4 +1,6 @@
-﻿using Robust.Shared.GameStates;
+﻿using Content.Shared.Item;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared._RMC14.Webbing;
 
@@ -11,4 +13,10 @@ public sealed partial class WebbingClothingComponent : Component
 
     [DataField, AutoNetworkedField]
     public EntityUid? Webbing;
+
+    /// <summary>
+    /// The item size this piece of clothing had without webbing.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public ProtoId<ItemSizePrototype>? UnequippedSize;
 }


### PR DESCRIPTION
## About the PR

This PR makes it so that pieces of clothing that have webbing attached adjust their size to the one of the webbing

## Why / Balance

- Fixes #4613

## Technical details

Store the old size, overwrite it, and reset.

## Media

https://github.com/user-attachments/assets/c2f6a738-3d53-4052-9c12-b84d6d9c12dc

## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- fix: Fixed clothes with attached webbing not being larger.
