### PR TITLE
Le Thunder

### DIFF
--- a/Resources/Maps/_RMC14/Shuttles/ert_pmc_shuttle.yml
+++ b/Resources/Maps/_RMC14/Shuttles/ert_pmc_shuttle.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 251.0.1
   forkId: ""
   forkVersion: ""
-  time: 06/05/2025 15:11:13
-  entityCount: 67
+  time: 06/07/2025 13:28:17
+  entityCount: 73
 maps: []
 grids:
 - 1
@@ -77,6 +77,98 @@ entities:
         chunkSize: 4
     - type: GasTileOverlay
     - type: RadiationGridResistance
+    - type: AreaGrid
+      labels: {}
+      areaEntities: {}
+      colors: {}
+      areas:
+        3,-7: RMCAreaShuttleERT
+        3,-6: RMCAreaShuttleERT
+        3,-5: RMCAreaShuttleERT
+        3,-4: RMCAreaShuttleERT
+        3,-3: RMCAreaShuttleERT
+        3,-2: RMCAreaShuttleERT
+        3,-1: RMCAreaShuttleERT
+        3,0: RMCAreaShuttleERT
+        3,1: RMCAreaShuttleERT
+        3,2: RMCAreaShuttleERT
+        3,3: RMCAreaShuttleERT
+        2,-7: RMCAreaShuttleERT
+        2,-6: RMCAreaShuttleERT
+        2,-5: RMCAreaShuttleERT
+        2,-4: RMCAreaShuttleERT
+        2,-3: RMCAreaShuttleERT
+        2,-2: RMCAreaShuttleERT
+        2,-1: RMCAreaShuttleERT
+        2,0: RMCAreaShuttleERT
+        2,1: RMCAreaShuttleERT
+        2,2: RMCAreaShuttleERT
+        2,3: RMCAreaShuttleERT
+        1,-7: RMCAreaShuttleERT
+        1,-6: RMCAreaShuttleERT
+        1,-5: RMCAreaShuttleERT
+        1,-4: RMCAreaShuttleERT
+        1,-3: RMCAreaShuttleERT
+        1,-2: RMCAreaShuttleERT
+        1,-1: RMCAreaShuttleERT
+        1,0: RMCAreaShuttleERT
+        1,1: RMCAreaShuttleERT
+        1,2: RMCAreaShuttleERT
+        1,3: RMCAreaShuttleERT
+        0,-7: RMCAreaShuttleERT
+        0,-6: RMCAreaShuttleERT
+        0,-5: RMCAreaShuttleERT
+        0,-4: RMCAreaShuttleERT
+        0,-3: RMCAreaShuttleERT
+        0,-2: RMCAreaShuttleERT
+        0,-1: RMCAreaShuttleERT
+        -2,0: RMCAreaShuttleERT
+        0,0: RMCAreaShuttleERT
+        0,1: RMCAreaShuttleERT
+        0,2: RMCAreaShuttleERT
+        0,3: RMCAreaShuttleERT
+        -1,-7: RMCAreaShuttleERT
+        -1,-6: RMCAreaShuttleERT
+        -1,-5: RMCAreaShuttleERT
+        -1,-4: RMCAreaShuttleERT
+        -1,-3: RMCAreaShuttleERT
+        -1,-2: RMCAreaShuttleERT
+        -1,-1: RMCAreaShuttleERT
+        -1,0: RMCAreaShuttleERT
+        -1,1: RMCAreaShuttleERT
+        -1,2: RMCAreaShuttleERT
+        -1,3: RMCAreaShuttleERT
+        -2,-7: RMCAreaShuttleERT
+        -2,-6: RMCAreaShuttleERT
+        -2,-5: RMCAreaShuttleERT
+        -2,-4: RMCAreaShuttleERT
+        -2,-3: RMCAreaShuttleERT
+        -2,-2: RMCAreaShuttleERT
+        -2,-1: RMCAreaShuttleERT
+        -2,1: RMCAreaShuttleERT
+        -2,2: RMCAreaShuttleERT
+        -2,3: RMCAreaShuttleERT
+        -3,-7: RMCAreaShuttleERT
+        -3,-6: RMCAreaShuttleERT
+        -3,-5: RMCAreaShuttleERT
+        -3,-4: RMCAreaShuttleERT
+        -3,-3: RMCAreaShuttleERT
+        -3,-2: RMCAreaShuttleERT
+        -3,-1: RMCAreaShuttleERT
+        -3,0: RMCAreaShuttleERT
+        -3,1: RMCAreaShuttleERT
+        -3,2: RMCAreaShuttleERT
+        -3,3: RMCAreaShuttleERT
+        1,5: RMCAreaShuttleERT
+        0,5: RMCAreaShuttleERT
+        -1,5: RMCAreaShuttleERT
+        3,4: RMCAreaShuttleERT
+        2,4: RMCAreaShuttleERT
+        1,4: RMCAreaShuttleERT
+        0,4: RMCAreaShuttleERT
+        -1,4: RMCAreaShuttleERT
+        -2,4: RMCAreaShuttleERT
+        -3,4: RMCAreaShuttleERT
 - proto: CMAdvFirstAidKitFilled
   entities:
   - uid: 59
