### PR TITLE
Fix evacuation doors being pryable while locked and kill anyone left outside the docking area after a lifeboat departs

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Numerics;
+using Content.Server._RMC14.Shuttles;
 using Content.Server.Shuttles.Components;
 using Content.Server.Shuttles.Events;
 using Content.Server.Station.Events;
@@ -393,6 +394,10 @@ public sealed partial class ShuttleSystem
         var ftlMap = EnsureFTLMap();
         var body = _physicsQuery.GetComponent(entity);
         var shuttleCenter = grid.LocalAABB.Center;
+
+        // RMC14
+        var beforeFTL = new BeforeFTLStartedEvent(uid);
+        RaiseLocalEvent(uid, ref beforeFTL);
 
         // Leave audio at the old spot
         // Just so we don't clip

--- a/Content.Server/_RMC14/Shuttles/RMCShuttleSystem.cs
+++ b/Content.Server/_RMC14/Shuttles/RMCShuttleSystem.cs
@@ -1,17 +1,24 @@
 ﻿using Content.Server.Shuttles.Events;
 using Content.Shared._RMC14.Shuttles;
 using Robust.Server.Audio;
+using Robust.Server.GameObjects;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Physics;
 
 namespace Content.Server._RMC14.Shuttles;
 
 public sealed class RMCShuttleSystem : SharedRMCShuttleSystem
 {
     [Dependency] private readonly AudioSystem _audio = default!;
+    [Dependency] private readonly MapSystem _mapSystem = default!;
 
     public override void Initialize()
     {
         base.Initialize();
         SubscribeLocalEvent<PlaySoundOnFTLStartComponent, FTLStartedEvent>(OnPlaySoundOnFTLStart);
+
+        SubscribeLocalEvent<RMCSpawnEntityOnFTLStartComponent, BeforeFTLStartedEvent>(BeforeFTLStarted);
+        SubscribeLocalEvent<RMCSpawnEntityOnFTLStartComponent, FTLStartedEvent>(OnSpawnEntityOnFTLStart);
     }
 
     private void OnPlaySoundOnFTLStart(Entity<PlaySoundOnFTLStartComponent> ent, ref FTLStartedEvent args)
@@ -22,4 +29,57 @@ public sealed class RMCShuttleSystem : SharedRMCShuttleSystem
         _audio.PlayPvs(ent.Comp.Sound, grid);
         RemCompDeferred<PlaySoundOnFTLStartComponent>(ent);
     }
+
+    /// <summary>
+    ///     Spawn an entity on every tile that the FTLing grid occupied after it has moved to FTL space.
+    /// </summary>
+    private void OnSpawnEntityOnFTLStart(Entity<RMCSpawnEntityOnFTLStartComponent> ent, ref FTLStartedEvent args)
+    {
+        foreach (var coordinate in ent.Comp.Coordinates)
+        {
+            Spawn(ent.Comp.SpawnedEntity, coordinate);
+        }
+    }
+
+    /// <summary>
+    ///     Get the MapCoordinates for every tile that the grid about to FTL is occupying.
+    /// </summary>
+    private void BeforeFTLStarted(Entity<RMCSpawnEntityOnFTLStartComponent> ent, ref BeforeFTLStartedEvent args)
+    {
+        var uid = args.FTLEntity;
+        var manager = args.Manager;
+        var grid = args.Grid;
+        var xform = args.Xform;
+
+        if (!Resolve(uid, ref manager, ref grid, ref xform) || xform.MapUid == null)
+            return;
+
+        var tiles = new HashSet<Vector2i>();
+        if (TryComp(uid, out MapGridComponent? shuttleGrid))
+        {
+            var enumerator = _mapSystem.GetAllTilesEnumerator(uid, shuttleGrid);
+            while (enumerator.MoveNext(out var tile))
+            {
+                tiles.Add(tile.Value.GridIndices);
+            }
+        }
+
+        foreach (var fixture in manager.Fixtures.Values)
+        {
+            if (!fixture.Hard)
+                continue;
+
+            foreach (var tile in tiles)
+            {
+                if(!TryComp(uid, out MapGridComponent? mapGrid))
+                    return;
+
+                var mapCoords = _mapSystem.GridTileToWorld(uid, mapGrid, tile);
+                ent.Comp.Coordinates.Add(mapCoords);
+            }
+        }
+    }
 }
+
+[ByRefEvent]
+public record struct BeforeFTLStartedEvent(EntityUid FTLEntity, FixturesComponent? Manager = null, MapGridComponent? Grid = null, TransformComponent? Xform = null);

--- a/Content.Server/_RMC14/Shuttles/RMCSpawnEntityOnFTLStartComponent.cs
+++ b/Content.Server/_RMC14/Shuttles/RMCSpawnEntityOnFTLStartComponent.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._RMC14.Shuttles;
+
+[RegisterComponent]
+public sealed partial class RMCSpawnEntityOnFTLStartComponent : Component
+{
+    [DataField]
+    public HashSet<MapCoordinates> Coordinates = new();
+
+    [DataField]
+    public EntProtoId SpawnedEntity = "FloorDeathEntity";
+}

