### PR TITLE
Add burst fire delay modifier and add M4SPR custom burst mode

### DIFF
--- a/Content.Shared/_RMC14/Weapons/Ranged/RMCSelectiveFireComponent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/RMCSelectiveFireComponent.cs
@@ -69,6 +69,12 @@ public sealed partial class RMCSelectiveFireComponent : Component
     public float BaseFireRate = 1.429f;
 
     /// <summary>
+    /// This is the multiplier by of the base fire rate during burst mode. Sets the GunComponent.BurstFireRate.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float BurstFireRateMultiplier = 2.0f;
+
+    /// <summary>
     /// This is the multiplier applied to the additional scatter added by a SelectiveFireModifierSet with UseBurstScatterMult set to true.
     /// Conversion from 13 guns: burst_scatter_mult
     /// </summary>

--- a/Content.Shared/_RMC14/Weapons/Ranged/RMCSelectiveFireSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/RMCSelectiveFireSystem.cs
@@ -107,7 +107,7 @@ public sealed class RMCSelectiveFireSystem : EntitySystem
         gunComponent.AngleIncrease = gun.Comp.ScatterIncrease;
         gunComponent.AngleDecay = gun.Comp.ScatterDecay;
 
-        var ev = new GunGetFireRateEvent(gunComponent.SelectedMode == SelectiveFire.Burst ? gun.Comp.BaseFireRate * 2 : gun.Comp.BaseFireRate);
+        var ev = new GunGetFireRateEvent(gunComponent.SelectedMode == SelectiveFire.Burst ? gun.Comp.BaseFireRate * gun.Comp.BurstFireRateMultiplier : gun.Comp.BaseFireRate);
         RaiseLocalEvent(gun, ref ev);
         gunComponent.FireRate = ev.FireRate;
 

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m4spr_scout_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m4spr_scout_rifle.yml
@@ -18,11 +18,20 @@
   - type: RMCSelectiveFire
     baseFireModes:
     - SemiAuto
+    - Burst
     recoilWielded: 1
     recoilUnwielded: 4
     scatterWielded: 2.5
     scatterUnwielded: 8
     baseFireRate: 1.8
+    burstFireRateMultiplier: 15
+    modifiers:
+      Burst:
+        # fireDelay: 0.01
+        maxScatterModifier: 10
+        useBurstScatterMult: true
+        unwieldedScatterMultiplier: 2
+        shotsToMaxScatter: 6
   - type: RMCWeaponAccuracy
     accuracyMultiplier: 1.1
   - type: GunDamageModifier
@@ -34,9 +43,11 @@
     heavy: 1
   - type: Gun
     shotsPerBurst: 2
+    burstCooldown: 0.75
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto
+    - Burst
     soundGunshot:
       path: /Audio/_RMC14/Weapons/Guns/Gunshots/gun_m4spr.ogg
   - type: GunUserWhitelist


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
From CM13

## Technical details
Added a new BurstFireRateMultiplier, 2 by default
This is so the scout rifle bullets during burst can shoot during the same time

## Media

https://github.com/user-attachments/assets/26039e47-e7ec-4830-a3af-15c797572fc3




:cl:
- tweak: The M4SPR custom scout rifle now has a quick 2-shot burst.
