### PR TITLE
Add storage ejection to pill containers & nested storage

### DIFF
--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -42,6 +42,7 @@ using Robust.Shared.Random;
 using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
+using Content.Shared._RMC14.Hands;
 
 namespace Content.Shared.Storage.EntitySystems;
 
@@ -74,6 +75,7 @@ public abstract class SharedStorageSystem : EntitySystem
 
     // RMC14
     [Dependency] protected readonly RMCStorageSystem RMCStorage = default!;
+    [Dependency] private readonly RMCHandsSystem _rmcHands = default!;
 
     private EntityQuery<ItemComponent> _itemQuery;
     private EntityQuery<StackComponent> _stackQuery;
@@ -658,6 +660,9 @@ public abstract class SharedStorageSystem : EntitySystem
         // If the user's active hand is empty, try pick up the item.
         if (player.Comp.ActiveHandEntity == null)
         {
+            if (_rmcHands.TryStorageEjectHand(player, item))
+                return;
+
             _adminLog.Add(
                 LogType.Storage,
                 LogImpact.Low,

--- a/Content.Shared/_RMC14/Hands/RMCHandsSystem.cs
+++ b/Content.Shared/_RMC14/Hands/RMCHandsSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared._RMC14.Storage;
+using Content.Shared._RMC14.Storage;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
@@ -86,25 +86,7 @@ public abstract class RMCHandsSystem : EntitySystem
         if (!args.CanInteract)
             return;
 
-        if (!_inventory.TryGetContainingSlot(ent.Owner, out var slot))
-            return;
-
         var user = args.User;
-
-        AlternativeVerb unequipVerb = new()
-        {
-            Text = "Unequip",
-            Act = () =>
-            {
-                if (_inventory.TryGetContainingSlot(ent.Owner, out slot) &&
-                    _inventory.TryUnequip(user, user, slot.Name, checkDoafter: true))
-                {
-                    _hands.TryPickupAnyHand(user, ent.Owner);
-                }
-            },
-        };
-
-        args.Verbs.Add(unequipVerb);
 
         if (!ent.Comp.CanToggleStorage)
             return;
@@ -133,6 +115,24 @@ public abstract class RMCHandsSystem : EntitySystem
         };
 
         args.Verbs.Add(switchStorageVerb);
+
+        if (!_inventory.TryGetContainingSlot(ent.Owner, out var slot))
+            return;
+
+        AlternativeVerb unequipVerb = new()
+        {
+            Text = "Unequip",
+            Act = () =>
+            {
+                if (_inventory.TryGetContainingSlot(ent.Owner, out slot) &&
+                    _inventory.TryUnequip(user, user, slot.Name, checkDoafter: true))
+                {
+                    _hands.TryPickupAnyHand(user, ent.Owner);
+                }
+            },
+        };
+
+        args.Verbs.Add(unequipVerb);
     }
 
     private static RMCStorageEjectState GetNextState(RMCStorageEjectState current) =>
@@ -192,6 +192,12 @@ public abstract class RMCHandsSystem : EntitySystem
         if (!TryComp(item, out RMCStorageEjectHandComponent? eject) ||
             !TryComp(item, out StorageComponent? storage))
         {
+            return false;
+        }
+
+        if (!_rmcStorage.CanDraw(item, user, out var popup))
+        {
+            _popup.PopupClient(popup, user, user);
             return false;
         }
 

--- a/Content.Shared/_RMC14/Hands/RMCHandsSystem.cs
+++ b/Content.Shared/_RMC14/Hands/RMCHandsSystem.cs
@@ -207,7 +207,7 @@ public abstract class RMCHandsSystem : EntitySystem
 
         if (!_rmcStorage.CanEject(item, user, out var popup))
         {
-            _popup.PopupClient(popup, user, user);
+            _popup.PopupClient(popup, user, user, PopupType.SmallCaution);
             return false;
         }
 

--- a/Content.Shared/_RMC14/Hands/RMCHandsSystem.cs
+++ b/Content.Shared/_RMC14/Hands/RMCHandsSystem.cs
@@ -195,12 +195,6 @@ public abstract class RMCHandsSystem : EntitySystem
             return false;
         }
 
-        if (!_rmcStorage.CanDraw(item, user, out var popup))
-        {
-            _popup.PopupClient(popup, user, user);
-            return false;
-        }
-
         if (eject.State == RMCStorageEjectState.Unequip)
         {
             return false;
@@ -209,6 +203,12 @@ public abstract class RMCHandsSystem : EntitySystem
         {
             _storage.OpenStorageUI(item, user, storage, false, false);
             return true;
+        }
+
+        if (!_rmcStorage.CanEject(item, user, out var popup))
+        {
+            _popup.PopupClient(popup, user, user);
+            return false;
         }
 
         if (eject.Whitelist != null)

--- a/Content.Shared/_RMC14/Storage/RMCStorageSystem.cs
+++ b/Content.Shared/_RMC14/Storage/RMCStorageSystem.cs
@@ -343,6 +343,27 @@ public sealed class RMCStorageSystem : EntitySystem
         return true;
     }
 
