### PR TITLE
Fix airburst grenades not bouncing at the proper angle, and their projectiles always having the over penetration penalty

### DIFF
--- a/Content.Server/Explosion/Components/ProjectileGrenadeComponent.cs
+++ b/Content.Server/Explosion/Components/ProjectileGrenadeComponent.cs
@@ -4,7 +4,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Server.Explosion.Components;
 /// <summary>
-/// Grenades that, when triggered, explode into projectiles
+///     Grenades that, when triggered, explode into projectiles
 /// </summary>
 [RegisterComponent, Access(typeof(ProjectileGrenadeSystem), typeof(RMCProjectileGrenadeSystem))]
 public sealed partial class ProjectileGrenadeComponent : Component
@@ -12,7 +12,7 @@ public sealed partial class ProjectileGrenadeComponent : Component
     public Container Container = default!;
 
     /// <summary>
-    /// The kind of projectile that the prototype is filled with.
+    ///     The kind of projectile that the prototype is filled with.
     /// </summary>
     [DataField]
     public EntProtoId? FillPrototype;
@@ -35,14 +35,20 @@ public sealed partial class ProjectileGrenadeComponent : Component
     public bool RandomAngle = false;
 
     /// <summary>
-    /// The minimum speed the projectiles may come out at
+    ///     The minimum speed the projectiles may come out at
     /// </summary>
     [DataField]
     public float MinVelocity = 2f;
 
     /// <summary>
-    /// The maximum speed the projectiles may come out at
+    ///     The maximum speed the projectiles may come out at
     /// </summary>
     [DataField]
     public float MaxVelocity = 6f;
+
+    /// <summary>
+    ///     The amount of payload projectiles that should hit on a direct hit.
+    /// </summary>
+    [DataField]
+    public int DirectHitProjectiles = 5;
 }

--- a/Content.Server/Explosion/Components/RMCProjectileGrenadeComponent.cs
+++ b/Content.Server/Explosion/Components/RMCProjectileGrenadeComponent.cs
@@ -18,10 +18,10 @@ public sealed partial class ProjectileGrenadeComponent
     public float DirectionAngle = -90;
 
     /// <summary>
-    ///     The degrees added to the direction angle when the grenade rebounds
+    ///     How many seconds after rebounding the projectile should be triggered.
     /// </summary>
     [DataField]
-    public float ReboundAngle = 180;
+    public float ReboundTimer = 0.05f;
 
     /// <summary>
     ///     The angle of the projectile spray

--- a/Content.Server/Explosion/EntitySystems/ProjectileGrenadeSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ProjectileGrenadeSystem.cs
@@ -62,6 +62,11 @@ public sealed class ProjectileGrenadeSystem : EntitySystem
         var grenadeCoord = _transformSystem.GetMapCoordinates(uid);
         var shootCount = 0;
         var totalCount = component.Container.ContainedEntities.Count + component.UnspawnedCount;
+
+        // RMC14 it was sometimes dividing by 0.
+        if(totalCount == 0)
+            return;
+
         var segmentAngle = 360 / totalCount;
 
         _spawned.Clear();

--- a/Content.Server/Explosion/EntitySystems/ProjectileGrenadeSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ProjectileGrenadeSystem.cs
@@ -64,9 +64,10 @@ public sealed class ProjectileGrenadeSystem : EntitySystem
         var totalCount = component.Container.ContainedEntities.Count + component.UnspawnedCount;
 
         // RMC14 it was sometimes dividing by 0.
-        if(totalCount == 0)
+        if(totalCount <= 0)
             return;
 
+        var hitEntities = new List<EntityUid>();
         var segmentAngle = 360 / totalCount;
 
         _spawned.Clear();
@@ -82,11 +83,16 @@ public sealed class ProjectileGrenadeSystem : EntitySystem
                 angle = Angle.FromDegrees(_random.Next(angleMin, angleMax));
 
                 // RMC14
-                var ev = new FragmentIntoProjectilesEvent(contentUid, totalCount, angle, shootCount);
+                var ev = new FragmentIntoProjectilesEvent(contentUid, totalCount, angle, shootCount, hitEntities);
                 RaiseLocalEvent(uid, ref ev);
 
+                if(ev.TotalCount <= 0)
+                    return;
                 if (ev.Handled)
