### PR TITLE
Fix raffles being 10 seconds too long

### DIFF
--- a/Content.Server/_RMC14/Ghost/Roles/RMCGhostRoleSystem.cs
+++ b/Content.Server/_RMC14/Ghost/Roles/RMCGhostRoleSystem.cs
@@ -17,8 +17,7 @@ public sealed class RMCGhostRoleSystem : EntitySystem
     /// </summary>
     private void OnGhostRoleRaffle(Entity<GhostRoleRaffleComponent> ent, ref GhostRoleRaffleEvent args)
     {
-        var max = Math.Max(args.CountDown.TotalSeconds, args.RoundTimeRequirement);
-        var timeUntilRequirement = Math.Clamp(args.RoundTimeRequirement - _gameTicker.RoundDuration().TotalSeconds, args.CountDown.TotalSeconds, max);
+        var timeUntilRequirement = Math.Max(0, args.RoundTimeRequirement - _gameTicker.RoundDuration().TotalSeconds);
         args.CountDown = args.CountDown += TimeSpan.FromSeconds(timeUntilRequirement);
         args.Handled = true;
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Raffles now have the proper timer again.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
No CL
