### PR TITLE
Split Brute Armor into three.

### DIFF
--- a/Content.Shared/_RMC14/Armor/CMArmorComponent.cs
+++ b/Content.Shared/_RMC14/Armor/CMArmorComponent.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.GameStates;
+using Robust.Shared.GameStates;
 
 namespace Content.Shared._RMC14.Armor;
 
@@ -8,7 +8,13 @@ public sealed partial class CMArmorComponent : Component
 {
     // TODO RMC14 other types of armor
     [DataField, AutoNetworkedField]
-    public int Armor;
+    public int XenoArmor;
+
+    [DataField, AutoNetworkedField]
+    public int Melee;
+
+    [DataField, AutoNetworkedField]
+    public int Bullet;
 
     [DataField, AutoNetworkedField]
     public int Bio;

--- a/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
+++ b/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using Content.Shared._RMC14.Medical.Surgery;
 using Content.Shared._RMC14.Medical.Surgery.Steps;
 using Content.Shared._RMC14.Projectiles;
+using Content.Shared._RMC14.Weapons.Ranged;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared._RMC14.Xenonids.Projectile;
 using Content.Shared._RMC14.Xenonids.Projectile.Spit.Slowing;
@@ -262,15 +263,15 @@ public sealed class CMArmorSystem : EntitySystem
         }
 
         args.Damage = new DamageSpecifier(args.Damage);
-        if (TryComp<XenoComponent>(ent, out var xeno2))
+        if (TryComp<XenoComponent>(ent, out var xenoResist))
         {
             Resist(args.Damage, ev.XenoArmor, ArmorGroup);
         }
-        else if (!TryComp<XenoProjectileComponent>(args.Tool, out var spit) && TryComp<RMCProjectileAccuracyComponent>(args.Tool, out var bullet))
+        else if (TryComp<RMCBulletComponent>(args.Tool, out var bulletResist))
         {
             Resist(args.Damage, ev.Bullet, ArmorGroup);
         }
-        else if(!TryComp<XenoProjectileComponent>(args.Tool, out var spit2))
+        else if(!TryComp<XenoProjectileComponent>(args.Tool, out var meleeResist))
         {
             Resist(args.Damage, ev.Melee, ArmorGroup);
         }

--- a/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
+++ b/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
@@ -10,6 +10,7 @@ using Content.Shared.Alert;
 using Content.Shared.Clothing.Components;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
+using Content.Shared.Destructible;
 using Content.Shared.Explosion;
 using Content.Shared.FixedPoint;
 using Content.Shared.Inventory;
@@ -248,6 +249,7 @@ public sealed class CMArmorSystem : EntitySystem
 
             ev.Bio -= armorPiercing;
         }
+
         if (args.Origin is { } origin)
         {
             var originCoords = _transform.GetMapCoordinates(origin);
@@ -264,20 +266,22 @@ public sealed class CMArmorSystem : EntitySystem
         }
 
         args.Damage = new DamageSpecifier(args.Damage);
-        if (HasComp<XenoComponent>(ent))
+        if (!HasComp<XenoComponent>(ent))
+        {
+            if (HasComp<RMCBulletComponent>(args.Tool))
+            {
+                Resist(args.Damage, ev.Bullet, ArmorGroup);
+            }
+            else if (HasComp<MeleeWeaponComponent>(args.Tool))
+            {
+                Resist(args.Damage, ev.Melee, ArmorGroup);
+            }
+            Resist(args.Damage, ev.Bio, BioGroup);
+        }
+        else
         {
             Resist(args.Damage, ev.XenoArmor, ArmorGroup);
         }
-        else if (HasComp<RMCBulletComponent>(args.Tool))
-        {
-            Resist(args.Damage, ev.Bullet, ArmorGroup);
-        }
-        else if (HasComp<MeleeWeaponComponent>(args.Tool))
-        {
-            Resist(args.Damage, ev.Melee, ArmorGroup);
-        }
-
-        Resist(args.Damage, ev.Bio, BioGroup);
     }
 
     private void Resist(DamageSpecifier damage, int armor, ProtoId<DamageGroupPrototype> group)

--- a/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
+++ b/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Content.Shared._RMC14.Medical.Surgery;
 using Content.Shared._RMC14.Medical.Surgery.Steps;
+using Content.Shared._RMC14.Projectiles;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared._RMC14.Xenonids.Projectile.Spit.Slowing;
 using Content.Shared.Alert;
@@ -77,10 +78,10 @@ public sealed class CMArmorSystem : EntitySystem
         {
             var ev = new CMGetArmorEvent(SlotFlags.OUTERCLOTHING | SlotFlags.INNERCLOTHING);
             RaiseLocalEvent(armored, ref ev);
-            string? armorMessage = FixedPoint2.New(ev.Armor * ev.ArmorModifier) + " / " + armored.Comp.Armor;
+            string? armorMessage = FixedPoint2.New(ev.XenoArmor * ev.ArmorModifier) + " / " + armored.Comp.XenoArmor;
             var max = _alerts.GetMaxSeverity(xeno.ArmorAlert);
 
-            var severity = max - ContentHelpers.RoundToLevels(ev.Armor * ev.ArmorModifier, MaxXenoArmor, max + 1);
+            var severity = max - ContentHelpers.RoundToLevels(ev.XenoArmor * ev.ArmorModifier, MaxXenoArmor, max + 1);
             _alerts.ShowAlert(armored, xeno.ArmorAlert, (short)severity, dynamicMessage: armorMessage);
         }
     }
