### PR TITLE
Use the right CanInsert for ItemSlot transfers

### DIFF
--- a/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
+++ b/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
@@ -231,7 +231,6 @@ public abstract class SharedCMInventorySystem : EntitySystem
     {
         if(!TryComp(args.Used, out ItemSlotsComponent? usedStorage) ||
            !TryComp(ent, out ItemSlotsComponent? storage) ||
-           !HasComp<StorageComponent>(ent) ||
            args.Handled)
             return;
 
@@ -247,7 +246,7 @@ public abstract class SharedCMInventorySystem : EntitySystem
                 if(!_container.TryGetContainer(ent, itemSlot.Key, out var container))
                     continue;
 
-                if(_storage.CanInsert(ent.Owner, args.Used, args.User, out _))
+                if(_itemSlots.CanInsert(ent.Owner, args.Used, args.User, itemSlot.Value))
                 {
                     // If the container fits, break the loop and insert the container.
                     if (_container.Insert(args.Used, container))
@@ -261,7 +260,7 @@ public abstract class SharedCMInventorySystem : EntitySystem
                 // If the container does not fit, check if the entities in the container do.
                 foreach (var entity in usedContainer.ContainedEntities)
                 {
-                    if (!_storage.CanInsert(ent.Owner, entity, args.User, out _))
+                    if (!_itemSlots.CanInsert(ent.Owner, entity, args.User, itemSlot.Value))
                         continue;
 
                     if (!_container.Insert(entity, container))


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I changed the CanInsert check used for transferring entities between ItemSlots

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
#6213 Fixed the whitelist issue, but prevents transferring between ItemSlots(Flare pack to flare pouch for example) as it uses the wrong CanInsert function(I was tired and stupidly only tested if the whitelist was respected)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
No CL, I can't believe I missed this a second time.