### PR TITLE
Corpses and ghostroles now get random markings

### DIFF
--- a/Content.Server/_RMC14/Humanoid/Markings/RMCRandomMarkingsSystem.cs
+++ b/Content.Server/_RMC14/Humanoid/Markings/RMCRandomMarkingsSystem.cs
@@ -3,18 +3,11 @@ using Content.Server.Humanoid.Systems;
 using Content.Shared._RMC14.Humanoid.Markings;
 using Content.Shared.Humanoid;
 using Content.Shared.Humanoid.Markings;
-using Content.Shared.Humanoid.Prototypes;
-using Robust.Shared.GameStates;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
-using Robust.Shared.Serialization;
 
 namespace Content.Server._RMC14.Humanoid.Markings;
 
-/// <summary>
-/// Adds an action to toggle wagging animation for tails markings that supporting this
-/// </summary>
-public sealed class WaggingSystem : EntitySystem
+public sealed class RMCRandomMarkingsSystem : EntitySystem
 {
     [Dependency] private readonly HumanoidAppearanceSystem _humanoidAppearance = default!;
     [Dependency] private readonly MarkingManager _markings = default!;

--- a/Content.Server/_RMC14/Humanoid/Markings/RMCRandomMarkingsSystem.cs
+++ b/Content.Server/_RMC14/Humanoid/Markings/RMCRandomMarkingsSystem.cs
@@ -1,0 +1,76 @@
+using Content.Server.Humanoid;
+using Content.Server.Humanoid.Systems;
+using Content.Shared._RMC14.Humanoid.Markings;
+using Content.Shared.Humanoid;
+using Content.Shared.Humanoid.Markings;
+using Content.Shared.Humanoid.Prototypes;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+using Robust.Shared.Serialization;
+
+namespace Content.Server._RMC14.Humanoid.Markings;
+
+/// <summary>
+/// Adds an action to toggle wagging animation for tails markings that supporting this
+/// </summary>
+public sealed class WaggingSystem : EntitySystem
+{
+    [Dependency] private readonly HumanoidAppearanceSystem _humanoidAppearance = default!;
+    [Dependency] private readonly MarkingManager _markings = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<RMCRandomMarkingsComponent, MapInitEvent>(OnMapInit,
+            after: new[] { typeof(RandomHumanoidAppearanceSystem), typeof(RandomHumanoidSystem) }
+        );
+    }
+
+    private void OnMapInit(Entity<RMCRandomMarkingsComponent> ent, ref MapInitEvent args)
+    {
+        if (!TryComp<HumanoidAppearanceComponent>(ent.Owner, out var humanoid))
+            return;
+
+        if (!ent.Comp.Markings.TryGetValue(humanoid.Species, out var speciesCategory))
+            return;
+
+        foreach (var type in speciesCategory)
+        {
+            if (!_random.Prob(type.Value))
+                continue;
+
+            var possibleMarkings = _markings.MarkingsByCategoryAndSpeciesAndSex(type.Key, humanoid.Species, humanoid.Sex);
+            var pickedMarking = _random.Pick(possibleMarkings);
+
+            if (!humanoid.MarkingSet.Markings.TryGetValue(type.Key, out var markings))
+            {
+                _humanoidAppearance.AddMarking(ent, pickedMarking.Key, humanoid.SkinColor, forced: true);
+                continue;
+            }
+
+            if (markings.Count == 0)
+            {
+                _humanoidAppearance.AddMarking(ent, pickedMarking.Key, humanoid.SkinColor, forced: true);
+                continue;
+            }
+
+            for (var idx = 0; idx < markings.Count; idx++) // Replace existing markings
+            {
+                _humanoidAppearance.SetMarkingId(ent, type.Key, idx, pickedMarking.Key);
+
+                var colors = new List<Color>();
+                var markingColors = markings[idx].MarkingColors.Count;
+
+                for (int i = 0; i < markingColors - 1; i++)
+                {
+                    colors.Add(humanoid.SkinColor);
+                }
+
+                _humanoidAppearance.SetMarkingColor(ent, type.Key, idx, colors);
+            }
+        }
+    }
+}

--- a/Content.Shared/_RMC14/Humanoid/Markings/RMCRandomMarkingsComponent.cs
+++ b/Content.Shared/_RMC14/Humanoid/Markings/RMCRandomMarkingsComponent.cs
@@ -2,7 +2,6 @@
 using Content.Shared.Humanoid.Prototypes;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization;
 
 namespace Content.Shared._RMC14.Humanoid.Markings;
 

