### PR TITLE
Fix FORECON CO icon not appearing

### DIFF
--- a/Content.Server/_RMC14/Marines/MarineSystem.cs
+++ b/Content.Server/_RMC14/Marines/MarineSystem.cs
@@ -1,5 +1,34 @@
 ﻿using Content.Shared._RMC14.Marines;
+using Content.Shared.GameTicking;
+using Content.Shared.Roles;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
 
 namespace Content.Server._RMC14.Marines;
 
-public sealed class MarineSystem : SharedMarineSystem;
+public sealed class MarineSystem : SharedMarineSystem
+{
+    [Dependency] private readonly IPrototypeManager _prototypes = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<MarineComponent, PlayerSpawnCompleteEvent>(OnPlayerSpawning);
+    }
+
+    private void OnPlayerSpawning(Entity<MarineComponent> ent, ref PlayerSpawnCompleteEvent args)
+    {
+        if (args.JobId is not { } jobId)
+            return;
+
+        if (!_prototypes.TryIndex<JobPrototype>(jobId, out var job) || !job.IsCM)
+            return;
+
+        SpriteSpecifier? icon = null;
+        if (job.HasIcon && _prototypes.TryIndex(job.Icon, out var jobIcon))
+            icon = jobIcon.Icon;
+
+        MakeMarine(args.Mob, icon);
+    }
+}

--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
@@ -851,13 +851,6 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
                 ev.SpawnResult = _stationSpawning.SpawnPlayerMob(coordinates, ev.Job, ev.HumanoidCharacterProfile, ev.Station);
             }
 
-            // TODO RMC14 split this out with an event
-            SpriteSpecifier? icon = null;
-            if (job.HasIcon && _prototypes.TryIndex(job.Icon, out var jobIcon))
-                icon = jobIcon.Icon;
-
-            _marines.MakeMarine(ev.SpawnResult.Value, icon);
-
             if (squad != null)
             {
                 _squad.AssignSquad(ev.SpawnResult.Value, squad.Value, jobId);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
(for some reason when i used spawn as job the icon worked so uh thats how i didnt notice this)

Restructures some marine icon changing, moves it out of distress signal as per the note
It broke because there isnt a valid job spawner for the CO yet, so it just doesnt give it the icon.

## Media
![image](https://github.com/user-attachments/assets/241306c3-2c6b-460a-8353-5cd326ac934b)

:cl:
- fix: Fixed FORECON CO icon not appearing.
