### PR TITLE
Splits marines in the crew manifest into squads

### DIFF
--- a/Content.Client/CrewManifest/UI/CrewManifestSection.cs
+++ b/Content.Client/CrewManifest/UI/CrewManifestSection.cs
@@ -4,7 +4,6 @@ using Robust.Client.GameObjects;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Prototypes;
 using System.Numerics;
-using Content.Shared.Roles;
 
 namespace Content.Client.CrewManifest.UI;
 
@@ -13,7 +12,7 @@ public sealed class CrewManifestSection : BoxContainer
     public CrewManifestSection(
         IPrototypeManager prototypeManager,
         SpriteSystem spriteSystem,
-        DepartmentPrototype section,
+        string sectionName,
         List<CrewManifestEntry> entries)
     {
         Orientation = LayoutOrientation.Vertical;
@@ -22,13 +21,13 @@ public sealed class CrewManifestSection : BoxContainer
         AddChild(new Label()
         {
             StyleClasses = { "LabelBig" },
-            Text = Loc.GetString(section.Name)
+            Text = Loc.GetString(sectionName),
         });
 
         var gridContainer = new GridContainer()
         {
             HorizontalExpand = true,
-            Columns = 2
+            Columns = 2,
         };
 
         AddChild(gridContainer);

--- a/Content.Server/CrewManifest/CrewManifestSystem.cs
+++ b/Content.Server/CrewManifest/CrewManifestSystem.cs
@@ -15,7 +15,6 @@ using Robust.Shared.Configuration;
 using Robust.Shared.Console;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Utility;
 
 namespace Content.Server.CrewManifest;
 
@@ -52,12 +51,17 @@ public sealed class CrewManifestSystem : EntitySystem
 
     public override void Update(float frameTime)
     {
+        base.Update(frameTime);
+
+        if (_queuedManifests.Count < 1)
+            return;
+
         foreach (var queuedStation in _queuedManifests)
         {
             BuildCrewManifest(queuedStation);
             UpdateEuis(queuedStation);
         }
-        base.Update(frameTime);
+        _queuedManifests.Clear();
     }
 
     private void OnRoundRestart(RoundRestartCleanupEvent ev)

--- a/Content.Server/CrewManifest/CrewManifestSystem.cs
+++ b/Content.Server/CrewManifest/CrewManifestSystem.cs
@@ -245,7 +245,7 @@ public sealed class CrewManifestSystem : EntitySystem
         foreach (var recordObject in iter)
         {
             var record = recordObject.Item2;
-            var entry = new CrewManifestEntry(record.Name, record.JobTitle, record.JobIcon, record.JobPrototype);
+            var entry = new CrewManifestEntry(record.Name, record.JobTitle, record.JobIcon, record.JobPrototype, record.Squad);
 
             _prototypeManager.TryIndex(record.JobPrototype, out JobPrototype? job);
             entriesSort.Add((job, entry));

--- a/Content.Shared/CrewManifest/SharedCrewManifestSystem.cs
+++ b/Content.Shared/CrewManifest/SharedCrewManifestSystem.cs
@@ -54,12 +54,15 @@ public sealed class CrewManifestEntry
 
     public string JobPrototype { get; }
 
-    public CrewManifestEntry(string name, string jobTitle, string jobIcon, string jobPrototype)
+    public string? Squad { get; }
+
+    public CrewManifestEntry(string name, string jobTitle, string jobIcon, string jobPrototype, string? squad)
     {
         Name = name;
         JobTitle = jobTitle;
         JobIcon = jobIcon;
         JobPrototype = jobPrototype;
+        Squad = squad;
     }
 }
 

--- a/Content.Shared/StationRecords/GeneralStationRecord.cs
+++ b/Content.Shared/StationRecords/GeneralStationRecord.cs
@@ -37,6 +37,12 @@ public sealed record GeneralStationRecord
     public string JobPrototype = string.Empty;
 
     /// <summary>
+    ///     RCM - Squad of the marine that this station record represents, if applicable.
+    /// </summary>
+    [DataField]
+    public string? Squad;
+
+    /// <summary>
     ///     Species tied to this station record.
     /// </summary>
     [DataField]

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/combat_tech.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/combat_tech.yml
@@ -28,6 +28,7 @@
   overwatchSortPriority: -1
   overwatchRoleName: Combat Technicians
   roleWeight: 1
+  displayWeight: 1
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/fireteam_leader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/fireteam_leader.yml
@@ -28,6 +28,7 @@
   overwatchSortPriority: -5
   overwatchRoleName: Fire Team Leaders
   roleWeight: 1
+  displayWeight: 5
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/hospital_corpsman.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/hospital_corpsman.yml
@@ -31,6 +31,7 @@
   overwatchSortPriority: -2
   overwatchRoleName: Hospital Corpsmen
   roleWeight: 1
+  displayWeight: 2
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/rifleman.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/rifleman.yml
@@ -23,6 +23,7 @@
   - Rifleman
   hasIcon: false
   roleWeight: 1
+  displayWeight: 0
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/smart_gun_operator.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/smart_gun_operator.yml
@@ -29,6 +29,7 @@
   overwatchShowName: true
   overwatchRoleName: Smart Gun Operator
   roleWeight: 1
+  displayWeight: 3
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/squad_leader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/squad_leader.yml
@@ -38,6 +38,7 @@
   overwatchShowName: true
   overwatchRoleName: Squad Leader
   roleWeight: 1
+  displayWeight: 6
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/weapons_specialist.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/weapons_specialist.yml
@@ -29,6 +29,7 @@
   overwatchShowName: true
   overwatchRoleName: Specialist
   roleWeight: 1
+  displayWeight: 4
   special:
   - !type:AddComponentSpecial
     components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Marines are now split into squads and are actually sorted based on their weight

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I was playing with my friend and they said "I hate that I can't see which squad those marines belong to in the crew manifest". Well, now you can

## Technical details
<!-- Summary of code changes for easier review. -->
There were multiple comments signifying the performance issues, so I tried to resolve them as I was modifying that code anyway. Client code is around two orders of magnitute faster due to a reverse lookup
Server code now build the crew manifest based on a queeu in Update, rather than on each change. Should significantly improve it's performance on round start (one build instead of n builds for n players)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/831799eb-7361-4b40-bedf-7f22824c2e58



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Marines in the crew manifest are now sorted and split into squads!
