### PR TITLE
Survivor fixes

### DIFF
--- a/Content.Shared/_RMC14/Survivor/SurvivorSystem.cs
+++ b/Content.Shared/_RMC14/Survivor/SurvivorSystem.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Shared._RMC14.Armor;
 using Content.Shared.GameTicking;
+using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Inventory;
 using Content.Shared.Storage;
 using Content.Shared.Storage.EntitySystems;
@@ -18,6 +19,8 @@ public sealed class SurvivorSystem : EntitySystem
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly SharedStorageSystem _storage = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly SharedHandsSystem _hands = default!;
+
 
     public override void Initialize()
     {
@@ -49,7 +52,7 @@ public sealed class SurvivorSystem : EntitySystem
             var gear = _random.Pick(comp.PrimaryWeapons);
             foreach (var item in gear)
             {
-                Equip(mob, item);
+                Equip(mob, item, tryInHand: true);
             }
         }
 
@@ -87,7 +90,7 @@ public sealed class SurvivorSystem : EntitySystem
         }
     }
 
-    private void Equip(EntityUid mob, EntProtoId toSpawn, bool tryStorage = true)
+    private void Equip(EntityUid mob, EntProtoId toSpawn, bool tryStorage = true, bool tryInHand = false)
     {
         if (_net.IsClient)
             return;
@@ -115,6 +118,9 @@ public sealed class SurvivorSystem : EntitySystem
                         return;
                 }
             }
+
+            if (tryInHand && _hands.TryPickupAnyHand(mob, spawn))
+                return;
 
             if (_inventory.TryEquip(mob, spawn, slot.ID, true))
                 return;

--- a/Content.Shared/_RMC14/Survivor/SurvivorSystem.cs
+++ b/Content.Shared/_RMC14/Survivor/SurvivorSystem.cs
@@ -21,7 +21,6 @@ public sealed class SurvivorSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedHandsSystem _hands = default!;
 
-
     public override void Initialize()
     {
         SubscribeLocalEvent<EquipSurvivorPresetComponent, PlayerSpawnCompleteEvent>(OnPresetPlayerSpawnComplete, after: [typeof(CMArmorSystem)]);

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/squad_leader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/squad_leader.yml
@@ -65,4 +65,4 @@
   components:
   - type: SurvivorPreset
     primaryWeapons:
-    - [ WeaponShotgunM42A2, CMShellShotgunSlugs ]
+    - [ WeaponShotgunM42A2, RMCBoxShotgunSlugs ]

--- a/Resources/Textures/_RMC14/Interface/cm_job_icons.rsi/meta.json
+++ b/Resources/Textures/_RMC14/Interface/cm_job_icons.rsi/meta.json
@@ -380,9 +380,6 @@
       "name": "rmc_commander"
     },
     {
-      "name": "hudsquad_spec_sniper"
-    },
-    {
       "name": "hudsquad_vo"
     },
     {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
FORECON SL spawns with slug box instead of a stack in CM13
![image](https://github.com/user-attachments/assets/a24a65a9-5f85-4c08-9dae-4a8e222020a6)

Removes duplicate meta.json entry
Allows primary weapons to spawn inhand, like CM13
Currently if you have no suit storage or its full, the gun will not spawn

:cl:
- fix: Fixed civilian survivors not spawning with primary weapons.