### PR TITLE
Engineering skill reduces tool use delay

### DIFF
--- a/Content.Shared/Tools/Components/RMCToolComponent.cs
+++ b/Content.Shared/Tools/Components/RMCToolComponent.cs
@@ -1,0 +1,16 @@
+using Content.Shared._RMC14.Marines.Skills;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Tools.Components;
+
+/// <summary>
+///     This is en extension of the upstream ToolComponent
+/// </summary>
+public sealed partial class ToolComponent
+{
+    /// <summary>
+    ///     The skill that modifies the doafter delay when using this tool.
+    /// </summary>
+    [DataField]
+    public EntProtoId<SkillDefinitionComponent> Skill = "RMCSkillEngineer";
+}

--- a/Content.Shared/Tools/Systems/SharedToolSystem.cs
+++ b/Content.Shared/Tools/Systems/SharedToolSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._RMC14.Tools;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.DoAfter;
@@ -167,6 +168,13 @@ public abstract partial class SharedToolSystem : EntitySystem
 
         if (!CanStartToolUse(tool, user, target, fuel, toolQualitiesNeeded, toolComponent))
             return false;
+
+        // RMC14
+        var ev = new RMCToolUseEvent(user, delay);
+
+        RaiseLocalEvent(tool, ref ev);
+        if(ev.Handled)
+            delay = ev.Delay;
 
         var toolEvent = new ToolDoAfterEvent(fuel, doAfterEv, GetNetEntity(target));
         var doAfterArgs = new DoAfterArgs(EntityManager, user, delay / toolComponent.SpeedModifier, toolEvent, tool, target: target, used: tool)

--- a/Content.Shared/_RMC14/Power/SharedRMCPowerSystem.cs
+++ b/Content.Shared/_RMC14/Power/SharedRMCPowerSystem.cs
@@ -649,7 +649,6 @@ public abstract class SharedRMCPowerSystem : EntitySystem
             return;
         }
 
-        var delay = ent.Comp.RepairDelay * _skills.GetSkillDelayMultiplier(user, ent.Comp.Skill);
         var quality = state switch
         {
             RMCFusionReactorState.Wrench => ent.Comp.WrenchQuality,
@@ -662,7 +661,7 @@ public abstract class SharedRMCPowerSystem : EntitySystem
             used,
             user,
             ent,
-            (float) delay.TotalSeconds,
+            (float)ent.Comp.RepairDelay.TotalSeconds,
             quality,
             new RMCFusionReactorRepairDoAfterEvent(state),
             ent.Comp.WeldingCost,

--- a/Content.Shared/_RMC14/Repairable/RMCRepairableSystem.cs
+++ b/Content.Shared/_RMC14/Repairable/RMCRepairableSystem.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Shared._RMC14.Damage;
 using Content.Shared._RMC14.Marines.Skills;
+using Content.Shared._RMC14.Tools;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Components.SolutionManager;
 using Content.Shared.Chemistry.EntitySystems;
@@ -48,7 +49,7 @@ public sealed class RMCRepairableSystem : EntitySystem
 
         SubscribeLocalEvent<ReagentTankComponent, InteractUsingEvent>(OnWelderInteractUsing);
     }
-
+//
     private void OnRepairableInteractUsing(Entity<RMCRepairableComponent> repairable, ref InteractUsingEvent args)
     {
         if (args.Handled)
@@ -105,6 +106,11 @@ public sealed class RMCRepairableSystem : EntitySystem
             BlockDuplicate = true,
             DuplicateCondition = DuplicateConditions.SameEvent
         };
