### PR TITLE
implemented foxtrot

### DIFF
--- a/Content.Server/_RMC14/Ghost/GhostRoleApplySpecialComponent.cs
+++ b/Content.Server/_RMC14/Ghost/GhostRoleApplySpecialComponent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._RMC14.Ghost;
+
+[RegisterComponent]
+public sealed partial class GhostRoleApplySpecialComponent : Component
+{
+    [DataField]
+    public EntProtoId? Squad;
+}

--- a/Content.Server/_RMC14/Ghost/GhostRoleApplySpecialSystem.cs
+++ b/Content.Server/_RMC14/Ghost/GhostRoleApplySpecialSystem.cs
@@ -1,0 +1,73 @@
+using Content.Server._RMC14.Marines.Roles.Ranks;
+using Content.Server.Ghost.Roles.Components;
+using Content.Shared._RMC14.Marines.Squads;
+using Content.Shared.Access.Components;
+using Content.Shared.Clothing;
+using Content.Shared.Inventory;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._RMC14.Ghost;
+
+public sealed partial class GhostRoleApplySpecialSystem : EntitySystem
+{
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly LoadoutSystem _loadout = default!;
+    [Dependency] private readonly InventorySystem _inventory = default!;
+    [Dependency] private readonly SquadSystem _squad = default!;
+    [Dependency] private readonly MetaDataSystem _meta = default!;
+    [Dependency] private readonly RankSystem _rank = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<GhostRoleApplySpecialComponent, ComponentStartup>(OnStartup);
+    }
+
+    private void OnStartup(Entity<GhostRoleApplySpecialComponent> ent, ref ComponentStartup args)
+    {
+        if (!TryComp<GhostRoleComponent>(ent, out var ghostRole) ||
+            !TryComp(ent, out MetaDataComponent? metaData))
+            return;
+
+        if (ghostRole.JobProto is not { } jobProto)
+            return;
+
+        if (!_prototype.TryIndex(jobProto, out var job))
+            return;
+
+        if (job.StartingGear is { } gear)
+            _loadout.Equip(ent, [gear], null);
+
+        if (_inventory.TryGetSlotContainer(ent, "id", out var container, out var _))
+        {
+            foreach (var item in container.ContainedEntities)
+            {
+                if (TryComp<IdCardComponent>(item, out var card))
+                {
+                    card.FullName = metaData.EntityName;
+                    _meta.SetEntityName(item, $"{metaData.EntityName} ({job.LocalizedName})");
+                }
+            }
+        }
+
+        foreach (var special in job.Special)
+            special.AfterEquip(ent);
+
+        if (ent.Comp.Squad is { } squadProto && _squad.TryEnsureSquad(squadProto, out var squad))
+            _squad.AssignSquad(ent, squad.Owner, jobProto);
+
+        if (job.Ranks is { } ranks)
+        {
+            foreach (var rank in ranks)
+            {
+                if (rank.Value is null || rank.Value.Count == 0)
+                {
+                    _rank.SetRank(ent, rank.Key);
+                    break;
+                }
+            }
+        }
+
+        RemComp<GhostRoleApplySpecialComponent>(ent);
+    }
+}

--- a/Content.Server/_RMC14/Ghost/GhostRoleApplySpecialSystem.cs
+++ b/Content.Server/_RMC14/Ghost/GhostRoleApplySpecialSystem.cs
@@ -1,6 +1,7 @@
 using Content.Server._RMC14.Marines.Roles.Ranks;
 using Content.Server.Ghost.Roles.Components;
 using Content.Shared._RMC14.Marines.Squads;
+using Content.Shared._RMC14.Roles;
 using Content.Shared.Access.Components;
 using Content.Shared.Clothing;
 using Content.Shared.Inventory;
@@ -38,7 +39,7 @@ public sealed partial class GhostRoleApplySpecialSystem : EntitySystem
         if (job.StartingGear is { } gear)
             _loadout.Equip(ent, [gear], null);
 
-        if (_inventory.TryGetSlotContainer(ent, "id", out var container, out var _))
+        if (_inventory.TryGetSlotContainer(ent, "id", out var container, out _))
         {
             foreach (var item in container.ContainedEntities)
             {
@@ -50,11 +51,17 @@ public sealed partial class GhostRoleApplySpecialSystem : EntitySystem
             }
         }
 
+        AddComp(ent, new OriginalRoleComponent() { Job = jobProto });
         foreach (var special in job.Special)
             special.AfterEquip(ent);
 
         if (ent.Comp.Squad is { } squadProto && _squad.TryEnsureSquad(squadProto, out var squad))
+        {
+            if (_squad.TryGetSquadLeader(squad, out _))
+                RemComp<SquadLeaderComponent>(ent);
+
             _squad.AssignSquad(ent, squad.Owner, jobProto);
+        }
 
         if (job.Ranks is { } ranks)
         {

--- a/Content.Server/_RMC14/Ghost/GhostRolePreventCryoSleepComponent.cs
+++ b/Content.Server/_RMC14/Ghost/GhostRolePreventCryoSleepComponent.cs
@@ -1,0 +1,7 @@
+namespace Content.Server._RMC14.Ghost;
+
+[RegisterComponent]
+public sealed partial class GhostRolePreventCryoSleepComponent : Component
+{
+
+}

--- a/Content.Server/_RMC14/Ghost/GhostRolePreventCryoSleepSystem.cs
+++ b/Content.Server/_RMC14/Ghost/GhostRolePreventCryoSleepSystem.cs
@@ -14,8 +14,7 @@ public sealed partial class GhostRolePreventCryoSleepSystem : EntitySystem
 
     public void OnStartup(Entity<GhostRolePreventCryoSleepComponent> ent, ref ComponentStartup args)
     {
-        if (!RemComp<CanEnterCryostorageComponent>(ent))
-            RemComp<GhostRolePreventCryoSleepComponent>(ent);
+        RemComp<CanEnterCryostorageComponent>(ent);
     }
 
     public void OnTakeover(Entity<GhostRolePreventCryoSleepComponent> ent, ref MindAddedMessage args)

--- a/Content.Server/_RMC14/Ghost/GhostRolePreventCryoSleepSystem.cs
+++ b/Content.Server/_RMC14/Ghost/GhostRolePreventCryoSleepSystem.cs
@@ -1,0 +1,26 @@
+using Content.Shared.Bed.Cryostorage;
+using Content.Shared.Mind.Components;
+
+namespace Content.Server._RMC14.Ghost;
+
+public sealed partial class GhostRolePreventCryoSleepSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<GhostRolePreventCryoSleepComponent, ComponentStartup>(OnStartup);
+        SubscribeLocalEvent<GhostRolePreventCryoSleepComponent, MindAddedMessage>(OnTakeover);
+    }
+
+    public void OnStartup(Entity<GhostRolePreventCryoSleepComponent> ent, ref ComponentStartup args)
+    {
+        if (!RemComp<CanEnterCryostorageComponent>(ent))
+            RemComp<GhostRolePreventCryoSleepComponent>(ent);
+    }
+
+    public void OnTakeover(Entity<GhostRolePreventCryoSleepComponent> ent, ref MindAddedMessage args)
+    {
+        AddComp<CanEnterCryostorageComponent>(ent);
+        RemComp<GhostRolePreventCryoSleepComponent>(ent);
+    }
+}

