### PR TITLE
Forecon co fix

### DIFF
--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
@@ -705,7 +705,7 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
                         }
                     }
                 }
-;
+
                 var selectedSurvivors = 0;
                 for (var i = priorities - 1; i >= 0; i--)
                 {

--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
@@ -705,14 +705,15 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
                         }
                     }
                 }
-
+;
                 var selectedSurvivors = 0;
                 for (var i = priorities - 1; i >= 0; i--)
                 {
                     foreach (var (job, players) in survivorCandidates)
                     {
                         var list = players[i];
-                        while (list.Count > 0 && selectedSurvivors < totalSurvivors)
+                        var ignoreLimit = comp.IgnoreMaximumSurvivorJobs.Contains(job);
+                        while (list.Count > 0 && (ignoreLimit || selectedSurvivors < totalSurvivors))
                         {
                             if (SpawnSurvivor(job, list, out var stop) is { } id)
                             {
@@ -724,7 +725,8 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
                                     }
                                 }
 
-                                selectedSurvivors++;
+                                if (!ignoreLimit)
+                                    selectedSurvivors++;
                             }
 
                             if (stop)

--- a/Content.Shared/_RMC14/Rules/CMDistressSignalRuleComponent.cs
+++ b/Content.Shared/_RMC14/Rules/CMDistressSignalRuleComponent.cs
@@ -112,6 +112,9 @@ public sealed partial class CMDistressSignalRuleComponent : Component
     };
 
     [DataField]
+    public List<ProtoId<JobPrototype>> IgnoreMaximumSurvivorJobs = new() { "RMCSurvivorForeconCommander" };
+
+    [DataField]
     public Dictionary<ProtoId<JobPrototype>, List<(ProtoId<JobPrototype> Insert, int Amount)>>? SurvivorJobInserts;
 
     [DataField]

--- a/Resources/Prototypes/_RMC14/Entities/rmc_planets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/rmc_planets.yml
@@ -98,8 +98,6 @@
       CMSurvivorDoctor: RMCSurvivorForeconBase
       CMSurvivorEngineer: RMCSurvivorForeconBase
       CMSurvivorSecurity: RMCSurvivorForeconBase
-    ignoreSurvivorMaximumLimitJobs: # todo synth
-    - RMCSurvivorCommandingOfficer
 
 - type: entity
   id: RMCPlanetHybrisa

--- a/Resources/Prototypes/_RMC14/Entities/rmc_planets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/rmc_planets.yml
@@ -80,8 +80,8 @@
     camouflage: Classic
     announcement: "Pan-Pan. This is the commanding officer of the UNS Hanyut, UNMC FORECON. We are currently grounded on planet LV-522 in the immediate area of Chance's Claim. We are unable to contact the Hanyut and our dropships are unable to take off at this time. We are requesting assistance from any nearby vessels; this broadcast is set to repeat every 24 hours."
     survivorJobs:
-    - RMCSurvivorForeconBase: 7
     - RMCSurvivorCommandingOfficer: 1
+    - RMCSurvivorForeconBase: 7
     survivorJobInserts:
       RMCSurvivorCommandingOfficer:
       - RMCSurvivorForeconCommander: -1
@@ -98,6 +98,8 @@
       CMSurvivorDoctor: RMCSurvivorForeconBase
       CMSurvivorEngineer: RMCSurvivorForeconBase
       CMSurvivorSecurity: RMCSurvivorForeconBase
+    ignoreSurvivorMaximumLimitJobs: # todo synth
+    - RMCSurvivorCommandingOfficer
 
 - type: entity
   id: RMCPlanetHybrisa


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
FORECON CO should always spawn if someone is rolling it.
Adds a list with jobs that ignore the maximum surv cvar, and restructures the chances claim map list to make forecon commander roll first

:cl:
- fix: Fixed FORECON CO not being rolled first.
- fix: Fixed FORECON CO not being ignoring the maximum survivor limit.