@@ -98,14 +99,30 @@ public sealed class CMArmorSystem : EntitySystem
 
     private void OnGetArmor(Entity<CMArmorComponent> armored, ref CMGetArmorEvent args)
     {
-        args.Armor += armored.Comp.Armor;
-        args.Bio += armored.Comp.Bio;
+        if (TryComp<XenoComponent>(armored, out var xeno))
+        {
+            args.XenoArmor += armored.Comp.XenoArmor;
+        }
+        else
+        {
+            args.Melee += armored.Comp.Melee;
+            args.Bullet += armored.Comp.Bullet;
+            args.Bio += armored.Comp.Bio;
+        }
     }
 
     private void OnGetArmorRelayed(Entity<CMArmorComponent> armored, ref InventoryRelayedEvent<CMGetArmorEvent> args)
     {
-        args.Args.Armor += armored.Comp.Armor;
-        args.Args.Bio += armored.Comp.Bio;
+        if (TryComp<XenoComponent>(armored, out var xeno))
+        {
+            args.Args.XenoArmor += armored.Comp.XenoArmor;
+        }
+        else
+        {
+            args.Args.Melee += armored.Comp.Melee;
+            args.Args.Bullet += armored.Comp.Bullet;
+            args.Args.Bio += armored.Comp.Bio;
+        }
     }
 
     private void OnGetExplosionResistanceRelayed(Entity<CMArmorComponent> ent, ref InventoryRelayedEvent<GetExplosionResistanceEvent> args)
@@ -213,10 +230,20 @@ public sealed class CMArmorSystem : EntitySystem
             armorPiercing += piercingEv.Piercing;
         }
 
-        ev.Armor = (int) (ev.Armor * ev.ArmorModifier);
-        ev.Armor -= armorPiercing;
-        ev.Bio -= armorPiercing;
+        if (TryComp<XenoComponent>(ent, out var xeno))
+        {
+            ev.XenoArmor = (int)(ev.XenoArmor * ev.ArmorModifier);
+            ev.XenoArmor -= armorPiercing;
+        }
+        else
+        {
+            ev.Melee = (int)(ev.Melee * ev.ArmorModifier);
+            ev.Bullet = (int)(ev.Bullet * ev.ArmorModifier);
 
+            ev.Melee -= armorPiercing;
+            ev.Bullet -= armorPiercing;
+            ev.Bio -= armorPiercing;
+        }
         if (args.Origin is { } origin)
         {
             var originCoords = _transform.GetMapCoordinates(origin);
@@ -227,13 +254,25 @@ public sealed class CMArmorSystem : EntitySystem
                 var diff = (originCoords.Position - armorCoords.Position).ToWorldAngle().GetCardinalDir();
                 if (diff == _transform.GetWorldRotation(ent).GetCardinalDir())
                 {
-                    ev.Armor += ev.FrontalArmor;
+                    ev.XenoArmor += ev.FrontalArmor;
                 }
             }
         }
-
         args.Damage = new DamageSpecifier(args.Damage);
-        Resist(args.Damage, ev.Armor, ArmorGroup);
+
+        if (TryComp<XenoComponent>(ent, out var xeno2))
+        {
+            Resist(args.Damage, ev.XenoArmor, ArmorGroup);
+        }
+        else if (TryComp<RMCProjectileAccuracyComponent>(args.Tool, out var accuracy))
+        {
+            Resist(args.Damage, ev.Bullet, ArmorGroup);
+        }
+        else
+        {
+            Resist(args.Damage, ev.Melee, ArmorGroup);
+        }
+
         Resist(args.Damage, ev.Bio, BioGroup);
     }
 

--- a/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
+++ b/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared._RMC14.Medical.Surgery;
 using Content.Shared._RMC14.Medical.Surgery.Steps;
 using Content.Shared._RMC14.Projectiles;
 using Content.Shared._RMC14.Xenonids;
+using Content.Shared._RMC14.Xenonids.Projectile;
 using Content.Shared._RMC14.Xenonids.Projectile.Spit.Slowing;
 using Content.Shared.Alert;
 using Content.Shared.Clothing.Components;
@@ -238,10 +239,11 @@ public sealed class CMArmorSystem : EntitySystem
         else
         {
             ev.Melee = (int)(ev.Melee * ev.ArmorModifier);
-            ev.Bullet = (int)(ev.Bullet * ev.ArmorModifier);
-
             ev.Melee -= armorPiercing;
+
+            ev.Bullet = (int)(ev.Bullet * ev.ArmorModifier);
             ev.Bullet -= armorPiercing;
+
             ev.Bio -= armorPiercing;
         }
         if (args.Origin is { } origin)
@@ -258,17 +260,17 @@ public sealed class CMArmorSystem : EntitySystem
                 }
             }
         }
-        args.Damage = new DamageSpecifier(args.Damage);
 
+        args.Damage = new DamageSpecifier(args.Damage);
         if (TryComp<XenoComponent>(ent, out var xeno2))
         {
             Resist(args.Damage, ev.XenoArmor, ArmorGroup);
         }
-        else if (TryComp<RMCProjectileAccuracyComponent>(args.Tool, out var accuracy))
+        else if (!TryComp<XenoProjectileComponent>(args.Tool, out var spit) && TryComp<RMCProjectileAccuracyComponent>(args.Tool, out var bullet))
         {
             Resist(args.Damage, ev.Bullet, ArmorGroup);
         }
-        else
+        else if(!TryComp<XenoProjectileComponent>(args.Tool, out var spit2))
         {
             Resist(args.Damage, ev.Melee, ArmorGroup);
         }

--- a/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
+++ b/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
@@ -16,6 +16,7 @@ using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Preferences;
 using Content.Shared.Rounding;
+using Content.Shared.Weapons.Melee;
 using Robust.Shared.Prototypes;
 
 namespace Content.Shared._RMC14.Armor;
