### PR TITLE
Baton slugs stun on landing

### DIFF
--- a/Content.Shared/_RMC14/Stun/RMCSizeStunSystem.cs
+++ b/Content.Shared/_RMC14/Stun/RMCSizeStunSystem.cs
@@ -101,7 +101,7 @@ public sealed class RMCSizeStunSystem : EntitySystem
         //Try to daze before the big size check, because big xenos can still be dazed.
         _dazed.TryDaze(args.Target, bullet.Comp.DazeTime * dazeMultiplier);
 
-        if (!TryComp<RMCSizeComponent>(args.Target, out var size) || size.Size >= RMCSizes.Big)
+        if (!TryComp<RMCSizeComponent>(args.Target, out var size))
             return;
 
         KnockBack(args.Target, bullet);
@@ -137,9 +137,14 @@ public sealed class RMCSizeStunSystem : EntitySystem
     /// </summary>
     private void ApplyEffects(EntityUid uid, TimeSpan stun, TimeSpan slow, TimeSpan superSlow)
     {
-        _stun.TryParalyze(uid, stun, true);
         _slow.TrySlowdown(uid, slow);
         _slow.TrySuperSlowdown(uid, superSlow);
+
+        // Don't paralyze if big
+        if (!TryComp<RMCSizeComponent>(uid, out var size) || size.Size >= RMCSizes.Big)
+            return;
+
+        _stun.TryParalyze(uid, stun, true);
     }
 
     /// <summary>

--- a/Content.Shared/_RMC14/Stun/RMCSizeStunSystem.cs
+++ b/Content.Shared/_RMC14/Stun/RMCSizeStunSystem.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using Content.Shared._RMC14.Explosion;
 using Content.Shared._RMC14.Pulling;
 using Content.Shared._RMC14.Slow;
 using Content.Shared.ActionBlocker;
@@ -8,6 +9,7 @@ using Content.Shared.Movement.Systems;
 using Content.Shared.Popups;
 using Content.Shared.Projectiles;
 using Content.Shared.Standing;
+using Content.Shared.StatusEffect;
 using Content.Shared.Stunnable;
 using Content.Shared.Throwing;
 using Robust.Shared.Network;
@@ -38,6 +40,7 @@ public sealed class RMCSizeStunSystem : EntitySystem
     [Dependency] private readonly RMCSlowSystem _slow = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly RMCDazedSystem _dazed = default!;
+    [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
 
     public override void Initialize()
     {
@@ -45,6 +48,7 @@ public sealed class RMCSizeStunSystem : EntitySystem
 
         SubscribeLocalEvent<RMCStunOnHitComponent, MapInitEvent>(OnSizeStunMapInit);
         SubscribeLocalEvent<RMCStunOnHitComponent, ProjectileHitEvent>(OnHit);
+        SubscribeLocalEvent<RMCStunOnHitComponent, RMCTriggerEvent>(OnTrigger);
     }
 
     public bool IsHumanoidSized(Entity<RMCSizeComponent> ent)
@@ -100,21 +104,7 @@ public sealed class RMCSizeStunSystem : EntitySystem
         if (!TryComp<RMCSizeComponent>(args.Target, out var size) || size.Size >= RMCSizes.Big)
             return;
 
-        //TODO Camera Shake
-
-        //Knockback
-        _physics.SetLinearVelocity(args.Target, Vector2.Zero);
-        _physics.SetAngularVelocity(args.Target, 0f);
-
-        var vec = _transform.GetMoverCoordinates(args.Target).Position - bullet.Comp.ShotFrom.Value.Position;
-        if (vec.Length() != 0)
-        {
-            _rmcPulling.TryStopPullsOn(args.Target);
-            var knockBackPower = _random.NextFloat(bullet.Comp.KnockBackPowerMin, bullet.Comp.KnockBackPowerMax);
-            var direction = vec.Normalized() * knockBackPower;
-            _throwing.TryThrow(args.Target, direction, bullet.Comp.KnockBackSpeed, animated: false, playSound: false, doSpin: false);
-            // RMC-14 TODO Thrown into obstacle mechanics
-        }
+        KnockBack(args.Target, bullet);
 
         if (_net.IsClient)
             return;
@@ -133,14 +123,65 @@ public sealed class RMCSizeStunSystem : EntitySystem
                 slow -= TimeSpan.FromSeconds(distance / 5);
             }
 
