### PR TITLE
fix(yaml): yaml linter crash and other errors

### DIFF
--- a/Resources/Prototypes/SoundCollections/lobby.yml
+++ b/Resources/Prototypes/SoundCollections/lobby.yml
@@ -20,5 +20,5 @@
   - /Audio/_RMC14/Lobby/the_fallen_queen.ogg
   - /Audio/_RMC14/Lobby/enemy_is_unknown.ogg
   - /Audio/_RMC14/Lobby/Dire_Situation.ogg
-  - /Audio/_RMC14/Lobby/Time_Is_running_Out.ogg
+  - /Audio/_RMC14/Lobby/Time_Is_Running_Out.ogg
   - /Audio/_RMC14/Lobby/Dropzone.ogg

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
@@ -342,7 +342,6 @@
     durationMultiplier: 0.666
   - type: RMCCanBeFultoned
   - type: CMArmor
-    explosionArmor: 10
   - type: CriticalGraceTime
   - type: RMCObstacleSlamming
   - type: Buckle

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
@@ -342,7 +342,7 @@
     durationMultiplier: 0.666
   - type: RMCCanBeFultoned
   - type: CMArmor
-    explosionArmorStep: 10
+    explosionArmor: 10
   - type: CriticalGraceTime
   - type: RMCObstacleSlamming
   - type: Buckle

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/defender.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/defender.yml
@@ -152,8 +152,8 @@
       groups:
         Brute: 30
   - type: XenoFortify
+    armor: 10
     frontalArmor: 15
-    xenoArmor: 10
     changeExplosionWeakness: false
     canHeadbuttFortified: true
     canMoveFortified: true

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Tools/rmc_flag.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Tools/rmc_flag.yml
@@ -8,7 +8,6 @@
     layers:
     - state: icon
       map: [ "base" ]
-    state: icon
   - type: Item
     size: Large
   - type: Corrodible

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Tools/rmc_flag.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Tools/rmc_flag.yml
@@ -1,4 +1,5 @@
-﻿- type: entity
+- type: entity
+  abstract: true
   parent: BaseItem
   id: RMCFlagCarriableBase
   name: flag

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Tools/rmc_flag.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Tools/rmc_flag.yml
@@ -1,4 +1,4 @@
-- type: entity
+﻿- type: entity
   abstract: true
   parent: BaseItem
   id: RMCFlagCarriableBase

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Walls/mineral_walls.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Walls/mineral_walls.yml
@@ -14,7 +14,7 @@
   - type: IconSmooth
     key: walls
     base: stone
-    
+
 - type: entity
   parent: CMWallRock
   id: RMCWallSandstoneRuned
@@ -26,7 +26,7 @@
     state: runedstone
     color: "#c6a480"
   - type: Icon
-    sprite: _RMC14/Structures/Walls/stone.rsi
+    sprite: _RMC14/Structures/Walls/runedstone.rsi
     state: runedstone
   - type: IconSmooth
     key: walls


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Turns out that a missing `abstract: true` in `RMCFlagCarriableBase` from #6011 sent the poor YAML linter to the grave. Since the test was crashing and couldn't point out where the error was, it took several hours for me to debug and in that time I have learned the code is made of paper and glue. Anyway it's fixed now haha

After nurturing the YAML linter back to life I also fixed the errors it was complaining about.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Test fails. This also fixes wrong steelcrest defender armor, wrong base xeno explosion armor, and the missing lobby song.

## Technical details
<!-- Summary of code changes for easier review. -->

yaml

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: (Already uploaded) Fixed Steelcrest Defender having 80 total frontal armor when fortified instead of 60.