### PR TITLE
Fix bipod not slowing on break + fix drop not breaking it

### DIFF
--- a/Content.Shared/_RMC14/Attachable/Components/AttachableToggleableComponent.cs
+++ b/Content.Shared/_RMC14/Attachable/Components/AttachableToggleableComponent.cs
@@ -47,6 +47,18 @@ public sealed partial class AttachableToggleableComponent : Component
     public bool BreakOnFullRotate = false;
 
     /// <summary>
+    /// If set to true, the attachment will deactivate upon being dropped.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool BreakOnDrop = false;
+
+    /// <summary>
+    /// If set to true, the attachment will slow the user upon being toggled due to any source but toggling it manually.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool SlowOnBreak = false;
+
+    /// <summary>
     /// If set to true, the attachment can only be toggled when the holder is wielded.
     /// </summary>
     [DataField, AutoNetworkedField]

--- a/Content.Shared/_RMC14/Attachable/Systems/AttachableHolderSystem.cs
+++ b/Content.Shared/_RMC14/Attachable/Systems/AttachableHolderSystem.cs
@@ -15,6 +15,7 @@ using Content.Shared.Hands;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
+using Content.Shared.Interaction.Events;
 using Content.Shared.Storage.EntitySystems;
 using Content.Shared.Verbs;
 using Content.Shared.Weapons.Melee.Events;
@@ -84,6 +85,7 @@ public sealed class AttachableHolderSystem : EntitySystem
         SubscribeLocalEvent<AttachableHolderComponent, GetFireModesEvent>(RelayEvent);
         SubscribeLocalEvent<AttachableHolderComponent, GetDamageFalloffEvent>(RelayEvent);
         SubscribeLocalEvent<AttachableHolderComponent, GetWeaponAccuracyEvent>(RelayEvent);
+        SubscribeLocalEvent<AttachableHolderComponent, DroppedEvent>(RelayEvent);
 
 
         CommandBinds.Builder

--- a/Content.Shared/_RMC14/Attachable/Systems/AttachableToggleableSystem.cs
+++ b/Content.Shared/_RMC14/Attachable/Systems/AttachableToggleableSystem.cs
@@ -531,7 +531,7 @@ public sealed class AttachableToggleableSystem : EntitySystem
                 {
                     foreach (var entity in ents)
                     {
-                        if (!TryComp(entity, out FixturesComponent? fixturesComponent))
+                        if (!TryComp(entity, out FixturesComponent? fixturesComponent) || !Transform(entity).Anchored)
                             continue;
 
                         foreach (var fixture in fixturesComponent.Fixtures.Values)

--- a/Content.Shared/_RMC14/Attachable/Systems/AttachableToggleableSystem.cs
+++ b/Content.Shared/_RMC14/Attachable/Systems/AttachableToggleableSystem.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using Content.Shared._RMC14.Attachable.Components;
 using Content.Shared._RMC14.Attachable.Events;
+using Content.Shared._RMC14.Slow;
 using Content.Shared._RMC14.Weapons.Ranged;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared.Actions;
@@ -10,6 +11,7 @@ using Content.Shared.Fluids;
 using Content.Shared.Hands;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
+using Content.Shared.Interaction.Events;
 using Content.Shared.Light;
 using Content.Shared.Movement.Events;
 using Content.Shared.Physics;
@@ -41,6 +43,7 @@ public sealed class AttachableToggleableSystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
     [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
     [Dependency] private readonly UseDelaySystem _useDelaySystem = default!;
+    [Dependency] private readonly RMCSlowSystem _slow = default!;
 
     private const string attachableToggleUseDelayID = "RMCAttachableToggle";
 
@@ -69,6 +72,8 @@ public sealed class AttachableToggleableSystem : EntitySystem
         SubscribeLocalEvent<AttachableToggleableComponent, AttachableRelayedEvent<GotEquippedHandEvent>>(OnGotEquippedHand);
         SubscribeLocalEvent<AttachableToggleableComponent, AttachableRelayedEvent<GotUnequippedHandEvent>>(OnGotUnequippedHand);
         SubscribeLocalEvent<AttachableToggleableComponent, SprayAttemptEvent>(OnSprayAttempt);
+        SubscribeLocalEvent<AttachableToggleableComponent, DroppedEvent>(OnDropped);
+        SubscribeLocalEvent<AttachableToggleableComponent, AttachableRelayedEvent<DroppedEvent>>(OnDropped);
 
         SubscribeLocalEvent<AttachableMovementLockedComponent, MoveInputEvent>(OnAttachableMovementLockedMoveInput);
 
@@ -287,9 +292,13 @@ public sealed class AttachableToggleableSystem : EntitySystem
 
         args.Args.Handled = true;
 
-        if (attachable.Comp.NeedHand && attachable.Comp.Active)
+        if ((attachable.Comp.NeedHand || attachable.Comp.BreakOnDrop) && attachable.Comp.Active)
+        {
             Toggle(attachable, args.Args.User, attachable.Comp.DoInterrupt);
 
+            if (attachable.Comp.SlowOnBreak)
+                BreakSlow(args.Args.User);
+        }
 
         var removeEv = new RemoveAttachableActionsEvent(args.Args.User);
         RaiseLocalEvent(attachable, ref removeEv);
@@ -302,6 +311,40 @@ public sealed class AttachableToggleableSystem : EntitySystem
 
         if (attachable.Comp.AttachedOnly && !attachable.Comp.Attached)
             args.Cancelled = true;
+    }
+
+    private void OnDropped(Entity<AttachableToggleableComponent> attachable, ref DroppedEvent args)
+    {
+        if (attachable.Comp.AttachedOnly && !attachable.Comp.Attached)
+            return;
+
+        if (!attachable.Comp.BreakOnDrop || !attachable.Comp.Active)
+            return;
+
+        Toggle(attachable, args.User);
+
+        if (attachable.Comp.SlowOnBreak)
+            BreakSlow(args.User);
+    }
+
+    private void OnDropped(Entity<AttachableToggleableComponent> attachable, ref AttachableRelayedEvent<DroppedEvent> args)
+    {
+        if (attachable.Comp.AttachedOnly && !attachable.Comp.Attached)
+            return;
+
+        if (!attachable.Comp.BreakOnDrop || !attachable.Comp.Active)
+            return;
+
+        Toggle(attachable, args.Args.User);
+
+        if (attachable.Comp.SlowOnBreak)
+            BreakSlow(args.Args.User);
+    }
+
+    private void BreakSlow(EntityUid user)
+    {
+        _slow.TrySlowdown(user, TimeSpan.FromSeconds(4));
+        _slow.TrySuperSlowdown(user, TimeSpan.FromSeconds(2));
     }
 
     private void OnAttachableMovementLockedMoveInput(Entity<AttachableMovementLockedComponent> user, ref MoveInputEvent args)
@@ -320,6 +363,8 @@ public sealed class AttachableToggleableSystem : EntitySystem
             }
 
             Toggle((attachableUid, toggleableComponent), user.Owner, toggleableComponent.DoInterrupt);
+            if (toggleableComponent.SlowOnBreak)
+                BreakSlow(user);
         }
     }
 
