### PR TITLE
xenology part 2: blood and plasma

### DIFF
--- a/Content.Server/Body/Components/BloodstreamComponent.cs
+++ b/Content.Server/Body/Components/BloodstreamComponent.cs
@@ -138,9 +138,10 @@ namespace Content.Server.Body.Components
         /// </summary>
         /// <remarks>
         ///     Slime-people might use slime as their blood or something like that.
+        ///     RMC14: Xenos have multiple reagents as blood.
         /// </remarks>
         [DataField]
-        public ProtoId<ReagentPrototype> BloodReagent = "Blood";
+        public ProtoId<ReagentPrototype>[] BloodReagent = ["Blood"];
 
         /// <summary>Name/Key that <see cref="BloodSolution"/> is indexed by.</summary>
         [DataField]

--- a/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerComponent.cs
+++ b/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerComponent.cs
@@ -1,4 +1,6 @@
+using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Storage;
+using Robust.Shared.Prototypes;
 
 namespace Content.Server.Medical.BiomassReclaimer
 {
@@ -37,7 +39,7 @@ namespace Content.Server.Medical.BiomassReclaimer
         /// The reagent that will be spilled while processing a mob.
         /// </summary>
         [ViewVariables]
-        public string? BloodReagent;
+        public ProtoId<ReagentPrototype>[] BloodReagent = [];
 
         /// <summary>
         /// Entities that can be randomly spawned while processing a mob.

--- a/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
+++ b/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
@@ -72,7 +72,9 @@ namespace Content.Server.Medical.BiomassReclaimer
                     if (_robustRandom.Prob(0.2f) && reclaimer.BloodReagent is not null)
                     {
                         Solution blood = new();
-                        blood.AddReagent(reclaimer.BloodReagent, 50);
+                        var bloodPart = 50 / reclaimer.BloodReagent.Length;
+                        foreach (var reagent in reclaimer.BloodReagent)
+                            blood.AddReagent(reagent, bloodPart);
                         _puddleSystem.TrySpillAt(uid, blood, out _);
                     }
                     if (_robustRandom.Prob(0.03f) && reclaimer.SpawnedEntities.Count > 0)
@@ -93,7 +95,7 @@ namespace Content.Server.Medical.BiomassReclaimer
                 reclaimer.CurrentExpectedYield = reclaimer.CurrentExpectedYield - actualYield; // store non-integer leftovers
                 _material.SpawnMultipleFromMaterial(actualYield, BiomassPrototype, Transform(uid).Coordinates);
 
-                reclaimer.BloodReagent = null;
+                reclaimer.BloodReagent = [];
                 reclaimer.SpawnedEntities.Clear();
                 RemCompDeferred<ActiveBiomassReclaimerComponent>(uid);
             }

--- a/Content.Server/_RMC14/Chemistry/Conditions/BloodThreshold.cs
+++ b/Content.Server/_RMC14/Chemistry/Conditions/BloodThreshold.cs
@@ -1,0 +1,31 @@
+using Content.Server.Body.Components;
+using Content.Shared.EntityEffects;
+using Content.Shared.FixedPoint;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._RMC14.Chemistry.Conditions;
+public sealed partial class BloodThreshold : EntityEffectCondition
+{
+    [DataField]
+    public FixedPoint2 Min = FixedPoint2.Zero;
+
+    [DataField]
+    public FixedPoint2 Max = FixedPoint2.MaxValue;
+
+    public override bool Condition(EntityEffectBaseArgs args)
+    {
+        var entity = args.EntityManager;
+        if (!entity.TryGetComponent<BloodstreamComponent>(args.TargetEntity, out var bloodstream) || bloodstream.BloodSolution is not { } blood)
+            return false;
+
+        var volume = blood.Comp.Solution.Volume;
+        return volume >= Min && volume <= Max;
+    }
+
+    public override string GuidebookExplanation(IPrototypeManager prototype)
+    {
+        return Loc.GetString("reagent-effect-condition-guidebook-blood-threshold",
+            ("max", Max == FixedPoint2.MaxValue ? int.MaxValue : Max.Float()),
+            ("min", Min.Float()));
+    }
+}

--- a/Content.Server/_RMC14/Chemistry/Conditions/ParasiteStatus.cs
+++ b/Content.Server/_RMC14/Chemistry/Conditions/ParasiteStatus.cs
@@ -1,0 +1,20 @@
+using Content.Shared._RMC14.Xenonids.Parasite;
+using Content.Shared.EntityEffects;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._RMC14.Chemistry.Conditions;
+public sealed partial class ParasiteStatus : EntityEffectCondition
+{
+    [DataField(required: true)]
+    public bool Infected = default!;
+
+    public override bool Condition(EntityEffectBaseArgs args)
+    {
+        return args.EntityManager.HasComponent<VictimInfectedComponent>(args.TargetEntity) == Infected;
+    }
+
+    public override string GuidebookExplanation(IPrototypeManager prototype)
+    {
+        return Loc.GetString("reagent-effect-condition-guidebook-infected", ("infected", Infected));
+    }
+}

--- a/Content.Server/_RMC14/Chemistry/Conditions/ParasiteValidHost.cs
+++ b/Content.Server/_RMC14/Chemistry/Conditions/ParasiteValidHost.cs
@@ -1,0 +1,20 @@
+using Content.Shared._RMC14.Xenonids.Parasite;
+using Content.Shared.EntityEffects;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._RMC14.Chemistry.Conditions;
+public sealed partial class ParasiteValidHost : EntityEffectCondition
+{
+    [DataField]
+    public bool Valid = true;
+
+    public override bool Condition(EntityEffectBaseArgs args)
+    {
+        return args.EntityManager.HasComponent<InfectableComponent>(args.TargetEntity) == Valid;
+    }
+
+    public override string GuidebookExplanation(IPrototypeManager prototype)
+    {
+        return Loc.GetString("reagent-effect-condition-guidebook-valid-host", ("valid", Valid));
+    }
+}

--- a/Content.Server/_RMC14/Chemistry/Effects/AddNeurotoxinImmunity.cs
+++ b/Content.Server/_RMC14/Chemistry/Effects/AddNeurotoxinImmunity.cs
@@ -1,0 +1,19 @@
+using Content.Shared._RMC14.Xenonids.Neurotoxin;
+using Content.Shared.EntityEffects;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._RMC14.Chemistry.Effects;
+
+public sealed partial class AddNeurotoxinImmunity : EntityEffect
+{
+    protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
+    {
+        return Loc.GetString("reagent-effect-guidebook-neurotoxin-immunity", ("chance", Probability));
+    }
+
+    public override void Effect(EntityEffectBaseArgs args)
+    {
+        args.EntityManager.EnsureComponent<NeurotoxinImmunityComponent>(args.TargetEntity);
+        args.EntityManager.RemoveComponent<NeurotoxinComponent>(args.TargetEntity);
+    }
+}

