### PR TITLE
Disable mob collision while invisible using the ghillie suit

### DIFF
--- a/Content.Shared/_RMC14/Armor/Ghillie/SharedGhillieSuitSystem.cs
+++ b/Content.Shared/_RMC14/Armor/Ghillie/SharedGhillieSuitSystem.cs
@@ -2,21 +2,16 @@ using Content.Shared.Whitelist;
 using Content.Shared.Actions;
 using Content.Shared.DoAfter;
 using Content.Shared.Inventory;
-using Content.Shared.Item.ItemToggle;
 using Content.Shared.Popups;
-using Content.Shared.Timing;
 using Content.Shared._RMC14.Stealth;
 using Content.Shared.Weapons.Ranged.Systems;
 using Content.Shared.Movement.Events;
-using Content.Shared.Item.ItemToggle.Components;
 using Content.Shared._RMC14.NightVision;
 using Content.Shared._RMC14.Weapons.Ranged.IFF;
 using Robust.Shared.Timing;
 using Content.Shared.Inventory.Events;
 using Content.Shared._RMC14.Chemistry;
 using Content.Shared.Weapons.Ranged.Components;
-using Content.Shared.Coordinates;
-using Robust.Shared.Network;
 using Content.Shared._RMC14.Armor.ThermalCloak;
 
 namespace Content.Shared._RMC14.Armor.Ghillie;
@@ -31,7 +26,6 @@ public sealed class SharedGhillieSuitSystem : EntitySystem
     [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
     [Dependency] private readonly InventorySystem _inventory = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
-    [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly ThermalCloakSystem _thermalCloak = default!;
 
     public override void Initialize()
@@ -165,6 +159,7 @@ public sealed class SharedGhillieSuitSystem : EntitySystem
 
             var activeInvisibility = EnsureComp<EntityActiveInvisibleComponent>(user);
             activeInvisibility.Opacity = comp.Opacity;
+            activeInvisibility.DisableMobCollision = true;
             Dirty(user, activeInvisibility);
 
             turnInvisible.UncloakTime = _timing.CurTime;

--- a/Content.Shared/_RMC14/Stealth/ActiveInvisibleSystem.cs
+++ b/Content.Shared/_RMC14/Stealth/ActiveInvisibleSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared._RMC14.Evasion;
+using Content.Shared.Movement.Systems;
 
 namespace Content.Shared._RMC14.Stealth;
 
@@ -11,6 +12,8 @@ public sealed class ActiveInvisibleSystem : EntitySystem
         SubscribeLocalEvent<EntityActiveInvisibleComponent, ComponentAdd>(OnInvisibleComponentAdd);
         SubscribeLocalEvent<EntityActiveInvisibleComponent, ComponentRemove>(OnInvisibleComponentRemove);
         SubscribeLocalEvent<EntityActiveInvisibleComponent, EvasionRefreshModifiersEvent>(OnInvisibleRefreshModifiers);
+        SubscribeLocalEvent<EntityActiveInvisibleComponent, AttemptMobCollideEvent>(OnAttemptMobCollide);
+        SubscribeLocalEvent<EntityActiveInvisibleComponent, AttemptMobTargetCollideEvent>(OnAttemptMobTargetCollide);
     }
 
     private void OnInvisibleComponentAdd(Entity<EntityActiveInvisibleComponent> entity, ref ComponentAdd args)
@@ -30,5 +33,17 @@ public sealed class ActiveInvisibleSystem : EntitySystem
 
         args.Evasion += entity.Comp.EvasionModifier;
         args.EvasionFriendly += entity.Comp.EvasionFriendlyModifier;
+    }
+
+    private void OnAttemptMobCollide(Entity<EntityActiveInvisibleComponent> ent, ref AttemptMobCollideEvent args)
+    {
+        if (ent.Comp.DisableMobCollision)
+            args.Cancelled = true;
+    }
+
+    private void OnAttemptMobTargetCollide(Entity<EntityActiveInvisibleComponent> ent, ref AttemptMobTargetCollideEvent args)
+    {
+        if (ent.Comp.DisableMobCollision)
+            args.Cancelled = true;
     }
 }

--- a/Content.Shared/_RMC14/Stealth/EntityActiveInvisibleComponent.cs
+++ b/Content.Shared/_RMC14/Stealth/EntityActiveInvisibleComponent.cs
@@ -14,4 +14,10 @@ public sealed partial class EntityActiveInvisibleComponent : Component
 
     [DataField, AutoNetworkedField]
     public FixedPoint2 EvasionFriendlyModifier = 1000;
+
+    /// <summary>
+    /// If the entity should collide with other mobs while invisible.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool DisableMobCollision;
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Snipers that are invisible won't be pushed around by other mobs anymore.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Dygon
- fix: Invisible snipers now have their mob collision disabled.