--- a/Content.Shared/_RMC14/Humanoid/Markings/RMCRandomMarkingsComponent.cs
+++ b/Content.Shared/_RMC14/Humanoid/Markings/RMCRandomMarkingsComponent.cs
@@ -1,0 +1,20 @@
+﻿using Content.Shared.Humanoid.Markings;
+using Content.Shared.Humanoid.Prototypes;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Humanoid.Markings;
+
+/// <summary>
+/// Applies a random marking set on mapinit for humanoids
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class RMCRandomMarkingsComponent : Component
+{
+    /// <summary>
+    /// A list of species prototype, contains a list of marking categories with a number. The number is the chance of this category being randomized.
+    /// </summary>
+    [DataField]
+    public Dictionary<ProtoId<SpeciesPrototype>, Dictionary<MarkingCategories, float>> Markings;
+}

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Corpses/base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Corpses/base.yml
@@ -1,7 +1,7 @@
 - type: randomHumanoidSettings
+  parent: RMCEventHumanoid
   id: RMCCorpse
   components:
-  - type: RandomHumanoidAppearance
   - type: Damageable
     damage:
       types:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Freelancers/leader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Freelancers/leader.yml
@@ -28,7 +28,7 @@
     settings: RMCFreelancerLeader
 
 - type: randomHumanoidSettings
-  parent: EventHumanoid
+  parent: RMCEventHumanoid
   id: RMCFreelancerLeader
   components:
   - type: GhostRole

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Freelancers/medic.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Freelancers/medic.yml
@@ -27,7 +27,7 @@
     settings: RMCFreelancerMedic
 
 - type: randomHumanoidSettings
-  parent: EventHumanoid
+  parent: RMCEventHumanoid
   id: RMCFreelancerMedic
   components:
   - type: GhostRole

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Freelancers/standard.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Freelancers/standard.yml
@@ -27,7 +27,7 @@
     settings: RMCFreelancerStandard
 
 - type: randomHumanoidSettings
-  parent: EventHumanoid
+  parent: RMCEventHumanoid
   id: RMCFreelancerStandard
   components:
   - type: GhostRole

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/SPP/leader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/SPP/leader.yml
@@ -57,7 +57,7 @@
     settings: RMCSPPLeader
 
 - type: randomHumanoidSettings
-  parent: EventHumanoid
+  parent: RMCEventHumanoid
   id: RMCSPPLeader
   components:
   - type: GhostRole

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/SPP/medic.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/SPP/medic.yml
@@ -43,7 +43,7 @@
     settings: RMCSPPMedic
 
 - type: randomHumanoidSettings
-  parent: EventHumanoid
+  parent: RMCEventHumanoid
   id: RMCSPPMedic
   components:
   - type: GhostRole

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/SPP/rifleman.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/SPP/rifleman.yml
@@ -38,7 +38,7 @@
     settings: RMCSPPRifleman
 
 - type: randomHumanoidSettings
-  parent: EventHumanoid
+  parent: RMCEventHumanoid
   id: RMCSPPRifleman
   components:
   - type: GhostRole

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/SPP/sapper.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/SPP/sapper.yml
@@ -44,7 +44,7 @@
     settings: RMCSPPEngineer
 
 - type: randomHumanoidSettings
-  parent: EventHumanoid
+  parent: RMCEventHumanoid
   id: RMCSPPEngineer
   components:
   - type: GhostRole

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/SPP/specialist.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/SPP/specialist.yml
@@ -47,7 +47,7 @@
     settings: RMCSPPSpecialist
 
 - type: randomHumanoidSettings
-  parent: EventHumanoid
+  parent: RMCEventHumanoid
   id: RMCSPPSpecialist
   components:
   - type: GhostRole

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/WeYa/engineer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/WeYa/engineer.yml
@@ -97,7 +97,7 @@
     settings: RMCPMCEngineer
 
 - type: randomHumanoidSettings
-  parent: EventHumanoid
+  parent: RMCEventHumanoid
   id: RMCPMCEngineer
   components:
   - type: GhostRole

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/WeYa/gunner.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/WeYa/gunner.yml
@@ -81,7 +81,7 @@
     settings: RMCPMCGunner
 
 - type: randomHumanoidSettings
