### PR TITLE
XO and SO vendor additions

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/command.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/command.yml
@@ -179,12 +179,45 @@
       - id: CMMaskGas
       - id: CMMaskCoif
       - id: RMCMaskRebreather
+
+    - name: Rail Attachments
+      entries:
+      - id: RMCAttachmentMagneticHarness
+        points: 12
+      - id: RMCAttachmentS5RedDotSight
+        points: 15
+      - id: RMCAttachmentS6ReflexSight
+        points: 15
+      - id: RMCAttachmentS42xTelescopicMiniscope
+        points: 15
+        
+    - name: Underbarrel Attachments
+      entries:
+      - id: RMCAttachmentLaserSight
+        points: 15
+      - id: RMCAttachmentAngledGrip
+        points: 15
+      - id: RMCAttachmentVerticalGrip
+        points: 15
+      - id: RMCAttachmentU7UnderbarrelShotgun
+        points: 15
+      - id: RMCAttachmentUnderbarrelExtinguisher
+        points: 15
+      - id: RMCAttachmentU1GrenadeLauncher
+        points: 5
+    - name: Barrel Attachments
+      entries:
+      - id: RMCAttachmentExtendedBarrel
+        points: 15
+      - id: RMCAttachmentRecoilCompensator
+        points: 15
+      - id: RMCAttachmentSuppressor
+        points: 15
+
     - name: Other Supplies
       entries:
       # - id: CMHelmetVisorMedical
       #   points: 5
-      - id: RMCAttachmentMagneticHarness
-        points: 12
       - id: RMCBackpackRTO
         points: 15
       - id: RMCBinoculars
@@ -301,6 +334,10 @@
         points: 15
     - name: Other Supplies
       entries:
+      - id: RMCBackpackRTO
+        points: 15
+      - id: RMCWeldingGoggles # Replace with RMCHelmetWeldingVisor when available
+        points: 5
       - id: CMHandsInsulated
         points: 3
       - id: RMCPouchMacheteFilled
@@ -688,6 +725,9 @@
       - id: CMBeltSecurityMPFilled
         name: M276 pattern security rig (Full)
         recommended: true
+      - id: CMBeltMedicalFilled
+        name: M276 pattern medical storage rig (Full)
+        recommended: true 
       - id: CMBeltMedicBagFilled
         name: M276 pattern lifesaver bag (Full)
         recommended: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Title
## Why / Balance
(Quality of life)
Follows the spirit of my original CO vendor PR. 
These changes will help reduce equip time for staff officers and the XO so they do not have to run around the ship to get most of their equipment.

 (Running around the Almayer to get equipped is a pain) 
## Technical details
Edits command.yml
## Media
Staff Officer:
![image](https://github.com/user-attachments/assets/f0f4a16e-a959-4aeb-bb16-817869796823)
Executive Officer:
![image](https://github.com/user-attachments/assets/0ff41d6a-0f2f-4c01-be4f-99141a6156cc)
![image](https://github.com/user-attachments/assets/077dc93c-60a4-4ae2-a471-f50e2f756fe8)



## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Attachments to SO vendor!
- add: RTO pack, welding goggles, as well as the M276 medical storage rig to XO's vendor!
