### PR TITLE
Use the new layer hiding to fix the gas mask snout bug

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Masks/masks.yml
@@ -304,3 +304,4 @@
     sprite: _RMC14/Objects/Clothing/Mask/Keffiyeh/keffiyeh_red.rsi
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/Mask/Keffiyeh/keffiyeh_red.rsi
+    

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Masks/masks.yml
@@ -4,8 +4,8 @@
   abstract: true
   components:
   - type: HideLayerClothing
-    slots:
-    - Snout
+    layers:
+      Snout: Mask
     hideOnToggle: true
 
 - type: entity
@@ -68,7 +68,7 @@
     - Mask
   - type: Item
     size: Small
-    
+
 - type: entity
   parent: CMBaseMask
   id: RMCMaskKutjevoRespirator


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixes #5173 by using the new functionality added upstream to the HideLayerClothingComponent

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Ugly bug on some sprites.

## Technical details
<!-- Summary of code changes for easier review. -->
Uses the new `layers` Dictionary in `HideLayerClothingComponent` (introduced upstream here: https://github.com/space-wizards/space-station-14/pull/34080) to specify that a mask should only cover the snout when equipped on the mask slot. Without this change, it is possible that the gas mask will start hiding snouts when equipped to the suitstorage slot of an engineering vest. So, this both fixes the core of a bug but also prevents a new bug from being introduced by the fix upstream.

This SHOULD NOT BE MERGED until the upstream PR it depends on has been brought down here. It WILL break without those changes (which is why the YAML linter doesn't like it right now).

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Particularly large-snouted members of their species should now be able to fit their noses into their gas masks.
