### PR TITLE
Sentry projectiles now home in on their target

### DIFF
--- a/Content.Shared/_RMC14/Sentry/SentryComponent.cs
+++ b/Content.Shared/_RMC14/Sentry/SentryComponent.cs
@@ -59,6 +59,9 @@ public sealed partial class SentryComponent : Component
 
     [DataField, AutoNetworkedField]
     public EntProtoId<SkillDefinitionComponent> DelaySkill = "RMCSkillConstruction";
+
+    [DataField, AutoNetworkedField]
+    public bool HomingShots = true;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/_RMC14/Sentry/SentrySystem.cs
+++ b/Content.Shared/_RMC14/Sentry/SentrySystem.cs
@@ -5,6 +5,7 @@ using Content.Shared._RMC14.Map;
 using Content.Shared._RMC14.Marines.Skills;
 using Content.Shared._RMC14.NPC;
 using Content.Shared._RMC14.Tools;
+using Content.Shared._RMC14.Weapons.Ranged.Homing;
 using Content.Shared.Damage;
 using Content.Shared.DoAfter;
 using Content.Shared.Examine;
@@ -18,6 +19,7 @@ using Content.Shared.Tag;
 using Content.Shared.Tools.Systems;
 using Content.Shared.Weapons.Melee.Events;
 using Content.Shared.Weapons.Ranged.Components;
+using Content.Shared.Weapons.Ranged.Events;
 using Content.Shared.Weapons.Ranged.Systems;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
@@ -60,6 +62,7 @@ public sealed class SentrySystem : EntitySystem
         SubscribeLocalEvent<SentryComponent, UseInHandEvent>(OnSentryUseInHand);
         SubscribeLocalEvent<SentryComponent, SentryDeployDoAfterEvent>(OnSentryDeployDoAfter);
         SubscribeLocalEvent<SentryComponent, ActivateInWorldEvent>(OnSentryActivateInWorld);
+        SubscribeLocalEvent<SentryComponent, AmmoShotEvent>(OnSentryAmmoShot);
         SubscribeLocalEvent<SentryComponent, AttemptShootEvent>(OnSentryAttemptShoot);
         SubscribeLocalEvent<SentryComponent, InteractUsingEvent>(OnSentryInteractUsing);
         SubscribeLocalEvent<SentryComponent, SentryInsertMagazineDoAfterEvent>(OnSentryInsertMagazineDoAfter);
@@ -176,6 +179,22 @@ public sealed class SentrySystem : EntitySystem
     {
         if (args.User != ent.Owner)
             args.Cancelled = true;
+    }
+
+    private void OnSentryAmmoShot(Entity<SentryComponent> ent, ref AmmoShotEvent args)
+    {
+        if(!ent.Comp.HomingShots)
+            return;
+
+        //Make projectiles shot from a sentry gun homing.
+        foreach (var projectile in args.FiredProjectiles)
+        {
+            if(!TryComp(projectile, out TargetedProjectileComponent? targeted))
+                return;
+
+            var homing = EnsureComp<HomingProjectileComponent>(projectile);
+            homing.Target = targeted.Target;
+        }
     }
 
     private void OnSentryInteractUsing(Entity<SentryComponent> sentry, ref InteractUsingEvent args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Projectiles shot by a sentry gun now home towards in on their target mid-flight.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Turrets are currently less consistent than in CM13, as just running around a bit will make them miss all their shots, after this change the projectile has a better chance to hit.

## Technical details
<!-- Summary of code changes for easier review. -->
Projectiles shot by sentries now get the HomingProjectileComponent

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/beae7a65-59ba-4f0f-abd9-2bba3af6e925


https://github.com/user-attachments/assets/85b66c46-2d17-407e-91b3-7d394d3bcefd


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Dygon
- fix: Sentry projectiles now home in on their target.

