### PR TITLE
Fix being able to drop intel and continue to read

### DIFF
--- a/Content.Shared/_RMC14/Intel/IntelSystem.cs
+++ b/Content.Shared/_RMC14/Intel/IntelSystem.cs
@@ -248,7 +248,7 @@ public sealed class IntelSystem : EntitySystem
 
         var delay = ent.Comp.Delay * _skills.GetSkillDelayMultiplier(user, ent.Comp.Skill);
         var ev = new IntelReadDoAfterEvent();
-        var doAfter = new DoAfterArgs(EntityManager, user, delay, ev, ent) { BreakOnDropItem = true };
+        var doAfter = new DoAfterArgs(EntityManager, user, delay, ev, ent) { BreakOnDropItem = true, NeedHand = true };
         if (_doAfter.TryStartDoAfter(doAfter))
             _popup.PopupClient($"You start reading the {Name(ent)}", ent, user);
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Intel reading was missing a required attribute for `BreakOnItemDrop` in it's doafter parameters: `NeedHand`. Allowing someone to drop the intel and walk away from it while still reading it
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Reading something you drop, and further being able to walk away from it seems like a bit of a super power
## Technical details
<!-- Summary of code changes for easier review. -->
Add the `NeedHand` parameter to the Intel Reading do after 
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
before:
https://github.com/user-attachments/assets/1b96136b-b913-424f-a294-2c51b1c5666c
after:
https://github.com/user-attachments/assets/21ceccea-d21c-4544-b507-67956b8f9d15



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Kickguy223
- fix: Fixed being able to drop and walk away from a piece of intel you're reading