+                {
+                    hitEntities = ev.HitEntities;
                     angle = ev.Angle;
+                }
                 shootCount++;
             }
 
@@ -98,7 +104,7 @@ public sealed class ProjectileGrenadeSystem : EntitySystem
             _spawned.Add(contentUid);
         }
 
-        var clusterEv = new CMClusterSpawnedEvent(_spawned);
+        var clusterEv = new CMClusterSpawnedEvent(_spawned, hitEntities, uid);
         RaiseLocalEvent(uid, ref clusterEv);
         RaiseLocalEvent(uid,
             new AmmoShotEvent

--- a/Content.Server/Explosion/EntitySystems/RMCProjectileGrenadeSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/RMCProjectileGrenadeSystem.cs
@@ -1,18 +1,30 @@
 using Content.Server.Explosion.Components;
+using Content.Shared._RMC14.Armor;
+using Content.Shared._RMC14.Explosion;
 using Content.Shared._RMC14.Weapons.Ranged.IFF;
+using Content.Shared.Damage;
 using Content.Shared.Explosion.Components;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Mobs.Systems;
 using Content.Shared.Projectiles;
 using Robust.Server.GameObjects;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Random;
+using Robust.Shared.Timing;
 
 namespace Content.Server.Explosion.EntitySystems;
 
 public sealed class RMCProjectileGrenadeSystem : EntitySystem
 {
+    private readonly List<EntityUid> _hitEntities = new();
+
     [Dependency] private readonly IRobustRandom _random = default!;
-    [Dependency] private readonly TransformSystem _transformSystem = default!;
+    [Dependency] private readonly TransformSystem _transform = default!;
     [Dependency] private readonly GunIFFSystem _gunIFF = default!;
+    [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
+    [Dependency] private readonly DamageableSystem _damage = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
 
     public override void Initialize()
     {
@@ -42,10 +54,20 @@ public sealed class RMCProjectileGrenadeSystem : EntitySystem
     /// </summary>
     private void OnFragmentIntoProjectiles(Entity<ProjectileGrenadeComponent> ent, ref FragmentIntoProjectilesEvent args)
     {
-        args.Handled = true;
+        if (args.ShootCount == 0)
+        {
+            _hitEntities.Clear();
+            var directHit = DirectHit(ent, args.ContentUid, args.TotalCount);
+            if (directHit != null)
+            {
+                args.HitEntities = _hitEntities;
+                args.TotalCount = directHit.Value;
+            }
+        }
 
+        args.Handled = true;
         var segmentAngle = ent.Comp.SpreadAngle / args.TotalCount;
-        var projectileRotation = _transformSystem.GetMoverCoordinateRotation(ent.Owner, Transform(ent.Owner)).worldRot.Degrees + ent.Comp.DirectionAngle;
+        var projectileRotation = _transform.GetMoverCoordinateRotation(ent.Owner, Transform(ent.Owner)).worldRot.Degrees + ent.Comp.DirectionAngle;
 
         // Give the same IFF faction and enabled state to the projectiles shot from the grenade
         if (ent.Comp.InheritIFF)
@@ -65,12 +87,53 @@ public sealed class RMCProjectileGrenadeSystem : EntitySystem
             args.Angle = Angle.FromDegrees(_random.Next((int)angleMin, (int)angleMax));
     }
 
+    // Directly hit any entities close enough to the grenade.
+    private int? DirectHit(Entity<ProjectileGrenadeComponent> ent, EntityUid payloadUid,  int projectileCount)
+    {
+        if (!TryComp(payloadUid, out ProjectileComponent? projectile))
+            return null;
+
+        var nearbyEntities = _entityLookup.GetEntitiesInRange<MobStateComponent>(Transform(ent).Coordinates, 0.5f);
+        var armorPiercing = 0;
+
+        foreach (var entity in nearbyEntities)
+        {
+            if (_mobState.IsDead(entity))
+                continue;
+
+            // Deal damage directly and remove projectiles from the grenade
+            var newProjectileCount = projectileCount - ent.Comp.DirectHitProjectiles;
+            var damage = projectile.Damage * ent.Comp.DirectHitProjectiles;
+            if (newProjectileCount < 0)
+                damage += projectile.Damage * newProjectileCount;
+
+            if (TryComp(payloadUid, out CMArmorPiercingComponent? armorPiercingComp))
+                armorPiercing = armorPiercingComp.Amount;
+
+            projectileCount = Math.Max(newProjectileCount, 0);
+            _damage.TryChangeDamage(entity, damage, armorPiercing: armorPiercing);
+
+            // Make sure the leftover projectiles don't hit the entity that was hit directly
+            if (!TryComp(entity, out UserLimitHitsComponent? limit))
+                continue;
+
+            _hitEntities.Add(entity);
+            limit.HitBy.Add(new Hit(GetNetEntity(ent.Owner), _timing.CurTime + limit.Expire));
+            Dirty(entity,limit);
+
+            if(projectileCount == 0)
+                break;
+        }
+
+        return projectileCount;
+    }
+
     public override void Update(float frametime)
     {
         var query = EntityQueryEnumerator<ProjectileGrenadeComponent, PhysicsComponent>();
         while (query.MoveNext(out var projectileUid, out _, out var physics))
         {
-            _transformSystem.SetWorldRotationNoLerp(projectileUid, physics.LinearVelocity.ToWorldAngle());
+            _transform.SetWorldRotationNoLerp(projectileUid, physics.LinearVelocity.ToWorldAngle());
         }
     }
 }
@@ -79,4 +142,4 @@ public sealed class RMCProjectileGrenadeSystem : EntitySystem
 ///     Raised when a projectile grenade is being triggered
 /// </summary>
 [ByRefEvent]
-public record struct FragmentIntoProjectilesEvent(EntityUid ContentUid, int TotalCount, Angle Angle, int ShootCount, bool Handled = false);
+public record struct FragmentIntoProjectilesEvent(EntityUid ContentUid, int TotalCount, Angle Angle, int ShootCount, List<EntityUid> HitEntities, bool Handled = false);

--- a/Content.Shared/_RMC14/Atmos/SharedRMCFlammableSystem.cs
+++ b/Content.Shared/_RMC14/Atmos/SharedRMCFlammableSystem.cs
@@ -101,7 +101,6 @@ public abstract class SharedRMCFlammableSystem : EntitySystem
         SubscribeLocalEvent<TileFireOnTriggerComponent, CMExplosiveTriggeredEvent>(OnTileFireOnTriggerExplosive);
 
         SubscribeLocalEvent<DirectionalTileFireOnTriggerComponent, RMCTriggerEvent>(OnDirectionTileFireTriggered);
-        SubscribeLocalEvent<DirectionalTileFireOnTriggerComponent, RMCProjectileReboundEvent>(OnProjectileRebounded);
 
         SubscribeLocalEvent<RMCIgniteOnCollideComponent, StartCollideEvent>(OnIgniteCollide);
         SubscribeLocalEvent<RMCIgniteOnCollideComponent, DamageCollideEvent>(OnIgniteDamageCollide);
@@ -272,15 +271,6 @@ public abstract class SharedRMCFlammableSystem : EntitySystem
 
         SpawnFireCone(ent, tile, ent.Comp.Intensity, ent.Comp.Duration);
         QueueDel(ent);
-    }
-
-    private void OnProjectileRebounded(Entity<DirectionalTileFireOnTriggerComponent> ent,
-        ref RMCProjectileReboundEvent args)
-    {
-        var originalDirection = ent.Comp.Direction.ToAngle().Degrees;
-        ent.Comp.Direction = Angle.FromDegrees(originalDirection + args.ReboundAngle).GetDir();
-        ent.Comp.Rebounded = true;
-        Dirty(ent);
     }
 
     private void OnTileFireOnTriggerExplosive(Entity<TileFireOnTriggerComponent> ent, ref CMExplosiveTriggeredEvent args)

--- a/Content.Shared/_RMC14/Explosion/CMClusterSpawnedEvent.cs
+++ b/Content.Shared/_RMC14/Explosion/CMClusterSpawnedEvent.cs
@@ -1,4 +1,4 @@
 ﻿namespace Content.Shared._RMC14.Explosion;
 
 [ByRefEvent]
-public readonly record struct CMClusterSpawnedEvent(List<EntityUid> Spawned);
+public readonly record struct CMClusterSpawnedEvent(List<EntityUid> Spawned, List<EntityUid> HitEntities, EntityUid OriginEntity);

--- a/Content.Shared/_RMC14/Explosion/ProjectileLimitHitsComponent.cs
+++ b/Content.Shared/_RMC14/Explosion/ProjectileLimitHitsComponent.cs
@@ -3,11 +3,13 @@
 namespace Content.Shared._RMC14.Explosion;
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-[Access(typeof(CMClusterGrenadeSystem))]
 public sealed partial class ProjectileLimitHitsComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public int Id;
+    public List<EntityUid> IgnoredEntities = new ();
+
+    [DataField, AutoNetworkedField]
+    public EntityUid OriginEntity;
 
     [DataField, AutoNetworkedField]
     public int Limit = 1;

--- a/Content.Shared/_RMC14/Explosion/UserLimitHitsComponent.cs
+++ b/Content.Shared/_RMC14/Explosion/UserLimitHitsComponent.cs
@@ -5,7 +5,6 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 namespace Content.Shared._RMC14.Explosion;
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-[Access(typeof(CMClusterGrenadeSystem))]
 public sealed partial class UserLimitHitsComponent : Component
 {
     [DataField, AutoNetworkedField]
@@ -18,7 +17,7 @@ public sealed partial class UserLimitHitsComponent : Component
 [DataRecord]
 [Serializable, NetSerializable]
 public partial record struct Hit(
-    int Id,
+    NetEntity Id,
     [field: DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
     TimeSpan ExpireAt
 );

--- a/Content.Shared/_RMC14/Projectiles/RMCProjectileReboundEvent.cs
+++ b/Content.Shared/_RMC14/Projectiles/RMCProjectileReboundEvent.cs
@@ -1,4 +1,0 @@
-namespace Content.Shared._RMC14.Projectiles;
-
-[ByRefEvent]
-public record struct RMCProjectileReboundEvent(float ReboundAngle);

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m74_airburst_grenades.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m74_airburst_grenades.yml
@@ -145,7 +145,7 @@
     soundHit:
       path: /Audio/Effects/gen_hit.ogg
   - type: ClusterLimitHits
-    limit: 5
+    limit: 0
   - type: CMExplosionEffect
     maxShrapnel: 0
   - type: ContainerContainer

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m74_airburst_grenades.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m74_airburst_grenades.yml
@@ -157,10 +157,9 @@
         shape:
           !type:PhysShapeAabb
           bounds: "-0.15,-0.45,0.15,0.15"
-        hard: false
         mask:
-        - Impassable
-        - BulletImpassable
+        - ItemMask
+        restitution: 1
   - type: IgnorePredictionHide
 
 - type: entity
@@ -276,7 +275,7 @@
     sound: /Audio/Effects/smoke.ogg
   - type: DeleteOnTrigger
 
-#Payloads
+#Payload projectiles
 - type: entity
   parent: RMCBaseBullet
   id: RMCStarShellBullet


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Rebound:
- Airburst grenades now rebound at the angle of incidence when they collide instead of always rebounding at 180 degrees.
- Airburst grenades now collide with the same things a normal grenade shot from a launcher would.

Projectile spawning:
- If an airburst projectile detonates on top of an entity, it will now deal the damage of 5 projectiles and remove 5 projectiles from the total projectiles in the grenade. Any leftover projectiles will ignore the directly hit target.
- There is no hit limit of 5 projectiles per target anymore if the grenade didn't directly hit the target.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity.

When I ported over the airburst grenades, I accidentally always gave them the over penetration behavior instead of only when directly hitting an entity.

## Technical details
<!-- Summary of code changes for easier review. -->
The direction of an airburst grenade is now changed every tick using the projectile's velocity.
Instead of adding 180 degrees to the angle when the grenade collides, it now uses the physics system to bounce when colliding in the same way as an entity thrown at a wall would.

The mask is changed to ItemMask instead of Impassable | BulletImpassable and it's fixture is now hard.

When a projectile grenade spawns it's first projectile, it will now search for any entity within 1 tile and remove 5 projectiles from the total projectiles it contains per found entity.  Entities found this way are added to a list that prevents them from being hit by any leftover projectiles from the same projectile grenade.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- tweak: Airburst grenades now rebound at the angle of incidence instead of always rebounding at 180 degrees.
- fix: Airburst grenade projectiles now receive the overpenetration penalty only when a target is directly impacted by the grenade. For example, with the Hornet grenade, you can potentially hit all 15 projectiles if you aim directly in front of a target, instead of the previous limit of 5.