### PR TITLE
Standardize Xeno Visual State Enums

### DIFF
--- a/Content.Client/_RMC14/Xenonids/Acider/XenoAciderGenerationVisualsSystem.cs
+++ b/Content.Client/_RMC14/Xenonids/Acider/XenoAciderGenerationVisualsSystem.cs
@@ -26,9 +26,9 @@ public sealed class XenoAciderGenerationVisualsSystem : VisualizerSystem<XenoAci
 
         string layerState = "acid";
 
-        if (AppearanceSystem.TryGetData(uid, XenoHealerVisuals.Downed, out bool downed) && downed)
+        if (AppearanceSystem.TryGetData(uid, XenoAcidGeneratingVisuals.Downed, out bool downed) && downed)
             layerState += "_downed";
-        else if (AppearanceSystem.TryGetData(uid, XenoHealerVisuals.Resting, out bool resting) && resting)
+        else if (AppearanceSystem.TryGetData(uid, XenoAcidGeneratingVisuals.Resting, out bool resting) && resting)
             layerState += "_rest";
 
         sprite.LayerSetState(layer, layerState);

--- a/Content.Client/_RMC14/Xenonids/Acider/XenoAciderGenerationVisualsSystem.cs
+++ b/Content.Client/_RMC14/Xenonids/Acider/XenoAciderGenerationVisualsSystem.cs
@@ -1,5 +1,5 @@
+using Content.Shared._RMC14.Xenonids;
 using Content.Shared._RMC14.Xenonids.AciderGeneration;
-using Content.Shared._RMC14.Xenonids.Heal;
 using Robust.Client.GameObjects;
 
 namespace Content.Client._RMC14.Xenonids.Acider;
@@ -26,9 +26,9 @@ public sealed class XenoAciderGenerationVisualsSystem : VisualizerSystem<XenoAci
 
         string layerState = "acid";
 
-        if (AppearanceSystem.TryGetData(uid, XenoAcidGeneratingVisuals.Downed, out bool downed) && downed)
+        if (AppearanceSystem.TryGetData(uid, RMCXenoStateVisuals.Downed, out bool downed) && downed)
             layerState += "_downed";
-        else if (AppearanceSystem.TryGetData(uid, XenoAcidGeneratingVisuals.Resting, out bool resting) && resting)
+        else if (AppearanceSystem.TryGetData(uid, RMCXenoStateVisuals.Resting, out bool resting) && resting)
             layerState += "_rest";
 
         sprite.LayerSetState(layer, layerState);

--- a/Content.Client/_RMC14/Xenonids/Damage/RMCXenoDamageVisualsSystem.cs
+++ b/Content.Client/_RMC14/Xenonids/Damage/RMCXenoDamageVisualsSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._RMC14.Xenonids;
 using Content.Shared._RMC14.Xenonids.Damage;
 using Robust.Client.GameObjects;
 
@@ -24,19 +25,19 @@ public sealed class RMCXenoDamageVisualsSystem : VisualizerSystem<RMCXenoDamageV
         sprite.LayerSetVisible(layer, true);
 
         var state = component.States - level + 1;
-        if (AppearanceSystem.TryGetData(uid, RMCDamageVisuals.Downed, out bool downed) && downed)
+        if (AppearanceSystem.TryGetData(uid, RMCXenoStateVisuals.Downed, out bool downed) && downed)
         {
             sprite.LayerSetState(layer, $"{component.Prefix}_downed_{state}");
             return;
         }
 
-        if (AppearanceSystem.TryGetData(uid, RMCDamageVisuals.Fortified, out bool fortified) && fortified)
+        if (AppearanceSystem.TryGetData(uid, RMCXenoStateVisuals.Fortified, out bool fortified) && fortified)
         {
             sprite.LayerSetState(layer, $"{component.Prefix}_fortify_{state}");
             return;
         }
 
