### PR TITLE
Screen Announces

### DIFF
--- a/Content.Client/_RMC14/Marines/ScreenAnnounce/ScreenAnnounceOverlay.cs
+++ b/Content.Client/_RMC14/Marines/ScreenAnnounce/ScreenAnnounceOverlay.cs
@@ -1,0 +1,45 @@
+using System.Numerics;
+using Robust.Client.Graphics;
+using Robust.Client.UserInterface;
+using Robust.Shared.Enums;
+using Content.Shared._RMC14.Marines;
+using Content.Shared._RMC14.Marines.ScreenAnnounce;
+
+namespace Content.Client._RMC14.Marines.ScreenAnnounce;
+
+public sealed class ScreenAnnounceOverlay : Overlay
+{
+    [Dependency] private readonly IUserInterfaceManager _uiManager = default!;
+    
+    private ScreenAnnounceControl _control;
+
+    public override OverlaySpace Space => OverlaySpace.ScreenSpace;
+
+    public ScreenAnnounceOverlay()
+    {
+        IoCManager.InjectDependencies(this);
+        _control = new ScreenAnnounceControl();
+    }
+
+    protected override void Draw(in OverlayDrawArgs args)
+    {
+        if (args.ViewportControl == null)
+            return;
+
+        if (_control.Parent == null)
+        {
+            _uiManager.RootControl.AddChild(_control);
+        }
+    }
+
+    protected override void DisposeBehavior()
+    {
+        base.DisposeBehavior();
+        _control.Orphan();
+    }
+
+    public void UpdateAnnouncement(string[] announceText, ScreenAnnounceTarget type, ScreenAnnounceArgs settings, string startingMessage, NetEntity? squad)
+    {
+        _control.UpdateAnnouncement(announceText, type, settings, startingMessage, squad);
+    }
+}

--- a/Content.Client/_RMC14/Marines/ScreenAnnounce/ScreenAnnounceSystem.cs
+++ b/Content.Client/_RMC14/Marines/ScreenAnnounce/ScreenAnnounceSystem.cs
@@ -1,0 +1,42 @@
+using Robust.Client.Graphics;
+using Robust.Client.Player;
+using Robust.Shared.Player;
+using Content.Shared._RMC14.Marines;
+using Content.Shared._RMC14.Marines.ScreenAnnounce;
+using Robust.Client.UserInterface;
+
+namespace Content.Client._RMC14.Marines.ScreenAnnounce;
+
+public sealed class ScreenAnnounceSystem : EntitySystem
+{
+    [Dependency] private readonly IPlayerManager _player = default!;
+    [Dependency] private readonly IOverlayManager _overlayMan = default!;
+    [Dependency] private readonly IUserInterfaceManager _uiManager = default!;
+
+    private ScreenAnnounceOverlay _overlay = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeNetworkEvent<ScreenAnnounceMessage>(OnAnnounce);
+        SubscribeLocalEvent<MarineComponent, ComponentShutdown>(OnShutdown);
+        
+        _overlay = new ScreenAnnounceOverlay();
+        _overlayMan.AddOverlay(_overlay);
+    }
+
+    private void OnAnnounce(ScreenAnnounceMessage args)
+    {
+        if (_uiManager.GetUIController<ScreenAnnounceUIController>() is { } uiController)
+        {
+            uiController.UpdateAnnouncement(args.AnnounceText, args.Target, args.ScreenAnnounceArgs, args.StartingMessage, args.Squad);
+        }
+    }
+
+    private void OnShutdown(EntityUid uid, MarineComponent component, ComponentShutdown args)
+    {
+        if (_player.LocalEntity == uid)
+            _overlayMan.RemoveOverlay(_overlay);
+    }
+}

