### PR TITLE
[April Fools] Add Cool Melee Weapons to Rifleman Vendor

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/rifleman.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/rifleman.yml
@@ -20,6 +20,16 @@
       - id: CMMRE
         name: MRE
       #- id: CMMap # TODO: Make a map
+    - name: SuperSpecial
+      entries:
+      - id: Throngler
+        points: 46
+      - id: WeaponMeleeToolboxRobust
+        points: 45
+      - id: Chainsaw
+        points: 5
+      - id: WeaponBagguete
+        points: 5
     - name: Armor
       choices: { CMArmour: 1 }
       entries:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/rifleman.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/rifleman.yml
@@ -28,7 +28,7 @@
         points: 45
       - id: Chainsaw
         points: 5
-      - id: WeaponBagguete
+      - id: WeaponBaguette
         points: 5
     - name: Armor
       choices: { CMArmour: 1 }


### PR DESCRIPTION
## About the PR

Adds next melee weapons to Rifleman Vendor:
- Throngler (Fast)
- Battle Red Toolbox (Robust)
- Battle Baguette (French)
- Chainsaw (Just like in anime)

Because:
- Marines currently lack any good melee weapons (boot knife, crowbar and throwable knifes??? **CHILDS PLAY!!**).
- Melee cool.
- Why can Xenos stab, but marines cant? Sounds woke.
- Imagine using pulses or whatever to propel bullets?

(April Fools Update.)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- add: Added Battle Toolbox, Chainsaw and Baguette to Rifleman vendor.
