### PR TITLE
fixed the speedloader box for M44 marksman

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magazine_boxes.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magazine_boxes.yml
@@ -751,7 +751,7 @@
     slot:
       whitelist:
         tags:
-        - RMCSpeedLoaderM44
+        - RMCSpeedLoader44Marksman
 
 # Nailgun
 

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magazine_boxes.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magazine_boxes.yml
@@ -738,7 +738,7 @@
     slot:
       whitelist:
         tags:
-        - RMCSpeedLoaderM44
+        - RMCSpeedLoader44Marksman
 
 - type: entity
   parent: RMCBoxMagazineRevolverM44MarksmanEmpty


### PR DESCRIPTION
## About the PR

Fixes the whitelist of the speedloader box for M44 marksman.

## Why / Balance

bugfix

## Technical details

Had the wrong whitelist tag.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: The marksman M44 speedloader box can now be refilled.