--- a/Content.Client/_RMC14/Marines/ScreenAnnounce/ScreenAnnounceUIController.cs
+++ b/Content.Client/_RMC14/Marines/ScreenAnnounce/ScreenAnnounceUIController.cs
@@ -1,0 +1,400 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Text;
+using Content.Client.Gameplay;
+using Content.Client.Stylesheets;
+using Content.Shared._RMC14.Marines;
+using Content.Shared._RMC14.Marines.Squads;
+using Content.Shared._RMC14.Stealth;
+using Content.Shared._RMC14.Marines.ScreenAnnounce;
+using Robust.Client.Graphics;
+using Robust.Client.Player;
+using Robust.Client.ResourceManagement;
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controllers;
+using Robust.Shared;
+using Robust.Shared.Configuration;
+using Robust.Shared.Enums;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Maths;
+using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+
+namespace Content.Client._RMC14.Marines.ScreenAnnounce;
+
+public sealed class ScreenAnnounceUIController : UIController, IOnStateEntered<GameplayState>, IOnStateExited<GameplayState>
+{
+    [UISystemDependency] private readonly ScreenAnnounceSystem? _screenAnnounce = default!;
+
+    private ScreenAnnounceControl? _screenAnnounceControl;
+
+    public void OnStateEntered(GameplayState state)
+    {
+        _screenAnnounceControl = new ScreenAnnounceControl();
+        UIManager.RootControl.AddChild(_screenAnnounceControl);
+    }
+
+    public void OnStateExited(GameplayState state)
+    {
+        if (_screenAnnounceControl != null)
+        {
+            UIManager.RootControl.RemoveChild(_screenAnnounceControl);
+            _screenAnnounceControl = null;
+        }
+    }
+
+    public void UpdateAnnouncement(string[] announceText, ScreenAnnounceTarget type, ScreenAnnounceArgs settings, string startingMessage, NetEntity? squad)
+    {
+        _screenAnnounceControl?.UpdateAnnouncement(announceText, type, settings, startingMessage, squad);
+    }
+}
+
+public sealed class ScreenAnnounceControl : Control
+{
+    [Dependency] private readonly IPlayerManager _playerManager = default!;
+    [Dependency] private readonly IEntityManager _entMan = default!;
+    [Dependency] private readonly IResourceCache _resCache = default!;
+    [Dependency] private readonly IConfigurationManager _configManager = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+
+    private readonly Font _font;
+    private string[] _announceText = Array.Empty<string>();
+    private string _startingMessage = string.Empty;
+    private ScreenAnnounceTarget _type;
+    private EntityUid? _squad;
+
+    private float _printSpeed = 0.03f;
+    private float _shakeIntensity = 0.8f;
+    private float _flickerChance = 0.02f;
+    private float _glitchChance = 0.01f;
+    private float _holdDuration = 3f;
+    private float _fadeDuration = 1.5f;
+    private float _lineHeightUnscaled = 40f;
+    private float _maxTextWidthFraction = 0.9f;
+
+    private float _timer;
+    private float _globalTime;
+    private float _holdStartTime;
+    private int _currentLine;
+    private int _currentChar;
+    private bool _finished;
+    private bool _fadingOut;
+
+    public ScreenAnnounceControl()
+    {
+        IoCManager.InjectDependencies(this);
+        _font = _resCache.NotoStack(variation: "Bold", 15);
+    }
+
+    public void UpdateAnnouncement(string[] announceText, ScreenAnnounceTarget type, ScreenAnnounceArgs settings, string startingMessage, NetEntity? squad)
+    {
+        _announceText = announceText;
+        _startingMessage = startingMessage;
+        _type = type;
+        _squad = _entMan.GetEntity(squad);
+
+        _printSpeed = settings.PrintSpeed;
+        _shakeIntensity = settings.ShakeIntensity;
+        _flickerChance = settings.FlickerChance;
+        _glitchChance = settings.GlitchChance;
+        _holdDuration = settings.HoldDuration;
+        _fadeDuration = settings.FadeDuration;
+        _lineHeightUnscaled = settings.LineHeightUnscaled;
+        _maxTextWidthFraction = settings.MaxTextWidthFraction;
+
+        _timer = 0;
+        _globalTime = 0;
+        _currentLine = 0;
+        _currentChar = 0;
+        _finished = false;
+        _fadingOut = false;
+    }
+
+    protected override void Draw(DrawingHandleScreen handle)
+    {
+        base.Draw(handle);
+
+        var player = _playerManager.LocalSession?.AttachedEntity;
+        if (player == null || !_entMan.HasComponent<MarineComponent>(player))
+            return;
+
+        var screenSize = PixelSize;
+
+        float scale = _configManager.GetCVar(CVars.DisplayUIScale);
+        if (scale <= 0f)
+            scale = 1f;
+        scale *= 1.5f;
+
+        _globalTime += (float)_timing.FrameTime.TotalSeconds;
+        float alpha = GetAlpha();
+
+        switch (_type)
+        {
+            case ScreenAnnounceTarget.FirstDeploy:
+                DrawFirstDeployAnnounce(handle, screenSize, scale, alpha);
+                break;
+
+            case ScreenAnnounceTarget.AllMarines:
+                DrawCenteredAnnouncement(
+                    handle, 
+                    screenSize, 
+                    scale, 
+                    Color.LimeGreen, 
+                    alpha,
+                    _startingMessage
+                );
+                break;
+
+            case ScreenAnnounceTarget.SquadOnly:
+                if (_squad != null && 
+                    _entMan.TryGetComponent<SquadMemberComponent>(player, out var squadComp) && 
+                    squadComp.Squad == _squad &&
+                    _entMan.TryGetComponent<SquadTeamComponent>(_squad, out var squadTeam))
+                {
+                    DrawCenteredAnnouncement(
+                        handle,
+                        screenSize,
+                        scale,
+                        squadTeam.Color,
+                        alpha,
+                        _startingMessage
+                    );
+                }
+                break;
+        }
+
+        UpdateState((float)_timing.FrameTime.TotalSeconds);
+    }
+
+    private void DrawFirstDeployAnnounce(DrawingHandleScreen handle, Vector2i screenSize, float scale, float alpha)
+    {
+        var lineHeight = _lineHeightUnscaled * scale;
+        var totalHeight = _announceText.Length * lineHeight;
+        var padding = 20f * scale;
+        var baseX = padding;
+        var baseY = screenSize.Y - totalHeight - padding;
+
+        for (int i = 0; i <= _currentLine && i < _announceText.Length; i++)
+        {
+            var text = BuildVisibleText(i, alpha);
+            var offset = _random.NextVector2(-_shakeIntensity, _shakeIntensity) * alpha;
+            var textPos = new Vector2(baseX, baseY + i * lineHeight) + offset;
+
+            DrawTextWithOutline(handle, text, textPos, scale, GetTextColor(i, alpha), alpha);
+        }
+    }
+
+    private void DrawCenteredAnnouncement(DrawingHandleScreen handle, Vector2i screenSize, float scale, Color color, float alpha, string startingMessage)
+    {
+        var allLines = new List<string>();
+        var lineHeight = _lineHeightUnscaled * scale;
+        var maxWidth = screenSize.X * _maxTextWidthFraction;
+
+        // Add starting message if it exists
+        if (!string.IsNullOrEmpty(startingMessage))
+        {
+            var underlinedMessage = $"[u]{startingMessage}[/u]";
+            allLines.AddRange(WrapText(new[] { underlinedMessage }, maxWidth, scale));
+            allLines.Add(""); // Empty line as separator
+        }
+
+        // Add main announcement text
+        allLines.AddRange(WrapText(_announceText, maxWidth, scale));
+
+        // Calculate total height
+        var totalHeight = allLines.Count * lineHeight;
+        var baseY = (screenSize.Y - totalHeight) / 2f;
+
+        for (int i = 0; i < allLines.Count; i++)
+        {
+            var line = allLines[i];
+            if (string.IsNullOrEmpty(line))
+                continue;
+
+            var textWidth = MeasureTextWidth(_font, line, scale);
+            var baseX = (screenSize.X - textWidth) / 2f;
+            var offset = _random.NextVector2(-_shakeIntensity, _shakeIntensity) * alpha;
+            var textPos = new Vector2(baseX, baseY + i * lineHeight) + offset;
+
+            var lineColor = color;
+            if (line.StartsWith("[u]") && line.EndsWith("[/u]"))
+            {
+                lineColor = color.WithAlpha(alpha * 0.8f); // Slightly transparent for underlined text
+            }
+
+            DrawTextWithOutline(handle, line, textPos, scale, lineColor.WithAlpha(alpha), alpha);
+        }
+    }
+
+    private void DrawTextWithOutline(DrawingHandleScreen handle, string text, Vector2 position, float scale, Color color, float alpha)
+    {
+        // Draw outline (4 directions)
+        var outlineColor = Color.Black.WithAlpha(alpha * 0.7f);
+        var outlineOffset = 1f * scale;
+        handle.DrawString(_font, position + new Vector2(-outlineOffset, 0), text, scale, outlineColor);
+        handle.DrawString(_font, position + new Vector2(outlineOffset, 0), text, scale, outlineColor);
+        handle.DrawString(_font, position + new Vector2(0, -outlineOffset), text, scale, outlineColor);
+        handle.DrawString(_font, position + new Vector2(0, outlineOffset), text, scale, outlineColor);
+
+        // Draw main text
+        handle.DrawString(_font, position, text, scale, color);
+    }
+
+    private List<string> WrapText(string[] lines, float maxWidth, float scale)
+    {
+        var result = new List<string>();
+
+        foreach (var line in lines)
+        {
+            if (string.IsNullOrEmpty(line))
+            {
+                result.Add(line);
+                continue;
+            }
+
+            // Handle special formatting (like underlines)
+            bool isUnderlined = line.StartsWith("[u]") && line.EndsWith("[/u]");
+            string cleanLine = isUnderlined ? line.Substring(3, line.Length - 7) : line;
+
+            var words = cleanLine.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            var current = new StringBuilder();
+
+            foreach (var word in words)
+            {
+                var next = current.Length == 0 ? word : $"{current} {word}";
+                var width = MeasureTextWidth(_font, isUnderlined ? $"[u]{next}[/u]" : next, scale);
+
+                if (width > maxWidth)
+                {
+                    if (current.Length > 0)
+                        result.Add(isUnderlined ? $"[u]{current}[/u]" : current.ToString());
+                    current.Clear().Append(word);
+                }
+                else
+                {
+                    if (current.Length > 0)
+                        current.Append(' ');
+                    current.Append(word);
+                }
+            }
+
+            if (current.Length > 0)
+                result.Add(isUnderlined ? $"[u]{current}[/u]" : current.ToString());
+        }
+
+        return result;
+    }
+
+    private float GetAlpha()
+    {
+        if (!_finished)
+            return MathF.Min(1f, _globalTime / _fadeDuration);
+
+        if (_fadingOut)
+            return MathF.Max(0f, 1f - (_globalTime - _holdStartTime - _holdDuration) / _fadeDuration);
+
+        return 1f;
+    }
+
+    private string BuildVisibleText(int lineIndex, float alpha)
+    {
+        if (lineIndex < _currentLine)
+            return _announceText[lineIndex];
+
+        if (lineIndex > _currentLine)
+            return string.Empty;
+
+        int visibleChars = _currentChar;
+
+        string fullText = _announceText[lineIndex];
+
+        if (_random.Prob(_glitchChance * alpha))
+        {
+            var glitched = new StringBuilder();
+            for (int i = 0; i < fullText.Length; i++)
+            {
+                if (i < visibleChars)
+                    glitched.Append(_random.Prob(0.3f) ? (char)_random.Next(33, 126) : fullText[i]);
+                else
+                    glitched.Append(_random.Next(2) == 0 ? ' ' : (char)_random.Next(33, 126));
+            }
+            return glitched.ToString();
+        }
+
+        var sb = new StringBuilder();
+        for (int i = 0; i < visibleChars && i < fullText.Length; i++)
+        {
+            sb.Append(_random.Prob(0.1f) && i > 0 ? ' ' : fullText[i]);
+        }
+
+        return sb.ToString();
+    }
+
+    private Color GetTextColor(int lineIndex, float alpha)
+    {
+        if (_random.Prob(_flickerChance * alpha))
+            return Color.LimeGreen.WithAlpha(0.8f * alpha);
+
+        if ((_globalTime + lineIndex * 0.2f) % 0.5f < 0.1f)
+            return Color.LimeGreen.WithAlpha(0.9f * alpha);
+
+        return Color.LimeGreen.WithAlpha(alpha);
+    }
+
+    private void UpdateState(float deltaTime)
+    {
+        if (_finished)
+        {
+            if (!_fadingOut && (_globalTime - _holdStartTime) > _holdDuration)
+                _fadingOut = true;
+            return;
+        }
+
+        _timer += deltaTime;
+        if (_timer < _printSpeed)
+            return;
+
+        _timer = 0;
+
+        if (_currentLine >= _announceText.Length)
+        {
+            _finished = true;
+            _holdStartTime = _globalTime;
+            return;
+        }
+
+        var line = _announceText[_currentLine];
+
+        if (_currentChar < line.Length)
+        {
+            _currentChar++;
+
+            if (_random.Prob(0.05f) && _currentChar > 5)
+                _timer = -_random.NextFloat(0.1f, 0.5f);
+        }
+        else
+        {
+            _currentLine++;
+            _currentChar = 0;
+            _timer = -_random.NextFloat(0.2f, 0.8f);
+        }
+    }
+
+    public static float MeasureTextWidth(Font font, string text, float scale)
+    {
+        float total = 0f;
+        foreach (var rune in text.EnumerateRunes())
+        {
+            if (font.TryGetCharMetrics(rune, scale, out var metrics))
+            {
+                total += metrics.Advance;
+            }
+        }
+
+        return total;
+    }
+}

