### PR TITLE
Make shotgun hold 10 shells

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/pump_shotgun.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/pump_shotgun.yml
@@ -24,6 +24,7 @@
     baseFireRate: 0.5
     burstScatterMult: 5
   - type: BallisticAmmoProvider
+    capacity: 10 # todo change to 9 when bullet chambering is added
     whitelist:
       tags:
       - RMCShellShotgunBuckshot


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
You can hold 10 shells in CM13 because of bullet chambering
This is pretty important because stacks are 5 each, added 10 capacity until bullet chambering

:cl:
- tweak: Pump shotgun can now hold 10 shells instead of 9.