-        if (AppearanceSystem.TryGetData(uid, RMCDamageVisuals.Resting, out bool resting) && resting)
+        if (AppearanceSystem.TryGetData(uid, RMCXenoStateVisuals.Resting, out bool resting) && resting)
         {
             sprite.LayerSetState(layer, $"{component.Prefix}_rest_{state}");
             return;

--- a/Content.Client/_RMC14/Xenonids/Egg/XenoEggStorageVisualizerSystem.cs
+++ b/Content.Client/_RMC14/Xenonids/Egg/XenoEggStorageVisualizerSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._RMC14.Xenonids;
 using Content.Shared._RMC14.Xenonids.Egg.EggRetriever;
 using Robust.Client.GameObjects;
 
@@ -20,9 +21,9 @@ public sealed partial class XenoEggStorageVisualizerSystem : VisualizerSystem<Xe
         int level = Math.Clamp((int)Math.Ceiling(((double)eggs / component.MaxEggs) * component.FullStates), 0, component.FullStates);
         layerState += level;
 
-        if (AppearanceSystem.TryGetData(uid, XenoEggStorageVisuals.Downed, out bool downed) && downed)
+        if (AppearanceSystem.TryGetData(uid, RMCXenoStateVisuals.Downed, out bool downed) && downed)
             layerState += "_downed";
-        else if (AppearanceSystem.TryGetData(uid, XenoEggStorageVisuals.Resting, out bool resting) && resting)
+        else if (AppearanceSystem.TryGetData(uid, RMCXenoStateVisuals.Resting, out bool resting) && resting)
             layerState += "_rest";
 
         if (AppearanceSystem.TryGetData(uid, XenoEggStorageVisuals.Active, out bool active) && active)
@@ -30,7 +31,7 @@ public sealed partial class XenoEggStorageVisualizerSystem : VisualizerSystem<Xe
 
         sprite.LayerSetState(layer, layerState);
 
-        if (AppearanceSystem.TryGetData(uid, XenoEggStorageVisuals.Dead, out bool dead) && dead)
+        if (AppearanceSystem.TryGetData(uid, RMCXenoStateVisuals.Dead, out bool dead) && dead)
             sprite.LayerSetVisible(layer, false);
         else
             sprite.LayerSetVisible(layer, true);

--- a/Content.Client/_RMC14/Xenonids/Heal/XenoSalveVisualsSystem.cs
+++ b/Content.Client/_RMC14/Xenonids/Heal/XenoSalveVisualsSystem.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared._RMC14.Xenonids.Heal;
+using Content.Shared._RMC14.Xenonids;
+using Content.Shared._RMC14.Xenonids.Heal;
 using Content.Shared._RMC14.Xenonids.Salve;
 using Robust.Client.GameObjects;
 
@@ -26,9 +27,9 @@ public sealed class XenoSalveVisualsSystem : VisualizerSystem<XenoSalveVisualsCo
 
         string layerState = "salved";
 
-        if (AppearanceSystem.TryGetData(uid, XenoHealerVisuals.Downed, out bool downed) && downed)
+        if (AppearanceSystem.TryGetData(uid, RMCXenoStateVisuals.Downed, out bool downed) && downed)
             layerState += "_downed";
-        else if (AppearanceSystem.TryGetData(uid, XenoHealerVisuals.Resting, out bool resting) && resting)
+        else if (AppearanceSystem.TryGetData(uid, RMCXenoStateVisuals.Resting, out bool resting) && resting)
             layerState += "_rest";
 
         sprite.LayerSetState(layer, layerState);

--- a/Content.Client/_RMC14/Xenonids/Inhands/XenoInhandsVisualsSystem.cs
+++ b/Content.Client/_RMC14/Xenonids/Inhands/XenoInhandsVisualsSystem.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared._RMC14.Xenonids.Inhands;
+using Content.Shared._RMC14.Xenonids;
+using Content.Shared._RMC14.Xenonids.Inhands;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 
@@ -13,19 +14,19 @@ public sealed class XenoInhandsVisualsSystem : VisualizerSystem<XenoInhandsCompo
         if (sprite == null)
             return;
 
-        if (!AppearanceSystem.TryGetData(uid, XenoInhandVisuals.Right, out string right))
+        if (!AppearanceSystem.TryGetData(uid, XenoInhandVisuals.RightHand, out string right))
             return;
 
-        if (!AppearanceSystem.TryGetData(uid, XenoInhandVisuals.Left, out string left))
+        if (!AppearanceSystem.TryGetData(uid, XenoInhandVisuals.LeftHand, out string left))
             return;
 
         bool downed = false;
         bool resting = false;
         bool ovi = false;
 
-        AppearanceSystem.TryGetData(uid, XenoInhandVisuals.Downed, out downed);
-        AppearanceSystem.TryGetData(uid, XenoInhandVisuals.Resting, out resting);
-        AppearanceSystem.TryGetData(uid, XenoInhandVisuals.Ovi, out ovi);
+        AppearanceSystem.TryGetData(uid, RMCXenoStateVisuals.Downed, out downed);
+        AppearanceSystem.TryGetData(uid, RMCXenoStateVisuals.Resting, out resting);
+        AppearanceSystem.TryGetData(uid, RMCXenoStateVisuals.Ovipositor, out ovi);
 
         string name = left;
         XenoInhandVisualLayers layerDef = XenoInhandVisualLayers.Left;

--- a/Content.Client/_RMC14/Xenonids/Parasite/XenoParasitesVisualSystem.cs
+++ b/Content.Client/_RMC14/Xenonids/Parasite/XenoParasitesVisualSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared._RMC14.Xenonids.Parasite;
+using Content.Shared._RMC14.Xenonids;
 using Content.Shared._RMC14.Xenonids.Projectile.Parasite;
 using Robust.Client.GameObjects;
 
@@ -15,9 +15,9 @@ public sealed class XenoParasitesVisualSystem : VisualizerSystem<XenoParasiteThr
 
         string layerState = "para_";
 
-        if(AppearanceSystem.TryGetData(uid, ParasiteOverlayVisuals.Downed, out bool downed) && downed)
+        if(AppearanceSystem.TryGetData(uid, RMCXenoStateVisuals.Downed, out bool downed) && downed)
             layerState = "para_downed_";
-        else if(AppearanceSystem.TryGetData(uid, ParasiteOverlayVisuals.Resting, out bool resting) && resting)
+        else if(AppearanceSystem.TryGetData(uid, RMCXenoStateVisuals.Resting, out bool resting) && resting)
             layerState = "para_rest_";
 
         foreach(var layer in Enum.GetValues<ParasiteOverlayLayers>())

--- a/Content.Server/_RMC14/Xenonids/Parasite/XenoParasiteThrowerSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Parasite/XenoParasiteThrowerSystem.cs
@@ -42,6 +42,7 @@ public sealed partial class XenoParasiteThrowerSystem : SharedXenoParasiteThrowe
         base.Initialize();
 
         SubscribeLocalEvent<XenoParasiteThrowerComponent, XenoThrowParasiteActionEvent>(OnToggleParasiteThrow);
+        SubscribeLocalEvent<XenoParasiteThrowerComponent, MobStateChangedEvent>(OnMobStateChanged);
 
         SubscribeLocalEvent<XenoParasiteThrowerComponent, UserActivateInWorldEvent>(OnXenoParasiteThrowerUseInHand);
         SubscribeLocalEvent<XenoParasiteThrowerComponent, XenoEvolutionDoAfterEvent>(OnXenoEvolveDoAfter);
@@ -195,12 +196,11 @@ public sealed partial class XenoParasiteThrowerSystem : SharedXenoParasiteThrowe
         DropAllStoredParasites(xeno);
     }
 
