### PR TITLE
Add warding bleedout reduction and crit grace period

### DIFF
--- a/Content.Client/_RMC14/Xenonids/Hud/XenoHudOverlay.cs
+++ b/Content.Client/_RMC14/Xenonids/Hud/XenoHudOverlay.cs
@@ -28,6 +28,7 @@ using Robust.Shared.Utility;
 using Content.Shared._RMC14.Xenonids.Finesse;
 using static Robust.Shared.Utility.SpriteSpecifier;
 using Content.Shared._RMC14.Slow;
+using Content.Shared._RMC14.Xenonids.CriticalGrace;
 
 namespace Content.Client._RMC14.Xenonids.Hud;
 
@@ -474,7 +475,8 @@ public sealed class XenoHudOverlay : Overlay
         _mobThresholds.TryGetDeadThreshold(uid, out var deadThresholdNullable, mobThresholds);
 
         string state;
-        if (_mobState.IsCritical(uid, mobState))
+        if (_mobState.IsCritical(uid, mobState) ||
+            (_mobState.IsAlive(uid) && critThresholdNullable != null && damageable.TotalDamage > critThresholdNullable))
         {
             if (critThresholdNullable is not { } critThreshold || deadThresholdNullable is not { } deadThreshold)
                 return;

--- a/Content.Client/_RMC14/Xenonids/Hud/XenoHudOverlay.cs
+++ b/Content.Client/_RMC14/Xenonids/Hud/XenoHudOverlay.cs
@@ -28,7 +28,6 @@ using Robust.Shared.Utility;
 using Content.Shared._RMC14.Xenonids.Finesse;
 using static Robust.Shared.Utility.SpriteSpecifier;
 using Content.Shared._RMC14.Slow;
-using Content.Shared._RMC14.Xenonids.CriticalGrace;
 
 namespace Content.Client._RMC14.Xenonids.Hud;
 

--- a/Content.Shared/_RMC14/Damage/DamageStateCritBeforeDamageEvent.cs
+++ b/Content.Shared/_RMC14/Damage/DamageStateCritBeforeDamageEvent.cs
@@ -1,0 +1,6 @@
+using Content.Shared.Damage;
+
+namespace Content.Shared._RMC14.Damage;
+
+[ByRefEvent]
+public record struct DamageStateCritBeforeDamageEvent(DamageSpecifier Damage);

--- a/Content.Shared/_RMC14/Damage/SharedRMCDamageableSystem.cs
+++ b/Content.Shared/_RMC14/Damage/SharedRMCDamageableSystem.cs
@@ -392,6 +392,7 @@ public abstract class SharedRMCDamageableSystem : EntitySystem
                 case MobState.Critical:
                     _damageable.TryChangeDamage(uid, comp.NonDeadDamage, true, damageable: damageable);
                     var ev = new DamageStateCritBeforeDamageEvent(comp.CritDamage);
+                    RaiseLocalEvent(uid, ref ev);
                     _damageable.TryChangeDamage(uid, ev.Damage, true, damageable: damageable);
                     break;
             }

--- a/Content.Shared/_RMC14/Damage/SharedRMCDamageableSystem.cs
+++ b/Content.Shared/_RMC14/Damage/SharedRMCDamageableSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared._RMC14.Armor;
+using Content.Shared._RMC14.Armor;
 using Content.Shared._RMC14.Entrenching;
 using Content.Shared._RMC14.Map;
 using Content.Shared._RMC14.Marines.Orders;
@@ -391,7 +391,8 @@ public abstract class SharedRMCDamageableSystem : EntitySystem
                     break;
                 case MobState.Critical:
                     _damageable.TryChangeDamage(uid, comp.NonDeadDamage, true, damageable: damageable);
-                    _damageable.TryChangeDamage(uid, comp.CritDamage, true, damageable: damageable);
+                    var ev = new DamageStateCritBeforeDamageEvent(comp.CritDamage);
+                    _damageable.TryChangeDamage(uid, ev.Damage, true, damageable: damageable);
                     break;
             }
         }

