### PR TITLE
Swap medium and light armor explosion armor values

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
@@ -11,7 +11,7 @@
     melee: 20
     bullet: 20
     bio: 20
-    explosionArmor: 15
+    explosionArmor: 20
   - type: RMCArmorSpeedTier
     speedTier: medium
   - type: ClothingSpeedModifier
@@ -139,7 +139,6 @@
   - type: CMArmor
     melee: 25
     bio: 25
-    explosionArmor: 20
   - type: ItemCamouflage
     camouflageVariations:
       Jungle: _RMC14/Objects/Clothing/OuterClothing/Armor/m3/b12/jungle.rsi
@@ -335,7 +334,6 @@
   - type: CMArmor
     bullet: 30
     bio: 20
-    explosionArmor: 15
   - type: SmartGunArmor
   - type: Storage
     maxItemSize: Small
@@ -360,7 +358,6 @@
   - type: CMArmor
     bullet: 30
     bio: 20
-    explosionArmor: 15
   - type: SmartGunArmor
   - type: Storage
     maxItemSize: Small
@@ -429,7 +426,7 @@
     melee: 15
     bullet: 15
     bio: 15
-    explosionArmor: 20
+    explosionArmor: 15
   - type: RMCArmorSpeedTier
     speedTier: light
   - type: ClothingSpeedModifier
@@ -762,8 +759,6 @@
     maxItemSize: Small
     grid:
     - 0,0,3,1 # 2 slots
-  - type: CMArmor
-    explosionArmor: 20
   - type: RMCArmorSpeedTier
     speedTier: light
   - type: ClothingSpeedModifier
@@ -792,7 +787,6 @@
     melee: 25
     bullet: 20
     bio: 15
-    explosionArmor: 20
   - type: RMCArmorSpeedTier
     speedTier: light
   - type: ClothingSpeedModifier


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
New parity.

## Technical details
<!-- Summary of code changes for easier review. -->
YML. Removed extra definitions since they'd were just the same as the parent.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed light armors having better explosion protection than medium. Their values are now swapped.
