### PR TITLE
Made the M4 free for SL

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/leader.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/leader.yml
@@ -31,11 +31,6 @@
       - id: RMCMOU53Case
       - id: RMCCaseXM88
       - id: RMCKitEngineering
-    - name: Armors
-      entries:
-      - id: RMCArmorM4Zipties
-        name: leader M4 pattern marine armor (zipties)
-        points: 16
     - name: Clothing Items
       entries:
       - id: RMCBackpackRTO
@@ -219,10 +214,15 @@
       takeAll: CMStandard
       entries:
       - id: CMVendorBundleSquadLeaderApparel
-      - id: RMCArmorB12Zipties
-        name: leader B12 pattern marine armor (zipties)
       - id: CMMRE
       #- id: CMMap # TODO: Make a map
+    - name: Armor
+      choices: { CMArmour: 1 }
+      entries:
+      - id: RMCArmorB12Zipties
+        name: leader B12 pattern marine armor (zipties)
+      - id: RMCArmorM4Zipties
+        name: leader M4 pattern marine armor (zipties)
     - name: Backpack
       choices: { CMBackpack: 1 }
       entries:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
NOT PARITY !!! But hear me out.
Transferred the M4 in the SL vend from point buyable (16 points) to free, and CHOOSE between that and M4 and B12

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It hardly does.
Stat wise B12 and M4 compensate eachother.
Defense wise, M4 is worse than B12 except for acid. However, M4 got one more storage slot.

Thus, both of these armors being on par, both should be of the same price, in this case free.

## Technical details
<!-- Summary of code changes for easier review. -->
yml, nothing too hard, check code change, very small.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

![fergedghe](https://github.com/user-attachments/assets/0236554e-4209-4801-aba6-b3a8e646ffcc)
![efeefef](https://github.com/user-attachments/assets/fbad4d83-dcc9-4352-90af-593b11ff8474)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: SLs can now choose between B12 and M4 for free (instead of having to buy the M4)
