### PR TITLE
Fix Bodybags not being able to Buckle onto Rollerbeds/Medevac.

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/morgue.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/morgue.yml
@@ -38,7 +38,6 @@
   - type: EntityStorage
     isCollidableWhenOpen: true
     showContents: false
-    capacity: 1
     enteringOffset: 0, -1
     closeSound:
       path: /Audio/Items/deconstruct.ogg
@@ -115,7 +114,6 @@
   - type: EntityStorage
     isCollidableWhenOpen: true
     showContents: false
-    capacity: 1
     enteringOffset: 0, -1
     closeSound:
       path: /Audio/Items/deconstruct.ogg

--- a/Resources/Prototypes/Entities/Structures/Storage/morgue.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/morgue.yml
@@ -38,6 +38,7 @@
   - type: EntityStorage
     isCollidableWhenOpen: true
     showContents: false
+    capacity: 1
     enteringOffset: 0, -1
     closeSound:
       path: /Audio/Items/deconstruct.ogg
@@ -114,6 +115,7 @@
   - type: EntityStorage
     isCollidableWhenOpen: true
     showContents: false
+    capacity: 1
     enteringOffset: 0, -1
     closeSound:
       path: /Audio/Items/deconstruct.ogg

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Medical/bodybags.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Medical/bodybags.yml
@@ -8,6 +8,7 @@
     size: Small
   - type: Sprite
     sprite: _RMC14/Objects/Medical/bodybags.rsi
+    drawdepth: Mobs
     layers:
     - state: bodybag_closed
       map: ["unfoldedLayer", "enum.StorageVisualLayers.Base"]
@@ -92,6 +93,15 @@
     containers:
       entity_storage: !type:Container
       paper_label: !type:ContainerSlot
+  - type: Buckle
+    buckleDelay: 0
+    clickUnbuckle: false
+  - type: BuckleWhitelist
+    whitelist:
+      components:
+      - MedevacStretcher
+      tags:
+      - CMRollerItem
 
 - type: entity
   parent: CMBodyBag


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Bodybags can now be buckled onto rollerbeds and medevac stretchers.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Partiy
## Technical details
<!-- Summary of code changes for easier review. -->
Added drawdepth of Mobs and copied CMStasisBag buckle component stuff to CMBodyBags.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- tweaked: Bodybags can be buckled to stretchers and medevacs now.
-->
