### PR TITLE
Fix xenonid actions with a DoAfter being useable while resting

### DIFF
--- a/Content.Shared/DoAfter/DoAfterArgs.cs
+++ b/Content.Shared/DoAfter/DoAfterArgs.cs
@@ -155,6 +155,13 @@ public sealed partial class DoAfterArgs
     /// </summary>
     [DataField]
     public bool RequireCanInteract = true;
+
+    /// <summary>
+    ///     RMC14
+    ///     If the doafter should break when the user rests.
+    /// </summary>
+    [DataField]
+    public bool BreakOnRest = true;
     #endregion
 
     #region Duplicates
@@ -279,6 +286,7 @@ public sealed partial class DoAfterArgs
         CancelDuplicate = other.CancelDuplicate;
         DuplicateCondition = other.DuplicateCondition;
         ForceVisible = other.ForceVisible;
+        BreakOnRest = other.BreakOnRest;
 
         // Networked
         NetUser = other.NetUser;

--- a/Content.Shared/DoAfter/SharedDoAfterSystem.Update.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.Update.cs
@@ -1,3 +1,4 @@
+using Content.Shared._RMC14.DoAfter;
 using Content.Shared.Gravity;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
@@ -15,6 +16,7 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
     [Dependency] private readonly SharedInteractionSystem _interaction = default!;
     [Dependency] private readonly SharedHandsSystem _hands = default!;
     [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly RMCDoafterSystem _rmcDoafter = default!;
 
     private DoAfter[] _doAfters = Array.Empty<DoAfter>();
 
@@ -86,6 +88,14 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
             }
 
             if (ShouldCancel(doAfter, xformQuery, handsQuery))
+            {
+                InternalCancel(doAfter, comp);
+                dirty = true;
+                continue;
+            }
+
+            // RMC14
+            if (_rmcDoafter.ShouldCancel(doAfter))
             {
                 InternalCancel(doAfter, comp);
                 dirty = true;

--- a/Content.Shared/_RMC14/DoAfter/RMCDoafterSystem.cs
+++ b/Content.Shared/_RMC14/DoAfter/RMCDoafterSystem.cs
@@ -1,0 +1,15 @@
+using Content.Shared._RMC14.Xenonids.Rest;
+
+namespace Content.Shared._RMC14.DoAfter;
+
+public sealed class RMCDoafterSystem : EntitySystem
+{
+    public bool ShouldCancel(Shared.DoAfter.DoAfter doAfter)
+    {
+        // Cancel the DoAfter is the entity is resting.
+        if (doAfter.Args.BreakOnRest && HasComp<XenoRestingComponent>(doAfter.Args.User))
+            return true;
+
+        return false;
+    }
+}

--- a/Content.Shared/_RMC14/PowerLoader/PowerLoaderComponent.cs
+++ b/Content.Shared/_RMC14/PowerLoader/PowerLoaderComponent.cs
@@ -27,5 +27,5 @@ public sealed partial class PowerLoaderComponent : Component
     public EntProtoId VirtualLeft = "RMCVirtualPowerLoaderLeft";
 
     [DataField, AutoNetworkedField]
-    public DoAfter.DoAfter? DoAfter;
+    public Shared.DoAfter.DoAfter? DoAfter;
 }

--- a/Content.Shared/_RMC14/Rangefinder/RangefinderComponent.cs
+++ b/Content.Shared/_RMC14/Rangefinder/RangefinderComponent.cs
@@ -42,7 +42,7 @@ public sealed partial class RangefinderComponent : Component
     public TimeSpan SwitchModeDelay = TimeSpan.FromSeconds(0.5);
 
     [DataField, AutoNetworkedField]
-    public DoAfter.DoAfter? DoAfter;
+    public Shared.DoAfter.DoAfter? DoAfter;
 
     [DataField, AutoNetworkedField]
     public TimeSpan Delay = TimeSpan.FromSeconds(10);

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
@@ -548,6 +548,7 @@
     - ActionXenoAcidShroud
     cooldown: 20
     onPerform: false
+  - type: ActionBlockIfResting
 
 - type: entity
   parent: ActionXenoBase


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Resting now prevents using all actions that have a doafter.
If a xenonid rests during a  doafter, the doafter will be interrupted.
While checking CM13 to make sure the above changes were parity I also noticed that the RMC14 cooldown is 20 seconds instead of the 30 seconds in CM13, so I added that to this PR too.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Dygon
- fix: Resting will now interrupt and prevent the use of all actions with a DoAfter.
