### PR TITLE
Fixing StunFriendlyXenoOnStep

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Collision/XenoCollisionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Collision/XenoCollisionSystem.cs
@@ -56,7 +56,7 @@ public sealed class XenoCollisionSystem : EntitySystem
     private void OnStunUpdated<T>(Entity<StunFriendlyXenoOnStepComponent> ent, ref T args)
     {
         ent.Comp.Enabled = _mobState.IsAlive(ent) &&
-                           HasComp<XenoRestingComponent>(ent) &&
+                           !HasComp<XenoRestingComponent>(ent) &&
                            !_statusEffects.HasStatusEffect(ent, ent.Comp.DisableStatus) &&
                            CompOrNull<XenoAttachedOvipositorComponent>(ent) is not { Running: true };
         Dirty(ent);
@@ -68,6 +68,9 @@ public sealed class XenoCollisionSystem : EntitySystem
         var query = EntityQueryEnumerator<StunFriendlyXenoOnStepComponent, TransformComponent>();
         while (query.MoveNext(out var uid, out var comp, out var xform))
         {
+            if (!comp.Enabled)
+                continue;
+
             _contacts.Clear();
             _physics.GetContactingEntities(uid, _contacts);
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Now `StunFriendlyXenoOnStep` sets the `enabled` variable correctly and now `enabled` affects stun.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Now the queen does not stun xenomorphs on her ovipositor, when resting, or even after her death.