--- a/Content.Server/_RMC14/Intel/Tech/TechSystem.cs
+++ b/Content.Server/_RMC14/Intel/Tech/TechSystem.cs
@@ -1,0 +1,82 @@
+using Content.Server.Ghost.Roles.Components;
+using Content.Server.Humanoid.Components;
+using Content.Server.Spawners.Components;
+using Content.Shared._RMC14.Intel.Tech;
+using Content.Shared.Humanoid.Prototypes;
+using Robust.Server.GameObjects;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+
+namespace Content.Server._RMC14.Intel.Tech;
+
+public sealed class ServerTechSystem : EntitySystem
+{
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly IPrototypeManager _proto = default!;
+    [Dependency] private readonly IComponentFactory _componentFactory = default!;
+    [Dependency] private readonly TransformSystem _transform = default!;
+
+    private static readonly EntProtoId CombatTechProto = "RMCRandomHumanoidFoxtrotCombatTech";
+    private static readonly EntProtoId FireteamLeaderProto = "RMCRandomHumanoidFoxtrotFireteamLeader";
+    private static readonly EntProtoId HospitalCorpsmanProto = "RMCRandomHumanoidFoxtrotHospitalCorpsman";
+    private static readonly EntProtoId RiflemanProto = "RMCRandomHumanoidFoxtrotRifleman";
+    private static readonly EntProtoId SmartGunOperatorProto = "RMCRandomHumanoidFoxtrotSmartGunOperator";
+    private static readonly EntProtoId SquadLeaderProto = "RMCRandomHumanoidFoxtrotSquadLeader";
+    private static readonly EntProtoId WeaponsSpecialistProto = "RMCRandomHumanoidFoxtrotWeaponsSpecialist";
+
+    private bool _cryoMarinesPurchased = false;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<TechCryoMarinesEvent>(OnTechCryoMarines);
+        SubscribeLocalEvent<TechCryoSpecEvent>(OnTechCryoSpec);
+    }
+
+    private void OnTechCryoMarines(TechCryoMarinesEvent ev)
+    {
+        if (_cryoMarinesPurchased)
+            SpawnCryo(FireteamLeaderProto, 1);
+        else
+            SpawnCryo(SquadLeaderProto, 1);
+
+        SpawnCryo(CombatTechProto, 2);
+        SpawnCryo(HospitalCorpsmanProto, 2);
+        SpawnCryo(RiflemanProto, 5);
+
+        _cryoMarinesPurchased = true;
+    }
+
+    private void OnTechCryoSpec(TechCryoSpecEvent ev)
+    {
+        SpawnCryo(WeaponsSpecialistProto, 1);
+    }
+
+    private void SpawnCryo(EntProtoId spawnerId, uint amount)
+    {
+        if (!_proto.TryIndex(spawnerId, out var spawner) ||
+            !spawner.TryGetComponent<RandomHumanoidSpawnerComponent>(out var human, _componentFactory) ||
+            human.SettingsPrototypeId is null ||
+            !_proto.TryIndex<RandomHumanoidSettingsPrototype>(human.SettingsPrototypeId, out var settings) ||
+            settings.Components is null ||
+            !settings.Components.TryGetComponent("GhostRole", out var ghostI))
+            return;
+
+        var ghost = (GhostRoleComponent)ghostI;
+
+        var spawners = AllEntityQuery<SpawnPointComponent>();
+        List<EntityUid> valid = [];
+        while (spawners.MoveNext(out var uid, out var comp))
+            if (comp.Job == ghost.JobProto)
+                valid.Add(uid);
+
+        if (valid.Count == 0)
+            return;
+
+        for (var i = 0; i < amount; i++)
+        {
+            var choice = _random.Pick(valid);
+            Spawn(spawnerId, _transform.GetMapCoordinates(choice));
+        }
+    }
+}

--- a/Content.Server/_RMC14/Intel/Tech/TechSystem.cs
+++ b/Content.Server/_RMC14/Intel/Tech/TechSystem.cs
@@ -35,11 +35,7 @@ public sealed class ServerTechSystem : EntitySystem
 
     private void OnTechCryoMarines(TechCryoMarinesEvent ev)
     {
-        if (_cryoMarinesPurchased)
-            SpawnCryo(FireteamLeaderProto, 1);
-        else
-            SpawnCryo(SquadLeaderProto, 1);
-
+        SpawnCryo(_cryoMarinesPurchased ? FireteamLeaderProto : SquadLeaderProto, 1);
         SpawnCryo(CombatTechProto, 1);
         SpawnCryo(HospitalCorpsmanProto, 1);
         SpawnCryo(RiflemanProto, 2);

--- a/Content.Server/_RMC14/Intel/Tech/TechSystem.cs
+++ b/Content.Server/_RMC14/Intel/Tech/TechSystem.cs
@@ -40,9 +40,9 @@ public sealed class ServerTechSystem : EntitySystem
         else
             SpawnCryo(SquadLeaderProto, 1);
 
-        SpawnCryo(CombatTechProto, 2);
-        SpawnCryo(HospitalCorpsmanProto, 2);
-        SpawnCryo(RiflemanProto, 5);
+        SpawnCryo(CombatTechProto, 1);
+        SpawnCryo(HospitalCorpsmanProto, 1);
+        SpawnCryo(RiflemanProto, 2);
 
         _cryoMarinesPurchased = true;
     }

