### PR TITLE
make dogtags not corrodible

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/IdCards/cm_base_id.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/IdCards/cm_base_id.yml
@@ -31,6 +31,9 @@
         enum.DogtagVisuals.Taken:
           True: { state: "dogtag_taken" }
           False: { state: "dogtag" }
+  - type: Corrodible
+    isCorrodible: false
+
 
 - type: entity
   parent: BaseItem


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Dog tags not corrodible, shouldn't have an effect on gameplay as far as I can think of
Requested by this [feature request](https://discord.com/channels/1168210010233376858/1328972047119810622), and the reasoning makes sense

**Changelog**

:cl: Whisper

- tweak: Dogtags can no longer be melted by acid.