+    private bool CanEjectStoreSkill(Entity<StorageComponent?, StorageSkillRequiredComponent?> store, EntityUid? user, out LocId popup)
+    {
+        popup = default;
+        if (user == null)
+            return true;
+
+        if (!Resolve(store, ref store.Comp2, false) ||
+            !_storageQuery.Resolve(store, ref store.Comp1, false))
+        {
+            return true;
+        }
+
+        if (!_skills.HasAllSkills(user.Value, store.Comp2.Skills))
+        {
+            _popup.PopupClient(Loc.GetString("cm-storage-unskilled"), store, user, PopupType.SmallCaution);
+            return false;
+        }
+
+        return true;
+    }
+
     public bool TryGetLastItem(Entity<StorageComponent?> storage, out EntityUid item)
     {
         item = default;
@@ -410,25 +431,12 @@ public sealed class RMCStorageSystem : EntitySystem
         return true;
     }
 
-    public bool CanDraw(Entity<StorageComponent?, StorageStoreSkillRequiredComponent?> store, EntityUid user, out LocId popup)
+    public bool CanEject(EntityUid storage, EntityUid user, out LocId popup)
     {
-        popup = default;
-        Log.Debug("Went to CanDraw");
 
-        if (!Resolve(store, ref store.Comp2, false))
-        {
-            return true;
-        }
-
-        foreach (var entry in store.Comp2.Entries)
-        {
-
-            if (_skills.HasSkills(user, entry.Skills))
-                continue;
-
-            popup = "rmc-storage-store-skill-unable";
+        if (!CanEjectStoreSkill(storage, user, out popup))
             return false;
-        }
+
         return true;
     }
 

--- a/Content.Shared/_RMC14/Storage/RMCStorageSystem.cs
+++ b/Content.Shared/_RMC14/Storage/RMCStorageSystem.cs
@@ -356,7 +356,7 @@ public sealed class RMCStorageSystem : EntitySystem
 
         if (!_skills.HasAllSkills(user.Value, store.Comp2.Skills))
         {
-            _popup.PopupClient(Loc.GetString("cm-storage-unskilled"), store, user, PopupType.SmallCaution);
+            popup = Loc.GetString("cm-storage-unskilled");
             return false;
         }
 

--- a/Content.Shared/_RMC14/Storage/RMCStorageSystem.cs
+++ b/Content.Shared/_RMC14/Storage/RMCStorageSystem.cs
@@ -16,7 +16,6 @@ using Content.Shared.Whitelist;
 using Robust.Shared.Containers;
 using Robust.Shared.Network;
 using Robust.Shared.Timing;
-using System.Diagnostics;
 using static Content.Shared.Storage.StorageComponent;
 
 namespace Content.Shared._RMC14.Storage;

--- a/Content.Shared/_RMC14/Storage/RMCStorageSystem.cs
+++ b/Content.Shared/_RMC14/Storage/RMCStorageSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared._RMC14.Marines;
+using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.Marines.Skills;
 using Content.Shared._RMC14.Prototypes;
 using Content.Shared.DoAfter;
@@ -16,6 +16,7 @@ using Content.Shared.Whitelist;
 using Robust.Shared.Containers;
 using Robust.Shared.Network;
 using Robust.Shared.Timing;
+using System.Diagnostics;
 using static Content.Shared.Storage.StorageComponent;
 
 namespace Content.Shared._RMC14.Storage;
@@ -406,6 +407,28 @@ public sealed class RMCStorageSystem : EntitySystem
         if (!CanInsertStoreSkill((storage, storage, null), toInsert, user, out popup))
             return false;
 
+        return true;
+    }
+
+    public bool CanDraw(Entity<StorageComponent?, StorageStoreSkillRequiredComponent?> store, EntityUid user, out LocId popup)
+    {
+        popup = default;
+        Log.Debug("Went to CanDraw");
+
+        if (!Resolve(store, ref store.Comp2, false))
+        {
+            return true;
+        }
+
+        foreach (var entry in store.Comp2.Entries)
+        {
+
+            if (_skills.HasSkills(user, entry.Skills))
+                continue;
+
+            popup = "rmc-storage-store-skill-unable";
+            return false;
+        }
         return true;
     }
 

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Medical/pill_canisters.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Medical/pill_canisters.yml
@@ -77,6 +77,7 @@
     slots:
     - suitstorage
   - type: RMCStorageEjectHand
+    state: Last
 
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Medical/pill_canisters.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Medical/pill_canisters.yml
@@ -76,6 +76,7 @@
     quickEquip: false
     slots:
     - suitstorage
+  - type: RMCStorageEjectHand
 
 
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Pill canisters can now toggle storage ejection modes to use while in hand, or in storage. Additionally adds the capability for skill-restricted nested storage items (medkits, engineering kits) and non-clothing items to use the storage eject system, but no other items have been given the component in this PR.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity.

## Technical details
<!-- Summary of code changes for easier review. -->
Adds a public `CanEject` method to RMCStorage and populates it with the `CanEjectStoreSkill` check. Small upstream change required in `SharedStorageSystem` to allow for nested storage ejection.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
### Unskilled Usage
https://github.com/user-attachments/assets/e619e2e9-fc1f-4aad-9ba1-9e164ee661d5

### Skilled Usage
https://github.com/user-attachments/assets/970c1b65-d7d4-4e50-9044-5a322d827420

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Pill canisters can now toggle storage ejection, and can be used while nested inside storage.
