### PR TITLE
berserker apprehend speed buff fix

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Crippling/XenoActiveCripplingStrikeComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Crippling/XenoActiveCripplingStrikeComponent.cs
@@ -11,6 +11,9 @@ public sealed partial class XenoActiveCripplingStrikeComponent : Component
     public TimeSpan ExpireAt;
 
     [DataField, AutoNetworkedField]
+    public bool NextSlashBuffed = true;
+
+    [DataField, AutoNetworkedField]
     public TimeSpan SlowDuration = TimeSpan.FromSeconds(5);
 
     [DataField, AutoNetworkedField]
@@ -18,6 +21,9 @@ public sealed partial class XenoActiveCripplingStrikeComponent : Component
 
     [DataField, AutoNetworkedField]
     public LocId HitText = "cm-xeno-crippling-strike-hit";
+
+    [DataField, AutoNetworkedField]
+    public LocId? DeactivateText;
 
     [DataField, AutoNetworkedField]
     public LocId ExpireText = "cm-xeno-crippling-strike-expire";

--- a/Content.Shared/_RMC14/Xenonids/Crippling/XenoCripplingStrikeComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Crippling/XenoCripplingStrikeComponent.cs
@@ -27,6 +27,9 @@ public sealed partial class XenoCripplingStrikeComponent : Component
     public LocId HitText = "cm-xeno-crippling-strike-hit";
 
     [DataField, AutoNetworkedField]
+    public LocId? DeactivateText;
+
+    [DataField, AutoNetworkedField]
     public LocId ExpireText = "cm-xeno-crippling-strike-expire";
 
     [DataField, AutoNetworkedField]

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
@@ -354,6 +354,7 @@ rmc-xeno-sustain-death = {CAPITALIZE(THE($xeno))} throes as its eggsac bursts in
 
 # Apprehend
 rmc-xeno-apprehend-activate = Our next slash will slow!
+rmc-xeno-apprehend-deactivate = We feel our speed wane!
 rmc-xeno-apprehend-expire = We have waited too long, our slash will no longer slow enemies!
 
 # Rage

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/ravager.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/ravager.yml
@@ -194,6 +194,7 @@
     plasmaRegenOnWeeds: 0
   - type: XenoCripplingStrike
     activateText: rmc-xeno-apprehend-activate
+    deactivateText: rmc-xeno-apprehend-deactivate
     expireText: rmc-xeno-apprehend-expire
     auraColor: "#522020"
     damageMult: 1


### PR DESCRIPTION
## About the PR
Apprehend speed buff was supposed to last for the entire duration of the ability and not removed after the attack.

Dont think i need to list it in changelog since its a fix for an update that is not out yet.

## Technical details
Since XenoActiveCripplingStrikeComponent is what keeps track of the speed buff duration i had to add a bool that is turned off after one attack, so the component can stay and apply speed buff for the rest of the ability duration.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed Berserker Ravager Apprehend bonus movement speed being removed after an attack instead of lasting for the full 5 seconds.
