### PR TITLE
Fix marine operations uniform camo not working

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/marines.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/marines.yml
@@ -248,6 +248,7 @@
     sprite: _RMC14/Objects/Clothing/Uniforms/boiler/jungle.rsi
   - type: FoldableClothing
     foldedEquippedPrefix: sleeves
+  - type: Appearance
   - type: ItemCamouflage
     camouflageVariations:
       Jungle: _RMC14/Objects/Clothing/Uniforms/boiler/jungle.rsi


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Title
## Why / Balance
Fix
## Technical details
Edits marine.yml
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed marine operations uniform not having camouflage specific sprites. 