### PR TITLE
Add pointblank cooldown

### DIFF
--- a/Content.Shared/_RMC14/Weapons/Ranged/CMGunSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/CMGunSystem.cs
@@ -21,6 +21,7 @@ using Content.Shared.Projectiles;
 using Content.Shared.Standing;
 using Content.Shared.Timing;
 using Content.Shared.Weapons.Melee;
+using Content.Shared.Weapons.Melee.Events;
 using Content.Shared.Weapons.Ranged;
 using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Weapons.Ranged.Events;
@@ -369,6 +370,20 @@ public sealed class CMGunSystem : EntitySystem
         }
     }
 
+    private void OnGunPointBlankMeleeHit(Entity<GunPointBlankComponent> gun, ref MeleeHitEvent args)
+    {
+        if (!TryComp<MeleeWeaponComponent>(gun, out var melee))
+            return;
+
+        if (!TryGetGunUser(gun.Owner, out var user))
+            return;
+
+        var userDelay = EnsureComp<UserPointblankCooldownComponent>(user);
+
+        //After meleeing can't PB
+        userDelay.LastPBAt = _timing.CurTime;
+    }
+
     private void OnGunPointBlankAmmoShot(Entity<GunPointBlankComponent> gun, ref AmmoShotEvent args)
     {
         if (!TryComp(gun.Owner, out GunComponent? gunComp) ||
@@ -412,6 +427,7 @@ public sealed class CMGunSystem : EntitySystem
 
         if (!TryComp<MeleeWeaponComponent>(gun, out var melee))
             return;
+
         //Can't melee right after a PB
         melee.NextAttack = userDelay.LastPBAt + userDelay.TimeBetweenPBs;
         Dirty(gun, melee);

--- a/Content.Shared/_RMC14/Weapons/Ranged/CMGunSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/CMGunSystem.cs
@@ -20,6 +20,7 @@ using Content.Shared.Popups;
 using Content.Shared.Projectiles;
 using Content.Shared.Standing;
 using Content.Shared.Timing;
+using Content.Shared.Weapons.Melee;
 using Content.Shared.Weapons.Ranged;
 using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Weapons.Ranged.Events;
@@ -408,6 +409,11 @@ public sealed class CMGunSystem : EntitySystem
         }
 
         userDelay.LastPBAt = _timing.CurTime;
+
+        if (!TryComp<MeleeWeaponComponent>(gun, out var melee))
+            return;
+        //Can't melee right after a PB
+        melee.NextAttack = userDelay.LastPBAt;
     }
 
     private void OnRecoilSkilledRefreshModifiers(Entity<GunSkilledRecoilComponent> ent, ref GunRefreshModifiersEvent args)

--- a/Content.Shared/_RMC14/Weapons/Ranged/CMGunSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/CMGunSystem.cs
@@ -414,6 +414,7 @@ public sealed class CMGunSystem : EntitySystem
             return;
         //Can't melee right after a PB
         melee.NextAttack = userDelay.LastPBAt;
+        Dirty(gun, melee);
     }
 
     private void OnRecoilSkilledRefreshModifiers(Entity<GunSkilledRecoilComponent> ent, ref GunRefreshModifiersEvent args)

--- a/Content.Shared/_RMC14/Weapons/Ranged/CMGunSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/CMGunSystem.cs
@@ -413,7 +413,7 @@ public sealed class CMGunSystem : EntitySystem
         if (!TryComp<MeleeWeaponComponent>(gun, out var melee))
             return;
         //Can't melee right after a PB
-        melee.NextAttack = userDelay.LastPBAt;
+        melee.NextAttack = userDelay.LastPBAt + userDelay.TimeBetweenPBs;
         Dirty(gun, melee);
     }
 

--- a/Content.Shared/_RMC14/Weapons/Ranged/UserPointblankCooldownComponent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/UserPointblankCooldownComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Weapons.Ranged;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class UserPointblankCooldownComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public TimeSpan LastPBAt;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan TimeBetweenPBs = TimeSpan.FromSeconds(1.1);
+}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
parity! In CM it works off click delay (so melee attack speed), but I just made it it's own tracked time here. Fixes #5132
, fixes #5473

## Technical details
<!-- Summary of code changes for easier review. -->
New userpointblankcooldowncomp, that keeps track of the last PB time and has a set time between PB attempts (This is 1.1 atm, gotten from item attack speed in CM), and also sets the next melee attack speed so you can't instantly melee after PBing.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/1dc3435c-43d7-4ed9-b2d7-4c75390d5720



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed there being no delays between PB shots. There is now a 1.1 second interval between when you PB anything, before you can PB again. Shots will just register as normal shots until the delay is over.
- fix: Fixed PBing not putting a gun on melee cooldown. Meleeing also puts a gun on PB cooldown.
