### PR TITLE
Fix vampire lurker and berserker healing while on fire

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Heal/SharedXenoHealSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Heal/SharedXenoHealSystem.cs
@@ -346,8 +346,11 @@ public abstract class SharedXenoHealSystem : EntitySystem
         _damageable.TryChangeDamage(target, -damage, true);
     }
 
-    public void CreateHealStacks(EntityUid target, FixedPoint2 healAmount, TimeSpan timeBetweenHeals, int charges, TimeSpan nextHealAt)
+    public void CreateHealStacks(EntityUid target, FixedPoint2 healAmount, TimeSpan timeBetweenHeals, int charges, TimeSpan nextHealAt, bool ignoreFire = false)
     {
+        if (!ignoreFire && _flammable.IsOnFire(target))
+            return;
+
         var heal = EnsureComp<XenoBeingHealedComponent>(target);
         var healStack = new XenoHealStack()
         {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I thought the heal stack component already accounted for being on fire
Adds a check to the create heal stacks method


:cl:
- fix: Fixed vampire lurker and berserker being able to heal while on fire