### PR TITLE
rules clarification

### DIFF
--- a/Resources/ServerInfo/Guidebook/_RMC14/Rules/Roleplay/RMCGeneralRoleplayStandards.xml
+++ b/Resources/ServerInfo/Guidebook/_RMC14/Rules/Roleplay/RMCGeneralRoleplayStandards.xml
@@ -39,8 +39,8 @@
 
   Some parts of the game cannot be covered by mechanics to ensure proper roleplay and balance.
 
-  - Surrounding a comms tower or APC entirely with reinforced walls to prevent Xenonids attacking it [bold]without T3s[/bold] is not allowed. This is usually only relevant in the early game.\nWalls can be used to cover most of the object, however there must remain access for other xenos IE barricades.\nThis rule is no longer applied as soon as a T3 Xenonid has been witnessed.
-  - Xenonids also cannot surround a comms tower or APC entirely with walls, but can make an accessable room of it with a resin door.
+  - Surrounding an objective structure such as towers or APCs entirely with reinforced walls to prevent Xenonids attacking it [bold]without T3s[/bold] is not allowed. This is usually only relevant in the early game.\nWalls can be used to cover most of the object, however there must remain access for other xenos IE barricades.\nThis rule is no longer applied as soon as a T3 Xenonid has been witnessed.
+  - Xenonids also cannot surround an objective structure or APC entirely with walls, but can make an accessable room of it with a resin door. A room at minimum should have a tile of walkable space around the structure, with the spirit of the rule being that you are building a base that includes the structure, not encasing it in resin solely for out of character gameplay purposes.
   - Exploitation of any current game bugs. You can ask in ahelp if something is a bug to avoid this.
 
   [bold]Below is a list of common questions.[/bold]

--- a/Resources/ServerInfo/Guidebook/_RMC14/Rules/Roleplay/RMCGeneralRoleplayStandards.xml
+++ b/Resources/ServerInfo/Guidebook/_RMC14/Rules/Roleplay/RMCGeneralRoleplayStandards.xml
@@ -40,7 +40,7 @@
   Some parts of the game cannot be covered by mechanics to ensure proper roleplay and balance.
 
   - Surrounding an objective structure such as towers or APCs entirely with reinforced walls to prevent Xenonids attacking it [bold]without T3s[/bold] is not allowed. This is usually only relevant in the early game.\nWalls can be used to cover most of the object, however there must remain access for other xenos IE barricades.\nThis rule is no longer applied as soon as a T3 Xenonid has been witnessed.
-  - Xenonids also cannot surround an objective structure or APC entirely with walls, but can make an accessable room of it with a resin door. A room at minimum should have a tile of walkable space around the structure, with the spirit of the rule being that you are building a base that includes the structure, not encasing it in resin solely for out of character gameplay purposes.
+  - Xenonids also cannot surround an objective structure or APC entirely with walls, but can make an accessible room of it with a resin door. A room at minimum should have a tile of walkable space around the structure, with the spirit of the rule being that you are building a base that includes the structure, not encasing it in resin solely for out of character gameplay purposes.
   - Exploitation of any current game bugs. You can ask in ahelp if something is a bug to avoid this.
 
   [bold]Below is a list of common questions.[/bold]


### PR DESCRIPTION
  Some parts of the game cannot be covered by mechanics to ensure proper roleplay and balance.

  - Surrounding an objective structure such as towers or APCs entirely with reinforced walls to prevent Xenonids attacking it without T3s is not allowed. This is usually only relevant in the early game. Walls can be used to cover most of the object, however there must remain access for other xenos IE barricades. This rule is no longer applied as soon as a T3 Xenonid has been witnessed.
  - Xenonids also cannot surround an objective structure or APC entirely with walls, but can make an accessible room of it with a resin door. A room at minimum should have a tile of walkable space around the structure, with the spirit of the rule being that you are building a base that includes the structure, not encasing it in resin solely for out of character gameplay purposes.

