### PR TITLE
Fix healer appearing twice in evolve menu

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/drone.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/drone.yml
@@ -120,7 +120,6 @@
     strains:
     - CMXenoDroneGardener
     - CMXenoDroneHealer
-    - CMXenoDroneHealer
   - type: XenoAcid
   - type: AcidTrap
     trapLevel: 1


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Title
## Why / Balance
Fixes healer appearing twice in the strain menu

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [ ] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed healer appearing twice in the drone evolution menu.
