### PR TITLE
Solaris Ridge: Add timed rock walls to west caves

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Walls/solaris_walls.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Walls/solaris_walls.yml
@@ -62,3 +62,11 @@
   - type: IconSmooth
     key: walls
     base: solaris_rock
+
+- type: entity
+  parent: CMWallSolarisRock
+  id: RMCWallSolarisRockTimed
+  suffix: Timed
+  components:
+  - type: TimedDespawn
+    lifetime: 2400


### PR DESCRIPTION
## About the PR

Add rock walls with Timed Destruction set to 40 mins (40 * 60) to Solaris West Caves. Parity.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Solaris Caves north of Mining now have rock walls that disappear 40 minutes into a round.