--- a/Content.Shared/_RMC14/Marines/ScreenAnnounce/DeployAnnounceDropshipComponent.cs
+++ b/Content.Shared/_RMC14/Marines/ScreenAnnounce/DeployAnnounceDropshipComponent.cs
@@ -1,0 +1,23 @@
+using Content.Shared.Shuttles.Systems;
+using Robust.Shared.Audio;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Shared._RMC14.Marines.ScreenDeployAnnounce;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(SharedDeployAnnounceSystem))]
+public sealed partial class DeployAnnounceDropshipComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public LocId AnnounceText = "deploy-combat-alert";
+
+    [DataField, AutoNetworkedField]
+    public SoundSpecifier? AfterAnnounceSound;
+
+    [DataField, AutoNetworkedField]
+    public bool Deployed = false;
+}
+

--- a/Content.Shared/_RMC14/Marines/ScreenAnnounce/ScreenAnnounceArgs.cs
+++ b/Content.Shared/_RMC14/Marines/ScreenAnnounce/ScreenAnnounceArgs.cs
@@ -1,0 +1,77 @@
+using Content.Shared.Shuttles.Systems;
+using Robust.Shared.Audio;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Shared._RMC14.Marines.ScreenAnnounce;
+
+[NetSerializable, Serializable]
+public sealed class ScreenAnnounceArgs
+{
+    public float PrintSpeed;
+    public float ShakeIntensity;
+    public float FlickerChance;
+    public float GlitchChance;
+    public float HoldDuration;
+    public float FadeDuration;
+    public float LineHeightUnscaled;
+    public float MaxTextWidthFraction;
+
+    public ScreenAnnounceArgs()
+    {
+        PrintSpeed = 0.03f;
+        ShakeIntensity = 0.8f;
+        FlickerChance = 0.02f;
+        GlitchChance = 0.01f;
+        HoldDuration = 3f;
+        FadeDuration = 1.5f;
+        LineHeightUnscaled = 40f;
+        MaxTextWidthFraction = 0.9f;
+    }
+
+    public ScreenAnnounceArgs(
+        float printSpeed,
+        float shakeIntensity,
+        float flickerChance,
+        float glitchChance,
+        float holdDuration,
+        float fadeDuration,
+        float lineHeightUnscaled,
+        float maxTextWidthFraction)
+    {
+        PrintSpeed = printSpeed;
+        ShakeIntensity = shakeIntensity;
+        FlickerChance = flickerChance;
+        GlitchChance = glitchChance;
+        HoldDuration = holdDuration;
+        FadeDuration = fadeDuration;
+        LineHeightUnscaled = lineHeightUnscaled;
+        MaxTextWidthFraction = maxTextWidthFraction;
+    }
+
+    public ScreenAnnounceArgs With(
+        float? printSpeed = null,
+        float? shakeIntensity = null,
+        float? flickerChance = null,
+        float? glitchChance = null,
+        float? holdDuration = null,
+        float? fadeDuration = null,
+        float? lineHeightUnscaled = null,
+        float? maxTextWidthFraction = null)
+    {
+        return new ScreenAnnounceArgs(
+            printSpeed ?? PrintSpeed,
+            shakeIntensity ?? ShakeIntensity,
+            flickerChance ?? FlickerChance,
+            glitchChance ?? GlitchChance,
+            holdDuration ?? HoldDuration,
+            fadeDuration ?? FadeDuration,
+            lineHeightUnscaled ?? LineHeightUnscaled,
+            maxTextWidthFraction ?? MaxTextWidthFraction
+        );
+    }
+
+    public static readonly ScreenAnnounceArgs Default = new();
+}