@@ -101,7 +102,7 @@ public sealed class CMArmorSystem : EntitySystem
 
     private void OnGetArmor(Entity<CMArmorComponent> armored, ref CMGetArmorEvent args)
     {
-        if (TryComp<XenoComponent>(armored, out var xeno))
+        if (HasComp<XenoComponent>(armored))
         {
             args.XenoArmor += armored.Comp.XenoArmor;
         }
@@ -115,7 +116,7 @@ public sealed class CMArmorSystem : EntitySystem
 
     private void OnGetArmorRelayed(Entity<CMArmorComponent> armored, ref InventoryRelayedEvent<CMGetArmorEvent> args)
     {
-        if (TryComp<XenoComponent>(armored, out var xeno))
+        if (HasComp<XenoComponent>(armored))
         {
             args.Args.XenoArmor += armored.Comp.XenoArmor;
         }
@@ -232,7 +233,7 @@ public sealed class CMArmorSystem : EntitySystem
             armorPiercing += piercingEv.Piercing;
         }
 
-        if (TryComp<XenoComponent>(ent, out var xeno))
+        if (HasComp<XenoComponent>(ent))
         {
             ev.XenoArmor = (int)(ev.XenoArmor * ev.ArmorModifier);
             ev.XenoArmor -= armorPiercing;
@@ -263,15 +264,15 @@ public sealed class CMArmorSystem : EntitySystem
         }
 
         args.Damage = new DamageSpecifier(args.Damage);
-        if (TryComp<XenoComponent>(ent, out var xenoResist))
+        if (HasComp<XenoComponent>(ent))
         {
             Resist(args.Damage, ev.XenoArmor, ArmorGroup);
         }
-        else if (TryComp<RMCBulletComponent>(args.Tool, out var bulletResist))
+        else if (HasComp<RMCBulletComponent>(args.Tool))
         {
             Resist(args.Damage, ev.Bullet, ArmorGroup);
         }
-        else if(!TryComp<XenoProjectileComponent>(args.Tool, out var meleeResist))
+        else if (HasComp<MeleeWeaponComponent>(args.Tool))
         {
             Resist(args.Damage, ev.Melee, ArmorGroup);
         }

--- a/Content.Shared/_RMC14/Armor/CMGetArmorEvent.cs
+++ b/Content.Shared/_RMC14/Armor/CMGetArmorEvent.cs
@@ -1,6 +1,6 @@
-﻿using Content.Shared.Inventory;
+using Content.Shared.Inventory;
 
 namespace Content.Shared._RMC14.Armor;
 
 [ByRefEvent]
-public record struct CMGetArmorEvent(SlotFlags TargetSlots, int Armor = 0, int Bio = 0, int FrontalArmor = 0, double ArmorModifier = 1) : IInventoryRelayEvent;
+public record struct CMGetArmorEvent(SlotFlags TargetSlots, int XenoArmor = 0, int Melee = 0, int Bullet = 0, int Bio = 0, int FrontalArmor = 0, double ArmorModifier = 1) : IInventoryRelayEvent;

--- a/Content.Shared/_RMC14/Weapons/Ranged/RMCBulletComponent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/RMCBulletComponent.cs
@@ -1,0 +1,12 @@
+using Content.Shared._RMC14.Projectiles;
+
+namespace Content.Shared._RMC14.Weapons.Ranged;
+
+/// <summary>
+///     Projectiles with this component are bullets.
+/// </summary>
+[RegisterComponent]
+[Access(typeof(RMCProjectileSystem), typeof(CMGunSystem))]
+public sealed partial class RMCBulletComponent : Component
+{
+}

--- a/Content.Shared/_RMC14/Xenonids/Crest/XenoCrestSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Crest/XenoCrestSystem.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Content.Shared._RMC14.Armor;
 using Content.Shared._RMC14.Stun;
 using Content.Shared._RMC14.Xenonids.Fortify;
@@ -82,7 +82,7 @@ public sealed class XenoCrestSystem : EntitySystem
     private void OnXenoCrestGetArmor(Entity<XenoCrestComponent> xeno, ref CMGetArmorEvent args)
     {
         if (xeno.Comp.Lowered)
-            args.Armor += xeno.Comp.Armor;
+            args.XenoArmor += xeno.Comp.Armor;
     }
 
     private void OnXenoCrestBeforeStatusAdded(Entity<XenoCrestComponent> xeno, ref BeforeStatusEffectAddedEvent args)

--- a/Content.Shared/_RMC14/Xenonids/Fortify/XenoFortifySystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Fortify/XenoFortifySystem.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Content.Shared._RMC14.Armor;
 using Content.Shared._RMC14.Explosion;
 using Content.Shared._RMC14.Stun;
@@ -82,7 +82,7 @@ public sealed class XenoFortifySystem : EntitySystem
     {
         if (xeno.Comp.Fortified)
         {
-            args.Armor += xeno.Comp.Armor;
+            args.XenoArmor += xeno.Comp.Armor;
             args.FrontalArmor += xeno.Comp.FrontalArmor;
         }
     }

--- a/Content.Shared/_RMC14/Xenonids/Projectile/Spit/XenoSpitSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/Spit/XenoSpitSystem.cs
@@ -116,7 +116,7 @@ public sealed class XenoSpitSystem : EntitySystem
 
     private void OnActiveChargingSpitGetArmor(Entity<XenoActiveChargingSpitComponent> ent, ref CMGetArmorEvent args)
     {
-        args.Armor += ent.Comp.Armor;
+        args.XenoArmor += ent.Comp.Armor;
     }
 
     private void OnActiveChargingSpitRefreshSpeed(Entity<XenoActiveChargingSpitComponent> ent, ref RefreshMovementSpeedModifiersEvent args)

--- a/Content.Shared/_RMC14/Xenonids/Tantrum/XenoTantrumSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Tantrum/XenoTantrumSystem.cs
@@ -70,7 +70,7 @@ public sealed class XenoTantrumSystem : EntitySystem
         if (HasComp<TantrumSpeedBuffComponent>(xeno) || !xeno.Comp.Running)
             return;
 
-        args.Armor += xeno.Comp.ArmorGain;
+        args.XenoArmor += xeno.Comp.ArmorGain;
     }
 
     private void OnXenoTantrumAction(Entity<XenoTantrumComponent> xeno, ref XenoTantrumActionEvent args)

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/armored_vest.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/armored_vest.yml
@@ -12,7 +12,8 @@
     walkModifier: 0.725
     sprintModifier: 0.725
   - type: CMArmor