--- a/Content.Shared/_RMC14/Intel/Tech/TechCryoMarinesEvent.cs
+++ b/Content.Shared/_RMC14/Intel/Tech/TechCryoMarinesEvent.cs
@@ -1,0 +1,7 @@
+﻿using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Intel.Tech;
+
+[DataRecord]
+[Serializable, NetSerializable]
+public sealed record TechCryoMarinesEvent();

--- a/Content.Shared/_RMC14/Intel/Tech/TechCryoSpecEvent.cs
+++ b/Content.Shared/_RMC14/Intel/Tech/TechCryoSpecEvent.cs
@@ -1,0 +1,7 @@
+﻿using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Intel.Tech;
+
+[DataRecord]
+[Serializable, NetSerializable]
+public sealed record TechCryoSpecEvent();

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Devices/portable_vendor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Devices/portable_vendor.yml
@@ -100,5 +100,7 @@
         points: 15
       - id: CMEncryptionKeyEcho
         points: 15
+      - id: CMEncryptionKeyFoxtrot
+        points: 15
       - id: CMEncryptionKeyColony
         points: 20

--- a/Resources/Prototypes/_RMC14/Entities/Objects/rmc_intel.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/rmc_intel.yml
@@ -268,6 +268,54 @@
           icon:
             sprite: _RMC14/Interface/tech_tree.rsi
             state: ob_cluster
+        - name: Unlock Tier 3
+          description: Transitions the tree to another tier.
+          cost: 5
+          events:
+          - !type:TechUnlockTierEvent
+            tier: 3
+          - !type:TechAnnounceEvent
+            author: ALMAYER DEFCON LEVEL INCREASED
+            message: "THREAT ASSESSMENT LEVEL INCREASED TO LEVEL 3.
+
+              LEVEL 3 assets have been authorised to handle the situation."
+          icon:
+            sprite: _RMC14/Interface/tech_tree.rsi
+            state: upgrade
+      -
+        - name: Wake Up Additional Troops
+          description: Wakes up additional troops to fight against any threats.
+          cost: 6
+          increase: 6
+          repurchasable: true
+          events:
+          - !type:TechCryoMarinesEvent
+          - !type:TechAnnounceEvent
+            author: ALMAYER SPECIAL ASSETS AUTHORIZED
+            message: Additional troops are being taken out of cryo.
+          icon:
+            sprite: _RMC14/Interface/tech_tree.rsi
+            state: cryotroops
+        - name: Wake Up Additional Specialist
+          description: Wakes up an additional specialist to fight against any threats.
+          cost: 8
+          events:
+          - !type:TechCryoSpecEvent
+          - !type:TechAnnounceEvent
+            author: ALMAYER SPECIAL ASSETS AUTHORIZED
+            message: An additional specialist is being taken out of cryo.
+          icon:
+            sprite: _RMC14/Interface/tech_tree.rsi
+            state: overshield
 
 - type: Tag
   id: RMCIntelItem
+
+- type: entity
+  parent: RMCIntelPaperScrap
+  id: RMCIntelDebug
+  suffix: DEBUG, DO NOT MAP
+  components:
+  - type: IntelReadObjective
+    state: Active
+    value: 999

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
@@ -615,6 +615,8 @@
         amount: 5
       - id: CMEncryptionKeyEcho
         amount: 5
+      - id: CMEncryptionKeyFoxtrot
+        amount: 5
       - id: CMEncryptionKeyEngineer
         amount: 5
       - id: CMEncryptionKeyIntel

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/mappings.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/mappings.yml
@@ -9,6 +9,8 @@
       SquadBravo: CMHeadsetBravo
       SquadCharlie: CMHeadsetCharlie
       SquadDelta: CMHeadsetDelta
+      SquadEcho: CMHeadsetEcho
+      SquadFoxtrot: CMHeadsetFoxtrot
 
 - type: entity
   id: CMVendorHeadsetSquadLeader
@@ -21,6 +23,8 @@
       SquadBravo: CMHeadsetBravoLeader
       SquadCharlie: CMHeadsetCharlieLeader
       SquadDelta: CMHeadsetDeltaLeader
+      SquadEcho: CMHeadsetEchoLeader
+      SquadFoxtrot: CMHeadsetFoxtrotLeader
 
 - type: entity
   id: CMVendorHeadsetSquadFTL
@@ -33,6 +37,8 @@
       SquadBravo: CMHeadsetBravoTeamLeader
       SquadCharlie: CMHeadsetCharlieTeamLeader
       SquadDelta: CMHeadsetDeltaTeamLeader
+      SquadEcho: CMHeadsetEchoTeamLeader
+      SquadFoxtrot: CMHeadsetFoxtrotTeamLeader
 
 - type: entity
   id: CMVendorHeadsetSquadComTech
@@ -45,6 +51,8 @@
       SquadBravo: CMHeadsetBravoEngineer
       SquadCharlie: CMHeadsetCharlieEngineer
       SquadDelta: CMHeadsetDeltaEngineer
+      SquadEcho: CMHeadsetEchoEngineer
+      SquadFoxtrot: CMHeadsetFoxtrotEngineer
 
 - type: entity
   id: CMVendorHeadsetSquadCorpsman
@@ -57,3 +65,5 @@
       SquadBravo: CMHeadsetBravoMedic
       SquadCharlie: CMHeadsetCharlieMedic
       SquadDelta: CMHeadsetDeltaMedic
+      SquadEcho: CMHeadsetEchoMedic
+      SquadFoxtrot: CMHeadsetFoxtrotMedic

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/combat_tech.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/combat_tech.yml
@@ -122,3 +122,20 @@
     role: CMCombatTech
   - type: Sprite
     state: engi_spawn_delta
