### PR TITLE
Fixes survivors not spawning with a fireaxe

### DIFF
--- a/Content.Shared/_RMC14/Survivor/SurvivorSystem.cs
+++ b/Content.Shared/_RMC14/Survivor/SurvivorSystem.cs
@@ -69,7 +69,7 @@ public sealed class SurvivorSystem : EntitySystem
             var gear = _random.Pick(comp.RandomGear);
             foreach (var item in gear)
             {
-                Equip(mob, item);
+                Equip(mob, item, tryInHand: true);
             }
         }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fireaxe cant be put on storage, so it trys inhand now
Its in the random gear section

:cl:
- fix: Fixed survivors not spawning with a fireaxe as random gear.