-    armor: 15 # TODO RMC14 20 bullet
+    melee: 15
+    bullet: 20
     bio: 20
     explosionArmor: 10
   - type: CMHardArmor

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/basic_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/basic_armor.yml
@@ -16,7 +16,8 @@
     walkModifier: 0.62
     sprintModifier: 0.62
   - type: CMArmor
-    armor: 30
+    melee: 30
+    bullet: 30
     explosionArmor: 10
   - type: CMHardArmor
   - type: RMCNameItemOnVend

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/cmb.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/cmb.yml
@@ -7,7 +7,8 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/CMB/cmb_light_armor.rsi
   - type: CMArmor
-    armor: 25
+    melee: 20
+    bullet: 25
     bio: 15
     explosionArmor: 20
   - type: RMCArmorSpeedTier
@@ -31,7 +32,8 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/CMB/cmb_heavy_armor.rsi
   - type: CMArmor
-    armor: 25
+    melee: 25
+    bullet: 25
     bio: 15
     explosionArmor: 25
   - type: RMCArmorSpeedTier
@@ -54,7 +56,8 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/CMB/cmb_sheriff_armor.rsi
   - type: CMArmor
-    armor: 25
+    melee: 25
+    bullet: 30
     bio: 15
     explosionArmor: 30
   - type: RMCArmorSpeedTier

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/coats.yml
@@ -239,7 +239,7 @@
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/OuterClothing/Coats/cmp.rsi
   - type: CMArmor
-    armor: 10
+    melee: 10
 
 
 # Military Warden
@@ -254,7 +254,7 @@
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/OuterClothing/Coats/warden.rsi
   - type: CMArmor
-    armor: 10
+    melee: 10
 
 # Military Police
 - type: entity
@@ -268,7 +268,7 @@
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/OuterClothing/Coats/mp.rsi
   - type: CMArmor
-    armor: 10
+    melee: 10
   - type: Appearance
   - type: Foldable
     canFoldInsideContainer: true
@@ -302,7 +302,7 @@
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/OuterClothing/Coats/chef.rsi
   - type: CMArmor
-    armor: 10
+    melee: 10
 
 # Auxiliary Supply Officer
 - type: entity
@@ -316,7 +316,7 @@
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/OuterClothing/Coats/aso/jungle.rsi
   - type: CMArmor
-    armor: 10
+    melee: 10
   - type: Appearance
   - type: ItemCamouflage
     camouflageVariations:
@@ -338,7 +338,7 @@
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/OuterClothing/Coats/CO/jacket.rsi
   - type: CMArmor
-    armor: 10
+    melee: 10
 
 - type: entity
   parent: CMCoatCO
@@ -351,7 +351,7 @@
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/OuterClothing/Coats/CO/bomber.rsi
   - type: CMArmor
-    armor: 10
+    melee: 10
   - type: Appearance
   - type: Foldable
     canFoldInsideContainer: true
@@ -371,7 +371,7 @@
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/OuterClothing/Coats/CO/formal_black.rsi
   - type: CMArmor
-    armor: 10
+    melee: 10
 
 - type: entity
   parent: CMCoatCO
@@ -384,7 +384,7 @@
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/OuterClothing/Coats/CO/formal_white.rsi
   - type: CMArmor
-    armor: 10
+    melee: 10
 
 # Executive Officer
 
@@ -399,7 +399,7 @@
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/OuterClothing/Coats/coat_formal.rsi
   - type: CMArmor
-    armor: 10
+    melee: 10
   - type: Appearance
   - type: Foldable
     canFoldInsideContainer: true
@@ -419,7 +419,7 @@
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/OuterClothing/Coats/officer.rsi
   - type: CMArmor
-    armor: 10
+    melee: 10
 
 - type: entity
   parent: CMCoatOfficer
@@ -431,7 +431,7 @@
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/OuterClothing/Coats/service/jungle.rsi
   - type: CMArmor
-    armor: 10 # TODO RMC14 10 melee
+    melee: 10
   - type: Appearance
   - type: Foldable
     canFoldInsideContainer: true

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/detective_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/detective_armor.yml
@@ -10,7 +10,8 @@
     walkModifier: 0.725
     sprintModifier: 0.725
   - type: CMArmor
-    armor: 15 # TODO RMC14 20 bullet
+    melee: 15
+    bullet: 20
     bio: 20
     explosionArmor: 10
   - type: CMHardArmor

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/faction_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/faction_armor.yml
@@ -10,7 +10,8 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/marsoc.rsi
   - type: CMArmor
-    armor: 30 # CLOTHING_ARMOR_HIGH
+    melee: 30 # CLOTHING_ARMOR_HIGH
+    bullet: 30
     bio: 15 # CLOTHING_ARMOR_MEDIUMLOW
     explosionArmor: 40 # CLOTHING_ARMOR_VERYHIGH
   - type: RMCArmorSpeedTier
