### PR TITLE
Fix helmet accessory limit

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Head/Helmets/basic_helmets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Head/Helmets/basic_helmets.yml
@@ -11,7 +11,7 @@
   - type: Storage
     maxItemSize: Tiny
     grid:
-    - 0,0,7,1 # 4 slots, 2 reserved for helmet accessories
+    - 0,0,7,1 # 4 slots, only 2 can fit useful items (meds, cigarettes)
     blacklist:
       tags:
       - Pouch
@@ -43,11 +43,6 @@
         - PillPacket
         - Syringe
         - Pill
-    - popup: rmc-storage-limit-accessories
-      count: 2
-      whitelist:
-        components:
-        - HelmetAccessory
   - type: ContainerContainer
     containers:
       storagebase: !type:Container


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
CM13 Parity

Helmets can fit 4 accessories, but only 2 useful items such as meds

:cl:
- tweak: Helmets can now fit 4 accessories instead of just 2.
