### PR TITLE
Fixes CMJobSquaderLeader

### DIFF
--- a/Resources/Locale/en-US/_RMC14/job/marines.ftl
+++ b/Resources/Locale/en-US/_RMC14/job/marines.ftl
@@ -7,7 +7,7 @@ CMJobRifleman = Rifleman
 cm-job-name-squad-leader = Squad Leader
 cm-job-description-squad-leader = Leader of one of the four marine squads. Give your squad and fireteams objectives and follow orders from Command. Keep your squad in one piece.
 cm-job-prefix-squad-leader = SL
-CMJobSquaderLeader = Squad Leader
+CMJobSquadLeader = Squad Leader
 
 cm-job-name-fireteam-leader = Fireteam Leader
 cm-job-description-fireteam-leader = Follow the squad leader's orders and command your fireteam. Co-ordinate with CAS and fire support elements.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
changes "CMJobSquaderLeader" to "CMJobSquadLeader" 

fixing the below to display "Squad Leader" correctly
![image](https://github.com/user-attachments/assets/379cded6-a7aa-40ad-8768-f1b3eb6dd4bf)


## Why / Balance
discord reported issue
https://discord.com/channels/1168210010233376858/1343905817988038656/1343905817988038656
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

