### PR TITLE
Asphyxiation to Airloss

### DIFF
--- a/Resources/Prototypes/_RMC14/Reagents/medicine.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/medicine.yml
@@ -185,13 +185,13 @@
         - Brute: -1.5
         - Burn: -1
         - Toxin: -1.5
+        - Airloss: -1
       - !type:HealthChange
         conditions:
         - !type:Temperature
           max: 170
         damage:
           types:
-            Asphyxiation: -1
             Cellular: -0.12
 
 # TODO RMC14 other effects
@@ -483,10 +483,7 @@
         - Brute: -0.25
         - Burn: -0.25
         - Toxin: -0.5
-      - !type:HealthChange
-        damage:
-          types:
-            Asphyxiation: -0.25
+        - Airloss: -0.25
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Switches Asphyxiation to Airloss for tric and cryox
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Tricordrazine and Cryoxadone was not healing bloodloss damage while Dexalin and Dexalin Plus was.
## Technical details
<!-- Summary of code changes for easier review. -->
yaml
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
No need. It's still healing the same amount.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
