### PR TITLE
Grass landing radius for small drone is limited

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Construction/Events/XenoPlantWeedsActionEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/Events/XenoPlantWeedsActionEvent.cs
@@ -16,4 +16,7 @@ public sealed partial class XenoPlantWeedsActionEvent : InstantActionEvent
     // TODO: do this properly
     [DataField]
     public bool UseOnSemiWeedable = false;
+
+    [DataField]
+    public bool LimitDistance = false;
 }

--- a/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
@@ -236,6 +236,12 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
             }
         }
 
+        if (args.LimitDistance && !_xenoWeeds.HasWeedsNearby((gridUid, grid), coordinates))
+        {
+            _popup.PopupClient("We can only plant weed nodes near other weed nodes our hive owns!", xeno, xeno, PopupType.SmallCaution);
+            return;
+        }
+
         if (!_xenoPlasma.TryRemovePlasmaPopup(xeno.Owner, args.PlasmaCost))
             return;
 

--- a/Content.Shared/_RMC14/Xenonids/Weeds/SharedXenoWeedsSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Weeds/SharedXenoWeedsSystem.cs
@@ -288,6 +288,21 @@ public abstract class SharedXenoWeedsSystem : EntitySystem
         Dirty(ent);
     }
 
+    public bool HasWeedsNearby(Entity<MapGridComponent> grid, EntityCoordinates coordinates)
+    {
+        var range = 5;
+        var position = _mapSystem.LocalToTile(grid, grid, coordinates);
+        var checkArea = new Box2(position.X - range, position.Y - range, position.X + range, position.Y + range);
+        var enumerable = _mapSystem.GetLocalAnchoredEntities(grid, grid, checkArea);
+
+        foreach (var anchored in enumerable)
+        {
+            if (TryComp<XenoWeedsComponent>(anchored, out var weeds) && weeds.IsSource)
+                return true;
+        }
+        return false;
+    }
+
     public bool IsOnHiveWeeds(Entity<MapGridComponent> grid, EntityCoordinates coordinates, bool sourceOnly = false)
     {
         var weed = GetWeedsOnFloor(grid, coordinates, sourceOnly);

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_construction_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_construction_actions.yml
@@ -183,3 +183,18 @@
       state: build_tunnel
     useDelay: 300
 
+# For lesser drone
+- type: entity
+  id: ActionLesserDronePlantWeeds
+  parent: ActionXenoBase
+  name: Plant Weeds (75) # TODO RMC14 proper plasma costs
+  description: Plant a weed node that will spread more weeds.
+  components:
+  - type: InstantAction
+    itemIconStyle: NoItem
+    icon:
+      sprite: _RMC14/Actions/xeno_actions.rsi
+      state: plant_weeds
+    event: !type:XenoPlantWeedsActionEvent
+      limitDistance: true
+    useDelay: 1

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lesser_drone.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lesser_drone.yml
@@ -32,7 +32,7 @@
     - ActionXenoTailStab
     - ActionXenoAcidWeak
     - ActionXenoPheromones
-    - ActionXenoPlantWeeds # TODO RMC14 only near other weeds for lesser drones
+    - ActionLesserDronePlantWeeds
     - ActionXenoChooseStructure
     - ActionXenoSecreteStructure
     tier: 0


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
See title

## Why / Balance
Parity
https://github.com/cmss13-devs/cmss13/blob/4dfaca73cc5d9d08f79c487d4af079b5afbb1999/code/modules/mob/living/carbon/xenomorph/abilities/lesser_drone/lesser_drone_powers.dm

## Media

https://github.com/user-attachments/assets/87fafc29-6edb-4c21-b095-e9ae0467f01e



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
- fix: Fixed lesser drones being able to plant new weed nodes further than 5 tiles away from another weed node.