### PR TITLE
[Fix] Shale/blue rock not being semi weedable

### DIFF
--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_construction_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_construction_actions.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   id: CMGuidebookActionXenoBase
   abstract: true
   components:
@@ -155,7 +155,6 @@
     event: !type:XenoPlantWeedsActionEvent
       plasmaCost: 125
       prototype: XenoHardyWeedsSource
-      useOnSemiWeedable: true
     useDelay: 120
 
 # For healer drone

--- a/Resources/Prototypes/_RMC14/Tiles/planet.yml
+++ b/Resources/Prototypes/_RMC14/Tiles/planet.yml
@@ -872,6 +872,7 @@
     North: /Textures/_RMC14/Tiles/planet/auto_shale/layer1_double_edge.png
     West: /Textures/_RMC14/Tiles/planet/auto_shale/layer1_double_edge.png
   weedsSpreadable: false
+  semiWeedable: true
 
 - type: tile
   parent: RMCPlanetShale


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
makes chances claims shale tiles, aka blue rock tiles, semi weedable.
makes hardy nodes no longer placeable on semi weedables, hardy weeds can still grow over semi weedables.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
parity. ![image](https://github.com/user-attachments/assets/cd280d97-bce4-415a-acf9-6471c7a364a4) 
### linked image from the original cm13 pr
![image](https://github.com/user-attachments/assets/8d78e5be-614a-41d9-b01d-47c09b9a13b2)

backed up by the code https://github.com/cmss13-devs/cmss13/blob/552158f6197be7e4708d163d9cf5f2afa143d7f3/code/game/turfs/turf.dm#L708
and map viewer 
![image](https://github.com/user-attachments/assets/ebf1a1a1-5d91-400b-9437-22c7b5e7cdbf)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
### Hive Core speading hive weeds
https://github.com/user-attachments/assets/a18d90a3-4bac-4b2c-8c23-aa5b24a5bc1e

### Hive cluster spreading hive weeds
https://github.com/user-attachments/assets/f0a3eb57-16f6-42b8-8bf8-98acd8c52dd3

### spreading hardy weeds
https://github.com/user-attachments/assets/a76766bf-6aa2-4ba6-95d2-fd8d89725b68

### failing to spread normal weeds
https://github.com/user-attachments/assets/382d3993-ebd5-43c3-a264-1ae01f504f6f


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed shale tiles (blue rock) not being semi weedable.
- fix: Fixed hardy weed nodes being placeable on semi weedable tiles, but hardy weeds can still spread over semi weedable tiles.