--- a/Content.Server/_RMC14/Chemistry/Effects/AddXenoEmbryo.cs
+++ b/Content.Server/_RMC14/Chemistry/Effects/AddXenoEmbryo.cs
@@ -1,0 +1,25 @@
+using Content.Shared._RMC14.Xenonids.Parasite;
+using Content.Shared.EntityEffects;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._RMC14.Chemistry.Effects;
+
+public sealed partial class AddXenoEmbryo : EntityEffect
+{
+    protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
+    {
+        return Loc.GetString("reagent-effect-guidebook-plasma-egg", ("chance", Probability));
+    }
+
+    public override void Effect(EntityEffectBaseArgs args)
+    {
+        var entityManager = args.EntityManager;
+        if (!entityManager.TryGetComponent<InfectableComponent>(args.TargetEntity, out var infected) ||
+            infected.BeingInfected ||
+            entityManager.HasComponent<VictimInfectedComponent>(args.TargetEntity))
+            return;
+
+        // TODO: Set hive.
+        entityManager.AddComponent<VictimInfectedComponent>(args.TargetEntity);
+    }
+}

--- a/Content.Server/_RMC14/Chemistry/Effects/ClearOtherReagents.cs
+++ b/Content.Server/_RMC14/Chemistry/Effects/ClearOtherReagents.cs
@@ -1,0 +1,35 @@
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.EntityEffects;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._RMC14.Chemistry.Effects;
+
+public sealed partial class ClearOtherReagents : EntityEffect
+{
+    /// <summary>
+    /// Only this reagent will be kept.
+    /// </summary>
+    [DataField]
+    public ProtoId<ReagentPrototype>? Reagent = null;
+    protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
+    {
+        return Loc.GetString("reagent-effect-guidebook-excreting", ("chance", Probability));
+    }
+
+    public override void Effect(EntityEffectBaseArgs args)
+    {
+        if (args is not EntityEffectReagentArgs reagentArgs)
+            return;
+
+        if (reagentArgs.Source == null)
+            return;
+
+        foreach (var quant in reagentArgs.Source.Contents.ToArray())
+        {
+            if (quant.Reagent.Prototype == Reagent)
+                continue;
+
+            reagentArgs.Source.RemoveReagent(quant);
+        }
+    }
+}

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -143,11 +143,11 @@ public sealed partial class ZombieComponent : Component
     /// The blood reagent of the humanoid to restore in case of cloning
     /// </summary>
     [DataField("beforeZombifiedBloodReagent")]
-    public string BeforeZombifiedBloodReagent = string.Empty;
+    public ProtoId<ReagentPrototype>[] BeforeZombifiedBloodReagent = [];
 
     /// <summary>
     /// The blood reagent to give the zombie. In case you want zombies that bleed milk, or something.
     /// </summary>
-    [DataField("newBloodReagent", customTypeSerializer: typeof(PrototypeIdSerializer<ReagentPrototype>))]
-    public string NewBloodReagent = "ZombieBlood";
+    [DataField("newBloodReagent")]
+    public ProtoId<ReagentPrototype>[] NewBloodReagent = ["ZombieBlood"];
 }

--- a/Content.Shared/_RMC14/Xenonids/Neurotoxin/NeurotoxinImmunityComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Neurotoxin/NeurotoxinImmunityComponent.cs
@@ -1,0 +1,7 @@
+using Content.Shared.Damage;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.Neurotoxin;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class NeurotoxinImmunityComponent : Component;

--- a/Content.Shared/_RMC14/Xenonids/Neurotoxin/SharedNeurotoxinSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Neurotoxin/SharedNeurotoxinSystem.cs
@@ -60,7 +60,7 @@ public abstract class SharedNeurotoxinSystem : EntitySystem
 
     private void OnProjectileHit(Entity<NeurotoxinInjectorComponent> ent, ref ProjectileHitEvent args)
     {
-        if (!HasComp<MarineComponent>(args.Target))
+        if (!HasComp<MarineComponent>(args.Target) || HasComp<NeurotoxinImmunityComponent>(args.Target))
             return;
 
         if (!ent.Comp.AffectsDead && _mobState.IsDead(args.Target))
@@ -117,6 +117,9 @@ public abstract class SharedNeurotoxinSystem : EntitySystem
                     continue;
                 }
 
