### PR TITLE
A few more xeno chatsans

### DIFF
--- a/Resources/Locale/en-US/_RMC14/cm-chatsan.ftl
+++ b/Resources/Locale/en-US/_RMC14/cm-chatsan.ftl
@@ -336,8 +336,11 @@ cm-chatsan-replacement-rocket = boom spit
 cm-chatsan-word-grenadier = grenadier
 cm-chatsan-replacement-grenadier = boomstick spitter
 
-cm-chatsan-word-scout = scout
+cm-chatsan-word-scout = scout spec
 cm-chatsan-replacement-scout = tall lurker
+
+cm-chatsan-word-scout-specialist = scout specialist
+cm-chatsan-replacement-scout-specialist = tall lurker
 
 cm-chatsan-word-mortar = mortar
 cm-chatsan-replacement-mortar = skyboom
@@ -413,3 +416,18 @@ cm-chatsan-replacement-nade = boomsticks
 
 cm-chatsan-word-nuke = nuke
 cm-chatsan-replacement-nuke = hive killer
+
+cm-chatsan-word-intel = intel
+cm-chatsan-replacement-intel = scavenger talls
+
+cm-chatsan-word-survivor = survivor
+cm-chatsan-replacement-survivor = planet tall
+
+cm-chatsan-word-survivors = survivors
+cm-chatsan-replacement-survivors = planet talls
+
+cm-chatsan-word-surv = surv
+cm-chatsan-replacement-surv = planet tall
+
+cm-chatsan-word-survs = survs
+cm-chatsan-replacement-survs = planet talls

--- a/Resources/Locale/en-US/_RMC14/cm-chatsan.ftl
+++ b/Resources/Locale/en-US/_RMC14/cm-chatsan.ftl
@@ -1,4 +1,4 @@
-﻿cm-chatsan-word-deltard = deltard
+cm-chatsan-word-deltard = deltard
 cm-chatsan-replacement-deltard = delta
 
 cm-chatsan-word-deltards = deltards
@@ -54,6 +54,9 @@ cm-chatsan-replacement-sniper = long spitter
 
 cm-chatsan-word-flare = flare
 cm-chatsan-replacement-flare = glow stick
+
+cm-chatsan-word-flares = flares
+cm-chatsan-replacement-flares = glow sticks
 
 cm-chatsan-word-synth = synth
 cm-chatsan-replacement-synth = fake hosts
@@ -363,11 +366,20 @@ cm-chatsan-replacement-sensor-tower = tall eye tower
 cm-chatsan-word-comms = comms
 cm-chatsan-replacement-comms = tall hivemind tower
 
+cm-chatsan-word-tcomms = tcomms
+cm-chatsan-replacement-tcomms = tall hivemind tower
+
 cm-chatsan-word-communications-tower = communications tower
 cm-chatsan-replacement-communications-tower = tall hivemind tower
 
 cm-chatsan-word-smart-gun = smart gun
 cm-chatsan-replacement-smartgun = smart spitter
+
+cm-chatsan-word-sg = sg
+cm-chatsan-replacement-sg = smart spitter
+
+cm-chatsan-word-sgs = sgs
+cm-chatsan-replacement-sgs = smart spitters
 
 cm-chatsan-word-smartgun = smartgun
 cm-chatsan-replacement-smart-gun = smart spitter
@@ -392,3 +404,12 @@ cm-chatsan-replacement-squads = castes
 
 cm-chatsan-word-shotgun = shotgun
 cm-chatsan-replacement-shotgun = scatter spitter
+
+cm-chatsan-word-nade = nade
+cm-chatsan-replacement-nade = boomstick
+
+cm-chatsan-word-nade = nades
+cm-chatsan-replacement-nade = boomsticks
+
+cm-chatsan-word-nuke = nuke
+cm-chatsan-replacement-nuke = hive killer

--- a/Resources/Prototypes/_RMC14/Accents/cm_word_replacements.yml
+++ b/Resources/Prototypes/_RMC14/Accents/cm_word_replacements.yml
@@ -1,4 +1,4 @@
-﻿- type: accent
+- type: accent
   id: CMChatSanitize
   wordReplacements:
     cm-chatsan-word-deltard: cm-chatsan-replacement-deltard
@@ -129,6 +129,7 @@
     cm-chatsan-word-sensors: cm-chatsan-replacement-sensors
     cm-chatsan-word-sensor-tower: cm-chatsan-replacement-sensor-tower
     cm-chatsan-word-comms: cm-chatsan-replacement-comms
+    cm-chatsan-word-tcomms: cm-chatsan-replacement-tcomms
     cm-chatsan-word-communications-tower: cm-chatsan-replacement-communications-tower
     cm-chatsan-word-smart-gun: cm-chatsan-replacement-smart-gun
     cm-chatsan-word-smartgun: cm-chatsan-replacement-smartgun
@@ -139,4 +140,10 @@
     cm-chatsan-word-shotgun: cm-chatsan-replacement-shotgun
     cm-chatsan-word-squad: cm-chatsan-replacement-squad
     cm-chatsan-word-squads: cm-chatsan-replacement-squads
+    cm-chatsan-word-sg: cm-chatsan-replacement-sg
+    cm-chatsan-word-sgs: cm-chatsan-replacement-sgs
+    cm-chatsan-word-flares: cm-chatsan-replacement-flares
+    cm-chatsan-word-nade: cm-chatsan-replacement-nade
+    cm-chatsan-word-nades: cm-chatsan-replacement-nades
+    cm-chatsan-word-nuke: cm-chatsan-replacement-nuke
 

--- a/Resources/Prototypes/_RMC14/Accents/cm_word_replacements.yml
+++ b/Resources/Prototypes/_RMC14/Accents/cm_word_replacements.yml
@@ -120,6 +120,7 @@
     cm-chatsan-word-rocket: cm-chatsan-replacement-rocket
     cm-chatsan-word-grenadier: cm-chatsan-replacement-grenadier
     cm-chatsan-word-scout: cm-chatsan-replacement-scout
+    cm-chatsan-word-scout-specialist: cm-chatsan-replacement-scout-specialist
     cm-chatsan-word-mortar: cm-chatsan-replacement-mortar
     cm-chatsan-word-demo: cm-chatsan-replacement-demo
     cm-chatsan-word-demolitionist: cm-chatsan-replacement-demolitionist
@@ -146,4 +147,9 @@
     cm-chatsan-word-nade: cm-chatsan-replacement-nade
     cm-chatsan-word-nades: cm-chatsan-replacement-nades
     cm-chatsan-word-nuke: cm-chatsan-replacement-nuke
+    cm-chatsan-word-intel: cm-chatsan-replacement-intel
+    cm-chatsan-word-survivor: cm-chatsan-replacement-survivor
+    cm-chatsan-word-survivors: cm-chatsan-replacement-survivors
+    cm-chatsan-word-surv: cm-chatsan-replacement-surv
+    cm-chatsan-word-survs: cm-chatsan-replacement-survs
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This ones smaller, mostly adding sanitation for shortened stuff (nades) or adding a few missed ways to refer to things.

Few changes:
Scout removed, now it's Scout Spec/Scout Specialist (too common a term)
nuke -> hive killer (parity)
intel -> scavenger talls (What they've been called so far, xenos shouldn't have to ever refer to the papers/etc as intel I think)
survivor/survivors/surv/survs -> planet tall/planet talls (opposite of sky talls)


## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: More xeno chatsans, most for abbreviated terms, intel, and survivors.
- tweak: Scout is no longer part of the xeno chatsan. Scout spec and scout specialist are sanitized instead.
