### PR TITLE
Warrior lunge is homing

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Lunge/XenoLungeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Lunge/XenoLungeSystem.cs
@@ -115,7 +115,6 @@ public sealed class XenoLungeSystem : EntitySystem
         RemComp<HomingProjectileComponent>(xeno);
     }
 
-
     private bool ApplyLungeHitEffects(Entity<XenoLungeComponent> xeno, EntityUid targetId)
     {
         // TODO RMC14 lag compensation


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Warrior lunge is homing on the target, making it impossible to dodge after the lunge has started, with a time limit of course, no warriors flying across the map chasing a guy.

## Why / Balance
Ima be honest here i am a young warrior and every time i try to do a lunge, it misses, i have no idea how warrior wizards land their lunges but it has never worked for me, its pretty bad.

## Technical details
I simply give warrior a `HomingProjectile` component that aimed shot uses, and remove it once the warrior lands, which is called either directly by the `XenoLungeSystem` once warrior hits something, or by the `ThrownItemSystem` once the throw duration exprires.

## Media
To make change even visible at all the speed numbers have been divided by 7.

https://github.com/user-attachments/assets/82d26451-5152-49d6-b7a4-596e58ebd3d2



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Warrior lunge should reliably hit targeted marine now.
