### PR TITLE
Fix Commanding Officer Colonel ID

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Loadouts/Items/role_specific.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Loadouts/Items/role_specific.yml
@@ -13,32 +13,6 @@
     - CMHeadBeretCOCol
 
 - type: loadout
-  id: ColIDCardRMC
-  cost: 3 # same price as headwear
-  effects:
-  - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:RoleTimeRequirement
-      role: CMJobCommandingOfficer
-      time: 630000 # 175 hrs
-  equipment:
-    id: RMCIDCardCommandingOfficerPlus
-
-- type: loadout
-  id: ColNormalIDCardRMC
-  cost: 0
-  effects:
-  - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:RoleTimeRequirement
-      role: CMJobCommandingOfficer
-      time: 252000 # 70 hrs
-      inverted: true
-  equipment:
-    id: CMIDCardCommandingOfficer
-
-
-- type: loadout
   id: LtColBeretRMC
   cost: 3
   effects:
@@ -50,3 +24,26 @@
   storage:
     back:
     - CMHeadBeretCOLtCol
+
+- type: loadout
+  id: ColIDCardRMC
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: CMJobCommandingOfficer
+      time: 630000 # 175 hrs
+  equipment:
+    id: RMCIDCardCommandingOfficerPlus
+
+- type: loadout
+  id: ColNormalIDCardRMC
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: CMJobCommandingOfficer
+      time: 630000 # 175 hrs
+      inverted: true # if you have atleast 175 hours you get the colonel ID, so invert this
+  equipment:
+    id: CMIDCardCommandingOfficer


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixes loadout code for colonel ID
makes none of the IDs cost points

adds a 175 inverted requirement for the default ID
the requirement at 70 hours makes it so that lieutenant colonels do not spawn with an ID

re-arranges loadouts to bring the berets after eachother and the IDs after eachother
