### PR TITLE
Add area names to tacmap alert tooltips

### DIFF
--- a/Content.Shared/_RMC14/CCVar/RMCCVars.cs
+++ b/Content.Shared/_RMC14/CCVar/RMCCVars.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared;
+using Robust.Shared;
 using Robust.Shared.Configuration;
 
 namespace Content.Shared._RMC14.CCVar;
@@ -393,4 +393,7 @@ public sealed class RMCCVars : CVars
 
     public static readonly CVarDef<int> RMCIntelHumanoidCorpsesMax =
         CVarDef.Create("rmc.intel_humanoid_corpses_max", 48, CVar.REPLICATED | CVar.SERVER);
+
+    public static readonly CVarDef<float> RMCMaxTacmapAlertProcessTimeMilliseconds =
+    CVarDef.Create("rmc.tacmap_alert_max_process_time_milliseconds", 1f, CVar.REPLICATED | CVar.SERVER);
 }

--- a/Content.Shared/_RMC14/TacticalMap/TacMapMarineAlertComponent.cs
+++ b/Content.Shared/_RMC14/TacticalMap/TacMapMarineAlertComponent.cs
@@ -15,5 +15,5 @@ public sealed partial class TacMapMarineAlertComponent : Component
     public TimeSpan NextUpdateTime;
 
     [DataField]
-    public TimeSpan UpdateInterval;
+    public TimeSpan UpdateInterval = TimeSpan.FromSeconds(2);
 }

--- a/Content.Shared/_RMC14/TacticalMap/TacMapMarineAlertComponent.cs
+++ b/Content.Shared/_RMC14/TacticalMap/TacMapMarineAlertComponent.cs
@@ -5,9 +5,15 @@ using Robust.Shared.Prototypes;
 namespace Content.Shared._RMC14.TacticalMap;
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-[Access(typeof(SharedTacticalMapSystem))]
+[Access(typeof(SharedTacticalMapSystem), typeof(TacMapMarineAlertSystem))]
 public sealed partial class TacMapMarineAlertComponent : Component
 {
     [DataField, AutoNetworkedField]
     public ProtoId<AlertPrototype> Alert = "MarineTacMapAlert";
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan NextUpdateTime;
+
+    [DataField]
+    public TimeSpan UpdateInterval;
 }

--- a/Content.Shared/_RMC14/TacticalMap/TacMapMarineAlertSystem.cs
+++ b/Content.Shared/_RMC14/TacticalMap/TacMapMarineAlertSystem.cs
@@ -100,7 +100,7 @@ public sealed class TacMapMarineAlertSystem : EntitySystem
                 continue;
 
             _marineAlertQueue.Enqueue((uid, alert));
-            alert.NextUpdateTime = _timing.CurTime + alert.UpdateInterval;
+            alert.NextUpdateTime = time + alert.UpdateInterval;
         }
     }
 }

--- a/Content.Shared/_RMC14/TacticalMap/TacMapMarineAlertSystem.cs
+++ b/Content.Shared/_RMC14/TacticalMap/TacMapMarineAlertSystem.cs
@@ -89,7 +89,7 @@ public sealed class TacMapMarineAlertSystem : EntitySystem
                     continue;
 
                 _alerts.ShowAlert(ent, ent.Comp.Alert, dynamicMessage: Loc.GetString("rmc-tacmap-alert-area", ("area", GetAreaName(ent))));
-                ent.Comp.NextUpdateTime += ent.Comp.UpdateInterval;
+                ent.Comp.NextUpdateTime = _timing.CurTime + ent.Comp.UpdateInterval;
             }
         }
 
@@ -101,7 +101,6 @@ public sealed class TacMapMarineAlertSystem : EntitySystem
                 continue;
 
             _marineAlertQueue.Enqueue((uid, alert));
-            alert.NextUpdateTime = time + alert.UpdateInterval;
         }
     }
 }

