### PR TITLE
assign rank when using the admin menu to spawn someone

### DIFF
--- a/Content.Server/_RMC14/Admin/RMCAdminSystem.cs
+++ b/Content.Server/_RMC14/Admin/RMCAdminSystem.cs
@@ -1,4 +1,5 @@
-﻿using Content.Server._RMC14.TacticalMap;
+﻿using Content.Server._RMC14.Marines;
+using Content.Server._RMC14.TacticalMap;
 using Content.Server.Administration.Logs;
 using Content.Server.Administration.Systems;
 using Content.Server.EUI;
@@ -11,6 +12,7 @@ using Content.Server.Roles.Jobs;
 using Content.Server.Station.Systems;
 using Content.Shared._RMC14.Admin;
 using Content.Shared._RMC14.CCVar;
+using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.TacticalMap;
 using Content.Shared.Database;
 using Content.Shared.Humanoid.Prototypes;
@@ -38,6 +40,7 @@ public sealed class RMCAdminSystem : SharedRMCAdminSystem
     [Dependency] private readonly StationSystem _station = default!;
     [Dependency] private readonly StationSpawningSystem _stationSpawning = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly MarineSystem _marine = default!;
 
     public readonly Queue<(Guid Id, List<TacticalMapLine> Lines, string Actor, int Round)> LinesDrawn = new();
 
@@ -93,6 +96,12 @@ public sealed class RMCAdminSystem : SharedRMCAdminSystem
 
         if (mobUid != null)
             _transform.SetCoordinates(mobUid.Value, coords.Value);
+
+        if (HasComp<MarineComponent>(mobUid) &&
+            _prototypes.TryIndex(ev.JobId, out var job) &&
+            job.Icon != "CMJobIconEmpty" &&
+            _prototypes.TryIndex(job.Icon, out var icon))
+            _marine.SetMarineIcon(mobUid.Value, icon.Icon);
 
         _adminLog.Add(LogType.RMCSpawnJob, $"{ToPrettyString(user)} spawned {ToPrettyString(mobUid)} as job {jobName}");
     }

--- a/Content.Shared/_RMC14/Admin/SpawnAsJobDialogEvent.cs
+++ b/Content.Shared/_RMC14/Admin/SpawnAsJobDialogEvent.cs
@@ -1,6 +1,8 @@
-﻿using Robust.Shared.Serialization;
+﻿using Content.Shared.Roles;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
 
 namespace Content.Shared._RMC14.Admin;
 
 [Serializable, NetSerializable]
-public sealed record SpawnAsJobDialogEvent(NetEntity User, NetEntity Target, string JobId);
+public sealed record SpawnAsJobDialogEvent(NetEntity User, NetEntity Target, ProtoId<JobPrototype> JobId);


### PR DESCRIPTION
## About the PR

This PR makes it so that anyone spawned via the admin menu gets assign their respective icon.

## Why / Balance

Admins yearn for icons.

## Technical details

Simply sending the `PlayerSpawnCompleteEvent` fixes everything. Also fixes ranks and names on ID.

## Media

https://github.com/user-attachments/assets/ddf36b5d-5584-45ff-b137-4a4e01c68e9c

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
ADMIN:
- tweak: "Spawn here as job" now also sets the respective icon.
