### PR TITLE
Add shotgun shell pouch and belt fill visualizers

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/base.yml
@@ -7,16 +7,6 @@
   description: Can hold various things.
   components:
   - type: Appearance
-  - type: Sprite
-    layers:
-    - state: icon
-    - state: half
-      map: [ "openLayer" ]
-    - state: full
-      map: [ "closedLayer" ]
-  - type: CMStorageVisualizer
-    storageClosed: closedLayer
-    storageOpen: openLayer
   - type: Item
     size: Large
   - type: UserInterface
@@ -34,7 +24,7 @@
 - type: entity
   abstract: true
   parent: CMBeltBase
-  id: CMBeltBaseStorage
+  id: CMBeltBaseStorageNoVisuals
   components:
   - type: Storage
     maxItemSize: Small
@@ -47,3 +37,18 @@
   - type: RMCStorageEjectHand
   - type: StoreAfterFailedInteract
 
+- type: entity
+  abstract: true
+  parent: CMBeltBaseStorageNoVisuals
+  id: CMBeltBaseStorage
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+    - state: half
+      map: [ "openLayer" ]
+    - state: full
+      map: [ "closedLayer" ]
+  - type: CMStorageVisualizer
+    storageClosed: closedLayer
+    storageOpen: openLayer

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
@@ -67,10 +67,8 @@
     - state: icon
     - state: half
       visible: false
-      map: [ "halfLayer" ]
     - state: full
       visible: false
-      map: [ "fullLayer" ]
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/Belt/shotgun/jungle-classic.rsi
   - type: Item
@@ -98,13 +96,13 @@
       Classic: _RMC14/Objects/Clothing/Belt/shotgun/jungle-classic.rsi
   - type: ItemMapper
     mapLayers:
-      halfLayer:
+      half:
         minCount: 1
         whitelist:
           tags:
           - RMCShellShotgun
           - RMCCartridge458SOCOM
-      fullLayer:
+      full:
         minCount: 14
         whitelist:
           tags:

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
@@ -56,13 +56,21 @@
       Classic: _RMC14/Objects/Clothing/Belt/marine/jungle-classic.rsi
 
 - type: entity
-  parent: CMBeltBaseStorage
+  parent: CMBeltBaseStorageNoVisuals
   id: RMCM276ShotgunShellLoadingRig
   name: M276 pattern shotgun shell loading rig
   description: An ammunition belt designed to hold shotgun shells. # or individual bullets. TODO RMC14
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Belt/shotgun/jungle-classic.rsi
+    layers:
+    - state: icon
+    - state: half
+      visible: false
+      map: [ "halfLayer" ]
+    - state: full
+      visible: false
+      map: [ "fullLayer" ]
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/Belt/shotgun/jungle-classic.rsi
   - type: Item
@@ -88,6 +96,20 @@
       Desert: _RMC14/Objects/Clothing/Belt/shotgun/desert.rsi
       Urban: _RMC14/Objects/Clothing/Belt/shotgun/snow-urban.rsi
       Classic: _RMC14/Objects/Clothing/Belt/shotgun/jungle-classic.rsi
+  - type: ItemMapper
+    mapLayers:
+      halfLayer:
+        minCount: 1
+        whitelist:
+          tags:
+          - RMCShellShotgun
+          - RMCCartridge458SOCOM
+      fullLayer:
+        minCount: 14
+        whitelist:
+          tags:
+          - RMCShellShotgun
+          - RMCCartridge458SOCOM
 
 - type: entity
   parent: RMCM276ShotgunShellLoadingRig

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Pouches/storage.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Pouches/storage.yml
@@ -310,10 +310,8 @@
     - state: icon
     - state: half
       visible: false
-      map: [ "halfLayer" ]
     - state: full
       visible: false
-      map: [ "fullLayer" ]
   - type: Storage
     grid:
     - 0,0,9,1 #5 slots
@@ -332,13 +330,13 @@
     - RMCPouchShotgunShells
   - type: ItemMapper
     mapLayers:
-      halfLayer:
+      half:
         minCount: 1
         whitelist:
           tags:
           - RMCShellShotgun
           - RMCCartridge458SOCOM
-      fullLayer:
+      full:
         minCount: 5
         whitelist:
           tags:
@@ -365,6 +363,20 @@
     items:
       tags:
       - RMCShellShotgun
+  - type: ItemMapper
+    mapLayers:
+      half:
+        minCount: 1
+        whitelist:
+          tags:
+          - RMCShellShotgun
+          - RMCCartridge458SOCOM
+      full:
+        minCount: 7
+        whitelist:
+          tags:
+          - RMCShellShotgun
+          - RMCCartridge458SOCOM
 
 - type: entity
   parent: RMCPouchShotgunLarge

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Pouches/storage.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Pouches/storage.yml
@@ -306,6 +306,14 @@
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Pouches/medium_shotshells.rsi
+    layers:
+    - state: icon
+    - state: half
+      visible: false
+      map: [ "halfLayer" ]
+    - state: full
+      visible: false
+      map: [ "fullLayer" ]
   - type: Storage
     grid:
     - 0,0,9,1 #5 slots
@@ -322,7 +330,20 @@
     tags:
     - Pouch
     - RMCPouchShotgunShells
-
+  - type: ItemMapper
+    mapLayers:
+      halfLayer:
+        minCount: 1
+        whitelist:
+          tags:
+          - RMCShellShotgun
+          - RMCCartridge458SOCOM
+      fullLayer:
+        minCount: 5
+        whitelist:
+          tags:
+          - RMCShellShotgun
+          - RMCCartridge458SOCOM
 
 # Large Shotgun Shell Pouch
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
They are cool

## Media

https://github.com/user-attachments/assets/b96048fe-fe7c-4242-9556-708a29bd8946



:cl:
- add: Added fill visuals for shotgun shell pouch and loading rig.
