### PR TITLE
Gun attachment prediction and masterkey PBs

### DIFF
--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Numerics;
+using Content.Shared._RMC14.Attachable.Systems;
 using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Random;
 using Content.Shared._RMC14.Weapons.Ranged.Flamer;
@@ -88,6 +89,7 @@ public abstract partial class SharedGunSystem : EntitySystem
     [Dependency] private   readonly INetConfigurationManager _netConfig = default!;
 
     // RMC14
+    [Dependency] private readonly AttachableHolderSystem _attachableHolder = default!;
     [Dependency] private readonly SharedRMCFlamerSystem _flamer = default!;
 
     private const float InteractNextFire = 0.3f;
@@ -178,6 +180,9 @@ public abstract partial class SharedGunSystem : EntitySystem
 
     public bool TryGetGun(EntityUid entity, out EntityUid gunEntity, [NotNullWhen(true)] out GunComponent? gunComp)
     {
+        if(_attachableHolder.TryGetInhandSupercedingGun(entity, out gunEntity, out gunComp))
+            return true;
+
         gunEntity = default;
         gunComp = null;
 

--- a/Content.Shared/_RMC14/Weapons/Ranged/CMGunSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/CMGunSystem.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using Content.Shared._RMC14.Attachable.Components;
 using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Evasion;
 using Content.Shared._RMC14.Marines.Orders;
@@ -723,6 +724,9 @@ public sealed class CMGunSystem : EntitySystem
             user = (container.Owner, hands);
             return true;
         }
+
+        if (container != null && TryComp(container.Owner, out AttachableHolderComponent? holder) && holder.SupercedingAttachable == gun)
+            return TryGetGunUser(container.Owner, out user);
 
         user = default;
         return false;

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/under_attachments.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/under_attachments.yml
@@ -338,6 +338,7 @@
       Breaching: 10.8
   - type: UseDelay
   - type: RMCWeaponAccuracy
+  - type: GunPointBlank
   - type: AttachableToggleable
     userOnly: true
     attachedOnly: true
@@ -452,6 +453,7 @@
     resetOnHandSelected: false
   - type: RMCSelectiveFire
     baseFireRate: 0.417
+  - type: GunIgnorePrediction
   - type: BallisticAmmoProvider
     cycleable: false
     whitelist:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Title. Makes attachable guns predicted and lets you PB with the masterkey.

Closes #5163

## Why / Balance
Because normal guns are predicted.

## Technical details
This changes the `TryGetGun` method in the upstream gun system. I tried to figure out if there's a good way of handling this without doing that, but I don't think there is.

This way, the gun system just treats the attachment as the active gun and directly works with it. This has the side benefit of making the client not spew shoot requests at an attachment that shot too recently.

The other way is to intercept `RequestStopShootEvent` to redirect it at the attachment and make `SharedGunPredictionSystem.ShootRequested` target the attachment. The problem is that this might break if we or upstream make something new that requires the use of `TryGetGun` and doesn't account for attachments.

Basically, I think the small upstream change is a better solution for us than the alternative, especially long-term, but if you think it's better to avoid that, I'll change it.

## Media
Masterkey PB:

https://github.com/user-attachments/assets/a74cba4d-cdcf-4a6f-822b-d507288c8262


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl: Sigil
- fix: Shootable attachments are now predicted.
- fix: The masterkey can be used for PBs.