--- a/Content.Shared/_RMC14/Marines/ScreenAnnounce/ScreenAnnounceMessage.cs
+++ b/Content.Shared/_RMC14/Marines/ScreenAnnounce/ScreenAnnounceMessage.cs
@@ -1,0 +1,34 @@
+using Content.Shared.Shuttles.Systems;
+using Robust.Shared.Audio;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Shared._RMC14.Marines.ScreenAnnounce;
+
+[NetSerializable, Serializable]
+public sealed class ScreenAnnounceMessage : EntityEventArgs
+{
+    public string[] AnnounceText;
+    public ScreenAnnounceTarget Target;
+    public NetEntity? Squad;
+    public ScreenAnnounceArgs ScreenAnnounceArgs;
+    public string StartingMessage = string.Empty;
+
+    public ScreenAnnounceMessage(string[] announceText, ScreenAnnounceTarget target, ScreenAnnounceArgs screenAnnounceArgs, string startingMessage, NetEntity? squad = null)
+    {
+        AnnounceText = announceText;
+        Target = target;
+        Squad = squad;
+        ScreenAnnounceArgs = screenAnnounceArgs;
+        StartingMessage = startingMessage;
+    }
+}
+
+public enum ScreenAnnounceTarget
+{
+    FirstDeploy,
+    SquadOnly,
+    AllMarines
+}

