### PR TITLE
mechanic enforced roleplay for correspondent and liaison

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Hands/color.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Hands/color.yml
@@ -14,7 +14,7 @@
     fiberColor: fibers-brown
 
 - type: entity
-  parent: CMHandsBlackMarine
+  parent: ClothingHandsBase
   id: CMHandsBrown
   name: brown gloves
   description: A pair of brown gloves.
@@ -27,7 +27,7 @@
     fiberColor: fibers-brown
 
 - type: entity
-  parent: CMHandsBlackMarine
+  parent: ClothingHandsBase
   id: CMHandsLightBrown
   name: light brown gloves
   description: A pair of light brown gloves.
@@ -40,7 +40,7 @@
     fiberColor: fibers-brown
 
 - type: entity
-  parent: CMHandsBlackMarine
+  parent: ClothingHandsBase
   id: CMHandsWhite
   name: white gloves
   description: A pair of white gloves.

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Hands/marine.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Hands/marine.yml
@@ -12,6 +12,7 @@
     fiberMaterial: fibers-leather
     fiberColor: fibers-black
   - type: FingerprintMask
+  - type: RMCBulkyArmor
 
 - type: entity
   parent: CMHandsBlackMarine

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Hands/misc.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Hands/misc.yml
@@ -13,7 +13,7 @@
     fiberColor: fibers-brown
 
 - type: entity
-  parent: CMHandsBlackMarine
+  parent: ClothingHandsBase
   id: CMHandsLatex
   name: latex gloves
   description: A pair of latex gloves.

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Head/Helmets/marine_helmets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Head/Helmets/marine_helmets.yml
@@ -250,6 +250,8 @@
     sprite: _RMC14/Objects/Clothing/Head/Helmets/press.rsi
   - type: ItemCamouflage
     camouflageVariations: { }
+  - type: RMCBulkyArmor
+    isBulky: false
 
 # M3-S Scout Spec
 - type: entity

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
@@ -547,6 +547,8 @@
   name: press body armor
   description: Body armor used by war correspondents in battles and wars across the universe.
   components:
+  - type: RMCBulkyArmor
+    isBulky: false
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/press.rsi
   - type: ItemCamouflage # this is needed, otherwise it looks like M3MediumArmor

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Shoes/boots.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Shoes/boots.yml
@@ -38,6 +38,7 @@
   name: marine combat boots
   description: Standard issue combat boots for combat scenarios or combat situations. All combat, all the time.
   components:
+  - type: RMCBulkyArmor
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Shoes/Boots/black.rsi
     layers:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/correspondent.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/correspondent.yml
@@ -26,6 +26,7 @@
   special:
   - !type:AddComponentSpecial
     components:
+    - type: RMCUserBulkyArmorIncapable
     - type: Skills
       skills:
         RMCSkillFirearms: 0

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/liaison.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/liaison.yml
@@ -50,6 +50,7 @@
   special:
   - !type:AddComponentSpecial
     components:
+    - type: RMCUserBulkyArmorIncapable
     - type: NpcFactionMember
       factions:
       - WeYa


### PR DESCRIPTION
Consistent admin issue

**Changelog**

:cl: Whisper

- tweak: Civilian Correspondent and Liaison may no longer equip marine armor. Non-combat armor such as press armor and emergency ballistic vests provided by code red situations are not affected.
