### PR TITLE
Fix sometimes getting a second crit grace period

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/CriticalGrace/CriticalGraceSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/CriticalGrace/CriticalGraceSystem.cs
@@ -31,6 +31,10 @@ public sealed partial class CriticalGraceSystem : EntitySystem
             return;
         }
 
+        //If already crit can't crit gracee
+        if (_mobState.IsCritical(ent))
+            return;
+
         var grace = EnsureComp<InCriticalGraceComponent>(ent);
         var ev = new GetCriticalGraceTimeEvent(ent.Comp.GraceDuration);
         RaiseLocalEvent(ent, ref ev);

--- a/Content.Shared/_RMC14/Xenonids/CriticalGrace/CriticalGraceSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/CriticalGrace/CriticalGraceSystem.cs
@@ -31,8 +31,8 @@ public sealed partial class CriticalGraceSystem : EntitySystem
             return;
         }
 
-        //If already crit can't crit gracee
-        if (_mobState.IsCritical(ent))
+        //If already crit/dead can't crit gracee
+        if (!_mobState.IsAlive(ent))
             return;
 
         var grace = EnsureComp<InCriticalGraceComponent>(ent);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug.

## Technical details
<!-- Summary of code changes for easier review. -->
Now is a check to not crit grace someone if they are in fact, not alive before the state change.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed critical grace activating if you were already in crit.
