### PR TITLE
Hive weed sources can now actually spread on semi-weedable tiles

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/Hive/xeno_hive_cluster.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/Hive/xeno_hive_cluster.yml
@@ -27,6 +27,7 @@
     spawns: XenoHiveWeedsCluster
     level: 3
     blockOtherWeeds: true
+    spreadsOnSemiWeedable: true
   - type: ReplaceWeedSourceOnWeeding
     replacementPairs:
       RMCCommunicationsTower: HivePylonXeno

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/Hive/xeno_hive_core.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/Hive/xeno_hive_core.yml
@@ -1,4 +1,4 @@
-- type: entity
+﻿- type: entity
   id: HiveCoreXeno
   parent: BaseHiveStructure
   name: hive core
@@ -57,6 +57,7 @@
     spawns: XenoHiveWeedsCore
     level: 3
     blockOtherWeeds: true
+    spreadsOnSemiWeedable: true
   - type: GhostRole
     name: roles-lesser-drone-name
     description: roles-lesser-drone-description


### PR DESCRIPTION
## About the PR
Hive cluster/core placed in a semi-weedable area will now actually make weeds instead of just sitting there doing absolutely nothing

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed hive weed sources (hive cluster/core) not spreading weeds onto semi-weedable tiles directly.
