### PR TITLE
AMR Magazine & Potted Plant Fixes

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Snipers/xm43e1_anti_materiel_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Snipers/xm43e1_anti_materiel_rifle.yml
@@ -93,6 +93,7 @@
   - type: Tag
     tags:
     - RMCMagazineXM43E1
+    - CMMagazineSniper
   - type: BallisticAmmoProvider
     mayTransfer: True
     whitelist:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Furniture/potted_plants.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Furniture/potted_plants.yml
@@ -50,6 +50,8 @@
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Furniture/potted_plants.rsi
+  - type: SecretStash
+    maxItemSize: Tiny
 
 - type: entity
   parent: CMPottedPlantBase


### PR DESCRIPTION
## About the PR
Adds the CMSniperMagazine tag to AMR Magazines so they fit in all the relevant inventories, and tweaks CMPottedPlantBase to only store Tiny size items.
## Why / Balance
Parity
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: XM43E1 Magazines now fit in magazine pouches and all other related storages.
- fix: Potted plants can now only hold Tiny items.
