### PR TITLE
Prevent "Find Parasite" action from opening standard UI if the user cannot take a parasite role at that time.

### DIFF
--- a/Content.Server/_RMC14/Roles/FindParasiteSystem.cs
+++ b/Content.Server/_RMC14/Roles/FindParasiteSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server._RMC14.Xenonids.Parasite;
 using Content.Shared._RMC14.Areas;
 using Content.Shared._RMC14.Roles.FindParasite;
 using Content.Shared._RMC14.Xenonids.Construction.EggMorpher;
@@ -17,6 +18,7 @@ public sealed partial class FindParasiteSystem : EntitySystem
     [Dependency] private readonly EntityManager _entities = default!;
     [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
     [Dependency] private readonly AreaSystem _areas = default!;
+    [Dependency] private readonly XenoEggRoleSystem _parasiteRole = default!;
     public override void Initialize()
     {
         base.Initialize();
@@ -30,11 +32,10 @@ public sealed partial class FindParasiteSystem : EntitySystem
 
     private void FindParasites(Entity<FindParasiteComponent> parasiteFinderEnt, ref FindParasiteActionEvent args)
     {
-        if (args.Handled)
+        if (args.Handled || !_parasiteRole.UserCheck(parasiteFinderEnt.Owner))
         {
             return;
         }
-        var ent = args.Performer;
 
         _ui.OpenUi(parasiteFinderEnt.Owner, XenoFindParasiteUI.Key, parasiteFinderEnt);
         args.Handled = true;

--- a/Content.Server/_RMC14/Xenonids/Parasite/XenoParasiteRoleSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Parasite/XenoParasiteRoleSystem.cs
@@ -99,12 +99,13 @@ public sealed class XenoEggRoleSystem : EntitySystem
                 _ghostRole.GhostRoleInternalCreateMindAndTransfer(session, parasite.Value, parasite.Value);
         }
     }
-
-    private bool SharedChecks(EntityUid ent, EntityUid user)
+    /// <summary>
+    /// Can this user take a parasite role
+    /// </summary>
+    /// <param name="user"></param>
+    /// <returns></returns>
+    public bool UserCheck(EntityUid user)
     {
-        //TODO RMC14 parasite bans should be checked here
-        _ui.CloseUi(ent, XenoParasiteGhostUI.Key);
-
         if (_net.IsClient)
             return false;
 
@@ -132,5 +133,12 @@ public sealed class XenoEggRoleSystem : EntitySystem
         }
 
         return true;
+    }
+    private bool SharedChecks(EntityUid ent, EntityUid user)
+    {
+        //TODO RMC14 parasite bans should be checked here
+        _ui.CloseUi(ent, XenoParasiteGhostUI.Key);
+
+        return UserCheck(user);
     }
 }


### PR DESCRIPTION

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Ghost Role Parasite QOL
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: "Find Parasite" action does not show standard UI and shows a warning popup if the user cannot take a ghost role
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