-  parent: EventHumanoid
+  parent: RMCEventHumanoid
   id: RMCPMCGunner
   components:
   - type: GhostRole

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/WeYa/leader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/WeYa/leader.yml
@@ -103,7 +103,7 @@
     settings: RMCPMCLeader
 
 - type: randomHumanoidSettings
-  parent: EventHumanoid
+  parent: RMCEventHumanoid
   id: RMCPMCLeader
   components:
   - type: GhostRole

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/WeYa/medic.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/WeYa/medic.yml
@@ -91,7 +91,7 @@
     settings: RMCPMCMedic
 
 - type: randomHumanoidSettings
-  parent: EventHumanoid
+  parent: RMCEventHumanoid
   id: RMCPMCMedic
   components:
   - type: GhostRole

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/WeYa/site_director.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/WeYa/site_director.yml
@@ -75,7 +75,7 @@
     settings: RMCPMCDirector
 
 - type: randomHumanoidSettings
-  parent: EventHumanoid
+  parent: RMCEventHumanoid
   id: RMCPMCDirector
   components:
   - type: GhostRole

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/WeYa/sniper.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/WeYa/sniper.yml
@@ -96,7 +96,7 @@
     settings: RMCPMCSniper
 
 - type: randomHumanoidSettings
-  parent: EventHumanoid
+  parent: RMCEventHumanoid
   id: RMCPMCSniper
   components:
   - type: GhostRole

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/WeYa/standard.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/WeYa/standard.yml
@@ -46,7 +46,7 @@
     settings: RMCPMCStandardM63B2
 
 - type: randomHumanoidSettings
-  parent: EventHumanoid
+  parent: RMCEventHumanoid
   id: RMCPMCStandardM63B2
   components:
   - type: GhostRole
@@ -117,7 +117,7 @@
     settings: RMCPMCStandardSSG45
 
 - type: randomHumanoidSettings
-  parent: EventHumanoid
+  parent: RMCEventHumanoid
   id: RMCPMCStandardSSG45
   components:
   - type: GhostRole
@@ -186,7 +186,7 @@
     settings: RMCPMCStandardM54C2
 
 - type: randomHumanoidSettings
-  parent: EventHumanoid
+  parent: RMCEventHumanoid
   id: RMCPMCStandardM54C2
   components:
   - type: GhostRole

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/bureau.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/bureau.yml
@@ -27,7 +27,7 @@
       settings: RMCBureauMarshal
 
 - type: randomHumanoidSettings
-  parent: EventHumanoid
+  parent: RMCEventHumanoid
   id: RMCBureauMarshal
   components:
     - type: GhostRole
@@ -102,7 +102,7 @@
       settings: RMCBureauDeputy
 
 - type: randomHumanoidSettings
-  parent: EventHumanoid
+  parent: RMCEventHumanoid
   id: RMCBureauDeputy
   components:
     - type: GhostRole

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/bureau_observer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/bureau_observer.yml
@@ -25,7 +25,7 @@
     settings: RMCBureauObserver
 
 - type: randomHumanoidSettings
-  parent: EventHumanoid
+  parent: RMCEventHumanoid
   id: RMCBureauObserver
   components:
   - type: GhostRole

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/corporate_executive_specialist.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/corporate_executive_specialist.yml
@@ -25,7 +25,7 @@
     settings: RMCCorporateExecutiveSpecialist
 
 - type: randomHumanoidSettings
-  parent: EventHumanoid
+  parent: RMCEventHumanoid
   id: RMCCorporateExecutiveSpecialist
   components:
   - type: GhostRole

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/corporate_executive_supervisor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/corporate_executive_supervisor.yml
@@ -25,7 +25,7 @@
     settings: RMCCorporateExecutiveSupervisor
 
 - type: randomHumanoidSettings
-  parent: EventHumanoid
+  parent: RMCEventHumanoid
   id: RMCCorporateExecutiveSupervisor
   components:
   - type: GhostRole

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/interstellar_commerce_bureau_liaison.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/interstellar_commerce_bureau_liaison.yml
@@ -25,7 +25,7 @@
     settings: RMCICBLiaison
 
 - type: randomHumanoidSettings
