### PR TITLE
Add helmet accessory toggling

### DIFF
--- a/Content.Shared/_RMC14/Clothing/HelmetAccessoriesSystem.cs
+++ b/Content.Shared/_RMC14/Clothing/HelmetAccessoriesSystem.cs
@@ -2,6 +2,8 @@
 using Content.Shared.Clothing.EntitySystems;
 using Content.Shared.Inventory;
 using Content.Shared.Item;
+using Content.Shared.Item.ItemToggle;
+using Content.Shared.Item.ItemToggle.Components;
 using Content.Shared.Storage;
 using Robust.Shared.Containers;
 
@@ -11,6 +13,7 @@ public sealed class HelmetAccessoriesSystem : EntitySystem
 {
     [Dependency] private readonly InventorySystem _inventory = default!;
     [Dependency] private readonly SharedItemSystem _item = default!;
+    [Dependency] private readonly ItemToggleSystem _itemToggle = default!;
 
     private EntityQuery<StorageComponent> _storageQuery;
     private EntityQuery<HelmetAccessoryComponent> _accessoryQuery;
@@ -25,6 +28,8 @@ public sealed class HelmetAccessoriesSystem : EntitySystem
         SubscribeLocalEvent<HelmetAccessoryHolderComponent, EntInsertedIntoContainerMessage>(OnEntInserted);
         SubscribeLocalEvent<HelmetAccessoryHolderComponent, EntRemovedFromContainerMessage>(OnEntRemoved);
         SubscribeLocalEvent<HelmetAccessoryHolderComponent, GetEquipmentVisualsEvent>(OnGetEquipmentVisuals, after: [typeof(ClothingSystem)]);
+
+        SubscribeLocalEvent<HelmetAccessoryComponent, ItemToggledEvent>(OnToggled);
     }
 
     private void OnEntInserted(Entity<HelmetAccessoryHolderComponent> ent, ref EntInsertedIntoContainerMessage args)
@@ -35,6 +40,11 @@ public sealed class HelmetAccessoriesSystem : EntitySystem
     private void OnEntRemoved(Entity<HelmetAccessoryHolderComponent> ent, ref EntRemovedFromContainerMessage args)
     {
         _item.VisualsChanged(ent);
+    }
+
+    private void OnToggled(Entity<HelmetAccessoryComponent> ent, ref ItemToggledEvent args)
+    {
+        _item.VisualsChanged(Transform(ent).ParentUid);
     }
 
     private void OnGetEquipmentVisuals(Entity<HelmetAccessoryHolderComponent> ent, ref GetEquipmentVisualsEvent args)
@@ -60,10 +70,14 @@ public sealed class HelmetAccessoriesSystem : EntitySystem
             if (!_accessoryQuery.TryComp(item, out var accessoryComp))
                 continue;
 
+            var rsi = _itemToggle.IsActivated(item) && accessoryComp.ToggledRsi != null
+                ? accessoryComp.ToggledRsi
+                : accessoryComp.Rsi;
+
             args.Layers.Add((layer, new PrototypeLayerData
             {
-                RsiPath = accessoryComp.Rsi.RsiPath.ToString(),
-                State = accessoryComp.Rsi.RsiState,
+                RsiPath = rsi.RsiPath.ToString(),
+                State = rsi.RsiState,
                 Visible = true,
             }));
 

--- a/Resources/Locale/en-US/_RMC14/rmc-helmetgarbs.ftl
+++ b/Resources/Locale/en-US/_RMC14/rmc-helmetgarbs.ftl
@@ -1,0 +1,2 @@
+﻿rmc-helmetgarbs-off = Pull up headgear
+rmc-helmetgarbs-on = Pull down headgear

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Eyes/glasses.yml
@@ -202,7 +202,7 @@
     sprite: _RMC14/Objects/Clothing/Eyes/Glasses/old_rpg_glasses.rsi
 
 - type: entity
-  parent: ClothingEyesBase
+  parent: [ClothingEyesBase, RMCHelmetGarbToggleableBase]
   id: RMCGogglesBallistic
   name: marine ballistic goggles
   description: Standard issue UNMC goggles. While commonly found mounted atop M10 pattern helmets, they are also capable of preventing insects, dust, and other things from getting into one's eyes.
