### PR TITLE
cancel powerloader doafter on exit

### DIFF
--- a/Content.Shared/_RMC14/PowerLoader/PowerLoaderComponent.cs
+++ b/Content.Shared/_RMC14/PowerLoader/PowerLoaderComponent.cs
@@ -25,4 +25,7 @@ public sealed partial class PowerLoaderComponent : Component
 
     [DataField, AutoNetworkedField]
     public EntProtoId VirtualLeft = "RMCVirtualPowerLoaderLeft";
+
+    [DataField, AutoNetworkedField]
+    public DoAfter.DoAfter? DoAfter;
 }

--- a/Content.Shared/_RMC14/PowerLoader/PowerLoaderSystem.cs
+++ b/Content.Shared/_RMC14/PowerLoader/PowerLoaderSystem.cs
@@ -179,6 +179,9 @@ public sealed class PowerLoaderSystem : EntitySystem
 
         _movementSpeed.RefreshMovementSpeedModifiers(ent);
         DeleteVirtuals(ent, buckle);
+
+        if (ent.Comp.DoAfter != null && _doAfter.IsRunning(ent.Comp.DoAfter.Id))
+            _doAfter.Cancel(ent.Comp.DoAfter.Id);
     }
 
     private void OnUserActivateInWorld(Entity<PowerLoaderComponent> ent, ref UserActivateInWorldEvent args)
@@ -195,7 +198,8 @@ public sealed class PowerLoaderSystem : EntitySystem
             DuplicateCondition = DuplicateConditions.SameEvent,
         };
 
-        _doAfter.TryStartDoAfter(doAfter);
+        if (_doAfter.TryStartDoAfter(doAfter))
+            ent.Comp.DoAfter = ev.DoAfter;
     }
 
     private void OnGrabDoAfter(Entity<PowerLoaderComponent> ent, ref PowerLoaderGrabDoAfterEvent args)
@@ -246,7 +250,8 @@ public sealed class PowerLoaderSystem : EntitySystem
             DuplicateCondition = DuplicateConditions.SameEvent,
         };
 
-        _doAfter.TryStartDoAfter(doAfter);
+        if (_doAfter.TryStartDoAfter(doAfter))
+            ent.Comp.DoAfter = ev.DoAfter;
     }
 
     private void OnPointActivateInWorld(Entity<DropshipWeaponPointComponent> ent, ref ActivateInWorldEvent args)
@@ -276,7 +281,8 @@ public sealed class PowerLoaderSystem : EntitySystem
             DuplicateCondition = DuplicateConditions.SameEvent,
         };
 
-        _doAfter.TryStartDoAfter(doAfter);
+        if (_doAfter.TryStartDoAfter(doAfter))
+            loader.DoAfter = ev.DoAfter;
     }
 
     private void OnPointActivateInWorld(Entity<DropshipUtilityPointComponent> ent, ref ActivateInWorldEvent args)
@@ -306,7 +312,8 @@ public sealed class PowerLoaderSystem : EntitySystem
             DuplicateCondition = DuplicateConditions.SameEvent,
         };
 
-        _doAfter.TryStartDoAfter(doAfter);
+        if (_doAfter.TryStartDoAfter(doAfter))
+            loader.DoAfter = ev.DoAfter;
     }
 
     private void OnGrabbablePickupAttempt(Entity<PowerLoaderGrabbableComponent> ent, ref PickupAttemptEvent args)
@@ -605,7 +612,8 @@ public sealed class PowerLoaderSystem : EntitySystem
             BreakOnMove = true,
             DuplicateCondition = DuplicateConditions.SameEvent,
         };
-        _doAfter.TryStartDoAfter(doAfter);
+        if (_doAfter.TryStartDoAfter(doAfter) && TryComp<PowerLoaderComponent>(args.User, out var loader))
+            loader.DoAfter = ev.DoAfter;
     }
 
     private void OnActivePilotPreventCollide(Entity<ActivePowerLoaderPilotComponent> ent, ref PreventCollideEvent args)


### PR DESCRIPTION
## About the PR

This PR makes it so that exiting a power loader cancels any actions it started.

## Why / Balance

- Fixes #5640 

## Technical details

Keep track of the last doafter it started and cancel it when dismounting.

## Media

https://github.com/user-attachments/assets/159ee99f-13b4-4f40-8146-c4e49a6bd598

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed Power loaders continuing to load or unload after the operator gets out.