### PR TITLE
Weed/Node damage modifier

### DIFF
--- a/Resources/Prototypes/_RMC14/Damage/xeno_modifier_sets.yml
+++ b/Resources/Prototypes/_RMC14/Damage/xeno_modifier_sets.yml
@@ -1,4 +1,14 @@
-﻿- type: damageModifierSet
+- type: damageModifierSet
   id: Resin # TODO RMC14 rebalance
   coefficients:
     Heat: 1.5
+
+- type: damageModifierSet
+  id: Weed
+  coefficients:
+    Blunt: 0.333
+    Slash: 0.333
+    Piercing: 0.333
+    Heat: 0.333
+    Shock: 0.333
+    Structural: 0.333

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_weeds.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_weeds.yml
@@ -77,6 +77,7 @@
   - type: XenoFriendly
   - type: Damageable
     damageContainer: StructuralXeno
+    damageModifierSet: Weed
   - type: Destructible
     thresholds:
     - trigger:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
gave weeds and nodes a damageModifierSet called Weed.
it gives each dmg it can actually take a .333 multiplier 

in essence this will make stronger weeds, actually strong, and not have every weed type get one(1) hit by anything doing at least 15dmg
### Examples of the PRs effect.
M5 bayonet, which does 25dmg.
can one(1) hit normal weeds.
requires two(2) hits for hardy and hive weeds.

M2132 Machete, which does 35dmg.
can one(1) hit normal and hardy weeds.
requires two(2) hits for hive weeds.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
parity.
https://github.com/cmss13-devs/cmss13/blob/59470a445b14d316a8e1474bc09c614d1e1bff0a/code/modules/cm_aliens/weeds.dm#L384 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
### M5 Bayonet


https://github.com/user-attachments/assets/25ce5d08-250d-42cd-b12d-1fd854bb814d

### M2132 Machete

https://github.com/user-attachments/assets/d0bc7be8-c552-4550-a9e5-b79bcd062fe2

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Weeds and nodes now have their intended .333 damage reduction multiplier.