--- a/Content.Shared/_RMC14/TacticalMap/TacMapMarineAlertSystem.cs
+++ b/Content.Shared/_RMC14/TacticalMap/TacMapMarineAlertSystem.cs
@@ -89,7 +89,6 @@ public sealed class TacMapMarineAlertSystem : EntitySystem
                     continue;
 
                 _alerts.ShowAlert(ent, ent.Comp.Alert, dynamicMessage: Loc.GetString("rmc-tacmap-alert-area", ("area", GetAreaName(ent))));
-                ent.Comp.NextUpdateTime = _timing.CurTime + ent.Comp.UpdateInterval;
             }
         }
 
@@ -101,6 +100,7 @@ public sealed class TacMapMarineAlertSystem : EntitySystem
                 continue;
 
             _marineAlertQueue.Enqueue((uid, alert));
+            alert.NextUpdateTime = _timing.CurTime + alert.UpdateInterval;
         }
     }
 }

--- a/Content.Shared/_RMC14/TacticalMap/TacMapMarineAlertSystem.cs
+++ b/Content.Shared/_RMC14/TacticalMap/TacMapMarineAlertSystem.cs
@@ -101,7 +101,7 @@ public sealed class TacMapMarineAlertSystem : EntitySystem
                 continue;
 
             _marineAlertQueue.Enqueue((uid, alert));
-            alert.NextUpdateTime += alert.UpdateInterval;
+            alert.NextUpdateTime = time + alert.UpdateInterval;
         }
     }
 }

--- a/Content.Shared/_RMC14/TacticalMap/TacMapXenoAlertComponent.cs
+++ b/Content.Shared/_RMC14/TacticalMap/TacMapXenoAlertComponent.cs
@@ -5,9 +5,15 @@ using Robust.Shared.Prototypes;
 namespace Content.Shared._RMC14.TacticalMap;
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-[Access(typeof(SharedTacticalMapSystem))]
+[Access(typeof(SharedTacticalMapSystem), typeof(TacMapXenoAlertSystem))]
 public sealed partial class TacMapXenoAlertComponent : Component
 {
     [DataField, AutoNetworkedField]
     public ProtoId<AlertPrototype> Alert = "XenoTacMapAlert";
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan NextUpdateTime;
+
+    [DataField]
+    public TimeSpan UpdateInterval;
 }

--- a/Content.Shared/_RMC14/TacticalMap/TacMapXenoAlertComponent.cs
+++ b/Content.Shared/_RMC14/TacticalMap/TacMapXenoAlertComponent.cs
@@ -15,5 +15,5 @@ public sealed partial class TacMapXenoAlertComponent : Component
     public TimeSpan NextUpdateTime;
 
     [DataField]
-    public TimeSpan UpdateInterval;
+    public TimeSpan UpdateInterval = TimeSpan.FromSeconds(2);
 }

--- a/Content.Shared/_RMC14/TacticalMap/TacMapXenoAlertSystem.cs
+++ b/Content.Shared/_RMC14/TacticalMap/TacMapXenoAlertSystem.cs
@@ -73,7 +73,7 @@ public sealed class TacMapXenoAlertSystem : EntitySystem
                 continue;
 
             _xenoAlertQueue.Enqueue((uid, alert));
-            alert.NextUpdateTime = _timing.CurTime + alert.UpdateInterval;
+            alert.NextUpdateTime = time + alert.UpdateInterval;
         }
     }
 }

--- a/Content.Shared/_RMC14/TacticalMap/TacMapXenoAlertSystem.cs
+++ b/Content.Shared/_RMC14/TacticalMap/TacMapXenoAlertSystem.cs
@@ -1,23 +1,38 @@
+using Content.Shared._RMC14.Areas;
 using Content.Shared.Alert;
