### PR TITLE
Nerf M79 & Buff M83 Firerates

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m79_grenade_launcher.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m79_grenade_launcher.yml
@@ -18,7 +18,7 @@
     soundGunshot:
       path: /Audio/_RMC14/Weapons/Guns/Gunshots/m79_shoot.ogg
   - type: RMCSelectiveFire
-    baseFireRate: 0.833
+    baseFireRate: 0.3125
   - type: BallisticAmmoProvider
     whitelist:
       tags:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m83_grenade_launcher.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m83_grenade_launcher.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   name: M83 grenade launcher
   parent: [ RMCBaseWeaponGrenadeLauncher ]
   id: WeaponLauncherM83
@@ -23,7 +23,7 @@
   #- type: Clothing
   #  sprite: _RMC14/Objects/Weapons/Guns/GrenadeLaunchers/m83inhands.rsi
   - type: RMCSelectiveFire
-    baseFireRate: 0.3125
+    baseFireRate: 0.833
   - type: GunUserWhitelist
     whitelist:
       components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Swaps the baseFireRate yml entry in the M79 and M83 with each other. 

M79 was 0.833 => Now 0.3125
M83 was 0.3125 => Now 0.833
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
M79 is accessable and usable by ALL MARINES
- Six are usually stocked in requisitions
- Any Marine can buy one for 30 points from their barracks vender
- No additional skill checks are needed to use it optimally
- Limit of use is by requisition's budget. If req does not hand out enough grenades then the marine is SOL.

M79 is better than the Weapon specialist's M83
- Firerate is faster than M83
- Reload speed is mechanically capped at how fast you can cycle thru keybindings
- Wield delay is the same for both M83 and M79
- It is common to see Grenadier Weapon Specialists take a M79 from Requisitions into battle instead of their Special M83 gun that only they can use and is un-meltable.
## Technical details
<!-- Summary of code changes for easier review. -->
Swaps the numbered used in: 

m79_grenade_lancher.yml
type: RMCSelectiveFire
         baseFireRate: 0.833 [OLD => 0.3125]

m83_grenade_launcher.yml
type: RMCSelectiveFire
         baseFireRate: 0.3125 [OLD => 0.833]

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/4ae97f78-f45a-4b08-996d-fbf10e8200bb


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The M79 and M83 grenade launchers' fire rates are swapped with each other.