### PR TITLE
Fix fultons, burrows, and supply drops keeping pulls

### DIFF
--- a/Content.Shared/_RMC14/Dropship/Utility/Systems/RMCFultonSystem.cs
+++ b/Content.Shared/_RMC14/Dropship/Utility/Systems/RMCFultonSystem.cs
@@ -1,8 +1,9 @@
-﻿using Content.Shared._RMC14.Areas;
+using Content.Shared._RMC14.Areas;
 using Content.Shared._RMC14.Dropship.Utility.Components;
 using Content.Shared._RMC14.Dropship.Utility.Events;
 using Content.Shared._RMC14.Dropship.Weapon;
 using Content.Shared._RMC14.Marines.Skills;
+using Content.Shared._RMC14.Pulling;
 using Content.Shared._RMC14.Rules;
 using Content.Shared.Atmos.Rotting;
 using Content.Shared.Coordinates;
@@ -35,6 +36,7 @@ public sealed class RMCFultonSystem : EntitySystem
     [Dependency] private readonly SharedStackSystem _stack = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly RMCPullingSystem _rmcpulling = default!;
 
     private int _fultonCount;
     private MapId? _fultonMap;
@@ -114,6 +116,7 @@ public sealed class RMCFultonSystem : EntitySystem
 
         var name = Name(target);
         _dropshipWeapon.MakeTarget(target, name, false);
+        _rmcpulling.TryStopAllPullsFromAndOn(target);
 
         var mapId = EnsureMap();
         _transform.SetMapCoordinates(target, new MapCoordinates(_fultonCount++ * 50, 0, mapId));

--- a/Content.Shared/_RMC14/SupplyDrop/SharedSupplyDropSystem.cs
+++ b/Content.Shared/_RMC14/SupplyDrop/SharedSupplyDropSystem.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Numerics;
 using Content.Shared._RMC14.Areas;
 using Content.Shared._RMC14.CameraShake;
@@ -6,6 +6,7 @@ using Content.Shared._RMC14.Extensions;
 using Content.Shared._RMC14.Map;
 using Content.Shared._RMC14.Marines.Announce;
 using Content.Shared._RMC14.Marines.Squads;
+using Content.Shared._RMC14.Pulling;
 using Content.Shared._RMC14.Rules;
 using Content.Shared.Coordinates;
 using Content.Shared.Damage;
@@ -41,6 +42,7 @@ public abstract class SharedSupplyDropSystem : EntitySystem
     [Dependency] private readonly RMCPlanetSystem _rmcPlanet = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly RMCPullingSystem _rmcpulling = default!;
 
     private int _supplyDropCount;
     private MapId? _supplyDropMap;
@@ -174,26 +176,26 @@ public abstract class SharedSupplyDropSystem : EntitySystem
             !_rmcPlanet.TryPlanetToCoordinates(computer.Comp.Coordinates, out var mapCoordinates) ||
             !CanSupplyDropSquad(squad))
         {
-            _popup.PopupCursor("Supply drop pad is not operational.", user, PopupType.MediumCaution);
+            _popup.PopupCursor(Loc.GetString("rmc-supply-drop-not-operational"), user, PopupType.MediumCaution);
             return false;
         }
 
         if (!TryFindCrate(computer, out var crate))
         {
-            _popup.PopupCursor("No crate was detected on the drop pad. Get Requisitions on the line!", user, PopupType.MediumCaution);
+            _popup.PopupCursor(Loc.GetString("rmc-supply-drop-no-crate"), user, PopupType.MediumCaution);
             return false;
         }
 
         if (!_area.CanSupplyDrop(mapCoordinates))
         {
-            _popup.PopupCursor("The landing zone is underground. The supply drop cannot reach here.", user, PopupType.MediumCaution);
+            _popup.PopupCursor(Loc.GetString("rmc-supply-drop-underground"), user, PopupType.MediumCaution);
             return false;
         }
 
         if (_rmcMap.IsTileBlocked(mapCoordinates) ||
             _rmcMap.TryGetTileDef(mapCoordinates, out var tile) && tile.ID == ContentTileDefinition.SpaceID)
         {
-            _popup.PopupCursor("The landing zone appears to be obstructed or out of bounds. Package would be lost on drop.", user, PopupType.MediumCaution);
+            _popup.PopupCursor(Loc.GetString("rmc-supply-drop-blocked"), user, PopupType.MediumCaution);
             return false;
         }
 
