### PR TITLE
[Fix] input "human" being able to use xenonid thrust attack

### DIFF
--- a/Content.Client/Input/ContentContexts.cs
+++ b/Content.Client/Input/ContentContexts.cs
@@ -148,7 +148,7 @@ namespace Content.Client.Input
             human.AddFunction(CMKeyFunctions.RMCRest);
 
             //Xenonid
-            var xenonid = contexts.New("xenonid","human")
+            var xenonid = contexts.New("xenonid", "human");
             xenonid.AddFunction(CMKeyFunctions.CMXenoWideSwing);
         }
     }

--- a/Content.Client/Input/ContentContexts.cs
+++ b/Content.Client/Input/ContentContexts.cs
@@ -147,8 +147,9 @@ namespace Content.Client.Input
             human.AddFunction(CMKeyFunctions.RMCInteractWithOtherHand);
             human.AddFunction(CMKeyFunctions.RMCRest);
 
-            //Xeno
-            human.AddFunction(CMKeyFunctions.CMXenoWideSwing);
+            //Xenonid
+            var xenonid = contexts.New("xenonid","human")
+            xenonid.AddFunction(CMKeyFunctions.CMXenoWideSwing);
         }
     }
 }

--- a/Resources/Locale/en-US/_RMC14/escape-menu/options-menu.ftl
+++ b/Resources/Locale/en-US/_RMC14/escape-menu/options-menu.ftl
@@ -15,6 +15,6 @@ ui-options-function-rmc-pick-up-dropped-items = Pick up dropped items
 ui-options-function-rmc-interact-with-other-hand = Interact with other hand
 ui-options-function-rmc-rest = Rest
 
-ui-options-header-rmc-xeno = Xeno
+ui-options-header-rmc-xeno = Xenonid
 
-ui-options-function-cm-xeno-wide-swing = Xeno wide swing
+ui-options-function-cm-xeno-wide-swing = Xenonid thrust attack

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
@@ -81,7 +81,7 @@
   - type: Climbing
   - type: Insulated
   - type: Input
-    context: "human"
+    context: "xenonid"
   - type: Clickable
   - type: InteractionOutline
   - type: InputMover


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
fixes a bug/oversight from #5276.
made a new input context "Xenonid" that parents from the input context "human"

changed CMXenoBase input context from "human" to "Xenonid"

changed the xenonid control options and category names from "Xeno" to "Xenonid"
changed the "Xeno wide swing" name to "Xenonid thrust attack", as to reflect the semi recent change, that switched xenonids wideswing to a thrust instead.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
fixes
## Technical details
<!-- Summary of code changes for easier review. -->
`    var xenonid = contexts.New("xenonid", "human");`
this makes the new xenonid input parent from the human input, which means that xenonids input are unchanged.

`human.AddFunction(CMKeyFunctions.CMXenoWideSwing);`
got changed to 
`xenonid.AddFunction(CMKeyFunctions.CMXenoWideSwing);`
this is moves the xeno thrust attack to only things with the xenonid input
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Changed the option name "Xeno wide swing" to "Xenonid thrust attack".
<!-- fix: Fixed non Xenonids being able to use the Xenonid thrust attack while unarmed.