-    protected override void OnMobStateChanged(Entity<XenoParasiteThrowerComponent> xeno, ref MobStateChangedEvent args)
+    private void OnMobStateChanged(Entity<XenoParasiteThrowerComponent> xeno, ref MobStateChangedEvent args)
     {
-        base.OnMobStateChanged(xeno, ref args);
-
         if (args.NewMobState != MobState.Dead)
             return;
+
         DropAllStoredParasites(xeno, 0.75f);
     }
 
@@ -286,7 +286,7 @@ public sealed partial class XenoParasiteThrowerSystem : SharedXenoParasiteThrowe
         Dirty(xeno);
 
         //Need to clone the array for it to dirty properly
-        Appearance.SetData(xeno, ParasiteOverlayVisuals.States, xeno.Comp.VisiblePositions.Clone());
+        _appearance.SetData(xeno, ParasiteOverlayVisuals.States, xeno.Comp.VisiblePositions.Clone());
     }
 
     private List<int> GetVisualIndexes(bool[] bools, bool visible)

--- a/Content.Shared/_RMC14/Xenonids/AciderGeneration/XenoAciderGenerationComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/AciderGeneration/XenoAciderGenerationComponent.cs
@@ -26,8 +26,6 @@ public sealed partial class XenoAciderGenerationComponent : Component
 public enum XenoAcidGeneratingVisuals
 {
     Generating,
-    Downed,
-    Resting,
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/_RMC14/Xenonids/AciderGeneration/XenoAciderGenerationSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/AciderGeneration/XenoAciderGenerationSystem.cs
@@ -19,10 +19,6 @@ public sealed class XenoAciderGenerationSystem : EntitySystem
     public override void Initialize()
     {
         SubscribeLocalEvent<XenoAciderGenerationComponent, MeleeHitEvent>(OnMeleeHit);
-        SubscribeLocalEvent<XenoAciderGenerationComponent, MobStateChangedEvent>(OnMobStateChanged);
-        SubscribeLocalEvent<XenoAciderGenerationComponent, XenoRestEvent>(OnVisualsRest);
-        SubscribeLocalEvent<XenoAciderGenerationComponent, KnockedDownEvent>(OnVisualsKnockedDown);
-        SubscribeLocalEvent<XenoAciderGenerationComponent, StatusEffectEndedEvent>(OnVisualsStatusEffectEnded);
     }
 
     private void OnMeleeHit(Entity<XenoAciderGenerationComponent> xeno, ref MeleeHitEvent args)
@@ -43,39 +39,6 @@ public sealed class XenoAciderGenerationSystem : EntitySystem
         _appearance.SetData(xeno, XenoAcidGeneratingVisuals.Generating, true);
         xeno.Comp.ExpireAt = _timing.CurTime + xeno.Comp.ExpireDuration;
         Dirty(xeno);
-    }
-
-    private void OnMobStateChanged(Entity<XenoAciderGenerationComponent> xeno, ref MobStateChangedEvent args)
-    {
-        if (_timing.ApplyingState)
-            return;
-
-        _appearance.SetData(xeno, XenoAcidGeneratingVisuals.Downed, args.NewMobState != MobState.Alive);
-    }
-
-    private void OnVisualsRest(Entity<XenoAciderGenerationComponent> xeno, ref XenoRestEvent args)
-    {
-        if (_timing.ApplyingState)
-            return;
-
-        _appearance.SetData(xeno, XenoAcidGeneratingVisuals.Resting, args.Resting);
-    }
-
-    private void OnVisualsKnockedDown(Entity<XenoAciderGenerationComponent> xeno, ref KnockedDownEvent args)
-    {
-        if (_timing.ApplyingState)
-            return;
-
-        _appearance.SetData(xeno, XenoAcidGeneratingVisuals.Downed, true);
-    }
-
-    private void OnVisualsStatusEffectEnded(Entity<XenoAciderGenerationComponent> xeno, ref StatusEffectEndedEvent args)
-    {
-        if (_timing.ApplyingState)
-            return;
-
-        if (args.Key == "KnockedDown")
-            _appearance.SetData(xeno, XenoAcidGeneratingVisuals.Downed, false);
     }
 
     public override void Update(float frameTime)

