### PR TITLE
Make attacking/tackling cause a delay for pulling

### DIFF
--- a/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
+++ b/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
@@ -61,6 +61,7 @@ public sealed class RMCPullingSystem : EntitySystem
 
         SubscribeLocalEvent<ParalyzeOnPullAttemptComponent, PullAttemptEvent>(OnParalyzeOnPullAttempt);
         SubscribeLocalEvent<InfectOnPullAttemptComponent, PullAttemptEvent>(OnInfectOnPullAttempt);
+        SubscribeLocalEvent<MeleeWeaponComponent, PullAttemptEvent>(OnMeleePullAttempt);
 
         SubscribeLocalEvent<SlowOnPullComponent, PullStartedMessage>(OnSlowPullStarted);
         SubscribeLocalEvent<SlowOnPullComponent, PullStoppedMessage>(OnSlowPullStopped);
@@ -235,6 +236,16 @@ public sealed class RMCPullingSystem : EntitySystem
             _popup.PopupClient(msg, ent, args.PullerUid, PopupType.SmallCaution);
             args.Cancelled = true;
         }
+    }
+
+    private void OnMeleePullAttempt(Entity<MeleeWeaponComponent> ent, ref PullAttemptEvent args)
+    {
+        if (args.PullerUid != ent.Owner)
+            return;
+
+        var weapon = ent.Comp;
+        if (weapon.Attacking || weapon.NextAttack > _timing.CurTime)
+            args.Cancelled = true;
     }
 
     private void OnPreventPulledWhileAliveStart(Entity<PreventPulledWhileAliveComponent> ent, ref PullStartedMessage args)

--- a/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
+++ b/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
@@ -59,6 +59,8 @@ public sealed class RMCPullingSystem : EntitySystem
     {
         _firemanQuery = GetEntityQuery<FiremanCarriableComponent>();
 
+        SubscribeLocalEvent<XenoComponent, RMCPullToggleEvent>(OnXenoPullToggle);
+
         SubscribeLocalEvent<ParalyzeOnPullAttemptComponent, PullAttemptEvent>(OnParalyzeOnPullAttempt);
         SubscribeLocalEvent<InfectOnPullAttemptComponent, PullAttemptEvent>(OnInfectOnPullAttempt);
         SubscribeLocalEvent<MeleeWeaponComponent, PullAttemptEvent>(OnMeleePullAttempt);
@@ -243,9 +245,13 @@ public sealed class RMCPullingSystem : EntitySystem
         if (args.PullerUid != ent.Owner)
             return;
 
-        var weapon = ent.Comp;
-        if (weapon.Attacking || weapon.NextAttack > _timing.CurTime)
+        if (ent.Comp.NextAttack > _timing.CurTime)
             args.Cancelled = true;
+    }
+
+    private void OnXenoPullToggle(Entity<XenoComponent> ent, ref RMCPullToggleEvent args)
+    {
+        args.Handled = true;
     }
 
     private void OnPreventPulledWhileAliveStart(Entity<PreventPulledWhileAliveComponent> ent, ref PullStartedMessage args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
CM13 Parity
based on click delay, if you do any attack you can't pull

Makes it harder to pull off some combos 
also fixes xenos being able to cancel their pulls by spamming the pull keybind
this makes it harder to accidentally let go of a pull and to make it harder to do noise spam

in these videos i am spamming the pull hotkey

https://github.com/user-attachments/assets/9883c6b3-bc74-4440-b535-373c81669bc4



https://github.com/user-attachments/assets/800f041e-332e-49cc-a5d8-bd45a119a6ed



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

:cl:
- fix: Fixed using melee not delaying being able to pull someone.