### PR TITLE
Prevent hive clusters being plantable on non-weedable surfaces

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Construction/HiveConstructionRequiresWeedableSurfaceComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/HiveConstructionRequiresWeedableSurfaceComponent.cs
@@ -1,0 +1,9 @@
+namespace Content.Shared._RMC14.Xenonids.Construction;
+
+/// <summary>
+/// Indicates that the hive structure must be built on a weedable tile
+/// </summary>
+[RegisterComponent]
+public sealed partial class HiveConstructionRequiresWeedableSurfaceComponent : Component
+{
+}

--- a/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
@@ -983,8 +983,7 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
                     tileDef.ID == ContentTileDefinition.SpaceID ||
                     tileDef is ContentTileDefinition { WeedsSpreadable: false })
                 {
-                    if (_net.IsServer)
-                        _popup.PopupEntity(Loc.GetString("cm-xeno-construction-failed-cant-build"), xeno, xeno);
+                    _popup.PopupClient(Loc.GetString("cm-xeno-construction-failed-cant-build"), xeno, xeno);
                     return false;
                 }
             }

--- a/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
@@ -73,6 +73,7 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
     [Dependency] private readonly XenoNestSystem _xenoNest = default!;
     [Dependency] private readonly XenoPlasmaSystem _xenoPlasma = default!;
     [Dependency] private readonly SharedXenoWeedsSystem _xenoWeeds = default!;
+    [Dependency] private readonly ITileDefinitionManager _tile = default!;
 
     private static readonly ImmutableArray<Direction> Directions = Enum.GetValues<Direction>()
         .Where(d => d != Direction.Invalid)
@@ -975,6 +976,19 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
         if (choice != null &&
             _prototype.TryIndex(choice, out var choiceProto))
         {
+            if (choiceProto.HasComponent<HiveConstructionRequiresWeedableSurfaceComponent>(_compFactory))
+            {
+                if (!_mapSystem.TryGetTileRef(gridId, grid, tile, out var tileRef) ||
+                    !_tile.TryGetDefinition(tileRef.Tile.TypeId, out var tileDef) ||
+                    tileDef.ID == ContentTileDefinition.SpaceID ||
+                    tileDef is ContentTileDefinition { WeedsSpreadable: false })
+                {
+                    if (_net.IsServer)
+                        _popup.PopupEntity(Loc.GetString("cm-xeno-construction-failed-cant-build"), xeno, xeno);
+                    return false;
+                }
+            }
+
             if (choiceProto.HasComponent<HiveConstructionRequiresHiveCoreComponent>(_compFactory))
             {
                 if (_hive.GetHive(xeno.Owner) is { } hiveEnt)

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/Hive/xeno_hive_cluster.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/Hive/xeno_hive_cluster.yml
@@ -33,6 +33,7 @@
       RMCCommunicationsTower: HivePylonXeno
   - type: XenoWeedsSpreading
   - type: HiveConstructionRequiresHiveCore
+  - type: HiveConstructionRequiresWeedableSurface
   - type: HiveConstructionLimited
     id: HiveClusterXeno
   - type: RepairableXenoStructure

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/Hive/xeno_hive_cluster.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/Hive/xeno_hive_cluster.yml
@@ -77,6 +77,7 @@
     plasmaCost: 300
     spawn: HiveClusterXeno
   - type: HiveConstructionRequiresHiveCore
+  - type: HiveConstructionRequiresWeedableSurface
   - type: HiveConstructionLimited
     id: HiveClusterXeno
   - type: WarpPoint


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Prevents hive clusters from being made on unweedable surfaces.
Parity.

Resolves #6607
## Technical details
<!-- Summary of code changes for easier review. -->

## Media

https://github.com/user-attachments/assets/e91f21fd-dd3e-4215-912c-b6d40b2b37eb



:cl:
- fix: Fixed hive clusters being able to be placed on unweedable surfaces, like grass.
