### PR TITLE
Vamp lurker fixes, add wall slam stun from vamp lurker tail jab

### DIFF
--- a/Content.Shared/_RMC14/Damage/ObstacleSlamming/RMCObstacleSlamBonusEffectsComponent.cs
+++ b/Content.Shared/_RMC14/Damage/ObstacleSlamming/RMCObstacleSlamBonusEffectsComponent.cs
@@ -1,0 +1,18 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Shared._RMC14.Damage.ObstacleSlamming;
+
+/// <summary>
+/// Makes a mob immune to obstacle slamming for a certain period of time.
+/// </summary>
+[Access(typeof(RMCObstacleSlammingSystem))]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class RMCObstacleSlamImmuneComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public TimeSpan ExpireIn = TimeSpan.FromSeconds(2);
+
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField]
+    public TimeSpan? ExpireAt;
+}

--- a/Content.Shared/_RMC14/Damage/ObstacleSlamming/RMCObstacleSlamBonusEffectsComponent.cs
+++ b/Content.Shared/_RMC14/Damage/ObstacleSlamming/RMCObstacleSlamBonusEffectsComponent.cs
@@ -4,15 +4,22 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 namespace Content.Shared._RMC14.Damage.ObstacleSlamming;
 
 /// <summary>
-/// Makes a mob immune to obstacle slamming for a certain period of time.
+/// Gives a mob extra damage or stun on obstacle slam when this component is available.
+/// Useful for things like xeno abilities which stun when an ability causes obstacle slams.
 /// </summary>
 [Access(typeof(RMCObstacleSlammingSystem))]
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-public sealed partial class RMCObstacleSlamImmuneComponent : Component
+public sealed partial class RMCObstacleSlamBonusEffectsComponent : Component
 {
     [DataField, AutoNetworkedField]
     public TimeSpan ExpireIn = TimeSpan.FromSeconds(2);
 
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField]
     public TimeSpan? ExpireAt;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan Stun = TimeSpan.FromSeconds(0);
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan Slow = TimeSpan.FromSeconds(0);
 }

--- a/Content.Shared/_RMC14/Damage/ObstacleSlamming/RMCObstacleSlamBonusEffectsComponent.cs
+++ b/Content.Shared/_RMC14/Damage/ObstacleSlamming/RMCObstacleSlamBonusEffectsComponent.cs
@@ -12,7 +12,7 @@ namespace Content.Shared._RMC14.Damage.ObstacleSlamming;
 public sealed partial class RMCObstacleSlamBonusEffectsComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public TimeSpan ExpireIn = TimeSpan.FromSeconds(2);
+    public TimeSpan ExpireIn = TimeSpan.FromSeconds(1);
 
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField]
     public TimeSpan? ExpireAt;

--- a/Content.Shared/_RMC14/Damage/ObstacleSlamming/RMCObstacleSlamImmuneComponent.cs
+++ b/Content.Shared/_RMC14/Damage/ObstacleSlamming/RMCObstacleSlamImmuneComponent.cs
@@ -4,15 +4,22 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 namespace Content.Shared._RMC14.Damage.ObstacleSlamming;
 
 /// <summary>
-/// Makes a mob immune to obstacle slamming for a certain period of time.
+/// Gives a mob extra damage or stun on obstacle slam when this component is available.
+/// Useful for things like xeno abilities which stun when an ability causes obstacle slams.
 /// </summary>
 [Access(typeof(RMCObstacleSlammingSystem))]
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-public sealed partial class RMCObstacleSlamImmuneComponent : Component
+public sealed partial class RMCObstacleSlamBonusEffectsComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public TimeSpan ExpireIn = TimeSpan.FromSeconds(2);
+    public TimeSpan ExpireIn = TimeSpan.FromSeconds(1);
 
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField]
     public TimeSpan? ExpireAt;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan Stun = TimeSpan.FromSeconds(0);
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan Slow = TimeSpan.FromSeconds(0);
 }

--- a/Content.Shared/_RMC14/Damage/ObstacleSlamming/RMCObstacleSlamImmuneComponent.cs
+++ b/Content.Shared/_RMC14/Damage/ObstacleSlamming/RMCObstacleSlamImmuneComponent.cs
@@ -11,7 +11,7 @@ namespace Content.Shared._RMC14.Damage.ObstacleSlamming;
 public sealed partial class RMCObstacleSlamImmuneComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public TimeSpan ExpireIn = TimeSpan.FromSeconds(1);
