### PR TITLE
m13 vends empty

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/m10_auto_pistol.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/m10_auto_pistol.yml
@@ -77,23 +77,24 @@
   #- type: Tag
    # id: RMCWeaponPistolM13
 
-## Not sure if this needs an empty sprite
-#- type: entity
-#  parent: CMWeaponPistolM1984
-#  id: CMWeaponPistolM1984Empty
-#  suffix: Empty
-#  components:
-#  - type: ItemSlots
-#    slots:
-#      gun_magazine:
-#        name: Magazine
-#        insertSound: /Audio/_RMC14/Weapons/Guns/Reload/gun_mk80_reload.ogg
-#        ejectSound: /Audio/_RMC14/Weapons/Guns/Reload/gun_88m4_unload.ogg
-#        priority: 2
-#       whitelist:
-#          tags:
-#          - CMMagazinePistolM1984
-#          - RMCMagazinePistolM1984AP
+
+- type: entity
+  parent: RMCWeaponPistolM13
+  id: RMCWeaponPistolM13Empty
+  suffix: Empty
+  components:
+  - type: ItemSlots
+    slots:
+      gun_magazine:
+        name: Magazine
+        insertSound: /Audio/_RMC14/Weapons/Guns/Reload/gun_mk80_reload.ogg
+        ejectSound: /Audio/_RMC14/Weapons/Guns/Reload/gun_88m4_unload.ogg
+        priority: 2
+        whitelist:
+          tags:
+          - RMCMagazinePistolM13
+          - RMCMagazinePistolM13Ext
+          - RMCMagazinePistolM13Drum
 
 #uses the smg 10x20mm
 - type: entity

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/prep.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/prep.yml
@@ -49,7 +49,7 @@
         amount: 25
       - id: CMWeaponPistolM1984Empty
         amount: 25
-      - id: RMCWeaponPistolM13
+      - id: RMCWeaponPistolM13Empty
         amount: 25
       #- id: WeaponFlareM82F
       #  amount: 10


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The M13 now has a child entity (like other weapons) to vend it empty from the weapon rack.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
All the other weapons vend empty...
## Technical details
<!-- Summary of code changes for easier review. -->
Changes to m13 yaml and the weapon vendor yaml
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/64f1b95d-50af-4392-b7e6-b0388ed17992


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed M13's vending with a magazine in them.
