### PR TITLE
Fix civilian survivor appearing naked on the character editor

### DIFF
--- a/Content.Shared/_RMC14/Survivor/SurvivorSystem.cs
+++ b/Content.Shared/_RMC14/Survivor/SurvivorSystem.cs
@@ -120,10 +120,10 @@ public sealed class SurvivorSystem : EntitySystem
 
             if (_inventory.TryEquip(mob, spawn, slot.ID, true))
                 return;
-
-            if (tryInHand && _hands.TryPickupAnyHand(mob, spawn))
-                return;
         }
+
+        if (tryInHand && _hands.TryPickupAnyHand(mob, spawn))
+            return;
 
         Log.Warning($"Couldn't equip {ToPrettyString(spawn)} on {ToPrettyString(mob)}");
         QueueDel(spawn);

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/civilian_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/civilian_survivor.yml
@@ -17,6 +17,7 @@
   ranks:
     RMCRankCivilian: []
   startingGear: RMCGearSurvivor
+  dummyStartingGear: RMCGearSurvivorEquipped
   icon: "CMJobIconEmpty"
   joinNotifyCrew: false
   supervisors: cm-job-supervisors-nobody
@@ -54,6 +55,13 @@
     ears: CMHeadsetColony
     pocket1: RMCPouchSurvivalFill
     pocket2: RMCPouchGeneral
+
+- type: startingGear
+  parent: RMCGearSurvivor
+  id: RMCGearSurvivorEquipped
+  equipment:
+    jumpsuit: CMJumpsuitColonist
+    shoes: RMCShoesBlack
 
 - type: entity
   parent: CMSpawnPointJobBase


### PR DESCRIPTION
Forgot to give them a dummy starting gear
![image](https://github.com/user-attachments/assets/ccddeb29-1d45-4b9c-91ee-bdb3d44f30b6)

also moves the gun to OUTSIDE the slot iteration loop, because it runs for every slot so if it fails to equip it'll put inhand