--- a/Content.Shared/_RMC14/Xenonids/Damage/RMCXenoDamageVisualsComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Damage/RMCXenoDamageVisualsComponent.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.GameStates;
+using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared._RMC14.Xenonids.Damage;
@@ -17,9 +17,6 @@ public sealed partial class RMCXenoDamageVisualsComponent : Component
 [Serializable, NetSerializable]
 public enum RMCDamageVisuals
 {
-    Resting,
-    Downed,
-    Fortified,
     State,
 }
 

--- a/Content.Shared/_RMC14/Xenonids/Damage/RMCXenoDamageVisualsSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Damage/RMCXenoDamageVisualsSystem.cs
@@ -1,12 +1,7 @@
-using Content.Shared._RMC14.Xenonids.Fortify;
-using Content.Shared._RMC14.Xenonids.Rest;
 using Content.Shared.Damage;
-using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Rounding;
-using Content.Shared.Stunnable;
-using Content.Shared.StatusEffect;
 
 namespace Content.Shared._RMC14.Xenonids.Damage;
 
@@ -21,38 +16,7 @@ public sealed class RMCXenoDamageVisualsSystem : EntitySystem
     {
         _mobThresholdsQuery = GetEntityQuery<MobThresholdsComponent>();
 
-        SubscribeLocalEvent<RMCXenoDamageVisualsComponent, MobStateChangedEvent>(OnVisualsMobStateChanged);
-        SubscribeLocalEvent<RMCXenoDamageVisualsComponent, XenoFortifiedEvent>(OnVisualsFortified);
-        SubscribeLocalEvent<RMCXenoDamageVisualsComponent, XenoRestEvent>(OnVisualsRest);
         SubscribeLocalEvent<RMCXenoDamageVisualsComponent, DamageChangedEvent>(OnVisualsDamageChanged);
-        SubscribeLocalEvent<RMCXenoDamageVisualsComponent, KnockedDownEvent>(OnVisualsKnockedDown);
-        SubscribeLocalEvent<RMCXenoDamageVisualsComponent, StatusEffectEndedEvent>(OnVisualsStatusEffectEnded);
-    }
-
-    private void OnVisualsMobStateChanged(Entity<RMCXenoDamageVisualsComponent> ent, ref MobStateChangedEvent args)
-    {
-        _appearance.SetData(ent, RMCDamageVisuals.Downed, args.NewMobState != MobState.Alive);
-    }
-
-    private void OnVisualsFortified(Entity<RMCXenoDamageVisualsComponent> ent, ref XenoFortifiedEvent args)
-    {
-        _appearance.SetData(ent, RMCDamageVisuals.Fortified, args.Fortified);
-    }
-
-    private void OnVisualsRest(Entity<RMCXenoDamageVisualsComponent> ent, ref XenoRestEvent args)
-    {
-        _appearance.SetData(ent, RMCDamageVisuals.Resting, args.Resting);
-    }
-
-    private void OnVisualsKnockedDown(Entity<RMCXenoDamageVisualsComponent> xeno, ref KnockedDownEvent args)
-    {
-        _appearance.SetData(xeno, RMCDamageVisuals.Downed, true);
-    }
-
-    private void OnVisualsStatusEffectEnded(Entity<RMCXenoDamageVisualsComponent> xeno, ref StatusEffectEndedEvent args)
-    {
-        if (args.Key == "KnockedDown")
-            _appearance.SetData(xeno, RMCDamageVisuals.Downed, false);
     }
 
     private void OnVisualsDamageChanged(Entity<RMCXenoDamageVisualsComponent> ent, ref DamageChangedEvent args)

--- a/Content.Shared/_RMC14/Xenonids/Egg/EggRetriever/SharedXenoEggRetrieverSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Egg/EggRetriever/SharedXenoEggRetrieverSystem.cs
@@ -1,11 +1,8 @@
 using Content.Shared._RMC14.Actions;
-using Content.Shared._RMC14.Xenonids.Rest;
 using Content.Shared.Actions;
 using Content.Shared.Examine;
 using Content.Shared.Mobs;
 using Content.Shared.Popups;
-using Content.Shared.StatusEffect;
-using Content.Shared.Stunnable;
 using Robust.Shared.Network;
 using Robust.Shared.Timing;
 
@@ -26,11 +23,6 @@ public abstract partial class SharedXenoEggRetrieverSystem : EntitySystem
 
         SubscribeLocalEvent<XenoEggRetrieverComponent, ExaminedEvent>(OnEggRetrieverExamine);
 
-        SubscribeLocalEvent<XenoEggStorageVisualsComponent, MobStateChangedEvent>(OnMobStateChanged);
-        SubscribeLocalEvent<XenoEggStorageVisualsComponent, XenoRestEvent>(OnVisualsRest);
-        SubscribeLocalEvent<XenoEggStorageVisualsComponent, KnockedDownEvent>(OnVisualsKnockedDown);
-        SubscribeLocalEvent<XenoEggStorageVisualsComponent, StatusEffectEndedEvent>(OnVisualsStatusEffectEnded);
-
         SubscribeLocalEvent<XenoGenerateEggsComponent, XenoGenerateEggsActionEvent>(OnXenoProduceEggsAction);
         SubscribeLocalEvent<XenoGenerateEggsComponent, MobStateChangedEvent>(OnXenoProduceEggsDeath);
     }
