### PR TITLE
Flare packs can directly transfer their content to a flare pouch

### DIFF
--- a/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
+++ b/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
@@ -229,7 +229,9 @@ public abstract class SharedCMInventorySystem : EntitySystem
     /// </summary>
     private void OnInteractUsing(Entity<CMItemSlotsComponent> ent, ref InteractUsingEvent args)
     {
-        if(!TryComp(args.Used, out ItemSlotsComponent? usedStorage) || !TryComp(ent, out ItemSlotsComponent? storage))
+        if(!TryComp(args.Used, out ItemSlotsComponent? usedStorage) ||
+           !TryComp(ent, out ItemSlotsComponent? storage) ||
+           args.Handled)
             return;
 
         SoundSpecifier? insertSound = null;

--- a/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
+++ b/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
@@ -246,8 +246,8 @@ public abstract class SharedCMInventorySystem : EntitySystem
                     if(!_container.TryGetContainer(ent, itemSlot.Key, out var container))
                         continue;
 
-                    _container.Insert(entity, container);
-                    insertSound = itemSlot.Value.InsertSound;
+                    if(_container.Insert(entity, container))
+                        insertSound = itemSlot.Value.InsertSound;
                 }
             }
         }

--- a/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
+++ b/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
@@ -18,6 +18,7 @@ using Content.Shared.Verbs;
 using Content.Shared.Weapons.Melee;
 using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Whitelist;
+using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Input.Binding;
@@ -81,6 +82,7 @@ public abstract class SharedCMInventorySystem : EntitySystem
         SubscribeLocalEvent<CMItemSlotsComponent, ItemSlotEjectAttemptEvent>(OnSlotsEjectAttempt);
         SubscribeLocalEvent<CMItemSlotsComponent, EntInsertedIntoContainerMessage>(OnSlotsEntInsertedIntoContainer);
         SubscribeLocalEvent<CMItemSlotsComponent, EntRemovedFromContainerMessage>(OnSlotsEntRemovedFromContainer);
+        SubscribeLocalEvent<CMItemSlotsComponent, InteractUsingEvent>(OnInteractUsing);
 
         SubscribeLocalEvent<CMHolsterComponent, GetVerbsEvent<AlternativeVerb>>(OnHolsterGetAltVerbs);
         SubscribeLocalEvent<CMHolsterComponent, AfterAutoHandleStateEvent>(OnHolsterComponentHandleState);
@@ -220,6 +222,37 @@ public abstract class SharedCMInventorySystem : EntitySystem
         {
             args.Cancelled = true;
         }
+    }
+
+    /// <summary>
+    ///     Try to transfer contents from ItemSlots of one entity to the ItemSlots of another.
+    /// </summary>
+    private void OnInteractUsing(Entity<CMItemSlotsComponent> ent, ref InteractUsingEvent args)
+    {
+        if(!TryComp(args.Used, out ItemSlotsComponent? usedStorage) || !TryComp(ent, out ItemSlotsComponent? storage))
+            return;
+
+        SoundSpecifier? insertSound = null;
+
+        foreach (var usedStorageItemSlot in usedStorage.Slots)
+        {
+            if(!_container.TryGetContainer(args.Used, usedStorageItemSlot.Key, out var usedContainer))
+                continue;
+
+            foreach (var entity in usedContainer.ContainedEntities)
+            {
+                foreach (var itemSlot in storage.Slots)
+                {
+                    if(!_container.TryGetContainer(ent, itemSlot.Key, out var container))
+                        continue;
+
+                    _container.Insert(entity, container);
+                    insertSound = itemSlot.Value.InsertSound;
+                }
+            }
+        }
+
+        _audio.PlayPredicted(insertSound, ent, args.User);
     }
 
     protected void OnSlotsEntInsertedIntoContainer(Entity<CMItemSlotsComponent> ent, ref EntInsertedIntoContainerMessage args)

--- a/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
+++ b/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
@@ -246,8 +246,11 @@ public abstract class SharedCMInventorySystem : EntitySystem
                     if(!_container.TryGetContainer(ent, itemSlot.Key, out var container))
                         continue;
 
-                    if(_container.Insert(entity, container))
+                    if (_container.Insert(entity, container))
+                    {
                         insertSound = itemSlot.Value.InsertSound;
+                        args.Handled = true;
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Entities with the CMItemSlotComponent can now directly transfer their content to another entity with the ItemSlotComponent.
This means that for example flare packs can instantly transfer all their flares to a flare pouch by using the flare pack on the pouch.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The description of the flare pouch describes this interaction, but it currently doesn't exist.

## Technical details
<!-- Summary of code changes for easier review. -->
When an entity with the CMItemSlotsComponent is interacted with, it checks whether the interacting entity has any item slots. If it does, it attempts to transfer all contents from the interacting entity into itself.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/adc2e022-e1fb-4b70-a00e-94f664b365b8


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Dygon
- add: Flare packs can now directly transfer their content to a flare pouch.