@@ -35,7 +36,8 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/SPP/bear.rsi
   - type: CMArmor
-    armor: 25
+    melee: 20
+    bullet: 25
     bio: 20
     explosionArmor: 20 # CLOTHING_ARMOR_MEDIUM
   - type: ClothingSpeedModifier # SLOWDOWN_ARMOR_VERY_LIGHT
@@ -52,7 +54,8 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/Dutch/vest.rsi
   - type: CMArmor
-    armor: 32 # CLOTHING_ARMOR_HIGH (melee); CLOTHING_ARMOR_HIGHPLUS (bullets); intermediate value until more damage types implemented
+    melee: 30 # CLOTHING_ARMOR_HIGH 
+    bullet: 35 # CLOTHING_ARMOR_HIGHPLUS 
     bio: 20
     explosionArmor: 30 # CLOTHING_ARMOR_HIGH
   - type: ClothingSpeedModifier # SLOWDOWN_ARMOR_VERY_LIGHT
@@ -76,7 +79,7 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/Dutch/bandolier.rsi
   - type: CMArmor
-    armor: 25
+    melee: 25
     bio: 20
     explosionArmor: 20 # CLOTHING_ARMOR_MEDIUM
   - type: RMCArmorSpeedTier
@@ -95,7 +98,8 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/freelancer.rsi
   - type: CMArmor
-    armor: 25 # CLOTHING_ARMOR_MEDIUMHIGH
+    melee: 25 # CLOTHING_ARMOR_MEDIUMHIGH
+    bullet: 25
     bio: 15
     explosionArmor: 20
   - type: RMCArmorSpeedTier
@@ -124,7 +128,8 @@
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/OuterClothing/Militia/rebel.rsi
   - type: CMArmor
-    armor: 18 # CLOTHING_ARMOR_MEDIUM (melee); CLOTHING_ARMOR_MEDIUMLOW (bullets)
+    melee: 20 # CLOTHING_ARMOR_MEDIUM 
+    bullet: 15 # CLOTHING_ARMOR_MEDIUMLOW (bullets)
     explosionArmor: 20 # CLOTHING_ARMOR_MEDIUM
   - type: RMCArmorSpeedTier
     speedTier: light
@@ -203,7 +208,8 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/Mercenary/heavy.rsi
   - type: CMArmor
-    armor: 40 # CLOTHING_ARMOR_VERYHIGH
+    melee: 40 # CLOTHING_ARMOR_VERYHIGH
+    bullet: 40
     bio: 20
     explosionArmor: 20 # CLOTHING_ARMOR_MEDIUM
   - type: RMCArmorSpeedTier
@@ -223,7 +229,8 @@
   description: A set of grey, heavy ceramic armor with dark blue highlights. It has been modified with extra ceramic plates placed in its storage pouch, and seems intended to support an extremely heavy weapon.
   components:
   - type: CMArmor
-    armor: 52 # CLOTHING_ARMOR_ULTRAHIGH (melee); CLOTHING_ARMOR_ULTRAHIGHPLUS (bullet)
+    melee: 50 # CLOTHING_ARMOR_ULTRAHIGH 
+    bullet: 55 # CLOTHING_ARMOR_ULTRAHIGHPLUS 
     bio: 20
     explosionArmor: 35 # CLOTHING_ARMOR_HIGHPLUS
   - type: Storage
@@ -264,7 +271,8 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/Mercenary/hefa.rsi
   - type: CMArmor
-    armor: 40 # CLOTHING_ARMOR_VERYHIGH
+    melee: 40 # CLOTHING_ARMOR_VERYHIGH
+    bullet: 40
     bio: 15
     explosionArmor: 70 # CLOTHING_ARMOR_GIGAHIGH
   - type: ItemCamouflage
@@ -280,7 +288,8 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/riot.rsi
   - type: CMArmor
-    armor: 25 # CLOTHING_ARMOR_MEDIUMHIGH
+    melee: 25 # CLOTHING_ARMOR_MEDIUMHIGH
+    bullet: 25
     bio: 20
     explosionArmor: 20 # CLOTHING_ARMOR_MEDIUM
   - type: RMCArmorSpeedTier
@@ -296,7 +305,10 @@
   description: Based on the M3 pattern employed by the UNMC, the UN-M1 body armor is employed by security, riot control and union-busting teams. The UN-1MS modification is Synthetic programming compliant, sacrificing protection for speed and carrying capacity.
   components:
   - type: CMArmor
-    armor: 0
+    melee: 0
+    bullet: 0
+    bio: 0
+    explosionArmor: 0
   - type: RMCArmorSpeedTier
     speedTier: super light
   - type: ClothingSpeedModifier # SLOWDOWN_ARMOR_SUPER_LIGHT
@@ -316,7 +328,8 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/cbrn.rsi
   - type: CMArmor
-    armor: 20 # CLOTHING_ARMOR_MEDIUM
+    melee: 20 # CLOTHING_ARMOR_MEDIUM
+    bullet: 20
     explosionArmor: 20 # CLOTHING_ARMOR_MEDIUM
     bio: 10 # CLOTHING_ARMOR_LOW
   - type: RMCArmorSpeedTier
@@ -333,6 +346,7 @@
   name: CBRN M3-M advanced armor
   components:
   - type: CMArmor
-    armor: 20 # CLOTHING_ARMOR_MEDIUM
+    melee: 30 # CLOTHING_ARMOR_HIGH
+    bullet: 25
     explosionArmor: 50 # CLOTHING_ARMOR_ULTRAHIGH
     bio: 75 # CLOTHING_ARMOR_GIGAHIGHPLUS

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/faction_coats.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/faction_coats.yml
@@ -12,7 +12,8 @@
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/OuterClothing/Coats/Bureau/deputy.rsi
   - type: CMArmor
