### PR TITLE
Add lance corporal rifleman limit

### DIFF
--- a/Content.Server/_RMC14/Marines/Roles/Ranks/RankSystem.cs
+++ b/Content.Server/_RMC14/Marines/Roles/Ranks/RankSystem.cs
@@ -77,7 +77,10 @@ public sealed class RankSystem : SharedRankSystem
                 if (!failed)
                 {
                     SetRank(ev.Mob, rankPrototype);
-                    _distressSignal.RoleRankLimits[ev.JobId] = currentCount + 1;
+
+                    if (rankPrototype.RoleLimits != null && rankPrototype.RoleLimits.TryGetValue(ev.JobId, out var limit) && limit > 0)
+                        _distressSignal.RoleRankLimits[ev.JobId] = currentCount + 1;
+
                     break;
                 }
             }

--- a/Content.Server/_RMC14/Marines/Roles/Ranks/RankSystem.cs
+++ b/Content.Server/_RMC14/Marines/Roles/Ranks/RankSystem.cs
@@ -68,7 +68,7 @@ public sealed class RankSystem : SharedRankSystem
 
                 _distressSignal.RoleRankLimits.TryGetValue(ev.JobId, out var currentCount);
 
-                if (rankPrototype.RoleLimits != null && !rankPrototype.RoleLimits.TryGetValue(ev.JobId, out var maxLimit))
+                if (rankPrototype.RoleLimits != null && rankPrototype.RoleLimits.TryGetValue(ev.JobId, out var maxLimit))
                 {
                     if (currentCount >= maxLimit)
                         failed = true;

--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
@@ -177,6 +177,9 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
     [ViewVariables]
     public string? OperationName { get; private set; }
 
+    [ViewVariables]
+    public Dictionary<ProtoId<JobPrototype>, int> RoleRankLimits = new();
+
     private readonly Dictionary<EntProtoId<RMCPlanetMapPrototypeComponent>, int> _carryoverVotes = new();
 
     public override void Initialize()
@@ -708,6 +711,7 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
     {
         StartPlanetVote();
         ResetSelectedPlanet();
+        RoleRankLimits.Clear();
         _config.SetCVar(CCVars.GameDisallowLateJoins, false);
 
         if (!_autoBalance)

--- a/Content.Shared/_RMC14/Marines/Roles/Ranks/RankPrototype.cs
+++ b/Content.Shared/_RMC14/Marines/Roles/Ranks/RankPrototype.cs
@@ -46,4 +46,8 @@ public sealed partial class RankPrototype : IPrototype, IInheritingPrototype
     [AlwaysPushInheritance]
     [DataField]
     public string? Paygrade { get; set; }
+
+    [AlwaysPushInheritance]
+    [DataField]
+    public Dictionary<ProtoId<JobPrototype>, int>? RoleLimits { get; set; }
 }

--- a/Resources/Prototypes/_RMC14/Roles/Ranks/UNMC/enlisted.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Ranks/UNMC/enlisted.yml
@@ -51,6 +51,8 @@
   name: Lance Corporal
   prefix: LCpl.
   paygrade: E3
+  roleLimits:
+    CMRifleman: 2
 
 - type: rank
   id: RMCRankPrivateFirstClass

--- a/Resources/Prototypes/_RMC14/Roles/Ranks/UNMC/enlisted.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Ranks/UNMC/enlisted.yml
@@ -52,7 +52,7 @@
   prefix: LCpl.
   paygrade: E3
   roleLimits:
-    CMRifleman: 2
+    CMRifleman: 7
 
 - type: rank
   id: RMCRankPrivateFirstClass


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds CM13's lance corporal rifleman limit of 7
If there are more than 7 lance corporal riflemen you will get PFC instead

:cl:
- add: Added a max limit of 7 lance corporal riflemen.