### PR TITLE
show the current tech tier in the objectives window

### DIFF
--- a/Content.Client/_RMC14/Intel/ViewIntelObjectivesBui.cs
+++ b/Content.Client/_RMC14/Intel/ViewIntelObjectivesBui.cs
@@ -26,6 +26,7 @@ public sealed class ViewIntelObjectivesBui(EntityUid owner, Enum uiKey) : BoundU
 
         var tree = comp.Tree;
         _window.CurrentPointsLabel.Text = $"{tree.Points.Double():F1}";
+        _window.CurrentTierLabel.Text = $"{tree.Tier}";
         _window.TotalPointsLabel.Text = $"Total earned credits: {tree.TotalEarned.Double():F1}";
         _window.DocumentsLabel.Text = $"{tree.Documents.Current} / {tree.Documents.Total}";
         // _window.UploadDataLabel.Text = $"{tree.UploadData.Current} / {tree.UploadData.Total}";

--- a/Content.Client/_RMC14/Intel/ViewIntelObjectivesWindow.xaml
+++ b/Content.Client/_RMC14/Intel/ViewIntelObjectivesWindow.xaml
@@ -5,9 +5,17 @@
     Title="Marine Tech Tree Objectives"
     MinSize="600 550">
     <BoxContainer Orientation="Vertical">
-        <RichTextLabel Text="[bold]Tech Points[/bold]" />
+        <BoxContainer Orientation="Horizontal">
+            <RichTextLabel Text="[bold]Tech Points[/bold]" />
+            <Control HorizontalExpand="True" />
+            <RichTextLabel Text="[bold]Tier[/bold]" />
+        </BoxContainer>
         <ui:BlueHorizontalSeparator />
-        <RichTextLabel Name="CurrentPointsLabel" Access="Public" />
+        <BoxContainer Orientation="Horizontal">
+            <RichTextLabel Name="CurrentPointsLabel" Access="Public" />
+            <Control HorizontalExpand="True" />
+            <RichTextLabel Name="CurrentTierLabel" Access="Public" />
+        </BoxContainer>
         <BoxContainer Orientation="Horizontal" Margin="0 15 0 0">
             <RichTextLabel Text="[bold]Objectives[/bold]" />
             <Control HorizontalExpand="True" />


### PR DESCRIPTION
## About the PR

This PR adds the current tech tier to the intel window.

## Why / Balance

QOL. You sometimes miss the announcement or join late and never see it.

## Technical details

Added the current tech tier next to current points in the "Marine Tech Tree Objectives" UI.

## Media

![image](https://github.com/user-attachments/assets/58b483f8-74f9-4c41-ad3c-4ad1c2bee7bc)


## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: The current tech tier can now be seen in the intel objectives window.
