### PR TITLE
Make crates undestroyable by xeno claws, crate drag speed change

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/ClawSharpness/XenoClawsComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/ClawSharpness/XenoClawsComponent.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.GameStates;
+using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared._RMC14.Xenonids.ClawSharpness;
@@ -17,5 +17,6 @@ public enum XenoClawType
 {
     Normal,
     Sharp,
-    VerySharp
+    VerySharp,
+    ImpossiblySharp //For receiver component on things that should be unbreakable
 }

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
@@ -212,6 +212,10 @@
       whitelist:
         tags:
         - BodyBag
+    - multiplier: 0.645
+      whitelist:
+        components:
+        - ResistLocker #Lockers/Crates
   - type: MobThresholds
     thresholds:
       0: Alive

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Storage/crates.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Storage/crates.yml
@@ -51,7 +51,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 50
+        damage: 100
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
@@ -100,6 +100,8 @@
     virtualRight: RMCVirtualCrateRight
     virtualLeft: RMCVirtualCrateLeft
   - type: RMCCanBeFultoned
+  - type: ReceiverXenoClaws
+    minimumClawStrength: VerySharp
 
 - type: entity
   parent: RMCCrateBase

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Storage/crates.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Storage/crates.yml
@@ -101,7 +101,7 @@
     virtualLeft: RMCVirtualCrateLeft
   - type: RMCCanBeFultoned
   - type: ReceiverXenoClaws
-    minimumClawStrength: VerySharp
+    minimumClawStrength: ImpossiblySharp
 
 - type: entity
   parent: RMCCrateBase


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Mostly parity. Crates can't be destroyed by xenos through attack in parity but I don't remember if we have a comp for just that so I made it require very sharp claws. They also have the 100 health they were supposed to.

Crate dragging speed is supposed to be the same as human dragging speed, so I tested it a bit to get them to mostly match up. The value for bodybags seemed to work the best here, so it's only off by a little probably.

## Technical details
<!-- Summary of code changes for easier review. -->
YML.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed xenos from being able to destroy crates with melee.
- fix: Fixed dragging crates not slowing you down.