--- a/Content.Shared/_RMC14/Xenonids/CriticalGrace/CriticalGraceSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/CriticalGrace/CriticalGraceSystem.cs
@@ -34,8 +34,6 @@ public sealed partial class CriticalGraceSystem : EntitySystem
         RaiseLocalEvent(ent, ref ev);
         grace.GraceEndsAt = _timing.CurTime + ev.Time;
 
-        //Don't run on stopping/stopped/removing/deleted
-        //if (grace.LifeStage < ComponentLifeStage.Stopping)
         args.State = Shared.Mobs.MobState.Alive;
     }
 

--- a/Content.Shared/_RMC14/Xenonids/CriticalGrace/CriticalGraceSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/CriticalGrace/CriticalGraceSystem.cs
@@ -1,0 +1,69 @@
+using Content.Shared.Mobs.Components;
+using Content.Shared.Mobs.Systems;
+using Robust.Shared.Network;
+using Robust.Shared.Timing;
+
+namespace Content.Shared._RMC14.Xenonids.CriticalGrace;
+
+public sealed partial class CriticalGraceSystem : EntitySystem
+{
+    [Dependency] private readonly MobThresholdSystem _mobThresholds = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly INetManager _net = default!;
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<CriticalGraceTimeComponent, UpdateMobStateEvent>(OnCriticalGraceMobState, after: [typeof(MobThresholdSystem)]);
+        SubscribeLocalEvent<InCriticalGraceComponent, ComponentShutdown>(OnInCriticalGraceRemove);
+    }
+
+    private void OnCriticalGraceMobState(Entity<CriticalGraceTimeComponent> ent, ref UpdateMobStateEvent args)
+    {
+        if (args.State != Shared.Mobs.MobState.Critical || !_mobState.HasState(ent, Shared.Mobs.MobState.Critical))
+            return;
+
+        if (TryComp<InCriticalGraceComponent>(ent, out var crit))
+        {
+            if (!crit.Over)
+                args.State = Shared.Mobs.MobState.Alive;
+            return;
+        }
+
+        var grace = EnsureComp<InCriticalGraceComponent>(ent);
+        var ev = new GetCriticalGraceTimeEvent(ent.Comp.GraceDuration);
+        RaiseLocalEvent(ent, ref ev);
+        grace.GraceEndsAt = _timing.CurTime + ev.Time;
+
+        //Don't run on stopping/stopped/removing/deleted
+        //if (grace.LifeStage < ComponentLifeStage.Stopping)
+        args.State = Shared.Mobs.MobState.Alive;
+    }
+
+    private void OnInCriticalGraceRemove(Entity<InCriticalGraceComponent> ent, ref ComponentShutdown args)
+    {
+        if (!TerminatingOrDeleted(ent) && TryComp<MobThresholdsComponent>(ent, out var thresholds))
+        {
+            _mobThresholds.VerifyThresholds(ent, thresholds);
+        }
+    }
+
+    public override void Update(float frameTime)
+    {
+        if (_net.IsClient)
+            return;
+
+        var time = _timing.CurTime;
+
+        var graceQuery = EntityQueryEnumerator<InCriticalGraceComponent>();
+
+        while (graceQuery.MoveNext(out var uid, out var grace))
+        {
+            if (time < grace.GraceEndsAt)
+                continue;
+
+            grace.Over = true;
+            RemCompDeferred<InCriticalGraceComponent>(uid);
+            Dirty(uid, grace);
+        }
+    }
+}

--- a/Content.Shared/_RMC14/Xenonids/CriticalGrace/CriticalGraceTimeComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/CriticalGrace/CriticalGraceTimeComponent.cs
@@ -1,0 +1,12 @@
+using Content.Shared.Alert;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._RMC14.Xenonids.CriticalGrace;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class CriticalGraceTimeComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public TimeSpan GraceDuration = TimeSpan.FromSeconds(1);
+}

--- a/Content.Shared/_RMC14/Xenonids/CriticalGrace/GetCriticalGraceTimeEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/CriticalGrace/GetCriticalGraceTimeEvent.cs
@@ -1,0 +1,4 @@
+namespace Content.Shared._RMC14.Xenonids.CriticalGrace;
+
+[ByRefEvent]
+public record struct GetCriticalGraceTimeEvent(TimeSpan Time);

