### PR TITLE
Fix gun melee attack damage being too low

### DIFF
--- a/Content.Shared/_RMC14/Marines/Skills/SkillsSystem.cs
+++ b/Content.Shared/_RMC14/Marines/Skills/SkillsSystem.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 using Content.Shared.Chemistry.Components.SolutionManager;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Chemistry.Reagent;
+using Content.Shared.Damage;
 using Content.Shared.Examine;
 using Content.Shared.Flash;
 using Content.Shared.Interaction;
@@ -82,7 +83,7 @@ public sealed class SkillsSystem : EntitySystem
         if (skill <= 0)
             return;
 
-        args.Damage *= 1 + 0.25 * skill;
+        args.Damage = ApplyMeleeSkillModifier(args.User, args.Damage);
     }
 
     private void OnAttemptHyposprayUse(Entity<MedicallyUnskilledDoAfterComponent> ent, ref AttemptHyposprayUseEvent args)
@@ -538,5 +539,12 @@ public sealed class SkillsSystem : EntitySystem
             multiplier = definitionComp.DelayMultipliers[^1];
 
         return multiplier;
+    }
+
+    public DamageSpecifier ApplyMeleeSkillModifier(EntityUid user, DamageSpecifier damage)
+    {
+        var skill = GetSkill(user, _meleeSkill);
+
+        return damage* (1 + 0.25 * skill);
     }
 }

--- a/Content.Shared/_RMC14/Marines/Skills/SkillsSystem.cs
+++ b/Content.Shared/_RMC14/Marines/Skills/SkillsSystem.cs
@@ -545,6 +545,6 @@ public sealed class SkillsSystem : EntitySystem
     {
         var skill = GetSkill(user, _meleeSkill);
 
-        return damage* (1 + 0.25 * skill);
+        return damage * (1 + 0.25 * skill);
     }
 }

--- a/Content.Shared/_RMC14/Weapons/Melee/SharedRMCMeleeWeaponSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Melee/SharedRMCMeleeWeaponSystem.cs
@@ -1,5 +1,6 @@
 ﻿using System.Numerics;
 using Content.Shared._RMC14.CCVar;
+using Content.Shared._RMC14.Marines.Skills;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared.Damage;
 using Content.Shared.Interaction.Events;
@@ -17,6 +18,7 @@ public abstract class SharedRMCMeleeWeaponSystem : EntitySystem
 {
     [Dependency] private readonly SharedMeleeWeaponSystem _melee = default!;
     [Dependency] private readonly INetConfigurationManager _netConfig = default!;
+    [Dependency] private readonly SkillsSystem _skills = default!;
     [Dependency] private readonly SharedStunSystem _stun = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
@@ -83,11 +85,14 @@ public abstract class SharedRMCMeleeWeaponSystem : EntitySystem
 
         var comp = ent.Comp;
 
+        args.BonusDamage = _skills.ApplyMeleeSkillModifier(args.User, args.BonusDamage);
+        var combinedDamage = args.BaseDamage + args.BonusDamage;
+
         foreach (var hit in args.HitEntities)
         {
             if (_whitelist.IsValid(comp.Whitelist, hit))
             {
-                var damage = args.BaseDamage * comp.Multiplier;
+                var damage = combinedDamage * comp.Multiplier;
                 args.BonusDamage += damage;
                 break;
             }

--- a/Content.Shared/_RMC14/Weapons/Melee/SharedRMCMeleeWeaponSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Melee/SharedRMCMeleeWeaponSystem.cs
@@ -86,13 +86,13 @@ public abstract class SharedRMCMeleeWeaponSystem : EntitySystem
         var comp = ent.Comp;
 
         args.BonusDamage = _skills.ApplyMeleeSkillModifier(args.User, args.BonusDamage);
-        var combinedDamage = args.BaseDamage + args.BonusDamage;
+        var totalDamage = args.BaseDamage + args.BonusDamage;
 
         foreach (var hit in args.HitEntities)
         {
             if (_whitelist.IsValid(comp.Whitelist, hit))
             {
-                var damage = combinedDamage * comp.Multiplier;
+                var damage = totalDamage * comp.Multiplier;
                 args.BonusDamage += damage;
                 break;
             }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Damage from attachments like the bayonet is now also increased by the user's melee weapon skill.
The bonus melee damage when melee attacking a xenonid is now also applied to attachment bonus damage.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity.

A melee attack using a gun, with attachments that improve melee damage, now deals more damage against xenonids because the 50% bonus melee damage is now also applied to the attachment damage.
A melee attack using a gun, with attachments that improve melee damage, now deals more damage if the user has RMCSkillMeleeWeapons on level 1 or higher

Example values:
Base melee damage of the M42A2 shotgun: 5
Bayonet bonus damage when attached: 20
Damage multiplier when melee attacking a xeno: 1.5

Example calculation before this PR without melee skill: 5 * 1.5 + 20 = 27.5
Example calculation after this PR without melee skill: 5 * 1.5 + 20 * 1.5 = 37.5

Example calculation before this PR with melee skill 1: 5 * 1.5 * 1.25 + 20 = 29.375
Example calculation after this PR with melee skill 1: 5 * 1.5 * 1.25 + 20 * 1.5 * 1.25 = 46.875

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Damage on a runner in CM13 after being hit by a weapon specialist's(level 1 melee skill) melee attack, using the M37A2 equipped with a bayonet.
![image](https://github.com/user-attachments/assets/de83f874-d553-4792-8e1d-12c2d1da7e98)


## Technical details
<!-- Summary of code changes for easier review. -->
Previously only the base melee damage was increased by the melee skill multiplier, a new method is now called on melee hit to also increase the bonus damage from attachments based on the user's melee skill.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Dygon
- fix: Weapon attachment damage now accounts for the user's melee skill level and any other melee damage modifiers.
