### PR TITLE
Acid spray extinguishing tile fires

### DIFF
--- a/Content.Shared/_RMC14/Atmos/ExtinguishFireComponent.cs
+++ b/Content.Shared/_RMC14/Atmos/ExtinguishFireComponent.cs
@@ -12,4 +12,7 @@ public sealed partial class ExtinguishFireComponent : Component
 
     [DataField, AutoNetworkedField]
     public CollisionGroup Collision = CollisionGroup.MobLayer | CollisionGroup.MobMask;
+
+    [DataField, AutoNetworkedField]
+    public float? ExtinguishingPower;
 }

--- a/Content.Shared/_RMC14/Atmos/TileFireComponent.cs
+++ b/Content.Shared/_RMC14/Atmos/TileFireComponent.cs
@@ -18,6 +18,9 @@ public sealed partial class TileFireComponent : Component
     [DataField, AutoNetworkedField]
     public float PatExtinguishMultiplier = 1;
 
+    [DataField, AutoNetworkedField]
+    public float AcidSprayExtinguishMultiplier = 1;
+
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
     public TimeSpan SpawnedAt;
 

--- a/Resources/Prototypes/_RMC14/Effects/xeno_acid.yml
+++ b/Resources/Prototypes/_RMC14/Effects/xeno_acid.yml
@@ -71,6 +71,7 @@
       - Marine
   - type: UncloakOnHit
   - type: ExtinguishFire
+    extinguishingPower: 6
   - type: IgnorePredictionHit
 
 - type: entity
@@ -89,6 +90,8 @@
         Heat: 36
   - type: TimedDespawn
     lifetime: 1.0
+  - type: ExtinguishFire
+    extinguishingPower: 18
 
 - type: entity
   parent: XenoAcidSprayWeak
@@ -107,6 +110,8 @@
         Heat: 24
   - type: TimedDespawn
     lifetime: 1.0
+  - type: ExtinguishFire
+    extinguishingPower: 13
 
 - type: entity
   parent: XenoAcidSprayWeak
@@ -127,6 +132,8 @@
         Heat: 14.2
   - type: TimedDespawn
     lifetime: 1.0
+  - type: ExtinguishFire
+    extinguishingPower: 13
 
 - type: entity
   parent: XenoAcidSprayTrap
@@ -147,6 +154,8 @@
         Heat: 12.2
   - type: TimedDespawn
     lifetime: 0.6
+  - type: ExtinguishFire
+    extinguishingPower: 6
 
 - type: entity
   parent: XenoAcidSprayTrap
@@ -167,6 +176,8 @@
         Heat: 21.3
   - type: TimedDespawn
     lifetime: 3.0
+  - type: ExtinguishFire
+    extinguishingPower: 18
 
 - type: entity
   id: XenoAcidExtinguishEffect

--- a/Resources/Prototypes/_RMC14/Entities/Tiles/tile_fire.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Tiles/tile_fire.yml
@@ -84,6 +84,7 @@
     id: RMCTileFireGreen
     extinguishInstantly: false
     patExtinguishMultiplier: 2
+    acidSprayExtinguishMultiplier: 3
   - type: SpeedModifierContacts
     walkSpeedModifier: 0.666
     sprintSpeedModifier: 0.666


### PR DESCRIPTION
## About the PR
Xeno spray now extinguishes tile fires.

## Why / Balance
parityy

## Technical details
Now, here is the reason i open it as a draft, the code is done, it works, but...
No matter how many times i re read CM13 code for this, i see the extinguishing power of every acid type
and i see how that value is applied, but then i see that _green fire specifically_ takes tripple the damage from acid sprays, i have not played CM13, i have no clue why it has to take tripple the damage, but the way it works out in current RMC14 is boiler can completely remove freshly placed green fire in one spray, meanwhile regular orange fire and blue fire still have most of their duration left.
Meanwhile weakest spitter spray removes meager 6 seconds of orange fire duration, out of 60 total.

I hardly believe that fancy green fire is supposed to be weaker than orange fire so i assume i am missing some critical information, either RMC14 just doesnt have full tile fire parity, and orange fire is not supposed to have same burn duration as green, or there is other more complex reason.

So i will leave maintainers to decide what do i even do with this.
## Media
https://github.com/user-attachments/assets/e0f5e751-ccf9-4bf0-b7a2-98e4c9a62554


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Xeno sprays now extinguish tile fires.
