### PR TITLE
Fiorina Science Annex Additions & M16 Ammo Boxes

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magazine_boxes.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magazine_boxes.yml
@@ -1246,7 +1246,3 @@
   - type: CMItemSlots
     startingItem: RMCMagazineRifleM16
     count: 12
-    slot:
-      whitelist:
-        tags:
-        - RMCMagazineRifleM16

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magazine_boxes.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magazine_boxes.yml
@@ -1209,3 +1209,44 @@
   components:
   - type: CMItemSlots
     startingItem: RMCCartridge458SOCOM
+
+  # M16
+- type: entity
+  parent: RMCBoxMagazineBase
+  id: RMCBoxMagazineRifleM16Empty
+  name: magazine box (M16 x 12)
+  components:
+  - type: Construction
+    graph: RMCBoxMagazine
+    node: RMCBoxMagazineRifleM16Empty
+  - type: Sprite
+    layers:
+    - state: base_m16 # icon_state = base color of box
+    - state: magaz_reg # overlay_content = sprite of mags
+      map: [ "enum.CMItemSlotsLayers.Fill" ]
+    - state: text_m16 # overlay_gun_type = text overlay
+    - state: base_type_reg # overlay_ammo_type = box stripe
+    - state: base_m16_lid # matches the base box
+      map: [ "lid" ]
+    - state: lid_type_reg # lid stripe,ends in the type of ammo used
+      map: [ "lid_stripe" ]
+  - type: CMItemSlots
+    count: 12
+    slot:
+      whitelist:
+        tags:
+        - RMCMagazineRifleM16
+
+- type: entity
+  parent: RMCBoxMagazineRifleM16Empty
+  id: RMCBoxMagazineRifleM16
+  suffix: Filled
+  name: magazine box (M16 x 12)
+  components:
+  - type: CMItemSlots
+    startingItem: RMCMagazineRifleM16
+    count: 12
+    slot:
+      whitelist:
+        tags:
+        - RMCMagazineRifleM16


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This PR is a big PR aimed at making most things Parity by adding many missing things to Fiorina (Plates, Tooboxes, Missing Motion Detectors, Mising M16 Ammo boxes, addition of Bipods near Survivor Camp, addition of all couches, addition of multiple missing pieces of clothing, Missing items in the Armory such Shotgun shell loading rig, missing Plasteel in the Engi Ring and reducing the amount of plasteel in the cabinet, adding crayons to the West of Engi Ring, equipping the entire kitchen south of the Engi Ring...)And my favorite. The Missing "Certified Powerloader Operator card"... Next to Fulton - Medevac Recovery systems[NorthEast of South LZ] many more changes.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity
## Technical details
<!-- Summary of code changes for easier review. -->
Bunch of .yml changes to prison.yml and .yml changes to magazine boxes.yml add M16 Boxes that spawn at West of LZ1
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
There is way too many changes to map to be able to properly send images of it. But here is the M16 Ammo boxes inside in-game entity spawner (I Tested them aswell they work well)
![image](https://github.com/user-attachments/assets/3d8c0b50-c1c0-4cf0-af62-9332c7ca4ee8)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Added missing plates, toolboxes, motion detectors, M16 ammo boxes, bipods, couches, clothing, shotgun shell loading rig, plasteel, crayons, kitchen items, and the powerloader operator card to Fiorina.


