### PR TITLE
Scale the cost of resin constructs with how many there are in an area

### DIFF
--- a/Content.Shared/_RMC14/Areas/AreaComponent.cs
+++ b/Content.Shared/_RMC14/Areas/AreaComponent.cs
@@ -84,4 +84,10 @@ public sealed partial class AreaComponent : Component
 
     [DataField, AutoNetworkedField]
     public bool RetrieveItemObjective;
+
+    [DataField, AutoNetworkedField]
+    public int BuildableTiles;
+
+    [DataField, AutoNetworkedField]
+    public int ResinConstructCount;
 }

--- a/Content.Shared/_RMC14/CCVar/RMCCVars.cs
+++ b/Content.Shared/_RMC14/CCVar/RMCCVars.cs
@@ -419,6 +419,13 @@ public sealed class RMCCVars : CVars
         CVarDef.Create("rmc.overwatch_console_update_every_seconds", 0.5f, CVar.REPLICATED | CVar.SERVER);
 
     /// <summary>
+    ///     If the amount of resin constructs divided by the amount of buildable tiles in an area is higher than this value, the
+    ///     plasma cost of new constructs in the area is increased.
+    /// </summary>
+    public static readonly CVarDef<float> RMCResinConstructionDensityCostIncreaseThreshold =
+        CVarDef.Create("rmc.resin_construction_density_cost_increase_threshold", 0.4f, CVar.REPLICATED | CVar.SERVER);
+
+    /// <summary>
     /// Whether this client uses alternate non-phobia inducing sprites
     /// </summary>
     public static readonly CVarDef<bool> RMCUseAlternateSprites =

--- a/Content.Shared/_RMC14/Xenonids/Construction/XenoConstructionComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/XenoConstructionComponent.cs
@@ -46,4 +46,16 @@ public sealed partial class XenoConstructionComponent : Component
 
     [DataField, AutoNetworkedField]
     public bool CanUpgrade;
+
+    /// <summary>
+    ///     If the density threshold is reached, this value is added to the density value before being multiplied.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float DensityConstructionCostModifier = 0.35f;
+
+    /// <summary>
+    ///     The base build cost * (density + DensityConstructionModifier) gets multiplied by this value if the DensityThreshold is reached.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float DensityConstructionCostMultiplier = 2f;
 }

--- a/Content.Shared/_RMC14/Xenonids/Construction/XenoConstructionPlasmaCostComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/XenoConstructionPlasmaCostComponent.cs
@@ -8,4 +8,7 @@ public sealed partial class XenoConstructionPlasmaCostComponent : Component
 {
     [DataField, AutoNetworkedField]
     public FixedPoint2 Plasma;
+
+    [DataField, AutoNetworkedField]
+    public bool ScalingCost;
 }

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_doors.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_doors.yml
@@ -74,6 +74,7 @@
     closingSpriteState: closed_unlit
   - type: XenoConstructionPlasmaCost
     plasma: 120
+    scalingCost: true
   - type: XenoStructureUpgradeable
     to: DoorXenoResinThick
     cost: 25
@@ -133,5 +134,6 @@
         Slash: 900
   - type: XenoConstructionPlasmaCost
     plasma: 145
+    scalingCost: true
   - type: XenoStructureUpgradeable
     to: null

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_walls.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_walls.yml
@@ -23,6 +23,7 @@
   - type: XenoNestSurface
   - type: XenoConstructionPlasmaCost
     plasma: 120
+    scalingCost: true
   - type: XenoStructureUpgradeable
     to: WallXenoResinThick
     cost: 50
@@ -59,6 +60,7 @@
         Slash: 338
   - type: XenoConstructionPlasmaCost
     plasma: 170
+    scalingCost: true
   - type: XenoStructureUpgradeable
     to: null
 
@@ -94,6 +96,7 @@
   - type: XenoNestSurface
   - type: XenoConstructionPlasmaCost
     plasma: 95
+    scalingCost: true
   - type: MeleeReceivedMultiplier
     xenoDamage:
       types:
@@ -153,6 +156,7 @@
         Slash: 300
   - type: XenoConstructionPlasmaCost
     plasma: 120
+    scalingCost: true
 
 - type: entity
   parent: WallXenoResin


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
If more than 40% of the buildable tiles in an area has a resin construct on it, new resin constructs in that area are more expensive to build.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity.

## Technical details
<!-- Summary of code changes for easier review. -->
If the amount of resin constructs divided by the buildable tiles in an area is higher than 0.4(density), the resin cost of new constructs in that area is increased using the following formula: base cost * (density + 0.35) * 2.
As an example: a resin wall with a base cost of 120 plasma that is built right when the threshold is exceeded will cost 120 * (0.4 + 0.35) * 2 = 180 plasma.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- tweak: The plasma cost of new xeno constructs now scales with how many existing constructs there are in an area if they exceed a threshold(40% of buildable tiles in an area).

