### PR TITLE
Give dropship crew and pilots access to We-ya Med and blood dispenser

### DIFF
--- a/Resources/Prototypes/_RMC14/Access/Groups/auxiliary_support_access_groups.yml
+++ b/Resources/Prototypes/_RMC14/Access/Groups/auxiliary_support_access_groups.yml
@@ -32,7 +32,6 @@
   - CMAccessCrewman
   - CMAccessMedical
 
-
 - type: accessGroup
   id: DropshipCrewChief
   tags:

--- a/Resources/Prototypes/_RMC14/Access/Groups/auxiliary_support_access_groups.yml
+++ b/Resources/Prototypes/_RMC14/Access/Groups/auxiliary_support_access_groups.yml
@@ -30,6 +30,8 @@
   - CMAccessDropship
   - CMAccessPilot
   - CMAccessCrewman
+  - CMAccessMedical
+
 
 - type: accessGroup
   id: DropshipCrewChief
@@ -38,6 +40,7 @@
   - CMAccessCommand
   - CMAccessDropship
   - CMAccessPilot
+  - CMAccessMedical
 
 - type: accessGroup
   id: IntelOfficer

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/medical.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/medical.yml
@@ -145,9 +145,7 @@
   suffix: ""
   components:
   - type: AccessReader
-    access:
-    - [ "CMAccessMedical" ]
-    - [ "CMAccessDropship" ]
+    access: [["CMAccessMedical"]]
 
 - type: entity
   parent: CMVendorMedical
@@ -340,7 +338,6 @@
   - type: AccessReader
     access:
     - [ "CMAccessMedical" ]
-    - [ "CMAccessDropship" ]
   - type: CMAutomatedVendor
     hackable: true
     sections:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/medical.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/medical.yml
@@ -145,7 +145,9 @@
   suffix: ""
   components:
   - type: AccessReader
-    access: [["CMAccessMedical"]]
+    access:
+    - [ "CMAccessMedical" ]
+    - [ "CMAccessDropship" ]
 
 - type: entity
   parent: CMVendorMedical
@@ -338,6 +340,7 @@
   - type: AccessReader
     access:
     - [ "CMAccessMedical" ]
+    - [ "CMAccessDropship" ]
   - type: CMAutomatedVendor
     hackable: true
     sections:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added Dropship access to We-Ya Med and Blood Disp

## Why / Balance
Requested as a parity feature.

## Technical details
yml change for CMVendorMedical and CMVendorBlood. 
Giving Pilot and DCC accessGroups CMAccessMedical  resulted in them having access to medical item rack, so it was not implemented.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Added medbay, We-Ya Med Plus, and Blood dispenser access to pilots and dropship crew chiefs.
