### PR TITLE
Fixes M15 grenades not fitting in M79 and fixes UGL not fitting airburst

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/under_attachments.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/under_attachments.yml
@@ -455,6 +455,7 @@
     whitelist:
       tags:
       - RMCGrenadeM40
+      - RMCAirburstGrenade
     capacity: 3
     soundInsert:
       path: /Audio/_RMC14/Weapons/Guns/Reload/grenade_insert.ogg

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m74_airburst_grenades.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m74_airburst_grenades.yml
@@ -30,6 +30,7 @@
     tags:
     - Grenade
     - LauncherCompatibleGrenade
+    - RMCAirburstGrenade
   - type: ContainerContainer
     containers:
       cluster-payload: !type:Container

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -190,6 +190,7 @@
   - type: Tag
     tags:
     - Grenade
+    - LauncherCompatibleGrenade
   - type: Ammo
   - type: ClusterLimitHits
   - type: CMExplosionEffect

--- a/Resources/Prototypes/_RMC14/tags.yml
+++ b/Resources/Prototypes/_RMC14/tags.yml
@@ -111,3 +111,6 @@
 
 - type: Tag
   id: RipOffOnInfection
+
+- type: Tag
+  id: RMCAirburstGrenade


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Resolves #5956
Resolves #5957

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed M15 grenades not fitting in the m79 and grenadier spec launcher.
- fix: Fixed airburst grenades not fitting in the U1 UGL.
