### PR TITLE
Add new migrations and fix hybrisa/fiorina loot

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/under_attachments.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/under_attachments.yml
@@ -706,6 +706,7 @@
   id: RMCAttachmentLaserLightModule
   name: MK80 laser-light module
   description: A Laser-Light module for the MK80 Service Pistol which is currently undergoing limited field testing as part of the marines' next generation pistol program. All MK80 pistols come equipped with the module.
+  suffix: DO NOT MAP
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/command.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/command.yml
@@ -290,7 +290,7 @@
       - id: RMCAttachmentUnderbarrelExtinguisher
         points: 15
       - id: RMCAttachmentMiniFlamethrower
-        points: 15 
+        points: 15
       - id: RMCAttachmentU1GrenadeLauncher
         points: 5
     - name: Barrel Attachments
@@ -605,6 +605,7 @@
   id: RMCVendorBundleXOFormal
   name: formal uniform
   description: Contains a peaked cap, formal uniform and jacket.
+  categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/Coats/coat_formal.rsi
@@ -620,6 +621,7 @@
   id: RMCVendorBundleXOShotgun
   name: M890 tactical shotgun
   description: Contains the M890 tactical shotgun and various shells.
+  categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Weapons/Guns/Shotguns/m890.rsi
@@ -635,6 +637,7 @@
   id: RMCVendorBundleMilitaryPoliceApparelCMP
   name: Essential Police Set
   description: Contains security HUD-glasses and a filled security belt.
+  categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Eyes/Glasses/security_glasses.rsi
@@ -892,7 +895,7 @@
       - id: ClothingEyesGlassesMeson # TODO change to CM13 engi goggles.
       - id: RMCNailgunTactical
       # TODO KN5500/2 PDA
-     
+
     - name: Uniform
       jobs:
       - CMChiefEngineer
@@ -939,7 +942,7 @@
       - id: RMCBeltUtilityGeneral
       - id: CMBeltUtilityFilled
         name: M276 pattern toolbelt rig (Full)
-       
+
     - name: Pouches
       jobs:
       - CMChiefEngineer
@@ -1257,14 +1260,14 @@
         recommended: true
       - id: CMWebbing
     - name: Spare Equipment
-      jobs: 
+      jobs:
       - CMCMO
       entries:
       - id: CMHeadsetMedical
         amount: 15
       - id: CMHeadsetResearcher
         amount: 15
-        
+
 
     # ////////////////////////////////////
     # Auxiliary Support Officer
@@ -1312,7 +1315,7 @@
       - id: CMHeadCapPeakedService
         recommended: true
       - id: CMHeadBeretTan
-        recommended: true  
+        recommended: true
     - name: Combat Equipment
       jobs:
       - CMAuxiliarySupportOfficer

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -1138,3 +1138,8 @@ ToxinChemistryBottle: ChemistryBottleToxin
 
 # 2025-04-14
 PlantBag: RMCStoragePlantBag
+
+# 2025-05-04
+CrateTrashCart: RMCTrashCart
+RMCVendorBundleXOShotgun: WeaponShotgunM890
+RMCAttachmentLaserLightModule: RMCAttachmentLaserSight

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -1142,4 +1142,3 @@ PlantBag: RMCStoragePlantBag
 # 2025-05-04
 CrateTrashCart: RMCTrashCart
 RMCVendorBundleXOShotgun: WeaponShotgunM890
-RMCAttachmentLaserLightModule: RMCAttachmentLaserSight


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- Adds trash cart to RMC trash cat migration, some upstream trash carts are still mapped
- Adds XO bundle m890 to m890, the mapper on fiorina made a mistake and it spawns the XO bundle entity instead of the thing
- Remove sintegrated laser sight from hybrisa, replaces it with a lasersight
- Adds DO NOT MAP suffix to the MK80 laser sight
- Adds hide spawn menu tags on some vendor bundles.

**Changelog**

:cl:
- fix: Fixed the M890 tactical shotgun on Fiorina being a ghost item.
- fix: Fixed the MK80 attachment spawning on Hybrisa.