### PR TITLE
Increase the duration of the slow and daze effects applied by tesla turrets

### DIFF
--- a/Content.Shared/_RMC14/Sentry/TeslaCoil/TeslaCoilComponent.cs
+++ b/Content.Shared/_RMC14/Sentry/TeslaCoil/TeslaCoilComponent.cs
@@ -49,11 +49,11 @@ public sealed partial class RMCTeslaCoilComponent : Component
     /// Duration of the Daze effect. If TimeSpan.Zero, daze is not applied.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public TimeSpan DazeDuration = TimeSpan.FromSeconds(8);
+    public TimeSpan DazeDuration = TimeSpan.FromSeconds(10);
 
     /// <summary>
     /// Duration of the Slowdown (superslow) effect. If TimeSpan.Zero, slow is not applied.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public TimeSpan SlowDuration = TimeSpan.FromSeconds(4);
+    public TimeSpan SlowDuration = TimeSpan.FromSeconds(6);
 }

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Sentries/tesla.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Sentries/tesla.yml
@@ -221,3 +221,4 @@
     fireDelay: 3
     stunDuration: 2
     slowDuration: 0
+    dazeDuration: 15


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

- Super slow duration of all tesla turrets that slow increased from 4 to 6 seconds.
- Daze duration of all tesla turrets, except the overclocked tesla, increased from 8 to 10 seconds.
- Daze duration of the overclocked tesla increased from 8 to 15 seconds.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix: Fixed the duration of the slow and daze effects applied by tesla turrets being too low. Super slow 4 > 6, daze 8 > 10 for most and 8 > 15 for the overclocked.
