### PR TITLE
Fix runner outrunning entity render range

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/runner.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/runner.yml
@@ -14,6 +14,8 @@
     name: cm-job-name-xeno-runner
   - type: Sprite
     sprite: _RMC14/Mobs/Xenonids/Runner/runner.rsi
+  - type: Eye
+    pvsScale: 1.5
   - type: MobState
     allowedStates:
     - Alive


### PR DESCRIPTION
## About the PR
Increased runner entity render range

## Why / Balance
No more runners running into marines that did not load on their screen until too late

## Media
https://github.com/user-attachments/assets/73bbd80f-7491-42da-81bf-270ab34029eb



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Runners should no longer see entities pop into existence when going too fast
