### PR TITLE
Change how speed modifiers are calculated.

### DIFF
--- a/Content.Shared/_RMC14/Marines/Orders/MoveOrderComponent.cs
+++ b/Content.Shared/_RMC14/Marines/Orders/MoveOrderComponent.cs
@@ -15,7 +15,7 @@ public sealed partial class MoveOrderComponent : Component, IOrderComponent
     public SpriteSpecifier Icon = new Rsi(new ResPath("/Textures/_RMC14/Interface/marine_orders.rsi"), "move");
 
     [DataField, AutoNetworkedField]
-    public FixedPoint2 MoveSpeedModifier = 0.1;
+    public FixedPoint2 MoveSpeedModifier = -0.1;
 
     [DataField, AutoNetworkedField]
     public FixedPoint2 EvasionModifier = 5;

--- a/Content.Shared/_RMC14/Marines/Orders/SharedMarineOrdersSystem.cs
+++ b/Content.Shared/_RMC14/Marines/Orders/SharedMarineOrdersSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared._RMC14.Evasion;
 using Content.Shared._RMC14.Marines.Skills;
+using Content.Shared._RMC14.Movement;
 using Content.Shared.Actions;
 using Content.Shared.Damage;
 using Content.Shared.Inventory;
@@ -20,6 +21,7 @@ public abstract class SharedMarineOrdersSystem : EntitySystem
     [Dependency] private readonly MovementSpeedModifierSystem _movementSpeed = default!;
     [Dependency] private readonly SkillsSystem _skills = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly TemporarySpeedModifiersSystem _temporarySpeed = default!;
 
     private readonly HashSet<Entity<MarineComponent>> _receivers = new();
 
@@ -97,8 +99,13 @@ public abstract class SharedMarineOrdersSystem : EntitySystem
         if (!hasArmor)
             return;
 
-        var speed = 1 + (comp.MoveSpeedModifier * comp.Received[0].Multiplier).Float();
-        args.ModifySpeed(speed, speed);
+        var speed = _temporarySpeed.CalculateSpeedModifier(orders, (comp.MoveSpeedModifier * comp.Received[0].Multiplier).Float());
+
+        if(speed == null)
+            return;
+
+        //var speed = 1 + (comp.MoveSpeedModifier * comp.Received[0].Multiplier).Float();
+        args.ModifySpeed(speed.Value, speed.Value);
     }
 
     private void OnMoveShutdown(Entity<MoveOrderComponent> uid, ref ComponentShutdown ev)

--- a/Content.Shared/_RMC14/Movement/TemporarySpeedModifiersSystem.cs
+++ b/Content.Shared/_RMC14/Movement/TemporarySpeedModifiersSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Systems;
 using Robust.Shared.Network;
 using Robust.Shared.Timing;
@@ -6,6 +7,8 @@ namespace Content.Shared._RMC14.Movement;
 
 public sealed class TemporarySpeedModifiersSystem : EntitySystem
 {
+    private const float MaxSpeedModifier = 1f;
+
     [Dependency] private readonly MovementSpeedModifierSystem _movementSpeedSystem = default!;
     [Dependency] private readonly INetManager _netManager = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
@@ -69,5 +72,20 @@ public sealed class TemporarySpeedModifiersSystem : EntitySystem
         {
             comp.Modifiers.Add((_timing.CurTime + modifier.Duration, modifier.Walk, modifier.Sprint));
         }
+    }
+
+    /// <summary>
+    ///     Calculate the multiplier to use for the speed modifier, the modifier entered should be the same as the one in CM13..
+    /// </summary>
+    /// <param name="uid">The entity whose speed is being modified.</param>
+    /// <param name="modifier">The speed modifier value, positive values are a slow, negative values are a buff</param>
+    /// <param name="movement">The <see cref="MovementSpeedModifierComponent"/> belonging to the entity</param>
+    /// <returns>Null or a float representing the calculated speed multiplier</returns>
+    public float? CalculateSpeedModifier(EntityUid uid, float modifier, MovementSpeedModifierComponent? movement = null)
+    {
+        if (!Resolve(uid, ref movement))
+            return null;
+
+        return 1 / (Math.Max(1 / movement.CurrentSprintSpeed * 10 + modifier, MaxSpeedModifier) / 10) / movement.CurrentSprintSpeed;
     }
 }