@@ -347,6 +392,8 @@ public sealed class AttachableToggleableSystem : EntitySystem
             }
 
             Toggle((attachableUid, toggleableComponent), user.Owner, toggleableComponent.DoInterrupt);
+            if (toggleableComponent.SlowOnBreak)
+                BreakSlow(user);
         }
     }
 
@@ -384,6 +431,8 @@ public sealed class AttachableToggleableSystem : EntitySystem
             }
 
             Toggle((attachableUid, toggleableComponent), user.Owner, toggleableComponent.DoInterrupt);
+            if (toggleableComponent.SlowOnBreak)
+                BreakSlow(user);
         }
     }
 #endregion

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/rail_attachments.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/rail_attachments.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   abstract: true
   parent: RMCAttachableBase
   id: RMCRailAttachmentBase

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/under_attachments.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/under_attachments.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   abstract: true
   parent: RMCAttachableBase
   id: RMCUnderAttachmentBase
@@ -51,6 +51,8 @@
     attachedOnly: true
     breakOnMove: true
     breakOnFullRotate: true
+    breakOnDrop: true
+    slowOnBreak: true
     doAfter: 1.5
     deactivateDoAfter: 0
     doAfterNeedHand: false


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity. Bipod breaks on drop in CM. And it slows you down if you don't toggle it before any of the forced breaking stuff happens.

Technically unequipping doesn't breaking it but requipping does (shrug) so I just put it on unequip aswell anyway.

Fixes #5918

Bipod requiring anchoring isn't parity, but it's silly that it doesn't honestly. A loose cade isn't very stable. Dragging one around in CM would be harder as it slows you down alot more (we don't have generally slower pull speed for alot of objects atm) and tiles block a lot more. It just makes more sense to check anchored. Technically the facing direction also needs to match which we don't have that being check either.

## Technical details
<!-- Summary of code changes for easier review. -->
DroppedEvent is relayed to the attachment holder now.

New fields for breaking on drop, and slowing on break. Slow atm is hardcoded for timings because I don't really think anything else has the behavior but if it does with diff numbers it won't be hard to add in.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/31ccb18b-abb3-4d33-8a07-9e0aa906251f



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed bipod not breaking on drop.
- fix: Fixed bipod not slowing you down if toggled by anything but the action. Manually undeploying the bipod with the action still won't slow you down.
- fix: Fixed bipod being instant deployable on non-anchored barricades.
