### PR TITLE
Loadout fixes

### DIFF
--- a/Resources/Locale/en-US/_RMC14/roles/loadouts.ftl
+++ b/Resources/Locale/en-US/_RMC14/roles/loadouts.ftl
@@ -2,7 +2,7 @@
 rmc-loadout-group-eyewear = Eyewear
 rmc-loadout-group-masks = Masks and scarves
 rmc-loadout-group-headwear = Headwear
-rmc-loadout-group-helmet-garbs = Helmet Garbs
+rmc-loadout-group-helmet-garbs = Helmet accessories
 rmc-loadout-group-paperwork = Paperwork
 rmc-loadout-group-plushies = Plushies
 rmc-loadout-group-weapons = Weapons

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/prep.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/prep.yml
@@ -258,14 +258,18 @@
         amount: 10
       - id: RMCGlassesMarineRpgOld
         amount: 10
-#      - id: M5 Integrated Gas Mask
-#        amount: 10
-#      - id: M10 Helmet Netting
-#        amount: 10
-#      - id: M10 Helmet Rain Cover
-#        amount: 10
-#      - id: Firearm Lubricant
-#        amount: 15
+      - id: RMCHelmetGarbGasmask
+        name: M5 integrated gas mask
+        amount: 10
+      - id: RMCHelmetGarbNetting
+        name: M10 helmet netting
+        amount: 10
+      - id: RMCHelmetGarbRainCover
+        name: M10 helmet rain cover
+        amount: 10
+      - id: RMCHelmetGarbGunOil
+        name: firearm lubricant
+        amount: 15
 #      - id: Marine Flair
 #        amount: 15
 #      - id: Falling Falcons Shoulder Patch

--- a/Resources/Prototypes/_RMC14/Roles/Loadouts/Items/head_garbs.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Loadouts/Items/head_garbs.yml
@@ -1,126 +1,126 @@
 # Helmet Garbs
 - type: loadout
   id: FakeNVGRMC
-  cost: 2
+  cost: 1
   storage:
     back:
     - RMCHelmetGarbNightVision
 
 - type: loadout
   id: NettingRMC
-  cost: 2
+  cost: 1
   storage:
     back:
     - RMCHelmetGarbNetting
 
 - type: loadout
   id: NettingUrbanRMC
-  cost: 2
+  cost: 1
   storage:
     back:
     - RMCHelmetGarbNettingUrban
 
 - type: loadout
   id: NettingDesertRMC
-  cost: 2
+  cost: 1
   storage:
     back:
     - RMCHelmetGarbNettingDesert
 
 - type: loadout
   id: NettingJungleRMC
-  cost: 2
+  cost: 1
   storage:
     back:
     - RMCHelmetGarbNettingJungle
 
 - type: loadout
   id: RaincoverRMC
-  cost: 2
+  cost: 1
   storage:
     back:
     - RMCHelmetGarbRainCover
 
 - type: loadout
   id: RaincoverUrbanRMC
-  cost: 2
+  cost: 1
   storage:
     back:
     - RMCHelmetGarbRainCoverUrban
 
 - type: loadout
   id: RaincoverDesertRMC
-  cost: 2
+  cost: 1
   storage:
     back:
     - RMCHelmetGarbRainCoverDesert
 
 - type: loadout
   id: RaincoverJungleRMC
-  cost: 2
+  cost: 1
   storage:
     back:
     - RMCHelmetGarbRainCoverJungle
 
 - type: loadout
   id: BuckshotSpentRMC
-  cost: 2
+  cost: 1
   storage:
     back:
     - RMCHelmetGarbBuckshot
 
 - type: loadout
   id: FlechetteSpentRMC
-  cost: 2
+  cost: 1
   storage:
     back:
     - RMCHelmetGarbFlechette
 
 - type: loadout
   id: SlugSpentRMC
-  cost: 2
+  cost: 1
   storage:
     back:
     - RMCHelmetGarbSlug
 
 - type: loadout
   id: CartridgeSpentRMC
-  cost: 2
+  cost: 1
   storage:
     back:
     - RMCHelmetGarbCartridge
 
 - type: loadout
   id: HelmetGasmaskRMC
-  cost: 2
+  cost: 1
   storage:
     back:
     - RMCHelmetGarbGasmask
 
 - type: loadout
   id: GunOilRMC
-  cost: 2
+  cost: 1
   storage:
     back:
     - RMCHelmetGarbGunOil
 
 - type: loadout
   id: RosaryRMC
-  cost: 2
+  cost: 1
   storage:
     back:
     - RMCHelmetGarbRosary
 
 - type: loadout
   id: PrescriptionRMC
-  cost: 2
+  cost: 1
   storage:
     back:
     - RMCHelmetGarbPrescription
 
 - type: loadout
   id: TrimmedWireRMC
-  cost: 2
+  cost: 1
   storage:
     back:
     - RMCHelmetGarbWire