+
+- type: randomHumanoidSettings
+  parent: RMCRandomHumanoidBase
+  id: RMCCombatTech
+  components:
+  - type: GhostRole
+    name: cm-job-name-combat-tech
+    description: cm-job-description-combat-tech
+    rules: ghost-role-information-nonantagonist-rules
+    reregister: false
+    raffle:
+      settings: default
+    job: CMCombatTech
+    requirements:
+    - !type:RoleTimeRequirement
+      role: CMJobCombatTech
+      time: 1

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/fireteam_leader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/fireteam_leader.yml
@@ -120,3 +120,20 @@
     role: CMFireteamLeader
   - type: Sprite
     state: tl_spawn_delta
+
+- type: randomHumanoidSettings
+  parent: RMCRandomHumanoidBase
+  id: RMCFireteamLeader
+  components:
+  - type: GhostRole
+    name: cm-job-name-fireteam-leader
+    description: cm-job-description-fireteam-leader
+    rules: ghost-role-information-nonantagonist-rules
+    reregister: false
+    raffle:
+      settings: default
+    job: CMFireteamLeader
+    requirements:
+    - !type:RoleTimeRequirement
+      role: CMJobFireteamLeader
+      time: 1

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/foxtrot.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/foxtrot.yml
@@ -1,0 +1,176 @@
+# combat technician
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidFoxtrotCombatTech
+  name: foxtrot ghost role combat technician
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCFoxtrotCombatTech
+
+- type: randomHumanoidSettings
+  parent: RMCFoxtrotBase
+  id: RMCFoxtrotCombatTech
+  components:
+  - type: GhostRole
+    name: cm-job-name-combat-tech
+    description: cm-job-description-combat-tech
+    rules: ghost-role-information-nonantagonist-rules
+    reregister: false
+    job: CMCombatTech
+
+# fireteam leader
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidFoxtrotFireteamLeader
+  name: foxtrot ghost role fireteam leader
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCFoxtrotFireteamLeader
+
+- type: randomHumanoidSettings
+  parent: RMCFoxtrotBase
+  id: RMCFoxtrotFireteamLeader
+  components:
+  - type: GhostRole
+    name: cm-job-name-fireteam-leader
+    description: cm-job-description-fireteam-leader
+    rules: ghost-role-information-nonantagonist-rules
+    reregister: false
+    job: CMFireteamLeader
+
+# hospital corpsman
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidFoxtrotHospitalCorpsman
+  name: foxtrot ghost role hospital corpsman
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCFoxtrotHospitalCorpsman
+
+- type: randomHumanoidSettings
+  parent: RMCFoxtrotBase
+  id: RMCFoxtrotHospitalCorpsman
+  components:
+  - type: GhostRole
+    name: cm-job-name-hospital-corpsman
+    description: cm-job-description-hospital-corpsman
+    rules: ghost-role-information-nonantagonist-rules
+    reregister: false
+    job: CMHospitalCorpsman
+
+# rifleman
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidFoxtrotRifleman
+  name: foxtrot ghost role rifleman
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCFoxtrotRifleman
+
+- type: randomHumanoidSettings
+  parent: RMCFoxtrotBase
+  id: RMCFoxtrotRifleman
+  components:
+  - type: GhostRole
+    name: cm-job-name-rifleman
+    description: cm-job-description-rifleman
+    rules: ghost-role-information-nonantagonist-rules
+    reregister: false
+    job: CMRifleman
+
+# smart gun operator
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidFoxtrotSmartGunOperator
+  name: foxtrot ghost role smart gun operator
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCFoxtrotSmartGunOperator
+
+- type: randomHumanoidSettings
+  parent: RMCFoxtrotBase
+  id: RMCFoxtrotSmartGunOperator
+  components:
+  - type: GhostRole
+    name: cm-job-name-smart-gun-operator
+    description: cm-job-description-smart-gun-operator
+    rules: ghost-role-information-nonantagonist-rules
+    reregister: false
+    job: CMSmartGunOperator
+
+# squad leader
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidFoxtrotSquadLeader
+  name: foxtrot ghost role squad leader
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCFoxtrotSquadLeader
+
+- type: randomHumanoidSettings
+  parent: RMCFoxtrotBase
+  id: RMCFoxtrotSquadLeader
+  components:
+  - type: GhostRole
+    name: cm-job-name-squad-leader
+    description: cm-job-description-squad-leader
+    rules: ghost-role-information-nonantagonist-rules
+    reregister: false
+    job: CMSquadLeader
+
+# weapons specialist
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidFoxtrotWeaponsSpecialist
+  name: foxtrot ghost role weapons specialist
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCFoxtrotWeaponsSpecialist
+
+- type: randomHumanoidSettings
+  parent: RMCFoxtrotBase
+  id: RMCFoxtrotWeaponsSpecialist
+  components:
+  - type: GhostRole
+    name: cm-job-name-weapons-specialist
+    description: cm-job-description-weapons-specialist
+    rules: ghost-role-information-nonantagonist-rules
+    reregister: false
+    job: CMWeaponsSpecialist
+
+# base
+- type: randomHumanoidSettings
+  parent: EventHumanoid
+  id: RMCFoxtrotBase
+  components:
+  - type: GhostRolePreventCryoSleep
+  - type: GhostRoleApplySpecial
+    squad: SquadFoxtrot

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/foxtrot.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/foxtrot.yml
@@ -20,6 +20,8 @@
     description: cm-job-description-combat-tech
     rules: ghost-role-information-nonantagonist-rules
     reregister: false
+    raffle:
+      settings: default
     job: CMCombatTech
 
 # fireteam leader
@@ -44,6 +46,8 @@
     description: cm-job-description-fireteam-leader
     rules: ghost-role-information-nonantagonist-rules
     reregister: false
+    raffle:
+      settings: default
     job: CMFireteamLeader
 
 # hospital corpsman
@@ -68,6 +72,8 @@
     description: cm-job-description-hospital-corpsman
     rules: ghost-role-information-nonantagonist-rules
     reregister: false
+    raffle:
+      settings: default
     job: CMHospitalCorpsman
 
 # rifleman
@@ -92,6 +98,8 @@
     description: cm-job-description-rifleman
     rules: ghost-role-information-nonantagonist-rules
     reregister: false
+    raffle:
+      settings: default
     job: CMRifleman
 
 # smart gun operator
