### PR TITLE
Adding a max players limit to planetary maps

### DIFF
--- a/Content.Shared/_RMC14/Rules/RMCPlanetMapPrototypeComponent.cs
+++ b/Content.Shared/_RMC14/Rules/RMCPlanetMapPrototypeComponent.cs
@@ -19,6 +19,9 @@ public sealed partial class RMCPlanetMapPrototypeComponent : Component
     [DataField, AutoNetworkedField]
     public int MinPlayers;
 
+    [DataField, AutoNetworkedField]
+    public int MaxPlayers;
+
     [DataField(required: true), AutoNetworkedField]
     public string Announcement = string.Empty;
 

--- a/Content.Shared/_RMC14/Rules/RMCPlanetSystem.cs
+++ b/Content.Shared/_RMC14/Rules/RMCPlanetSystem.cs
@@ -165,7 +165,7 @@ public sealed class RMCPlanetSystem : EntitySystem
                 continue;
             }
 
-            if (players == 0 || comp.MinPlayers == 0 || players >= comp.MinPlayers)
+            if (players == 0 || (comp.MinPlayers == 0 || players >= comp.MinPlayers) && (comp.MaxPlayers == 0 || players <= comp.MaxPlayers))
                 candidates.Add(new RMCPlanet(planetProto, comp));
         }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added a limit on the maximum number of players at which a planetmap can be selected as a candidate for voting

## Why / Balance
Not having a maximum online limit on maps is bad

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
