### PR TITLE
make foxtrot ws ignore SharedSpecLimit

### DIFF
--- a/Content.Shared/_RMC14/Vendors/IgnoreSpecLimitsComponent.cs
+++ b/Content.Shared/_RMC14/Vendors/IgnoreSpecLimitsComponent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Vendors;
+
+/// <summary>
+/// Entities with this component ignore the SharedSpecLimit.
+/// Used by the foxtrot WS.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class IgnoreSpecLimitsComponent : Component;

--- a/Content.Shared/_RMC14/Vendors/SharedCMAutomatedVendorSystem.cs
+++ b/Content.Shared/_RMC14/Vendors/SharedCMAutomatedVendorSystem.cs
@@ -362,7 +362,7 @@ public abstract class SharedCMAutomatedVendorSystem : EntitySystem
                 user.TakeOne.Remove(takeOne);
         }
 
-        if (section.SharedSpecLimit is { } globalLimit)
+        if (section.SharedSpecLimit is { } globalLimit && !HasComp<IgnoreSpecLimitsComponent>(actor))
         {
             if (HasComp<RMCVendorSpecialistComponent>(vendor))
             {

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/ghosts/foxtrot.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/ghosts/foxtrot.yml
@@ -116,3 +116,5 @@
 - type: randomHumanoidSettings
   parent: [RMCWeaponsSpecialist, RMCFoxtrotBase]
   id: RMCFoxtrotWeaponsSpecialist
+  components:
+  - type: IgnoreSpecLimits


### PR DESCRIPTION
## About the PR

Makes it so that the Foxtrot WS bypasses spec limit

## Why / Balance

Parity. Fixes #6095

## Technical details

New comp and if statement.

## Media

https://github.com/user-attachments/assets/8a290653-9240-4951-b842-3a42d9287de5

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- tweak: The foxtrot WS can now pick any kit.
