### PR TITLE
Reduce the slow and stun durations of the Warrior's fling ability, and fix the Ravager's Clothesline ability applying the wrong effect

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Fling/XenoFlingComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Fling/XenoFlingComponent.cs
@@ -25,7 +25,7 @@ public sealed partial class XenoFlingComponent : Component
     public TimeSpan ParalyzeTime = TimeSpan.FromSeconds(1);
 
     [DataField, AutoNetworkedField]
-    public TimeSpan SlowTime = TimeSpan.FromSeconds(8);
+    public TimeSpan SlowTime = TimeSpan.FromSeconds(4);
 
     [DataField, AutoNetworkedField]
     public EntProtoId Effect = "CMEffectPunch";

--- a/Content.Shared/_RMC14/Xenonids/Fling/XenoFlingComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Fling/XenoFlingComponent.cs
@@ -22,7 +22,7 @@ public sealed partial class XenoFlingComponent : Component
     public float ThrowSpeed = 10f;
 
     [DataField, AutoNetworkedField]
-    public TimeSpan ParalyzeTime = TimeSpan.FromSeconds(2);
+    public TimeSpan ParalyzeTime = TimeSpan.FromSeconds(1);
 
     [DataField, AutoNetworkedField]
     public TimeSpan SlowTime = TimeSpan.FromSeconds(8);

--- a/Content.Shared/_RMC14/Xenonids/Fling/XenoFlingComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Fling/XenoFlingComponent.cs
@@ -28,6 +28,9 @@ public sealed partial class XenoFlingComponent : Component
     public TimeSpan SlowTime = TimeSpan.FromSeconds(4);
 
     [DataField, AutoNetworkedField]
+    public TimeSpan DazeTime = TimeSpan.FromSeconds(0);
+
+    [DataField, AutoNetworkedField]
     public EntProtoId Effect = "CMEffectPunch";
 
     [DataField, AutoNetworkedField]

--- a/Content.Shared/_RMC14/Xenonids/Fling/XenoFlingSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Fling/XenoFlingSystem.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Shared._RMC14.Pulling;
 using Content.Shared._RMC14.Slow;
+using Content.Shared._RMC14.Stun;
 using Content.Shared._RMC14.Weapons.Melee;
 using Content.Shared._RMC14.Xenonids.Heal;
 using Content.Shared._RMC14.Xenonids.Rage;
@@ -30,6 +31,7 @@ public sealed class XenoFlingSystem : EntitySystem
     [Dependency] private readonly SharedRMCMeleeWeaponSystem _rmcMelee = default!;
     [Dependency] private readonly SharedXenoHealSystem _xenoHeal = default!;
     [Dependency] private readonly XenoRageSystem _rage = default!;
+    [Dependency] private readonly RMCDazedSystem _dazed = default!;
 
     public override void Initialize()
     {
@@ -89,6 +91,7 @@ public sealed class XenoFlingSystem : EntitySystem
             return;
 
         _rmcSlow.TrySlowdown(targetId, xeno.Comp.SlowTime);
+        _dazed.TryDaze(targetId, xeno.Comp.DazeTime, true);
         _stun.TryParalyze(targetId, xeno.Comp.ParalyzeTime, true);
         _throwing.TryThrow(targetId, diff, xeno.Comp.ThrowSpeed);
 

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/ravager.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/ravager.yml
@@ -223,6 +223,8 @@
     healAmount: 75
     enragedHealAmount: 100
     paralyzeTime: 0
+    slowTime: 0
+    dazeTime: 4
     throwSpeed: 12
     damage:
       groups:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The Warrior's fling ability now stuns for 1 second instead of 2 seconds.
The Warrior's fling ability now slows for 4 seconds instead of 8 seconds.
The Ravager's Clothesline ability now applies 4 seconds of daze instead of 8 seconds of slow.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity.
Clothesline is a fling in the code so that's why I also put it in this PR.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Parity durations are 0.5 and 2, we multiply stun and slow durations by 2 when porting them over:

![image](https://github.com/user-attachments/assets/709ba3f1-dfc5-44da-bed3-628f49aaf7f1)
![image](https://github.com/user-attachments/assets/4d64234f-edc7-4f84-982b-615294d21ff6)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Dygon
- fix: Fixed the Warrior's fling ability stunning and slowing for too long. It now stuns for 1 second instead of 2 seconds, and slows for 4 seconds instead of 8 seconds.
- fix: Fixed the Ravager's Clothesline ability applying the wrong effect, it now dazes for 4 seconds instead of slowing for 8 seconds.

