### PR TITLE
FIX CRUSHER ARMOR!

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/crusher.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/crusher.yml
@@ -59,7 +59,7 @@
     maxPlasma: 400
     plasmaRegenOnWeeds: 4
   - type: CMArmor
-    armor: 30
+    xenoArmor: 30
     explosionArmor: 100
   - type: XenoClaws
     clawType: VerySharp


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
fixes crushers having the old legacy armor (removed datafield) and replaces it with xeno armor

:cl:
- fix: Fixed crushers having zero armor