### PR TITLE
Doafter bars now have the same opacity as the entity performing the action.

### DIFF
--- a/Content.Client/DoAfter/DoAfterOverlay.cs
+++ b/Content.Client/DoAfter/DoAfterOverlay.cs
@@ -118,20 +118,23 @@ public sealed class DoAfterOverlay : Overlay
                 }
 
                 //RMC14
-                // Don't show the doafter bar to other clients if the entity's sprite isn't visible.
-                if(!sprite.Visible && uid != localEnt)
-                    continue;
+                if (!doAfter.Args.ForceVisible)
+                {
+                    // Don't show the doafter bar to other clients if the entity's sprite isn't visible.
+                    if(!sprite.Visible && uid != localEnt)
+                        continue;
 
-                // Set the doafter bar alpha to the alpha of the sprite.
-                alpha = sprite.Color.A;
+                    // Set the doafter bar alpha to the alpha of the sprite.
+                    alpha = sprite.Color.A;
 
-                // The system using this component does not edit the sprite alpha, so we use separate logic for it.
-                var invisibleQuery = _entManager.GetEntityQuery<EntityActiveInvisibleComponent>();
-                invisibleQuery.TryGetComponent(uid, out var invisible);
+                    // The system using this component does not edit the sprite alpha, so we use separate logic for it.
+                    var invisibleQuery = _entManager.GetEntityQuery<EntityActiveInvisibleComponent>();
+                    invisibleQuery.TryGetComponent(uid, out var invisible);
 
-                // Make the doafter bar alpha the same as the opacity of the invisibility.
-                if (invisible != null)
-                    alpha = invisible.Opacity;
+                    // Make the doafter bar alpha the same as the opacity of the invisibility.
+                    if (invisible != null)
+                        alpha = invisible.Opacity;
+                }
 
                 // Use the sprite itself if we know its bounds. This means short or tall sprites don't get overlapped
                 // by the bar.

--- a/Content.Client/DoAfter/DoAfterOverlay.cs
+++ b/Content.Client/DoAfter/DoAfterOverlay.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using Content.Shared.DoAfter;
 using Content.Client.UserInterface.Systems;
+using Content.Shared._RMC14.Stealth;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Shared.Enums;
@@ -116,6 +117,22 @@ public sealed class DoAfterOverlay : Overlay
                     alpha = 0.5f;
                 }
 
+                //RMC14
+                // Don't show the doafter bar to other clients if the entity's sprite isn't visible.
+                if(!sprite.Visible && uid != localEnt)
+                    continue;
+
+                // Set the doafter bar alpha to the alpha of the sprite.
+                alpha = sprite.Color.A;
+
+                // The system using this component does not edit the sprite alpha, so we use separate logic for it.
+                var invisibleQuery = _entManager.GetEntityQuery<EntityActiveInvisibleComponent>();
+                invisibleQuery.TryGetComponent(uid, out var invisible);
+
+                // Make the doafter bar alpha the same as the opacity of the invisibility.
+                if (invisible != null)
+                    alpha = invisible.Opacity;
+
                 // Use the sprite itself if we know its bounds. This means short or tall sprites don't get overlapped
                 // by the bar.
                 float yOffset = sprite.Bounds.Height / 2f + 0.05f;
@@ -126,7 +143,7 @@ public sealed class DoAfterOverlay : Overlay
                     yOffset / scale + offset / EyeManager.PixelsPerMeter * scale);
 
                 // Draw the underlying bar texture
-                handle.DrawTexture(_barTexture, position);
+                handle.DrawTexture(_barTexture, position, Color.White.WithAlpha(alpha));
 
                 Color color;
                 float elapsedRatio;

--- a/Content.Client/_RMC14/Effect/RMCEffectSystem.cs
+++ b/Content.Client/_RMC14/Effect/RMCEffectSystem.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Shared._RMC14.Effect;
+using Content.Shared._RMC14.Stealth;
 using Robust.Client.GameObjects;
 using Robust.Shared.Timing;
 