@@ -45,40 +37,6 @@ public abstract partial class SharedXenoEggRetrieverSystem : EntitySystem
             args.PushMarkup(Loc.GetString("rmc-xeno-retrieve-egg-current", ("xeno", retriever),
                 ("cur_eggs", retriever.Comp.CurEggs), ("max_eggs", retriever.Comp.MaxEggs)));
         }
-    }
-
-    protected virtual void OnMobStateChanged(Entity<XenoEggStorageVisualsComponent> xeno, ref MobStateChangedEvent args)
-    {
-        if (_timing.ApplyingState)
-            return;
-
-        _appearance.SetData(xeno, XenoEggStorageVisuals.Downed, args.NewMobState != MobState.Alive);
-        _appearance.SetData(xeno, XenoEggStorageVisuals.Dead, args.NewMobState == MobState.Dead);
-    }
-
-    private void OnVisualsRest(Entity<XenoEggStorageVisualsComponent> xeno, ref XenoRestEvent args)
-    {
-        if (_timing.ApplyingState)
-            return;
-
-        _appearance.SetData(xeno, XenoEggStorageVisuals.Resting, args.Resting);
-    }
-
-    private void OnVisualsKnockedDown(Entity<XenoEggStorageVisualsComponent> xeno, ref KnockedDownEvent args)
-    {
-        if (_timing.ApplyingState)
-            return;
-
-        _appearance.SetData(xeno, XenoEggStorageVisuals.Downed, true);
-    }
-
-    private void OnVisualsStatusEffectEnded(Entity<XenoEggStorageVisualsComponent> xeno, ref StatusEffectEndedEvent args)
-    {
-        if (_timing.ApplyingState)
-            return;
-
-        if (args.Key == "KnockedDown")
-            _appearance.SetData(xeno, XenoEggStorageVisuals.Downed, false);
     }
 
     private void OnXenoProduceEggsAction(Entity<XenoGenerateEggsComponent> xeno, ref XenoGenerateEggsActionEvent args)

--- a/Content.Shared/_RMC14/Xenonids/Egg/EggRetriever/XenoEggStorageVisualsComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Egg/EggRetriever/XenoEggStorageVisualsComponent.cs
@@ -22,9 +22,6 @@ public enum XenoEggStorageVisualLayers
 [Serializable, NetSerializable]
 public enum XenoEggStorageVisuals
 {
-    Resting,
-    Downed,
     Active,
-    Dead,
     Number
 }

--- a/Content.Shared/_RMC14/Xenonids/Inhands/XenoInhandSpriteComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Inhands/XenoInhandSpriteComponent.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.GameStates;
+using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared._RMC14.Xenonids.Inhands;
@@ -20,9 +20,6 @@ public enum XenoInhandVisualLayers
 [Serializable, NetSerializable]
 public enum XenoInhandVisuals
 {
-    Left,
-    Right,
-    Downed,
-    Resting,
-    Ovi,
+    LeftHand,
+    RightHand,
 }

--- a/Content.Shared/_RMC14/Xenonids/Inhands/XenoInhandsSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Inhands/XenoInhandsSystem.cs
@@ -1,12 +1,6 @@
-﻿using Content.Shared._RMC14.Xenonids.Egg;
-using Content.Shared._RMC14.Xenonids.Rest;
 using Content.Shared.Hands;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
-using Content.Shared.Interaction.Events;
-using Content.Shared.Mobs;
-using Content.Shared.StatusEffect;
-using Content.Shared.Stunnable;
 using Robust.Shared.Timing;
 
 namespace Content.Shared._RMC14.Xenonids.Inhands;
@@ -20,12 +14,6 @@ public sealed class XenoInhandsSystem : EntitySystem
     {
         SubscribeLocalEvent<XenoInhandsComponent, DidEquipHandEvent>(OnXenoSpritePickedUp);
         SubscribeLocalEvent<XenoInhandsComponent, DidUnequipHandEvent>(OnXenoSpriteDropped);
-
-        SubscribeLocalEvent<XenoInhandsComponent, MobStateChangedEvent>(OnMobStateChanged);
-        SubscribeLocalEvent<XenoInhandsComponent, XenoRestEvent>(OnVisualsRest);
-        SubscribeLocalEvent<XenoInhandsComponent, KnockedDownEvent>(OnVisualsKnockedDown);
-        SubscribeLocalEvent<XenoInhandsComponent, StatusEffectEndedEvent>(OnVisualsStatusEffectEnded);
-        SubscribeLocalEvent<XenoInhandsComponent, XenoOvipositorChangedEvent>(OnVisualsOvipositor);
     }
 
     public void OnXenoSpritePickedUp(Entity<XenoInhandsComponent> xeno, ref DidEquipHandEvent args)
@@ -56,48 +44,7 @@ public sealed class XenoInhandsSystem : EntitySystem
         }
 
         _appearance.SetData(user,
-        hand.Location == HandLocation.Left ? XenoInhandVisuals.Left : XenoInhandVisuals.Right,
+        hand.Location == HandLocation.Left ? XenoInhandVisuals.LeftHand : XenoInhandVisuals.RightHand,
         held);
