### PR TITLE
Highlighting the speech of squad and hive leaders in a speech bubble

### DIFF
--- a/Content.Client/Chat/UI/SpeechBubble.cs
+++ b/Content.Client/Chat/UI/SpeechBubble.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using Content.Client.Chat.Managers;
+using Content.Shared._RMC14.Marines.Squads;
 using Content.Shared.CCVar;
 using Content.Shared.Chat;
 using Content.Shared.Speech;
@@ -267,6 +268,15 @@ namespace Content.Client.Chat.UI
             //We'll be honest. *Yes* this is hacky. Doing this in a cleaner way would require a bottom-up refactor of how saycode handles sending chat messages. -Myr
             bubbleHeader.SetMessage(ExtractAndFormatSpeechSubstring(message, "BubbleHeader", fontColor));
             bubbleContent.SetMessage(ExtractAndFormatSpeechSubstring(message, "BubbleContent", fontColor));
+
+            var entityManager = IoCManager.Resolve<IEntityManager>();
+            var senderUid = entityManager.GetEntity(message.SenderEntity);
+
+            //RMC14 If the speaker is a squad leader and speaks in normal speech, use the command style.
+            if (speechStyleClass == "sayBox" && entityManager.HasComponent<SquadLeaderComponent>(senderUid))
+            {
+                speechStyleClass = "commanderSpeech";
+            }
 
             //As for below: Some day this could probably be converted to xaml. But that is not today. -Myr
             var mainPanel = new PanelContainer

--- a/Content.Client/Chat/UI/SpeechBubble.cs
+++ b/Content.Client/Chat/UI/SpeechBubble.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using Content.Client.Chat.Managers;
 using Content.Shared._RMC14.Marines.Squads;
+using Content.Shared._RMC14.Xenonids.HiveLeader;
 using Content.Shared.CCVar;
 using Content.Shared.Chat;
 using Content.Shared.Speech;
@@ -272,8 +273,9 @@ namespace Content.Client.Chat.UI
             var entityManager = IoCManager.Resolve<IEntityManager>();
             var senderUid = entityManager.GetEntity(message.SenderEntity);
 
-            //RMC14 If the speaker is a squad leader and speaks in normal speech, use the command style.
-            if (speechStyleClass == "sayBox" && entityManager.HasComponent<SquadLeaderComponent>(senderUid))
+            //RMC14 If the speaker is a squad leader or a hive leader and speaks in normal speech, use the command style.
+            if (speechStyleClass == "sayBox" &&
+                (entityManager.HasComponent<SquadLeaderComponent>(senderUid) || entityManager.HasComponent<HiveLeaderComponent>(senderUid)))
             {
                 speechStyleClass = "commanderSpeech";
             }

--- a/Content.Client/Stylesheets/StyleNano.cs
+++ b/Content.Client/Stylesheets/StyleNano.cs
@@ -973,6 +973,21 @@ namespace Content.Client.Stylesheets
                     new StyleProperty("font", notoSansItalic12),
                 }),
 
+                // RMC14
+                new StyleRule(new SelectorChild(
+                    new SelectorElement(typeof(PanelContainer), new[] { "speechBox", "commanderSpeech" }, null, null),
+                    new SelectorElement(typeof(RichTextLabel), new[] { "bubbleContent" }, null, null)),
+                    new[]
+                {
+                    new StyleProperty("font", notoSansBold16),
+                }),
+
+                // RMC14
+                new StyleRule(new SelectorElement(typeof(PanelContainer), new[] {"speechBox", "commanderSpeech"}, null, null), new[]
+                {
+                    new StyleProperty(PanelContainer.StylePropertyPanel, tooltipBox)
+                }),
+
                 new StyleRule(new SelectorElement(typeof(RichTextLabel), new[] {StyleClassLabelKeyText}, null, null), new[]
                 {
                     new StyleProperty(Label.StylePropertyFont, notoSansBold12),


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds larger bold text to squad and hive leaders popups

🔹 Squad leader (SquadLeaderComponent) and hive leader (HiveLeaderComponent) now speak in larger bold text in the text bubbles above their heads.
🔹 Chat remains unchanged, as in SS13, commanders were only highlighted in popup text.
🔹 Whisper and other speech types (whisperBox, emoteBox) remain standard.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity
This is a carryover from Colonial Marines in SS13, where squad leaders were highlighted with larger bold text in pop-up messages. It really helps to notice orders.
## Technical details
<!-- Summary of code changes for easier review. -->

- SpeechBubble.cs now checks if the speaker has a SquadLeaderComponent or HiveLeaderComponent.

- If he is a commander and speaks in a normal voice (sayBox), the commanderSpeech style is applied instead of sayBox.

- StyleNano.cs creates commanderSpeech, which inherits everything from sayBox, but makes the text bold and larger.

I am a beginner developer and it took me several days to add these lines, I spent a lot of time to at least begin to understand what is happening, so if I did something wrong, please help me, I would really like to see this in the game! 😭 
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
For hive leaders it looks exactly the same

Speech **not** from the squad leader:
![image](https://github.com/user-attachments/assets/da541842-3022-4e02-bd54-d7f8bc44be5d)

Speech by the squad leader:
![image](https://github.com/user-attachments/assets/6de86148-dc82-4cb6-8a54-fced849cf7f8)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: to4no_fix
- add: Squad and hive leaders speech in chat bubbles is now bold and significantly larger for better visibility.
