### PR TITLE
Fix blitz and lunge not checking stun/death on hit

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Blitz/XenoBlitzSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Blitz/XenoBlitzSystem.cs
@@ -14,6 +14,7 @@ using Content.Shared._RMC14.Xenonids.Sweep;
 using Robust.Shared.Audio.Systems;
 using Content.Shared._RMC14.Shields;
 using Content.Shared.Interaction;
+using Content.Shared.Stunnable;
 
 namespace Content.Shared._RMC14.Xenonids.Blitz;
 
@@ -84,7 +85,7 @@ public sealed class XenoBlitzSystem : EntitySystem
 
         SetBlitzDelays(xeno);
 
-        if (!_mob.IsAlive(xeno))
+        if (!_mob.IsAlive(xeno) || HasComp<StunnedComponent>(xeno))
             return;
 
         var ev = new XenoLeapAttemptEvent();

--- a/Content.Shared/_RMC14/Xenonids/Lunge/XenoLungeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Lunge/XenoLungeSystem.cs
@@ -1,7 +1,8 @@
-﻿using Content.Shared._RMC14.Marines;
+using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.Pulling;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared.Coordinates;
+using Content.Shared.Mobs.Systems;
 using Content.Shared.Movement.Pulling.Events;
 using Content.Shared.Movement.Pulling.Systems;
 using Content.Shared.StatusEffect;
@@ -28,6 +29,7 @@ public sealed class XenoLungeSystem : EntitySystem
     [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
     [Dependency] private readonly XenoSystem _xeno = default!;
     [Dependency] private readonly RMCPullingSystem _rmcPulling = default!;
+    [Dependency] private readonly MobStateSystem _mob = default!;
 
     private EntityQuery<PhysicsComponent> _physicsQuery;
     private EntityQuery<ThrownItemComponent> _thrownItemQuery;
@@ -87,6 +89,12 @@ public sealed class XenoLungeSystem : EntitySystem
 
     private void OnXenoLungeHit(Entity<XenoLungeComponent> xeno, ref ThrowDoHitEvent args)
     {
+        if (!_mob.IsAlive(xeno) || HasComp<StunnedComponent>(xeno))
+        {
+            xeno.Comp.Charge = null;
+            return;
+        }
+
         ApplyLungeHitEffects(xeno, args.Target);
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugs.

## Technical details
<!-- Summary of code changes for easier review. -->
Check for IsAlive and the stunned comp and cancel the lunge/blitz if so.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed lunge and blitz persisting after stun (and death) in some cases.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!

-->
