### PR TITLE
Fire stack and fire intensity fixes.

### DIFF
--- a/Content.Shared/_RMC14/Atmos/IgniteOnProjectileHitComponent.cs
+++ b/Content.Shared/_RMC14/Atmos/IgniteOnProjectileHitComponent.cs
@@ -8,9 +8,6 @@ namespace Content.Shared._RMC14.Atmos;
 public sealed partial class IgniteOnProjectileHitComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public int Stacks = 20;
-
-    [DataField, AutoNetworkedField]
     public int Intensity = 30;
 
     [DataField, AutoNetworkedField]

--- a/Content.Shared/_RMC14/Atmos/SharedRMCFlammableSystem.cs
+++ b/Content.Shared/_RMC14/Atmos/SharedRMCFlammableSystem.cs
@@ -118,7 +118,7 @@ public abstract class SharedRMCFlammableSystem : EntitySystem
 
     private void OnIgniteOnProjectileHit(Entity<IgniteOnProjectileHitComponent> ent, ref ProjectileHitEvent args)
     {
-        Ignite(args.Target, ent.Comp.Stacks, ent.Comp.Intensity, ent.Comp.Duration, false);
+        Ignite(args.Target, ent.Comp.Intensity, ent.Comp.Duration, ent.Comp.Duration, false);
     }
 
     private void OnTileFireMapInit(Entity<TileFireComponent> ent, ref MapInitEvent args)
@@ -674,14 +674,14 @@ public abstract class SharedRMCFlammableSystem : EntitySystem
         if (!Resolve(flammableEnt, ref flammableEnt.Comp, false))
             return;
 
+        EnsureComp<SteppingOnFireComponent>(other);
+
         var wasOnFire = IsOnFire(flammableEnt);
         if (checkIgnited && wasOnFire)
             return;
 
         if (!Ignite(flammableEnt, ent.Comp.Intensity, ent.Comp.Duration, ent.Comp.MaxStacks))
             return;
-
-        EnsureComp<SteppingOnFireComponent>(other);
 
         if (!wasOnFire && IsOnFire(flammableEnt) && !HasComp<RMCImmuneToFireTileDamageComponent>(ent))
             _damageable.TryChangeDamage(flammableEnt, flammableEnt.Comp.Damage * ent.Comp.Intensity, true);

--- a/Content.Shared/_RMC14/Projectiles/Aimed/AimedProjectileSystem.cs
+++ b/Content.Shared/_RMC14/Projectiles/Aimed/AimedProjectileSystem.cs
@@ -77,7 +77,7 @@ public sealed class AimedProjectileSystem : EntitySystem
         // Apply firestacks
         if (TryComp(ent, out IgniteOnProjectileHitComponent? ignite))
         {
-            ignite.Stacks += aimedEffect.FireStacksOnHit;
+            ignite.Duration += aimedEffect.FireStacksOnHit;
         }
     }
 

--- a/Resources/Prototypes/_RMC14/Entities/Objects/PowerLoader/Dropship/rmc_dropship_ammo.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/PowerLoader/Dropship/rmc_dropship_ammo.yml
@@ -184,6 +184,4 @@
       max: 50
     fire:
       type: RMCTileFireNapalm
-      intensity: 60
-      duration: 30
       range: 3

--- a/Resources/Prototypes/_RMC14/Entities/Objects/PowerLoader/Dropship/rmc_dropship_laser_cannon.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/PowerLoader/Dropship/rmc_dropship_laser_cannon.yml
@@ -60,7 +60,5 @@
     fire:
       type: RMCTileFireLaser
       range: 3
-      intensity: 75
-      duration: 5
       total: 16
     deleteOnEmpty: true

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m74_airburst_grenades.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m74_airburst_grenades.yml
@@ -313,7 +313,7 @@
     radius: 2.0
     energy: 7.0
   - type: IgniteOnProjectileHit
-    stacks: 2
+    intensity: 2
 
 - type: entity
   parent: RMCBaseBullet

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Snipers/m96s_sniper.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Snipers/m96s_sniper.yml
@@ -215,7 +215,6 @@
   - type: CMArmorPiercing
     amount: 20
   - type: IgniteOnProjectileHit
-    stacks: 40
   - type: AimedShotEffect
     extraHits: 0
     fireStacksOnHit: 10

--- a/Resources/Prototypes/_RMC14/Entities/Tiles/tile_fire.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Tiles/tile_fire.yml
@@ -35,6 +35,7 @@
     tags:
     - HideContextMenu
   - type: RMCIgniteOnCollide
+    maxStacks: 20
     tileDamage:
       types:
         Heat: 0.5
@@ -109,6 +110,7 @@
   - type: PointLight
     color: "#8fcbeb"
   - type: RMCIgniteOnCollide
+    maxStacks: 70
     intensity: 80
     duration: 70
   - type: TileFire
@@ -138,6 +140,8 @@
         Heat: 100
   - type: RMCIgniteOnCollide
     maxStacks: 5
+    intensity: 75
+    duration: 5
     tileDamage:
       types:
         Heat: 0.13
@@ -160,3 +164,6 @@
   components:
   - type: TileFire
     duration: 30
+  - type: RMCIgniteOnCollide
+    maxStacks: 60
+    intensity: 60


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- The fire damage over time applied by projectiles now deals 50% more damage per second.
- Fire from the flamer, incendiary airburst and molotov now applies 20 fire stacks instead of 45.
- The fire from a napalm rocket now applies 45 fire stacks instead of 30.
- You now take double damage if a fire tile spawns below you and you don't move, previously you had to move before the game would notice you were on a fire tile.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug fix and parity.

I set the max stacks the default tile fire can apply to 20 instead of it having no limit, which meant it would be limited to 45 by the FlammableComponent. 20 stacks means you need to drop and roll 2 times instead of 4(by the time you roll a fourth time 5 firestacks will be removed over time already). Previously this bug wasn't noticed as dropping and rolling wrongly removed 20 stacks instead of 10.

The napalm rocket fire and the incendiary OB fire now apply 45 firestacks, which means you need to drop and roll 4 times to extinguish it.

## Technical details
<!-- Summary of code changes for easier review. -->
The OnIgniteOnProjectileHit method passed the wrong values to the Ignite method, it passed Stacks(default value of 20) as intensity and intensity(default value of 30) as duration. Now it passes the proper values, making it so the intensity of all projectiles using the default IgniteOnProjectileHitComponent(almost all of them) now have an intensity of 30 instead of 20. Their duration is now also 20 instead of 30.

Regular tile fires were applying their duration multiple times until the cap of 45 set by the FlammableComponent on the lit entity was reached, it is now capped at 20 stacks. 

An entity now receives the SteppingOnFireComponent even if the tile failed to ignite it, making it so the entity receives double fire damage when they don't move after a fire tile spawns below it.

I moved the intensity and duration of the laser and napalm fire from the DropshipAmmoComponent to the fire tile prototype.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Dygon
- fix: Fixed fire from incendiary projectiles dealing 50% less damage than intended and having a 33% longer duration than intended.
- fix: You no longer need to move before you start taking double fire damage when a fire tile spawns below you.
- fix: Fixed fortifying as a defender while on a fire tile preventing taking double fire damage.
- fix: The fire effect applied by fire tiles spawned from the AGM-99 'Napalm' now lasts 50% longer, making it harder to extinguish.