--- a/Resources/Prototypes/_RMC14/Roles/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Loadouts/role_loadouts.yml
@@ -8,9 +8,9 @@
   points: 7
   groups:
   - MarineLeatherBackpack
+  - HeadwearRMC
   - EyewearRMC
   - MasksRMC
-  - HeadwearRMC
   - PaperworkRMC
   - PlushiesRMC
   - WeaponsRMC
@@ -26,9 +26,9 @@
   points: 7
   groups:
   - MarineLeatherBackpack
+  - HeadwearRMC
   - EyewearRMC
   - MasksRMC
-  - HeadwearRMC
   - HelmetGarbsRMC
   - PaperworkRMC
   - PlushiesRMC
@@ -45,9 +45,9 @@
   points: 7
   groups:
   - MarineLeatherBackpack
+  - HeadwearRMC
   - EyewearRMC
   - MasksRMC
-  - HeadwearRMC
   - HelmetGarbsRMC
   - PaperworkRMC
   - PlushiesRMC
@@ -64,9 +64,9 @@
   points: 7
   groups:
   - MarineLeatherBackpack
+  - HeadwearRMC
   - EyewearRMC
   - MasksRMC
-  - HeadwearRMC
   - HelmetGarbsRMC
   - PaperworkRMC
   - PlushiesRMC
@@ -83,9 +83,9 @@
   points: 7
   groups:
   - MarineBackpack
+  - HeadwearRMC
   - EyewearRMC
   - MasksRMC
-  - HeadwearRMC
   - HelmetGarbsRMC
   - PaperworkRMC
   - PlushiesRMC
@@ -104,9 +104,9 @@
   groups:
   - MarineLeatherBackpack
   - CommandingOfficerRoleSpecificRMC
+  - HeadwearRMC
   - EyewearRMC
   - MasksRMC
-  - HeadwearRMC
   - HelmetGarbsRMC
   - PaperworkRMC
   - PlushiesRMC
@@ -123,9 +123,9 @@
   points: 7
   groups:
   - MarineLeatherBackpack
+  - HeadwearRMC
   - EyewearRMC
   - MasksRMC
-  - HeadwearRMC
   - HelmetGarbsRMC
   - PaperworkRMC
   - PlushiesRMC
@@ -142,9 +142,9 @@
   points: 7
   groups:
   - MarineBackpack
+  - HeadwearRMC
   - EyewearRMC
   - MasksRMC
-  - HeadwearRMC
   - HelmetGarbsRMC
   - PaperworkRMC
   - PlushiesRMC
@@ -162,9 +162,9 @@
   points: 7
   groups:
   - MarineTechnicianBackpack
+  - HeadwearRMC
   - EyewearRMC
   - MasksRMC
-  - HeadwearRMC
   - PaperworkRMC
   - PlushiesRMC
   - WeaponsRMC
@@ -180,9 +180,9 @@
   points: 7
   groups:
   - MarineTechnicianBackpack
+  - HeadwearRMC
   - EyewearRMC
   - MasksRMC
-  - HeadwearRMC
   - PaperworkRMC
   - PlushiesRMC
   - WeaponsRMC
@@ -198,9 +198,9 @@
   points: 7
   groups:
   - MarineTechnicianBackpack
+  - HeadwearRMC
   - EyewearRMC
   - MasksRMC
-  - HeadwearRMC
   - PaperworkRMC
   - PlushiesRMC
   - WeaponsRMC
@@ -217,9 +217,9 @@
   points: 7
   groups:
   - MarineTechnicianBackpack
+  - HeadwearRMC
   - EyewearRMC
   - MasksRMC
-  - HeadwearRMC
   - HelmetGarbsRMC
   - PaperworkRMC
   - PlushiesRMC
@@ -236,9 +236,9 @@
   points: 7
   groups:
   - MarineBackpack
+  - HeadwearRMC
   - EyewearRMC
   - MasksRMC
-  - HeadwearRMC
   - HelmetGarbsRMC
   - PaperworkRMC
   - PlushiesRMC
@@ -255,9 +255,9 @@
   points: 7
   groups:
   - MarineMedicBackpack
+  - HeadwearRMC
   - EyewearRMC
   - MasksRMC
-  - HeadwearRMC
   - HelmetGarbsRMC
   - PaperworkRMC
   - PlushiesRMC
@@ -274,9 +274,9 @@
   points: 7
   groups:
   - MarineBackpack
+  - HeadwearRMC
   - EyewearRMC
   - MasksRMC
-  - HeadwearRMC
   - HelmetGarbsRMC
   - PaperworkRMC
   - PlushiesRMC
@@ -293,9 +293,9 @@
   points: 7
   groups:
   - MarineBackpack
+  - HeadwearRMC
   - EyewearRMC
   - MasksRMC
-  - HeadwearRMC
   - HelmetGarbsRMC
   - PaperworkRMC
   - PlushiesRMC
