### PR TITLE
reset foxtrot state on round start

### DIFF
--- a/Content.Server/_RMC14/Intel/Tech/TechSystem.cs
+++ b/Content.Server/_RMC14/Intel/Tech/TechSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server.GameTicking.Events;
 using Content.Server.Ghost.Roles.Components;
 using Content.Server.Humanoid.Components;
 using Content.Server.Spawners.Components;
@@ -31,6 +32,12 @@ public sealed class ServerTechSystem : EntitySystem
         base.Initialize();
         SubscribeLocalEvent<TechCryoMarinesEvent>(OnTechCryoMarines);
         SubscribeLocalEvent<TechCryoSpecEvent>(OnTechCryoSpec);
+        SubscribeLocalEvent<RoundStartingEvent>(OnRoundStart);
+    }
+
+    private void OnRoundStart(RoundStartingEvent ev)
+    {
+        _cryoMarinesPurchased = false;
     }
 
     private void OnTechCryoMarines(TechCryoMarinesEvent ev)

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/squads.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/squads.yml
@@ -90,6 +90,7 @@
     minimapBackground:
      sprite: _RMC14/Interface/map_blips.rsi
      state: background_foxtrot
+    canSupplyDrop: false
 
 - type: entity
   parent: SquadBase


### PR DESCRIPTION
## About the PR

Bugfix. The state did not reset between rounds leading to no SL spawns.

## Why / Balance

Bugfix

## Technical details

Listen for roundstartevent and reset the state.

## Media

No

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Foxtrot Squad Leaders can now reliably be woken up.
