### PR TITLE
Fix getting rooted crashing your client

### DIFF
--- a/Content.Shared/_RMC14/Movement/TemporarySpeedModifiersSystem.cs
+++ b/Content.Shared/_RMC14/Movement/TemporarySpeedModifiersSystem.cs
@@ -107,7 +107,7 @@ public sealed class TemporarySpeedModifiersSystem : EntitySystem
     /// <returns>Null or a float representing the calculated speed multiplier</returns>
     public float? CalculateSpeedModifier(EntityUid uid, float modifier, MovementSpeedModifierComponent? movement = null)
     {
-        if (!Resolve(uid, ref movement))
+        if (!Resolve(uid, ref movement) || movement.CurrentSprintSpeed == 0)
             return null;
 
         var currentSpeed = movement.CurrentSprintSpeed;

--- a/Content.Shared/_RMC14/Slow/RMCSlowSystem.cs
+++ b/Content.Shared/_RMC14/Slow/RMCSlowSystem.cs
@@ -26,9 +26,9 @@ public sealed class RMCSlowSystem : EntitySystem
         SubscribeLocalEvent<RMCSuperSlowdownComponent, ComponentStartup>(OnAdded);
         SubscribeLocalEvent<RMCRootedComponent, ComponentStartup>(OnAdded);
 
-        SubscribeLocalEvent<RMCSlowdownComponent, ComponentRemove>(OnExpire);
-        SubscribeLocalEvent<RMCSuperSlowdownComponent, ComponentRemove>(OnExpire);
-        SubscribeLocalEvent<RMCRootedComponent, ComponentRemove>(OnExpire);
+        SubscribeLocalEvent<RMCSlowdownComponent, ComponentShutdown>(OnExpire);
+        SubscribeLocalEvent<RMCSuperSlowdownComponent, ComponentShutdown>(OnExpire);
+        SubscribeLocalEvent<RMCRootedComponent, ComponentShutdown>(OnExpire);
 
         SubscribeLocalEvent<RMCSlowdownComponent, RejuvenateEvent>(OnRejuvenate);
         SubscribeLocalEvent<RMCSuperSlowdownComponent, RejuvenateEvent>(OnRejuvenate);
@@ -107,7 +107,7 @@ public sealed class RMCSlowSystem : EntitySystem
             EnsureComp<XenoImmobileVisualsComponent>(ent);
     }
 
-    private void OnExpire<T>(Entity<T> ent, ref ComponentRemove args) where T : IComponent
+    private void OnExpire<T>(Entity<T> ent, ref ComponentShutdown args) where T : IComponent
     {
         if (!TerminatingOrDeleted(ent))
             _speed.RefreshMovementSpeedModifiers(ent);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Thanks @Vermidia for noticing this bug. and figuring out what caused it.

Movement speed won't be modified if it's 0.
Slows and root removal logic is now handled on ComponentShutDown again instead of ComponentRemove.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

No CL as the bug is not on live yet