@@ -116,6 +124,8 @@
     description: cm-job-description-smart-gun-operator
     rules: ghost-role-information-nonantagonist-rules
     reregister: false
+    raffle:
+      settings: default
     job: CMSmartGunOperator
 
 # squad leader
@@ -140,6 +150,8 @@
     description: cm-job-description-squad-leader
     rules: ghost-role-information-nonantagonist-rules
     reregister: false
+    raffle:
+      settings: default
     job: CMSquadLeader
 
 # weapons specialist
@@ -164,6 +176,8 @@
     description: cm-job-description-weapons-specialist
     rules: ghost-role-information-nonantagonist-rules
     reregister: false
+    raffle:
+      settings: default
     job: CMWeaponsSpecialist
 
 # base

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/ghosts/alpha.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/ghosts/alpha.yml
@@ -1,0 +1,118 @@
+# combat technician
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidAlphaCombatTech
+  name: alpha ghost role combat technician
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCAlphaCombatTech
+
+- type: randomHumanoidSettings
+  parent: [RMCCombatTech, RMCAlphaBase]
+  id: RMCAlphaCombatTech
+
+# fireteam leader
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidAlphaFireteamLeader
+  name: alpha ghost role fireteam leader
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCAlphaFireteamLeader
+
+- type: randomHumanoidSettings
+  parent: [RMCFireteamLeader, RMCAlphaBase]
+  id: RMCAlphaFireteamLeader
+
+# hospital corpsman
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidAlphaHospitalCorpsman
+  name: alpha ghost role hospital corpsman
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCAlphaHospitalCorpsman
+
+- type: randomHumanoidSettings
+  parent: [RMCHospitalCorpsman, RMCAlphaBase]
+  id: RMCAlphaHospitalCorpsman
+
+# rifleman
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidAlphaRifleman
+  name: alpha ghost role rifleman
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCAlphaRifleman
+
+- type: randomHumanoidSettings
+  parent: [RMCRifleman, RMCAlphaBase]
+  id: RMCAlphaRifleman
+
+# smart gun operator
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidAlphaSmartGunOperator
+  name: alpha ghost role smart gun operator
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCAlphaSmartGunOperator
+
+- type: randomHumanoidSettings
+  parent: [RMCSmartGunOperator, RMCAlphaBase]
+  id: RMCAlphaSmartGunOperator
+
+# squad leader
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidAlphaSquadLeader
+  name: alpha ghost role squad leader
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCAlphaSquadLeader
+
+- type: randomHumanoidSettings
+  parent: [RMCSquadLeader, RMCAlphaBase]
+  id: RMCAlphaSquadLeader
+
+# weapons specialist
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidAlphaWeaponsSpecialist
+  name: alpha ghost role weapons specialist
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCAlphaWeaponsSpecialist
+
+- type: randomHumanoidSettings
+  parent: [RMCWeaponsSpecialist, RMCAlphaBase]
+  id: RMCAlphaWeaponsSpecialist

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/ghosts/bravo.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/ghosts/bravo.yml
@@ -1,0 +1,118 @@
+# combat technician
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidBravoCombatTech
+  name: bravo ghost role combat technician
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCBravoCombatTech
+
+- type: randomHumanoidSettings
+  parent: [RMCCombatTech, RMCBravoBase]
+  id: RMCBravoCombatTech
+
+# fireteam leader
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidBravoFireteamLeader
+  name: bravo ghost role fireteam leader
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCBravoFireteamLeader
+
+- type: randomHumanoidSettings
+  parent: [RMCFireteamLeader, RMCBravoBase]
+  id: RMCBravoFireteamLeader
+
+# hospital corpsman
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidBravoHospitalCorpsman
+  name: bravo ghost role hospital corpsman
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCBravoHospitalCorpsman
+
+- type: randomHumanoidSettings
+  parent: [RMCHospitalCorpsman, RMCBravoBase]
+  id: RMCBravoHospitalCorpsman
+
+# rifleman
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidBravoRifleman
+  name: bravo ghost role rifleman
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCBravoRifleman
+
+- type: randomHumanoidSettings
+  parent: [RMCRifleman, RMCBravoBase]
+  id: RMCBravoRifleman
+
+# smart gun operator
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidBravoSmartGunOperator
+  name: bravo ghost role smart gun operator
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCBravoSmartGunOperator
+
+- type: randomHumanoidSettings
+  parent: [RMCSmartGunOperator, RMCBravoBase]
+  id: RMCBravoSmartGunOperator
+
+# squad leader
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidBravoSquadLeader
+  name: bravo ghost role squad leader
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCBravoSquadLeader
+
+- type: randomHumanoidSettings
+  parent: [RMCSquadLeader, RMCBravoBase]
+  id: RMCBravoSquadLeader
+
+# weapons specialist
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidBravoWeaponsSpecialist
+  name: bravo ghost role weapons specialist
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCBravoWeaponsSpecialist
+
+- type: randomHumanoidSettings
+  parent: [RMCWeaponsSpecialist, RMCBravoBase]
+  id: RMCBravoWeaponsSpecialist

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/ghosts/charlie.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/ghosts/charlie.yml
@@ -1,0 +1,118 @@
+# combat technician
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidCharlieCombatTech
+  name: charlie ghost role combat technician
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCCharlieCombatTech
+
+- type: randomHumanoidSettings
+  parent: [RMCCombatTech, RMCCharlieBase]
+  id: RMCCharlieCombatTech
+
+# fireteam leader
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidCharlieFireteamLeader
+  name: charlie ghost role fireteam leader
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCCharlieFireteamLeader
+
+- type: randomHumanoidSettings
+  parent: [RMCFireteamLeader, RMCCharlieBase]
+  id: RMCCharlieFireteamLeader
+
+# hospital corpsman
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidCharlieHospitalCorpsman
+  name: charlie ghost role hospital corpsman
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCCharlieHospitalCorpsman
+
+- type: randomHumanoidSettings
+  parent: [RMCHospitalCorpsman, RMCCharlieBase]
+  id: RMCCharlieHospitalCorpsman
+
+# rifleman
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidCharlieRifleman
+  name: charlie ghost role rifleman
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCCharlieRifleman
+
+- type: randomHumanoidSettings
+  parent: [RMCRifleman, RMCCharlieBase]
+  id: RMCCharlieRifleman
+
+# smart gun operator
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidCharlieSmartGunOperator
+  name: charlie ghost role smart gun operator
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCCharlieSmartGunOperator
+
+- type: randomHumanoidSettings
+  parent: [RMCSmartGunOperator, RMCCharlieBase]
+  id: RMCCharlieSmartGunOperator
+
+# squad leader
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidCharlieSquadLeader
+  name: charlie ghost role squad leader
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCCharlieSquadLeader
+
+- type: randomHumanoidSettings
+  parent: [RMCSquadLeader, RMCCharlieBase]
+  id: RMCCharlieSquadLeader
+
+# weapons specialist
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidCharlieWeaponsSpecialist
+  name: charlie ghost role weapons specialist
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCCharlieWeaponsSpecialist
+
+- type: randomHumanoidSettings
+  parent: [RMCWeaponsSpecialist, RMCCharlieBase]
+  id: RMCCharlieWeaponsSpecialist

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/ghosts/delta.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/ghosts/delta.yml
@@ -1,0 +1,118 @@
+# combat technician
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidDeltaCombatTech
+  name: delta ghost role combat technician
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCDeltaCombatTech
+
+- type: randomHumanoidSettings
+  parent: [RMCCombatTech, RMCDeltaBase]
+  id: RMCDeltaCombatTech
+
+# fireteam leader
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidDeltaFireteamLeader
+  name: delta ghost role fireteam leader
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCDeltaFireteamLeader
+
+- type: randomHumanoidSettings
+  parent: [RMCFireteamLeader, RMCDeltaBase]
+  id: RMCDeltaFireteamLeader
+
+# hospital corpsman
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidDeltaHospitalCorpsman
+  name: delta ghost role hospital corpsman
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCDeltaHospitalCorpsman
+
+- type: randomHumanoidSettings
+  parent: [RMCHospitalCorpsman, RMCDeltaBase]
+  id: RMCDeltaHospitalCorpsman
+
+# rifleman
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidDeltaRifleman
+  name: delta ghost role rifleman
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCDeltaRifleman
+
+- type: randomHumanoidSettings
+  parent: [RMCRifleman, RMCDeltaBase]
+  id: RMCDeltaRifleman
+
+# smart gun operator
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidDeltaSmartGunOperator
+  name: delta ghost role smart gun operator
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCDeltaSmartGunOperator
+
+- type: randomHumanoidSettings
+  parent: [RMCSmartGunOperator, RMCDeltaBase]
+  id: RMCDeltaSmartGunOperator
+
+# squad leader
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidDeltaSquadLeader
+  name: delta ghost role squad leader
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCDeltaSquadLeader
+
+- type: randomHumanoidSettings
+  parent: [RMCSquadLeader, RMCDeltaBase]
+  id: RMCDeltaSquadLeader
+
+# weapons specialist
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidDeltaWeaponsSpecialist
+  name: delta ghost role weapons specialist
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCDeltaWeaponsSpecialist
+
+- type: randomHumanoidSettings
+  parent: [RMCWeaponsSpecialist, RMCDeltaBase]
+  id: RMCDeltaWeaponsSpecialist

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/ghosts/echo.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/ghosts/echo.yml
@@ -1,0 +1,118 @@
+# combat technician
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidEchoCombatTech
+  name: echo ghost role combat technician
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCEchoCombatTech
+
+- type: randomHumanoidSettings
+  parent: [RMCCombatTech, RMCEchoBase]
+  id: RMCEchoCombatTech
+
+# fireteam leader
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidEchoFireteamLeader
+  name: echo ghost role fireteam leader
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCEchoFireteamLeader
+
+- type: randomHumanoidSettings
+  parent: [RMCFireteamLeader, RMCEchoBase]
+  id: RMCEchoFireteamLeader
+
+# hospital corpsman
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidEchoHospitalCorpsman
+  name: echo ghost role hospital corpsman
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCEchoHospitalCorpsman
+
+- type: randomHumanoidSettings
+  parent: [RMCHospitalCorpsman, RMCEchoBase]
+  id: RMCEchoHospitalCorpsman
+
+# rifleman
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidEchoRifleman
+  name: echo ghost role rifleman
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCEchoRifleman
+
+- type: randomHumanoidSettings
+  parent: [RMCRifleman, RMCEchoBase]
+  id: RMCEchoRifleman
+
+# smart gun operator
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidEchoSmartGunOperator
+  name: echo ghost role smart gun operator
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCEchoSmartGunOperator
+
+- type: randomHumanoidSettings
+  parent: [RMCSmartGunOperator, RMCEchoBase]
+  id: RMCEchoSmartGunOperator
+
+# squad leader
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidEchoSquadLeader
+  name: echo ghost role squad leader
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCEchoSquadLeader
+
+- type: randomHumanoidSettings
+  parent: [RMCSquadLeader, RMCEchoBase]
+  id: RMCEchoSquadLeader
+
+# weapons specialist
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidEchoWeaponsSpecialist
+  name: echo ghost role weapons specialist
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCEchoWeaponsSpecialist
+
+- type: randomHumanoidSettings
+  parent: [RMCWeaponsSpecialist, RMCEchoBase]
+  id: RMCEchoWeaponsSpecialist

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/ghosts/foxtrot.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/ghosts/foxtrot.yml
@@ -12,17 +12,8 @@
     settings: RMCFoxtrotCombatTech
 
 - type: randomHumanoidSettings
