### PR TITLE
Fix xeno pheromone UI spawning in screen corners when watching other xenos.

### DIFF
--- a/Content.Client/_RMC14/Xenonids/Pheromones/XenoPheromonesBui.cs
+++ b/Content.Client/_RMC14/Xenonids/Pheromones/XenoPheromonesBui.cs
@@ -74,7 +74,12 @@ public sealed class XenoPheromonesBui : BoundUserInterface
 
         var vpSize = _displayManager.ScreenSize;
         var pos = _inputManager.MouseScreenPosition.Position / vpSize;
-        if (_player.LocalEntity is { } ent)
+
+        if (EntMan.TryGetComponent<EyeComponent>(Owner, out var eyeComp) &&
+            eyeComp.Target != null)
+            pos = _eye.WorldToScreen(_transform.GetMapCoordinates((EntityUid)eyeComp.Target).Position) / vpSize;
+
+        else if (_player.LocalEntity is { } ent)
             pos = _eye.WorldToScreen(_transform.GetMapCoordinates(ent).Position) / vpSize;
 
         _xenoPheromonesMenu.OpenCenteredAt(pos);


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
i fix it

## Technical details
If user eyeComponent currently has a follow target (like when watching other xeno), use that to spawn the UI instead of users physical body position

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

:cl:
- fix: Xeno pheromone UI no longer spawns in screen corners when watching other xeno.