+    public TimeSpan ExpireIn = TimeSpan.FromSeconds(2);
 
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField]
     public TimeSpan? ExpireAt;

--- a/Content.Shared/_RMC14/Damage/ObstacleSlamming/RMCObstacleSlamImmuneComponent.cs
+++ b/Content.Shared/_RMC14/Damage/ObstacleSlamming/RMCObstacleSlamImmuneComponent.cs
@@ -4,22 +4,15 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 namespace Content.Shared._RMC14.Damage.ObstacleSlamming;
 
 /// <summary>
-/// Gives a mob extra damage or stun on obstacle slam when this component is available.
-/// Useful for things like xeno abilities which stun when an ability causes obstacle slams.
+/// Makes a mob immune to obstacle slamming for a certain period of time.
 /// </summary>
 [Access(typeof(RMCObstacleSlammingSystem))]
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-public sealed partial class RMCObstacleSlamBonusEffectsComponent : Component
+public sealed partial class RMCObstacleSlamImmuneComponent : Component
 {
     [DataField, AutoNetworkedField]
     public TimeSpan ExpireIn = TimeSpan.FromSeconds(1);
 
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField]
     public TimeSpan? ExpireAt;
-
-    [DataField, AutoNetworkedField]
-    public TimeSpan Stun = TimeSpan.FromSeconds(0);
-
-    [DataField, AutoNetworkedField]
-    public TimeSpan Slow = TimeSpan.FromSeconds(0);
 }

--- a/Content.Shared/_RMC14/Damage/ObstacleSlamming/RMCObstacleSlammingSystem.cs
+++ b/Content.Shared/_RMC14/Damage/ObstacleSlamming/RMCObstacleSlammingSystem.cs
@@ -1,10 +1,12 @@
 using System.Numerics;
+using Content.Shared._RMC14.Slow;
 using Content.Shared._RMC14.Stun;
 using Content.Shared.Coordinates;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.Effects;
 using Content.Shared.Popups;
+using Content.Shared.Stunnable;
 using Content.Shared.Throwing;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Network;
@@ -25,12 +27,15 @@ public sealed class RMCObstacleSlammingSystem : EntitySystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly SharedStunSystem _stun = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedColorFlashEffectSystem _color = default!;
     [Dependency] private readonly RMCSizeStunSystem _size = default!;
+    [Dependency] private readonly RMCSlowSystem _slow = default!;
 
     private static readonly ProtoId<DamageTypePrototype> SlamDamageType = "Blunt";
     private readonly HashSet<EntityUid> _queuedImmuneEntities = new();
+    private readonly HashSet<EntityUid> _queuedBonusEntities = new();
 
     public override void Initialize()
     {
@@ -87,6 +92,12 @@ public sealed class RMCObstacleSlammingSystem : EntitySystem
         _damageable.TryChangeDamage(user, damage);
         _color.RaiseEffect(Color.Red, new List<EntityUid>() { user }, Filter.Pvs(user));
 
+        if (TryComp<RMCObstacleSlamBonusEffectsComponent>(user, out var bonus))
+        {
+            _slow.TrySlowdown(user, bonus.Slow, false);
+            _stun.TryParalyze(user, bonus.Stun, false);
+        }
+
         // Knockback around 1 tile
         _physics.SetLinearVelocity(ent, Vector2.Zero);
         _physics.SetAngularVelocity(ent, 0f);
@@ -118,14 +129,23 @@ public sealed class RMCObstacleSlammingSystem : EntitySystem
         Dirty(uid, comp);
     }
 
+    public void ApplyBonuses(EntityUid uid, TimeSpan stun, TimeSpan slow)
+    {
+        var comp = EnsureComp<RMCObstacleSlamBonusEffectsComponent>(uid);
+        comp.ExpireAt = _timing.CurTime + comp.ExpireIn;
+        comp.Stun = stun;
+        comp.Slow = slow;
+        Dirty(uid, comp);
+    }
+
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
 
         _queuedImmuneEntities.Clear();
 
