### PR TITLE
Make acider FoH radius area parity

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/ForTheHive/SharedXenoForTheHiveSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/ForTheHive/SharedXenoForTheHiveSystem.cs
@@ -173,8 +173,8 @@ public abstract partial class SharedXenoForTheHiveSystem : EntitySystem
                     if (!TryComp<XenoEnergyComponent>(xeno, out var acid))
                         return;
 
-                    var acidRange = acid.Current / active.AcidRangeRatio;
-                    var burnRange = acid.Current / active.BurnRangeRatio;
+                    var acidRange = (float)Math.Sqrt(Math.Pow((acid.Current / active.AcidRangeRatio) * 2 + 1, 2) / Math.PI);
+                    var burnRange = (float)Math.Sqrt(Math.Pow((acid.Current / active.BurnRangeRatio) * 2 + 1, 2) / Math.PI);
 
                     var maxBurnDamage = acid.Current / active.BurnDamageRatio;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Same as other AOE moves, to make the area match parity.

## Technical details
<!-- Summary of code changes for easier review. -->
So this one I kinda had to make it do the math to get the radius so it's not just a straight up number. For reference max acid range radius is about 6.2 now from 5.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/3216dcfa-f505-41cb-b17c-f5d145a985dd



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed Acider Runner's For the Hive radius being slightly too small.