-            _stun.TryParalyze(args.Target, stun, true);
-            _slow.TrySlowdown(args.Target, slow);
-            _slow.TrySuperSlowdown(args.Target, superSlow);
+            ApplyEffects(args.Target, stun, slow, superSlow);
 
             _popup.PopupEntity(Loc.GetString("rmc-xeno-stun-shaken"), args.Target, args.Target, PopupType.MediumCaution);
         }
         else
             _stamina.TakeStaminaDamage(args.Target, args.Damage.GetTotal().Float());
 
+    }
+
+    /// <summary>
+    ///     Applies the effects from the component
+    /// </summary>
+    private void ApplyEffects(EntityUid uid, TimeSpan stun, TimeSpan slow, TimeSpan superSlow)
+    {
+        _stun.TryParalyze(uid, stun, true);
+        _slow.TrySlowdown(uid, slow);
+        _slow.TrySuperSlowdown(uid, superSlow);
+    }
+
+    /// <summary>
+    ///     Tries to knock back the target.
+    /// </summary>
+    private void KnockBack(EntityUid target, Entity<RMCStunOnHitComponent> bullet)
+    {
+        if (!TryComp<RMCSizeComponent>(target, out var size) || size.Size >= RMCSizes.Big)
+            return;
+
+        if(bullet.Comp.ShotFrom == null)
+            return;
+
+        //TODO Camera Shake
+        _physics.SetLinearVelocity(target, Vector2.Zero);
+        _physics.SetAngularVelocity(target, 0f);
+
+        var vec = _transform.GetMoverCoordinates(target).Position - bullet.Comp.ShotFrom.Value.Position;
+        if (vec.Length() != 0)
+        {
+            _rmcPulling.TryStopPullsOn(target);
+            var knockBackPower = _random.NextFloat(bullet.Comp.KnockBackPowerMin, bullet.Comp.KnockBackPowerMax);
+            var direction = vec.Normalized() * knockBackPower;
+            _throwing.TryThrow(target, direction, bullet.Comp.KnockBackSpeed, animated: false, playSound: false, doSpin: false);
+            // RMC-14 TODO Thrown into obstacle mechanics
+        }
+    }
+
+    /// <summary>
+    ///     Tries to stun a target near the entity when it is triggered.
+    /// </summary>
+    private void OnTrigger(Entity<RMCStunOnHitComponent> ent, ref RMCTriggerEvent args)
+    {
+        var moverCoordinates = _transform.GetMoverCoordinates(ent, Transform(ent));
+
+        var location = _entityLookup.GetEntitiesInRange<StatusEffectsComponent>(moverCoordinates, ent.Comp.StunArea);
+
+        foreach (var target in location)
+        {
+            ApplyEffects(target, ent.Comp.StunTime, ent.Comp.SlowTime, ent.Comp.SuperSlowTime);
+            KnockBack(target, ent);
+            break;
+        }
     }
 }

--- a/Content.Shared/_RMC14/Stun/RMCStunOnHitComponent.cs
+++ b/Content.Shared/_RMC14/Stun/RMCStunOnHitComponent.cs
@@ -39,5 +39,6 @@ public sealed partial class RMCStunOnHitComponent : Component
     [DataField, AutoNetworkedField]
     public TimeSpan DazeTime;
 
-
+    [DataField, AutoNetworkedField]
+    public float StunArea = 0.5f;
 }

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m74_airburst_grenades.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m74_airburst_grenades.yml
@@ -116,6 +116,8 @@
   components:
   - type: TriggerOnFixedDistanceStop
     delay: 0
+  - type: SpawnOnTrigger
+    proto: CMExplosionEffectGrenade
   - type: Sprite
     sprite: _RMC14/Objects/Weapons/Guns/Ammunition/Explosives/grenade_launcher.rsi
     layers:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Baton slugs now stun an entity when they land, ignoring IFF.
M74 grenades now spawn the CMGrenadeExplosionEffect when detonating

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
No Changelog if merged before patch drops