-    armor: 15
+    melee: 15
+    bullet: 15
     bio: 10
     explosionArmor: 10
 
@@ -40,7 +41,8 @@
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/OuterClothing/Coats/jacket_general.rsi
   - type: CMArmor
-    armor: 35
+    melee: 35
+    bullet: 35
     bio: 10
     explosionArmor: 40
   - type: ExplosionResistance

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
@@ -8,7 +8,8 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/m3/standard/padded/jungle.rsi
   - type: CMArmor
-    armor: 20
+    melee: 20
+    bullet: 20
     bio: 20
     explosionArmor: 15
   - type: RMCArmorSpeedTier
@@ -136,7 +137,7 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/m3/b12/jungle.rsi
   - type: CMArmor
-    armor: 25
+    melee: 25
     bio: 25
     explosionArmor: 20
   - type: ItemCamouflage
@@ -156,7 +157,8 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/m3/eod/padded/jungle.rsi
   - type: CMArmor
-    armor: 25
+    melee: 25
+    bullet: 35
     bio: 25
     explosionArmor: 35
   - type: RMCArmorSpeedTier
@@ -331,7 +333,7 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/m3/co.rsi
   - type: CMArmor
-    armor: 30
+    bullet: 30
     bio: 20
     explosionArmor: 15
   - type: SmartGunArmor
@@ -356,7 +358,7 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/m3/ceremonial.rsi
   - type: CMArmor
-    armor: 30
+    bullet: 30
     bio: 20
     explosionArmor: 15
   - type: SmartGunArmor
@@ -376,7 +378,8 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/m3/g4/jungle.rsi
   - type: CMArmor
-    armor: 25
+    melee: 25
+    bullet: 25
     bio: 15
     explosionArmor: 40
   - type: Corrodible
@@ -423,7 +426,8 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/m3/light/padded/jungle.rsi
   - type: CMArmor
-    armor: 15
+    melee: 15
+    bullet: 15
     bio: 15
     explosionArmor: 20
   - type: RMCArmorSpeedTier
@@ -567,7 +571,7 @@
     walkModifier: .725
     sprintModifier: .725
   - type: CMArmor
-    armor: 25
+    melee: 25
   - type: Tag
     tags:
       - RMCScoutArmor
@@ -588,7 +592,8 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/m3/vl.rsi
   - type: CMArmor
-    armor: 15
+    melee: 15
+    bullet: 30
     bio: 15
     explosionArmor: 10
   - type: Storage
@@ -625,7 +630,10 @@
     equipDelay: 1
     unequipDelay: 0.5
   - type: CMArmor
-    armor: 0 # CLOTHING_ARMOR_NONE
+    melee: 0 # CLOTHING_ARMOR_NONE
+    bullet: 0
+    bio: 0
+    explosionArmor: 0
   - type: RMCArmorSpeedTier
     speedTier: super light
   - type: ClothingSpeedModifier # SLOWDOWN_ARMOR_SUPER_LIGHT
@@ -678,6 +686,8 @@
     sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/m35/jungle.rsi
   - type: Corrodible
     isCorrodible: false
+  - type: CMArmor
+    bio: 25
   - type: ItemCamouflage
     camouflageVariations:
       Jungle: _RMC14/Objects/Clothing/OuterClothing/Armor/m35/jungle.rsi
@@ -697,6 +707,8 @@
     sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/ghillie/jungle.rsi
   - type: Corrodible
     isCorrodible: false
+  - type: CMArmor
+    bio: 25
   - type: RMCArmorSpeedTier
     speedTier: light
   - type: ClothingSpeedModifier # light armor speed
@@ -727,6 +739,8 @@
     maxItemSize: Small
     grid:
     - 0,0,3,1 # 2 slots
+  - type: CMArmor
+    explosionArmor: 20
   - type: RMCArmorSpeedTier
     speedTier: light
   - type: ClothingSpeedModifier
@@ -752,7 +766,8 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/m2/mp/jungle.rsi
   - type: CMArmor
-    armor: 25
+    melee: 25
+    bullet: 20
     bio: 15
     explosionArmor: 20
   - type: RMCArmorSpeedTier

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/pmc.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/pmc.yml
@@ -8,7 +8,7 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/PMC/pmc.rsi
   - type: CMArmor
-    armor: 25 # CLOTHING_ARMOR_MEDIUMHIGH
+    bullet: 25 # CLOTHING_ARMOR_MEDIUMHIGH
     bio: 20 # CLOTHING_ARMOR_MEDIUM
     explosionArmor: 20 # CLOTHING_ARMOR_MEDIUM
   - type: ClothingSpeedModifier # SLOWDOWN_ARMOR_LIGHT
@@ -29,7 +29,8 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/PMC/sniper.rsi
   - type: CMArmor
-    armor: 20 # CLOTHING_ARMOR_MEDIUM
+    melee: 15
+    bullet: 20 # CLOTHING_ARMOR_MEDIUM
     bio: 20 # CLOTHING_ARMOR_MEDIUM
     explosionArmor: 15 # CLOTHING_ARMOR_MEDIUMLOW
   - type: ClothingSpeedModifier # SLOWDOWN_ARMOR_VERY_LIGHT
@@ -73,7 +74,10 @@
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/PMC/sniper.rsi
-
+  - type: CMArmor
+    bullet: 25
+    explosionArmor: 20
+    
 - type: entity
   parent: CMArmorM4PMCLight
   id: CMArmorM4PMCSynth
@@ -84,7 +88,10 @@
     equipDelay: 1
     unequipDelay: 0.5
   - type: CMArmor
