### PR TITLE
make booze dispenser invincible

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Science/Dispensers/booze.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Science/Dispensers/booze.yml
@@ -21,6 +21,7 @@
       - Xeno
   - type: ApcPowerReceiver
     needsPower: false
+  - type: Godmode # todo rmc14 we really need the technology to remove single components because copying an entire parent is actually torturous and prone to errors in the future
 
 - type: reagentDispenserInventory
   id: CMDispenserBoozeInventory


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed booze dispenser being destructible, which was not intended behavior.
They're apparently supposed to be part of vendors being tipped over which makes sense to me.

**Changelog**

:cl: Whisper

- fix: Fixed booze dispensers being destructible.