+                if (HasComp<NeurotoxinImmunityComponent>(marine))
+                    continue;
+
                 if (!EnsureComp<NeurotoxinComponent>(marine, out var builtNeurotoxin))
                 {
                     builtNeurotoxin.LastMessage = time;
@@ -143,7 +146,7 @@ public abstract class SharedNeurotoxinSystem : EntitySystem
         {
             neuro.NeurotoxinAmount -= frameTime * neuro.DepletionPerSecond;
 
-            if(neuro.NeurotoxinAmount <= 0)
+            if (neuro.NeurotoxinAmount <= 0 || HasComp<NeurotoxinImmunityComponent>(uid))
             {
                 RemCompDeferred<NeurotoxinComponent>(uid);
                 continue;

--- a/Content.Shared/_RMC14/Xenonids/Stab/SharedXenoTailStabSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Stab/SharedXenoTailStabSystem.cs
@@ -190,6 +190,9 @@ public abstract class SharedXenoTailStabSystem : EntitySystem
 
                     if (stab.Comp.InjectNeuro)
                     {
+                        if (HasComp<NeurotoxinImmunityComponent>(hit))
+                            continue;
+
                         if (!TryComp<NeurotoxinInjectorComponent>(stab, out var neuroTox))
                            continue;
 

--- a/Resources/Locale/en-US/_RMC14/medical/xeno.ftl
+++ b/Resources/Locale/en-US/_RMC14/medical/xeno.ftl
@@ -37,8 +37,6 @@ reagent-effect-guidebook-excreting =
 
 reagent-name-rmc-xenoplasmaegg = Egg Plasma
 reagent-desc-rmc-xenoplasmaegg = A white-ish plasma with a high concentration of protein...
-reagent-name-rmc-xenoplasmaegg-helper = Alien Egg
-reagent-desc-rmc-xenoplasmaegg-helper = A coagulated mass of egg plasma.
 reagent-effect-plasma-egg = Your stomach cramps and you suddenly feel very sick!
 reagent-effect-guidebook-plasma-egg =
     { $chance ->
@@ -57,3 +55,9 @@ reagent-effect-condition-guidebook-blood-threshold =
                     *[other] there's between {NATURALFIXED($min, 2)}u and {NATURALFIXED($max, 2)}u of blood
                  }
     }
+
+reagent-effect-condition-guidebook-infected =
+    the individual { $infected ->
+        [true] hosts
+        *[false] does not host
+    } an alien parasite

--- a/Resources/Locale/en-US/_RMC14/medical/xeno.ftl
+++ b/Resources/Locale/en-US/_RMC14/medical/xeno.ftl
@@ -61,3 +61,9 @@ reagent-effect-condition-guidebook-infected =
         [true] hosts
         *[false] does not host
     } an alien parasite
+
+reagent-effect-condition-guidebook-valid-host =
+    the individual { $valid ->
+        [true] is
+        *[false] is not
+    } a valid host

--- a/Resources/Locale/en-US/_RMC14/medical/xeno.ftl
+++ b/Resources/Locale/en-US/_RMC14/medical/xeno.ftl
@@ -48,3 +48,12 @@ reagent-effect-guidebook-plasma-egg =
 
 reagent-name-rmc-xenoplasmaroyal = Royal Plasma
 reagent-desc-rmc-xenoplasmaroyal = A dark purple-ish plasma...
+
+reagent-effect-condition-guidebook-blood-threshold =
+    { $max ->
+        [2147483648] there's at least {NATURALFIXED($min, 2)}u of blood
+        *[other] { $min ->
+                    [0] there's at most {NATURALFIXED($max, 2)}u of blood
+                    *[other] there's between {NATURALFIXED($min, 2)}u and {NATURALFIXED($max, 2)}u of blood
+                 }
+    }

--- a/Resources/Locale/en-US/_RMC14/medical/xeno.ftl
+++ b/Resources/Locale/en-US/_RMC14/medical/xeno.ftl
@@ -1,5 +1,5 @@
 reagent-name-rmc-xenoblood = Acidic Blood
-reagent-desc-rmc-xenoblood = A corrosive blood like substance. Makeup appears to be made out of acids and blood plasma.
+reagent-desc-rmc-xenoblood = A corrosive blood like substance. It appears to be made out of acids and blood plasma.
 
 reagent-name-rmc-xenobloodroyal = Dark Acidic Blood
 
@@ -36,7 +36,7 @@ reagent-effect-guidebook-excreting =
     } all other reagents from the body
 
 reagent-name-rmc-xenoplasmaegg = Egg Plasma
-reagent-desc-rmc-xenoplasmaegg = A white-ish plasma high with a high concentration of protein...
+reagent-desc-rmc-xenoplasmaegg = A white-ish plasma with a high concentration of protein...
 reagent-name-rmc-xenoplasmaegg-helper = Alien Egg
 reagent-desc-rmc-xenoplasmaegg-helper = A coagulated mass of egg plasma.
 reagent-effect-plasma-egg = Your stomach cramps and you suddenly feel very sick!

--- a/Resources/Locale/en-US/_RMC14/medical/xeno.ftl
+++ b/Resources/Locale/en-US/_RMC14/medical/xeno.ftl
@@ -1,0 +1,50 @@
+reagent-name-rmc-xenoblood = Acidic Blood
+reagent-desc-rmc-xenoblood = A corrosive blood like substance. Makeup appears to be made out of acids and blood plasma.
+
+reagent-name-rmc-xenobloodroyal = Dark Acidic Blood
+
+reagent-name-rmc-plasma = Plasma
+reagent-desc-rmc-plasma = A clear extracellular fluid separated from blood.
+
+reagent-name-rmc-xenoplasmapurple = Purple Plasma
+reagent-desc-rmc-xenoplasmapurple = A purple-ish plasma...
+
+reagent-name-rmc-xenoplasmapheromone = Pheromone Plasma
+reagent-desc-rmc-xenoplasmapheromone = A funny smelling plasma...
+
+reagent-name-rmc-xenoplasmachitin = Chitin Plasma
+reagent-desc-rmc-xenoplasmachitin = A very thick fibrous plasma...
+
+reagent-name-rmc-xenoplasmacatecholamine = Catecholamine Plasma
+reagent-desc-rmc-xenoplasmacatecholamine = A red-ish plasma...
+
+reagent-name-rmc-xenoplasmaneurotixin = Neurotoxin Plasma
+reagent-desc-rmc-xenoplasmaneurotixin = A plasma containing an unknown but potent neurotoxin.
+
+reagent-name-rmc-xenoplasmaantineurotixin = Anti-Neurotoxin
+reagent-desc-rmc-xenoplasmaantineurotixin = A counteragent to Neurotoxin Plasma.
+reagent-effect-guidebook-neurotoxin-immunity =
+    { $chance ->
+        [1] Provides
+        *[other] provide
+    } immunity against alien neurotoxin
+
+reagent-effect-guidebook-excreting =
+    { $chance ->
+        [1] Removes
+        *[other] remove
+    } all other reagents from the body
+
+reagent-name-rmc-xenoplasmaegg = Egg Plasma
+reagent-desc-rmc-xenoplasmaegg = A white-ish plasma high with a high concentration of protein...
+reagent-name-rmc-xenoplasmaegg-helper = Alien Egg
+reagent-desc-rmc-xenoplasmaegg-helper = A coagulated mass of egg plasma.
+reagent-effect-plasma-egg = Your stomach cramps and you suddenly feel very sick!
+reagent-effect-guidebook-plasma-egg =
+    { $chance ->
+        [1] Infects
+        *[other] infect
+    } an individual with an alien parasite
+
+reagent-name-rmc-xenoplasmaroyal = Royal Plasma
+reagent-desc-rmc-xenoplasmaroyal = A dark purple-ish plasma...

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -350,7 +350,7 @@
       Dead:
         Base: cockroach_dead
   - type: Bloodstream
-    bloodReagent: InsectBlood
+    bloodReagent: [InsectBlood]
     bloodMaxVolume: 20
   - type: Food
   - type: FlavorProfile
@@ -508,7 +508,7 @@
     damageContainer: Biological
     damageModifierSet: Moth
   - type: Bloodstream
-    bloodReagent: InsectBlood
+    bloodReagent: [InsectBlood]
   - type: Respirator
     damage:
       types:
@@ -916,7 +916,7 @@
     accent: crab
   - type: Bloodstream
     bloodMaxVolume: 50
-    bloodReagent: CopperBlood
+    bloodReagent: [CopperBlood]
   - type: Tag
     tags:
     - VimPilot
@@ -1879,7 +1879,7 @@
   - type: RadiationSource
     intensity: 0.3
   - type: Bloodstream
-    bloodReagent: UnstableMutagen
+    bloodReagent: [UnstableMutagen]
   - type: SolutionContainerManager
     solutions:
       food:
@@ -2353,7 +2353,7 @@
   - type: IgnoreSpiderWeb
   - type: Bloodstream
     bloodMaxVolume: 150
-    bloodReagent: CopperBlood
+    bloodReagent: [CopperBlood]
   - type: Speech
     speechVerb: Arachnid
     speechSounds: Arachnid
@@ -2499,7 +2499,7 @@
       speechVerb: Cluwne
     - type: Bloodstream
       bloodMaxVolume: 150
-      bloodReagent: Laughter
+      bloodReagent: [Laughter]
 
 - type: entity
   name: wizard spider
@@ -2822,7 +2822,7 @@
     attributes:
       gender: epicene
   - type: Bloodstream
-    bloodReagent: DemonsBlood
+    bloodReagent: [DemonsBlood]
   - type: Damageable
     damageContainer: BiologicalMetaphysical
     damageModifierSet: Infernal
@@ -3445,7 +3445,7 @@
     speciesId: cat
     templateId: pet
   - type: Bloodstream
-    bloodReagent: Sap
+    bloodReagent: [Sap]
     bloodMaxVolume: 60
   - type: DamageStateVisuals
     states:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/argocyte.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/argocyte.yml
@@ -18,7 +18,7 @@
   - type: ReplacementAccent
     accent: xeno
   - type: Bloodstream
-    bloodReagent: FerrochromicAcid
+    bloodReagent: [FerrochromicAcid]
     bloodMaxVolume: 75 #we don't want the map to become pools of blood
     bloodlossDamage:
       types:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/behonker.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/behonker.yml
@@ -116,7 +116,7 @@
       context: "human"
     - type: Bloodstream
       bloodMaxVolume: 300
-      bloodReagent: Laughter
+      bloodReagent: [Laughter]
 
 - type: entity
   name: behonker

--- a/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
@@ -262,7 +262,7 @@
     speedModifierThresholds:
       50: 0.4
   - type: Bloodstream
-    bloodReagent: Water
+    bloodReagent: [Water]
     chemicalMaxVolume: 100
   - type: StatusEffects
     allowed:
@@ -332,7 +332,7 @@
   suffix: Beer
   components:
   - type: Bloodstream
-    bloodReagent: Beer
+    bloodReagent: [Beer]
   - type: PointLight
     color: "#cfa85f"
   - type: Sprite
@@ -349,7 +349,7 @@
   suffix: Pax
   components:
   - type: Bloodstream
-    bloodReagent: Pax
+    bloodReagent: [Pax]
   - type: PointLight
     color: "#AAAAAA"
   - type: Sprite
@@ -369,7 +369,7 @@
   suffix: Nocturine
   components:
   - type: Bloodstream
-    bloodReagent: Nocturine
+    bloodReagent: [Nocturine]
   - type: PointLight
     color: "#128e80"
   - type: Sprite
@@ -389,7 +389,7 @@
   suffix: THC
   components:
   - type: Bloodstream
-    bloodReagent: THC
+    bloodReagent: [THC]
   - type: PointLight
     color: "#808080"
   - type: Sprite
@@ -406,7 +406,7 @@
   suffix: Bicaridine
   components:
   - type: Bloodstream
-    bloodReagent: Bicaridine
+    bloodReagent: [Bicaridine]
   - type: PointLight
     color: "#ffaa00"
   - type: Sprite
@@ -423,7 +423,7 @@
   suffix: Toxin
   components:
   - type: Bloodstream
-    bloodReagent: Toxin
+    bloodReagent: [Toxin]
   - type: PointLight
     color: "#cf3600"
   - type: Sprite
@@ -440,7 +440,7 @@
   suffix: Napalm
   components:
   - type: Bloodstream
-    bloodReagent: Napalm
+    bloodReagent: [Napalm]
   - type: PointLight
     color: "#FA00AF"
   - type: Sprite
@@ -457,7 +457,7 @@
   suffix: Omnizine
   components:
   - type: Bloodstream
-    bloodReagent: Omnizine
+    bloodReagent: [Omnizine]
   - type: PointLight
     color: "#fcf7f9"
   - type: Sprite
@@ -474,7 +474,7 @@
   suffix: Mute Toxin
   components:
   - type: Bloodstream
-    bloodReagent: MuteToxin
+    bloodReagent: [MuteToxin]
   - type: PointLight
     color: "#0f0f0f"
   - type: Sprite
@@ -491,7 +491,7 @@
   suffix: Norepinephric Acid
   components:
   - type: Bloodstream
-    bloodReagent: NorepinephricAcid
+    bloodReagent: [NorepinephricAcid]
   - type: PointLight
     color: "#96a8b5"
   - type: Sprite
@@ -508,7 +508,7 @@
   suffix: Ephedrine
   components:
   - type: Bloodstream
-    bloodReagent: Ephedrine
+    bloodReagent: [Ephedrine]
   - type: PointLight
     color: "#D2FFFA"
   - type: Sprite
@@ -525,7 +525,7 @@
   suffix: Robust Harvest
   components:
   - type: Bloodstream
-    bloodReagent: RobustHarvest
+    bloodReagent: [RobustHarvest]
   - type: PointLight
     color: "#3e901c"
   - type: Sprite

--- a/Resources/Prototypes/Entities/Mobs/NPCs/miscellaneous.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/miscellaneous.yml
@@ -142,7 +142,7 @@
       - map: [ "enum.DamageStateVisualLayers.Base" ]
         state: alive
   - type: Bloodstream
-    bloodReagent: JuiceTomato
+    bloodReagent: [JuiceTomato]
     bloodMaxVolume: 50
     chemicalMaxVolume: 30
   - type: DamageStateVisuals

--- a/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
@@ -55,7 +55,7 @@
     damageContainer: Biological
     damageModifierSet: Slime
   - type: Bloodstream
-    bloodReagent: Slime
+    bloodReagent: [Slime]
     bloodlossDamage:
       types:
         Bloodloss:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
@@ -40,7 +40,7 @@
   - type: MovementAlwaysTouching
   - type: Bloodstream
     bloodMaxVolume: 300
-    bloodReagent: Cryoxadone
+    bloodReagent: [Cryoxadone]
   - type: CombatMode
   - type: Temperature
     heatDamageThreshold: 500
@@ -212,7 +212,7 @@
       prob: 0.5
   - type: Bloodstream
     bloodMaxVolume: 250
-    bloodReagent: Cryoxadone
+    bloodReagent: [Cryoxadone]
   - type: Fixtures
     fixtures:
       fix1:
@@ -315,7 +315,7 @@
           prob: 0.3
     - type: Bloodstream
       bloodMaxVolume: 200
-      bloodReagent: Cryoxadone
+      bloodReagent: [Cryoxadone]
     - type: Fixtures
       fixtures:
         fix1:
@@ -479,7 +479,7 @@
     combatToggleAction: ActionCombatModeToggleOff
   - type: Bloodstream
     bloodMaxVolume: 30
-    bloodReagent: Cryoxadone
+    bloodReagent: [Cryoxadone]
   - type: CanEscapeInventory
   - type: MobPrice
     price: 50

--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -67,7 +67,7 @@
   - type: Stamina
     critThreshold: 200
   - type: Bloodstream
-    bloodReagent: FluorosulfuricAcid
+    bloodReagent: [FluorosulfuricAcid]
     bloodMaxVolume: 650
   - type: MeleeWeapon
     altDisarm: false

--- a/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
@@ -43,7 +43,7 @@
       - !type:WashCreamPieReaction
   # Damage (Self)
   - type: Bloodstream
-    bloodReagent: CopperBlood
+    bloodReagent: [CopperBlood]
   # Damage (Others)
   - type: MeleeWeapon
     animation: WeaponArcBite

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -33,7 +33,7 @@
       - id: FoodMeatPlant
         amount: 5
   - type: Bloodstream
-    bloodReagent: Sap
+    bloodReagent: [Sap]
   - type: Reactive
     groups:
       Flammable: [ Touch ]

--- a/Resources/Prototypes/Entities/Mobs/Species/gingerbread.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/gingerbread.yml
@@ -29,7 +29,7 @@
       - id: FoodBakedCookie #should be replaced with gingerbread sheets or something... provided you're willing to make a full spriteset of those.
         amount: 5
   - type: Bloodstream
-    bloodReagent: Sugar
+    bloodReagent: [Sugar]
   - type: Fixtures
     fixtures:
       fix1:

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -33,7 +33,7 @@
     - id: FoodMeat
       amount: 5
   - type: Bloodstream
-    bloodReagent: InsectBlood
+    bloodReagent: [InsectBlood]
   - type: DamageVisuals
     damageOverlayGroups:
       Brute:

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -69,7 +69,7 @@
       Burn:
         sprite: Mobs/Effects/burn_damage.rsi
   - type: Bloodstream
-    bloodReagent: Slime # TODO Color slime blood based on their slime color or smth
+    bloodReagent: [Slime] # TODO Color slime blood based on their slime color or smth
   - type: Barotrauma
     damage:
       types:

--- a/Resources/Prototypes/Entities/Mobs/Species/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vox.yml
@@ -52,7 +52,7 @@
       Burn:
         sprite: Mobs/Effects/burn_damage.rsi
   - type: Bloodstream
-    bloodReagent: AmmoniaBlood
+    bloodReagent: [AmmoniaBlood]
   - type: MeleeWeapon
     soundHit:
       collection: AlienClaw

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
@@ -32,7 +32,7 @@
   - type: InjectableSolution
     solution: chemicals
   - type: Bloodstream
-    bloodReagent: Blood
+    bloodReagent: [Blood]
     bloodMaxVolume: 560
     maxBleedAmount: 50
     bleedReductionAmount: 0

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
@@ -298,6 +298,15 @@
   - type: RMCCanBeFultoned
   - type: CMArmor
   - type: CriticalGraceTime
+  - type: Bloodstream
+    bloodReagent: [RMCXenoBlood]
+    bloodMaxVolume: 560
+    maxBleedAmount: 50
+    bleedReductionAmount: 5
+    bloodRefreshAmount: 5
+    bloodlossThreshold: 0 # TODO: no blood-loss damage for now
+    bloodlossDamage: {}
+    bloodlossHealDamage: {}
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/boiler.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/boiler.yml
@@ -149,3 +149,5 @@
     damage: #per second, scales with number of fire 'stacks'
       types:
         Heat: 3
+  - type: Bloodstream
+    bloodReagent: [RMCXenoBlood, RMCPlasmaNeurotoxin]

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/burrower.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/burrower.yml
@@ -112,3 +112,5 @@
     - HiveRecoveryNodeXenoConstructionNode
   - type: IntelRecoverCorpseObjectiveOnDeath
     value: 0.2
+  - type: Bloodstream
+    bloodReagent: [RMCXenoBlood, RMCPlasmaPurple]

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/carrier.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/carrier.yml
@@ -131,3 +131,5 @@
     prefix: carrier
   - type: IntelRecoverCorpseObjectiveOnDeath
     value: 0.2
+  - type: Bloodstream
+    bloodReagent: [RMCXenoBlood, RMCPlasmaPurple]

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/crusher.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/crusher.yml
@@ -108,3 +108,5 @@
   - type: IntelRecoverCorpseObjectiveOnDeath
     value: 0.7
   - type: TantrumSpeedBuff
+  - type: Bloodstream
+    bloodReagent: [RMCXenoBlood, RMCPlasmaChitin]

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/defender.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/defender.yml
@@ -96,6 +96,8 @@
       state: defender
   - type: IntelRecoverCorpseObjectiveOnDeath
     value: 0.1
+  - type: Bloodstream
+    bloodReagent: [RMCXenoBlood, RMCPlasmaChitin]
 
 - type: entity
   parent: CMXenoDefenderBase

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/drone.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/drone.yml
@@ -95,6 +95,8 @@
     prefix: drone
   - type: IntelRecoverCorpseObjectiveOnDeath
     value: 0.1
+  - type: Bloodstream
+    bloodReagent: [RMCXenoBlood, RMCPlasmaPurple]
 
 - type: entity
   parent: CMXenoDroneBase

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/hivelord.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/hivelord.yml
@@ -91,6 +91,8 @@
       state: hivelord
   - type: XenoInhands
     prefix: hivelord
+  - type: Bloodstream
+    bloodReagent: [RMCXenoBlood, RMCPlasmaPurple, RMCPlasmaPheromone]
 
 - type: entity
   parent: CMXenoHivelordBase

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lesser_drone.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lesser_drone.yml
@@ -101,3 +101,5 @@
     evasion: 10
   - type: XenoInhands
     prefix: lesser
+  - type: Bloodstream
+    bloodReagent: [RMCXenoBlood, RMCPlasmaPurple]

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lurker.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lurker.yml
@@ -104,3 +104,5 @@
       state: lurker
   - type: IntelRecoverCorpseObjectiveOnDeath
     value: 0.2
+  - type: Bloodstream
+    bloodReagent: [RMCXenoBlood, RMCPlasmaCatecholamine]

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/praetorian.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/praetorian.yml
@@ -116,6 +116,8 @@
         - XenoHeavy
   - type: IntelRecoverCorpseObjectiveOnDeath
     value: 0.7
+  - type: Bloodstream
+    bloodReagent: [RMCXenoBloodRoyal, RMCPlasmaPheromone, RMCPlasmaNeurotoxin]
 
 - type: entity
   parent: CMXenoPraetorianBase
@@ -245,6 +247,8 @@
       groups:
         Brute: 40
   - type: XenoTailTrip
+  - type: Bloodstream
+    bloodReagent: [RMCXenoBloodRoyal, RMCPlasmaCatecholamine]
 
 - type: entity
   parent: CMXenoPraetorianBase
@@ -356,3 +360,5 @@
     damage:
       groups:
         Brute: 15
+  - type: Bloodstream
+    bloodReagent: [RMCXenoBloodRoyal, RMCPlasmaNeurotoxin, RMCPlasmaChitin]

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
@@ -231,7 +231,7 @@
   - type: IntelRecoverCorpseObjectiveOnDeath
     value: 1.4
   - type: Bloodstream
-    bloodReagent: [RMCXenoBloodRoyal, RMCPlasmaChitin, RMCPlasmaPheromone, RMCPlasmaNeurotoxin]
+    bloodReagent: [RMCXenoBloodRoyal, RMCPlasmaRoyal, RMCPlasmaChitin, RMCPlasmaPheromone, RMCPlasmaNeurotoxin]
 
 - type: entity
   id: XenoLeaderPheromoneRelay

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
@@ -230,6 +230,8 @@
     debuffModifier: 1.4
   - type: IntelRecoverCorpseObjectiveOnDeath
     value: 1.4
+  - type: Bloodstream
+    bloodReagent: [RMCXenoBloodRoyal, RMCPlasmaChitin, RMCPlasmaPheromone, RMCPlasmaNeurotoxin]
 
 - type: entity
   id: XenoLeaderPheromoneRelay

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/ravager.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/ravager.yml
@@ -145,3 +145,5 @@
     damage:
       types:
         Slash: 40
+  - type: Bloodstream
+    bloodReagent: [RMCXenoBlood, RMCPlasmaCatecholamine]

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/runner.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/runner.yml
@@ -109,6 +109,8 @@
     baseSprintSpeed: 10
   - type: IntelRecoverCorpseObjectiveOnDeath
     value: 0.1
+  - type: Bloodstream
+    bloodReagent: [RMCXenoBlood, RMCPlasmaCatecholamine]
 
 - type: entity
   parent: CMXenoRunnerBase

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/sentinel.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/sentinel.yml
@@ -87,3 +87,5 @@
     spray: XenoAcidSprayTrapWeak
   - type: IntelRecoverCorpseObjectiveOnDeath
     value: 0.1
+  - type: Bloodstream
+    bloodReagent: [RMCXenoBlood, RMCPlasmaNeurotoxin]

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/spitter.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/spitter.yml
@@ -105,3 +105,5 @@
   - type: AcidTrap
   - type: IntelRecoverCorpseObjectiveOnDeath
     value: 0.2
+  - type: Bloodstream
+    bloodReagent: [RMCXenoBlood, RMCPlasmaNeurotoxin]

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/warrior.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/warrior.yml
@@ -96,3 +96,5 @@
       state: warrior
   - type: IntelRecoverCorpseObjectiveOnDeath
     value: 0.2
+  - type: Bloodstream
+    bloodReagent: [RMCXenoBlood, RMCPlasmaChitin]

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_egg.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_egg.yml
@@ -84,6 +84,14 @@
   - type: RequireProjectileTarget
   - type: XenoInhandSprite
     stateName: egg
+  - type: Extractable
+    grindableSolutionName: egg
+  - type: SolutionContainerManager
+    solutions:
+      egg:
+        reagents:
+        - ReagentId: RMCPlasmaEgg
+          Quantity: 60
 
 - type: entity
   parent: BaseItem

--- a/Resources/Prototypes/_RMC14/Reagents/xeno.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/xeno.yml
@@ -372,6 +372,21 @@
           min: 100
         reagent: RMCPlasmaEggHelper
         amount: 1
+      - !type:AdjustReagent
+        conditions:
+        - !type:ReagentThreshold
+          max: 100
+        - !type:BloodThreshold
+          min: 10
+        reagent: RMCPlasmaEgg
+        amount: 1.2
+      - !type:ModifyBloodLevel
+        conditions:
+        - !type:ReagentThreshold
+          max: 100
+        - !type:BloodThreshold
+          min: 10
+        amount: -10
 
 - type: reagent
   parent: RMCPlasmaEgg

--- a/Resources/Prototypes/_RMC14/Reagents/xeno.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/xeno.yml
@@ -245,7 +245,7 @@
       - !type:GenericStatusEffect
         key: StaminaModifier
         component: StaminaModifier
-        time: 3
+        time: 1.1
         type: Add
       # TODO: Pain
       - !type:HealthChange

--- a/Resources/Prototypes/_RMC14/Reagents/xeno.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/xeno.yml
@@ -1,0 +1,472 @@
+# Blood
+- type: reagent
+  parent: CMReagent
+  id: RMCXenoBlood
+  name: reagent-name-rmc-xenoblood
+  desc: reagent-desc-rmc-xenoblood
+  physicalDesc: reagent-physical-desc-acidic
+  color: "#dffc00"
+  unknown: true
+  metabolisms:
+    # CORROSIVE = 3
+    # TODO: Melt items.
+    Poison:
+      metabolismRate: 0.2
+      effects:
+      - !type:HealthChange
+        damage:
+          groups:
+            Burn: 0.6
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
+        damage:
+          groups:
+            Burn: 0.6
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 50
+        damage:
+          groups:
+            Burn: 1.2
+
+- type: reagent
+  parent: RMCXenoBlood
+  id: RMCXenoBloodRoyal
+  name: reagent-name-rmc-xenobloodroyal
+  color: "#bbb900"
+  metabolisms:
+    # CORROSIVE = 6
+    # TODO: Melt items.
+    Poison:
+      metabolismRate: 0.2
+      effects:
+      - !type:HealthChange
+        damage:
+          groups:
+            Burn: 1.2
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
+        damage:
+          groups:
+            Burn: 1.2
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 50
+        damage:
+          groups:
+            Burn: 2.4
+
+# Plasma
+- type: reagent
+  parent: CMReagent
+  id: RMCPlasma # Technically the "human" kind.
+  name: reagent-name-rmc-plasma
+  desc: reagent-desc-rmc-plasma
+  physicalDesc: reagent-physical-desc-viscous
+  color: "#f1e8cf"
+  unknown: true
+  overdose: 30
+
+- type: reagent
+  parent: RMCPlasma
+  id: RMCPlasmaPurple
+  name: reagent-name-rmc-xenoplasmapurple
+  desc: reagent-desc-rmc-xenoplasmapurple
+  color: "#a65d7f"
+  metabolisms:
+    # BIOCIDIC = 2
+    Poison:
+      metabolismRate: 0.2
+      effects:
+      - !type:HealthChange
+        damage:
+          groups:
+            Brute: 0.4
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
+        damage:
+          groups:
+            Brute: 0.4
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 50
+        damage:
+          groups:
+            Brute: 0.8
+
+- type: reagent
+  parent: RMCPlasma
+  id: RMCPlasmaPheromone
+  name: reagent-name-rmc-xenoplasmapheromone
+  desc: reagent-desc-rmc-xenoplasmapheromone
+  physicalDesc: reagent-physical-desc-exotic-smelling
+  color: "#a2e7d6"
+  metabolisms:
+    # HALLUCINOGENIC = 8, NERVESTIMULATING = 6
+    Narcotic:
+      metabolismRate: 0.2
+      effects:
+      - !type:Emote
+        emote: Laugh
+        showInChat: true
+        probability: 0.02
+      - !type:Emote
+        emote: Whistle
+        showInChat: true
+        probability: 0.02
+      - !type:GenericStatusEffect
+        key: SeeingRainbows
+        component: SeeingRainbows
+        type: Add
+        time: 1.2
+      - !type:Jitter
+      # TODO: Stumble around at OD
+      - !type:GenericStatusEffect
+          conditions:
+          - !type:ReagentThreshold
+            min: 50
+          key: KnockedDown
+          component: KnockedDown
+          time: 4
+          type: Add
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 50
+        damage:
+          groups:
+            Toxin: 1.6 # TODO: Should be brain damage.
+      # And now the stimulant, I hope I got them all
+      - !type:GenericStatusEffect
+          key: KnockedDown
+          time: 1.2
+          type: Remove
+      - !type:GenericStatusEffect
+          key: Stun
+          time: 1.2
+          type: Remove
+      - !type:GenericStatusEffect
+          key: Drunk
+          time: 2.4
+          type: Remove
+      - !type:GenericStatusEffect
+          key: Stutter
+          time: 2.4
+          type: Remove
+      - !type:GenericStatusEffect
+          key: Jitter
+          time: 2.4
+          type: Remove
+      - !type:GenericStatusEffect
+          key: SeeingRainbows
+          time: 2.4
+          type: Remove
+      - !type:GenericStatusEffect
+          key: ForcedSleep
+          time: 2.4
+          type: Remove
+      - !type:GenericStatusEffect
+          key: TemporaryBlindness
+          time: 2.4
+          type: Remove
+      - !type:GenericStatusEffect
+          key: Drowsiness
+          time: 2.4
+          type: Remove
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
+        damage:
+          groups:
+            Toxin: 2.4
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 50
+        damage:
+          groups:
+            Brute: 1.2
+            Burn: 1.2
+            Toxin: 1.2
+
+- type: reagent
+  parent: RMCPlasma
+  id: RMCPlasmaChitin
+  name: reagent-name-rmc-xenoplasmachitin
+  desc: reagent-desc-rmc-xenoplasmachitin
+  physicalDesc: reagent-physical-desc-fibrous
+  color: "#6d7694"
+  metabolisms:
+    # HYPERDENSIFICATING = 1
+    Narcotic:
+      metabolismRate: 1
+      effects:
+      # TODO: Prevent fractures
+      - !type:MovespeedModifier
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
+        walkSpeedModifier: 0.8
+        sprintSpeedModifier: 0.8
+        statusLifetime: 1.1
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 50
+        damage:
+          groups:
+            Brute: 3
+
+- type: reagent
+  parent: RMCPlasma
+  id: RMCPlasmaCatecholamine
+  name: reagent-name-rmc-xenoplasmacatecholamine
+  desc: reagent-desc-rmc-xenoplasmacatecholamine
+  color: "#cf7551"
+  metabolisms:
+    # PAINING = 2, MUSCLESTIMULATING = 6
+    Narcotic:
+      metabolismRate: 1
+      effects:
+      - !type:MovespeedModifier
+        walkSpeedModifier: 1.5
+        sprintSpeedModifier: 1.5
+        statusLifetime: 1.1
+      - !type:GenericStatusEffect
+        key: StaminaModifier
+        component: StaminaModifier
+        time: 3
+        type: Add
+      # TODO: Pain
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
+        damage:
+          groups:
+            Brute: 8 # TODO: Part is heart damage.
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 50
+        damage:
+          groups:
+            Brute: 8
+
+- type: reagent
+  parent: RMCPlasma
+  id: RMCPlasmaNeurotoxin
+  name: reagent-name-rmc-xenoplasmaneurotixin
+  desc: reagent-desc-rmc-xenoplasmaneurotixin
+  physicalDesc: reagent-physical-desc-pungent
+  color: "#ba8216"
+  metabolisms:
+    # NEUROTOXIC = 4, EXCRETING = 2, HALLUCINOGENIC = 6
+    Narcotic:
+      metabolismRate: 0.2
+      effects:
+      - !type:Emote
+        emote: Laugh
+        showInChat: true
+        probability: 0.02
+      - !type:Emote
+        emote: Whistle
+        showInChat: true
+        probability: 0.02
+      - !type:GenericStatusEffect
+        key: SeeingRainbows
+        component: SeeingRainbows
+        type: Add
+        time: 1.1
+      - !type:Jitter
+      # TODO: Stumble around at OD
+      - !type:GenericStatusEffect
+          conditions:
+          - !type:ReagentThreshold
+            min: 50
+          key: KnockedDown
+          component: KnockedDown
+          time: 3
+          type: Add
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 50
+        damage:
+          groups:
+            Toxin: 1.2 # TODO: Should be brain damage.
+      - !type:ClearOtherReagents
+        reagent: RMCPlasmaNeurotoxin
+      - !type:HealthChange
+        damage:
+          groups:
+            Toxin: 1.4 # TODO: Should be brain damage.
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
+        damage:
+          groups:
+            Toxin: 1 # TODO: Should be brain damage.
+      - !type:GenericStatusEffect
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
+        key: Drowsiness
+        time: 1.1
+        type: Add
+      # TODO: Apply neurotoxin
+
+- type: reagent
+  parent: RMCPlasma
+  id: RMCPlasmaAntiNeurotoxin
+  name: reagent-name-rmc-xenoplasmaantineurotixin
+  desc: reagent-desc-rmc-xenoplasmaantineurotixin
+  physicalDesc: reagent-physical-desc-neural
+  color: "#afffc9"
+  metabolisms:
+    # NEUROSHIELDING = 1
+    Narcotic:
+      metabolismRate: 0.2
+      effects:
+      - !type:AddNeurotoxinImmunity
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
+        damage:
+          groups:
+            Toxin: 0.2 # TODO: Should be liver damage.
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 50
+        damage:
+          groups:
+            Toxin: 0.4 # TODO: Should be brain damage.
+
+- type: reagent
+  parent: RMCPlasma
+  id: RMCPlasmaEgg
+  name: reagent-name-rmc-xenoplasmaegg
+  desc: reagent-desc-rmc-xenoplasmaegg
+  physicalDesc: reagent-physical-desc-mucus-like
+  color: "#c3c371"
+  metabolisms:
+    Poison:
+      metabolismRate: 0.2
+      effects:
+      - !type:AdjustReagent
+        conditions:
+        - !type:ReagentThreshold
+          min: 100
+        reagent: RMCPlasmaEggHelper
+        amount: 1
+
+- type: reagent
+  parent: RMCPlasmaEgg
+  id: RMCPlasmaEggHelper
+  name: reagent-name-rmc-xenoplasmaegg-helper
+  desc: reagent-desc-rmc-xenoplasmaegg-helper
+  metabolisms:
+    Poison:
+      metabolismRate: 1
+      effects:
+      - !type:AddXenoEmbryo
+      - !type:PopupMessage
+        type: Local
+        visualType: LargeCaution
+        messages: [ "reagent-effect-plasma-egg" ]
+      - !type:AdjustReagent
+        reagent: RMCPlasmaEgg
+        amount: -999
+
+- type: reagent
+  parent: RMCPlasma
+  id: RMCPlasmaRoyal
+  name: reagent-name-rmc-xenoplasmaroyal
+  desc: reagent-desc-rmc-xenoplasmaroyal
+  color: "#ffeb9c"
+  metabolisms:
+    # BIOCIDIC = 4, ADDICTIVE = 1, HALLUCINOGENIC = 4, CIPHERING = 1
+    Narcotic:
+      metabolismRate: 0.2
+      effects:
+      - !type:HealthChange
+        damage:
+          groups:
+            Brute: 0.8
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
+        damage:
+          groups:
+            Brute: 0.8
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 50
+        damage:
+          groups:
+            Brute: 1.6
+      ######
+      # TODO: Addictions
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
+        damage:
+          groups:
+            Brute: 0.4 # TODO: Should be brain damage.
+      - !type:GenericStatusEffect
+        conditions:
+        - !type:ReagentThreshold
+          min: 50
+        key: SeeingRainbows
+        component: SeeingRainbows
+        type: Add
+        time: 1.1
+      ######
+      - !type:Emote
+        emote: Laugh
+        showInChat: true
+        probability: 0.02
+      - !type:Emote
+        emote: Whistle
+        showInChat: true
+        probability: 0.02
+      - !type:GenericStatusEffect
+        key: SeeingRainbows
+        component: SeeingRainbows
+        type: Add
+        time: 1.1
+      - !type:Jitter
+      # TODO: Stumble around at OD
+      - !type:GenericStatusEffect
+          conditions:
+          - !type:ReagentThreshold
+            min: 50
+          key: KnockedDown
+          component: KnockedDown
+          time: 2
+          type: Add
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 50
+        damage:
+          groups:
+            Toxin: 0.8 # TODO: Should be brain damage.
+      ######
+      # TODO: Ciphering

--- a/Resources/Prototypes/_RMC14/Reagents/xeno.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/xeno.yml
@@ -385,6 +385,7 @@
       # Infect on 100
       - !type:PopupMessage
         conditions:
+        - !type:ParasiteValidHost
         - !type:ParasiteStatus
           infected: false
         - !type:ReagentThreshold
@@ -394,6 +395,7 @@
         messages: [ "reagent-effect-plasma-egg" ]
       - !type:AddXenoEmbryo
         conditions:
+        - !type:ParasiteValidHost
         - !type:ParasiteStatus
           infected: false
         - !type:ReagentThreshold
@@ -403,6 +405,12 @@
         conditions:
         - !type:ParasiteStatus
           infected: true
+        reagent: RMCPlasmaEgg
+        amount: -999
+      - !type:AdjustReagent
+        conditions:
+        - !type:ParasiteValidHost
+          valid: false
         reagent: RMCPlasmaEgg
         amount: -999
 

--- a/Resources/Prototypes/_RMC14/Reagents/xeno.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/xeno.yml
@@ -366,43 +366,43 @@
     Poison:
       metabolismRate: 0.2
       effects:
+      # Self replicate by consuming blood
       - !type:AdjustReagent
         conditions:
-        - !type:ReagentThreshold
-          min: 100
-        reagent: RMCPlasmaEggHelper
-        amount: 1
-      - !type:AdjustReagent
-        conditions:
-        - !type:ReagentThreshold
-          max: 100
         - !type:BloodThreshold
           min: 10
+        - !type:ParasiteStatus
+          infected: false
         reagent: RMCPlasmaEgg
         amount: 1.2
       - !type:ModifyBloodLevel
         conditions:
-        - !type:ReagentThreshold
-          max: 100
         - !type:BloodThreshold
           min: 10
+        - !type:ParasiteStatus
+          infected: false
         amount: -10
-
-- type: reagent
-  parent: RMCPlasmaEgg
-  id: RMCPlasmaEggHelper
-  name: reagent-name-rmc-xenoplasmaegg-helper
-  desc: reagent-desc-rmc-xenoplasmaegg-helper
-  metabolisms:
-    Poison:
-      metabolismRate: 1
-      effects:
-      - !type:AddXenoEmbryo
+      # Infect on 100
       - !type:PopupMessage
+        conditions:
+        - !type:ParasiteStatus
+          infected: false
+        - !type:ReagentThreshold
+          min: 100
         type: Local
         visualType: LargeCaution
         messages: [ "reagent-effect-plasma-egg" ]
+      - !type:AddXenoEmbryo
+        conditions:
+        - !type:ParasiteStatus
+          infected: false
+        - !type:ReagentThreshold
+          min: 100
+      # Bit off cleanup
       - !type:AdjustReagent
+        conditions:
+        - !type:ParasiteStatus
+          infected: true
         reagent: RMCPlasmaEgg
         amount: -999
 

--- a/Resources/Prototypes/_RMC14/Recipes/Reactions/xeno.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Reactions/xeno.yml
@@ -1,0 +1,29 @@
+- type: reaction
+  id: RMCPlasmaRoyal
+  reactants:
+    RMCPlasmaEgg:
+      amount: 1
+    RMCXenoBloodRoyal:
+      amount: 1
+  products:
+    RMCPlasmaRoyal: 2
+
+- type: reaction
+  id: RMCPlasmaAntiNeurotoxin
+  reactants:
+    RMCPlasmaNeurotoxin:
+      amount: 1
+    CMDylovene:
+      amount: 1
+  products:
+    RMCPlasmaAntiNeurotoxin: 1
+
+- type: reaction
+  id: RMCPlasmaEgg
+  reactants:
+    Blood:
+      amount: 10
+    RMCPlasmaEgg:
+      amount: 1
+  products:
+    RMCPlasmaEgg: 2


### PR DESCRIPTION
## About the PR

See #5869. This PR adds all the different xeno blood and plasma types.


Waiting on space-wizards/space-station-14/pull/35071, then creating a new PR upstream for multi reagent blood.

## Why / Balance

More stuff to port.

## Technical details

- BloodstreamComponent can now handle multiple types of blood.
- Xenos now have blood and can bleed. They currently recover quickly and do not take bloodloss damage.
- Added all the different plasma types and most of their effects.
	- Someone else please look over it cause I'm sure some values are wrong.

## Media

https://github.com/user-attachments/assets/8d8cd1bf-59e9-4e6b-b8ad-91e045cccfbf

![image](https://github.com/user-attachments/assets/fdcad955-8137-4da5-8c2d-4c9a87ca9058)

https://github.com/user-attachments/assets/68c729a3-8bee-4528-9d8f-d0309e90d189

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Xenos now have blood and plasma, that have a variety of uses.
