### PR TITLE
Fix burrower pulls for real

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Burrow/SharedXenoBurrowSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Burrow/SharedXenoBurrowSystem.cs
@@ -160,7 +160,6 @@ public abstract class SharedXenoBurrowSystem : EntitySystem
                 Dirty(action.Id, actComp);
             }
 
-            _rmcPulling.TryStopAllPullsFromAndOn(burrower);
             _transform.Unanchor(burrower);
             if (TryComp<PhysicsComponent>(burrower, out var body))
             {
@@ -300,6 +299,7 @@ public abstract class SharedXenoBurrowSystem : EntitySystem
 
         burrower.Comp.ForcedUnburrowAt = _time.CurTime + burrower.Comp.BurrowMaxDuration;
         burrower.Comp.NextBurrowAt = _time.CurTime + burrower.Comp.BurrowCooldown;
+        _rmcPulling.TryStopAllPullsFromAndOn(burrower);
         Dirty(burrower);
 
         var ev = new BurrowedEvent(true);
@@ -415,6 +415,7 @@ public abstract class SharedXenoBurrowSystem : EntitySystem
         burrower.Comp.Tunneling = false;
         burrower.Comp.NextTunnelAt = null;
         burrower.Comp.ForcedUnburrowAt = null;
+        _rmcPulling.TryStopAllPullsFromAndOn(burrower);
         Dirty(burrower);
         if (_net.IsServer)
             _transform.SetCoordinates(burrower, _entities.GetCoordinates(args.TargetCoords));


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Realized where I put it wouldn't fix it for burrower. Changed to be both after burrow finishes and after tunneling finishes but before teleporting.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
m'bad.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