-  parent: RMCFoxtrotBase
+  parent: [RMCCombatTech, RMCFoxtrotBase]
   id: RMCFoxtrotCombatTech
-  components:
-  - type: GhostRole
-    name: cm-job-name-combat-tech
-    description: cm-job-description-combat-tech
-    rules: ghost-role-information-nonantagonist-rules
-    reregister: false
-    raffle:
-      settings: default
-    job: CMCombatTech
 
 # fireteam leader
 - type: entity
@@ -38,17 +29,8 @@
     settings: RMCFoxtrotFireteamLeader
 
 - type: randomHumanoidSettings
-  parent: RMCFoxtrotBase
+  parent: [RMCFireteamLeader, RMCFoxtrotBase]
   id: RMCFoxtrotFireteamLeader
-  components:
-  - type: GhostRole
-    name: cm-job-name-fireteam-leader
-    description: cm-job-description-fireteam-leader
-    rules: ghost-role-information-nonantagonist-rules
-    reregister: false
-    raffle:
-      settings: default
-    job: CMFireteamLeader
 
 # hospital corpsman
 - type: entity
@@ -64,17 +46,8 @@
     settings: RMCFoxtrotHospitalCorpsman
 
 - type: randomHumanoidSettings
-  parent: RMCFoxtrotBase
+  parent: [RMCHospitalCorpsman, RMCFoxtrotBase]
   id: RMCFoxtrotHospitalCorpsman