-    }
-
-    private void OnMobStateChanged(Entity<XenoInhandsComponent> xeno, ref MobStateChangedEvent args)
-    {
-        if (_timing.ApplyingState)
-            return;
-
-        _appearance.SetData(xeno, XenoInhandVisuals.Downed, args.NewMobState != MobState.Alive);
-    }
-
-    private void OnVisualsRest(Entity<XenoInhandsComponent> xeno, ref XenoRestEvent args)
-    {
-        if (_timing.ApplyingState)
-            return;
-
-        _appearance.SetData(xeno, XenoInhandVisuals.Resting, args.Resting);
-    }
-
-    private void OnVisualsKnockedDown(Entity<XenoInhandsComponent> xeno, ref KnockedDownEvent args)
-    {
-        if (_timing.ApplyingState)
-            return;
-
-        _appearance.SetData(xeno, XenoInhandVisuals.Downed, true);
-    }
-
-    private void OnVisualsOvipositor(Entity<XenoInhandsComponent> xeno, ref XenoOvipositorChangedEvent args)
-    {
-        if (_timing.ApplyingState)
-            return;
-
-        _appearance.SetData(xeno, XenoInhandVisuals.Ovi, args.Attached);
-    }
-
-    private void OnVisualsStatusEffectEnded(Entity<XenoInhandsComponent> xeno, ref StatusEffectEndedEvent args)
-    {
-        if (_timing.ApplyingState)
-            return;
-
-        if (args.Key == "KnockedDown")
-            _appearance.SetData(xeno, XenoInhandVisuals.Downed, false);
     }
 }

--- a/Content.Shared/_RMC14/Xenonids/Projectile/Parasite/SharedXenoParasiteThrowerSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/Parasite/SharedXenoParasiteThrowerSystem.cs
@@ -15,7 +15,7 @@ namespace Content.Shared._RMC14.Xenonids.Projectile.Parasite;
 public abstract partial class SharedXenoParasiteThrowerSystem : EntitySystem
 {
     [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
-    [Dependency] protected readonly SharedAppearanceSystem Appearance = default!;
+    [Dependency] protected readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
 
     public override void Initialize()
@@ -26,11 +26,6 @@ public abstract partial class SharedXenoParasiteThrowerSystem : EntitySystem
         SubscribeLocalEvent<XenoParasiteThrowerComponent, XenoChangeParasiteReserveMessage>(OnParasiteReserveChange);
         SubscribeLocalEvent<XenoParasiteThrowerComponent, XenoReserveParasiteActionEvent>(OnSetReserve);
         SubscribeLocalEvent<XenoParasiteThrowerComponent, GetVerbsEvent<ActivationVerb>>(OnGetVerbs);
-
-        SubscribeLocalEvent<XenoParasiteThrowerComponent, MobStateChangedEvent>(OnMobStateChanged);
-        SubscribeLocalEvent<XenoParasiteThrowerComponent, XenoRestEvent>(OnVisualsRest);
-        SubscribeLocalEvent<XenoParasiteThrowerComponent, KnockedDownEvent>(OnVisualsKnockedDown);
-        SubscribeLocalEvent<XenoParasiteThrowerComponent, StatusEffectEndedEvent>(OnVisualsStatusEffectEnded);
     }
 
     private void OnParasiteThrowerExamine(Entity<XenoParasiteThrowerComponent> thrower, ref ExaminedEvent args)
@@ -100,38 +95,5 @@ public abstract partial class SharedXenoParasiteThrowerSystem : EntitySystem
         };
 
         args.Verbs.Add(parasiteVerb);
-    }
-
-    protected virtual void OnMobStateChanged(Entity<XenoParasiteThrowerComponent> xeno, ref MobStateChangedEvent args)
-    {
-        if (_timing.ApplyingState)
-            return;
-
-        Appearance.SetData(xeno, ParasiteOverlayVisuals.Downed, args.NewMobState != MobState.Alive);
-    }
-
-    private void OnVisualsRest(Entity<XenoParasiteThrowerComponent> xeno, ref XenoRestEvent args)
-    {
-        if (_timing.ApplyingState)
-            return;
-
-        Appearance.SetData(xeno, ParasiteOverlayVisuals.Resting, args.Resting);
-    }
-
-    private void OnVisualsKnockedDown(Entity<XenoParasiteThrowerComponent> xeno, ref KnockedDownEvent args)
-    {
-        if (_timing.ApplyingState)
-            return;
-
-        Appearance.SetData(xeno, ParasiteOverlayVisuals.Downed, true);
-    }
-
-    private void OnVisualsStatusEffectEnded(Entity<XenoParasiteThrowerComponent> xeno, ref StatusEffectEndedEvent args)
-    {
-        if (_timing.ApplyingState)
-            return;
-
-        if(args.Key == "KnockedDown")
-            Appearance.SetData(xeno, ParasiteOverlayVisuals.Downed, false);
     }
 }

--- a/Content.Shared/_RMC14/Xenonids/Projectile/Parasite/XenoParasiteThrowerComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/Parasite/XenoParasiteThrowerComponent.cs
@@ -41,8 +41,6 @@ public sealed partial class XenoParasiteThrowerComponent : Component
 [Serializable, NetSerializable]
 public enum ParasiteOverlayVisuals
 {
-    Resting,
-    Downed,
     States
 }
 