@@ -420,6 +512,42 @@ entities:
     components:
     - type: Transform
       pos: 3.5,-3.5
+      parent: 1
+- proto: RMCLightFixtureBlueDoubleAlwaysPowered
+  entities:
+  - uid: 68
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-4.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-4.5
       parent: 1
 - proto: RMCSeatDark
   entities:

--- a/Resources/Maps/_RMC14/Shuttles/ert_response_shuttle.yml
+++ b/Resources/Maps/_RMC14/Shuttles/ert_response_shuttle.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 251.0.1
   forkId: ""
   forkVersion: ""
-  time: 06/04/2025 20:58:03
-  entityCount: 67
+  time: 06/07/2025 13:28:34
+  entityCount: 73
 maps: []
 grids:
 - 1
@@ -77,6 +77,98 @@ entities:
         chunkSize: 4
     - type: GasTileOverlay
     - type: RadiationGridResistance
+    - type: AreaGrid
+      labels: {}
+      areaEntities: {}
+      colors: {}
+      areas:
+        -3,4: RMCAreaShuttleERT
+        -2,4: RMCAreaShuttleERT
+        -1,4: RMCAreaShuttleERT
+        0,4: RMCAreaShuttleERT
+        1,4: RMCAreaShuttleERT
+        2,4: RMCAreaShuttleERT
+        3,4: RMCAreaShuttleERT
+        -1,5: RMCAreaShuttleERT
+        0,5: RMCAreaShuttleERT
+        1,5: RMCAreaShuttleERT
+        -3,3: RMCAreaShuttleERT
+        -3,2: RMCAreaShuttleERT
+        -3,1: RMCAreaShuttleERT
+        -3,0: RMCAreaShuttleERT
+        -3,-1: RMCAreaShuttleERT
+        -3,-2: RMCAreaShuttleERT
+        -3,-3: RMCAreaShuttleERT
+        -3,-4: RMCAreaShuttleERT
+        -3,-5: RMCAreaShuttleERT
+        -2,3: RMCAreaShuttleERT
+        -2,2: RMCAreaShuttleERT
+        -2,1: RMCAreaShuttleERT
+        -2,0: RMCAreaShuttleERT
+        -2,-1: RMCAreaShuttleERT
+        -2,-2: RMCAreaShuttleERT
+        -2,-3: RMCAreaShuttleERT
+        -2,-4: RMCAreaShuttleERT
+        -2,-5: RMCAreaShuttleERT
+        -2,-6: RMCAreaShuttleERT
+        -2,-7: RMCAreaShuttleERT
+        -1,3: RMCAreaShuttleERT
+        -1,2: RMCAreaShuttleERT
+        -1,1: RMCAreaShuttleERT
+        -1,0: RMCAreaShuttleERT
+        -1,-1: RMCAreaShuttleERT
+        -1,-2: RMCAreaShuttleERT
+        -1,-3: RMCAreaShuttleERT
+        -1,-4: RMCAreaShuttleERT
+        -1,-5: RMCAreaShuttleERT
+        -1,-6: RMCAreaShuttleERT
+        -1,-7: RMCAreaShuttleERT
+        0,3: RMCAreaShuttleERT
+        0,2: RMCAreaShuttleERT
+        0,1: RMCAreaShuttleERT
+        0,0: RMCAreaShuttleERT
+        0,-1: RMCAreaShuttleERT
+        0,-2: RMCAreaShuttleERT
+        0,-3: RMCAreaShuttleERT
+        0,-4: RMCAreaShuttleERT
+        0,-5: RMCAreaShuttleERT
+        0,-6: RMCAreaShuttleERT
+        0,-7: RMCAreaShuttleERT
+        1,3: RMCAreaShuttleERT
+        1,2: RMCAreaShuttleERT
+        1,1: RMCAreaShuttleERT
+        1,0: RMCAreaShuttleERT
+        1,-1: RMCAreaShuttleERT
+        1,-2: RMCAreaShuttleERT
+        1,-3: RMCAreaShuttleERT
+        1,-4: RMCAreaShuttleERT
+        1,-5: RMCAreaShuttleERT
+        1,-6: RMCAreaShuttleERT
+        1,-7: RMCAreaShuttleERT
+        2,3: RMCAreaShuttleERT
+        2,2: RMCAreaShuttleERT
+        2,1: RMCAreaShuttleERT
+        2,0: RMCAreaShuttleERT
+        2,-1: RMCAreaShuttleERT
+        2,-2: RMCAreaShuttleERT
+        2,-3: RMCAreaShuttleERT
+        2,-4: RMCAreaShuttleERT
+        2,-5: RMCAreaShuttleERT
+        2,-6: RMCAreaShuttleERT
+        2,-7: RMCAreaShuttleERT
+        3,3: RMCAreaShuttleERT
+        3,2: RMCAreaShuttleERT
+        3,1: RMCAreaShuttleERT
+        3,0: RMCAreaShuttleERT
+        3,-1: RMCAreaShuttleERT
+        3,-2: RMCAreaShuttleERT
+        3,-3: RMCAreaShuttleERT
+        3,-4: RMCAreaShuttleERT
+        3,-5: RMCAreaShuttleERT
+        3,-6: RMCAreaShuttleERT
+        3,-7: RMCAreaShuttleERT
+        -3,-6: RMCAreaShuttleERT
+        -3,-7: RMCAreaShuttleERT
 - proto: CMAdvFirstAidKitFilled
   entities:
   - uid: 59
