### PR TITLE
CMP rankup to 25 hours

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/MilitaryPolice/chief_military_police.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/MilitaryPolice/chief_military_police.yml
@@ -18,7 +18,7 @@
     RMCRankFirstLT:
     - !type:RoleTimeRequirement
       role: CMJobChiefMP
-      time: 72000 # 20 hours
+      time: 90000 # 25 hours
     RMCRankSecondLT: []
   weight: 5
   startingGear: CMGearChiefMP


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This increases the rank ladder for CMP as follows:
- O1 (Second Lieutenant): *Start rank, unchanged.*
- O2 (First Lieutenant): 10 hours -> **25 hours**

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Discord discussion: https://discord.com/channels/1168210010233376858/1378962189066698773

The thread linked proposes CMP is demoted to an enlisted rank, in order to lessen the effect of new CMP's powertripping based on their seriously elevated position in marine law. It argues that the officer rank the CMP holds scares new players in this role from accepting help from (often veteran) Warden and MP players in the same round.

This discussion goes on, where the argument is raised that a demotion may not be the right way. Whisper specifically stated that the problem seems to be in the fact that it is very easy to achieve the O2 rankup as a CMP. This PR implements the solution as proposed.

No time was given, 25 hours was the consensus a short discussion in the mentor channel resulted, as this also nicely aligns with the silver medal requirement for CMP.

## Technical details
<!-- Summary of code changes for easier review. -->

Nada.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Nope.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl: Whisper, discussion contributors
- tweak: CMP now requires 25 hours instead of 10 hours to rank up from Second Lieutenant to First Lieutenant.