--- a/Content.Shared/_RMC14/Xenonids/Salve/RecentlySalvedComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Salve/RecentlySalvedComponent.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.GameStates;
+using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared._RMC14.Xenonids.Heal;
@@ -14,8 +14,6 @@ public sealed partial class RecentlySalvedComponent : Component
 public enum XenoHealerVisuals
 {
     Gooped,
-    Downed,
-    Resting,
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/_RMC14/Xenonids/Salve/XenoSalveSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Salve/XenoSalveSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared._RMC14.Xenonids.Heal;
+using Content.Shared._RMC14.Xenonids.Heal;
 using Content.Shared._RMC14.Xenonids.Rest;
 using Content.Shared.Mobs;
 using Content.Shared.StatusEffect;
@@ -17,10 +17,6 @@ public sealed class XenoSalveSystem : EntitySystem
     {
         SubscribeLocalEvent<RecentlySalvedComponent, ComponentStartup>(OnSalveAdded);
         SubscribeLocalEvent<RecentlySalvedComponent, ComponentShutdown>(OnSalveRemoved);
-        SubscribeLocalEvent<XenoSalveVisualsComponent, MobStateChangedEvent>(OnMobStateChanged);
-        SubscribeLocalEvent<XenoSalveVisualsComponent, XenoRestEvent>(OnVisualsRest);
-        SubscribeLocalEvent<XenoSalveVisualsComponent, KnockedDownEvent>(OnVisualsKnockedDown);
-        SubscribeLocalEvent<XenoSalveVisualsComponent, StatusEffectEndedEvent>(OnVisualsStatusEffectEnded);
     }
 
     private void OnSalveAdded(Entity<RecentlySalvedComponent> xeno, ref ComponentStartup args)
@@ -37,39 +33,6 @@ public sealed class XenoSalveSystem : EntitySystem
             return;
 
         _appearance.SetData(xeno, XenoHealerVisuals.Gooped, false);
-    }
-
-    private void OnMobStateChanged(Entity<XenoSalveVisualsComponent> xeno, ref MobStateChangedEvent args)
-    {
-        if (_timing.ApplyingState)
-            return;
-
-        _appearance.SetData(xeno, XenoHealerVisuals.Downed, args.NewMobState != MobState.Alive);
-    }
-
-    private void OnVisualsRest(Entity<XenoSalveVisualsComponent> xeno, ref XenoRestEvent args)
-    {
-        if (_timing.ApplyingState)
-            return;
-
-        _appearance.SetData(xeno, XenoHealerVisuals.Resting, args.Resting);
-    }
-
-    private void OnVisualsKnockedDown(Entity<XenoSalveVisualsComponent> xeno, ref KnockedDownEvent args)
-    {
-        if (_timing.ApplyingState)
-            return;
-
-        _appearance.SetData(xeno, XenoHealerVisuals.Downed, true);
-    }
-
-    private void OnVisualsStatusEffectEnded(Entity<XenoSalveVisualsComponent> xeno, ref StatusEffectEndedEvent args)
-    {
-        if (_timing.ApplyingState)
-            return;
-
-        if (args.Key == "KnockedDown")
-            _appearance.SetData(xeno, XenoHealerVisuals.Downed, false);
     }
 
     public override void Update(float frameTime)

--- a/Content.Shared/_RMC14/Xenonids/XenoStateVisualsComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/XenoStateVisualsComponent.cs
@@ -3,6 +3,4 @@ using Robust.Shared.GameStates;
 namespace Content.Shared._RMC14.Xenonids;
 
 [RegisterComponent, NetworkedComponent]
-public sealed partial class XenoStateVisualsComponent : Component
-{
-}
+public sealed partial class XenoStateVisualsComponent : Component;

--- a/Content.Shared/_RMC14/Xenonids/XenoStateVisualsComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/XenoStateVisualsComponent.cs
@@ -1,0 +1,8 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class XenoStateVisualsComponent : Component
+{
+}

--- a/Content.Shared/_RMC14/Xenonids/XenoSystem.Visuals.cs
+++ b/Content.Shared/_RMC14/Xenonids/XenoSystem.Visuals.cs
@@ -7,7 +7,7 @@ using Robust.Shared.Serialization;
 
 namespace Content.Shared._RMC14.Xenonids;
 
