### PR TITLE
Make weeds start with 5 HP and get 11 HP when they're done spreading

### DIFF
--- a/Content.Server/_RMC14/Xenonids/Weeds/XenoWeedsSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Weeds/XenoWeedsSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Weeds;
 using Content.Shared.Atmos;
 using Content.Shared.Coordinates;
+using Content.Shared.Damage;
 using Content.Shared.Maps;
 using Content.Shared.Tag;
 using Robust.Server.GameObjects;
@@ -27,6 +28,7 @@ public sealed class XenoWeedsSystem : SharedXenoWeedsSystem
     [Dependency] private readonly TransformSystem _transform = default!;
     [Dependency] private readonly EntityManager _entities = default!;
     [Dependency] private readonly AppearanceSystem _appearance = default!;
+    [Dependency] private readonly DamageableSystem _damageable = default!;
 
     private static readonly ProtoId<TagPrototype> IgnoredTag = "SpreaderIgnore";
 
@@ -131,7 +133,16 @@ public sealed class XenoWeedsSystem : SharedXenoWeedsSystem
                 var sourceLocal = _mapSystem.CoordinatesToTile(grid, gridComp, transform.Coordinates);
                 var diff = Vector2.Abs(neighbor - sourceLocal);
                 if (diff.X >= weeds.Range || diff.Y >= weeds.Range)
+                {
+                    if (source != null && sourceWeeds != null && !sourceWeeds.HasHealed)
+                    {
+                        sourceWeeds.HasHealed = true;
+                        _damageable.TryChangeDamage(source, sourceWeeds.HealOnStopSpreading, true);
+                        Dirty(source.Value, sourceWeeds);
+                    }
+
                     break;
+                }
 
                 if (!CanSpreadWeedsPopup(grid, neighbor, null, weeds.SpreadsOnSemiWeedable))
                     continue;

--- a/Content.Shared/_RMC14/Xenonids/Weeds/XenoWeedsComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Weeds/XenoWeedsComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Damage;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 
@@ -19,6 +20,15 @@ public sealed partial class XenoWeedsComponent : Component
     [DataField]
     public float SpeedMultiplierOutsiderArmor = 0.6666f;
 
+    /// <summary>
+    /// How much health is healed when the weeds stop spreading.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public DamageSpecifier HealOnStopSpreading = new();
+
+    [DataField, AutoNetworkedField]
+    public bool HasHealed = false;
+
     [DataField, AutoNetworkedField]
     public bool IsSource = true;
 
@@ -33,7 +43,7 @@ public sealed partial class XenoWeedsComponent : Component
 
     /// <summary>
     /// All anchored entities with Weedable component adjacent to this entity
-    /// are added here. 
+    /// are added here.
     /// </summary>
     [DataField, AutoNetworkedField]
     public List<EntityUid> LocalWeeded = new();

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_weeds.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_weeds.yml
@@ -142,6 +142,14 @@
       - XenoWeedNode
       - XenoWeedTile
   - type: QueenEyeVision
+  - type: Damageable
+    damage:
+      groups:
+        Brute: 6
+  - type: XenoWeeds
+    healOnStopSpreading:
+      groups:
+        Brute: -6
   - type: Tag
     tags:
     - XenoWeedNode


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Weeds now have 5 HP when they're first made and will get 11 when they're done spreading

Because of the way destructible items are coded in SS14, we give weed nodes a starting damage of 6 brute, and heal it 6 brute when they're done spreading.

## Why / Balance
CM13 
![image](https://github.com/user-attachments/assets/0b7cc13c-2737-4b8a-bc5b-9cf446cd3998)

## Media

https://github.com/user-attachments/assets/d3c88f00-15dc-4983-9aac-0f1d0262795f



:cl:
- tweak: Weed nodes will now have 5 health when they're first made and will get 11 health when they stop spreading.