### PR TITLE
Make CO actually ignore the maximum survivor limit

### DIFF
--- a/Content.Shared/_RMC14/Rules/CMDistressSignalRuleComponent.cs
+++ b/Content.Shared/_RMC14/Rules/CMDistressSignalRuleComponent.cs
@@ -112,7 +112,7 @@ public sealed partial class CMDistressSignalRuleComponent : Component
     };
 
     [DataField]
-    public List<ProtoId<JobPrototype>> IgnoreMaximumSurvivorJobs = new() { "RMCSurvivorForeconCommander" };
+    public List<ProtoId<JobPrototype>> IgnoreMaximumSurvivorJobs = new() { "RMCSurvivorCommandingOfficer" };
 
     [DataField]
     public Dictionary<ProtoId<JobPrototype>, List<(ProtoId<JobPrototype> Insert, int Amount)>>? SurvivorJobInserts;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
ok so i used the FORECON commander prototype instead of the base survivor CO prototype, in the candidate selection code it uses the original (which is base survivor CO, not the FORECON commander), not the insert so it never ignored the limit

it wasnt that bad though since atleast CO rolled first
now FORECON should PROPERLY have 1 CO and 7 FORECON marines (8 if we ever increase max survivor count), and 1 FORECON synth when we get that.

i am sorry for having to fix so much shit oh ym goodness

:cl:
- fix: Actually fixed FORECON commander not ignoring the max survivor limit.