-  components:
-  - type: GhostRole
-    name: cm-job-name-hospital-corpsman
-    description: cm-job-description-hospital-corpsman
-    rules: ghost-role-information-nonantagonist-rules
-    reregister: false
-    raffle:
-      settings: default
-    job: CMHospitalCorpsman
 
 # rifleman
 - type: entity
@@ -90,17 +63,8 @@
     settings: RMCFoxtrotRifleman
 
 - type: randomHumanoidSettings
-  parent: RMCFoxtrotBase
+  parent: [RMCRifleman, RMCFoxtrotBase]
   id: RMCFoxtrotRifleman
-  components:
-  - type: GhostRole
-    name: cm-job-name-rifleman
-    description: cm-job-description-rifleman
-    rules: ghost-role-information-nonantagonist-rules
-    reregister: false
-    raffle:
-      settings: default
-    job: CMRifleman
 
 # smart gun operator
 - type: entity
@@ -116,17 +80,8 @@
     settings: RMCFoxtrotSmartGunOperator
 
 - type: randomHumanoidSettings
-  parent: RMCFoxtrotBase
+  parent: [RMCSmartGunOperator, RMCFoxtrotBase]
   id: RMCFoxtrotSmartGunOperator
-  components:
-  - type: GhostRole
-    name: cm-job-name-smart-gun-operator
-    description: cm-job-description-smart-gun-operator
-    rules: ghost-role-information-nonantagonist-rules
-    reregister: false
-    raffle:
-      settings: default
-    job: CMSmartGunOperator
 
 # squad leader
 - type: entity
@@ -142,17 +97,8 @@
     settings: RMCFoxtrotSquadLeader
 
 - type: randomHumanoidSettings
-  parent: RMCFoxtrotBase
+  parent: [RMCSquadLeader, RMCFoxtrotBase]
   id: RMCFoxtrotSquadLeader
-  components:
-  - type: GhostRole
-    name: cm-job-name-squad-leader
-    description: cm-job-description-squad-leader
-    rules: ghost-role-information-nonantagonist-rules
-    reregister: false
-    raffle:
-      settings: default
-    job: CMSquadLeader
 
 # weapons specialist
 - type: entity
@@ -168,23 +114,5 @@
     settings: RMCFoxtrotWeaponsSpecialist
 
 - type: randomHumanoidSettings
-  parent: RMCFoxtrotBase
+  parent: [RMCWeaponsSpecialist, RMCFoxtrotBase]
   id: RMCFoxtrotWeaponsSpecialist
-  components:
-  - type: GhostRole
-    name: cm-job-name-weapons-specialist
-    description: cm-job-description-weapons-specialist
-    rules: ghost-role-information-nonantagonist-rules
-    reregister: false
-    raffle:
-      settings: default
-    job: CMWeaponsSpecialist
-
-# base
-- type: randomHumanoidSettings
-  parent: EventHumanoid
-  id: RMCFoxtrotBase
-  components:
-  - type: GhostRolePreventCryoSleep
-  - type: GhostRoleApplySpecial
-    squad: SquadFoxtrot

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/ghosts/intel.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/ghosts/intel.yml
@@ -1,0 +1,118 @@
+# combat technician
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidIntelCombatTech
+  name: intel ghost role combat technician
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCIntelCombatTech
+
+- type: randomHumanoidSettings
+  parent: [RMCCombatTech, RMCIntelBase]
+  id: RMCIntelCombatTech
+
+# fireteam leader
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidIntelFireteamLeader
+  name: intel ghost role fireteam leader
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCIntelFireteamLeader
+
+- type: randomHumanoidSettings
+  parent: [RMCFireteamLeader, RMCIntelBase]
+  id: RMCIntelFireteamLeader
+
+# hospital corpsman
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidIntelHospitalCorpsman
+  name: intel ghost role hospital corpsman
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCIntelHospitalCorpsman
+
+- type: randomHumanoidSettings
+  parent: [RMCHospitalCorpsman, RMCIntelBase]
+  id: RMCIntelHospitalCorpsman
+
+# rifleman
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidIntelRifleman
+  name: intel ghost role rifleman
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCIntelRifleman
+
+- type: randomHumanoidSettings
+  parent: [RMCRifleman, RMCIntelBase]
+  id: RMCIntelRifleman
+
+# smart gun operator
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidIntelSmartGunOperator
+  name: intel ghost role smart gun operator
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCIntelSmartGunOperator
+
+- type: randomHumanoidSettings
+  parent: [RMCSmartGunOperator, RMCIntelBase]
+  id: RMCIntelSmartGunOperator
+
+# squad leader
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidIntelSquadLeader
+  name: intel ghost role squad leader
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCIntelSquadLeader
+
+- type: randomHumanoidSettings
+  parent: [RMCSquadLeader, RMCIntelBase]
+  id: RMCIntelSquadLeader
+
+# weapons specialist
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidIntelWeaponsSpecialist
+  name: intel ghost role weapons specialist
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCIntelWeaponsSpecialist
+
+- type: randomHumanoidSettings
+  parent: [RMCWeaponsSpecialist, RMCIntelBase]
+  id: RMCIntelWeaponsSpecialist

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/hospital_corpsman.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/hospital_corpsman.yml
@@ -125,4 +125,19 @@
   - type: Sprite
     state: marine_spawn_delta
 
