### PR TITLE
Add a spawn as job menu name for job prototypes, fix FORECON names

### DIFF
--- a/Content.Server/Administration/Systems/AdminVerbSystem.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.cs
@@ -180,7 +180,7 @@ namespace Content.Server.Administration.Systems
                             foreach (var job in _prototypeManager.EnumerateCM<JobPrototype>())
                             {
                                 var ev = new SpawnAsJobDialogEvent(GetNetEntity(args.User), GetNetEntity(args.Target), job.ID);
-                                jobs.Add(new DialogOption(job.LocalizedName, ev));
+                                jobs.Add(new DialogOption(job.SpawnMenuRoleName ?? job.LocalizedName, ev));
                             }
 
                             jobs.Sort((a, b) => string.Compare(a.Text, b.Text, StringComparison.Ordinal));

--- a/Content.Shared/_RMC14/Marines/Roles/JobPrototype.cs
+++ b/Content.Shared/_RMC14/Marines/Roles/JobPrototype.cs
@@ -39,6 +39,9 @@ public sealed partial class JobPrototype : IInheritingPrototype, ICMSpecific
     public readonly string? OverwatchRoleName;
 
     [DataField]
+    public readonly string? SpawnMenuRoleName;
+
+    [DataField]
     public readonly Dictionary<ProtoId<RankPrototype>, HashSet<JobRequirement>?>? Ranks;
 
     [DataField]

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/WeYa/standard.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/WeYa/standard.yml
@@ -13,6 +13,7 @@
   accessGroups:
   - Colony
   - RMCWeYa
+  spawnMenuRoleName: WEYA PMC Operator (M63B2)
   special:
   - !type:AddComponentSpecial
     components:
@@ -98,6 +99,7 @@
   id: RMCPMCStandardSSG45
   playTimeTracker: RMCJobPMCStandardSSG45
   startingGear: RMCJobPMCStandardSSG45
+  spawnMenuRoleName: WEYA PMC Operator (SSG-45)
 
 - type: entity
   id: RMCRandomHumanoidPMCStandardSSG45
@@ -162,6 +164,7 @@
   id: RMCPMCStandardM54C2
   playTimeTracker: RMCJobPMCStandardM54C2
   startingGear: RMCJobPMCStandardM54C2
+  spawnMenuRoleName: WEYA PMC Operator (M54C2)
 
 - type: entity
   id: RMCRandomHumanoidPMCStandardM54C2

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/base_forecon.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/base_forecon.yml
@@ -13,6 +13,7 @@
   hasIcon: false
   greeting: rmc-job-greeting-forecon
   playTimeTracker: RMCSurvivorForecon
+  spawnMenuRoleName: FORECON Survivor (Base)
   hidden: true
 
 - type: startingGear

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/commander.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/commander.yml
@@ -11,6 +11,7 @@
   roleWeight: 0.25
   icon: "RMCJobIconForeconCommander"
   hasIcon: true
+  spawnMenuRoleName: FORECON Commander (Survivor)
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/marksman.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/marksman.yml
@@ -5,6 +5,7 @@
   playTimeTracker: RMCJobSurvivorMarksmanForecon
   startingGear: RMCGearForeconBase
   icon: "CMJobIconWeaponsSpecialist"
+  spawnMenuRoleName: FORECON Marksman (Survivor)
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/rifleman.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/rifleman.yml
@@ -3,6 +3,7 @@
   id: RMCSurvivorForeconRifleman
   name: cm-job-name-rifleman
   playTimeTracker: RMCJobSurvivorRiflemanForecon
+  spawnMenuRoleName: FORECON Rifleman (Survivor)
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/smart_gun_operator.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/smart_gun_operator.yml
@@ -5,6 +5,7 @@
   playTimeTracker: RMCJobSurvivorSmartgunOperatorForecon
   startingGear: RMCGearForeconSmartgunOperator
   icon: "CMJobIconSmartGunOperator"
+  spawnMenuRoleName: FORECON Smart Gun Operator (Survivor)
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/sniper.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/sniper.yml
@@ -5,6 +5,7 @@
   playTimeTracker: RMCJobSurvivorSniperForecon
   startingGear: RMCGearForeconSniper
   icon: "RMCJobIconForeconSniper"
+  spawnMenuRoleName: FORECON Sniper (Survivor)
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/squad_leader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/squad_leader.yml
@@ -8,6 +8,7 @@
   icon: "CMJobIconSquadLeader"
   roleWeight: 1
   hasIcon: true
+  spawnMenuRoleName: FORECON Squad Leader (Survivor)
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/support_technician.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/support_technician.yml
@@ -5,6 +5,7 @@
   playTimeTracker: RMCJobSurvivorSupportTechForecon
   startingGear: RMCGearForeconSupportTech
   icon: "CMJobIconCombatTech"
+  spawnMenuRoleName: FORECON Support Technician (Survivor)
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/survivor_co.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/survivor_co.yml
@@ -8,6 +8,7 @@
   joinNotifyCrew: false
   supervisors: cm-job-supervisors-nobody
   whitelisted: true
+  spawnMenuRoleName: Survivor CO (Base)
 
 - type: playTimeTracker
   id: RMCJobSurvivorCO


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Some job names share the same name with others, it'll add a duplicate entry in the spawn as job menu
Adds a datafield to job prototype which allows it to have a custom spawn menu name

![image](https://github.com/user-attachments/assets/92b662f3-234c-4ef1-a12d-1d01869c0b35)


:cl:
ADMIN:
- add: Added different job spawn menu names for FORECON and WeYA PMC operators.
