### PR TITLE
Fix shotgun shells slowing big xenos

### DIFF
--- a/Content.Shared/_RMC14/Stun/RMCSizeStunSystem.cs
+++ b/Content.Shared/_RMC14/Stun/RMCSizeStunSystem.cs
@@ -123,7 +123,8 @@ public sealed class RMCSizeStunSystem : EntitySystem
                 slow -= TimeSpan.FromSeconds(distance / 5);
             }
 
-            ApplyEffects(args.Target, stun, slow, superSlow);
+            if (bullet.Comp.SlowsEffectBigXenos || size.Size < RMCSizes.Big)
+                ApplyEffects(args.Target, stun, slow, superSlow);
 
             _popup.PopupEntity(Loc.GetString("rmc-xeno-stun-shaken"), args.Target, args.Target, PopupType.MediumCaution);
         }

--- a/Content.Shared/_RMC14/Stun/RMCStunOnHitComponent.cs
+++ b/Content.Shared/_RMC14/Stun/RMCStunOnHitComponent.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.GameStates;
+using Robust.Shared.GameStates;
 using Robust.Shared.Map;
 
 namespace Content.Shared._RMC14.Stun;
@@ -26,6 +26,9 @@ public sealed partial class RMCStunOnHitComponent : Component
 
     [DataField, AutoNetworkedField]
     public bool LosesEffectWithRange = false;
+
+    [DataField, AutoNetworkedField]
+    public bool SlowsEffectBigXenos = false;
 
     [DataField, AutoNetworkedField]
     public TimeSpan StunTime = TimeSpan.FromSeconds(1.4);

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m74_airburst_grenades.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m74_airburst_grenades.yml
@@ -414,6 +414,7 @@
     knockBackPowerMax: 3
     knockBackSpeed: 5
     forceKnockBack: true
+    slowsEffectBigXenos: true
     dazeTime: 3.4
   - type: RMCProjectileAccuracy
     accuracy: 100

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m79_grenade_launcher.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m79_grenade_launcher.yml
@@ -26,7 +26,7 @@
     capacity: 1
     soundInsert:
       path: /Audio/_RMC14/Weapons/Guns/Reload/m79_reload.ogg
-  #    proto: CMGrenadeHighExplosive # This needs to start with an HIRR baton slug when those get implemented.
+      proto: RMCBatonSlugHIRR
   - type: AttachableHolder
     slots:
       rmc-aslot-rail:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity. Only HIRR has the special behavior of applying some effects to big xenos. The rest don't.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed scout high impact and shotgun slugs and buckshot slowing big xenos.