-    armor: 0 # CLOTHING_ARMOR_NONE
+    melee: 0 # CLOTHING_ARMOR_NONE
+    bullet: 0
+    bio: 0
+    explosionArmor: 0
   - type: ClothingSpeedModifier # SLOWDOWN_ARMOR_SUPER_LIGHT
     walkModifier: 0.949
     sprintModifier: 0.949
@@ -101,7 +108,7 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/PMC/heavy.rsi
   - type: CMArmor
-    armor: 25 # CLOTHING_ARMOR_MEDIUMHIGH
+    bullet: 25 # CLOTHING_ARMOR_MEDIUMHIGH
     bio: 20 # CLOTHING_ARMOR_MEDIUM
     explosionArmor: 20 # CLOTHING_ARMOR_MEDIUM
   - type: ItemCamouflage
@@ -116,7 +123,8 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/PMC/commando.rsi
   - type: CMArmor
-    armor: 40 # CLOTHING_ARMOR_HIGH (melee); CLOTHING_ARMOR_ULTRAHIGH (bullets); going with an intermediate value until more damage types get implemented
+    melee: 30 # CLOTHING_ARMOR_HIGH (melee) 
+    bullet: 50 # CLOTHING_ARMOR_ULTRAHIGH (bullets)
     bio: 20 # CLOTHING_ARMOR_MEDIUM
     explosionArmor: 40 # CLOTHING_ARMOR_VERYHIGH
   - type: RMCArmorSpeedTier
@@ -136,7 +144,8 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/PMC/commando.rsi
   - type: CMArmor
-    armor: 45 # CLOTHING_ARMOR_VERYHIGH (melee); CLOTHING_ARMOR_ULTRAHIGH (bullets); going with an intermediate value until more damage types get implemented (more likely to be hit by bullets than melee)
+    melee: 40 # CLOTHING_ARMOR_VERYHIGH (melee); 
+    bullet: 50 # CLOTHING_ARMOR_ULTRAHIGH (bullets); going with an intermediate value until more damage types get implemented (more likely to be hit by bullets than melee)
     bio: 20 # CLOTHING_ARMOR_MEDIUM
     explosionArmor: 40 # CLOTHING_ARMOR_VERYHIGH
   - type: RMCArmorSpeedTier

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/provost.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/provost.yml
@@ -10,7 +10,7 @@
   - type: Item
     size: Normal
   - type: CMArmor
-    armor: 20 # CLOTHING_ARMOR_MEDIUM
+    bullet: 20 # CLOTHING_ARMOR_MEDIUM
     bio: 15
     explosionArmor: 25 # CLOTHING_ARMOR_MEDIUMHIGH
   - type: RMCArmorSpeedTier
@@ -92,7 +92,8 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/Provost/special.rsi
   - type: CMArmor
-    armor: 25 # CLOTHING_ARMOR_MEDIUMHIGH
+    melee: 25
+    bullet: 25 # CLOTHING_ARMOR_MEDIUMHIGH
     bio: 20
     explosionArmor: 20 # CLOTHING_ARMOR_MEDIUM
   - type: Storage

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/royal.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/royal.yml
@@ -17,7 +17,7 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/Royal/light.rsi
   - type: CMArmor
-    armor: 25 # CLOTHING_ARMOR_MEDIUMHIGH
+    bullet: 25 # CLOTHING_ARMOR_MEDIUMHIGH
     bio: 20
     explosionArmor: 20 # CLOTHING_ARMOR_MEDIUM
   - type: RMCArmorSpeedTier
@@ -54,7 +54,8 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/Royal/pointman.rsi
   - type: CMArmor
-    armor: 32 # CLOTHING_ARMOR_HIGH (melee); CLOTHING_ARMOR_HIGHPLUS (bullet)
+    melee: 30 # CLOTHING_ARMOR_HIGH 
+    bullet: 35 # CLOTHING_ARMOR_HIGHPLUS (bullet)
     explosionArmor: 35 # CLOTHING_ARMOR_HIGHPLUS
     bio: 20 # CLOTHING_ARMOR_MEDIUM
   - type: RMCArmorSpeedTier

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/security_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/security_armor.yml
@@ -12,7 +12,8 @@
     walkModifier: .725
     sprintModifier: .725
   - type: CMArmor
-    armor: 15 # TODO RMC14 20 bullet
+    melee: 15
+    bullet: 20
     bio: 20
     explosionArmor: 10
   - type: CMHardArmor

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/spp.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/spp.yml
@@ -95,7 +95,7 @@
     sprintModifier: 0.62
   - type: CMArmor
     melee: 25 # CLOTHING_ARMOR_MEDIUMHIGH (melee)
-    bullet: # CLOTHING_ARMOR_HIGHPLUS (bullets) 
+    bullet: 35 # CLOTHING_ARMOR_HIGHPLUS (bullets) 
     bio: 20 # CLOTHING_ARMOR_MEDIUM
     explosionArmor: 30 # CLOTHING_ARMOR_HIGH
   - type: Storage

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/spp.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/spp.yml
@@ -8,7 +8,7 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/SPP/spp.rsi
   - type: CMArmor
-    armor: 30 # CLOTHING_ARMOR_HIGH
+    bullet: 30 # CLOTHING_ARMOR_HIGH
     bio: 15 # CLOTHING_ARMOR_MEDIUMLOW
     explosionArmor: 20 # CLOTHING_ARMOR_MEDIUM
   - type: RMCArmorSpeedTier
@@ -30,6 +30,8 @@
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/SPP/support.rsi
+  - type: CMArmor
+    melee: 30 # CLOTHING_ARMOR_HIGH
   - type: RMCArmorSpeedTier
     speedTier: light
   - type: ClothingSpeedModifier # SLOWDOWN_ARMOR_LIGHT
