### PR TITLE
makes CO and department heads spawn with their stamps at roundstart

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Misc/stamps.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Misc/stamps.yml
@@ -134,7 +134,7 @@
 - type: entity
   parent: CMStampBase
   id: CMStampMarine
-  name: Marine rubber stamp
+  name: High command rubber stamp
   suffix: Admin
   components:
   - type: Sprite

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/auxiliary_support_officer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/auxiliary_support_officer.yml
@@ -81,6 +81,8 @@
   storage:
     pocket1:
     - RMCRangefinder
+      back:
+      - CMStampASO
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/auxiliary_support_officer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/auxiliary_support_officer.yml
@@ -81,8 +81,8 @@
   storage:
     pocket1:
     - RMCRangefinder
-      back:
-      - CMStampASO
+    back:
+    - CMStampASO
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Command/commanding_officer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Command/commanding_officer.yml
@@ -106,6 +106,9 @@
     pocket2: RMCPouchGeneralLarge
   inhand:
     - RMCMatebaCustomizationCase
+  storage:
+    back:
+    - CMStampCO
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Engineering/chief_engineer.yml
@@ -62,9 +62,9 @@
     ears: CMHeadsetCE
     belt: CMBeltUtilityFilled
     pocket1: RMCPouchElectronics
-    storage:
-      back:
-      - CMStampCE
+  storage:
+    back:
+    - CMStampCE
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Engineering/chief_engineer.yml
@@ -62,6 +62,9 @@
     ears: CMHeadsetCE
     belt: CMBeltUtilityFilled
     pocket1: RMCPouchElectronics
+    storage:
+      back:
+      - CMStampCE
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -73,6 +73,9 @@
     id: CMIDCardCMO
     ears: CMHeadsetCMO
     belt: CMBeltMedicalFilled
+    storage:
+      back:
+      - CMStampCMO
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -61,6 +61,9 @@
     shoes: ClothingShoesColorWhite
     id: CMIDCardCMO
     # TODO RMC14 random chemical synthesis note
+  storage:
+    back:
+    - CMStampCMO
 
 - type: startingGear
   id: CMGearCMOEquipped

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -73,9 +73,9 @@
     id: CMIDCardCMO
     ears: CMHeadsetCMO
     belt: CMBeltMedicalFilled
-    storage:
-      back:
-      - CMStampCMO
+  storage:
+    back:
+    - CMStampCMO
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/MilitaryPolice/chief_military_police.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/MilitaryPolice/chief_military_police.yml
@@ -74,6 +74,9 @@
     belt: CMBeltSecurityMPFilled
     #    pocket1: TODO RMC14 tape recorder
     pocket2: RMCPouchGeneralLarge
+  storage:
+    back:
+    - CMStampCMP
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Requisitions/quartermaster.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Requisitions/quartermaster.yml
@@ -67,6 +67,9 @@
     pocket2: RMCPouchGeneralLarge
   inhand:
   - CMStampApproved
+    storage:
+      back:
+      - CMStampQM
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Requisitions/quartermaster.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Requisitions/quartermaster.yml
@@ -67,9 +67,9 @@
     pocket2: RMCPouchGeneralLarge
   inhand:
   - CMStampApproved
-    storage:
-      back:
-      - CMStampQM
+  storage:
+    back:
+    - CMStampQM
 
 - type: entity
   parent: CMSpawnPointJobBase


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
makes the commanding officer and department heads spawn with their stamps at roundstart, additionally, renames the Marine rubber stamp to the High command rubber stamp to avoid confusion

## Why / Balance
Not parity but we have the department heads ready and made and we werent doing anything with them, also edited the HC stamp so that its easier to see that its an admin stamp. Also solves #5336 

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: makes the department heads and the CO spawn with their respective stamps
- tweak: renames the marine rubber stamp to High command rubber stamp to avoid confusion
