### PR TITLE
Fix the Vanguard's pierce ability doing twice as much damage as intended

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Pierce/XenoPierceSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Pierce/XenoPierceSystem.cs
@@ -13,6 +13,7 @@ using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
+using Robust.Shared.Timing;
 
 namespace Content.Shared._RMC14.Xenonids.Pierce;
 
@@ -31,6 +32,7 @@ public sealed class XenoPierceSystem : EntitySystem
     [Dependency] private readonly RMCActionsSystem _rmcActions = default!;
     [Dependency] private readonly LineSystem _line = default!;
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
 
     private readonly HashSet<EntityUid> _pierceEnts = new();
 
@@ -41,7 +43,7 @@ public sealed class XenoPierceSystem : EntitySystem
 
     private void OnXenoPierceAction(Entity<XenoPierceComponent> xeno, ref XenoPierceActionEvent args)
     {
-        if (args.Handled)
+        if (args.Handled || _timing.IsFirstTimePredicted)
             return;
 
         if (!_rmcActions.TryUseAction(xeno, args.Action))

--- a/Content.Shared/_RMC14/Xenonids/Pierce/XenoPierceSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Pierce/XenoPierceSystem.cs
@@ -35,6 +35,7 @@ public sealed class XenoPierceSystem : EntitySystem
     [Dependency] private readonly IGameTiming _timing = default!;
 
     private readonly HashSet<EntityUid> _pierceEnts = new();
+    private readonly HashSet<EntityUid> _hitEnts = new();
 
     public override void Initialize()
     {
@@ -77,6 +78,7 @@ public sealed class XenoPierceSystem : EntitySystem
 
         EntityUid? hitEnt = null;
 
+        _hitEnts.Clear();
         foreach (var tile in tiles)
         {
             _pierceEnts.Clear();
@@ -85,6 +87,9 @@ public sealed class XenoPierceSystem : EntitySystem
 
             foreach (var ent in _pierceEnts)
             {
+                if (_hitEnts.Contains(ent))
+                    continue;
+
                 if (!_interaction.InRangeUnobstructed(entTile, ent, xeno.Comp.Range.Float()))
                     continue;
 
@@ -105,7 +110,7 @@ public sealed class XenoPierceSystem : EntitySystem
                 hits++;
 
                 var change = _damage.TryChangeDamage(ent, xeno.Comp.Damage, origin: xeno, armorPiercing: xeno.Comp.AP, tool: xeno);
-
+                _hitEnts.Add(ent);
                 if (change?.GetTotal() > FixedPoint2.Zero)
                 {
                     var filter = Filter.Pvs(ent, entityManager: EntityManager).RemoveWhereAttachedEntity(o => o == xeno.Owner);

--- a/Content.Shared/_RMC14/Xenonids/Pierce/XenoPierceSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Pierce/XenoPierceSystem.cs
@@ -43,7 +43,7 @@ public sealed class XenoPierceSystem : EntitySystem
 
     private void OnXenoPierceAction(Entity<XenoPierceComponent> xeno, ref XenoPierceActionEvent args)
     {
-        if (args.Handled || _timing.IsFirstTimePredicted)
+        if (args.Handled || !_timing.IsFirstTimePredicted)
             return;
 
         if (!_rmcActions.TryUseAction(xeno, args.Action))


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The Vanguard's pierce ability now doesn't hit the same target twice.
Before this PR the same target could be hit twice, making an unarmored target take 90 damage in one hit instead of 45, and regenerating the shield even if you only hit only one target.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfix.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Dygon
- fix: Fix the Vanguard's pierce ability dealing twice as much damage as intended