### PR TITLE
Add Ziptie boxes to some MP vendors; Add a ziptie box slot to riot, warden, and cmp armor.

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/basic_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/basic_armor.yml
@@ -23,6 +23,39 @@
   - type: RMCNameItemOnVend
     item: Armor
   - type: RMCBulkyArmor
+  - type: Storage
+    maxItemSize: Small
+    grid:
+    - 0,0,1,1 # Only a ziptie box
+  - type: LimitedStorage
+    limits:
+    - popup: rmc-storage-limit-not-ziptie-box
+      blacklist:
+        tags:
+        - RMCBoxZipties
+      whitelist: null
+      count: 0
+  - type: ContainerContainer
+    containers:
+      storagebase: !type:Container
+        ents: [ ]
+  - type: UserInterface
+    interfaces:
+      enum.StorageUiKey.Key:
+        type: StorageBoundUserInterface
+  - type: FixedItemSizeStorage
+  - type: IgnoreContentsSize
+    items:
+      tags:
+      - CMMagazineRifle
+      - CMMagazineSmg
+      - CMMagazineSniper
+      - CMMagazinePistol
+      - RMCMagazineRevolver
+      - MRE
+      - PillPacket
+      - PillCanister
+      - CMSurgicalCase
 
 - type: entity
   parent: CMArmorRiot

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
@@ -286,6 +286,18 @@
       Snow: _RMC14/Objects/Clothing/OuterClothing/Armor/m3/warden/snow.rsi
       Classic: _RMC14/Objects/Clothing/OuterClothing/Armor/m3/warden/classic.rsi
       Urban: _RMC14/Objects/Clothing/OuterClothing/Armor/m3/warden/urban.rsi
+  - type: Storage
+    maxItemSize: Small
+    grid:
+    - 0,0,5,1 # 2 slots + ziptie box
+  - type: LimitedStorage
+    limits:
+    - popup: rmc-storage-limit-not-ziptie-box
+      blacklist:
+        tags:
+        - RMCBoxZipties
+      whitelist: null
+      count: 2
 
 - type: entity
   parent: CMArmorM2MP
@@ -302,6 +314,18 @@
       Snow: _RMC14/Objects/Clothing/OuterClothing/Armor/m3/wo/snow.rsi
       Classic: _RMC14/Objects/Clothing/OuterClothing/Armor/m3/wo/classic.rsi
       Urban: _RMC14/Objects/Clothing/OuterClothing/Armor/m3/wo/urban.rsi
+  - type: Storage
+    maxItemSize: Small
+    grid:
+    - 0,0,5,1 # 2 slots + ziptie box
+  - type: LimitedStorage
+    limits:
+    - popup: rmc-storage-limit-not-ziptie-box
+      blacklist:
+        tags:
+        - RMCBoxZipties
+      whitelist: null
+      count: 2
 
 #Officer armors
 - type: entity
@@ -340,7 +364,7 @@
   - type: Storage
     maxItemSize: Small
     grid:
-    - 0,0,5,1 # 3 slots
+    - 0,0,7,1 # 3 slots + ziptie box
   - type: ItemCamouflage
     camouflageVariations:
       Jungle: _RMC14/Objects/Clothing/OuterClothing/Armor/m3/co/jungle.rsi

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/command.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/command.yml
@@ -823,7 +823,6 @@
       choices: { CMWeapon: 1 }
       entries:
       - id: RMCGunCaseRevolverRSh9
-      - id: RMCGunCasePistolMK80 # Non-Parity
       - id: RMCGunCasePistolM77
       - id: RMCGunCasePistolM44
       - id: RMCGunCasePistolM1984

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/command.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/command.yml
@@ -290,7 +290,7 @@
       - id: RMCAttachmentUnderbarrelExtinguisher
         points: 15
       - id: RMCAttachmentMiniFlamethrower
-        points: 15 
+        points: 15
       - id: RMCAttachmentU1GrenadeLauncher
         points: 5
     - name: Barrel Attachments
@@ -808,6 +808,7 @@
       - id: CMJumpsuitWO
       - id: CMHeadsetCMP
       - id: CMBootsBlackFilled
+      - id: RMCBoxZiptie # Non-Parity
     - name: Armor
       jobs:
       - CMChiefMP
@@ -822,6 +823,7 @@
       choices: { CMWeapon: 1 }
       entries:
       - id: RMCGunCaseRevolverRSh9
