### PR TITLE
M79 vendor fixes + daze duration multiplier

### DIFF
--- a/Content.Server/Explosion/Components/RMCProjectileGrenadeComponent.cs
+++ b/Content.Server/Explosion/Components/RMCProjectileGrenadeComponent.cs
@@ -23,7 +23,6 @@ public sealed partial class ProjectileGrenadeComponent
     [DataField]
     public float ReboundAngle = 180;
 
-
     /// <summary>
     ///     The angle of the projectile spray
     /// </summary>

--- a/Content.Server/Explosion/EntitySystems/RMCProjectileGrenadeSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/RMCProjectileGrenadeSystem.cs
@@ -3,7 +3,6 @@ using Content.Shared._RMC14.Projectiles;
 using Content.Shared._RMC14.Weapons.Ranged.IFF;
 using Content.Shared.Projectiles;
 using Robust.Server.GameObjects;
-using Robust.Shared.Physics.Events;
 using Robust.Shared.Random;
 
 namespace Content.Server.Explosion.EntitySystems;
@@ -41,8 +40,7 @@ public sealed class RMCProjectileGrenadeSystem : EntitySystem
     }
 
     /// <summary>
-    /// Spawns projectiles at the coordinates of the grenade upon triggering
-    /// Can customize the angle and velocity the projectiles come out at
+    /// Overwrites the logic of the upstream <seealso cref="ProjectileGrenadeSystem"/> to allow more customization
     /// </summary>
     private void OnFragmentIntoProjectiles(Entity<ProjectileGrenadeComponent> ent, ref FragmentIntoProjectilesEvent args)
     {
@@ -67,9 +65,9 @@ public sealed class RMCProjectileGrenadeSystem : EntitySystem
             args.Angle = Angle.FromDegrees((angleMin + angleMax) / 2);
         else
             args.Angle = Angle.FromDegrees(_random.Next((int)angleMin, (int)angleMax));
-
     }
 }
+
 /// <summary>
 ///     Raised when a projectile grenade is being triggered
 /// </summary>

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/rifleman.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/rifleman.yml
@@ -114,13 +114,13 @@
       - id: RMCPacketGrenadeSmokeFilled
         points: 10
       - id: RMCPacketGrenadeM74AGMFFilled
-        points: 20
+        points: 15
       - id: RMCPacketGrenadeM74AGMIFilled
-        points: 20
+        points: 15
       - id: RMCPacketGrenadeM74AGMSFilled
         points: 10
       - id: RMCPacketGrenadeM74AGMSHornetFilled
-        points: 20
+        points: 15
     #- id: CMM20MineBox4
     #  points: 20
     - name: Primary Ammunition

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/specialist.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/specialist.yml
@@ -77,6 +77,7 @@
         spawn: 6
       - id: RMC40MMGrenadeM74AGMI
         points: 40
+        spawn: 6
       - id: RMC40MMGrenadeM74AGMS
         points: 20
         spawn: 6


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fix WS vendor only spawning 1 M74 AGM-I 40mm incendiary grenade instead of 6.
Fix Rifleman vendor m74 grenade packet price being 20 instead of 15.
Added size multiplier to dazed duration.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
No changelog
