### PR TITLE
fixes the copyright of the nailgun ammo sprites

### DIFF
--- a/Resources/Textures/_RMC14/Objects/Weapons/Guns/Ammunition/Magazines/nailgun.rsi/meta.json
+++ b/Resources/Textures/_RMC14/Objects/Weapons/Guns/Ammunition/Magazines/nailgun.rsi/meta.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "license": "CC-BY-SA-3.0",
-  "copyright": "Taken from cmss13 at https://github.com/cmss13-devs/cmss13/blob/168c8a79a3d858a8c531ff7ed0bc3033e47d1d16/icons/obj/items/weapons/guns/ammo_by_faction/colony.dmi",
+  "copyright": "Sprites by VictorJob.",
   "size": {
     "x": 32,
     "y": 32


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

this PR fixes the copyright of the nailgun ammunition

## Why / Balance

I forgot to change the copyright of the nailgun ammo when I resprited it in this PR: https://github.com/RMC-14/RMC-14/pull/5979

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/89e9fb4b-c2e1-4a1e-989d-a79ff6e6d346)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
