### PR TITLE
Roundstart larva now spawns from a survivor corpse

### DIFF
--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleComponent.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleComponent.cs
@@ -152,4 +152,10 @@ public sealed partial class CMDistressSignalRuleComponent : Component
 
     [DataField]
     public ResPath Thunderdome = new("/Maps/_RMC14/thunderdome.yml");
+
+    [DataField]
+    public ProtoId<JobPrototype> XenoSurvivorCorpseJob = "CMSurvivor";
+
+    [DataField]
+    public TimeSpan XenoSurvivorCorpseBurstDelay = TimeSpan.FromSeconds(0);
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Makes it so roundstart larva spawn inside a survivor and need to burst of, the survivor is of the xeno player's character preferences

https://github.com/user-attachments/assets/a4dc7bca-570b-4b0b-a8dc-868986af193e


## Why/Balance
From CM13
More immersion

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.


:cl:
- add: Roundstart larva now spawn inside dead colonists and need to burst out