-public partial class XenoSystem
+public sealed partial class XenoSystem : EntitySystem
 {
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
 

--- a/Content.Shared/_RMC14/Xenonids/XenoSystem.Visuals.cs
+++ b/Content.Shared/_RMC14/Xenonids/XenoSystem.Visuals.cs
@@ -1,0 +1,72 @@
+using Content.Shared._RMC14.Xenonids.Egg;
+using Content.Shared._RMC14.Xenonids.Fortify;
+using Content.Shared._RMC14.Xenonids.Rest;
+using Content.Shared.Mobs;
+using Content.Shared.Standing;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Xenonids;
+
+public partial class XenoSystem
+{
+    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+
+    private void OnVisualsMobStateChanged(Entity<XenoStateVisualsComponent> ent, ref MobStateChangedEvent args)
+    {
+        if (_timing.ApplyingState)
+            return;
+
+        _appearance.SetData(ent, RMCXenoStateVisuals.Downed, args.NewMobState != MobState.Alive);
+        _appearance.SetData(ent, RMCXenoStateVisuals.Dead, args.NewMobState == MobState.Dead);
+    }
+
+    private void OnVisualsFortified(Entity<XenoStateVisualsComponent> ent, ref XenoFortifiedEvent args)
+    {
+        if (_timing.ApplyingState)
+            return;
+
+        _appearance.SetData(ent, RMCXenoStateVisuals.Fortified, args.Fortified);
+    }
+
+    private void OnVisualsRest(Entity<XenoStateVisualsComponent> ent, ref XenoRestEvent args)
+    {
+        if (_timing.ApplyingState)
+            return;
+
+        _appearance.SetData(ent, RMCXenoStateVisuals.Resting, args.Resting);
+    }
+
+    private void OnVisualsProne(Entity<XenoStateVisualsComponent> xeno, ref DownedEvent args)
+    {
+        if (_timing.ApplyingState)
+            return;
+
+        _appearance.SetData(xeno, RMCXenoStateVisuals.Downed, true);
+    }
+
+    private void OnVisualsStand(Entity<XenoStateVisualsComponent> xeno, ref StoodEvent args)
+    {
+        if (_timing.ApplyingState)
+            return;
+
+        _appearance.SetData(xeno, RMCXenoStateVisuals.Downed, false);
+    }
+
+    private void OnVisualsOvipositor(Entity<XenoStateVisualsComponent> xeno, ref XenoOvipositorChangedEvent args)
+    {
+        if (_timing.ApplyingState)
+            return;
+
+        _appearance.SetData(xeno, RMCXenoStateVisuals.Ovipositor, args.Attached);
+    }
+}
+
+[Serializable, NetSerializable]
+public enum RMCXenoStateVisuals
+{
+    Resting,
+    Downed,
+    Fortified,
+    Ovipositor,
+    Dead,
+}

--- a/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
@@ -9,10 +9,14 @@ using Content.Shared._RMC14.Rules;
 using Content.Shared._RMC14.Tackle;
 using Content.Shared._RMC14.Vendors;
 using Content.Shared._RMC14.Xenonids.Construction.Nest;
+using Content.Shared._RMC14.Xenonids.Damage;
 using Content.Shared._RMC14.Xenonids.Devour;
+using Content.Shared._RMC14.Xenonids.Egg;
 using Content.Shared._RMC14.Xenonids.Evolution;
+using Content.Shared._RMC14.Xenonids.Fortify;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.HiveLeader;
+using Content.Shared._RMC14.Xenonids.Inhands;
 using Content.Shared._RMC14.Xenonids.Parasite;
 using Content.Shared._RMC14.Xenonids.Pheromones;
 using Content.Shared._RMC14.Xenonids.Plasma;
@@ -51,7 +55,7 @@ using Robust.Shared.Timing;
 
 namespace Content.Shared._RMC14.Xenonids;
 
-public sealed class XenoSystem : EntitySystem
+public sealed partial class XenoSystem : EntitySystem
 {
     [Dependency] private readonly SharedActionsSystem _action = default!;
     [Dependency] private readonly IConfigurationManager _config = default!;
@@ -131,6 +135,14 @@ public sealed class XenoSystem : EntitySystem
 
         SubscribeLocalEvent<XenoRegenComponent, MapInitEvent>(OnXenoRegenMapInit, before: [typeof(SharedXenoPheromonesSystem)]);
         SubscribeLocalEvent<XenoRegenComponent, DamageStateCritBeforeDamageEvent>(OnXenoRegenBeforeCritDamage, before: [typeof(SharedXenoPheromonesSystem)]);
+
+        //In XenoSystem.Visuals
+        SubscribeLocalEvent<XenoStateVisualsComponent, MobStateChangedEvent>(OnVisualsMobStateChanged);
+        SubscribeLocalEvent<XenoStateVisualsComponent, XenoFortifiedEvent>(OnVisualsFortified);
+        SubscribeLocalEvent<XenoStateVisualsComponent, XenoRestEvent>(OnVisualsRest);
+        SubscribeLocalEvent<XenoStateVisualsComponent, DownedEvent>(OnVisualsProne);
+        SubscribeLocalEvent<XenoStateVisualsComponent, StoodEvent>(OnVisualsStand);
+        SubscribeLocalEvent<XenoStateVisualsComponent, XenoOvipositorChangedEvent>(OnVisualsOvipositor);
 
         Subs.CVar(_config, RMCCVars.CMXenoDamageDealtMultiplier, v => _xenoDamageDealtMultiplier = v, true);
         Subs.CVar(_config, RMCCVars.CMXenoDamageReceivedMultiplier, v => _xenoDamageReceivedMultiplier = v, true);

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
@@ -187,6 +187,7 @@
         - BulletImpassable
   - type: Xeno
   - type: XenoRegen
+  - type: XenoStateVisuals
   - type: UserInterface
     interfaces:
       enum.XenoEvolutionUIKey.Key:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.
Instead of each component changing it's own enum to track rest/ovi/downed/etc. It's all been consolidated into one enum that each of the visual systems use.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes an Acider Runner bug (accidently was checking healer states). Makes it easier to modify.

## Technical details
<!-- Summary of code changes for easier review. -->
So various enums and shared systems were touched to remove functions that were updating their own enum for something that's now in a new enum: RMCXenoStateVisuals, which stores rest, downed, dead, fortified, and ovipositor states. It's mostly a copy of the repeated code from the other systems with one change: Instead of checking for status ended and knockdown it checks for downed and stood events for that, to be more general.

All the subscriptions use XenoStateVisualsComponent to not mess with any XenoComponent Subscriptions.
I did test all the changed systems to make sure they work.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
no cl just code
