### PR TITLE
Fix FORECON CO spawn menu role name

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/commander.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/commander.yml
@@ -7,6 +7,7 @@
   ranks:
     RMCRankMajor: []
   startingGear: RMCGearForeconCommander
+  spawnMenuRoleName: FORECON Commander (Survivor)
   supervisors: cm-job-supervisors-marine-high-command
   roleWeight: 0.25
   icon: "RMCJobIconForeconCommander"


### PR DESCRIPTION
Accidentally removed it in #6535 (Why did it remove it when i merged master? I dont even remember removing it)