### PR TITLE
Fix acid melt times

### DIFF
--- a/Content.Shared/_RMC14/CCVar/RMCCVars.cs
+++ b/Content.Shared/_RMC14/CCVar/RMCCVars.cs
@@ -133,7 +133,7 @@ public sealed class RMCCVars : CVars
         CVarDef.Create("rmc.corrosive_acid_damage_type", "Heat", CVar.REPLICATED | CVar.SERVER);
 
     public static readonly CVarDef<int> RMCCorrosiveAcidDamageTimeSeconds =
-        CVarDef.Create("rmc.corrosive_acid_damage_time_seconds", 45, CVar.REPLICATED | CVar.SERVER);
+        CVarDef.Create("rmc.corrosive_acid_damage_time_seconds", 40, CVar.REPLICATED | CVar.SERVER);
 
     public static readonly CVarDef<int> RMCTailStabMaxTargets =
         CVarDef.Create("rmc.tail_stab_max_targets", 1, CVar.REPLICATED | CVar.SERVER);

--- a/Content.Shared/_RMC14/Xenonids/Acid/CorrodibleComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Acid/CorrodibleComponent.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.GameStates;
+using Robust.Shared.GameStates;
 
 namespace Content.Shared._RMC14.Xenonids.Acid;
 
@@ -15,4 +15,7 @@ public sealed partial class CorrodibleComponent : Component
 
     [DataField, AutoNetworkedField]
     public bool Structure = false;
+
+    [DataField, AutoNetworkedField]
+    public float MeltTimeMult = 1;
 }

--- a/Content.Shared/_RMC14/Xenonids/Acid/SharedXenoAcidSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Acid/SharedXenoAcidSystem.cs
@@ -11,7 +11,6 @@ using Robust.Shared.Timing;
 using Robust.Shared.Configuration;
 using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Xenonids.Energy;
-using Content.Shared.Flash.Components;
 
 namespace Content.Shared._RMC14.Xenonids.Acid;
 

--- a/Content.Shared/_RMC14/Xenonids/Acid/SharedXenoAcidSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Acid/SharedXenoAcidSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared._RMC14.Xenonids.Plasma;
+using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared.Coordinates;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
@@ -11,6 +11,7 @@ using Robust.Shared.Timing;
 using Robust.Shared.Configuration;
 using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Xenonids.Energy;
+using Content.Shared.Flash.Components;
 
 namespace Content.Shared._RMC14.Xenonids.Acid;
 
@@ -70,7 +71,7 @@ public abstract class SharedXenoAcidSystem : EntitySystem
     private void OnXenoCorrosiveAcid(Entity<XenoAcidComponent> xeno, ref XenoCorrosiveAcidEvent args)
     {
         if (xeno.Owner != args.Performer ||
-            !CheckCorrodiblePopups(xeno, args.Target, out var time))
+            !CheckCorrodiblePopups(xeno, args.Target, out var time, out var _))
         {
             return;
         }
@@ -101,7 +102,7 @@ public abstract class SharedXenoAcidSystem : EntitySystem
         if (args.Handled || args.Cancelled || args.Target is not { } target)
             return;
 
-        if (!CheckCorrodiblePopups(xeno, target, out var _))
+        if (!CheckCorrodiblePopups(xeno, target, out var _, out var mult))
             return;
 
         if (args.PlasmaCost != 0 && !_xenoPlasma.TryRemovePlasmaPopup(xeno.Owner, args.PlasmaCost))
@@ -115,12 +116,13 @@ public abstract class SharedXenoAcidSystem : EntitySystem
 
         args.Handled = true;
 
-        ApplyAcid(args.AcidId, target, args.Dps, args.ExpendableLightDps, args.Time);
+        ApplyAcid(args.AcidId, target, args.Dps, args.ExpendableLightDps, args.Time * mult);
     }
 
-    private bool CheckCorrodiblePopups(Entity<XenoAcidComponent> xeno, EntityUid target, out TimeSpan time)
+    private bool CheckCorrodiblePopups(Entity<XenoAcidComponent> xeno, EntityUid target, out TimeSpan time, out float mult)
     {
         time = TimeSpan.Zero;
+        mult = 1;
         if (!TryComp(target, out CorrodibleComponent? corrodible) ||
             !corrodible.IsCorrodible)
         {
@@ -141,6 +143,7 @@ public abstract class SharedXenoAcidSystem : EntitySystem
         }
 
         time = corrodible.TimeToApply;
+        mult = corrodible.MeltTimeMult;
 
         return true;
     }

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
@@ -12,7 +12,7 @@
     event: !type:XenoCorrosiveAcidEvent
       acidId: XenoAcidNormal
       plasmaCost: 100
-      time: 225 # seconds or 3.75 minutes
+      time: 50 # seconds
       dps: 8
       expendableLightDps: 2.5
     checkCanInteract: false
@@ -31,7 +31,7 @@
     event: !type:XenoCorrosiveAcidEvent
       acidId: XenoAcidWeak
       plasmaCost: 75
-      time: 562.5 # seconds or 9.375 minutes
+      time: 125 # seconds or 2~ minutes
       dps: 4
       expendableLightDps: 0.3
     checkCanInteract: false
@@ -50,7 +50,7 @@
     event: !type:XenoCorrosiveAcidEvent
       acidId: XenoAcidStrong
       plasmaCost: 125
-      time: 90 # seconds or 1.5 minutes
+      time: 20 # seconds
       dps: 20
       expendableLightDps: 23.4375
     checkCanInteract: false
@@ -71,7 +71,7 @@
       plasmaCost: 0
       energyCost: 100
       applyTimeMultiplier: 0.25
-      time: 90 # seconds or 1.5 minutes
+      time: 20 # seconds
       dps: 20
       expendableLightDps: 23.4375
     checkCanInteract: false

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Base/base_structure.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Base/base_structure.yml
@@ -123,6 +123,7 @@
   - type: Corrodible
     isCorrodible: true
     structure: true
+    meltTimeMult: 3
   - type: Clickable
   - type: RMCWallExplosionDeletable
   - type: DestroyedByExplosionType


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
parity. Ours was too long. The mistake was assuming items take 9 ticks to melt, they only take 3~ in parity. But in reality is 8 and 2 because the first tick is basically skipped to set up time stuffs and it deletes when it hits 0. So all acid times are much much faster.

Walls however now take longer because they count as turfs. Might be other things that need that but I put it on base wall for now.

## Technical details
<!-- Summary of code changes for easier review. -->
New Datafield for melt time mult, otherwise it's just YML. Also because of the -1 tick thing barricades were lasting 5 seconds too long.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed acid taking 4.5x as long as it should be to melt most things. Walls melting lasted 1.5x as long as they should have.
- fix: Fixed acid on barricades lasting 5 seconds too long.