@@ -201,14 +203,15 @@ public abstract class SharedSupplyDropSystem : EntitySystem
         if (_entityStorage.ResolveStorage(crate, ref storage) &&
             storage.Open)
         {
-            _popup.PopupCursor("The crate is not secure on the drop pad. Please close it!", user, PopupType.MediumCaution);
+            _popup.PopupCursor(Loc.GetString("rmc-supply-drop-crate-open"), user, PopupType.MediumCaution);
             return false;
         }
 
         var crateCoordinates = _transform.GetMoverCoordinates(crate);
-        _popup.PopupClient($"{Name(crate)} loads into a launch tube. Stand clear!", crateCoordinates, user, PopupType.Medium);
+        _popup.PopupClient(Loc.GetString("rmc-supply-drop-crate-load", ("crate", crate)), crateCoordinates, user, PopupType.Medium);
         _audio.PlayPredicted(crate.Comp.LaunchSound, crateCoordinates, user);
-        _marineAnnounce.AnnounceSquad($"{Name(crate)} supply drop incoming. Heads up!", squad);
+        _marineAnnounce.AnnounceSquad(Loc.GetString("rmc-supply-drop-squad-announcement", ("crate", crate)), squad);
+        _rmcpulling.TryStopAllPullsFromAndOn(crate);
 
         var mapId = EnsureMap();
         _transform.SetMapCoordinates(crate, new MapCoordinates(_supplyDropCount++ * 50, 0, mapId));

--- a/Content.Shared/_RMC14/Xenonids/Burrow/SharedXenoBurrowSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Burrow/SharedXenoBurrowSystem.cs
@@ -26,6 +26,7 @@ using Robust.Shared.Timing;
 using System.Diagnostics.CodeAnalysis;
 using Robust.Shared.Network;
 using Robust.Shared.Physics.Components;
+using Content.Shared._RMC14.Pulling;
 
 namespace Content.Shared._RMC14.Xenonids.Burrow;
 
@@ -51,6 +52,7 @@ public abstract class SharedXenoBurrowSystem : EntitySystem
     [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly XenoSystem _xeno = default!;
+    [Dependency] private readonly RMCPullingSystem _rmcPulling = default!;
 
     public override void Initialize()
     {
@@ -158,6 +160,7 @@ public abstract class SharedXenoBurrowSystem : EntitySystem
                 Dirty(action.Id, actComp);
             }
 
+            _rmcPulling.TryStopAllPullsFromAndOn(burrower);
             _transform.Unanchor(burrower);
             if (TryComp<PhysicsComponent>(burrower, out var body))
             {

--- a/Resources/Locale/en-US/_RMC14/supplydrop.ftl
+++ b/Resources/Locale/en-US/_RMC14/supplydrop.ftl
@@ -1,0 +1,8 @@
+rmc-supply-drop-not-operational = Supply drop pad is not operational.
+rmc-supply-drop-no-crate = No crate was detected on the drop pad. Get Requisitions on the line!
+rmc-supply-drop-underground = The landing zone is underground. The supply drop cannot reach here.
+rmc-supply-drop-blocked = The landing zone appears to be obstructed or out of bounds. Package would be lost on drop.
+rmc-supply-drop-crate-open = The crate is not secure on the drop pad. Please close it!
+
+rmc-supply-drop-crate-load = {$crate} loads into a launch tube. Stand clear!
+rmc-supply-drop-squad-announcement = {$crate} supply drop incoming. Heads up!


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug. You either get to teleport with them or your direction dies. Fixes #5619, discord issues.

## Technical details
<!-- Summary of code changes for easier review. -->
StopAllPullsFromAndOn added before any of said objects teleport/burrow. Also locale'd the supply drop system cause why not.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed burrow, fultoning, and supply drops not dropping pulls.
