### PR TITLE
Remove the last fleshy sound from bullet impacts

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/cm_base_gun.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/cm_base_gun.yml
@@ -60,4 +60,4 @@
   - type: RMCProjectileAccuracy
   - type: Projectile
     soundHit:
-     collection: RMCBallisticHit
+      path: /Audio/_RMC14/Bullets/bullet_impact1.ogg

--- a/Resources/Prototypes/_RMC14/SoundCollections/projectile.yml
+++ b/Resources/Prototypes/_RMC14/SoundCollections/projectile.yml
@@ -1,5 +1,0 @@
-- type: soundCollection
-  id: RMCBallisticHit
-  files:
-    - /Audio/_RMC14/Bullets/bullet_impact1.ogg
-    - /Audio/_RMC14/Bullets/bullet_impact2.ogg


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
removed the last fleshy sound "bullet_impact2" and deleted the sound collection since theres no need for a collection for just one sound

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
![image](https://github.com/user-attachments/assets/6db851ee-c19d-47dc-9861-bef19e429c7b)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Removed a fleshy bullet impact sound.