@@ -51,7 +53,10 @@
     equipDelay: 1
     unequipDelay: 0.5
   - type: CMArmor
-    armor: 0 # CLOTHING_ARMOR_NONE
+    melee: 0 # CLOTHING_ARMOR_NONE
+    bullet: 0
+    bio: 0
+    explosionArmor: 0
   - type: RMCArmorSpeedTier
     speedTier: very light
   - type: ClothingSpeedModifier # SLOWDOWN_ARMOR_VERY_LIGHT
@@ -89,7 +94,8 @@
     walkModifier: 0.62
     sprintModifier: 0.62
   - type: CMArmor
-    armor: 30 # CLOTHING_ARMOR_HIGHPLUS (bullets), CLOTHING_ARMOR_MEDIUMHIGH (melee); choosing an intermediate value until more damage types are implemented
+    melee: 25 # CLOTHING_ARMOR_MEDIUMHIGH (melee)
+    bullet: # CLOTHING_ARMOR_HIGHPLUS (bullets) 
     bio: 20 # CLOTHING_ARMOR_MEDIUM
     explosionArmor: 30 # CLOTHING_ARMOR_HIGH
   - type: Storage
@@ -108,7 +114,8 @@
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/OuterClothing/SPP/officer.rsi
   - type: CMArmor
-    armor: 10
+    melee: 10
+    bullet: 10
     bio: 10
     explosionArmor: 10
   - type: ExplosionResistance
@@ -129,6 +136,11 @@
     sprite: _RMC14/Objects/Clothing/OuterClothing/SPP/senior.rsi
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/OuterClothing/SPP/senior.rsi
+  - type: CMArmor
+    melee: 10
+    bullet: 10
+    bio: 10
+    explosionArmor: 10
   - type: Storage
     grid:
     - 0,0,7,1 # 4 slots
@@ -143,3 +155,8 @@
     sprite: _RMC14/Objects/Clothing/OuterClothing/SPP/mp.rsi
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/OuterClothing/SPP/mp.rsi
+  - type: CMArmor
+    melee: 10
+    bullet: 10
+    bio: 10
+    explosionArmor: 10

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/base.yml
@@ -68,4 +68,4 @@
   id: RMCMarineUniformBase
   components:
   - type: CMArmor
-    armor: 10
+    melee: 10

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/boiler.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/boiler.yml
@@ -69,7 +69,7 @@
     plasmaRegenOnWeeds: 7
   - type: XenoAcid
   - type: CMArmor
-    armor: 20
+    xenoArmor: 20
     explosionArmor: 20
   - type: XenoDevour
   - type: XenoZoom

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/burrower.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/burrower.yml
@@ -51,7 +51,7 @@
     plasmaRegenOnWeeds: 4.5
   - type: XenoAcid
   - type: CMArmor
-    armor: 25
+    xenoArmor: 25
     explosionArmor: 40
   - type: XenoDevour
   - type: XenoStomp

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/defender.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/defender.yml
@@ -46,7 +46,7 @@
     maxPlasma: 100
     plasmaRegenOnWeeds: 5
   - type: CMArmor
-    armor: 35
+    xenoArmor: 35
     explosionArmor: 70
   - type: XenoCrest
   - type: XenoDevour

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/praetorian.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/praetorian.yml
@@ -52,7 +52,7 @@
     maxPlasma: 800
     plasmaRegenOnWeeds: 3
   - type: CMArmor
-    armor: 25
+    xenoArmor: 25
     explosionArmor: 40
   - type: MeleeWeapon
     damage:

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
@@ -85,7 +85,7 @@
     maxPlasma: 1000
     plasmaRegenOnWeeds: 4
   - type: CMArmor
-    armor: 25
+    xenoArmor: 25
     explosionArmor: 100
   - type: XenoWordQueen
   - type: XenoGut

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/ravager.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/ravager.yml
@@ -48,7 +48,7 @@
     maxPlasma: 300
     plasmaRegenOnWeeds: 5
   - type: CMArmor
-    armor: 25
+    xenoArmor: 25
     explosionArmor: 80
   - type: XenoClaws
     clawType: VerySharp

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/spitter.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/spitter.yml
@@ -67,7 +67,7 @@
       groups:
         Brute: 36
   - type: CMArmor
-    armor: 15
+    xenoArmor: 15
     explosionArmor: 20
   - type: MeleeWeapon
     damage:

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/warrior.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/warrior.yml
@@ -59,7 +59,7 @@
     - CMXenoCrusher
     - CMXenoPraetorian
   - type: CMArmor
-    armor: 20
+    xenoArmor: 20
     explosionArmor: 40
   - type: XenoClaws
     clawType: Sharp

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/cm_base_gun.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/cm_base_gun.yml
@@ -55,4 +55,5 @@
     - state: bullet
       shader: unshaded
   - type: BulletholeGenerator
+  - type: RMCBullet
   - type: RMCProjectileAccuracy


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Changed CMArmorComponent and CMArmorSystem to facilitate Bullet Armor. Xenos now have XenoArmor in their prototypes, this is still the same as old Armor. Humanoids now have Melee and Bullet armor values. All relevant YMLs have been updated, as well as a couple of systems that enable some Xeno Castes to gain more armor. All jackets and uniforms no longer have resistance versus bullets. Unless you're SPP for some reason, ya dirty commie!
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity!
## Technical details
<!-- Summary of code changes for easier review. -->
Armor is now split into XenoArmor, Melee and Bullet. All Castes and Armor Variants have been updated to reflect this change.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed armors using the same value when resisting bullet and melee damage. This makes the M3-VL and M3-EOD heavy armor better at resisting bullet damage for example.