+using Content.Shared.Coordinates;
 
 namespace Content.Shared._RMC14.TacticalMap;
 
 public sealed class TacMapXenoAlertSystem : EntitySystem
 {
     [Dependency] private readonly AlertsSystem _alerts = default!;
+    [Dependency] private readonly AreaSystem _area = default!;
 
     public override void Initialize()
     {
         SubscribeLocalEvent<TacMapXenoAlertComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<TacMapXenoAlertComponent, ComponentRemove>(OnRemove);
+        SubscribeLocalEvent<TacMapXenoAlertComponent, MoveEvent>(OnMove);
     }
 
     private void OnMapInit(Entity<TacMapXenoAlertComponent> ent, ref MapInitEvent args)
     {
-        _alerts.ShowAlert(ent, ent.Comp.Alert);
+        _alerts.ShowAlert(ent, ent.Comp.Alert, dynamicMessage: Loc.GetString("rmc-tacmap-alert-area", ("area", GetAreaName(ent))));
+    }
+    private void OnMove(Entity<TacMapXenoAlertComponent> ent, ref MoveEvent args)
+    {
+        _alerts.ShowAlert(ent, ent.Comp.Alert, dynamicMessage: Loc.GetString("rmc-tacmap-alert-area", ("area", GetAreaName(ent))));
     }
     private void OnRemove(Entity<TacMapXenoAlertComponent> ent, ref ComponentRemove args)
     {
         _alerts.ClearAlert(ent, ent.Comp.Alert);
+    }
+    private string GetAreaName(EntityUid ent)
+    {
+        if (!_area.TryGetArea(ent.ToCoordinates(), out var _, out var areaProto))
+            return Loc.GetString("rmc-tacmap-alert-no-area");
+
+        return areaProto.Name;
     }
 }

--- a/Content.Shared/_RMC14/TacticalMap/TacMapXenoAlertSystem.cs
+++ b/Content.Shared/_RMC14/TacticalMap/TacMapXenoAlertSystem.cs
@@ -74,7 +74,7 @@ public sealed class TacMapXenoAlertSystem : EntitySystem
                 continue;
 
             _xenoAlertQueue.Enqueue((uid, alert));
-            alert.NextUpdateTime += alert.UpdateInterval;
+            alert.NextUpdateTime = time + alert.UpdateInterval;
         }
     }
 }

--- a/Content.Shared/_RMC14/TacticalMap/TacMapXenoAlertSystem.cs
+++ b/Content.Shared/_RMC14/TacticalMap/TacMapXenoAlertSystem.cs
@@ -62,7 +62,6 @@ public sealed class TacMapXenoAlertSystem : EntitySystem
                     continue;
 
                 _alerts.ShowAlert(ent, ent.Comp.Alert, dynamicMessage: Loc.GetString("rmc-tacmap-alert-area", ("area", GetAreaName(ent))));
-                ent.Comp.NextUpdateTime = _timing.CurTime + ent.Comp.UpdateInterval;
             }
         }
 
@@ -74,6 +73,7 @@ public sealed class TacMapXenoAlertSystem : EntitySystem
                 continue;
 
             _xenoAlertQueue.Enqueue((uid, alert));
+            alert.NextUpdateTime = _timing.CurTime + alert.UpdateInterval;
         }
     }
 }

--- a/Content.Shared/_RMC14/TacticalMap/TacMapXenoAlertSystem.cs
+++ b/Content.Shared/_RMC14/TacticalMap/TacMapXenoAlertSystem.cs
@@ -1,6 +1,8 @@
 using Content.Shared._RMC14.Areas;
 using Content.Shared.Alert;
 using Content.Shared.Coordinates;
+using Robust.Shared.Network;
+using Robust.Shared.Timing;
 
 namespace Content.Shared._RMC14.TacticalMap;
 
