### PR TITLE
Fix attachment offsets on the new M13 sprite

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/m10_auto_pistol.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/m10_auto_pistol.yml
@@ -81,9 +81,9 @@
           - RMCAttachmentLaserSight
   - type: AttachableHolderVisuals
     offsets:
-      rmc-aslot-barrel: 0.6, 0.05
-      rmc-aslot-rail: -0.05, 0.11
-      rmc-aslot-underbarrel: 0.31, -0.25
+      rmc-aslot-barrel: 0.75, 0.125
+      rmc-aslot-rail: -0.05, 0.215
+      rmc-aslot-underbarrel: 0.39, -0.18
   #- type: Tag
    # id: RMCWeaponPistolM13
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Attachment offsets in m13 yaml
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The new M13 sprite PR didn't adjust these values.
## Technical details
<!-- Summary of code changes for easier review. -->
Trial and error on attachment offsets until it looks pretty close
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/8cb1236e-10d3-4dd2-b425-2af3e19b55b7)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Attachment offsets on the new M13 sprite