@@ -408,6 +500,42 @@ entities:
     components:
     - type: Transform
       pos: 3.5,-3.5
+      parent: 1
+- proto: RMCLightFixtureDoubleAlwaysPowered
+  entities:
+  - uid: 68
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-4.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-4.5
       parent: 1
 - proto: RMCSeatDark
   entities:

--- a/Resources/Maps/_RMC14/Shuttles/ert_spp_shuttle.yml
+++ b/Resources/Maps/_RMC14/Shuttles/ert_spp_shuttle.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 251.0.1
   forkId: ""
   forkVersion: ""
-  time: 06/05/2025 15:20:28
-  entityCount: 67
+  time: 06/07/2025 13:27:43
+  entityCount: 73
 maps: []
 grids:
 - 1
@@ -77,6 +77,98 @@ entities:
         chunkSize: 4
     - type: GasTileOverlay
     - type: RadiationGridResistance
+    - type: AreaGrid
+      labels: {}
+      areaEntities: {}
+      colors: {}
+      areas:
+        -1,5: RMCAreaShuttleERT
+        0,5: RMCAreaShuttleERT
+        1,5: RMCAreaShuttleERT
+        -3,4: RMCAreaShuttleERT
+        -3,3: RMCAreaShuttleERT
+        -3,2: RMCAreaShuttleERT
+        -3,1: RMCAreaShuttleERT
+        -3,0: RMCAreaShuttleERT
+        -3,-1: RMCAreaShuttleERT
+        -3,-2: RMCAreaShuttleERT
+        -3,-3: RMCAreaShuttleERT
+        -3,-4: RMCAreaShuttleERT
+        -3,-6: RMCAreaShuttleERT
+        -3,-5: RMCAreaShuttleERT
+        -3,-7: RMCAreaShuttleERT
+        -2,4: RMCAreaShuttleERT
+        -2,3: RMCAreaShuttleERT
+        -2,2: RMCAreaShuttleERT
+        -2,1: RMCAreaShuttleERT
+        -2,0: RMCAreaShuttleERT
+        -2,-2: RMCAreaShuttleERT
+        -2,-3: RMCAreaShuttleERT
+        -2,-4: RMCAreaShuttleERT
+        -2,-5: RMCAreaShuttleERT
+        -2,-6: RMCAreaShuttleERT
+        -2,-7: RMCAreaShuttleERT
+        -1,4: RMCAreaShuttleERT
+        -1,3: RMCAreaShuttleERT
+        -1,2: RMCAreaShuttleERT
+        -1,1: RMCAreaShuttleERT
+        -1,-2: RMCAreaShuttleERT
+        -1,-1: RMCAreaShuttleERT
+        -1,-3: RMCAreaShuttleERT
+        -1,-4: RMCAreaShuttleERT
+        -1,-5: RMCAreaShuttleERT
+        -1,-6: RMCAreaShuttleERT
+        -1,-7: RMCAreaShuttleERT
+        0,4: RMCAreaShuttleERT
+        0,3: RMCAreaShuttleERT
+        -2,-1: RMCAreaShuttleERT
+        0,1: RMCAreaShuttleERT
+        0,0: RMCAreaShuttleERT
+        0,-1: RMCAreaShuttleERT
+        0,-2: RMCAreaShuttleERT
+        0,-3: RMCAreaShuttleERT
+        0,-4: RMCAreaShuttleERT
+        0,-5: RMCAreaShuttleERT
+        0,-6: RMCAreaShuttleERT
+        0,-7: RMCAreaShuttleERT
+        1,4: RMCAreaShuttleERT
+        1,3: RMCAreaShuttleERT
+        1,2: RMCAreaShuttleERT
+        1,1: RMCAreaShuttleERT
+        1,0: RMCAreaShuttleERT
+        1,-1: RMCAreaShuttleERT
+        1,-2: RMCAreaShuttleERT
+        1,-3: RMCAreaShuttleERT
+        1,-4: RMCAreaShuttleERT
+        1,-5: RMCAreaShuttleERT
+        1,-6: RMCAreaShuttleERT
+        1,-7: RMCAreaShuttleERT
+        2,4: RMCAreaShuttleERT
+        2,3: RMCAreaShuttleERT
+        2,2: RMCAreaShuttleERT
+        2,1: RMCAreaShuttleERT
+        2,0: RMCAreaShuttleERT
+        2,-1: RMCAreaShuttleERT
+        2,-2: RMCAreaShuttleERT
+        2,-3: RMCAreaShuttleERT
+        2,-4: RMCAreaShuttleERT
+        2,-5: RMCAreaShuttleERT
+        2,-6: RMCAreaShuttleERT
+        2,-7: RMCAreaShuttleERT
+        3,4: RMCAreaShuttleERT
+        3,3: RMCAreaShuttleERT
+        3,2: RMCAreaShuttleERT
+        3,1: RMCAreaShuttleERT
+        3,0: RMCAreaShuttleERT
+        3,-1: RMCAreaShuttleERT
+        3,-2: RMCAreaShuttleERT
+        3,-3: RMCAreaShuttleERT
+        3,-4: RMCAreaShuttleERT
+        3,-5: RMCAreaShuttleERT
+        3,-6: RMCAreaShuttleERT
+        3,-7: RMCAreaShuttleERT
+        0,2: RMCAreaShuttleERT
+        -1,0: RMCAreaShuttleERT
 - proto: CMAdvFirstAidKitFilled
   entities:
   - uid: 59
