### PR TITLE
Replaces magazines in m1984 weapon cases with AP rounds (MP sidearm change)

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/gun_cases.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/gun_cases.yml
@@ -130,13 +130,14 @@
     whitelist:
       tags:
       - CMWeaponPistolM1984
+      - RMCMagazinePistolM1984AP
       - CMMagazinePistolM1984
       - RMCAttachmentRailFlashlight
   - type: StorageFill
     contents:
     - id: RMCAttachmentRailFlashlight
     - id: CMWeaponPistolM1984
-    - id: CMMagazinePistolM1984
+    - id: RMCMagazinePistolM1984AP
       amount: 6
 
 # RSh9 Assault Revolver


### PR DESCRIPTION
Updates the magazines provided in the M1984 Weapon Case to AP, to match ammo provided in the other weapon cases

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added RMCWeaponMagazineM1984AP to the M1984 Weapon Case whitelist, and replaces the 6 standard magazines with AP instead
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Of the three sidearm choices available to MPs, the M1984 is the only one that does not come with AP magazines in reserve. This leaves it lacking against armored targets (such as bad-actor marines and post-hijack xenos) whereas the M77 and M44 will deal their full damage. 

This change replaces the reserve ammunition in the 1984 case with their AP variant, which deals 25 damage, on par with the M77 (before accounting for weapon modifiers). The 1984 otherwise has a higher rate of fire than the M77, but a lower total capacity.
I believe this change will make the 1984 a more attractive prospect for some MPs whilst also preventing the common occurance of the QM's supply of AP magazines being gobbled up by those MPs.

According to testing conducted by the MP enjoyers of MarineCord, this brings the TTC (time to crit) on an EOD-clad marine as follows:
M1984 AP - 7 shots
M77 - 7 shots
M44 Marksman - 4 shots 

Concerns of balance are that the higher firerate of the 1984 (and its affinity with the burstfire assembly) might make the 1984 TOO strong, but i feel the lower magazine size of the firearm (and limited supply of AP 9mm) negates this somewhat.


## Technical details
<!-- Summary of code changes for easier review. -->
Changes whitelist of M1984 guncase to allow AP magazines and replaces the 6 standard mags with AP
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Replaces the standard magazines in the MPs 1984 Weapon Case with their AP variant. No more raiding the QM's stash.
