### PR TITLE
Obstacle slamming fixes #2

### DIFF
--- a/Content.Server/_RMC14/Xenonids/Parasite/XenoParasiteThrowerSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Parasite/XenoParasiteThrowerSystem.cs
@@ -3,6 +3,7 @@ using System.Numerics;
 using Content.Server.Hands.Systems;
 using Content.Server.Mind;
 using Content.Shared._RMC14.Atmos;
+using Content.Shared._RMC14.Damage.ObstacleSlamming;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared._RMC14.Xenonids.Evolution;
 using Content.Shared._RMC14.Xenonids.Hive;
@@ -103,7 +104,10 @@ public sealed partial class XenoParasiteThrowerSystem : SharedXenoParasiteThrowe
                 var fixedTrajectory = (target.Position - coords.Position).Normalized() * xeno.Comp.ParasiteThrowDistance;
                 target = coords.WithPosition(coords.Position + fixedTrajectory);
             }
+
+            EnsureComp<RMCObstacleSlamImmuneComponent>(heldEntity);
             _throw.TryThrow(heldEntity, target, user: xeno, compensateFriction: true);
+
             // Not parity but should help the ability be more consistent/not look weird since para AI goes rest on idle. The stun dur + leap time makes it longer
             // Then jump time by 2 secs
             if (TryComp<ParasiteAIComponent>(heldEntity, out var ai) && !_mobState.IsDead(heldEntity))

--- a/Content.Shared/_RMC14/Xenonids/Empower/XenoEmpowerSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Empower/XenoEmpowerSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared._RMC14.Aura;
+using Content.Shared._RMC14.Damage.ObstacleSlamming;
 using Content.Shared._RMC14.Emote;
 using Content.Shared._RMC14.Pulling;
 using Content.Shared._RMC14.Shields;
@@ -207,6 +208,7 @@ public sealed class XenoEmpowerSystem : EntitySystem
         var diff = target.Position - origin.Position;
         diff = diff.Normalized() * xeno.Comp.FlingDistance;
 
+        EnsureComp<RMCObstacleSlamImmuneComponent>(args.Hit);
         _throwing.TryThrow(args.Hit, diff, 10);
     }
 

--- a/Content.Shared/_RMC14/Xenonids/Headbutt/XenoHeadbuttSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Headbutt/XenoHeadbuttSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared._RMC14.Actions;
+using Content.Shared._RMC14.Damage.ObstacleSlamming;
 using Content.Shared._RMC14.Pulling;
 using Content.Shared._RMC14.Xenonids.Animation;
 using Content.Shared._RMC14.Xenonids.Crest;
@@ -82,6 +83,7 @@ public sealed class XenoHeadbuttSystem : EntitySystem
         xeno.Comp.Charge = diff;
         Dirty(xeno);
 
+        EnsureComp<RMCObstacleSlamImmuneComponent>(xeno);
         _throwing.TryThrow(xeno, diff, 10);
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- Fixes parasites getting slammed into walls when thrown by a carrier
- Fixes ravager assault victims getting slammed into the ravager
- Fixes defender headbutt slamming victims


:cl:
- fix: Fixed parasites thrown by carriers slamming into walls
- fix: Fixed defender headbutt slamming victims
- fix: Fixed ravager assault slamming victims into themselves