--- a/Content.Shared/_RMC14/Evacuation/SharedEvacuationSystem.cs
+++ b/Content.Shared/_RMC14/Evacuation/SharedEvacuationSystem.cs
@@ -18,6 +18,7 @@ using Content.Shared.Examine;
 using Content.Shared.GameTicking;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Popups;
+using Content.Shared.Prying.Components;
 using Content.Shared.UserInterface;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
@@ -77,6 +78,7 @@ public abstract class SharedEvacuationSystem : EntitySystem
 
         SubscribeLocalEvent<EvacuationDoorComponent, BeforeDoorOpenedEvent>(OnEvacuationDoorBeforeOpened);
         SubscribeLocalEvent<EvacuationDoorComponent, BeforeDoorClosedEvent>(OnEvacuationDoorBeforeClosed);
+        SubscribeLocalEvent<EvacuationDoorComponent, BeforePryEvent>(OnEvacuationDoorBeforePry);
 
         SubscribeLocalEvent<EvacuationComputerComponent, ExaminedEvent>(OnEvacuationComputerExamined);
         SubscribeLocalEvent<EvacuationComputerComponent, ActivatableUIOpenAttemptEvent>(OnEvacuationComputerUIOpenAttempt);
@@ -210,6 +212,12 @@ public abstract class SharedEvacuationSystem : EntitySystem
     {
         if (ent.Comp.Locked)
             args.PerformCollisionCheck = false;
+    }
+
+    private void OnEvacuationDoorBeforePry(Entity<EvacuationDoorComponent> ent, ref BeforePryEvent args)
+    {
+        if (ent.Comp.Locked)
+            args.Cancelled = true;
     }
 
     private void OnEvacuationComputerExamined(Entity<EvacuationComputerComponent> ent, ref ExaminedEvent args)

--- a/Resources/Maps/_RMC14/lifeboat.yml
+++ b/Resources/Maps/_RMC14/lifeboat.yml
@@ -63,6 +63,7 @@ entities:
         chunkSize: 4
     - type: GasTileOverlay
     - type: RadiationGridResistance
+    - type: RMCSpawnEntityOnFTLStart
 - proto: CMLightFixtureAlwaysPowered
   entities:
   - uid: 116

--- a/Resources/Prototypes/Entities/Tiles/death.yml
+++ b/Resources/Prototypes/Entities/Tiles/death.yml
@@ -24,7 +24,7 @@
       fix1:
         shape:
           !type:PhysShapeAabb
-          bounds: "-0.85,-0.85,0.85,0.85"
+          bounds: "-1,-1,1,1"
         layer:
         - SlipLayer
         mask:
@@ -35,4 +35,4 @@
     tags:
     - HideContextMenu
   - type: TimedDespawn
-    lifetime: 10
+    lifetime: 30

--- a/Resources/Prototypes/Entities/Tiles/death.yml
+++ b/Resources/Prototypes/Entities/Tiles/death.yml
@@ -1,0 +1,38 @@
+- type: entity
+  id: FloorDeathEntity
+  name: death
+  placement:
+    mode: SnapgridCenter
+    snap:
+    - Wall
+  components:
+  - type: Transform
+    anchored: true
+  - type: DamageOnCollide
+    damageDead: false
+    damage:
+      groups:
+        Brute: 5000
+    whitelist:
+      components:
+        - MobState
+    ignoreResistances: true
+  - type: Physics
+    bodyType: Static
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.85,-0.85,0.85,0.85"
+        layer:
+        - SlipLayer
+        mask:
+        - ItemMask
+        density: 1000
+        hard: false
+  - type: Tag
+    tags:
+    - HideContextMenu
+  - type: TimedDespawn
+    lifetime: 10


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Evacuation doors now can't be pryed anymore while they are locked. This means that xeno's can't pry pod or lifeboat doors anymore after their launch sequence has been initiated or when hijack hasn't started yet.

When a lifeboat jumps into FTL space it now spawns a new entity on every tile it occupied that deals 5000 damage on collision with another entity.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Resolves #5586 
Resolves #4412

## Technical details
<!-- Summary of code changes for easier review. -->
Added an event listener that cancels pry attempts if an evacuation door is locked.

A new event is called before FTL is started. 
A new event listener stores every tile an entity occupies before it goes into FTL if the FTLing entity has the RMCSpawnEntityOnFTLStartComponent.
After the entity goes into FTL space, on every tile it previously occupied a new entity is spawned(the default one kills anything near it).

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/9d9f7b91-377b-46ad-9d2f-d3661dbfdab4


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix: Evacuation doors(pods, lifeboats) are now unable to be pryed open while locked.
- fix: Being outside the docking area when a lifeboat has left will now instantly kill you.