+
+        var toolEvent = new RMCToolUseEvent(user, doAfter.Delay);
+        RaiseLocalEvent(args.Used, ref toolEvent);
+        if (toolEvent.Handled)
+            doAfter.Delay = toolEvent.Delay;
 
         if (_doAfter.TryStartDoAfter(doAfter))
         {

--- a/Content.Shared/_RMC14/Repairable/RMCRepairableSystem.cs
+++ b/Content.Shared/_RMC14/Repairable/RMCRepairableSystem.cs
@@ -11,7 +11,6 @@ using Content.Shared.Interaction;
 using Content.Shared.Item.ItemToggle.Components;
 using Content.Shared.Popups;
 using Content.Shared.Stacks;
-using Content.Shared.Storage.EntitySystems;
 using Content.Shared.Tools.Components;
 using Content.Shared.Tools.Systems;
 using Content.Shared.Weapons.Ranged;
@@ -99,10 +98,8 @@ public sealed class RMCRepairableSystem : EntitySystem
         if (!UseFuel(args.Used, args.User, repairable.Comp.FuelUsed, true))
             return;
 
-        var delay = repairable.Comp.Delay * _skills.GetSkillDelayMultiplier(args.User, repairable.Comp.Skill);
-
         var ev = new RMCRepairableDoAfterEvent();
-        var doAfter = new DoAfterArgs(EntityManager, user, delay, ev, repairable, used: args.Used)
+        var doAfter = new DoAfterArgs(EntityManager, user, repairable.Comp.Delay, ev, repairable, used: args.Used)
         {
             BreakOnMove = true,
             BlockDuplicate = true,

--- a/Content.Shared/_RMC14/Sensor/SensorTowerSystem.cs
+++ b/Content.Shared/_RMC14/Sensor/SensorTowerSystem.cs
@@ -208,7 +208,6 @@ public sealed class SensorTowerSystem : EntitySystem
             _ => throw new ArgumentOutOfRangeException(nameof(state), state, null)
         };
 
-        delay *= _skills.GetSkillDelayMultiplier(user, tower.Comp.Skill);
         _tool.UseTool(
             used,
             user,

--- a/Content.Shared/_RMC14/Tools/RMCToolSystem.cs
+++ b/Content.Shared/_RMC14/Tools/RMCToolSystem.cs
@@ -110,7 +110,7 @@ public sealed class RMCToolSystem : EntitySystem
 }
 
 /// <summary>
-///     Raised on an entity when they use a tool to possibly edit the DoAfter duration of the action.
+///     Raised on a tool when it's being used to possibly alter the delay of it's action.
 /// </summary>
 [ByRefEvent]
 public record struct RMCToolUseEvent(EntityUid User, TimeSpan Delay, bool Handled = false);

--- a/Content.Shared/_RMC14/Tools/RMCToolSystem.cs
+++ b/Content.Shared/_RMC14/Tools/RMCToolSystem.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared.Coordinates;
+﻿using Content.Shared._RMC14.Marines.Skills;
+using Content.Shared.Coordinates;
 using Content.Shared.Examine;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
@@ -18,12 +19,14 @@ public sealed class RMCToolSystem : EntitySystem
     [Dependency] private readonly IPrototypeManager _prototypes = default!;
     [Dependency] private readonly SharedStackSystem _stack = default!;
     [Dependency] private readonly SharedToolSystem _tool = default!;
+    [Dependency] private readonly SkillsSystem _skills = default!;
 
     public override void Initialize()
     {
         SubscribeLocalEvent<RMCRefinableComponent, ExaminedEvent>(OnRefinableExamined);
         SubscribeLocalEvent<RMCRefinableComponent, InteractUsingEvent>(OnRefinableInteractUsing);
         SubscribeLocalEvent<RMCRefinableComponent, RMCRefinableDoAfterEvent>(OnRefinableDoAfter);
+        SubscribeLocalEvent<ToolComponent, RMCToolUseEvent>(OnToolUse);
     }
 
     private void OnRefinableExamined(Entity<RMCRefinableComponent> ent, ref ExaminedEvent args)
@@ -92,4 +95,22 @@ public sealed class RMCToolSystem : EntitySystem
             SpawnAtPosition(spawn, ent.Owner.ToCoordinates());
         }
     }
+
+    /// <summary>
+    ///     Reduce the DoAfter duration of the tool action based on it's skill specialisation.
+    /// </summary>
+    private void OnToolUse(Entity<ToolComponent> ent, ref RMCToolUseEvent args)
+    {
+        if (!TryComp(args.User, out SkillsComponent? skills) || args.Handled)
+            return;
+
+        args.Delay *= _skills.GetSkillDelayMultiplier(args.User, ent.Comp.Skill);
+        args.Handled = true;
+    }
 }
+
+/// <summary>
+///     Raised on an entity when they use a tool to possibly edit the DoAfter duration of the action.
+/// </summary>
+[ByRefEvent]
+public record struct RMCToolUseEvent(EntityUid User, TimeSpan Delay, bool Handled = false);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
When using a tool, the DoAfter duration of the action is reduced based on the engineering skill of the user.

~Engineering skill still does not reduce "normal"(repairing anything that's not a generator/tower) repairing actions since I don't know yet if that's parity.~

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Resolves #5672 

## Technical details
<!-- Summary of code changes for easier review. -->
An event is now called when an entity uses a tool, if the user has the engineering skill the DoAfter duration will be reduced based on the level of the engineering skill.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Dygon
- fix: The engineering skill now speeds up how fast you deconstruct and repair objects.

