### PR TITLE
reword forecon commander

### DIFF
--- a/Resources/Locale/en-US/_RMC14/job/command.ftl
+++ b/Resources/Locale/en-US/_RMC14/job/command.ftl
@@ -21,8 +21,7 @@ CMJobExecutiveOfficer = Executive Officer
 
 # Special forces
 rmc-job-prefix-forecon = FORECON
-rmc-job-prefix-forecon-co = FORECON CO
-
+rmc-job-prefix-forecon-co = FORECON Maj.
 # Admin only right now.
 cm-job-name-high-command = High Command
 

--- a/Resources/Locale/en-US/_RMC14/job/command.ftl
+++ b/Resources/Locale/en-US/_RMC14/job/command.ftl
@@ -21,7 +21,8 @@ CMJobExecutiveOfficer = Executive Officer
 
 # Special forces
 rmc-job-prefix-forecon = FORECON
-rmc-job-prefix-forecon-co = FORECON Maj.
+rmc-job-prefix-forecon-co = FORECON Cmdr.
+
 # Admin only right now.
 cm-job-name-high-command = High Command
 

--- a/Resources/Locale/en-US/_RMC14/job/survivor.ftl
+++ b/Resources/Locale/en-US/_RMC14/job/survivor.ftl
@@ -30,8 +30,8 @@ rmc-job-greeting-forecon = You are UNMC Force Reconnaissance (FORECON) marine fr
 
   You are [bold][color=#51A16C][font size=16]NON-HOSTILE to the UNMC![/font][/color][/bold]
 
-rmc-job-name-survivor-co = Survivor CO
-rmc-job-description-survivor-co = You are a commanding officer of the UNMC.
+rmc-job-name-survivor-co = FORECON Commander
+rmc-job-description-survivor-co = You are a Major of the UNMC.
 
 rmc-job-name-forecon = FORECON Survivor
 rmc-job-description-forecon = You are a stranded UNMC Forecon marine. Your ship, the UNS Hanyut, crashed and you are stranded on the planet. Do what it takes to survive!

--- a/Resources/Locale/en-US/_RMC14/job/survivor.ftl
+++ b/Resources/Locale/en-US/_RMC14/job/survivor.ftl
@@ -30,7 +30,7 @@ rmc-job-greeting-forecon = You are UNMC Force Reconnaissance (FORECON) marine fr
 
   You are [bold][color=#51A16C][font size=16]NON-HOSTILE to the UNMC![/font][/color][/bold]
 
-rmc-job-name-survivor-co = FORECON Commander
+rmc-job-name-survivor-co = Survivor Commander
 rmc-job-description-survivor-co = You are a Major of the UNMC.
 
 rmc-job-name-forecon = FORECON Survivor

--- a/Resources/Prototypes/_RMC14/Entities/rmc_planets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/rmc_planets.yml
@@ -78,7 +78,7 @@
   - type: RMCPlanetMapPrototype
     map: /Maps/_RMC14/chances.yml
     camouflage: Classic
-    announcement: "Pan-Pan. This is the commanding officer of the UNS Hanyut, UNMC FORECON. We are currently grounded on planet LV-522 in the immediate area of Chance's Claim. We are unable to contact the Hanyut and our dropships are unable to take off at this time. We are requesting assistance from any nearby vessels; this broadcast is set to repeat every 24 hours."
+    announcement: "Pan-Pan. This is the commander of the UNS Hanyut, UNMC FORECON. We are currently grounded on planet LV-522 in the immediate area of Chance's Claim. We are unable to contact the Hanyut and our dropships are unable to take off at this time. We are requesting assistance from any nearby vessels; this broadcast is set to repeat every 24 hours."
     survivorJobs:
     - RMCSurvivorCommandingOfficer: 1
     - RMCSurvivorForeconBase: 7

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/commander.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/commander.yml
@@ -67,7 +67,7 @@
 - type: entity
   parent: CMSpawnPointJobBase
   id: CMSpawnPointForeconCommander
-  name: commanding officer spawn point
+  name: FORECON Commander spawn point
   components:
   - type: SpawnPoint
     job_id: RMCSurvivorForeconCommander


### PR DESCRIPTION
Changes Forecon CO to be a Forecon Commander/Major

Reduces a lot of bloat in marine SOP / CO guidelines by not considering them a "Commanding Officer" by title or permissions.

"High ranking officers" (Major+) have been given their own permissions and SOP in place of this, which only needs to dictate the additional rights they receive rather than also what they do not.

This was done so I don't need to write what they're not allowed to do while not being the commanding officer of the ship but being a commanding officer. If that sounds confusing, it will make sense why I added this.

*This is still a whitelisted role only accessible by CO whitelisted players.

![image](https://github.com/user-attachments/assets/b52ec778-a625-4d9c-8ec4-058590a32b53)