--- a/Content.Shared/_RMC14/Slow/RMCSlowSystem.cs
+++ b/Content.Shared/_RMC14/Slow/RMCSlowSystem.cs
@@ -1,4 +1,4 @@
-using Content.Shared._RMC14.Standing;
+using Content.Shared._RMC14.Movement;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Rejuvenate;
@@ -16,6 +16,7 @@ public sealed class RMCSlowSystem : EntitySystem
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly MovementSpeedModifierSystem _speed = default!;
     [Dependency] private readonly StandingStateSystem _standing = default!;
+    [Dependency] private readonly TemporarySpeedModifiersSystem _temporarySpeed = default!;
 
     public override void Initialize()
     {
@@ -128,9 +129,14 @@ public sealed class RMCSlowSystem : EntitySystem
         if (!TryComp<RMCSpeciesSlowdownModifierComponent>(ent, out var slow) || !ent.Comp.Running)
             return;
 
+        var multiplier = _temporarySpeed.CalculateSpeedModifier(ent, slow.SlowModifier);
+
+        if(multiplier == null)
+            return;
+
         //Don't apply slow when superslow is in effect
         if (!TryComp<RMCSuperSlowdownComponent>(ent, out var comp) || !comp.Running)
-            args.ModifySpeed(slow.SlowMultiplier, slow.SlowMultiplier);
+            args.ModifySpeed(multiplier.Value, multiplier.Value);
     }
 
     private void OnSuperSlowdownRefresh(Entity<RMCSuperSlowdownComponent> ent, ref RefreshMovementSpeedModifiersEvent args)
@@ -138,7 +144,12 @@ public sealed class RMCSlowSystem : EntitySystem
         if (!TryComp<RMCSpeciesSlowdownModifierComponent>(ent, out var slow) || !ent.Comp.Running)
             return;
 
-        args.ModifySpeed(slow.SuperSlowMultiplier, slow.SuperSlowMultiplier);
+        var multiplier = _temporarySpeed.CalculateSpeedModifier(ent, slow.SuperSlowModifier);
+
+        if(multiplier == null)
+            return;
+
+        args.ModifySpeed(multiplier.Value, multiplier.Value);
     }
 
     private void OnRootRefresh(Entity<RMCRootedComponent> ent, ref RefreshMovementSpeedModifiersEvent args)

