### PR TITLE
Make a separate playtime ribbons component, add ribbons to correspondent and CL

### DIFF
--- a/Content.Server/_RMC14/Medal/PlaytimeMedalSystem.cs
+++ b/Content.Server/_RMC14/Medal/PlaytimeMedalSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.Players.PlayTimeTracking;
 using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Medal;
 using Content.Shared._RMC14.Survivor;
+using Content.Shared._RMC14.Ribbon;
 using Content.Shared.Coordinates;
 using Content.Shared.GameTicking;
 using Content.Shared.Roles;
@@ -57,7 +58,7 @@ public sealed class PlaytimeMedalSystem : SharedPlaytimeMedalSystem
         }
 
         EntProtoId? medalId = null;
-        if (HasComp<RMCSurvivorComponent>(ev.Mob))
+        if (HasComp<RMCRibbonComponent>(ev.Mob))
         {
             if (time >= _platinumTime)
                 medalId = BlueRibbon;

--- a/Content.Shared/_RMC14/Ribbon/RibbonComponent.cs
+++ b/Content.Shared/_RMC14/Ribbon/RibbonComponent.cs
@@ -1,0 +1,6 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Ribbon;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class RMCRibbonComponent : Component;

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/correspondent.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/correspondent.yml
@@ -36,6 +36,7 @@
       icon:
         sprite: _RMC14/Interface/map_blips.rsi
         state: correspondent
+    - type: RMCRibbon
   hasIcon: false
 
 - type: startingGear

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/liaison.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/liaison.yml
@@ -65,6 +65,7 @@
       icon:
         sprite: _RMC14/Interface/map_blips.rsi
         state: cl
+    - type: RMCRibbon
 
 - type: startingGear
   id: CMGearLiaison

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/civilian_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/civilian_survivor.yml
@@ -34,12 +34,12 @@
     - type: EquipSurvivorPreset
       preset: RMCSurvivorPresetCivilian
     - type: RMCSurvivor
+    - type: RMCRibbon
     - type: MotionDetectorTracked
     - type: NpcFactionMember
       factions:
       - Survivor
     - type: IntelRescueSurvivorObjective
-    - type: RMCRibbon
   greeting: rmc-job-greeting-survivor
   hasIcon: false
 

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/civilian_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/civilian_survivor.yml
@@ -39,6 +39,7 @@
       factions:
       - Survivor
     - type: IntelRescueSurvivorObjective
+    - type: RMCRibbon
   greeting: rmc-job-greeting-survivor
   hasIcon: false
 

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/colony_synth.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/colony_synth.yml
@@ -51,12 +51,12 @@
     - type: GrenadeSpecWhitelist
     - type: ScoutWhitelist
     - type: SniperWhitelist
+    - type: RMCRibbon
     - type: PyroWhitelist
     - type: TacticalMapIcon
       icon:
         sprite: _RMC14/Interface/map_blips.rsi
         state: synth
-    - type: RMCRibbon
   hidden: true
 
 - type: startingGear

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/colony_synth.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/colony_synth.yml
@@ -56,6 +56,7 @@
       icon:
         sprite: _RMC14/Interface/map_blips.rsi
         state: synth
+    - type: RMCRibbon
   hidden: true
 
 - type: startingGear

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/corporate_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/corporate_survivor.yml
@@ -35,6 +35,7 @@
     - type: RMCSurvivor
     - type: MotionDetectorTracked
     - type: NpcFactionMember
+    - type: RMCRibbon
       factions:
       - WeYa
     - type: IntelRescueSurvivorObjective

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/corporate_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/corporate_survivor.yml
@@ -33,9 +33,9 @@
     - type: EquipSurvivorPreset
       preset: RMCSurvivorPresetCorporate
     - type: RMCSurvivor
+    - type: RMCRibbon
     - type: MotionDetectorTracked
     - type: NpcFactionMember
-    - type: RMCRibbon
       factions:
       - WeYa
     - type: IntelRescueSurvivorObjective

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/doctor_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/doctor_survivor.yml
@@ -23,9 +23,9 @@
     - type: EquipSurvivorPreset
       preset: RMCSurvivorPresetDoctor
     - type: RMCSurvivor
+    - type: RMCRibbon
     - type: MotionDetectorTracked
     - type: NpcFactionMember
-    - type: RMCRibbon
       factions:
       - Survivor
     - type: IntelRescueSurvivorObjective

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/doctor_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/doctor_survivor.yml
@@ -25,6 +25,7 @@
     - type: RMCSurvivor
     - type: MotionDetectorTracked
     - type: NpcFactionMember
+    - type: RMCRibbon
       factions:
       - Survivor
     - type: IntelRescueSurvivorObjective

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/engineer_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/engineer_survivor.yml
@@ -22,9 +22,9 @@
     - type: EquipSurvivorPreset
       preset: RMCSurvivorPresetEngineer
     - type: RMCSurvivor
+    - type: RMCRibbon
     - type: MotionDetectorTracked
     - type: NpcFactionMember
-    - type: RMCRibbon
       factions:
       - Survivor
     - type: IntelRescueSurvivorObjective

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/engineer_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/engineer_survivor.yml
@@ -24,6 +24,7 @@
     - type: RMCSurvivor
     - type: MotionDetectorTracked
     - type: NpcFactionMember
+    - type: RMCRibbon
       factions:
       - Survivor
     - type: IntelRescueSurvivorObjective

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/security_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/security_survivor.yml
@@ -28,6 +28,7 @@
     - type: RMCSurvivor
     - type: MotionDetectorTracked
     - type: NpcFactionMember
+    - type: RMCRibbon
       factions:
       - Survivor
     - type: IntelRescueSurvivorObjective

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/security_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/security_survivor.yml
@@ -26,9 +26,9 @@
     - type: EquipSurvivorPreset
       preset: RMCSurvivorPresetSecurity
     - type: RMCSurvivor
+    - type: RMCRibbon
     - type: MotionDetectorTracked
     - type: NpcFactionMember
-    - type: RMCRibbon
       factions:
       - Survivor
     - type: IntelRescueSurvivorObjective


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Separated playtime ribbons from the RMCSurvivorComponent into a new, separate RMCRibbonComponent to allow use of playtime ribbons in any role. Also added this new component to CL, Correspondent, and all survs, meaning they now get playtime ribbons instead of service medals (finally!)

Need to be merged for #6271 
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
CL and Correspondent are civilians, they need ribbons not medals! New component so its easier to add to any future civilian jobs (like fax responders)
## Technical details
<!-- Summary of code changes for easier review. -->
New component RMCRibbonComponent, replaced the check for the surv component in PlaytimeMedalSystem for a check for the Ribbon component. 
My first time with C#, but nothing complex.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Adds playtime ribbons for CL and Correspondent