@@ -410,6 +502,42 @@ entities:
     components:
     - type: Transform
       pos: 3.5,-3.5
+      parent: 1
+- proto: RMCLightFixtureDoubleAlwaysPowered
+  entities:
+  - uid: 68
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-4.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-4.5
       parent: 1
 - proto: RMCSeatDark
   entities:

--- a/Resources/Maps/_RMC14/Shuttles/ert_tse_shuttle.yml
+++ b/Resources/Maps/_RMC14/Shuttles/ert_tse_shuttle.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 251.0.1
   forkId: ""
   forkVersion: ""
-  time: 06/05/2025 15:21:59
-  entityCount: 67
+  time: 06/07/2025 13:27:58
+  entityCount: 73
 maps: []
 grids:
 - 1
@@ -77,6 +77,98 @@ entities:
         chunkSize: 4
     - type: GasTileOverlay
     - type: RadiationGridResistance
+    - type: AreaGrid
+      labels: {}
+      areaEntities: {}
+      colors: {}
+      areas:
+        -3,4: RMCAreaShuttleERT
+        -2,4: RMCAreaShuttleERT
+        -1,4: RMCAreaShuttleERT
+        0,4: RMCAreaShuttleERT
+        1,4: RMCAreaShuttleERT
+        2,4: RMCAreaShuttleERT
+        3,4: RMCAreaShuttleERT
+        -1,5: RMCAreaShuttleERT
+        0,5: RMCAreaShuttleERT
+        1,5: RMCAreaShuttleERT
+        -3,3: RMCAreaShuttleERT
+        -3,2: RMCAreaShuttleERT
+        -3,1: RMCAreaShuttleERT
+        -3,0: RMCAreaShuttleERT
+        -3,-1: RMCAreaShuttleERT
+        -3,-2: RMCAreaShuttleERT
+        -3,-3: RMCAreaShuttleERT
+        -3,-4: RMCAreaShuttleERT
+        -3,-5: RMCAreaShuttleERT
+        -3,-6: RMCAreaShuttleERT
+        -3,-7: RMCAreaShuttleERT
+        -2,3: RMCAreaShuttleERT
+        -2,2: RMCAreaShuttleERT
+        -2,1: RMCAreaShuttleERT
+        -2,0: RMCAreaShuttleERT
+        -2,-1: RMCAreaShuttleERT
+        -2,-2: RMCAreaShuttleERT
+        -2,-3: RMCAreaShuttleERT
+        -2,-4: RMCAreaShuttleERT
+        -2,-5: RMCAreaShuttleERT
+        -2,-6: RMCAreaShuttleERT
+        -2,-7: RMCAreaShuttleERT
+        -1,3: RMCAreaShuttleERT
+        -1,2: RMCAreaShuttleERT
+        -1,1: RMCAreaShuttleERT
+        -1,0: RMCAreaShuttleERT
+        -1,-1: RMCAreaShuttleERT
+        -1,-2: RMCAreaShuttleERT
+        -1,-4: RMCAreaShuttleERT
+        -1,-5: RMCAreaShuttleERT
+        -1,-6: RMCAreaShuttleERT
+        -1,-7: RMCAreaShuttleERT
+        -1,-3: RMCAreaShuttleERT
+        0,1: RMCAreaShuttleERT
+        0,0: RMCAreaShuttleERT
+        0,-1: RMCAreaShuttleERT
+        0,-2: RMCAreaShuttleERT
+        0,-3: RMCAreaShuttleERT
+        0,-4: RMCAreaShuttleERT
+        0,-5: RMCAreaShuttleERT
+        0,-6: RMCAreaShuttleERT
+        0,-7: RMCAreaShuttleERT
+        1,3: RMCAreaShuttleERT
+        1,2: RMCAreaShuttleERT
+        1,1: RMCAreaShuttleERT
+        1,0: RMCAreaShuttleERT
+        1,-1: RMCAreaShuttleERT
+        1,-2: RMCAreaShuttleERT
+        1,-3: RMCAreaShuttleERT
+        1,-4: RMCAreaShuttleERT
+        1,-5: RMCAreaShuttleERT
+        0,3: RMCAreaShuttleERT
+        1,-7: RMCAreaShuttleERT
+        2,3: RMCAreaShuttleERT
+        2,2: RMCAreaShuttleERT
+        2,1: RMCAreaShuttleERT
+        2,0: RMCAreaShuttleERT
+        2,-1: RMCAreaShuttleERT
+        2,-2: RMCAreaShuttleERT
+        2,-3: RMCAreaShuttleERT
+        2,-4: RMCAreaShuttleERT
+        2,-5: RMCAreaShuttleERT
+        2,-6: RMCAreaShuttleERT
+        2,-7: RMCAreaShuttleERT
+        3,3: RMCAreaShuttleERT
+        3,2: RMCAreaShuttleERT
+        3,1: RMCAreaShuttleERT
+        3,0: RMCAreaShuttleERT
+        3,-1: RMCAreaShuttleERT
+        3,-2: RMCAreaShuttleERT
+        3,-3: RMCAreaShuttleERT
+        3,-4: RMCAreaShuttleERT
+        3,-5: RMCAreaShuttleERT
+        3,-6: RMCAreaShuttleERT
+        3,-7: RMCAreaShuttleERT
+        1,-6: RMCAreaShuttleERT
+        0,2: RMCAreaShuttleERT
 - proto: CMAirlockShuttle
   entities:
   - uid: 52