-  parent: EventHumanoid
+  parent: RMCEventHumanoid
   id: RMCICBLiaison
   components:
   - type: GhostRole

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/pizza.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/pizza.yml
@@ -34,7 +34,7 @@
     settings: RMCPizzaDeliveryBoy
 
 - type: randomHumanoidSettings
-  parent: EventHumanoid
+  parent: RMCEventHumanoid
   id: RMCPizzaDeliveryBoy
   components:
   - type: RMCJobSpawner

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/ghosts.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/ghosts.yml
@@ -3,6 +3,85 @@
   id: RMCEventHumanoid
   components:
   - type: RandomHumanoidAppearance
+  - type: RMCRandomMarkings
+    markings:
+      Moth:
+        Head: 0.5
+        HeadTop: 1
+        Chest: 0.25
+        Tail: 1
+        Arms: 0.25
+        Legs: 0.25
+      Reptilian:
+        Head: 0.25
+        Snout: 0.3
+        HeadTop: 0.5
+        HeadSide: 0.6
+        Chest: 0.5
+        Tail: 1
+        Arms: 0.25
+        Legs: 0.25
+      SlimePerson:
+        Head: 0.25
+        Arms: 0.25
+        Legs: 0.25
+      Diona:
+        Head: 0.5
+        HeadSide: 0.5
+        HeadTop: 0.5
+        Chest: 0.5
+      Arachnid:
+        HeadSide: 0.5
+        Chest: 0.25
+        Arms: 0.5
+        Legs: 0.5
+        Tail: 0.5
+      Skrell:
+        HeadTop: 1
+        Chest: 0.25
+      Avali:
+        Head: 0.5
+        HeadTop: 0.75
+        HeadSide: 0.25
+        Chest: 0.5
+        Tail: 0.75
+        Arms: 0.25
+        Legs: 0.25
+      Feroxi:
+        Head: 0.5
+        HeadTop: 0.75
+        HeadSide: 0.25
+        Chest: 0.5
+        Tail: 0.75
+        Arms: 0.25
+        Legs: 0.25
+      Rodentia:
+        Head: 1
+        HeadTop: 1
+        HeadSide: 1
+        Tail: 1
+        Arms: 1
+        Legs: 1
+      Vulpkanin:
+        Head: 0.5
+        HeadTop: 0.5
+        Chest: 0.25
+        Tail: 0.5
+        Arms: 0.1
+        Legs: 0.1
+      Felinid:
+        HeadTop: 0.5
+        Tail: 1
+      Human:
+        Head: 0.25
+        Chest: 0.25
+        Arms: 0.25
+        Legs: 0.25
+      Dwarf:
+        Head: 0.25
+        Chest: 0.25
+        Arms: 0.25
+        Legs: 0.25
 
 - type: randomHumanoidSettings
   parent: RMCEventHumanoid

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/ghosts.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/ghosts.yml
@@ -1,6 +1,11 @@
 # base
 - type: randomHumanoidSettings
-  parent: EventHumanoid
+  id: RMCEventHumanoid
+  components:
+  - type: RandomHumanoidAppearance
+
+- type: randomHumanoidSettings
+  parent: RMCEventHumanoid
   id: RMCRandomHumanoidBase
   components:
   - type: GhostRolePreventCryoSleep

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/ghosts.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/ghosts.yml
@@ -48,7 +48,7 @@
         Arms: 0.25
         Legs: 0.25
       Feroxi:
-        Head: 0.5
+        Head: 0.25
         HeadTop: 0.75
         HeadSide: 0.25
         Chest: 0.5
@@ -56,14 +56,14 @@
         Arms: 0.25
         Legs: 0.25
       Rodentia:
-        Head: 1
+        Head: 0.25
         HeadTop: 1
         HeadSide: 1
         Tail: 1
         Arms: 1
         Legs: 1
       Vulpkanin:
-        Head: 0.5
+        Head: 0.25
         HeadTop: 0.5
         Chest: 0.25
         Tail: 0.5

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/rmc_base_humanoid.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/rmc_base_humanoid.yml
@@ -1,5 +1,5 @@
 ﻿- type: randomHumanoidSettings
-  parent: EventHumanoid
+  parent: RMCEventHumanoid
   id: RMCSettingsGhostRole
   components:
   - type: GhostRole


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
More variety, the corpses and ghostroles will now actually look different instead of having default markings

## Media

https://github.com/user-attachments/assets/b5196b62-7218-4d9f-81bc-6376056643d1



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
