### PR TITLE
Fix crate misprediction

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
@@ -216,7 +216,7 @@
     - multiplier: 0.645
       whitelist:
         components:
-        - ResistLocker #Lockers/Crates
+        - RequisitionsCrate #Lockers/Crates
   - type: MobThresholds
     thresholds:
       0: Alive


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The ``ResistLocker`` component was serverside only, which was causing the misprediction (thank you @Vermidia for discovering this)
Makes it use a shared component, RequsitionsCrate


:cl:
- fix: Fixed crate drag slowdown mispredicting. (Rubberbanding when you pull them)
