### PR TITLE
Marines now get stunned and thrown by explosions, new cluster OB shockwave effects

### DIFF
--- a/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
+++ b/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
@@ -109,6 +109,8 @@ public sealed class CMArmorSystem : EntitySystem
 
     private void OnGetArmor(Entity<CMArmorComponent> armored, ref CMGetArmorEvent args)
     {
+        args.ExplosionArmor += armored.Comp.ExplosionArmor;
+
         if (HasComp<XenoComponent>(armored))
         {
             args.XenoArmor += armored.Comp.XenoArmor;
@@ -123,6 +125,8 @@ public sealed class CMArmorSystem : EntitySystem
 
     private void OnGetArmorRelayed(Entity<CMArmorComponent> armored, ref InventoryRelayedEvent<CMGetArmorEvent> args)
     {
+        args.Args.ExplosionArmor += armored.Comp.ExplosionArmor;
+
         if (HasComp<XenoComponent>(armored))
         {
             args.Args.XenoArmor += armored.Comp.XenoArmor;

--- a/Content.Shared/_RMC14/Armor/CMGetArmorEvent.cs
+++ b/Content.Shared/_RMC14/Armor/CMGetArmorEvent.cs
@@ -3,4 +3,4 @@ using Content.Shared.Inventory;
 namespace Content.Shared._RMC14.Armor;
 
 [ByRefEvent]
-public record struct CMGetArmorEvent(SlotFlags TargetSlots, int XenoArmor = 0, int Melee = 0, int Bullet = 0, int Bio = 0, int FrontalArmor = 0, double ArmorModifier = 1) : IInventoryRelayEvent;
+public record struct CMGetArmorEvent(SlotFlags TargetSlots, int XenoArmor = 0, int Melee = 0, int Bullet = 0, int Bio = 0, int FrontalArmor = 0, double ArmorModifier = 1, int ExplosionArmor = 0) : IInventoryRelayEvent;

--- a/Content.Shared/_RMC14/Explosion/SharedRMCExplosionSystem.cs
+++ b/Content.Shared/_RMC14/Explosion/SharedRMCExplosionSystem.cs
@@ -1,3 +1,5 @@
+using Content.Shared._RMC14.Armor;
+using Content.Shared._RMC14.BlurredVision;
 using Content.Shared._RMC14.Slow;
 using Content.Shared._RMC14.Stun;
 using Content.Shared.Body.Systems;
@@ -5,7 +7,10 @@ using Content.Shared.Coordinates;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.Explosion;
 using Content.Shared.FixedPoint;
+using Content.Shared.Flash.Components;
+using Content.Shared.Inventory;
 using Content.Shared.Standing;
+using Content.Shared.StatusEffect;
 using Content.Shared.Sticky.Components;
 using Content.Shared.Stunnable;
 using Content.Shared.Throwing;
@@ -28,8 +33,12 @@ public abstract class SharedRMCExplosionSystem : EntitySystem
     [Dependency] private readonly ThrowingSystem _throwing = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly RMCSlowSystem _slow = default!;
+    [Dependency] private readonly RMCDazedSystem _dazed = default!;
+    [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
 
     private static readonly ProtoId<DamageTypePrototype> StructuralDamage = "Structural";
+    public static readonly ProtoId<StatusEffectPrototype> FlashedKey = "Flashed";
+    private static readonly ProtoId<StatusEffectPrototype> BlindKey = "Blinded";
 
     private readonly HashSet<Entity<RMCWallExplosionDeletableComponent>> _walls = new();
 
@@ -98,6 +107,43 @@ public abstract class SharedRMCExplosionSystem : EntitySystem
             factor *= 0.5;
 
         _sizeStun.TryGetSize(ent, out var size);
+
+        var pos = _transform.GetWorldPosition(ent);
+        var dir = pos - args.Epicenter.Position;
+        if (dir.IsLengthZero())
+            dir = _random.NextVector2();
+
+        dir = dir.Normalized(); // TODO RMC14 size-based throw ranges and speeds
+
+        // Humanoid calcuations
+        if (size == RMCSizes.Humanoid)
+        {
+            var ev = new CMGetArmorEvent(SlotFlags.OUTERCLOTHING | SlotFlags.INNERCLOTHING);
+            RaiseLocalEvent(ent, ref ev);
+
+            var bombArmorMult = (100 - ev.ExplosionArmor) * 0.01;
+            var severity = factor * 5;
+
+            _statusEffects.TryAddStatusEffect<FlashedComponent>(ent, FlashedKey, ent.Comp.BlindTime * bombArmorMult, true);
+
+            var knockdownValue = severity * 0.1;
+            var knockoutValue = damage.Double() * 0.1;
+
+            var knockdownMinusArmor = Math.Max(knockdownValue * bombArmorMult, 1);
+            var knockdownTime = TimeSpan.FromSeconds(knockdownMinusArmor);
+            _stun.TryParalyze(ent, knockdownTime, false);
+
+            var knockoutMinusArmor = Math.Max(knockoutValue * bombArmorMult * 0.5, 0.5);
+            var knockoutTime = TimeSpan.FromSeconds(knockoutMinusArmor);
+            _stun.TryParalyze(ent, knockoutTime, false);
+
+            _dazed.TryDaze(ent, knockoutTime * 2, stutter: true);
+            _statusEffects.TryAddStatusEffect<RMCBlindedComponent>(ent, BlindKey, ent.Comp.BlurTime, false);
+
+            _throwing.TryThrow(ent, dir, (float)severity);
+            return;
+        }
+
         if (factor > 0 && ent.Comp.Weak)
         {
             var stunTime = TimeSpan.FromSeconds(factor / 2.5);
@@ -112,12 +158,6 @@ public abstract class SharedRMCExplosionSystem : EntitySystem
             else
                 _slow.TrySlowdown(ent, TimeSpan.FromSeconds(factor / 3));
 
-            var pos = _transform.GetWorldPosition(ent);
-            var dir = pos - args.Epicenter.Position;
-            if (dir.IsLengthZero())
-                dir = _random.NextVector2();
-
-            dir = dir.Normalized(); // TODO RMC14 size-based throw ranges and speeds
             _throwing.TryThrow(ent, dir, 5);
         }
         else if (factor > 10)

--- a/Content.Shared/_RMC14/Explosion/SharedRMCExplosionSystem.cs
+++ b/Content.Shared/_RMC14/Explosion/SharedRMCExplosionSystem.cs
@@ -37,7 +37,7 @@ public abstract class SharedRMCExplosionSystem : EntitySystem
     [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
 
     private static readonly ProtoId<DamageTypePrototype> StructuralDamage = "Structural";
-    public static readonly ProtoId<StatusEffectPrototype> FlashedKey = "Flashed";
+    private static readonly ProtoId<StatusEffectPrototype> FlashedKey = "Flashed";
     private static readonly ProtoId<StatusEffectPrototype> BlindKey = "Blinded";
 
     private readonly HashSet<Entity<RMCWallExplosionDeletableComponent>> _walls = new();

--- a/Content.Shared/_RMC14/Explosion/StunOnExplosionReceivedComponent.cs
+++ b/Content.Shared/_RMC14/Explosion/StunOnExplosionReceivedComponent.cs
@@ -10,7 +10,7 @@ public sealed partial class StunOnExplosionReceivedComponent : Component
     public bool Weak;
 
     [DataField, AutoNetworkedField]
-    public TimeSpan BlindTime = TimeSpan.FromSeconds(6);
+    public TimeSpan BlindTime = TimeSpan.FromSeconds(8);
 
     [DataField, AutoNetworkedField]
     public TimeSpan BlurTime = TimeSpan.FromSeconds(5);

--- a/Content.Shared/_RMC14/Explosion/StunOnExplosionReceivedComponent.cs
+++ b/Content.Shared/_RMC14/Explosion/StunOnExplosionReceivedComponent.cs
@@ -8,4 +8,10 @@ public sealed partial class StunOnExplosionReceivedComponent : Component
 {
     [DataField, AutoNetworkedField]
     public bool Weak;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan BlindTime = TimeSpan.FromSeconds(6);
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan BlurTime = TimeSpan.FromSeconds(5);
 }

--- a/Content.Shared/_RMC14/OrbitalCannon/OrbitalCannonExplosion.cs
+++ b/Content.Shared/_RMC14/OrbitalCannon/OrbitalCannonExplosion.cs
@@ -49,4 +49,7 @@ public sealed partial class OrbitalCannonExplosion
 
     [DataField]
     public bool CheckProtectionPer;
+
+    [DataField]
+    public EntProtoId? ExplosionEffect;
 }

--- a/Content.Shared/_RMC14/OrbitalCannon/OrbitalCannonSystem.cs
+++ b/Content.Shared/_RMC14/OrbitalCannon/OrbitalCannonSystem.cs
@@ -621,6 +621,12 @@ public sealed class OrbitalCannonSystem : EntitySystem
                     if (step.CheckProtectionPer && !_area.CanOrbitalBombard(coordinates, out _))
                         continue;
 
+                    if (step.ExplosionEffect != null)
+                    {
+                        var effect = Spawn(step.ExplosionEffect.Value, mapCoordinates);
+                        _rmcExplosion.TryDoEffect(effect);
+                    }
+
                     if (step.Type is { } type)
                         _rmcExplosion.QueueExplosion(mapCoordinates, type, step.Total, step.Slope, step.Max, uid, canCreateVacuum: false);
 

--- a/Content.Shared/_RMC14/Stun/RMCDazedSystem.cs
+++ b/Content.Shared/_RMC14/Stun/RMCDazedSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared._RMC14.Actions;
 using Content.Shared.Actions;
+using Content.Shared.Speech.EntitySystems;
 using Content.Shared.StatusEffect;
 
 namespace Content.Shared._RMC14.Stun;
@@ -8,6 +9,7 @@ public sealed class RMCDazedSystem : EntitySystem
 {
     [Dependency] private readonly StatusEffectsSystem _statusEffect = default!;
     [Dependency] private readonly SharedActionsSystem _actions = default!;
+    [Dependency] private readonly SharedStutteringSystem _stutter = default!;
 
     public override void Initialize()
     {
@@ -44,7 +46,7 @@ public sealed class RMCDazedSystem : EntitySystem
         }
     }
 
-    public bool TryDaze(EntityUid uid, TimeSpan time, bool refresh = false, StatusEffectsComponent? status = null)
+    public bool TryDaze(EntityUid uid, TimeSpan time, bool refresh = false, StatusEffectsComponent? status = null, bool stutter = false)
     {
         if (!Resolve(uid, ref status, false))
             return false;
@@ -54,6 +56,9 @@ public sealed class RMCDazedSystem : EntitySystem
 
         if (HasComp<RMCDazedComponent>(uid) || !_statusEffect.TryAddStatusEffect<RMCDazedComponent>(uid, "Dazed", time, refresh))
             return false;
+
+        if (stutter)
+            _stutter.DoStutter(uid, time, true);
 
         var ev = new DazedEvent(time);
         RaiseLocalEvent(uid, ref ev);

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
@@ -347,5 +347,4 @@
   - type: MobCollision
   - type: RMCMobCollision
   - type: RMCRest
-  - type: StunOnExplosionReceived
-    weak: true # TODO should also blind and cause hearing loss
+  - type: StunOnExplosionReceived # TODO should also cause hearing loss

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
@@ -348,3 +348,4 @@
   - type: RMCMobCollision
   - type: RMCRest
   - type: StunOnExplosionReceived
+    weak: true

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
@@ -348,4 +348,4 @@
   - type: RMCMobCollision
   - type: RMCRest
   - type: StunOnExplosionReceived
-    weak: true
+    weak: true # TODO should also blind and cause hearing loss

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
@@ -347,3 +347,4 @@
   - type: MobCollision
   - type: RMCMobCollision
   - type: RMCRest
+  - type: StunOnExplosionReceived

--- a/Resources/Prototypes/_RMC14/Entities/Structures/orbital_cannon.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/orbital_cannon.yml
@@ -199,6 +199,7 @@
       delayPer: 0.4
       spread: 12
       checkProtectionPer: true
+      explosionEffect: RMCExplosionEffectClusterOB
   - type: WarpPoint
     location: 1 orbital bombardment
 
@@ -283,3 +284,25 @@
   - type: Tag
     tags:
     - HideContextMenu
+
+# Effects
+- type: entity
+  id: RMCExplosionEffectClusterOB
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: TimedDespawn
+    lifetime: 2.5
+  - type: CMExplosionEffect
+    explosion: null
+    shockWave: RMCExplosionEffectClusterOBShockWave
+
+- type: entity
+  id: RMCExplosionEffectClusterOBShockWave
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: TimedDespawn
+    lifetime: 1
+  - type: RMCExplosionShockWave
+    falloffPower: 50
+    sharpness: 25
+    width: 0.7


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
From CM13
I am not sure if the stun times are exactly 100% right with cm13 will need to double check

Adds missing Cluster OB SHockwave effects

## Media


https://github.com/user-attachments/assets/5faad147-c811-4cd1-a5ad-c3c4fb8f8d06


Cluster OB effects: https://streamable.com/37skzk





:cl:
- fix: Fixed marines not being thrown, blinded and stunned from explosions.
- fix: Fixed Cluster OB not having a shockwave effect.