### PR TITLE
Acids-The-Map is no more

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Doors/Shutters/poddoor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Doors/Shutters/poddoor.yml
@@ -43,6 +43,8 @@
   - type: StaticPrice
     price: 280
   - type: RMCPodDoor
+  - type: Corrodible
+    isCorrodible: false
 
 - type: entity
   parent: RMCShutterBaseIndestructible
@@ -99,6 +101,8 @@
   components:
   - type: Door
     canPry: false # TODO RMC14
+  - type: Corrodible
+    isCorrodible: true
 
 - type: entity
   parent: RMCPodDoor


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Made Indestructible podlocks non-corrodible

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I don't think they should be corrodible. 
Maps use these to mark fully unaccessible zones, so Xenos being able to access them shouldn't happen.
Example is podlocks at the corners of the map which lead nowhere but can still be acided.

## Technical details
<!-- Summary of code changes for easier review. -->
Just made indestructible prototype noncorrodible and made the destructible podlocks corrodible since they have noncorrodible one as their parent.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://github.com/user-attachments/assets/19afab97-afec-4e14-8fc7-52b1efe9f861

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
-->
:cl: J C Denton
- fix: Indestructible podlocks are now unacidable too.