--- a/Content.Shared/_RMC14/Xenonids/CriticalGrace/InCriticalGraceComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/CriticalGrace/InCriticalGraceComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.CriticalGrace;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class InCriticalGraceComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public TimeSpan GraceEndsAt;
+
+    [DataField, AutoNetworkedField]
+    public bool Over = false;
+}

--- a/Content.Shared/_RMC14/Xenonids/Pheromones/XenoWardingPheromonesComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Pheromones/XenoWardingPheromonesComponent.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Damage.Prototypes;
+using Content.Shared.Damage.Prototypes;
 using Content.Shared.FixedPoint;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
@@ -15,8 +15,8 @@ public sealed partial class XenoWardingPheromonesComponent : Component
     public SpriteSpecifier Icon = new Rsi(new ResPath("/Textures/_RMC14/Interface/xeno_pheromones_hud.rsi"), "warding");
 
     [DataField, AutoNetworkedField]
-    public FixedPoint2 Multiplier;
+    public ProtoId<DamageGroupPrototype> CritDamageGroup = "Brute";
 
     [DataField, AutoNetworkedField]
-    public List<ProtoId<DamageTypePrototype>> DamageTypes = new() { "Bloodloss", "Asphyxiation" };
+    public FixedPoint2 Multiplier;
 }

--- a/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Content.Shared._RMC14.Atmos;
 using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Damage;
@@ -109,6 +109,7 @@ public sealed class XenoSystem : EntitySystem
         SubscribeLocalEvent<XenoComponent, MeleeHitEvent>(OnXenoMeleeHit);
         SubscribeLocalEvent<XenoComponent, HiveChangedEvent>(OnHiveChanged);
         SubscribeLocalEvent<XenoComponent, RMCIgniteEvent>(OnXenoIgnite);
+        SubscribeLocalEvent<XenoComponent, DamageStateCritBeforeDamageEvent>(OnXenoBeforeCritDamage);
 
         Subs.CVar(_config, RMCCVars.CMXenoDamageDealtMultiplier, v => _xenoDamageDealtMultiplier = v, true);
         Subs.CVar(_config, RMCCVars.CMXenoDamageReceivedMultiplier, v => _xenoDamageReceivedMultiplier = v, true);
@@ -258,6 +259,15 @@ public sealed class XenoSystem : EntitySystem
             _damageable.TryChangeDamage(held, damage, true);
             _hands.TryDrop(ent, held);
         }
+    }
+
+    private void OnXenoBeforeCritDamage(Entity<XenoComponent> ent, ref DamageStateCritBeforeDamageEvent args)
+    {
+        if (!_rmcFlammable.IsOnFire(ent.Owner))
+            return;
+
+        //Don't take bleedout damage on fire
+        args.Damage.ClampMax(0);
     }
 
     private void UpdateXenoSpeedMultiplier(float speed)

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
@@ -295,6 +295,7 @@
     durationMultiplier: 0.666
   - type: RMCCanBeFultoned
   - type: CMArmor
+  - type: CriticalGraceTime
 
 - type: entity
   abstract: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity! Finishing up pheros.

## Technical details
<!-- Summary of code changes for easier review. -->
Extra crit health is now 20 per level, removed that other phero TODOs (can't find anything about frenzy stacking in CM code other than comments which are...not helpful.)

Added an event that is raised before critical damage bleedout, so warding pheros can reduce it and heal on weeds. Also added an obscure thing where xenos won't take bleedout damage on fire (its a thing apparently).

Added a CriticalGraceSystem which handles the critical grace system of allowing those with the comp to move a bit if they would fall into crit. Uses an event to get duration.

Some changes were made to overlay and mobstate systems so they show the proper crit stuff while the mob is still "alive".

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/b7a0f52b-cc35-4473-a68f-30854600f76e


https://github.com/user-attachments/assets/aa2f2ed1-9b80-4543-bcbf-1087d97f4018



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed warding giving twice as much crit health as it should have
- fix: Fixed warding not slowing bleedout off weeds, and not healing crit xenos slightly on weeds
- fix: Fixed xenos bleeding out while on fire (they only take the fire damage, not bleedout damage)
- add: Added critical grace for xenos. By default for 1 second xenos can move around when they would have crit. Non-lesser warding pheros add an addition second or two to the critical grace timer.
