### PR TITLE
Obstacle slam hotfix

### DIFF
--- a/Content.Shared/_RMC14/Damage/ObstacleSlamming/RMCObstacleSlamImmuneComponent.cs
+++ b/Content.Shared/_RMC14/Damage/ObstacleSlamming/RMCObstacleSlamImmuneComponent.cs
@@ -1,0 +1,18 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Shared._RMC14.Damage.ObstacleSlamming;
+
+/// <summary>
+/// Makes a mob immune to obstacle slamming for a certain period of time.
+/// </summary>
+[Access(typeof(RMCObstacleSlammingSystem))]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class RMCObstacleSlamImmuneComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public TimeSpan ExpireIn = TimeSpan.FromSeconds(2);
+
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField]
+    public TimeSpan? ExpireAt;
+}

--- a/Content.Shared/_RMC14/Damage/ObstacleSlamming/RMCObstacleSlammingComponent.cs
+++ b/Content.Shared/_RMC14/Damage/ObstacleSlamming/RMCObstacleSlammingComponent.cs
@@ -14,7 +14,7 @@ namespace Content.Shared._RMC14.Damage.ObstacleSlamming;
 public sealed partial class RMCObstacleSlammingComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public float MinimumSpeed = 6;
+    public float MinimumSpeed = 4.5f;
 
     /// <summary>
     /// MOB_SIZE_COEFF in CM

--- a/Content.Shared/_RMC14/Damage/ObstacleSlamming/RMCObstacleSlammingComponent.cs
+++ b/Content.Shared/_RMC14/Damage/ObstacleSlamming/RMCObstacleSlammingComponent.cs
@@ -14,7 +14,7 @@ namespace Content.Shared._RMC14.Damage.ObstacleSlamming;
 public sealed partial class RMCObstacleSlammingComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public float MinimumSpeed = 9;
+    public float MinimumSpeed = 6;
 
     /// <summary>
     /// MOB_SIZE_COEFF in CM

--- a/Content.Shared/_RMC14/Damage/ObstacleSlamming/RMCObstacleSlammingSystem.cs
+++ b/Content.Shared/_RMC14/Damage/ObstacleSlamming/RMCObstacleSlammingSystem.cs
@@ -47,6 +47,9 @@ public sealed class RMCObstacleSlammingSystem : EntitySystem
         if (args.Handled)
             return;
 
+        if (user != ent.Owner)
+            return;
+
         if (!TryComp<PhysicsComponent>(user, out var body) || !TryComp<PhysicsComponent>(obstacle, out var bodyObstacle))
             return;
 

--- a/Content.Shared/_RMC14/Damage/ObstacleSlamming/RMCObstacleSlammingSystem.cs
+++ b/Content.Shared/_RMC14/Damage/ObstacleSlamming/RMCObstacleSlammingSystem.cs
@@ -82,7 +82,7 @@ public sealed class RMCObstacleSlammingSystem : EntitySystem
         _physics.SetLinearVelocity(ent, Vector2.Zero);
         _physics.SetAngularVelocity(ent, 0f);
 
-        var vec = _transform.GetMoverCoordinates(user).Position - _transform.GetMoverCoordinates(args.OtherEntity).Position;
+        var vec = _transform.GetMoverCoordinates(user).Position - _transform.GetMoverCoordinates(obstacle).Position;
         if (vec.Length() != 0)
         {
             var direction = vec.Normalized() * ent.Comp.KnockbackPower;
@@ -90,13 +90,13 @@ public sealed class RMCObstacleSlammingSystem : EntitySystem
         }
 
         if (_timing.IsFirstTimePredicted)
-            _audio.PlayPvs(ent.Comp.SoundHit, user);
+            _audio.PlayPvs(ent.Comp.SoundHit, obstacle);
 
         if (_net.IsServer)
             SpawnAttachedTo(ent.Comp.HitEffect, user.ToCoordinates());
 
-        var selfMessage = Loc.GetString("rmc-obstacle-slam-self", ("ent", user), ("object", args.OtherEntity));
-        var othersMessage = Loc.GetString("rmc-obstacle-slam-others", ("ent", user), ("object", args.OtherEntity));
+        var selfMessage = Loc.GetString("rmc-obstacle-slam-self", ("ent", user), ("object", obstacle));
+        var othersMessage = Loc.GetString("rmc-obstacle-slam-others", ("ent", user), ("object", obstacle));
         _popup.PopupPredicted(selfMessage, othersMessage, user, user, PopupType.MediumCaution);
 
         args.Handled = true;

--- a/Content.Shared/_RMC14/Xenonids/Charge/XenoChargeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Charge/XenoChargeSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._RMC14.Damage.ObstacleSlamming;
 using Content.Shared._RMC14.Pulling;
 using Content.Shared._RMC14.Slow;
 using Content.Shared._RMC14.Xenonids.Animation;
@@ -94,6 +95,7 @@ public sealed class XenoChargeSystem : EntitySystem
         xeno.Comp.Charge = diff;
         Dirty(xeno);
 
+        EnsureComp<RMCObstacleSlamImmuneComponent>(xeno);
         _throwing.TryThrow(xeno, diff, xeno.Comp.Strength, animated: false);
     }
 

--- a/Content.Shared/_RMC14/Xenonids/Lunge/XenoLungeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Lunge/XenoLungeSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._RMC14.Damage.ObstacleSlamming;
 using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.Pulling;
 using Content.Shared._RMC14.Xenonids.Hive;
@@ -73,6 +74,7 @@ public sealed class XenoLungeSystem : EntitySystem
         xeno.Comp.Charge = diff;
         Dirty(xeno);
 
+        EnsureComp<RMCObstacleSlamImmuneComponent>(xeno);
         _throwing.TryThrow(xeno, diff, 30, animated: false);
 
         if (!_physicsQuery.TryGetComponent(xeno, out var physics))


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixes some bugs related to obstacle slamming:

Warrior leap and crusher charge made you slam into the person
Runners, lurkers, and parasites could leap into walls and get hurt

## Technical details
Changes the obstacle slam event to be a thrown on hit event rather than a collide event
Reduces the min velocity from 9-->4.5 so shotgun stuns slam you aswell

Adds a ``RMCObstacleSlamImmuneComponent`` with a limited lifetime
This is given to the crusher and warrior whenever they charge or leap so they dont slam into any objects or people


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.