### PR TITLE
Fix ravager eviscerate not stunning if more than 3 rage

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Eviscerate/XenoEviscerateComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Eviscerate/XenoEviscerateComponent.cs
@@ -28,6 +28,9 @@ public sealed partial class XenoEviscerateComponent : Component
     public TimeSpan WindupTime = TimeSpan.FromSeconds(2);
 
     [DataField, AutoNetworkedField]
+    public TimeSpan StunTime = TimeSpan.FromSeconds(1.25);
+
+    [DataField, AutoNetworkedField]
     public TimeSpan HealDelay = TimeSpan.FromSeconds(0.05);
 
     [DataField, AutoNetworkedField]

--- a/Content.Shared/_RMC14/Xenonids/Eviscerate/XenoEviscerateSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Eviscerate/XenoEviscerateSystem.cs
@@ -124,6 +124,7 @@ public sealed class XenoEviscerateSystem : EntitySystem
             if (range > 1.5f)
             {
                 _audio.PlayPvs(xeno.Comp.RageHitSound, marine); // todo spawn gibs
+                _stun.TryParalyze(marine, xeno.Comp.StunTime, true);
             }
             else
             {

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/ravager.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/ravager.yml
@@ -212,7 +212,7 @@
     - groups:
         Brute: 70
     rangeAtRageLevels: [1.5, 1.5, 1.5, 2.5, 2.5]
-    windupReductionAtRageLevels: [0, 0.2, 4, 6, 10]
+    windupReductionAtRageLevels: [0, 0.2, 0.4, 0.6, 1]
   - type: XenoFling # TODO RMC14 target head
     range: 1.15
     enragedRange: 0.8


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Missed a line of code in CM13
![image](https://github.com/user-attachments/assets/e2f576c2-2bd5-4d54-b1bd-91c64f7fd248)
looks like get_xeno_stun_duration multiplies it by 1.25? if the target is humanoid sized

also fixes the windup time, i forgot to convert the other values from deciseconds to actual seconds 

:cl:
- fix: Fixed berserker ravager eviscerate not stunning if you have 4 or more rage.
