### PR TITLE
fixed missing icons on foxtrot

### DIFF
--- a/Content.Server/_RMC14/Ghost/GhostRoleApplySpecialSystem.cs
+++ b/Content.Server/_RMC14/Ghost/GhostRoleApplySpecialSystem.cs
@@ -1,5 +1,7 @@
+using Content.Server._RMC14.Marines;
 using Content.Server._RMC14.Marines.Roles.Ranks;
 using Content.Server.Ghost.Roles.Components;
+using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.Marines.Squads;
 using Content.Shared._RMC14.Roles;
 using Content.Shared.Access.Components;
@@ -17,6 +19,7 @@ public sealed partial class GhostRoleApplySpecialSystem : EntitySystem
     [Dependency] private readonly SquadSystem _squad = default!;
     [Dependency] private readonly MetaDataSystem _meta = default!;
     [Dependency] private readonly RankSystem _rank = default!;
+    [Dependency] private readonly MarineSystem _marine = default!;
 
     public override void Initialize()
     {
@@ -74,6 +77,11 @@ public sealed partial class GhostRoleApplySpecialSystem : EntitySystem
                 }
             }
         }
+
+        if (HasComp<MarineComponent>(ent) &&
+            job.Icon != "CMJobIconEmpty" &&
+            _prototype.TryIndex(job.Icon, out var icon))
+            _marine.SetMarineIcon(ent, icon.Icon);
 
         RemComp<GhostRoleApplySpecialComponent>(ent);
     }


### PR DESCRIPTION
## About the PR

Had to check out the replay to see if foxtrot worked. The foxtrot SL complained of the lack of icons. This PR fixes that.

## Why / Balance

Bugfix.

## Technical details

Add the related job icon to the marine component on spawn.

## Media

![image](https://github.com/user-attachments/assets/308427ba-6047-46df-a352-4ac1e10e998a)

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Role icons for foxtrot are now visible.
