### PR TITLE
Fix valk not removing unconscious

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/FightOrFlight/XenoFightOrFlightComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/FightOrFlight/XenoFightOrFlightComponent.cs
@@ -33,7 +33,7 @@ public sealed partial class XenoFightOrFlightComponent : Component
     public TimeSpan Jitter = TimeSpan.FromSeconds(1);
 
     [DataField, AutoNetworkedField]
-    public ProtoId<StatusEffectPrototype>[] AilmentsRemove = ["KnockedDown", "Stun"];
+    public ProtoId<StatusEffectPrototype>[] AilmentsRemove = ["KnockedDown", "Stun", "Dazed", "Unconscious"];
 
     [DataField]
     public ComponentRegistry ComponentsRemove;

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/praetorian.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/praetorian.yml
@@ -217,7 +217,6 @@
     - type: RMCSlowdown
     - type: RMCSuperSlowdown
     - type: RMCRooted
-    - type: RMCDazed
   - type: XenoHighGallop
   - type: XenoHidden
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Forgor.

## Technical details
<!-- Summary of code changes for easier review. -->
Added Dazed + Unconscious to the status remove list, and removed the dazed comp from being removed from the comp list, since the status removal should handle it.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
no cl not in game yet
