### PR TITLE
stop sentries from shooting walls

### DIFF
--- a/Content.Server/NPC/Systems/NPCUtilitySystem.cs
+++ b/Content.Server/NPC/Systems/NPCUtilitySystem.cs
@@ -10,6 +10,7 @@ using Content.Server.Nutrition.EntitySystems;
 using Content.Server.Storage.Components;
 using Content.Shared._RMC14.Interaction;
 using Content.Shared._RMC14.Xenonids;
+using Content.Shared._RMC14.Xenonids.Construction;
 using Content.Shared._RMC14.Xenonids.Construction.EggMorpher;
 using Content.Shared._RMC14.Xenonids.Construction.Nest;
 using Content.Shared._RMC14.Xenonids.Construction.ResinHole;
@@ -390,6 +391,10 @@ public sealed class NPCUtilitySystem : EntitySystem
             case TargetXenoCon:
             {
                 return HasComp<XenoComponent>(targetUid) ? 1f : 0f;
+            }
+            case TargetIsNotConstructCon:
+            {
+                return HasComp<XenoConstructComponent>(targetUid) ? 0f : 1f;
             }
             case CanFaceCon:
             {

--- a/Content.Server/_RMC14/NPC/TargetIsNotConstructCon.cs
+++ b/Content.Server/_RMC14/NPC/TargetIsNotConstructCon.cs
@@ -1,0 +1,5 @@
+using Content.Server.NPC.Queries.Considerations;
+
+namespace Content.Server._RMC14.NPC;
+
+public sealed partial class TargetIsNotConstructCon : UtilityConsideration;

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Sentries/sentries.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Sentries/sentries.yml
@@ -163,6 +163,8 @@
   query:
   - !type:NearbyHostilesQuery
   considerations:
+  - !type:TargetIsNotConstructCon
+    curve: !type:BoolCurve
   - !type:TargetIsNotDeadCon
     curve: !type:BoolCurve
   - !type:TargetDistanceCon


### PR DESCRIPTION
## About the PR

Stop sentries from shooting at walls.

## Why / Balance

bugfix

## Technical details

Why do resin walls have the npc faction component?

## Media

https://github.com/user-attachments/assets/bf2dc875-f891-4bca-adac-83da606ae493

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Sentries will no longer shoot at walls.
