### PR TITLE
Fix game breaking mess tech bug (make freezer crate actually a freezer)

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Storage/crates.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Storage/crates.yml
@@ -307,6 +307,7 @@
       map: ["enum.PaperLabelVisuals.Layer"]
   - type: Icon
     sprite: _RMC14/Structures/Storage/Crates/freezer.rsi
+  - type: AntiRottingContainer
 
 - type: entity
   parent: RMCCrateBase


### PR DESCRIPTION
## About the PR
Freezer crate did not actually freeze things inside.
Now it does.
## Why / Balance
A so called "Freezer crate" that doesn't freeze is just a scam

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Freezer crates will now actually keep things inside fresh.
