### PR TITLE
Ghost marine HUD toggle now hides health bars

### DIFF
--- a/Content.Server/_RMC14/Mobs/CMGhostSystem.cs
+++ b/Content.Server/_RMC14/Mobs/CMGhostSystem.cs
@@ -34,6 +34,8 @@ namespace Content.Server._RMC14.Mobs
             _actions.AddAction(uid, ref comp.FindParasiteEntity, comp.FindParasite);
 
             EnsureComp<ShowMarineIconsComponent>(uid);
+            var bars = EnsureComp<ShowHealthBarsComponent>(uid);
+            bars.DamageContainers.Add("Biological");
             EnsureComp<ShowHealthIconsComponent>(uid);
             EnsureComp<CMGhostXenoHudComponent>(uid);
         }
@@ -46,12 +48,15 @@ namespace Content.Server._RMC14.Mobs
             {
                 RemComp<ShowMarineIconsComponent>(uid);
                 RemCompDeferred<ShowHealthIconsComponent>(uid);
+                RemCompDeferred<ShowHealthBarsComponent>(uid);
                 _actions.SetToggled(comp.ToggleMarineHudEntity, true);
             }
             else
             {
                 AddComp<ShowMarineIconsComponent>(uid);
                 EnsureComp<ShowHealthIconsComponent>(uid);
+                var bars = EnsureComp<ShowHealthBarsComponent>(uid);
+                bars.DamageContainers.Add("Biological");
                 _actions.SetToggled(comp.ToggleMarineHudEntity, false);
             }
         }

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -67,9 +67,6 @@
     radius: 6
     enabled: false
   - type: ActiveInputMover
-  - type: ShowHealthBars
-    damageContainers:
-    - Biological
   - type: GhostColor
   # RMC - FindParasite Event
   - type: FindParasite


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The thing preventing this was fixed (probably on upstream) at some point so it just works. fixes #6125

## Technical details
<!-- Summary of code changes for easier review. -->
Just removing it in the observer and putting the stuff in the ghostsystem.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed ghost marine HUD toggle action not hiding marine health bars.