### PR TITLE
CO weapon fixes + Prototype rifle parity

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/co_d50_winter_wyvern.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/co_d50_winter_wyvern.yml
@@ -11,6 +11,8 @@
     - Burst
     soundGunshot:
       path: /Audio/_RMC14/Weapons/Guns/Gunshots/gun_DE50.ogg
+  - type: Corrodible
+    isCorrodible: false
   - type: RMCSelectiveFire
     baseFireModes:
     - SemiAuto

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Revolvers/mateba.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Revolvers/mateba.yml
@@ -51,10 +51,14 @@
         startingAttachable: RMCAttachmentMatebaStandard
         whitelist:
           tags:
-          - RMCAttachmentRecoilCompensator
           - RMCAttachmentMatebaStandard
           - RMCAttachmentMatebaMarksman
           - RMCAttachmentMatebaSnubNose
+
+      rmc-bslot-barrel:
+       whitelist:
+          tags:
+          - RMCAttachmentRecoilCompensator
           - RMCAttachmentBarrelCharger
       rmc-aslot-rail:
         whitelist:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Revolvers/mateba.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Revolvers/mateba.yml
@@ -55,7 +55,7 @@
           - RMCAttachmentMatebaStandard
           - RMCAttachmentMatebaMarksman
           - RMCAttachmentMatebaSnubNose
-          - RMCAttachmentBarrelCharger d
+          - RMCAttachmentBarrelCharger
       rmc-aslot-rail:
         whitelist:
           tags:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Revolvers/mateba.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Revolvers/mateba.yml
@@ -18,6 +18,7 @@
     tags:
     - Sidearm
     - RMCRevolver
+    - RMCMateba
   - type: Corrodible
     isCorrodible: false
   - type: RevolverAmmoProvider

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Revolvers/mateba.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Revolvers/mateba.yml
@@ -31,7 +31,7 @@
       - RMCCartridgeRevolverMatebaHIAP
       - RMCCartridgeRevolverMatebaHighImpact
       - RMCCartridgeRevolverMateba
-    proto: RMCCartridgeRevolverMateba
+    proto: RMCCartridgeRevolverMatebaHighImpact
     capacity: 6
     chambers: [ True, True, True, True, True, True ]
     ammoSlots: [ null, null, null, null, null, null ]
@@ -54,7 +54,7 @@
           - RMCAttachmentMatebaStandard
           - RMCAttachmentMatebaMarksman
           - RMCAttachmentMatebaSnubNose
-          - RMCAttachmentBarrelCharger
+          - RMCAttachmentBarrelCharger d
       rmc-aslot-rail:
         whitelist:
           tags:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Revolvers/mateba.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Revolvers/mateba.yml
@@ -18,7 +18,8 @@
     tags:
     - Sidearm
     - RMCRevolver
-    - RMCMateba
+  - type: Corrodible
+    isCorrodible: false
   - type: RevolverAmmoProvider
     whitelist:
       tags:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m54c_mk1_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m54c_mk1_rifle.yml
@@ -26,8 +26,6 @@
     soundGunshot:
       collection: CMM54CShoot
     shotsPerBurst: 4
-  - type: Corrodible
-    isCorrodible: false
   - type: RMCSelectiveFire
     baseFireModes:
     - SemiAuto

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m54c_mk1_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m54c_mk1_rifle.yml
@@ -26,6 +26,8 @@
     soundGunshot:
       collection: CMM54CShoot
     shotsPerBurst: 4
+  - type: Corrodible
+    isCorrodible: false
   - type: RMCSelectiveFire
     baseFireModes:
     - SemiAuto

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m59a_prototype_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m59a_prototype_rifle.yml
@@ -18,51 +18,47 @@
       gun_magazine: !type:ContainerSlot
       gun_chamber: !type:ContainerSlot
   - type: Gun
-    shotsPerBurst: 4
-    selectedMode: SemiAuto
+    selectedMode: FullAuto
     availableModes:
     - SemiAuto
     - Burst
     - FullAuto
     soundGunshot:
       collection: CMM54CShoot
+    shotsPerBurst: 4
   - type: RMCSelectiveFire
     baseFireModes:
     - SemiAuto
     - Burst
-    # - FullAuto #TODO RMC: re-enable when the full auto fire mode switch crash to desktop is fixed
+    - FullAuto
     recoilUnwielded: 4
-    #fireDelay: 0.2332
-    scatterWielded: 6
+    scatterWielded: 4
     scatterUnwielded: 20
-    baseFireRate: 4.85 #semi auto is -> 171 rpm - 2.86/s
-    burstScatterMult: 3
+    baseFireRate: 4
+    burstScatterMult: 1
     modifiers:
-      SemiAuto:
-        fireDelay: 0.15
       Burst:
-        fireDelay: 0.1 #290 rpm - 4.85/s
+        fireDelay: 0.1665
         maxScatterModifier: 10
         useBurstScatterMult: true
         unwieldedScatterMultiplier: 2
         shotsToMaxScatter: 6
       FullAuto:
-        fireDelay: 0  #290rpm - 4.85/s same as burst
-        maxScatterModifier: 8
+        fireDelay: 0
+        maxScatterModifier: 13
         useBurstScatterMult: true
         unwieldedScatterMultiplier: 2
         shotsToMaxScatter: 4
+  - type: RMCWeaponAccuracy
+    accuracyMultiplier: 1.15
+    accuracyMultiplierUnwielded: 0.65
   - type: GunIDLock
   - type: GunIFF
     enabled: true
   - type: IFFToggle
     requireIDLock: true
-    changeStats: true
-    iFFFireModes:
-    - SemiAuto
-    iFFModifiers:
-      SemiAuto:
-        fireDelay: 0.25 #133 rpm - 2.22/s
+
+
   - type: ItemSlots
     slots:
       gun_magazine:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m59a_prototype_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m59a_prototype_rifle.yml
@@ -26,6 +26,8 @@
     soundGunshot:
       collection: CMM54CShoot
     shotsPerBurst: 4
+  - type: Corrodible
+    isCorrodible: false
   - type: RMCSelectiveFire
     baseFireModes:
     - SemiAuto
@@ -77,7 +79,7 @@
           - RMCMagazineRifleM54CMK1Incendiary
         startingItem: RMCMagazineRifleM54CIncendiary
   - type: GunDamageModifier
-    multiplier: 1.15
+    multiplier: 1.1
   - type: RMCMagneticItem
   - type: AttachableHolder
     slots:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fix/Parity

## Why / Balance
CO weapons are suppose to be indestructible.
CO rifle now lines up to it's parity counterpart.
Mateba can now put on barrel attachments + mateba barrel
## Technical details
<!-- Summary of code changes for easier review. -->
YML.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed Mateba, M59a and Winter Wyvern being able to be melted! 
- tweak: Changed M59a to have the same stats as a MK1 but with added IFF.
- fix: Fixed the Mateba not having the correct ammo loaded.
- fix: Fixed the Mateba not being able to use barrel attachments and mateba barrels at the same time.

