### PR TITLE
Remove the time limit on the death area outside the docking bay

### DIFF
--- a/Resources/Prototypes/Entities/Tiles/death.yml
+++ b/Resources/Prototypes/Entities/Tiles/death.yml
@@ -34,5 +34,3 @@
   - type: Tag
     tags:
     - HideContextMenu
-  - type: TimedDespawn
-    lifetime: 30


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The entities causing everyone outside the docking bay to die now don't despawn after 30 seconds.

Another solution could be making it so the lifeboat doors don't reopen if something is on their tile when they close, I can change it to that if that is preferred.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The doors keep reopening if a corpse/body is on them, allowing players to still go into space after the kill area despawned..

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- tweak: The kill area outside the docking bay doesn't despawn anymore.