@@ -6,6 +7,9 @@ namespace Content.Client._RMC14.Effect;
 
 public sealed class RMCEffectSystem : SharedRMCEffectSystem
 {
+    // Most effects are pretty large and flashy so we're dividing the opacity of the parent by 3 before applying it to the effect.
+    private const int OpacityDivider = 3;
+
     [Dependency] private readonly IGameTiming _timing = default!;
 
     public override void FrameUpdate(float frameTime)
@@ -19,6 +23,24 @@ public sealed class RMCEffectSystem : SharedRMCEffectSystem
 
             var alpha = MathHelper.Lerp((spawned + effect.Delay).TotalSeconds, spawned.TotalSeconds, time.TotalSeconds);
             sprite.Color = sprite.Color.WithAlpha((float) alpha);
+        }
+
+        var query2 = EntityQueryEnumerator<RMCEffectComponent>();
+        while (query2.MoveNext(out var uid, out var effect))
+        {
+            var parent = Transform(uid).ParentUid;
+
+            if (!TryComp(parent, out SpriteComponent? parentSprite))
+                return;
+
+            if (!TryComp(uid, out SpriteComponent? sprite))
+                return;
+
+            // Only apply the reduced opacity to the effect if the parent's opacity is < 1.
+            if (TryComp(parent, out EntityActiveInvisibleComponent? invisible) && invisible.Opacity < 1)
+                sprite.Color = sprite.Color.WithAlpha(invisible.Opacity / OpacityDivider);
+            else if (sprite.Color.A < 1)
+                sprite.Color = sprite.Color.WithAlpha(parentSprite.Color.A / OpacityDivider);
         }
     }
 }

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -515,7 +515,8 @@ namespace Content.Shared.Cuffs
                 BreakOnWeightlessMove = false,
                 BreakOnDamage = true,
                 NeedHand = true,
-                DistanceThreshold = 1f // shorter than default but still feels good
+                DistanceThreshold = 1f, // shorter than default but still feels good
+                ForceVisible = user != target,
             };
 
             if (!_doAfter.TryStartDoAfter(doAfterEventArgs))
@@ -634,7 +635,8 @@ namespace Content.Shared.Cuffs
                 BreakOnDamage = true,
                 NeedHand = true,
                 RequireCanInteract = false, // Trust in UncuffAttemptEvent
-                DistanceThreshold = 1f // shorter than default but still feels good
+                DistanceThreshold = 1f, // shorter than default but still feels good
+                ForceVisible = user != target,
             };
 
             if (!_doAfter.TryStartDoAfter(doAfterEventArgs))

--- a/Content.Shared/DoAfter/DoAfterArgs.cs
+++ b/Content.Shared/DoAfter/DoAfterArgs.cs
@@ -47,6 +47,13 @@ public sealed partial class DoAfterArgs
     [DataField]
     public bool Hidden;
 
+    /// <summary>
+    /// RMC14
+    /// Whether the progress bar for this DoAfter should be visible regardless of other conditions.
+    /// </summary>
+    [DataField]
+    public bool ForceVisible;
+
     #region Event options
     /// <summary>
     ///     The event that will get raised when the DoAfter has finished. If null, this will simply raise a <see cref="SimpleDoAfterEvent"/>
@@ -271,6 +278,7 @@ public sealed partial class DoAfterArgs
         BlockDuplicate = other.BlockDuplicate;
         CancelDuplicate = other.CancelDuplicate;
         DuplicateCondition = other.DuplicateCondition;
+        ForceVisible = other.ForceVisible;
 
         // Networked
         NetUser = other.NetUser;

--- a/Content.Shared/Prying/Systems/PryingSystem.cs
+++ b/Content.Shared/Prying/Systems/PryingSystem.cs
@@ -146,6 +146,7 @@ public sealed class PryingSystem : EntitySystem
             BreakOnDamage = false,
             BreakOnMove = true,
             NeedHand = tool != user,
+            ForceVisible = tool == null,
         };
 
         if (tool != user && tool != null)

