### PR TITLE
Allow baseball caps to fit accessories

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Head/hats.yml
@@ -80,7 +80,7 @@
     sprite: _RMC14/Objects/Clothing/Head/Hats/CO/beret/jungle.rsi
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/Head/Hats/CO/beret/jungle.rsi
-  - type: Appearance 
+  - type: Appearance
   - type: ItemCamouflage
     camouflageVariations:
       Jungle: _RMC14/Objects/Clothing/Head/Hats/CO/beret/jungle.rsi
@@ -165,6 +165,7 @@
     whitelist:
       components:
       - RMCLighter
+      - HelmetAccessory
       tags:
       - Cigarette
       - Matchstick
@@ -177,6 +178,7 @@
       enum.StorageUiKey.Key:
         type: StorageBoundUserInterface
   - type: FixedItemSizeStorage
+  - type: HelmetAccessoryHolder
 
 - type: entity
   parent: CMHeadCapMP


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About PR
CM13 parity

:cl:
- fix: Fixed helmet accessories not fitting inside patrol caps.
