### PR TITLE
IO vendor M54C magazine fix

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/intel.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/intel.yml
@@ -33,7 +33,7 @@
         points: 10
       - id: CMMagazineSMGM63Ext
         points: 10
-      - id: CMMagazineRifleM54C
+      - id: CMMagazineRifleM54CAP
         points: 10
       - id: CMMagazineRifleM54CExt
         points: 10


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I replaced the regular M54C magazine purchasable for 10 points with the AP variant.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Dygon
- fix: The IO vendor now vends a M54C AP magazine for points instead of a regular one.

