### PR TITLE
Adjust fire damage of projectiles and the CAS laser.

### DIFF
--- a/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
@@ -425,7 +425,7 @@ namespace Content.Server.Atmos.EntitySystems
             _stunSystem.TryParalyze(uid, flammable.ResistDuration, true, force: true);
 
             // TODO FLAMMABLE: Make this not use TimerComponent...
-            uid.SpawnTimer(2000, () =>
+            uid.SpawnTimer(1000, () =>
             {
                 flammable.Resisting = false;
                 Dirty(uid, flammable);

--- a/Content.Shared/_RMC14/Atmos/IgniteOnProjectileHitComponent.cs
+++ b/Content.Shared/_RMC14/Atmos/IgniteOnProjectileHitComponent.cs
@@ -8,9 +8,6 @@ namespace Content.Shared._RMC14.Atmos;
 public sealed partial class IgniteOnProjectileHitComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public int Stacks = 20;
-
-    [DataField, AutoNetworkedField]
     public int Intensity = 30;
 
     [DataField, AutoNetworkedField]

--- a/Content.Shared/_RMC14/Atmos/SharedRMCFlammableSystem.cs
+++ b/Content.Shared/_RMC14/Atmos/SharedRMCFlammableSystem.cs
@@ -119,7 +119,7 @@ public abstract class SharedRMCFlammableSystem : EntitySystem
 
     private void OnIgniteOnProjectileHit(Entity<IgniteOnProjectileHitComponent> ent, ref ProjectileHitEvent args)
     {
-        Ignite(args.Target, ent.Comp.Stacks, ent.Comp.Intensity, ent.Comp.Duration, false);
+        Ignite(args.Target, ent.Comp.Intensity, ent.Comp.Duration, ent.Comp.Duration, false);
     }
 
     private void OnTileFireMapInit(Entity<TileFireComponent> ent, ref MapInitEvent args)
@@ -680,14 +680,14 @@ public abstract class SharedRMCFlammableSystem : EntitySystem
         if (!Resolve(flammableEnt, ref flammableEnt.Comp, false))
             return;
 
+        EnsureComp<SteppingOnFireComponent>(other);
+
         var wasOnFire = IsOnFire(flammableEnt);
         if (checkIgnited && wasOnFire)
             return;
 
         if (!Ignite(flammableEnt, ent.Comp.Intensity, ent.Comp.Duration, ent.Comp.MaxStacks))
             return;
-
-        EnsureComp<SteppingOnFireComponent>(other);
 
         if (!wasOnFire && IsOnFire(flammableEnt) && !HasComp<RMCImmuneToFireTileDamageComponent>(ent))
             _damageable.TryChangeDamage(flammableEnt, flammableEnt.Comp.Damage * ent.Comp.Intensity, true);

--- a/Content.Shared/_RMC14/Projectiles/Aimed/AimedProjectileSystem.cs
+++ b/Content.Shared/_RMC14/Projectiles/Aimed/AimedProjectileSystem.cs
@@ -77,7 +77,7 @@ public sealed class AimedProjectileSystem : EntitySystem
         // Apply firestacks
         if (TryComp(ent, out IgniteOnProjectileHitComponent? ignite))
         {
-            ignite.Stacks += aimedEffect.FireStacksOnHit;
+            ignite.Intensity += aimedEffect.FireStacksOnHit;
         }
     }
 

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m74_airburst_grenades.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m74_airburst_grenades.yml
@@ -312,7 +312,7 @@
     radius: 2.0
     energy: 7.0
   - type: IgniteOnProjectileHit
-    stacks: 2
+    intensity: 2
 
 - type: entity
   parent: RMCBaseBullet

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Snipers/m96s_sniper.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Snipers/m96s_sniper.yml
@@ -215,7 +215,6 @@
   - type: CMArmorPiercing
     amount: 20
   - type: IgniteOnProjectileHit
-    stacks: 40
   - type: AimedShotEffect
     extraHits: 0
     fireStacksOnHit: 10

--- a/Resources/Prototypes/_RMC14/Entities/Tiles/tile_fire.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Tiles/tile_fire.yml
@@ -134,7 +134,7 @@
   - type: DamageOnCollide
     damage:
       types:
-        Heat: 100 #TODO make this 200 after adding a way to prevent being hit by multiple shots if you stand in between tiles
+        Heat: 200
   - type: RMCIgniteOnCollide
     maxStacks: 5
     intensity: 75

--- a/Resources/Prototypes/_RMC14/Entities/Tiles/tile_fire.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Tiles/tile_fire.yml
@@ -134,7 +134,7 @@
   - type: DamageOnCollide
     damage:
       types:
-        Heat: 200
+        Heat: 100 #TODO make this 200 after adding a way to prevent being hit by multiple shots if you stand in between tiles
   - type: RMCIgniteOnCollide
     maxStacks: 5
     intensity: 75

--- a/Resources/Prototypes/_RMC14/Entities/Tiles/tile_fire.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Tiles/tile_fire.yml
@@ -134,12 +134,10 @@
   - type: DamageOnCollide
     damage:
       types:
-        Heat: 100
+        Heat: 200
   - type: RMCIgniteOnCollide
     maxStacks: 5
-    tileDamage:
-      types:
-        Heat: 0.13
+    intensity: 75
   - type: TileFire
     duration: 5
   - type: PointLight


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

- The CAS laser cannon now deals twice as much initial damage on a direct hit.
- Resisting fire is now half as effective, making it so you have to drop and roll twice for most fire sources.(green and CAS laser fires still require only one).
- The fire damage over time applied by projectiles now deals 50% more damage per second.
- You now take double damage if a fire tile spawns below you and you don't move, previously you had to move before the game would notice you were on a fire tile.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity. The fire damage from projectiles and CAS laser is currently lower than in CM13.

- Getting hit directly by the CAS laser cannon now deals 200 damage up from 100,
- Stepping into a fire tile from the CAS laser now instantly inflicts 75 damage.

## Technical details
<!-- Summary of code changes for easier review. -->
The OnIgniteOnProjectileHit method passed the wrong values to the Ignite method, it passed Stacks(default value of 20) as intensity and intensity(default value of 30) as duration. Now it passes the proper values, making it so the intensity of all projectiles using the default IgniteOnProjectileHitComponent(almost all of them) now have an intensity of 30 instead of 20. Their duration is now also 20 instead of 30.

I halved the amount of seconds the firestacks would be reduced while resisting from 2 to 1, effectively making to so you remove 10 firestacks per resist instead of 20. You lose 10 stacks per second for 1 second, instead of the previous 10 stacks per second for 2 seconds.

You now receive the SteppingOnFireComponent even if the tile failed to ignite you.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->


https://github.com/user-attachments/assets/f6f12c44-b707-4a85-84f1-3d9c7aafaf1b



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Dygon
- tweak: Resisting fire(Drop and Roll) is now half as effective as before, it now removes 10 fire stacks instead of 20.
- tweak: A direct hit from the CAS laser now deals 200 damage instead of 100, walking into a laser fire tile deals 75 damage.
- fix: Fire from incendiary projectiles now deals 50% more damage.
- fix: You no longer need to move before you start taking double fire damage when a fire tile spawns below you.
- fix: Fortifying as a defender while on a fire tile no longer prevents taking double fire damage.
