### PR TITLE
Adds more Shark plushie colors

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Fun/toys.yml
@@ -32,7 +32,7 @@
 - type: entity
   parent: PlushieSharkGrey
   id: RMCPlushieSharkGrey
-  name: Grey shark soft toy
+  suffix: RMC
   components:
   - type: UseDelay
     delay: 120
@@ -46,7 +46,7 @@
 - type: entity
   parent: PlushieSharkBlue
   id: RMCPlushieSharkBlue
-  name: Blue shark soft toy
+  suffix: RMC
   components:
   - type: UseDelay
     delay: 120
@@ -60,7 +60,7 @@
 - type: entity
   parent: PlushieSharkPink
   id: RMCPlushieSharkPink
-  name: Pink shark soft toy
+  suffix: RMC
   components:
   - type: UseDelay
     delay: 120

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Fun/toys.yml
@@ -32,6 +32,35 @@
 - type: entity
   parent: PlushieSharkGrey
   id: RMCPlushieSharkGrey
+  name: Grey shark soft toy
+  components:
+  - type: UseDelay
+    delay: 120
+  - type: EmitSoundOnLand
+    sound:
+      collection: ToyFall
+  - type: EmitSoundOnCollide
+    sound:
+      collection: ToyFall
+
+- type: entity
+  parent: PlushieSharkBlue
+  id: RMCPlushieSharkBlue
+  name: Blue shark soft toy
+  components:
+  - type: UseDelay
+    delay: 120
+  - type: EmitSoundOnLand
+    sound:
+      collection: ToyFall
+  - type: EmitSoundOnCollide
+    sound:
+      collection: ToyFall
+
+- type: entity
+  parent: PlushieSharkPink
+  id: RMCPlushieSharkPink
+  name: Pink shark soft toy
   components:
   - type: UseDelay
     delay: 120

--- a/Resources/Prototypes/_RMC14/Roles/Loadouts/Items/plushies.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Loadouts/Items/plushies.yml
@@ -21,11 +21,25 @@
     - CMPlushieBee
 
 - type: loadout
-  id: PlushieSharkRMC
+  id: PlushieSharkGreyRMC
   cost: 4
   storage:
     back:
     - RMCPlushieSharkGrey
+
+- type: loadout
+  id: PlushieSharkBlueRMC
+  cost: 4
+  storage:
+    back:
+    - RMCPlushieSharkBlue
+
+- type: loadout
+  id: PlushieSharkPinkRMC
+  cost: 4
+  storage:
+    back:
+    - RMCPlushieSharkPink
 
 - type: loadout
   id: PlushieMothRMC

--- a/Resources/Prototypes/_RMC14/Roles/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Loadouts/loadout_groups.yml
@@ -196,7 +196,9 @@
   - PlushieFarwaRMC
   - PlushieBarricadeRMC
   - PlushieBeeRMC
-  - PlushieSharkRMC
+  - PlushieSharkGreyRMC
+  - PlushieSharkBlueRMC
+  - PlushieSharkPinkRMC
   - PlushieMothRMC
   - PlushieRockRMC
   - PlushieTherapyRMC


### PR DESCRIPTION
## About the PR
Shork Gang Marketing brings you More Shork Colours!

## Why / Balance
Because Shorks

## Technical details
Added the two other colours of shark that are in base ss14, Added suffix as suggested, so there is differentiation in the entity spawner.

## Media
All 3 colours
![ShorkGang](https://github.com/user-attachments/assets/a74e4d9b-c4fa-4c2f-b7d1-a3b048cddc63)
Added to the loadout screen
![Loadoutpage](https://github.com/user-attachments/assets/a5d999fa-5116-4102-bc6b-9c5e4ff5bc98)
In the enitity Spawner
![image](https://github.com/user-attachments/assets/c60e0419-d459-435f-a880-63a3b3518c3f)


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Added more shark plushie colours