@@ -8,19 +10,16 @@ public sealed class TacMapXenoAlertSystem : EntitySystem
 {
     [Dependency] private readonly AlertsSystem _alerts = default!;
     [Dependency] private readonly AreaSystem _area = default!;
+    [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
 
     public override void Initialize()
     {
         SubscribeLocalEvent<TacMapXenoAlertComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<TacMapXenoAlertComponent, ComponentRemove>(OnRemove);
-        SubscribeLocalEvent<TacMapXenoAlertComponent, MoveEvent>(OnMove);
     }
 
     private void OnMapInit(Entity<TacMapXenoAlertComponent> ent, ref MapInitEvent args)
-    {
-        _alerts.ShowAlert(ent, ent.Comp.Alert, dynamicMessage: Loc.GetString("rmc-tacmap-alert-area", ("area", GetAreaName(ent))));
-    }
-    private void OnMove(Entity<TacMapXenoAlertComponent> ent, ref MoveEvent args)
     {
         _alerts.ShowAlert(ent, ent.Comp.Alert, dynamicMessage: Loc.GetString("rmc-tacmap-alert-area", ("area", GetAreaName(ent))));
     }
@@ -34,5 +33,23 @@ public sealed class TacMapXenoAlertSystem : EntitySystem
             return Loc.GetString("rmc-tacmap-alert-no-area");
 
         return areaProto.Name;
+    }
+
+    public override void Update(float frameTime)
+    {
+        if (_net.IsClient)
+            return;
+
+        var time = _timing.CurTime;
+        var tacMapQuery = EntityQueryEnumerator<TacMapXenoAlertComponent>();
+
+        while (tacMapQuery.MoveNext(out var uid, out var alert))
+        {
+            if (time < alert.NextUpdateTime)
+                continue;
+
+            _alerts.ShowAlert(uid, alert.Alert, dynamicMessage: Loc.GetString("rmc-tacmap-alert-area", ("area", GetAreaName(uid))));
+            alert.NextUpdateTime += alert.UpdateInterval;
+        }
     }
 }

--- a/Content.Shared/_RMC14/TacticalMap/TacMapXenoAlertSystem.cs
+++ b/Content.Shared/_RMC14/TacticalMap/TacMapXenoAlertSystem.cs
@@ -62,7 +62,7 @@ public sealed class TacMapXenoAlertSystem : EntitySystem
                     continue;
 
                 _alerts.ShowAlert(ent, ent.Comp.Alert, dynamicMessage: Loc.GetString("rmc-tacmap-alert-area", ("area", GetAreaName(ent))));
-                ent.Comp.NextUpdateTime += ent.Comp.UpdateInterval;
+                ent.Comp.NextUpdateTime = _timing.CurTime + ent.Comp.UpdateInterval;
             }
         }
 
@@ -74,7 +74,6 @@ public sealed class TacMapXenoAlertSystem : EntitySystem
                 continue;
 
             _xenoAlertQueue.Enqueue((uid, alert));
-            alert.NextUpdateTime = time + alert.UpdateInterval;
         }
     }
 }

--- a/Resources/Locale/en-US/_RMC14/ui.ftl
+++ b/Resources/Locale/en-US/_RMC14/ui.ftl
@@ -61,3 +61,6 @@ rmc-other-credits-tab = Other
 
 rmc-ui-auto-punctuate = Automatically punctuate in-character messages
 rmc-ui-auto-eject-magazines = Automatically eject magazines from guns
+
+rmc-tacmap-alert-area = Current Area: {$area}
+rmc-tacmap-alert-no-area = Unknown


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title. You can now see what area you're in if you hover over the tacmap alert.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
~Was told this was~ parity ~I can't find it in the status, but either way this is pretty much QOL. A new player won't know any of the areas, and many things will give an area name but there's not really a good way to get it rn. Ideally tacmaps will have either a tooltip revealing a name thing later or labels, but this should help aswell.~ You can get this in CM by examing the SL tracker for marines, or queen tracker for xenos.

## Technical details
<!-- Summary of code changes for easier review. -->
Made the tacmap alerts update ~~on movement~~ every 2 seconds, and get your area.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/83122aaa-b540-4578-9f63-7b8b8eaf3038


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added the name of the current area you are in in the tacmap alert tooltip.