--- a/Content.Shared/_RMC14/Slow/RMCSpeciesSlowdownModifierComponent.cs
+++ b/Content.Shared/_RMC14/Slow/RMCSpeciesSlowdownModifierComponent.cs
@@ -5,11 +5,17 @@ namespace Content.Shared._RMC14.Slow;
 
 public sealed partial class RMCSpeciesSlowdownModifierComponent : Component
 {
+    /// <summary>
+    /// The value used in the slow calculations, ported 1:1 from CM13.
+    /// </summary>
     [DataField]
-    public float SlowMultiplier;
+    public float SlowModifier;
 
+    /// <summary>
+    /// The value used in the superslow calculations, ported 1:1 from CM13.
+    /// </summary>
     [DataField]
-    public float SuperSlowMultiplier;
+    public float SuperSlowModifier;
 
     [DataField]
     public float DurationMultiplier = 1.0f;

--- a/Content.Shared/_RMC14/Xenonids/Fruit/Components/XenoFruitSpeedComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Fruit/Components/XenoFruitSpeedComponent.cs
@@ -9,10 +9,8 @@ namespace Content.Shared._RMC14.Xenonids.Fruit.Components;
 [Access(typeof(SharedXenoFruitSystem))]
 public sealed partial class XenoFruitSpeedComponent : Component
 {
-    // TODO: find appropriate value for this
-    // TODO: this should (?) be a flat value, not a multiplier
     [DataField, AutoNetworkedField]
-    public FixedPoint2 SpeedModifier = 0.4f;
+    public FixedPoint2 SpeedModifier = -0.4f;
 
     // Duration of effect
     [DataField]

--- a/Content.Shared/_RMC14/Xenonids/Fruit/SharedXenoFruitSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Fruit/SharedXenoFruitSystem.cs
@@ -43,6 +43,7 @@ using Content.Shared.Movement.Components;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.Aura;
+using Content.Shared._RMC14.Movement;
 using Robust.Shared.Spawners;
 
 namespace Content.Shared._RMC14.Xenonids.Fruit;
@@ -78,6 +79,7 @@ public sealed class SharedXenoFruitSystem : EntitySystem
     [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
     [Dependency] private readonly SharedAuraSystem _aura = default!;
     [Dependency] private readonly IComponentFactory _componentFactory = default!;
+    [Dependency] private readonly TemporarySpeedModifiersSystem _temporarySpeed = default!;
 
     private static readonly ProtoId<DamageTypePrototype> FruitPlantDamageType = "Blunt";
 
@@ -805,7 +807,12 @@ public sealed class SharedXenoFruitSystem : EntitySystem
         var comp = EnsureComp<XenoFruitEffectSpeedComponent>(target);
 
         comp.Duration = fruit.Comp.Duration;
-        comp.SpeedModifier = fruit.Comp.SpeedModifier;
+
+        var multiplier = _temporarySpeed.CalculateSpeedModifier(target, fruit.Comp.SpeedModifier.Float()) ;
+        if(multiplier == null)
+            return;
+
+        comp.SpeedModifier = multiplier.Value;
 
         _movementSpeed.RefreshMovementSpeedModifiers(target);
     }
@@ -822,10 +829,10 @@ public sealed class SharedXenoFruitSystem : EntitySystem
         if (!TryComp<MovementSpeedModifierComponent>(xeno, out var baseSpeed))
             return;
 
-        var modSpeedWalk = baseSpeed.BaseWalkSpeed + comp.SpeedModifier.Float();
-        var modSpeedSprint = baseSpeed.BaseSprintSpeed + comp.SpeedModifier.Float();
+        var modSpeedWalk = baseSpeed.BaseWalkSpeed * comp.SpeedModifier.Float();
+        var modSpeedSprint = baseSpeed.BaseSprintSpeed * comp.SpeedModifier.Float();
 
-        args.ModifySpeed(modSpeedWalk / baseSpeed.BaseWalkSpeed, modSpeedSprint / baseSpeed.BaseSprintSpeed);
+        args.ModifySpeed(comp.SpeedModifier.Float(), comp.SpeedModifier.Float());
     }
 
     // Shield (unstable fruit)

--- a/Content.Shared/_RMC14/Xenonids/Pheromones/SharedXenoPheromonesSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Pheromones/SharedXenoPheromonesSystem.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Content.Shared._RMC14.Atmos;
 using Content.Shared._RMC14.Damage;
+using Content.Shared._RMC14.Movement;
 using Content.Shared._RMC14.Pulling;
 using Content.Shared._RMC14.Xenonids.CriticalGrace;
 using Content.Shared._RMC14.Xenonids.Plasma;
@@ -43,6 +44,7 @@ public abstract class SharedXenoPheromonesSystem : EntitySystem
     [Dependency] private readonly SharedRMCFlammableSystem _rmcFlammable = default!;
     [Dependency] private readonly SharedXenoWeedsSystem _weeds = default!;
     [Dependency] private readonly IPrototypeManager _protoManager = default!;
+    [Dependency] private readonly TemporarySpeedModifiersSystem _temporarySpeed = default!;
 
     private readonly TimeSpan _pheromonePlasmaUseDelay = TimeSpan.FromSeconds(1);
 
@@ -196,11 +198,16 @@ public abstract class SharedXenoPheromonesSystem : EntitySystem
 
     private void OnFrenzyMovementSpeedModifiers(Entity<XenoFrenzyPheromonesComponent> frenzy, ref RefreshMovementSpeedModifiersEvent args)
     {
-        var speed = 1 + (frenzy.Comp.MovementSpeedModifier * frenzy.Comp.Multiplier).Float();
+        var speed = _temporarySpeed.CalculateSpeedModifier(frenzy,
+            (frenzy.Comp.MovementSpeedModifier * frenzy.Comp.Multiplier).Float());
         if (HasComp<PullingSlowedComponent>(frenzy.Owner))
-            speed = 1 + (frenzy.Comp.PullMovementSpeedModifier * frenzy.Comp.Multiplier).Float();
+            speed = _temporarySpeed.CalculateSpeedModifier(frenzy,
+                (frenzy.Comp.PullMovementSpeedModifier * frenzy.Comp.Multiplier).Float());
 
-        args.ModifySpeed(speed, speed);
+        if(speed == null)
+            return;
+
+        args.ModifySpeed(speed.Value, speed.Value);
     }
 
     private void OnFrenzyPullStarted(Entity<XenoFrenzyPheromonesComponent> frenzy, ref PullStartedMessage args)

--- a/Content.Shared/_RMC14/Xenonids/Pheromones/XenoFrenzyPheromonesComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Pheromones/XenoFrenzyPheromonesComponent.cs
@@ -21,10 +21,10 @@ public sealed partial class XenoFrenzyPheromonesComponent : Component
     public float AttackDamageAddPerMult = 2;
 
     [DataField, AutoNetworkedField]
-    public FixedPoint2 MovementSpeedModifier = 0.06;
+    public FixedPoint2 MovementSpeedModifier = -0.05;
 
     [DataField, AutoNetworkedField]
-    public FixedPoint2 PullMovementSpeedModifier = 0.03;
+    public FixedPoint2 PullMovementSpeedModifier = -0.025;
 
     [DataField, AutoNetworkedField]
     public ProtoId<DamageGroupPrototype> DamageGroup = "Brute";

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
@@ -317,8 +317,8 @@
   - type: RMCPickupDroppedItems
   - type: CommendationReceiver
   - type: RMCSpeciesSlowdownModifier
-    slowMultiplier: 0.66
-    superSlowMultiplier: 0.33
+    slowModifier: 2
+    superSlowModifier: 4
   - type: RMCHandEmotes
   - type: RMCBuckleDrawDepth
   - type: RMCObstacleSlamming

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
@@ -337,8 +337,8 @@
   - type: BlockIdExamine
   - type: NoStunOnExit
   - type: RMCSpeciesSlowdownModifier
-    slowMultiplier: 0.87
-    superSlowMultiplier: 0.75
+    slowModifier: 0.75
+    superSlowModifier: 1.5
     durationMultiplier: 0.666
   - type: RMCCanBeFultoned
   - type: CMArmor

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Snipers/m96s_sniper.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Snipers/m96s_sniper.yml
@@ -235,7 +235,7 @@
     amount: 0
   - type: AimedShotEffect
     extraHits: 1
-    superSlowDuration: 7
+    superSlowDuration: 14
   - type: RMCAreaDamage
     damageArea: 2.5
     falloffDistance: 1.5

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_fruit.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_fruit.yml
@@ -172,7 +172,6 @@
     color: "#5B248C"
     outlineColor: "#9061BA80"
   - type: XenoFruitSpeed
-    speedModifier: 0.2
 
 - type: entity
   parent: XenoFruitBase


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Speed modifiers now use a different formula to convert RMC14 movement speeds to CM13 movement delays before adding the modifiers, the movement delays from CM13 can be ported 1:1.
Slows and speed buffs now have a more significant impact on faster entities and a reduced effect on slower ones. In general, speed buffs have a lower overall impact.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Currently slows and speed buffs are using placeholder multiplier values, the formula in this PR brings it closer to parity.
Slows and superslows on xenos are currently too low and will increase with this PR.
Overall the speed increase of speed buffs has been decreased, the effect of slows has been increased.

## Technical details
<!-- Summary of code changes for easier review. -->
The following formula is used to convert our movement speeds to CM13 values before adding the speed modifier and converting it back to RMC values: 1 / (Math.Max(1 / CurrentSprintSpeed * 10 + modifier, MaxSpeedModifier) / 10) / CurrentSprintSpeed

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Dygon
- tweak: Slows and super slows are now more effective on fast entities and have stronger effect on xenonids.
- tweak: Positive speed modifiers have their values tweaked and are less effective in general.
