### PR TITLE
Don't show popups to nearby players while invisible

### DIFF
--- a/Content.Server/Popups/PopupSystem.cs
+++ b/Content.Server/Popups/PopupSystem.cs
@@ -1,5 +1,4 @@
-using Content.Shared._RMC14.Stealth;
-using Content.Shared._RMC14.Xenonids.Invisibility;
+using Content.Server._RMC14.Popups;
 using Content.Shared.Popups;
 using Robust.Server.GameObjects;
 using Robust.Server.Player;
@@ -14,6 +13,7 @@ namespace Content.Server.Popups
         [Dependency] private readonly IPlayerManager _player = default!;
         [Dependency] private readonly IConfigurationManager _cfg = default!;
         [Dependency] private readonly SharedTransformSystem _transform = default!;
+        [Dependency] private readonly RMCPopupSystem _rmcPopup = default!;
 
         public override void PopupCursor(string? message, PopupType type = PopupType.Small)
         {
@@ -140,8 +140,8 @@ namespace Content.Server.Popups
 
             if (recipient != null)
             {
-                // RMC14 Don't show popups to other's while invisible.
-                if(HasComp<EntityActiveInvisibleComponent>(recipient) || HasComp<XenoActiveInvisibleComponent>(recipient))
+                // RMC14 Check if popups should be shown to nearby players.
+                if(_rmcPopup.ShouldPopup(recipient.Value))
                     return;
 
                 // Don't send to recipient, since they predicted it locally

--- a/Content.Server/Popups/PopupSystem.cs
+++ b/Content.Server/Popups/PopupSystem.cs
@@ -1,3 +1,5 @@
+using Content.Shared._RMC14.Stealth;
+using Content.Shared._RMC14.Xenonids.Invisibility;
 using Content.Shared.Popups;
 using Robust.Server.GameObjects;
 using Robust.Server.Player;
@@ -138,6 +140,10 @@ namespace Content.Server.Popups
 
             if (recipient != null)
             {
+                // RMC14 Don't show popups to other's while invisible.
+                if(HasComp<EntityActiveInvisibleComponent>(recipient) || HasComp<XenoActiveInvisibleComponent>(recipient))
+                    return;
+
                 // Don't send to recipient, since they predicted it locally
                 var filter = Filter.PvsExcept(recipient.Value, entityManager: EntityManager);
                 RaiseNetworkEvent(new PopupEntityEvent(message, type, GetNetEntity(uid)), filter);

--- a/Content.Server/_RMC14/Popups/RMCPopupSystem.cs
+++ b/Content.Server/_RMC14/Popups/RMCPopupSystem.cs
@@ -1,0 +1,16 @@
+using Content.Shared._RMC14.Stealth;
+using Content.Shared._RMC14.Xenonids.Invisibility;
+
+namespace Content.Server._RMC14.Popups;
+
+public sealed class RMCPopupSystem : EntitySystem
+{
+    public bool ShouldPopup(EntityUid recipient)
+    {
+        // Don't show popups to others while invisible.
+        if(HasComp<EntityActiveInvisibleComponent>(recipient) || HasComp<XenoActiveInvisibleComponent>(recipient))
+            return false;
+
+        return true;
+    }
+}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Invisible entities don't show popups to nearby players anymore.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Popups from actions like wielding and unwielding your gun while invisible would betray your location to any nearby players.
After this PR they only show for yourself.

## Technical details
<!-- Summary of code changes for easier review. -->
If an entity with the XenoActiveInvisibleComponent or the EntityActiveInvisibleComponent does something that shows a popup, it only shows for the client doing the thing and not for other players.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Dygon
- fix: Invisible entities no longer show popups to nearby players.