--- a/Content.Shared/_RMC14/Marines/ScreenAnnounce/SharedDeployAnnounceSystem.cs
+++ b/Content.Shared/_RMC14/Marines/ScreenAnnounce/SharedDeployAnnounceSystem.cs
@@ -1,0 +1,79 @@
+using System.Linq;
+using Content.Shared._RMC14.Areas;
+using Content.Shared._RMC14.CameraShake;
+using Content.Shared._RMC14.CCVar;
+using Content.Shared._RMC14.Dropship;
+using Content.Shared._RMC14.Map;
+using Content.Shared._RMC14.Marines;
+using Content.Shared._RMC14.Marines.Announce;
+using Content.Shared._RMC14.Marines.ScreenDeployAnnounce;
+using Content.Shared._RMC14.Marines.ScreenAnnounce;
+using Content.Shared.Coordinates;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Configuration;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Network;
+using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
+
+namespace Content.Shared._RMC14.Marines.ScreenDeployAnnounce;
+
+public sealed class SharedDeployAnnounceSystem : EntitySystem
+{
+    [Dependency] private readonly AreaSystem _area = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<DropshipLaunchedFromWarshipEvent>(OnDropshipLaunchedFromWarship);
+    }
+
+    private void OnDropshipLaunchedFromWarship(ref DropshipLaunchedFromWarshipEvent ev)
+    {
+        if (_net.IsClient)
+            return;
+
+        if (ev.Dropship.Comp.Destination is not { } destination)
+            return;
+
+        var coordinates = destination.ToCoordinates();
+        if (!_area.TryGetArea(coordinates, out var lzArea, out _) ||
+            string.IsNullOrWhiteSpace(lzArea.Value.Comp.LinkedLz))
+        {
+            return;
+        }
+
+        if (!TryComp<DeployAnnounceDropshipComponent>(ev.Dropship, out var deployComp))
+            return;
+
+        if (deployComp.Deployed)
+            return;
+
+        DeployAnnounce(ev.Dropship, deployComp);
+    }
+
+    public void DeployAnnounce(EntityUid dropship, DeployAnnounceDropshipComponent deployComp)
+    {
+        var map = _transform.GetMapId(dropship);
+        var mapFilter = Filter.BroadcastMap(map);
+        mapFilter.RemoveWhereAttachedEntity(ent => !HasComp<MarineComponent>(ent));
+
+        var rawText = Loc.GetString(deployComp.AnnounceText);
+        var text = rawText.Split('\n')
+                          .Select(line => line.Trim())
+                          .Where(line => !string.IsNullOrWhiteSpace(line))
+                          .ToArray();
+
+        var ev = new ScreenAnnounceMessage(text, ScreenAnnounceTarget.FirstDeploy, ScreenAnnounceArgs.Default, string.Empty, null);
+        RaiseNetworkEvent(ev, mapFilter);
+
+        if (deployComp.AfterAnnounceSound is not null)
+            _audio.PlayGlobal(deployComp.AfterAnnounceSound, mapFilter, true, null);
+
+        deployComp.Deployed = true;
+    }
+}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR adds messages(example - overwatch transmit) at the top of the screen like in CMSS13 also it adds a mission start message when the dropship first flies out and plays music if it has it

## Why / Balance
Parity? i think

## Technical details
N/A

## Media
Later

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [ ] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl: NotInButIn