@@ -401,6 +493,42 @@ entities:
     components:
     - type: Transform
       pos: 3.5,-3.5
+      parent: 1
+- proto: RMCLightFixtureBlueDoubleAlwaysPowered
+  entities:
+  - uid: 68
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-4.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-4.5
       parent: 1
 - proto: RMCSeatDark
   entities:

--- a/Resources/Maps/_RMC14/thunderdome.yml
+++ b/Resources/Maps/_RMC14/thunderdome.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 251.0.1
   forkId: ""
   forkVersion: ""
-  time: 05/30/2025 17:24:52
-  entityCount: 1232
+  time: 06/07/2025 13:29:56
+  entityCount: 1236
 maps:
 - 1
 grids:
@@ -21717,6 +21717,34 @@ entities:
     components:
     - type: Transform
       pos: -28.5,-2.5
+      parent: 1
+- proto: RMCSpawnerERTShuttle
+  entities:
+  - uid: 1235
+    components:
+    - type: Transform
+      pos: -40.5,-9.5
+      parent: 1
+- proto: RMCSpawnerERTShuttleSPP
+  entities:
+  - uid: 1234
+    components:
+    - type: Transform
+      pos: -16.5,-27.5
+      parent: 1
+- proto: RMCSpawnerERTShuttleTSE
+  entities:
+  - uid: 1236
+    components:
+    - type: Transform
+      pos: -16.5,-9.5
+      parent: 1
+- proto: RMCSpawnerERTShuttleWeYa
+  entities:
+  - uid: 1233
+    components:
+    - type: Transform
+      pos: -40.5,-27.5
       parent: 1
 - proto: RMCSprayBottleSpaceCleaner
   entities:

--- a/Resources/Prototypes/_RMC14/Entities/Areas/areas_ert.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Areas/areas_ert.yml
@@ -34,3 +34,37 @@
   - type: Area
     powerNet: faxexterior
     avoidBioscan: true
+
+# Shuttles
+
+- type: entity
+  parent: RMCAreaBase
+  id: RMCAreaShuttleNS #Not Sulaco
+  name: Shuttle
+  components:
+  - type: Sprite
+    sprite: _RMC14/Areas/areas_shiva.rsi
+    state: shuttle
+  - type: Area
+    resinAllowed: false
+    avoidBioscan: false
+    noTunnel: true
+    unweedable: false
+    CAS: false
+    fulton: false
+    lasing: false
+    mortarPlacement: false
+    mortarFire: false
+    medevac: false
+    OB: false
+    supplyDrop: false
+    weatherEnabled: false
+
+- type: entity
+  parent: RMCAreaShuttleNS
+  id: RMCAreaShuttleERT #Not Sulaco
+  name: ERT Shuttle
+  components:
+  - type: Sprite
+    sprite: _RMC14/Areas/areas_almayer.rsi
+    state: lifeboat

--- a/Resources/Prototypes/_RMC14/Entities/Areas/areas_ert.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Areas/areas_ert.yml
@@ -62,7 +62,7 @@
 
 - type: entity
   parent: RMCAreaShuttleNS
-  id: RMCAreaShuttleERT #Not Sulaco
+  id: RMCAreaShuttleERT
   name: ERT Shuttle
   components:
   - type: Sprite

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/ert_machines.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/ert_machines.yml
@@ -11,7 +11,7 @@
     state: green
   - type: GridSpawner
     spawn: "/Maps/_RMC14/Shuttles/ert_response_shuttle.yml"
-    offset: 0.0,0.0
+    offset: -0.5,-0.5
 
 - type: entity
   parent: RMCSpawnerERTShuttle


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Continuation of #6632, adds ert shuttle to thunderdrome, equips them with light fixtures and shuttle areas

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity + OB protection + dark without lights

## Technical details
<!-- Summary of code changes for easier review. -->
Two new areas in ert_areas, generic one for shuttles and one for ert shuttles specifically
Changes offset of spawners to spawn shuttles in the middle of it

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="799" alt="Screenshot 2025-06-07 at 16 53 44" src="https://github.com/user-attachments/assets/478cc7cc-84d0-4288-8efa-e433487a439e" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
-->
:cl: J C Denton
- tweak: ERT Shuttles now spawn on Thunderdrome map.