### PR TITLE
Fix Nesart Onan Figurine not behaving like a container.

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/patron_figurines.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/patron_figurines.yml
@@ -443,6 +443,21 @@
     - 15
     - 25
     - 30
+  - type: Damageable
+    damageContainer: Inorganic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 50
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: GlassBreak
+      - !type:SpillBehavior { }
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: RMCFlask
 
 - type: entity
   parent: RMCBaseFigurinePatron

--- a/Resources/Prototypes/_RMC14/Entities/Objects/patron_figurines.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/patron_figurines.yml
@@ -414,7 +414,7 @@
     color: green
 
 - type: entity
-  parent: RMCBaseFigurinePatron
+  parent: [ RMCBaseFigurinePatron, CMCanteenBase ]
   id: RMCFigurinePatronNesartOnan
   name: Nesart Onan figurine
   description: "Blood loss is no joke! Come get some gauze from your local medbay today!"
@@ -430,21 +430,19 @@
     solutions:
       drink:
         maxVol: 30
-  - type: Damageable
-    damageContainer: Inorganic
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 50
-      behaviors:
-      - !type:PlaySoundBehavior
-        sound:
-          collection: GlassBreak
-      - !type:SpillBehavior { }
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
-  - type: RMCFlask
+        reagents:
+        - ReagentId: IceCream
+          Quantity: 30
+  - type: SolutionTransfer
+    transferAmount: 30
+    maxTransferAmount: 30
+    canChangeTransferAmount: true
+    transferAmounts:
+    - 5
+    - 10
+    - 15
+    - 25
+    - 30
 
 - type: entity
   parent: RMCBaseFigurinePatron


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed Nesart Onan Figurine missing components that prevented it from behaving like a container

## Why / Balance
![image](https://github.com/user-attachments/assets/ae6b24ba-0083-418e-8cf0-f585934b6a42)

## Technical details
It now inherts components from CMCanteenBase which also inherts from DrinkBase to properly behave like a container.

Changed max volume, transfer ammount, and added Ice Cream.

## Media
![Screenshot (128)](https://github.com/user-attachments/assets/a3093517-f0a6-4a03-9aba-c56dac5a927b)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed Nesart Onan Figurine not containing Ice Cream inside.