### PR TITLE
decouple jackets and hats from armor

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/coats.yml
@@ -411,8 +411,7 @@
 - type: entity
   parent: RMCBaseJacket
   id: CMCoatOfficer
-  name: marine service jacket
-  description: A service jacket typically worn by officers of the UNMC.
+  abstract: true
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/Coats/officer.rsi
@@ -424,7 +423,8 @@
 - type: entity
   parent: CMCoatOfficer
   id: RMCCoatService
-  description: A service jacket typically worn by officers of the UNMC. It has shards of light Kevlar to help protect against stabbing weapons and bullets.
+  name: marine service jacket
+  description: A service jacket typically worn by officers of the UNMC.
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/Coats/service/jungle.rsi

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/intel.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/intel.yml
@@ -129,6 +129,9 @@
       entries:
       - id: RMCArmorXM4
       - id: RMCArmorM3LightVariants
+    - name: Jacket
+      choices: { CMCoat: 1}
+      entries:
       - id: RMCCoatService
     - name: Backpack
       choices: { CMBag: 1 }
@@ -143,6 +146,9 @@
       entries:
       - id: RMCArmorHelmetM12Intel
         recommended: true
+    - name: Hat
+      choices: { CMHat: 1 }
+      entries:
       - id: RMCHeadBeretGreen
       - id: CMHeadBeretTan
       - id: CMHeadCapOfficer

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/intel.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/intel.yml
@@ -130,7 +130,7 @@
       - id: RMCArmorXM4
       - id: RMCArmorM3LightVariants
     - name: Jacket
-      choices: { CMCoat: 1}
+      choices: { CMCoat: 1 }
       entries:
       - id: RMCCoatService
     - name: Backpack

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/senior_enlisted_advisor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/senior_enlisted_advisor.yml
@@ -62,7 +62,7 @@
       - id: RMCArmorM3LightPadded
       - id: RMCArmorM3MediumVariants
     - name: Jacket
-      choices: { CMCoat: 1}
+      choices: { CMCoat: 1 }
       entries:
       - id: RMCCoatService
     - name: Eyewear

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/senior_enlisted_advisor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/senior_enlisted_advisor.yml
@@ -47,12 +47,23 @@
       - id: RMCPouchMedkit
       - id: RMCPouchPistol
       - id: RMCPouchSling
+    - name: Hat
+      choices: { CMHat: 1 }
+      entries:
+      - id: CMHeadCapDrill
+    - name: Helmet
+      choices: { CMHelmet: 1 }
+      entries:
+      - id: ArmorHelmetM10
     - name: Armor
       choices: { CMArmor: 1 }
       entries:
       - id: CMArmorM3VLBallistics
       - id: RMCArmorM3LightPadded
       - id: RMCArmorM3MediumVariants
+    - name: Jacket
+      choices: { CMCoat: 1}
+      entries:
       - id: RMCCoatService
     - name: Eyewear
       choices: { CMEyewear: 1 }
@@ -71,11 +82,6 @@
       - id: CMWebbingHolster
       - id: CMWebbing
       - id: CMWebbingPouch
-    - name: Headwear
-      choices: { CMHeadwear: 1 }
-      entries:
-      - id: CMHeadCapDrill
-      - id: ArmorHelmetM10
 
 - type: entity
   parent: ColMarTechBase


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
- Decouples jackets and hats from armor categories.
- made CMCoatOfficer abstract, it's a base for other jackets and not an item used in game. (Marine jacket uses camo, other jackets do not)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
- Allows players to take BOTH cosmetics and armor, so they're not locked into one option while shipside and still have access to personal armor.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/08c81a3a-1253-425e-8325-2891f49fcb19)
![image](https://github.com/user-attachments/assets/194acb67-8160-41e1-95ec-09dc28e49ed4)


**Changelog**

:cl: Whisper

- tweak: Intelligence Officers and Senior Enlisted Advisors can now take both armor and cosmetic items separately, no longer blocking taking the other.

