### PR TITLE
Xeno QOL And Scout is no longer pullable while invisible

### DIFF
--- a/Content.Shared/_RMC14/Armor/ThermalCloak/ThermalCloakSystem.cs
+++ b/Content.Shared/_RMC14/Armor/ThermalCloak/ThermalCloakSystem.cs
@@ -24,6 +24,7 @@ using Robust.Shared.Audio.Systems;
 using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
+using Content.Shared.Movement.Pulling.Components;
 
 namespace Content.Shared._RMC14.Armor.ThermalCloak;
 
@@ -125,6 +126,9 @@ public sealed class ThermalCloakSystem : EntitySystem
             activeInvisibility.Opacity = ent.Comp.Opacity;
             Dirty(user, activeInvisibility);
 
+            if (TryComp<PullableComponent>(user, out var pullable))
+                RemCompDeferred<PullableComponent>(user);// Removes the pullable component if invis (hopefully)
+
             ent.Comp.Enabled = true;
             turnInvisible.Enabled = true;
             if (TryComp<InstantActionComponent>(ent.Comp.Action, out var action))
@@ -199,6 +203,8 @@ public sealed class ThermalCloakSystem : EntitySystem
                 RemCompDeferred<EntityIFFComponent>(user);
 
             RemCompDeferred<EntityActiveInvisibleComponent>(user);
+
+            EnsureComp<PullableComponent>(user); //Give back pullable when not invis
 
             if (_net.IsServer)
                 _audio.PlayPvs(ent.Comp.UncloakSound, user);

--- a/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
+++ b/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
@@ -63,7 +63,6 @@ public sealed class RMCPullingSystem : EntitySystem
 
         SubscribeLocalEvent<ParalyzeOnPullAttemptComponent, PullAttemptEvent>(OnParalyzeOnPullAttempt);
         SubscribeLocalEvent<InfectOnPullAttemptComponent, PullAttemptEvent>(OnInfectOnPullAttempt);
-        SubscribeLocalEvent<MeleeWeaponComponent, PullAttemptEvent>(OnMeleePullAttempt);
 
         SubscribeLocalEvent<SlowOnPullComponent, PullStartedMessage>(OnSlowPullStarted);
         SubscribeLocalEvent<SlowOnPullComponent, PullStoppedMessage>(OnSlowPullStopped);
@@ -240,14 +239,6 @@ public sealed class RMCPullingSystem : EntitySystem
         }
     }
 
-    private void OnMeleePullAttempt(Entity<MeleeWeaponComponent> ent, ref PullAttemptEvent args)
-    {
-        if (args.PullerUid != ent.Owner)
-            return;
-
-        if (ent.Comp.NextAttack > _timing.CurTime)
-            args.Cancelled = true;
-    }
 
     private void OnXenoPullToggle(Entity<XenoComponent> ent, ref RMCPullToggleEvent args)
     {


### PR DESCRIPTION
Xeno pull is now non dependent of tackles anymore

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Removed the dependency on melee for pulling, to how it used to be. Made toggling scout cloak give/remove the PullableComponent

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The pulling change was merged to fix a cheesy strat to see scouts, by spamming pull on them. That pr didnt solve the issue.
Now its not doable anymore, and you can still use your pull normally as a xeno without suffering.


## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->



https://github.com/user-attachments/assets/3fe7f712-b39c-4222-af59-684ce2a03211



https://github.com/user-attachments/assets/6a4203bc-6ecc-45e3-b327-a66fff12c3bb




## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
- tweak: Xeno tackle is back to normal, Now  Scouts that are invisible cant be dragged.