@@ -220,6 +220,9 @@
     rsi:
       sprite: _RMC14/Objects/Clothing/Eyes/Glasses/ballistic_goggles.rsi
       state: helmet
+    toggledRsi:
+      sprite: _RMC14/Objects/Clothing/Eyes/Glasses/ballistic_goggles.rsi
+      state: helmet-down
 
 - type: entity
   parent: RMCGogglesBallistic
@@ -231,6 +234,13 @@
     sprite: _RMC14/Objects/Clothing/Eyes/Glasses/black_ballistic_goggles.rsi
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/Eyes/Glasses/black_ballistic_goggles.rsi
+  - type: HelmetAccessory
+    rsi:
+      sprite: _RMC14/Objects/Clothing/Eyes/Glasses/black_ballistic_goggles.rsi
+      state: helmet
+    toggledRsi:
+      sprite: _RMC14/Objects/Clothing/Eyes/Glasses/black_ballistic_goggles.rsi
+      state: helmet-down
 
 - type: entity
   parent: RMCGogglesBallistic
@@ -246,6 +256,9 @@
     rsi:
       sprite: _RMC14/Objects/Clothing/Eyes/Glasses/orange_ballistic_goggles.rsi
       state: helmet
+    toggledRsi:
+      sprite: _RMC14/Objects/Clothing/Eyes/Glasses/orange_ballistic_goggles.rsi
+      state: helmet-down
 
 - type: entity
   parent: RMCGogglesBallistic
@@ -261,6 +274,9 @@
     rsi:
       sprite: _RMC14/Objects/Clothing/Eyes/Glasses/red_ballistic_goggles.rsi
       state: helmet
+    toggledRsi:
+      sprite: _RMC14/Objects/Clothing/Eyes/Glasses/red_ballistic_goggles.rsi
+      state: helmet-down
 
 - type: entity
   parent: RMCGogglesBallistic
@@ -276,6 +292,9 @@
     rsi:
       sprite: _RMC14/Objects/Clothing/Eyes/Glasses/blue_ballistic_goggles.rsi
       state: helmet
+    toggledRsi:
+      sprite: _RMC14/Objects/Clothing/Eyes/Glasses/blue_ballistic_goggles.rsi
+      state: helmet-down
 
 - type: entity
   parent: RMCGogglesBallistic
@@ -291,6 +310,9 @@
     rsi:
       sprite: _RMC14/Objects/Clothing/Eyes/Glasses/purple_ballistic_goggles.rsi
       state: helmet
+    toggledRsi:
+      sprite: _RMC14/Objects/Clothing/Eyes/Glasses/purple_ballistic_goggles.rsi
+      state: helmet-down
 
 - type: entity
   parent: RMCGogglesBallistic
@@ -306,6 +328,9 @@
     rsi:
       sprite: _RMC14/Objects/Clothing/Eyes/Glasses/yellow_ballistic_goggles.rsi
       state: helmet
+    toggledRsi:
+      sprite: _RMC14/Objects/Clothing/Eyes/Glasses/yellow_ballistic_goggles.rsi
+      state: helmet-down
 
 - type: entity
   parent: RMCGogglesBallistic
@@ -321,6 +346,9 @@
     rsi:
       sprite: _RMC14/Objects/Clothing/Eyes/Glasses/blue_polarized_ballistic_goggles.rsi
       state: helmet
+    toggledRsi:
+      sprite: _RMC14/Objects/Clothing/Eyes/Glasses/blue_polarized_ballistic_goggles.rsi
+      state: helmet-down
 
 - type: entity
   parent: RMCGogglesBallistic
@@ -336,6 +364,9 @@
     rsi:
       sprite: _RMC14/Objects/Clothing/Eyes/Glasses/orange_polarized_ballistic_goggles.rsi
       state: helmet
+    toggledRsi:
+      sprite: _RMC14/Objects/Clothing/Eyes/Glasses/orange_polarized_ballistic_goggles.rsi
+      state: helmet-down
 
 - type: entity
   parent: RMCGogglesBallistic