--- a/Content.Shared/Sticky/Systems/StickySystem.cs
+++ b/Content.Shared/Sticky/Systems/StickySystem.cs
@@ -95,6 +95,7 @@ public sealed class StickySystem : EntitySystem
         {
             BreakOnMove = true,
             NeedHand = true,
+            ForceVisible = true,
         });
 
         return true;

--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -222,7 +222,8 @@ public abstract class SharedStrippableSystem : EntitySystem
             BreakOnDamage = true,
             BreakOnMove = true,
             NeedHand = true,
-            DuplicateCondition = DuplicateConditions.SameTool
+            DuplicateCondition = DuplicateConditions.SameTool,
+            ForceVisible = user.Owner != target,
         };
 
         _doAfterSystem.TryStartDoAfter(doAfterArgs);
@@ -316,7 +317,8 @@ public abstract class SharedStrippableSystem : EntitySystem
             BreakOnMove = true,
             NeedHand = true,
             BreakOnHandChange = false, // Allow simultaneously removing multiple items.
-            DuplicateCondition = DuplicateConditions.SameTool
+            DuplicateCondition = DuplicateConditions.SameTool,
+            ForceVisible = user != target,
         };
 
         _doAfterSystem.TryStartDoAfter(doAfterArgs);
@@ -418,7 +420,8 @@ public abstract class SharedStrippableSystem : EntitySystem
             BreakOnDamage = true,
             BreakOnMove = true,
             NeedHand = true,
-            DuplicateCondition = DuplicateConditions.SameTool
+            DuplicateCondition = DuplicateConditions.SameTool,
+            ForceVisible = user != target,
         };
 
         _doAfterSystem.TryStartDoAfter(doAfterArgs);
@@ -521,7 +524,8 @@ public abstract class SharedStrippableSystem : EntitySystem
             BreakOnMove = true,
             NeedHand = true,
             BreakOnHandChange = false, // Allow simultaneously removing multiple items.
-            DuplicateCondition = DuplicateConditions.SameTool
+            DuplicateCondition = DuplicateConditions.SameTool,
+            ForceVisible = user != target,
         };
 
         _doAfterSystem.TryStartDoAfter(doAfterArgs);

--- a/Content.Shared/Whistle/WhistleSystem.cs
+++ b/Content.Shared/Whistle/WhistleSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._RMC14.Stealth;
 using Content.Shared.Coordinates;
 using Content.Shared.Humanoid;
 using Content.Shared.Interaction.Events;
@@ -55,6 +56,11 @@ public sealed class WhistleSystem : EntitySystem
 
             //We don't want to ping user of whistle
             if (iterator.Owner == owner)
+                continue;
+
+            //RMC14
+            //Don't create an exclamation mark above invisible entities.
+            if(HasComp<EntityActiveInvisibleComponent>(iterator))
                 continue;
 
             ExclamateTarget(iterator, component);

--- a/Content.Shared/_RMC14/Effect/RMCEffectComponent.cs
+++ b/Content.Shared/_RMC14/Effect/RMCEffectComponent.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Effect;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class RMCEffectComponent : Component
+{
+
+}

--- a/Content.Shared/_RMC14/Fireman/FiremanCarrySystem.cs
+++ b/Content.Shared/_RMC14/Fireman/FiremanCarrySystem.cs
@@ -86,6 +86,7 @@ public sealed class FiremanCarrySystem : EntitySystem
         {
             BreakOnMove = true,
             AttemptFrequency = AttemptFrequency.EveryTick,
+            ForceVisible = true,
         };
 
         if (_doAfter.TryStartDoAfter(doAfter))

--- a/Content.Shared/_RMC14/Mortar/SharedMortarSystem.cs
+++ b/Content.Shared/_RMC14/Mortar/SharedMortarSystem.cs
@@ -203,6 +203,7 @@ public abstract class SharedMortarSystem : EntitySystem
         {
             BreakOnMove = true,
             BreakOnHandChange = true,
+            ForceVisible = true,
         };
 
         if (_doAfter.TryStartDoAfter(doAfter))

