### PR TITLE
adds ceremonial sabre to CO weapon vendor

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Melee/knife.yml
@@ -150,6 +150,9 @@
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Weapons/Melee/co_sabre.rsi
+  - type: Item
+    sprite: _RMC14/Objects/Weapons/Melee/co_sabre.rsi
+    size: Large
   - type: Tag
     tags:
     - RMCCeremonialSword

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/command.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/command.yml
@@ -516,6 +516,11 @@
       entries:
       - id: RMCD50WinterWyvernBeltFilled
       - id: RMCMatebaBeltFilled
+    - name: Ceremonial Weapon
+      choices: { CMCeremonial: 1 }
+      entries:
+      - id: RMCScabbardCeremonialFilled
+        name: Commander's Ceremonial Sabre
     - name: Primary Ammunition
       entries:
       - id: CMMagazineRifleM54CMK1


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds the ceremonial scabbard to the CO vendor (yes the full version so it also contains the sabre)

## Why / Balance
COs wanted it + its extra drip and its cooler to lead your troops while flailing around your big ornate sword

## Technical details
YAML

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: CO sabre to CO weapons vendor
