### PR TITLE
Hivelord ranged + fast transfer plasma

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Plasma/XenoPlasmaComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Plasma/XenoPlasmaComponent.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Alert;
+using Content.Shared.Alert;
 using Content.Shared.FixedPoint;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
@@ -17,7 +17,7 @@ public sealed partial class XenoPlasmaComponent : Component
     public int MaxPlasma = 300;
 
     [DataField, AutoNetworkedField]
-    public TimeSpan PlasmaTransferDelay = TimeSpan.FromSeconds(3);
+    public TimeSpan PlasmaTransferDelay = TimeSpan.FromSeconds(2);
 
     [DataField, AutoNetworkedField]
     public SoundSpecifier PlasmaTransferSound = new SoundCollectionSpecifier("XenoDrool");

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_utility_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_utility_actions.yml
@@ -25,7 +25,22 @@
       state: transfer_plasma
     event: !type:XenoTransferPlasmaActionEvent
       amount: 100
-    range: 2
+    range: 1.5
+
+- type: entity
+  id: ActionXenoTransferPlasmaHivelord
+  parent: ActionXenoBase
+  name: Transfer plasma (200) # TODO RMC14 proper plasma costs
+  description: Give plasma to a xenonid.
+  components:
+  - type: EntityTargetAction
+    itemIconStyle: NoItem
+    icon:
+      sprite: _RMC14/Actions/xeno_actions.rsi
+      state: transfer_plasma
+    event: !type:XenoTransferPlasmaActionEvent
+      amount: 200
+    range: 7
 
 - type: entity
   id: ActionXenoResinSurge

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_utility_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_utility_actions.yml
@@ -197,6 +197,7 @@
       state: apply_salve
     event: !type:XenoApplySalveActionEvent
     useDelay: 0.5
+    range: 2
 
 - type: entity
   parent: ActionXenoBase
@@ -211,3 +212,4 @@
       sprite: _RMC14/Actions/xeno_actions.rsi
       state: screech
     event: !type:XenoSacrificeHealActionEvent
+    range: 2

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/hivelord.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/hivelord.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   abstract: true
   parent:
   - CMXenoDeveloped
@@ -110,7 +110,7 @@
     - ActionXenoPlantWeeds
     - ActionXenoChooseStructure
     - ActionXenoSecreteStructure
-    - ActionXenoTransferPlasma
+    - ActionXenoTransferPlasmaHivelord
     - ActionXenoResinWalker
     - ActionXenoDevolve
   - type: XenoConstruction
@@ -128,6 +128,7 @@
     plasma: 1000
     maxPlasma: 1000
     plasmaRegenOnWeeds: 5.5
+    plasmaTransferDelay: 0.5
   - type: AcidTrap
   - type: XenoEvolution
     strains:
@@ -154,7 +155,7 @@
     - ActionXenoChooseStructure
     - ActionXenoCoerceResin
     - ActionXenoZoom
-    - ActionXenoTransferPlasma
+    - ActionXenoTransferPlasmaHivelord
     - ActionXenoResinWalker
     - ActionXenoDevolve
     hidden: true

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/hivelord.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/hivelord.yml
@@ -174,6 +174,7 @@
     plasma: 800
     maxPlasma: 800
     plasmaRegenOnWeeds: 5.5
+    plasmaTransferDelay: 0.5
   - type: XenoZoom
   - type: ResinWhisperer
     maxRemoteConstructDistance: 13


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity. They do just have a 0.5 second 200 ranged plasma transfer. Who knew. Also 3 seconds was wrong - in CM it's 20 decisecond aka 2 seconds for normal transfer.

Also healer's plasma range decreased to 1.5, cause it's 1 tile range on CM.

## Technical details
<!-- Summary of code changes for easier review. -->
YML + changing the default.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed drone transfer plasma's doafter taking too long (3 > 2 seconds)
- fix: Fixed hivelord having drone's transfer plasma. They now transfer 200 plasma in 0.5 seconds, up to 7 tiles away.