### PR TITLE
Fix deafness for real

### DIFF
--- a/Content.Client/_RMC14/Deafness/DeafnessSystem.cs
+++ b/Content.Client/_RMC14/Deafness/DeafnessSystem.cs
@@ -1,5 +1,4 @@
 using Content.Shared._RMC14.Deafness;
-using Content.Shared._RMC14.Xenonids.Acid;
 using Content.Shared.CCVar;
 using Content.Shared.StatusEffect;
 using Robust.Client.Audio;
@@ -63,20 +62,23 @@ public sealed class DeafnessSystem : SharedDeafnessSystem
 
             var lastsFor = (float)(statusTime.Item2 - statusTime.Item1).TotalSeconds;
             var timeLeft = (float)(statusTime.Item2 - curTime).TotalSeconds;
-            var timeDone = curTime - statusTime.Item1;
-
-            if (comp.FadeOutEndAt >= TimeSpan.Zero)
-                comp.FadeOutEndAt = curTime + comp.FadeOutDelay;
+            var timeDone = (float)(curTime - statusTime.Item1).TotalSeconds;
 
             var volume = 0f;
 
             var fadeOutDuration = Math.Clamp(lastsFor * 0.35f, 0.2f, 2f);
             var fadeInDuration = Math.Clamp(lastsFor * 0.15f, 0.1f, 1f);
 
