### PR TITLE
Minor Hybrisa Fixes

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/fence.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/fence.yml
@@ -97,7 +97,7 @@
     state: fence0
   - type: Construction
     graph: RMCFenceHybrisa
-    node: fenceMetalHybrisa
+    node: fenceMetal
 
 - type: entity
   parent: RMCFenceBroken
@@ -105,10 +105,10 @@
   components:
   - type: Sprite
     sprite: _RMC14/Structures/hybrisa_fences.rsi
-    state: fence0
+    state: brokenfence0
   - type: Construction
     graph: RMCFenceHybrisa
-    node: rmcFenceBrokenHybrisa
+    node: rmcFenceBroken
 
 - type: entity
   parent: CMFence
@@ -119,8 +119,8 @@
     sprite: _RMC14/Structures/hybrisa_fences_electric.rsi
     state: fence0
   - type: Construction
-    graph: RMCFenceHybrisa
-    node: fenceMetalHybrisaElectric
+    graph: RMCFenceHybrisaElectric
+    node: fenceMetal
 
 - type: entity
   parent: RMCFenceBroken
@@ -129,7 +129,7 @@
   components:
   - type: Sprite
     sprite: _RMC14/Structures/hybrisa_fences_electric.rsi
-    state: fence0
+    state: brokenfence0
   - type: Construction
-    graph: RMCFenceHybrisa
-    node: rmcFenceBrokenHybrisaElectric
+    graph: RMCFenceHybrisaElectric
+    node: rmcFenceBroken

--- a/Resources/Prototypes/_RMC14/Entities/Structures/prop_vehicles.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/prop_vehicles.yml
@@ -45,6 +45,7 @@
   components:
   - type: Transform
     anchored: true
+    noRot: true
   - type: Physics
     bodyType: Static
   - type: Fixtures

--- a/Resources/Prototypes/_RMC14/Recipes/Construction/Graphs/structures/hybrisa_fence.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Construction/Graphs/structures/hybrisa_fence.yml
@@ -7,7 +7,7 @@
     actions:
     - !type:DeleteEntity
     edges:
-    - to: fenceMetalHybrisa
+    - to: fenceMetal
       completed:
       - !type:SnapToGrid
         southRotation: true
@@ -19,7 +19,7 @@
   - node: fenceMetal
     entity: RMCFenceHybrisa
     edges:
-    - to: rmcFenceBrokenHybrisa
+    - to: rmcFenceBroken
       steps:
       - tool: Cutting
         doAfter: 1.0
@@ -36,7 +36,7 @@
       steps:
       - tool: Cutting
         doAfter: 5.0
-    - to: fenceMetalHybrisa
+    - to: fenceMetal
       steps:
       - material: BarbedWire
         amount: 2

--- a/Resources/Prototypes/_RMC14/Recipes/Construction/Graphs/structures/hybrisa_fence_electric.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Construction/Graphs/structures/hybrisa_fence_electric.yml
@@ -7,7 +7,7 @@
     actions:
     - !type:DeleteEntity
     edges:
-    - to: fenceMetalHybrisaElectric
+    - to: fenceMetal
       completed:
       - !type:SnapToGrid
         southRotation: true
@@ -36,7 +36,7 @@
       steps:
       - tool: Cutting
         doAfter: 5.0
-    - to: fenceMetalHybrisaElectric
+    - to: fenceMetal
       steps:
       - material: BarbedWire
         amount: 2


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixes rotated car hitboxes and Hybrisa fences throwing errors when loading.
## Technical details
Adds `noRot: true` to the Transform component of RMCPropVehicleBase in prop_vehicles.yml.
Fixes node names in the construction graphs of RMCHybrisaFence and RMCHybrisaFenceElectric, as well as the icon sprites for the broken variants.
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Car hitbox rotation in Hybrisa 
