### PR TITLE
Fix error when dying as a boiler

### DIFF
--- a/Content.Server/_RMC14/Xenonids/XenoRoleSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/XenoRoleSystem.cs
@@ -83,6 +83,9 @@ public sealed class XenoRoleSystem : EntitySystem
 
     private void OnPlayerDetached(Entity<XenoComponent> xeno, ref PlayerDetachedEvent args)
     {
+        if(TerminatingOrDeleted(xeno))
+            return;
+
         var disconnected = EnsureComp<XenoDisconnectedComponent>(xeno);
         disconnected.At = _timing.CurTime;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The game now checks if an entity is being terminated or deleted before trying to add the XenoDisconnectedComponent when a player's ghost leaves a xeno.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
No CL
