### PR TITLE
Fix being able to attach underbarrel flamethrowers to shotguns

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/hg3712.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/hg3712.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   parent: [ RMCBaseWeaponShotgun, RMCBaseAttachableHolder ]
   name: HG 37-12 pump shotgun
   id: RMCWeaponShotgunHG3712
@@ -63,9 +63,7 @@
           tags:
           - RMCAttachmentFlashlightGrip
           - RMCAttachmentGyroscopicStabilizer
-          - RMCAttachmentFlamer
         random:
-        - RMCAttachmentMiniFlamethrower
         - RMCAttachmentFlashlightGrip
       rmc-aslot-stock:
         locked: true

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/pump_shotgun.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/pump_shotgun.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   parent: [ RMCBaseWeaponShotgun, RMCBaseAttachableHolder ]
   name: M42A2 pump shotgun
   id: WeaponShotgunM42A2
@@ -63,7 +63,6 @@
           - RMCAttachmentFlashlightGrip
           - RMCAttachmentGyroscopicStabilizer
           - RMCAttachmentVerticalGrip
-          - RMCAttachmentFlamer
           - RMCAttachmentExtinguisher
   - type: AttachableHolderVisuals
     offsets:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/type23.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/type23.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   parent: [ RMCBaseWeaponShotgun, RMCBaseAttachableHolder ]
   name: Type 23 riot shotgun
   id: RMCWeaponShotgunType23
@@ -63,7 +63,6 @@
           tags:
           - RMCAttachmentFlashlightGrip
           - RMCAttachmentVerticalGrip
-          - RMCAttachmentFlamer
           - RMCAttachmentExtinguisher
           - RMCAttachmentBurstFireAssembly #TODO RMC14 Needs to be able to shoot 3 shells at once when this is on /similar to custombuilt etc...
   - type: AttachableHolderVisuals


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Removed the ability to attach underbarrel flamethrowers to shotguns.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity.
<!-- ## Technical details
<!-- Summary of code changes for easier review. -->

<!-- ## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed being able to attach underbarrel flamethrowers on shotguns.
