### PR TITLE
Fix weather not clearing

### DIFF
--- a/Content.Shared/_RMC14/Weather/RMCWeatherCycleComponent.cs
+++ b/Content.Shared/_RMC14/Weather/RMCWeatherCycleComponent.cs
@@ -37,6 +37,9 @@ public sealed partial class RMCWeatherEvent
     public TimeSpan Duration;
 
     [DataField]
+    public TimeSpan DurationRemaining;
+
+    [DataField]
     public ProtoId<WeatherPrototype> WeatherType;
 
     [DataField]

--- a/Content.Shared/_RMC14/Weather/RMCWeatherSystem.cs
+++ b/Content.Shared/_RMC14/Weather/RMCWeatherSystem.cs
@@ -113,6 +113,7 @@ public sealed class RMCWeatherSystem : EntitySystem
                 var endTime = _timing.CurTime + weatherPick.Duration;
 
                 cycle.CurrentEvent = weatherPick;
+                cycle.CurrentEvent.DurationRemaining = weatherPick.Duration;
                 _weather.SetWeather(Transform(uid).MapID, weatherProto, endTime);
 
                 var minTimeVariance = (-cycle.MinTimeVariance * 0.5) + _random.Next(cycle.MinTimeVariance);
@@ -122,6 +123,13 @@ public sealed class RMCWeatherSystem : EntitySystem
             // Process effects for ongoing weather event
             if (cycle.CurrentEvent != null)
             {
+                cycle.CurrentEvent.DurationRemaining -= TimeSpan.FromSeconds(frameTime);
+                if (cycle.CurrentEvent.DurationRemaining <= TimeSpan.Zero)
+                {
+                    cycle.CurrentEvent = null;
+                    continue;
+                }
+
                 cycle.CurrentEvent.LightningCooldown -= TimeSpan.FromSeconds(frameTime);
                 if (cycle.CurrentEvent.LightningCooldown <= TimeSpan.Zero)
                 {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Current weather event in RMCWeather wasn't actually getting cleared when the regular weather (upstream) was over, so added a timer for weather duration which clears current weather when done.
This fixes lightning happening after the weather event was over.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug fix

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed lightning continuing to happening after weather is over