-        var query = EntityQueryEnumerator<RMCObstacleSlamImmuneComponent>();
-        while (query.MoveNext(out var uid, out var comp))
+        var immuneQuery = EntityQueryEnumerator<RMCObstacleSlamImmuneComponent>();
+        while (immuneQuery.MoveNext(out var uid, out var comp))
         {
             if (comp.ExpireAt != null && comp.ExpireAt.Value > _timing.CurTime)
                 continue;
@@ -136,6 +156,22 @@ public sealed class RMCObstacleSlammingSystem : EntitySystem
         foreach (var queued in _queuedImmuneEntities)
         {
             RemComp<RMCObstacleSlamImmuneComponent>(queued);
+        }
+
+        _queuedBonusEntities.Clear();
+
+        var bonusQuery = EntityQueryEnumerator<RMCObstacleSlamBonusEffectsComponent>();
+        while (bonusQuery.MoveNext(out var uid, out var comp))
+        {
+            if (comp.ExpireAt != null && comp.ExpireAt.Value > _timing.CurTime)
+                continue;
+
+            _queuedBonusEntities.Add(uid);
+        }
+
+        foreach (var queued in _queuedBonusEntities)
+        {
+            RemComp<RMCObstacleSlamBonusEffectsComponent>(queued);
         }
     }
 }

--- a/Content.Shared/_RMC14/Xenonids/TailJab/XenoTailJabComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/TailJab/XenoTailJabComponent.cs
@@ -30,5 +30,11 @@ public sealed partial class XenoTailJabComponent : Component
     public TimeSpan SlowdownTime = TimeSpan.FromSeconds(0.5);
 
     [DataField, AutoNetworkedField]
+    public TimeSpan WallSlamSlowdownTime = TimeSpan.FromSeconds(0.5);
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan WallSlamStunTime = TimeSpan.FromSeconds(0.5);
+
+    [DataField, AutoNetworkedField]
     public float ThrowRange = 0.25f;
 }

--- a/Content.Shared/_RMC14/Xenonids/TailJab/XenoTailJabSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/TailJab/XenoTailJabSystem.cs
@@ -12,6 +12,7 @@ using Content.Shared._RMC14.Actions;
 using Content.Shared._RMC14.Slow;
 using Content.Shared.Throwing;
 using Content.Shared._RMC14.Xenonids.Stab;
+using Content.Shared._RMC14.Damage.ObstacleSlamming;
 
 namespace Content.Shared._RMC14.Xenonids.TailJab;
 
@@ -28,6 +29,7 @@ public sealed class XenoTailJabSystem : EntitySystem
     [Dependency] private readonly ThrowingSystem _throwing = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly XenoRotateSystem _rotate = default!;
+    [Dependency] private readonly RMCObstacleSlammingSystem _rmcObstacleSlamming = default!;
 
     public override void Initialize()
     {
@@ -62,7 +64,8 @@ public sealed class XenoTailJabSystem : EntitySystem
         }
 
         _rmcMelee.DoLunge(xeno, target);
-        _rmcSlow.TrySlowdown(xeno, xeno.Comp.SlowdownTime);
+        _rmcSlow.TrySlowdown(target, xeno.Comp.SlowdownTime);
+        _rmcObstacleSlamming.ApplyBonuses(target, xeno.Comp.WallSlamStunTime, xeno.Comp.WallSlamSlowdownTime);
 
         var origin = _transform.GetMoverCoordinates(xeno);
         var targetCoords = _transform.GetMoverCoordinates(target);

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lurker.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lurker.yml
@@ -158,7 +158,7 @@
     throwRange: 0.5
     damage:
       groups:
-        Brute: 35
+        Brute: 50
   - type: XenoFlurry
     damage:
       groups:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Cm13
It's supposed to deal 50 damage, not 35
missed an extra 15 damage from a seperate proc in the code

https://github.com/user-attachments/assets/52841598-2eae-47a6-a607-ec7e5493cbe3




:cl:
- fix: Fixed vamp lurker tail jab not doing 50 damage (was 35)
- fix: Fixed vamp lurker tail jab slowing the lurker
- tweak: Wall slamming a marine with tail jab will now stun and slow them for 0.5 seconds