### PR TITLE
AMR kit and sniper kit now share the same limit.

### DIFF
--- a/Content.Client/_RMC14/Vendors/CMAutomatedVendorBui.cs
+++ b/Content.Client/_RMC14/Vendors/CMAutomatedVendorBui.cs
@@ -128,7 +128,21 @@ public sealed class CMAutomatedVendorBui : BoundUserInterface
 
                         var sectionI = sectionIndex;
                         var entryI = entryIndex;
-                        uiEntry.Panel.Button.OnPressed += _ => OnButtonPressed(sectionI, entryI);
+                        var linkedEntryIndexes = new List<int>();
+
+                        foreach (var linkedEntry in entry.LinkedEntries)
+                        {
+                            var linkedEntryIndex = 0;
+                            foreach (var vendorEntry in section.Entries)
+                            {
+                                if(vendorEntry.Id == linkedEntry)
+                                    linkedEntryIndexes.Add(linkedEntryIndex);
+
+                                linkedEntryIndex++;
+                            }
+                        }
+
+                        uiEntry.Panel.Button.OnPressed += _ => OnButtonPressed(sectionI, entryI, linkedEntryIndexes);
                     }
 
                     uiSection.Entries.AddChild(uiEntry);
@@ -145,9 +159,9 @@ public sealed class CMAutomatedVendorBui : BoundUserInterface
         _window.OpenCentered();
     }
 
-    private void OnButtonPressed(int sectionIndex, int entryIndex)
+    private void OnButtonPressed(int sectionIndex, int entryIndex, List<int> linkedEntryIndexes)
     {
-        var msg = new CMVendorVendBuiMsg(sectionIndex, entryIndex);
+        var msg = new CMVendorVendBuiMsg(sectionIndex, entryIndex, linkedEntryIndexes);
         SendMessage(msg);
     }
 

--- a/Content.Shared/_RMC14/Vendors/CMAutomatedVendorUI.cs
+++ b/Content.Shared/_RMC14/Vendors/CMAutomatedVendorUI.cs
@@ -9,10 +9,11 @@ public enum CMAutomatedVendorUI : byte
 }
 
 [Serializable, NetSerializable]
-public sealed class CMVendorVendBuiMsg(int section, int entry) : BoundUserInterfaceMessage
+public sealed class CMVendorVendBuiMsg(int section, int entry, List<int> linkedEntries) : BoundUserInterfaceMessage
 {
     public readonly int Section = section;
     public readonly int Entry = entry;
+    public readonly List<int> LinkedEntries = linkedEntries;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/_RMC14/Vendors/CMVendorSection.cs
+++ b/Content.Shared/_RMC14/Vendors/CMVendorSection.cs
@@ -65,6 +65,9 @@ public sealed partial record CMVendorEntry
     [DataField]
     public int? Max;
 
+    [DataField]
+    public List<EntProtoId> LinkedEntries = new();
+
     [DataField, AutoNetworkedField]
     public EntProtoId? Box;
 

--- a/Content.Shared/_RMC14/Vendors/SharedCMAutomatedVendorSystem.cs
+++ b/Content.Shared/_RMC14/Vendors/SharedCMAutomatedVendorSystem.cs
@@ -388,6 +388,12 @@ public abstract class SharedCMAutomatedVendorSystem : EntitySystem
                 while (specVendors.MoveNext(out var vendorId, out _))
                 {
                     var specVendorComponent = EnsureComp<RMCVendorSpecialistComponent>(vendorId);
+                    foreach (var linkedEntry in args.LinkedEntries)
+                    {
+                        specVendorComponent.GlobalSharedVends.TryGetValue(linkedEntry, out var linkedCount);
+                        maxAmongVendors += linkedCount;
+                    }
+
                     if (specVendorComponent.GlobalSharedVends.TryGetValue(args.Entry, out vendCount))
                     {
                         if (vendCount > maxAmongVendors)

--- a/Resources/Prototypes/_RMC14/Actions/Marines/marine_action_items.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Marines/marine_action_items.yml
@@ -147,7 +147,7 @@
 - type: entity
   parent: ActionMarineToggleable
   id: RMCActionSpotTarget
-  description: Press the unique action key while hovering your mouse over a target to start spotting.
+  description: Hover your mouse over a target and press the unique action key to start spotting.
   name: Spot Target
   components:
   - type: InstantAction
@@ -175,7 +175,7 @@
   parent: ActionMarineToggleable
   id: RMCActionAimedShot
   name: Aimed Shot
-  description: Press the unique action key while hovering your mouse over a target while in combat mode to start aiming.
+  description: While in combat mode and hovering your mouse over a target, press the unique action key to begin aiming.
   components:
   - type: InstantAction
     itemIconStyle: NoItem

--- a/Resources/Prototypes/_RMC14/Actions/Marines/marine_action_items.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Marines/marine_action_items.yml
@@ -147,6 +147,7 @@
 - type: entity
   parent: ActionMarineToggleable
   id: RMCActionSpotTarget
+  description: Press the unique action key while hovering your mouse over a target to start spotting.
   name: Spot Target
   components:
   - type: InstantAction
@@ -174,6 +175,7 @@
   parent: ActionMarineToggleable
   id: RMCActionAimedShot
   name: Aimed Shot
+  description: Press the unique action key while hovering your mouse over a target while in combat mode to start aiming.
   components:
   - type: InstantAction
     itemIconStyle: NoItem

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/specialist.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/specialist.yml
@@ -28,7 +28,11 @@
       #  points: 0
       - id: RMCScoutSpecEquipmentCase
       - id: CMSniperEquipmentCase
+        linkedEntries:
+        - RMCAntiMaterielEquipmentCase
       - id: RMCAntiMaterielEquipmentCase
+        linkedEntries:
+        - CMSniperEquipmentCase
     - name: Extra Scout Ammunition
       entries:
       - id: RMCMagazineRifleM4SPRA19Impact


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The sniper and AMR kit share the same specialist limit now.
Added a short explanation to the description of the spotting and aimed shot actions.

## Technical details
<!-- Summary of code changes for easier review. -->
When a kit is selected, it now searches all entries in the vendor for it's LinkedEntries, if any linked entries are found their index is added to a list.
When checking how many of a specific kit are already taken, the amount of kits taken that are linked to said kit are also taken into account.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Dygon
- add: The spotting and aimed shot action descriptions now explain how to use them.
- fix: Fixed the sniper kit and the anti-materiel sniper kit not sharing the same specialist limit.

