### PR TITLE
fix tail seize semi-working on melee cooldown

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/TailSeize/XenoTailSeizeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/TailSeize/XenoTailSeizeSystem.cs
@@ -89,8 +89,6 @@ public sealed class XenoTailSeizeSystem : EntitySystem
         if (!_actionBlocker.CanAttack(xeno))
             return;
 
-        _projectile.TryShoot(xeno, args.Coords.Value, 0, xeno.Comp.Projectile, null, 1, Angle.Zero, xeno.Comp.Speed, target: args.Entity);
-
         if (TryComp(xeno, out MeleeWeaponComponent? melee))
         {
             if (_timing.CurTime < melee.NextAttack)
@@ -99,6 +97,8 @@ public sealed class XenoTailSeizeSystem : EntitySystem
             melee.NextAttack = _timing.CurTime + TimeSpan.FromSeconds(1);
             Dirty(xeno, melee);
         }
+
+        _projectile.TryShoot(xeno, args.Coords.Value, 0, xeno.Comp.Projectile, null, 1, Angle.Zero, xeno.Comp.Speed, target: args.Entity);
 
         var attackEv = new MeleeAttackEvent(xeno);
         RaiseLocalEvent(xeno, ref attackEv);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug.

## Technical details
<!-- Summary of code changes for easier review. -->
Tail Seize would shoot first, before checking if melee time was less than current time. So it would shoot without checking the cooldown, that would return, causing no sound and no cooldown. Just moves shoot after so if it is on cooldown it doesn't happen at all.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed using tail seize during melee cooldown not properly cancelling the ability.
