### PR TITLE
Fix clothing speed modifers not being calculated properly after a slow ends

### DIFF
--- a/Content.Shared/_RMC14/Slow/RMCSlowSystem.cs
+++ b/Content.Shared/_RMC14/Slow/RMCSlowSystem.cs
@@ -30,6 +30,10 @@ public sealed class RMCSlowSystem : EntitySystem
         SubscribeLocalEvent<RMCSuperSlowdownComponent, ComponentShutdown>(OnExpire);
         SubscribeLocalEvent<RMCRootedComponent, ComponentShutdown>(OnExpire);
 
+        SubscribeLocalEvent<RMCSlowdownComponent, ComponentRemove>(OnRemove);
+        SubscribeLocalEvent<RMCSuperSlowdownComponent, ComponentRemove>(OnRemove);
+        SubscribeLocalEvent<RMCRootedComponent, ComponentRemove>(OnRemove);
+
         SubscribeLocalEvent<RMCSlowdownComponent, RejuvenateEvent>(OnRejuvenate);
         SubscribeLocalEvent<RMCSuperSlowdownComponent, RejuvenateEvent>(OnRejuvenate);
         SubscribeLocalEvent<RMCRootedComponent, RejuvenateEvent>(OnRejuvenate);
@@ -109,8 +113,6 @@ public sealed class RMCSlowSystem : EntitySystem
 
     private void OnExpire<T>(Entity<T> ent, ref ComponentShutdown args) where T : IComponent
     {
-        if (!TerminatingOrDeleted(ent))
-            _speed.RefreshMovementSpeedModifiers(ent);
         if (typeof(T) != typeof(RMCRootedComponent))
         {
             if (typeof(T) == typeof(RMCSlowdownComponent))
@@ -120,6 +122,12 @@ public sealed class RMCSlowSystem : EntitySystem
         }
         else
             MaybeRemoveStunVisuals(ent);
+    }
+
+    private void OnRemove<T>(Entity<T> ent, ref ComponentRemove args) where T : Component
+    {
+        if (!TerminatingOrDeleted(ent))
+            _speed.RefreshMovementSpeedModifiers(ent);
     }
 
     private void OnRejuvenate<T>(Entity<T> ent, ref RejuvenateEvent args) where T : IComponent


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Movement speed is now refreshed on ComponentRemove instead of ComponentShutdown.
This fixes clothing speed modifiers not being applied properly after being slowed.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
No CL