+      - id: RMCGunCasePistolMK80 # Non-Parity
       - id: RMCGunCasePistolM77
       - id: RMCGunCasePistolM44
       - id: RMCGunCasePistolM1984
@@ -892,7 +894,7 @@
       - id: ClothingEyesGlassesMeson # TODO change to CM13 engi goggles.
       - id: RMCNailgunTactical
       # TODO KN5500/2 PDA
-     
+
     - name: Uniform
       jobs:
       - CMChiefEngineer
@@ -939,7 +941,7 @@
       - id: RMCBeltUtilityGeneral
       - id: CMBeltUtilityFilled
         name: M276 pattern toolbelt rig (Full)
-       
+
     - name: Pouches
       jobs:
       - CMChiefEngineer
@@ -1257,14 +1259,14 @@
         recommended: true
       - id: CMWebbing
     - name: Spare Equipment
-      jobs: 
+      jobs:
       - CMCMO
       entries:
       - id: CMHeadsetMedical
         amount: 15
       - id: CMHeadsetResearcher
         amount: 15
-        
+
 
     # ////////////////////////////////////
     # Auxiliary Support Officer
@@ -1312,7 +1314,7 @@
       - id: CMHeadCapPeakedService
         recommended: true
       - id: CMHeadBeretTan
-        recommended: true  
+        recommended: true
     - name: Combat Equipment
       jobs:
       - CMAuxiliarySupportOfficer

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/police.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/police.yml
@@ -34,6 +34,7 @@
     - name: Handgun Case
       choices: { CMGunCase: 1 }
       entries:
+      - id: RMCGunCasePistolMK80 # Non-Parity
       - id: RMCGunCasePistolM77
       - id: RMCGunCasePistolM44
       - id: RMCGunCasePistolM1984
@@ -99,6 +100,7 @@
       - id: CMHandsBlackMarine
       - id: CMHeadsetCMP
       - id: CMBootsBlackFilled
+      - id: RMCBoxZiptie # Non-Parity
     - name: Armor
       takeAll: CMArmor
       entries:
@@ -107,6 +109,7 @@
     - name: Handgun Case
       choices: { CMGunCase: 1 }
       entries:
+      - id: RMCGunCasePistolMK80 # Non-Parity
       - id: RMCGunCasePistolM77
       - id: RMCGunCasePistolM44
       - id: RMCGunCasePistolM1984

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/police.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/police.yml
@@ -34,7 +34,6 @@
     - name: Handgun Case
       choices: { CMGunCase: 1 }
       entries:
-      - id: RMCGunCasePistolMK80 # Non-Parity
       - id: RMCGunCasePistolM77
       - id: RMCGunCasePistolM44
       - id: RMCGunCasePistolM1984
@@ -109,7 +108,6 @@
     - name: Handgun Case
       choices: { CMGunCase: 1 }
       entries:
-      - id: RMCGunCasePistolMK80 # Non-Parity
       - id: RMCGunCasePistolM77
       - id: RMCGunCasePistolM44
       - id: RMCGunCasePistolM1984

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/vending_machines.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/vending_machines.yml
@@ -285,6 +285,7 @@
   id: RMCVendorRiot
   startingInventory: # TODO RMC14
     Zipties: 40
+    RMCBoxZiptie: 4 # Non-Parity
     RMCGrenadeFlashBang: 20
     RMCMagazineSMGM63Rubber: 40
     ##RMCGrenadeTearGas: 40


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR makes the following changes:
- Adds ziptie boxes to the riot tech.
- Adds a ziptie box to the MW and CMP vendors.
- Adds a ziptie box slot to the MW and CMPs armor.
- Adds a ziptie box slot to the riot suit.

## Why / Balance
As for the zipties, these are good for riot control, with the boxes being able to hold 10, which is important as with zipties now being a small item as opposed to tiny, it is hard to carry a significant amount of them for riot control. As such, CMP and Warden now get a box which also fits in their armor, and the riot suits have a slot for a box which can be obtained from the riot tech. While I understand why SLs have these, and agree that they should, I feel it makes little sense that the actual law enforcement people who may have to deal with riots do not have any way to obtain these.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or **it does not require an ingame showcase.**
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl: BramvanZijp
- add: Added a dedicated slot for a ziptie box to Riot Armor, CMP Armor, and Warden Armor.
- tweak: Ziptie boxes can now be obtained via the Riot Tech, CMP Vendor, and Warden Vendor.

