### PR TITLE
Rollerbed Misc/fixes

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Furniture/rollerbeds.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Furniture/rollerbeds.yml
@@ -5,7 +5,29 @@
   id: CMRollerBed
 
 - type: entity
-  parent: RollerBed
+  id: RMCRollerBedDestruction
+  abstract: true
+  components:
+  - type: Damageable
+    damageContainer: StructuralMarine
+    damageModifierSet: StructuralMarine
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: ReceiverXenoClaws
+    minimumClawStrength: Normal
+    hitsToDestroy: 1
+  - type: Construction
+    graph: RMCRollerBed
+    node: Metal
+
+- type: entity
+  parent: [ RMCRollerBedDestruction, RollerBed ]
   id: CMRollerBed
   name: roller bed
   description: A collapsed roller bed that can be carried around.
@@ -50,6 +72,9 @@
     slots:
     - suitstorage
   - type: RMCStrapNoDrawDepthChange
+  - type: PhysicalComposition
+    materialComposition:
+      RMCPlastic: 250
 
 - type: entity
   parent: CMRollerBed
@@ -80,6 +105,11 @@
       map: [ "buckledLayer" ]
       visible: false
   - type: Appearance
+  - type: ReceiverXenoClaws
+    minimumClawStrength: ImpossiblySharp
+  - type: PhysicalComposition
+    materialComposition:
+      RMCPlastic: 300
 
 - type: entity
   parent: CMPortableSurgicalBed
@@ -93,7 +123,7 @@
 
 # Copied most of RollerBed prototype except for pullable
 - type: entity
-  parent: [ BaseDeployFoldable ]
+  parent: [ RMCRollerBedDestruction, BaseDeployFoldable ]
   id: RMCMedevacStretcher
   name: medevac stretcher
   description: A collapsible stretcher that can be activated to send patients to an overhead dropship.
@@ -168,6 +198,12 @@
   - type: Tag
     tags:
     - CMRollerItem
+  - type: ReceiverXenoClaws 
+    minimumClawStrength: ImpossiblySharp
+  - type: PhysicalComposition
+    materialComposition:
+      RMCPlastic: 250
+      CMSteel: 133
 
 - type: entity
   parent: RMCMedevacStretcher

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Furniture/rollerbeds.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Furniture/rollerbeds.yml
@@ -72,9 +72,6 @@
     slots:
     - suitstorage
   - type: RMCStrapNoDrawDepthChange
-  - type: PhysicalComposition
-    materialComposition:
-      RMCPlastic: 250
 
 - type: entity
   parent: CMRollerBed
@@ -107,9 +104,6 @@
   - type: Appearance
   - type: ReceiverXenoClaws
     minimumClawStrength: ImpossiblySharp
-  - type: PhysicalComposition
-    materialComposition:
-      RMCPlastic: 300
 
 - type: entity
   parent: CMPortableSurgicalBed
@@ -200,10 +194,6 @@
     - CMRollerItem
   - type: ReceiverXenoClaws 
     minimumClawStrength: ImpossiblySharp
-  - type: PhysicalComposition
-    materialComposition:
-      RMCPlastic: 250
-      CMSteel: 133
 
 - type: entity
   parent: RMCMedevacStretcher

--- a/Resources/Prototypes/_RMC14/Recipes/Construction/Graphs/Furniture/rollerbeds.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Construction/Graphs/Furniture/rollerbeds.yml
@@ -1,0 +1,25 @@
+- type: constructionGraph
+  id: RMCRollerBed
+  start: start
+  graph:
+    - node: start
+      actions:
+        - !type:DeleteEntity {}
+    - node: Metal  #for normal rollerbed
+      edges:
+      - to: start
+        completed:
+          - !type:SpawnPrototype
+            prototype: CMSheetMetal1
+            amount: 1
+        steps:
+          - tool: Anchoring
+    - node: Plasteel  #for heavy rollerbed
+      edges:
+      - to: start
+        completed:
+          - !type:SpawnPrototype
+            prototype: CMSheetPlasteel1
+            amount: 1
+        steps:
+          - tool: Anchoring


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- fixes rollerbeds dropping upstream metal.
- adds construction graph for rollerbeds, allowing you to deconstruct them with a wrench.

sadly due to a bug from upstream with foldables in general, some of the changes won't actually work until thats fixed, these changes includes. https://github.com/space-wizards/space-station-14/issues/37233
- Xenonids being able to destroy rollerbeds in one hit. (i was able to test that this works, if you give a weapon the XenoClaw component and attack rollerbeds)
~~- being able to insert rollerbeds into lathes to recycle them for materials.~~ removed from the PR
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
parity
fixes #6258
<!-- ## Technical details
<!-- Summary of code changes for easier review. -->

<!-- ## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: You can now deconstruct rollerbeds with a wrench.
- fix: Rollerbeds no longer drop upstream metal sheets when destroyed.