@@ -312,9 +312,9 @@
   points: 7
   groups:
   - MarineBackpack
+  - HeadwearRMC
   - EyewearRMC
   - MasksRMC
-  - HeadwearRMC
   - HelmetGarbsRMC
   - PaperworkRMC
   - PlushiesRMC
@@ -331,9 +331,9 @@
   points: 7
   groups:
   - MarineBackpack
+  - HeadwearRMC
   - EyewearRMC
   - MasksRMC
-  - HeadwearRMC
   - HelmetGarbsRMC
   - PaperworkRMC
   - PlushiesRMC
@@ -351,9 +351,9 @@
   points: 7
   groups:
   - MarineLeatherBackpack
+  - HeadwearRMC
   - EyewearRMC
   - MasksRMC
-  - HeadwearRMC
   - PaperworkRMC
   - PlushiesRMC
   - WeaponsRMC
@@ -369,9 +369,9 @@
   points: 7
   groups:
   - MarineBackpack
+  - HeadwearRMC
   - EyewearRMC
   - MasksRMC
-  - HeadwearRMC
   - PaperworkRMC
   - PlushiesRMC
   - WeaponsRMC
@@ -387,9 +387,9 @@
   points: 7
   groups:
   - MarineBackpack
+  - HeadwearRMC
   - EyewearRMC
   - MasksRMC
-  - HeadwearRMC
   - PaperworkRMC
   - PlushiesRMC
   - WeaponsRMC
@@ -405,9 +405,9 @@
   points: 7
   groups:
   - MarineLeatherBackpack
+  - HeadwearRMC
   - EyewearRMC
   - MasksRMC
-  - HeadwearRMC
   - PaperworkRMC
   - PlushiesRMC
   - WeaponsRMC
@@ -424,9 +424,9 @@
   points: 7
   groups:
   - MarineSecurityBackpack
+  - HeadwearRMC
   - EyewearRMC
   - MasksRMC
-  - HeadwearRMC
   - HelmetGarbsRMC
   - PaperworkRMC
   - PlushiesRMC
@@ -443,9 +443,9 @@
   points: 7
   groups:
   - MarineSecurityBackpack
+  - HeadwearRMC
   - EyewearRMC
   - MasksRMC
-  - HeadwearRMC
   - HelmetGarbsRMC
   - PaperworkRMC
   - PlushiesRMC
@@ -462,9 +462,9 @@
   points: 7
   groups:
   - MarineSecurityBackpack
+  - HeadwearRMC
   - EyewearRMC
   - MasksRMC
-  - HeadwearRMC
   - HelmetGarbsRMC
   - PaperworkRMC
   - PlushiesRMC
@@ -482,9 +482,9 @@
   points: 7
   groups:
   - MarineLeatherBackpack
+  - HeadwearRMC
   - EyewearRMC
   - MasksRMC
-  - HeadwearRMC
   - PaperworkRMC
   - PlushiesRMC
   - WeaponsRMC
@@ -500,9 +500,9 @@
   points: 7
   groups:
   - MarineLeatherBackpack
+  - HeadwearRMC
   - EyewearRMC
   - MasksRMC
-  - HeadwearRMC
   - PaperworkRMC
   - PlushiesRMC
   - WeaponsRMC
@@ -518,9 +518,9 @@
   points: 7
   groups:
   - MarineBackpack
+  - HeadwearRMC
   - EyewearRMC
   - MasksRMC
-  - HeadwearRMC
   - PaperworkRMC
   - PlushiesRMC
   - WeaponsRMC
@@ -536,9 +536,9 @@
   points: 7
   groups:
   - MarineBackpack
+  - HeadwearRMC
   - EyewearRMC
   - MasksRMC
-  - HeadwearRMC
   - PaperworkRMC
   - PlushiesRMC
   - WeaponsRMC
@@ -555,9 +555,9 @@
   points: 7
   groups:
   - MarineTechnicianBackpack
+  - HeadwearRMC
   - EyewearRMC
   - MasksRMC
-  - HeadwearRMC
   - PaperworkRMC
   - PlushiesRMC
   - WeaponsRMC
@@ -573,9 +573,9 @@
   points: 7
   groups:
   - MarineTechnicianBackpack
+  - HeadwearRMC
   - EyewearRMC
   - MasksRMC
-  - HeadwearRMC
   - PaperworkRMC
   - PlushiesRMC
   - WeaponsRMC


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- Added some helmet garbs to squad prep like in CM13
- fixed loadout helmet garbs not being 1 point. CM13 has it as 1 point
- Re-arranged the headwear, eyewear and masks categories
- Headwear is now first, following is eyewear and mask/scarves

:cl:
- fix: Fixed helmet garbs not being 1 point in loadouts.
- add: Added M5 integrated gas mask, rain cover, netting, and gun oil to the surplus squad prep vendors.