@@ -351,6 +382,9 @@
     rsi:
       sprite: _RMC14/Objects/Clothing/Eyes/Glasses/M1A1_Ballistic_goggles.rsi
       state: helmet
+    toggledRsi:
+      sprite: _RMC14/Objects/Clothing/Eyes/Glasses/M1A1_Ballistic_goggles.rsi
+      state: helmet-down
 
 - type: entity
   parent: RMCGogglesBallistic
@@ -372,6 +406,9 @@
     rsi:
       sprite: _RMC14/Objects/Clothing/Eyes/Glasses/M1A1_Ballistic_goggles_blue.rsi
       state: helmet
+    toggledRsi:
+      sprite: _RMC14/Objects/Clothing/Eyes/Glasses/M1A1_Ballistic_goggles_blue.rsi
+      state: helmet-down
 
 - type: entity
   parent: ClothingEyesBase
@@ -509,6 +546,9 @@
     rsi:
       sprite: _RMC14/Objects/Clothing/Eyes/Glasses/welding_goggles.rsi
       state: helmet
+    toggledRsi:
+      sprite: _RMC14/Objects/Clothing/Eyes/Glasses/welding_goggles.rsi
+      state: helmet-down
 
 - type: Tag
   id: RMCWeldingGoggle

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Masks/masks.yml
@@ -68,7 +68,7 @@
     - Mask
   - type: Item
     size: Small
-    
+
 - type: entity
   parent: CMBaseMask
   id: RMCMaskKutjevoRespirator
@@ -228,7 +228,7 @@
     size: Small
 
 - type: entity
-  parent: CMBaseMask
+  parent: [CMBaseMask, RMCHelmetGarbToggleableBase]
   id: RMCVisorSWAT
   name: TC2 CMB riot shield
   description: Yellowish protective glass piece, can be lifted up when needed, makes you see everything in yellow.
@@ -245,6 +245,9 @@
     rsi:
       sprite: _RMC14/Objects/Clothing/Mask/swat_shield.rsi
       state: helmet
+    toggledRsi:
+      sprite: _RMC14/Objects/Clothing/Mask/swat_shield.rsi
+      state: helmet-down
 
 
 # Keffiyehs

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/helmet_garbs.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/helmet_garbs.yml
@@ -14,9 +14,10 @@
   id: RMCHelmetGarbToggleableBase
   abstract: true
   components:
-  - type: HelmetAccessory
   - type: ItemToggle
     activated: false
+    verbToggleOff: rmc-helmetgarbs-off
+    verbToggleOn: rmc-helmetgarbs-on
 
 # NVG
 

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/helmet_garbs.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/helmet_garbs.yml
@@ -7,11 +7,21 @@
   - type: Item
     size: Tiny
   - type: HelmetAccessory
+  - type: Appearance
+
+- type: entity
+  parent: RMCHelmetGarbBase
+  id: RMCHelmetGarbToggleableBase
+  abstract: true
+  components:
+  - type: HelmetAccessory
+  - type: ItemToggle
+    activated: false
 
 # NVG
 
 - type: entity
-  parent: RMCHelmetGarbBase
+  parent: RMCHelmetGarbToggleableBase
   id: RMCHelmetGarbNightVision
   name: old M2 night vision goggles
   description: This pair has been gutted of all electronics and therefore not working. But hey, they make you feel tacticool, and that's all that matters, right?
@@ -25,6 +35,9 @@
     rsi:
       sprite: _RMC14/Objects/Clothing/HelmetGarb/nv_goggles.rsi
       state: helmet
+    toggledRsi:
+      sprite: _RMC14/Objects/Clothing/HelmetGarb/nv_goggles.rsi
+      state: helmet-down
 
 # Netting
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
You can now toggle through activated and deactivated helmet accessory sprites with item toggle

## Media

https://github.com/user-attachments/assets/3b0efec2-7ed5-4921-8462-62a2fb11ae8f



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.


:cl:
- add: You can now toggle helmet accessories by pressing E or using a verb on it.