-
+- type: randomHumanoidSettings
+  parent: RMCRandomHumanoidBase
+  id: RMCHospitalCorpsman
+  components:
+  - type: GhostRole
+    name: cm-job-name-hospital-corpsman
+    description: cm-job-description-hospital-corpsman
+    rules: ghost-role-information-nonantagonist-rules
+    reregister: false
+    raffle:
+      settings: default
+    job: CMHospitalCorpsman
+    requirements:
+    - !type:RoleTimeRequirement
+      role: CMJobHospitalCorpsman
+      time: 1

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/rifleman.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/rifleman.yml
@@ -120,3 +120,20 @@
   components:
   - type: Sprite
     state: rifleman
+
+- type: randomHumanoidSettings
+  parent: RMCRandomHumanoidBase
+  id: RMCRifleman
+  components:
+  - type: GhostRole
+    name: cm-job-name-rifleman
+    description: cm-job-description-rifleman
+    rules: ghost-role-information-nonantagonist-rules
+    reregister: false
+    raffle:
+      settings: default
+    job: CMRifleman
+    requirements:
+    - !type:RoleTimeRequirement
+      role: CMJobRifleman
+      time: 1

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/smart_gun_operator.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/smart_gun_operator.yml
@@ -121,3 +121,19 @@
   - type: Sprite
     state: smartgunner_spawn_delta
 
+- type: randomHumanoidSettings
+  parent: RMCRandomHumanoidBase
+  id: RMCSmartGunOperator
+  components:
+  - type: GhostRole
+    name: cm-job-name-smart-gun-operator
+    description: cm-job-description-smart-gun-operator
+    rules: ghost-role-information-nonantagonist-rules
+    reregister: false
+    raffle:
+      settings: default
+    job: CMSmartGunOperator
+    requirements:
+    - !type:RoleTimeRequirement
+      role: CMJobSmartGunOperator
+      time: 1

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/squad_leader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/squad_leader.yml
@@ -144,3 +144,19 @@
   - type: Sprite
     state: leader_spawn_delta
 
+- type: randomHumanoidSettings
+  parent: RMCRandomHumanoidBase
+  id: RMCSquadLeader
+  components:
+  - type: GhostRole
+    name: cm-job-name-squad-leader
+    description: cm-job-description-squad-leader
+    rules: ghost-role-information-nonantagonist-rules
+    reregister: false
+    raffle:
+      settings: default
+    job: CMSquadLeader
+    requirements:
+    - !type:RoleTimeRequirement
+      role: CMJobSquadLeader
+      time: 1

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/weapons_specialist.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/weapons_specialist.yml
@@ -127,3 +127,19 @@
   - type: Sprite
     state: spec_spawn_delta
 
+- type: randomHumanoidSettings
+  parent: RMCRandomHumanoidBase
+  id: RMCWeaponsSpecialist
+  components:
+  - type: GhostRole
+    name: cm-job-name-weapons-specialist
+    description: cm-job-description-weapons-specialist
+    rules: ghost-role-information-nonantagonist-rules
+    reregister: false
+    raffle:
+      settings: default
+    job: CMWeaponsSpecialist
+    requirements:
+    - !type:RoleTimeRequirement
+      role: CMJobWeaponsSpecialist
+      time: 1

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/ghosts.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/ghosts.yml
@@ -1,0 +1,57 @@
+# base
+- type: randomHumanoidSettings
+  parent: EventHumanoid
+  id: RMCRandomHumanoidBase
+  components:
+  - type: GhostRolePreventCryoSleep
+  - type: GhostRoleApplySpecial
+
+# squads
+- type: randomHumanoidSettings
+  parent: RMCRandomHumanoidBase
+  id: RMCAlphaBase
+  components:
+  - type: GhostRoleApplySpecial
+    squad: SquadAlpha
+
+- type: randomHumanoidSettings
+  parent: RMCRandomHumanoidBase
+  id: RMCBravoBase
+  components:
+  - type: GhostRoleApplySpecial
+    squad: SquadBravo
+
+- type: randomHumanoidSettings
+  parent: RMCRandomHumanoidBase
+  id: RMCCharlieBase
+  components:
+  - type: GhostRoleApplySpecial
+    squad: SquadCharlie
+
+- type: randomHumanoidSettings
+  parent: RMCRandomHumanoidBase
+  id: RMCDeltaBase
+  components:
+  - type: GhostRoleApplySpecial
+    squad: SquadDelta
+
+- type: randomHumanoidSettings
+  parent: RMCRandomHumanoidBase
+  id: RMCEchoBase
+  components:
+  - type: GhostRoleApplySpecial
+    squad: SquadEcho
+
+- type: randomHumanoidSettings
+  parent: RMCRandomHumanoidBase
+  id: RMCFoxtrotBase
+  components:
+  - type: GhostRoleApplySpecial
+    squad: SquadFoxtrot
+
+- type: randomHumanoidSettings
+  parent: RMCRandomHumanoidBase
+  id: RMCIntelBase
+  components:
+  - type: GhostRoleApplySpecial
+    squad: SquadIntel


### PR DESCRIPTION
## About the PR

This PR adds DEFCON 3, which includes the foxtrot squad.

The specialist spawner just spawns one specialist and is a one time purchase.
The marines spawner spawns a squad leader the first time and FTLs after that in addition to a corpsman and technicians, and two rifleman.

## Why / Balance

parity

## Technical details

- GhostRoleApplySpecialComponent to basically have a "spawn job" component.
- GhostRolePreventCryoSleepComponent to prevent people from moving unclaimed ghost roles into cryosleep and potentially removing them.
- RMCIntelDebug for faster tech tree debugging
- TechCryoMarinesEvent and TechCryoSpecEvent in tier 3, as seen in CM13
- Foxtrot (and missing echo) keys and headsets in vendors
- Spawners for all squad roles
- ServerTechSystem extended to spawn foxtrot on the given events

## Media


https://github.com/user-attachments/assets/99218d9c-dfb6-44f3-82c8-cfa7498fdd77

Video went on a bit too long, as I forgot that the tracker wasn't in the frame.

![Screenshot From 2025-02-25 18-09-59](https://github.com/user-attachments/assets/63c31d44-d939-40de-a39a-48111479e95b)


## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: The foxtrot squad can now be awoken.
