### PR TITLE
M5 camera gear now works as overwatch camera

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Accessory/marine.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Accessory/marine.yml
@@ -27,3 +27,4 @@
   - type: Tag
     tags:
     - RipOffOnInfection
+  - type: OverwatchCamera


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
M5 camera gear now functions as an overwatch camera while wearing it.

## Technical details
<!-- Summary of code changes for easier review. -->
I added the OverwatchCameraComponent to the m5 camera gear.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Dygon
- fix: M5 camera gear now functions as a camera for the overwatch console.
