### PR TITLE
Add 20 minute setup period where NewCoreCooldown does not apply

### DIFF
--- a/Content.Server/_RMC14/Xenonids/Construction/XenoPylonSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Construction/XenoPylonSystem.cs
@@ -1,4 +1,5 @@
 using Content.Server._RMC14.Damage;
+using Content.Server.GameTicking;
 using Content.Server.Ghost.Roles;
 using Content.Server.Ghost.Roles.Events;
 using Content.Shared._RMC14.Dropship;
@@ -29,6 +30,7 @@ public sealed class XenoPylonSystem : SharedXenoPylonSystem
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly RMCDamageableSystem _rmcDamageable = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly GameTicker _gameTicker = default!;
     [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
     [Dependency] private readonly TagSystem _tagSystem = default!;
 
@@ -49,7 +51,8 @@ public sealed class XenoPylonSystem : SharedXenoPylonSystem
 
     private void OnHiveCoreDestruction(Entity<HiveCoreComponent> ent, ref DestructionEventArgs args)
     {
-        if (_hive.GetHive(ent.Owner) is {} hive)
+        if (_hive.GetHive(ent.Owner) is {} hive &&
+            _gameTicker.RoundDuration() > hive.Comp.PreSetupCutoff)
             hive.Comp.NewCoreAt = _timing.CurTime + hive.Comp.NewCoreCooldown;
     }
 

--- a/Content.Shared/_RMC14/Xenonids/Hive/HiveComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hive/HiveComponent.cs
@@ -56,6 +56,9 @@ public sealed partial class HiveComponent : Component
     [DataField, AutoNetworkedField]
     public TimeSpan NewCoreCooldown = TimeSpan.FromMinutes(5);
 
+    [DataField, AutoNetworkedField]
+    public TimeSpan PreSetupCutoff = TimeSpan.FromMinutes(20);
+
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
     public TimeSpan NewCoreAt;
 


### PR DESCRIPTION
## About the PR
title.

## Why / Balance
parity.

## Technical details
its a 7 line pr.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed Hive core not being able to be destroyed and rebuilt without a cooldown in the first 20 minutes of the game.
