### PR TITLE
Hijack hibernation + burrowed surge

### DIFF
--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
@@ -900,7 +900,7 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
 
                     var origin = _transform.GetMoverCoordinates(xeno);
 
-                    _popup.PopupCoordinates(Loc.GetString("rmc-xeno-hibernation"), origin, Filter.SinglePlayer(session), true, Shared.Popups.PopupType.MediumCaution);
+                    _popup.PopupCoordinates(Loc.GetString("rmc-xeno-hibernation"), origin, Filter.SinglePlayer(session), true, Shared.Popups.PopupType.MediumXeno);
                 }
                 QueueDel(xeno);
             }

--- a/Content.Shared/_RMC14/CCVar/RMCCVars.cs
+++ b/Content.Shared/_RMC14/CCVar/RMCCVars.cs
@@ -414,4 +414,10 @@ public sealed partial class RMCCVars : CVars
 
     public static readonly CVarDef<bool> RMCMovementBigXenosCancelMovement =
         CVarDef.Create("rmc.movement_big_xenos_cancel_movement", true, CVar.REPLICATED | CVar.SERVER);
+
+    public static readonly CVarDef<float> RMCHijackShipWeight =
+        CVarDef.Create("rmc.hijack_ship_weight", 0.5f, CVar.REPLICATED | CVar.SERVER);
+
+    public static readonly CVarDef<int> RMCMinimumHijackBurrowed =
+    CVarDef.Create("rmc.hijack_minimum_burrowed", 5, CVar.REPLICATED | CVar.SERVER);
 }

--- a/Content.Shared/_RMC14/Xenonids/Hive/HijackBurrowedSurgeComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hive/HijackBurrowedSurgeComponent.cs
@@ -1,0 +1,25 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.Hive;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class HijackBurrowedSurgeComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public TimeSpan NextSurgeAt;
+
+    [DataField, AutoNetworkedField]
+    public int PooledLarva;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan SurgeEvery = TimeSpan.FromSeconds(90);
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan ReduceSurgeBy = TimeSpan.FromSeconds(3);
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan MinSurgeTime = TimeSpan.FromSeconds(30);
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan ResetSurgeTime = TimeSpan.FromSeconds(90);
+}

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-death.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-death.ftl
@@ -2,3 +2,5 @@
 
 cm-xeno-death = Hive: {$xeno} has died at {$location}!
 cm-xeno-death-queen =  A sudden tremor ripples through the hive... the Queen has been slain! Vengeance!
+
+rmc-xeno-hibernation = The Queen has left without us. We quickly find a hiding place to enter hibernation as we lose touch with the hive mind...

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-surge.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-surge.ftl
@@ -1,2 +1,2 @@
-rmc-xeno-burrowed-surge-start = The hive swells with power! You will now steadily gain burrowed larva over time.
+rmc-xeno-burrowed-surge-start = The hive swells with power! We will now steadily gain burrowed larva over time.
 rmc-xeno-burrowed-surge-end = The hive's power wanes. We will no longer gain pooled larva over time.

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-surge.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-surge.ftl
@@ -1,0 +1,2 @@
+rmc-xeno-burrowed-surge-start = The hive swells with power! You will now steadily gain burrowed larva over time.
+rmc-xeno-burrowed-surge-end = The hive's power wanes. We will no longer gain pooled larva over time.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
parity!

## Technical details
<!-- Summary of code changes for easier review. -->
On Hijack Distress signal will now also go through xenos and delete them, ghosting players with a message. All xenos that count for slots get added as 1 burrowed for the hive.

For surge we get all the players alive on the ship that are infectable, add their role weights, and times it by a CVAR (whos value starts at 0.5) minus the amount of xenos. And we get the bigger of this vs the min value of 5 (also in a CVAR).

Once the pooled larva value is gotten a component is added to the hive to generate burrowed while a hivecore is up, reseting surge delay (which decreases as it makes burrowed) if hivecore disappears (how CM handles it because the timers are on the core). If it hits 0 or less it removes itself. There are hive announces for the start and end of the burrowed surge.

Only thing untested is if the role weight stuff works as that code has to get the job proto of each marine and spit out the roleweight.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/f6cd69c2-d64a-4c80-b8be-f1d58f6ef2c5


https://github.com/user-attachments/assets/9eda55d7-896f-4310-b69a-d655a10b747f



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed groundside xenos not becoming burrowed larva once hijack begins.
- add: Ported hijack burrowed larva surge. When hivecore is up, burrowed larva will be generated overtime depending on the initial disparity in numbers between marines and xenos. It generates slightly faster each time a new burrowed is made but speedup resets if hivecore is destroyed.
