### PR TITLE
Hivecore and pylon roof area fix

### DIFF
--- a/Content.Shared/_RMC14/Areas/RoofingEntityComponent.cs
+++ b/Content.Shared/_RMC14/Areas/RoofingEntityComponent.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.GameStates;
+using Robust.Shared.GameStates;
 
 namespace Content.Shared._RMC14.Areas;
 
@@ -7,7 +7,7 @@ namespace Content.Shared._RMC14.Areas;
 public sealed partial class RoofingEntityComponent : Component
 {
     [DataField(required: true), AutoNetworkedField]
-    public int Range;
+    public float Range;
 
     [DataField, AutoNetworkedField]
     public bool CanCAS;

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/Hive/xeno_hive_core.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/Hive/xeno_hive_core.yml
@@ -69,7 +69,7 @@
   - type: HiveConstructionLimited
     id: HiveCoreXeno
   - type: RoofingEntity
-    range: 10
+    range: 11.848 #rounded to 3 decimals
   - type: EvolutionBonus
   - type: WarpPoint
     location: hive core
@@ -143,7 +143,7 @@
   - type: HivePylon
   - type: XenoWeedsSpreading
   - type: RoofingEntity
-    range: 7
+    range: 8.463 #rounded to 3 decimals
     canOrbitalBombard: true
   - type: XenoWeeds
     range: 5


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
fixes the hivecore and pylon range to cover the same area as parity, rounded to 3 decimals.

the reason we don't have the same numbers as parity, is because we use circles, and cm13 uses a square.

thank you @Vermidia and @Rainbeon for helping.
## hivecore
change 10>11.848  
#### cm13.
21*21= 441m²
#### this pr. 
sqr(11.848)*π = 441m²
## pylon
 change 7>8.463
#### cm13.
15*15 = 225m²
#### this pr.
sqr(8.463)*π = 225m²
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
parity area coverage
## Technical details
<!-- Summary of code changes for easier review. -->
changes the range in the RoofingEntityComponent to a float from int.
<!--## Media
 Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: Increased hivecore and pylon roof range to cover the intended amount of total area.
