### PR TITLE
Stock melee modifier

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/stock_attachments.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/stock_attachments.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   abstract: true
   parent: RMCAttachableBase
   id: RMCStockAttachmentBase
@@ -61,11 +61,6 @@
   - type: AttachableWieldDelayMods
     modifiers:
       - delay: 0.4
-  - type: AttachableWeaponMeleeMods
-    modifiers:
-    - bonusDamage:
-        types:
-          Blunt: 10
   - type: AttachableWeaponRangedMods
     modifiers:
     - conditions:
@@ -102,11 +97,6 @@
     tags:
     - RMCAttachmentStock
     - RMCAttachmentMOU53Stock
-  - type: AttachableWeaponMeleeMods
-    modifiers:
-    - bonusDamage:
-        types:
-          Blunt: 10
   - type: AttachableSpeedMods
     modifiers:
     - conditions:
@@ -143,11 +133,6 @@
     tags:
     - RMCAttachmentStock
     - RMCAttachmentType23Stock
-  - type: AttachableWeaponMeleeMods
-    modifiers:
-    - bonusDamage:
-        types:
-          Blunt: 10
   - type: AttachableWieldDelayMods
     modifiers:
       - delay: 0.3
@@ -461,6 +446,11 @@
     - conditions:
         activeOnly: true
       delay: 0.2
+  - type: AttachableWeaponMeleeMods
+    modifiers:
+    - bonusDamage:
+        types:
+          Blunt: 5
   - type: AttachableWeaponRangedMods
     modifiers:
     - conditions:
@@ -666,6 +656,11 @@
     - conditions:
         activeOnly: true
       delay: 0.4
+  - type: AttachableWeaponMeleeMods
+    modifiers:
+    - bonusDamage:
+        types:
+          Blunt: 10
   - type: AttachableWeaponRangedMods
     modifiers:
     - conditions:
@@ -800,11 +795,6 @@
     tags:
     - RMCAttachmentStock
     - RMCAttachmentXM88Stock
-  - type: AttachableWeaponMeleeMods
-    modifiers:
-    - bonusDamage:
-        types:
-          Blunt: 5
   - type: AttachableSpeedMods
     modifiers:
     - conditions:
@@ -849,11 +839,6 @@
     tags:
     - RMCAttachmentStock
     - RMCAttachmentHG3712Stock
-  - type: AttachableWeaponMeleeMods
-    modifiers:
-    - bonusDamage:
-        types:
-          Blunt: 10
 
 - type: entity
   parent: RMCStockAttachmentBase
@@ -869,11 +854,6 @@
     tags:
     - RMCAttachmentStock
     - RMCAttachmentHG3712Stock
-  - type: AttachableWeaponMeleeMods
-    modifiers:
-    - bonusDamage:
-        types:
-          Blunt: 10
 
 - type: entity
   parent: RMCAttachableBase


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
adjusts some stocks melee modifiers closer to parity.

numbers were taken from here https://github.com/cmss13-devs/cmss13/blob/0815ef25fc13d42a3f145cc913c3f61270d49773/code/modules/projectiles/gun_attachables.dm
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
parity

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Adjusted some stocks melee dmg to their intended values (10 > 5).