--- a/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
+++ b/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
@@ -382,6 +382,9 @@ public sealed class RMCPullingSystem : EntitySystem
 
     public void PlayPullEffect(EntityUid puller, EntityUid pulled)
     {
+        if(!_timing.IsFirstTimePredicted)
+            return;
+
         var userXform = Transform(puller);
         var targetPos = _transform.GetWorldPosition(pulled);
         var localPos = Vector2.Transform(targetPos, _transform.GetInvWorldMatrix(userXform));
@@ -390,8 +393,7 @@ public sealed class RMCPullingSystem : EntitySystem
         _melee.DoLunge(puller, puller, Angle.Zero, localPos, null);
         _audio.PlayPredicted(_pullSound, pulled, puller);
 
-        if (_net.IsServer)
-            SpawnAttachedTo(PullEffect, pulled.ToCoordinates());
+        SpawnAttachedTo(PullEffect, pulled.ToCoordinates());
     }
 
     public override void Update(float frameTime)

--- a/Content.Shared/_RMC14/Sensor/SensorTowerSystem.cs
+++ b/Content.Shared/_RMC14/Sensor/SensorTowerSystem.cs
@@ -233,7 +233,11 @@ public sealed class SensorTowerSystem : EntitySystem
         }
 
         var ev = new SensorTowerDestroyDoAfterEvent();
-        var doAfter = new DoAfterArgs(EntityManager, user, tower.Comp.DestroyDelay, ev, tower, tower, user);
+        var doAfter = new DoAfterArgs(EntityManager, user, tower.Comp.DestroyDelay, ev, tower, tower, user)
+        {
+            ForceVisible = true,
+        };
+
         if (_doAfter.TryStartDoAfter(doAfter))
         {
             _popup.PopupClient($"You start wrenching apart the {Name(tower)}'s panels and reaching inside it!", tower, user, PopupType.Medium);

--- a/Content.Shared/_RMC14/Suicide/RMCSuicideSystem.cs
+++ b/Content.Shared/_RMC14/Suicide/RMCSuicideSystem.cs
@@ -67,6 +67,7 @@ public sealed class RMCSuicideSystem : EntitySystem
                     BreakOnMove = true,
                     NeedHand = true,
                     BreakOnHandChange = true,
+                    ForceVisible = true,
                 };
 
                 if (_doAfter.TryStartDoAfter(doAfter))

--- a/Content.Shared/_RMC14/Xenonids/Devour/XenoDevourSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Devour/XenoDevourSystem.cs
@@ -387,7 +387,8 @@ public sealed class XenoDevourSystem : EntitySystem
         var doAfter = new DoAfterArgs(EntityManager, xeno, devour.DevourDelay, new XenoDevourDoAfterEvent(), xeno, target)
         {
             BreakOnMove = true,
-            AttemptFrequency = AttemptFrequency.EveryTick
+            AttemptFrequency = AttemptFrequency.EveryTick,
+            ForceVisible = true,
         };
 
         _popup.PopupClient(Loc.GetString("cm-xeno-devour-start-self", ("target", target)), target, xeno);

--- a/Resources/Prototypes/_RMC14/Effects/base.yml
+++ b/Resources/Prototypes/_RMC14/Effects/base.yml
@@ -4,3 +4,4 @@
   components:
   - type: RMCNightVisionVisible
     priority: 1
+  - type: RMCEffect


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The opacity of a doafter bar is now the same as an entity's opacity.
Burrowers still see their own doafter bar while unburrowing, but nobody else sees it.
Lurkers, scouts and snipers have their doafter bar the same opacity as their invisibility.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity, the bars are still a little more visible than the CM13 circles even when transparent because of the used colours.

## Technical details
<!-- Summary of code changes for easier review. -->
Before the doafter bar is drawn, it's alpha is set to the same value as the alpha of the entity's sprite.
If an entity has the  EntityActiveInvisibleComponent, the opacity is set to the same level as defined in the component.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- tweak: Doafter bars now have the same opacity as the entity performing the action, except for some types of hostile doafters.