### PR TITLE
Make effects render over xenos and humans in night vision

### DIFF
--- a/Resources/Prototypes/Entities/Markers/pointing.yml
+++ b/Resources/Prototypes/Entities/Markers/pointing.yml
@@ -1,4 +1,5 @@
 ﻿- type: entity
+  parent: RMCBaseEffect
   name: pointing arrow
   id: PointingArrow
   save: false

--- a/Resources/Prototypes/_RMC14/Effects/attack.yml
+++ b/Resources/Prototypes/_RMC14/Effects/attack.yml
@@ -1,4 +1,5 @@
 ﻿- type: entity
+  parent: RMCBaseEffect
   # Just fades out with no movement animation
   id: CMEffectPunch
   categories: [ HideSpawnMenu ]
@@ -13,8 +14,11 @@
   - type: Tag
     tags:
     - HideContextMenu
+  - type: RMCNightVisionVisible
+    priority: 1
 
 - type: entity
+  parent: RMCBaseEffect
   # Just fades out with no movement animation
   id: CMEffectGrab
   categories: [ HideSpawnMenu ]
@@ -30,3 +34,5 @@
   - type: Tag
     tags:
     - HideContextMenu
+  - type: RMCNightVisionVisible
+    priority: 1

--- a/Resources/Prototypes/_RMC14/Effects/attack.yml
+++ b/Resources/Prototypes/_RMC14/Effects/attack.yml
@@ -14,8 +14,6 @@
   - type: Tag
     tags:
     - HideContextMenu
-  - type: RMCNightVisionVisible
-    priority: 1
 
 - type: entity
   parent: RMCBaseEffect
@@ -34,5 +32,3 @@
   - type: Tag
     tags:
     - HideContextMenu
-  - type: RMCNightVisionVisible
-    priority: 1

--- a/Resources/Prototypes/_RMC14/Effects/base.yml
+++ b/Resources/Prototypes/_RMC14/Effects/base.yml
@@ -1,0 +1,6 @@
+﻿- type: entity
+  id: RMCBaseEffect
+  abstract: true
+  components:
+  - type: RMCNightVisionVisible
+    priority: 1

--- a/Resources/Prototypes/_RMC14/Effects/disarm.yml
+++ b/Resources/Prototypes/_RMC14/Effects/disarm.yml
@@ -1,4 +1,5 @@
 - type: entity
+  parent: RMCBaseEffect
   id: RMCEffectDisarm
   categories: [ HideSpawnMenu ]
   components:

--- a/Resources/Prototypes/_RMC14/Effects/emotes.yml
+++ b/Resources/Prototypes/_RMC14/Effects/emotes.yml
@@ -1,4 +1,5 @@
 - type: entity
+  parent: RMCBaseEffect
   id: RMCEffectEmoteBase
   abstract: true
   categories: [ HideSpawnMenu ]

--- a/Resources/Prototypes/_RMC14/Effects/empower.yml
+++ b/Resources/Prototypes/_RMC14/Effects/empower.yml
@@ -1,4 +1,5 @@
 - type: entity
+  parent: RMCBaseEffect
   id: RMCEffectEmpower
   categories: [ HideSpawnMenu ]
   components:

--- a/Resources/Prototypes/_RMC14/Effects/heal.yml
+++ b/Resources/Prototypes/_RMC14/Effects/heal.yml
@@ -1,4 +1,5 @@
 ﻿- type: entity
+  parent: RMCBaseEffect
   id: RMCEffectHeal
   categories: [ HideSpawnMenu ]
   components:

--- a/Resources/Prototypes/_RMC14/Effects/screech.yml
+++ b/Resources/Prototypes/_RMC14/Effects/screech.yml
@@ -1,5 +1,6 @@
 - type: entity
   # Just fades out with no movement animation
+  parent: RMCBaseEffect
   id: CMEffectScreech
   categories: [ HideSpawnMenu ]
   components:

--- a/Resources/Prototypes/_RMC14/Effects/slam.yml
+++ b/Resources/Prototypes/_RMC14/Effects/slam.yml
@@ -1,4 +1,5 @@
 - type: entity
+  parent: RMCBaseEffect
   id: RMCEffectSlam
   categories: [ HideSpawnMenu ]
   components:

--- a/Resources/Prototypes/_RMC14/Effects/slash.yml
+++ b/Resources/Prototypes/_RMC14/Effects/slash.yml
@@ -14,11 +14,9 @@
   - type: Tag
     tags:
     - HideContextMenu
-  - type: RMCNightVisionVisible
-    priority: 1
 
 - type: entity
-  parent: WeaponArcClaw
+  parent: [WeaponArcClaw, RMCBaseEffect]
   id: RMCWeaponArcXenoClaw
   categories: [ HideSpawnMenu ]
   components:
@@ -28,5 +26,3 @@
     sprite: _RMC14/Effects/attacks.rsi
     noRot: true
     state: slash
-  - type: RMCNightVisionVisible
-    priority: 1

--- a/Resources/Prototypes/_RMC14/Effects/slash.yml
+++ b/Resources/Prototypes/_RMC14/Effects/slash.yml
@@ -1,4 +1,5 @@
 - type: entity
+  parent: RMCBaseEffect
   id: RMCEffectExtraSlash
   categories: [ HideSpawnMenu ]
   components:
@@ -13,6 +14,8 @@
   - type: Tag
     tags:
     - HideContextMenu
+  - type: RMCNightVisionVisible
+    priority: 1
 
 - type: entity
   parent: WeaponArcClaw
@@ -25,3 +28,5 @@
     sprite: _RMC14/Effects/attacks.rsi
     noRot: true
     state: slash
+  - type: RMCNightVisionVisible
+    priority: 1


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This makes effects night vision visible, as when a xeno has their night vision effects will be hidden under the sprites, same goes for pointing and such or the slash attack effect