-            if (timeDone <= comp.FadeOutDelay && comp.FadeOutEndAt < curTime) // Fade out during two seconds of deafness
+            if (timeDone <= 2f && !comp.DidFadeOut) // Fade out during two seconds of deafness
             {
-                var fadeOut = 1f - (float)timeDone.TotalSeconds / fadeOutDuration;
+                var fadeOut = 1f - timeDone / fadeOutDuration;
                 volume = fadeOut * _originalVolume;
+
+                if (volume <= 0.1f) // this is so audio doesn't clip out if a status
+                {
+                    volume = 0f;
+                    comp.DidFadeOut = true;
+                }
             }
             else if (timeLeft <= 1f) // Fade in during last second of deafness
             {

--- a/Content.Client/_RMC14/Deafness/DeafnessSystem.cs
+++ b/Content.Client/_RMC14/Deafness/DeafnessSystem.cs
@@ -50,7 +50,7 @@ public sealed class DeafnessSystem : SharedDeafnessSystem
         var curTime = _timing.CurTime;
 
         var query = EntityQueryEnumerator<DeafComponent>();
-        while (query.MoveNext(out var uid, out _))
+        while (query.MoveNext(out var uid, out var comp))
         {
             if (player != uid)
                 continue;
@@ -69,10 +69,16 @@ public sealed class DeafnessSystem : SharedDeafnessSystem
             var fadeOutDuration = Math.Clamp(lastsFor * 0.35f, 0.2f, 2f);
             var fadeInDuration = Math.Clamp(lastsFor * 0.15f, 0.1f, 1f);
 
-            if (timeDone <= 2f) // Fade out during two seconds of deafness
+            if (timeDone <= 2f && !comp.DidFadeOut) // Fade out during two seconds of deafness
             {
                 var fadeOut = 1f - timeDone / fadeOutDuration;
                 volume = fadeOut * _originalVolume;
+
+                if (volume <= 0.01f) // this is so audio doesn't clip out if a status effect is re-applied
+                {
+                    volume = 0f;
+                    comp.DidFadeOut = true;
+                }
             }
             else if (timeLeft <= 1f) // Fade in during last second of deafness
             {

--- a/Content.Client/_RMC14/Deafness/DeafnessSystem.cs
+++ b/Content.Client/_RMC14/Deafness/DeafnessSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared._RMC14.Deafness;
+using Content.Shared._RMC14.Xenonids.Acid;
 using Content.Shared.CCVar;
 using Content.Shared.StatusEffect;
 using Robust.Client.Audio;
@@ -62,23 +63,20 @@ public sealed class DeafnessSystem : SharedDeafnessSystem
 
             var lastsFor = (float)(statusTime.Item2 - statusTime.Item1).TotalSeconds;
             var timeLeft = (float)(statusTime.Item2 - curTime).TotalSeconds;
-            var timeDone = (float)(curTime - statusTime.Item1).TotalSeconds;
+            var timeDone = curTime - statusTime.Item1;
+
+            if (comp.FadeOutEndAt >= TimeSpan.Zero)
+                comp.FadeOutEndAt = curTime + comp.FadeOutDelay;
 
             var volume = 0f;
 
             var fadeOutDuration = Math.Clamp(lastsFor * 0.35f, 0.2f, 2f);
             var fadeInDuration = Math.Clamp(lastsFor * 0.15f, 0.1f, 1f);
 
-            if (timeDone <= 2f && !comp.DidFadeOut) // Fade out during two seconds of deafness
+            if (timeDone <= comp.FadeOutDelay && comp.FadeOutEndAt < curTime) // Fade out during two seconds of deafness
             {
-                var fadeOut = 1f - timeDone / fadeOutDuration;
+                var fadeOut = 1f - (float)timeDone.TotalSeconds / fadeOutDuration;
                 volume = fadeOut * _originalVolume;
-
-                if (volume <= 0.01f) // this is so audio doesn't clip out if a status effect is re-applied
-                {
-                    volume = 0f;
-                    comp.DidFadeOut = true;
-                }
             }
             else if (timeLeft <= 1f) // Fade in during last second of deafness
             {

--- a/Content.Client/_RMC14/Deafness/DeafnessSystem.cs
+++ b/Content.Client/_RMC14/Deafness/DeafnessSystem.cs
@@ -74,7 +74,7 @@ public sealed class DeafnessSystem : SharedDeafnessSystem
                 var fadeOut = 1f - timeDone / fadeOutDuration;
                 volume = fadeOut * _originalVolume;
 
-                if (volume <= 0.1f) // this is so audio doesn't clip out if a status
+                if (volume <= 0.1f) // this is so audio doesn't clip out if a status effect refreshes
                 {
                     volume = 0f;
                     comp.DidFadeOut = true;

--- a/Content.Server/_RMC14/Deafness/DeafnessSystem.cs
+++ b/Content.Server/_RMC14/Deafness/DeafnessSystem.cs
@@ -35,6 +35,8 @@ public sealed class DeafnessSystem : SharedDeafnessSystem
             || args.Channel == ChatChannel.Damage
             || args.Channel == ChatChannel.Visual
             || args.Channel == ChatChannel.Notifications
+            || args.Channel == ChatChannel.OOC
+            || args.Channel == ChatChannel.LOOC
         )
             return;
 

--- a/Content.Shared/_RMC14/Deafness/ActiveDeafenWhileCritComponent.cs
+++ b/Content.Shared/_RMC14/Deafness/ActiveDeafenWhileCritComponent.cs
@@ -14,7 +14,7 @@ public sealed partial class ActiveDeafenWhileCritComponent : Component
     public TimeSpan Add = TimeSpan.FromSeconds(4);
 
     [DataField, AutoNetworkedField]
-    public TimeSpan Every = TimeSpan.FromSeconds(1);
+    public TimeSpan Every = TimeSpan.FromSeconds(2);
 
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
     public TimeSpan AddAt = TimeSpan.Zero;

--- a/Content.Shared/_RMC14/Deafness/ActiveDeafenWhileCritComponent.cs
+++ b/Content.Shared/_RMC14/Deafness/ActiveDeafenWhileCritComponent.cs
@@ -11,7 +11,7 @@ namespace Content.Shared._RMC14.Deafness;
 public sealed partial class ActiveDeafenWhileCritComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public TimeSpan Add = TimeSpan.FromSeconds(2);
+    public TimeSpan Add = TimeSpan.FromSeconds(4);
 
     [DataField, AutoNetworkedField]
     public TimeSpan Every = TimeSpan.FromSeconds(1);

--- a/Content.Shared/_RMC14/Deafness/ActiveDeafenWhileCritComponent.cs
+++ b/Content.Shared/_RMC14/Deafness/ActiveDeafenWhileCritComponent.cs
@@ -11,7 +11,7 @@ namespace Content.Shared._RMC14.Deafness;
 public sealed partial class ActiveDeafenWhileCritComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public TimeSpan Add = TimeSpan.FromSeconds(6);
+    public TimeSpan Add = TimeSpan.FromSeconds(2);
 
     [DataField, AutoNetworkedField]
     public TimeSpan Every = TimeSpan.FromSeconds(1);

--- a/Content.Shared/_RMC14/Deafness/ActiveDeafenWhileCritComponent.cs
+++ b/Content.Shared/_RMC14/Deafness/ActiveDeafenWhileCritComponent.cs
@@ -11,7 +11,7 @@ namespace Content.Shared._RMC14.Deafness;
 public sealed partial class ActiveDeafenWhileCritComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public TimeSpan Add = TimeSpan.FromSeconds(4);
+    public TimeSpan Add = TimeSpan.FromSeconds(6);
 
     [DataField, AutoNetworkedField]
     public TimeSpan Every = TimeSpan.FromSeconds(1);

--- a/Content.Shared/_RMC14/Deafness/DeafComponent.cs
+++ b/Content.Shared/_RMC14/Deafness/DeafComponent.cs
@@ -14,4 +14,7 @@ public sealed partial class DeafComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public float HearChance = 0.4f;
+
+    [DataField]
+    public bool DidFadeOut = false;
 }

--- a/Content.Shared/_RMC14/Deafness/DeafComponent.cs
+++ b/Content.Shared/_RMC14/Deafness/DeafComponent.cs
@@ -7,7 +7,7 @@ namespace Content.Shared._RMC14.Deafness;
 ///     Having this component will make clients game volume 0. Will also prevent them from hearing chat.
 /// </summary>
 [Access(typeof(SharedDeafnessSystem))]
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class DeafComponent : Component
 {
     /// <summary>
@@ -16,12 +16,6 @@ public sealed partial class DeafComponent : Component
     [DataField, AutoNetworkedField]
     public float HearChance = 0.4f;
 
-    /// <summary>
-    ///     Time it takes for the audio to fully fade out.
-    /// </summary>
-    [DataField, AutoNetworkedField]
-    public TimeSpan FadeOutDelay = TimeSpan.FromSeconds(2);
-
-    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
-    public TimeSpan FadeOutEndAt;
+    [DataField]
+    public bool DidFadeOut = false;
 }

--- a/Content.Shared/_RMC14/Deafness/DeafComponent.cs
+++ b/Content.Shared/_RMC14/Deafness/DeafComponent.cs
@@ -1,4 +1,5 @@
 using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared._RMC14.Deafness;
 
@@ -6,7 +7,7 @@ namespace Content.Shared._RMC14.Deafness;
 ///     Having this component will make clients game volume 0. Will also prevent them from hearing chat.
 /// </summary>
 [Access(typeof(SharedDeafnessSystem))]
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
 public sealed partial class DeafComponent : Component
 {
     /// <summary>
@@ -15,6 +16,12 @@ public sealed partial class DeafComponent : Component
     [DataField, AutoNetworkedField]
     public float HearChance = 0.4f;
 
-    [DataField]
-    public bool DidFadeOut = false;
+    /// <summary>
+    ///     Time it takes for the audio to fully fade out.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public TimeSpan FadeOutDelay = TimeSpan.FromSeconds(2);
+
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
+    public TimeSpan FadeOutEndAt;
 }

--- a/Content.Shared/_RMC14/Deafness/SharedDeafnessSystem.cs
+++ b/Content.Shared/_RMC14/Deafness/SharedDeafnessSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Popups;
 using Content.Shared.StatusEffect;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
+using Robust.Shared.Network;
 
 namespace Content.Shared._RMC14.Deafness;
 
@@ -13,6 +14,7 @@ public abstract class SharedDeafnessSystem : EntitySystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly InventorySystem _inventory = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly INetManager _net = default!;
 
     public ProtoId<StatusEffectPrototype> DeafKey = "Deaf";
 
@@ -73,8 +75,11 @@ public abstract class SharedDeafnessSystem : EntitySystem
 
     public void DoEarLossPopups(EntityUid uid, bool end)
     {
+        if (_net.IsClient)
+            return;
+
         var msg = Loc.GetString(end ? "rmc-deaf-end" : "rmc-deaf-start");
-        _popup.PopupClient(msg, uid, uid, PopupType.MediumCaution);
+        _popup.PopupEntity(msg, uid, uid, PopupType.MediumCaution);
     }
 
     public bool HasEarProtection(EntityUid uid)
@@ -103,7 +108,7 @@ public abstract class SharedDeafnessSystem : EntitySystem
             if (comp.AddAt < time)
             {
                 comp.AddAt = time + comp.Every;
-                TryDeafen(uid, comp.Add, false, status, ignoreProtection: true);
+                TryDeafen(uid, comp.Add, true, status, ignoreProtection: true);
             }
         }
     }

--- a/Content.Shared/_RMC14/Deafness/SharedDeafnessSystem.cs
+++ b/Content.Shared/_RMC14/Deafness/SharedDeafnessSystem.cs
@@ -103,7 +103,7 @@ public abstract class SharedDeafnessSystem : EntitySystem
             if (comp.AddAt < time)
             {
                 comp.AddAt = time + comp.Every;
-                TryDeafen(uid, comp.Add, true, status, ignoreProtection: true);
+                TryDeafen(uid, comp.Add, false, status, ignoreProtection: true);
             }
         }
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Resolves #6440
Resolves #6439
Resolves #6438

Fixes all the above issues
Adds a IsServer check for the deafness popups, status effect starting isn't predicted for some reason
Adds a DidFadeOut bool for deafness so it wont fade out more than once with status effect refreshing

As you can see, the audio that plays when the buttons get hovered over does not play

https://github.com/user-attachments/assets/39f77391-861d-4f4e-ab5d-0eae193301d9




**Changelog**
:cl:
- fix: Fixed deafness audio clipping while crit.
- fix: Fixed deafness blocking LOOC messages.