### PR TITLE
Parity Engi and Requi doors.

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Doors/Airlocks/accesses-almayer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Doors/Airlocks/accesses-almayer.yml
@@ -5,7 +5,7 @@
   suffix: Requisitions, Locked
   components:
   - type: AccessReader
-    access: [ [ "CMAccessRequisitions" ] ]
+    access: [ ["CMAccessRequisitions"], ["CMAccessCommand"] ]
   - type: PaintableAirlock
     department: CMRequisitions
 
@@ -15,7 +15,7 @@
   suffix: Requisitions, Locked, Glass
   components:
   - type: AccessReader
-    access: [ [ "CMAccessRequisitions" ] ]
+    access: [ [ "CMAccessRequisitions" ], ["CMAccessCommand"] ]
 
 - type: entity
   parent: CMAirlockMaint
@@ -23,7 +23,7 @@
   suffix: Requisitions, Locked, Maint
   components:
   - type: AccessReader
-    access: [ [ "CMAccessRequisitions" ] ]
+    access: [ [ "CMAccessRequisitions" ], ["CMAccessCommand"] ]
   - type: PaintableAirlock
     department: CMRequisitions
 
@@ -64,7 +64,7 @@
   suffix: Engineering, Locked
   components:
   - type: AccessReader
-    access: [ [ "CMAccessEngineering" ] ]
+    access: [ [ "CMAccessEngineering" ], ["CMAccessCommand"] ]
 
 - type: entity
   parent: CMAirlockGlassEngineer
@@ -72,7 +72,7 @@
   suffix: Engineering, Locked, Glass
   components:
   - type: AccessReader
-    access: [ [ "CMAccessEngineering" ] ]
+    access: [ [ "CMAccessEngineering" ], ["CMAccessCommand"] ]
 
 - type: entity
   parent: CMAirlockMaint
@@ -80,7 +80,7 @@
   suffix: Engineering, Locked, Maint
   components:
   - type: AccessReader
-    access: [ [ "CMAccessEngineering" ] ]
+    access: [ [ "CMAccessEngineering" ], ["CMAccessCommand"] ]
   - type: PaintableAirlock
     department: CMEngineering
 

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Doors/Airlocks/accesses-almayer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Doors/Airlocks/accesses-almayer.yml
@@ -1,21 +1,14 @@
 # Req
 - type: entity
-  parent: CMAirlockEngineer
+  parent: CMAirlockPrep
   id: CMAirlockRequisitionsLocked
+  name: requisitions bay
   suffix: Requisitions, Locked
   components:
   - type: AccessReader
     access: [ ["CMAccessRequisitions"], ["CMAccessCommand"] ]
   - type: PaintableAirlock
     department: CMRequisitions
-
-- type: entity
-  parent: CMAirlockGlassEngineer
-  id: CMAirlockGlassRequisitionsLocked
-  suffix: Requisitions, Locked, Glass
-  components:
-  - type: AccessReader
-    access: [ [ "CMAccessRequisitions" ], ["CMAccessCommand"] ]
 
 - type: entity
   parent: CMAirlockMaint

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Doors/Airlocks/airlocks.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Doors/Airlocks/airlocks.yml
@@ -21,6 +21,7 @@
 - type: entity
   parent: CMAirlock
   id: CMAirlockCommand
+  name: command airlock
   suffix: Command
   components:
   - type: Sprite
@@ -31,6 +32,7 @@
 - type: entity
   parent: CMAirlock
   id: CMAirlockEngineer
+  name: engineering airlock
   suffix: Engineering
   components:
   - type: Sprite
@@ -41,6 +43,7 @@
 - type: entity
   parent: CMAirlock
   id: CMAirlockMedical
+  name: medical airlock
   suffix: Medical
   components:
   - type: Sprite
@@ -51,6 +54,7 @@
 - type: entity
   parent: CMAirlock
   id: CMAirlockSecurity
+  name: security airlock
   suffix: Security
   components:
   - type: Sprite
@@ -61,7 +65,7 @@
 - type: entity
   parent: CMAirlock
   id: CMAirlockMaint
-  name: maintenance
+  name: maintenance hatch
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Doors/Airlocks/maint_door.rsi
@@ -175,6 +179,7 @@
 - type: entity
   parent: CMAirlockGlass
   id: CMAirlockGlassEngineer
+  name: engineering airlock
   suffix: Engineer
   components:
   - type: Sprite
@@ -185,6 +190,7 @@
 - type: entity
   parent: CMAirlockGlass
   id: CMAirlockGlassMedical
+  name: medical airlock
   suffix: Medical
   components:
   - type: Sprite
@@ -195,6 +201,7 @@
 - type: entity
   parent: CMAirlockGlass
   id: CMAirlockGlassSecurity
+  name: security airlock
   suffix: Security
   components:
   - type: Sprite

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -1081,3 +1081,6 @@ RMCAreaSavannahPumpStarboard Quarter: RMCAreaSavannahPumpStarboardQuarter
 # 2025-02-21
 RMCWindowFrameHybrisaEngigReinforced: RMCWindowFrameHybrisaEngiReinforced
 RMCWindowHybrisaResearchlReinforced: RMCWindowHybrisaResearchReinforced
+
+# 2025-02-25
+CMAirlockGlassRequisitionsLocked: CMAirlockRequisitionsLocked


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Names airlocks, adds command access to Requi and Engi doors, changes Requi door sprite from Engi to Prep door.

Requi
```
/obj/structure/machinery/door/airlock/almayer/marine/requisitions
  req_one_access = list(ACCESS_MARINE_COMMAND, ACCESS_MARINE_CARGO)
```
Engi
```
/obj/structure/machinery/door/airlock/almayer/engineering
  req_one_access = list(ACCESS_MARINE_COMMAND, ACCESS_MARINE_ENGINEERING)
```
From `code/game/machinery/doors/airlock_types.dm`

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
