### PR TITLE
increase required playtime for pilots

### DIFF
--- a/Resources/Locale/en-US/_RMC14/job/cm-role-timers.ftl
+++ b/Resources/Locale/en-US/_RMC14/job/cm-role-timers.ftl
@@ -2,6 +2,7 @@
 role-timer-medical-roles = any medical roles
 role-timer-engineering-roles = any engineering roles
 role-timer-dropship-roles = any dropship roles
+role-timer-dropship-pilot-roles = any dropship pilot roles
 
 role-timer-total-department-insufficient = You require [color=yellow]{TOSTRING($time, "0")}[/color] more minutes as [color={$rolesColor}]{$roles}[/color] to play this role.
 role-timer-total-department-too-high = You require [color=yellow]{TOSTRING($time, "0")}[/color] fewer minutes as [color={$departmentColor}]{$rolesColor}[/color] to play this role. (Are you trying to play a trainee role?)

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/dropship_pilot.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/dropship_pilot.yml
@@ -7,7 +7,7 @@
   requirements:
   - !type:TotalJobsTimeRequirement
     group: CMJobsDropship
-    time: 36000 # 10 hours
+    time: 18000 # 5 hours
   ranks:
     RMCRankSecondLT: []
   startingGear: CMGearPilotDropship

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/dropship_pilot.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/dropship_pilot.yml
@@ -7,7 +7,7 @@
   requirements:
   - !type:TotalJobsTimeRequirement
     group: CMJobsDropship
-    time: 7200 # 2 hours
+    time: 36000 # 10 hours
   ranks:
     RMCRankSecondLT: []
   startingGear: CMGearPilotDropship

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/gunship_pilot.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/gunship_pilot.yml
@@ -6,7 +6,7 @@
   playTimeTracker: CMJobPilotGunship
   requirements:
   - !type:TotalJobsTimeRequirement
-    group: CMJobsDropship
+    group: CMJobsDropshipPilot
     time: 18000 # 5 hours
   ranks:
     RMCRankSecondLT: []

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/gunship_pilot.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/gunship_pilot.yml
@@ -7,7 +7,7 @@
   requirements:
   - !type:TotalJobsTimeRequirement
     group: CMJobsDropship
-    time: 7200 # 2 hours
+    time: 36000 # 10 hours
   ranks:
     RMCRankSecondLT: []
   startingGear: CMGearPilotGunship

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/gunship_pilot.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/gunship_pilot.yml
@@ -7,7 +7,7 @@
   requirements:
   - !type:TotalJobsTimeRequirement
     group: CMJobsDropship
-    time: 36000 # 10 hours
+    time: 18000 # 5 hours
   ranks:
     RMCRankSecondLT: []
   startingGear: CMGearPilotGunship

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Departments/human_job_groups.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Departments/human_job_groups.yml
@@ -58,3 +58,15 @@
     - CMDropshipCrewChief
     - CMPilotDropship
     - CMPilotGunship
+
+- type: entity
+  id: CMJobsDropshipPilot
+  categories:
+  - HideSpawnMenu
+  components:
+  - type: JobGroup
+    name: role-timer-dropship-pilot-roles
+    color: "#C38312"
+    jobs:
+    - CMPilotDropship
+    - CMPilotGunship


### PR DESCRIPTION
## About the PR

This PR increases the required playtime for pilots from 2h to 5h of DCC.

## Why / Balance

I have had too many pilots not knowing how to fly. Two hours are only 1-2 deployments of DCC and that's not enough. 

## Technical details

7200 * 2.5 = 18000

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- tweak: Playing DP now requires 5 hours of DCC time, up from 2.
- tweak: Playing GP now requires 5 hours of DP, up from 0. Existing GP time also contributes to this requirement.
