### PR TITLE
Fixes the economy of weapon specialist ammo

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/specialist.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/specialist.yml
@@ -36,27 +36,45 @@
     - name: Extra Scout Ammunition
       entries:
       - id: RMCMagazineRifleM4SPRA19Impact
+        name: A19 HV high impact magazine (10x24mm) (3)
         points: 40
+        spawn: 3
       - id: RMCMagazineRifleM4SPRA19Incendiary
+        name: A19 HV incendiary magazine (10x24mm) (3)
         points: 40
+        spawn: 3
       - id: RMCMagazineRifleM4SPRA19
+        name: A19 HV magazine (10x24mm) (5)
         points: 40
+        spawn: 5
     - name: Extra Sniper Ammunition
       entries:
       - id: CMMagazineSniperM96SFlak
+        name: M96S flak magazine (10x28mm) (5)
         points: 40
+        spawn: 5
       - id: CMMagazineSniperM96SIncendiary
+        name: M96S incendiary magazine (10x28mm) (5)
         points: 40
+        spawn: 5
       - id: CMMagazineSniperM96S
+        name: M96S marksman magazine (10x28mm) (5)
         points: 40
+        spawn: 5
       - id: RMCMagazineSniperXM43E1AntiMateriel
+        name: XM43E1 marksman magazine (10x99mm) (3)
         points: 40
+        spawn: 3
     - name: Extra Demolitionist Ammunition
       entries:
       - id: RMCRocket84mmAntiArmor
+        name: 84mm anti armor rocket (3)
         points: 40
+        spawn: 3
       - id: RMCRocket84mm
+        name: 84mm high explosive rocket (3)
         points: 40
+        spawn: 3
     #- id: 84mmWhitePhosphorusRocket
     #  points: 40
     - name: Extra Grenades


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changes the amount of weapon specialist ammo you can buy.

## Why / Balance
The main reason i made this PR is because the current meta for weapon specialists is buying grenades and exchanging them to req for specialist ammo due to the extreme value difference of grenades compared to the other ammo in the vendors. (basically putting yourself at a disadvantage for choosing ammo for your class).

This also becomes an IC issue in my opinion, as i do not think it makes sense that the UNMC is not providing their specialists enough ammo to a point where they specifically need to order ammunition from requisitions to be ready for an operation. 

This lines up the ammo prices in the vendor to the requestion prices. (each crate of ammunition being worth 3000) 

## Technical details
YML.

## Media
![image](https://github.com/user-attachments/assets/1c2ba68d-1d13-4175-b3f2-69f0355d8154)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Changed the amount of ammo weapon specialists get in their vendor.

