### PR TITLE
build speed of queen fixed

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
@@ -65,6 +65,7 @@
   - type: XenoHeavy
   - type: XenoAcid
   - type: XenoConstruction
+    buildDelay: 2
     canBuild:
     - WallXenoResin
     - WallXenoMembrane


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
build speed delay of queen is 2 seconds now (the same as drone)

## Why / Balance
Parity
https://github.com/cmss13-devs/cmss13/blob/c20d21622048d99106e10ed40c4bc2cb1a2ebd56/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm#L20
https://github.com/cmss13-devs/cmss13/blob/c20d21622048d99106e10ed40c4bc2cb1a2ebd56/code/__DEFINES/xeno.dm#L77

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed Queen building speed being half the intended amount.
