### PR TITLE
Made medical skills impact CPR

### DIFF
--- a/Content.Shared/_RMC14/Medical/CPR/CPRSystem.cs
+++ b/Content.Shared/_RMC14/Medical/CPR/CPRSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared._RMC14.Marines;
+using Content.Shared._RMC14.Marines.Skills;
 using Content.Shared.Atmos.Rotting;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
@@ -11,6 +12,7 @@ using Content.Shared.Mobs.Systems;
 using Content.Shared.Popups;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
 namespace Content.Shared._RMC14.Medical.CPR;
@@ -25,6 +27,9 @@ public sealed class CPRSystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popups = default!;
     [Dependency] private readonly SharedRottingSystem _rotting = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SkillsSystem _skills = default!;
+
+    public static readonly EntProtoId<SkillDefinitionComponent> SkillType = "RMCSkillMedical";
 
     // TODO RMC14 move this to a component
     [ValidatePrototypeId<DamageTypePrototype>]
@@ -177,8 +182,15 @@ public sealed class CPRSystem : EntitySystem
 
         EnsureComp<ReceivingCPRComponent>(target);
 
-        // TODO RMC14 less time for skilled doctors
-        var doAfter = new DoAfterArgs(EntityManager, performer, TimeSpan.FromSeconds(4), new CPRDoAfterEvent(), performer, target)
+        // If the performer has skills in medical their CPR time will be reduced.
+        var delay = TimeSpan.FromSeconds(4);
+
+        if (_skills.HasSkill(performer, SkillType, 4))
+            delay = TimeSpan.FromSeconds(1.4); // 4 * 0.35
+        else if (_skills.HasSkill(performer, SkillType, 2))
+            delay = TimeSpan.FromSeconds(3); // 4 * 0.75
+
+        var doAfter = new DoAfterArgs(EntityManager, performer, delay, new CPRDoAfterEvent(), performer, target)
         {
             BreakOnMove = true,
             NeedHand = true,

--- a/Content.Shared/_RMC14/Medical/CPR/CPRSystem.cs
+++ b/Content.Shared/_RMC14/Medical/CPR/CPRSystem.cs
@@ -183,12 +183,7 @@ public sealed class CPRSystem : EntitySystem
         EnsureComp<ReceivingCPRComponent>(target);
 
         // If the performer has skills in medical their CPR time will be reduced.
-        var delay = TimeSpan.FromSeconds(4);
-
-        if (_skills.HasSkill(performer, SkillType, 4))
-            delay = TimeSpan.FromSeconds(1.4); // 4 * 0.35
-        else if (_skills.HasSkill(performer, SkillType, 2))
-            delay = TimeSpan.FromSeconds(3); // 4 * 0.75
+        var delay = TimeSpan.FromSeconds(4 * _skills.GetSkillDelayMultiplier(performer, SkillType));
 
         var doAfter = new DoAfterArgs(EntityManager, performer, delay, new CPRDoAfterEvent(), performer, target)
         {

--- a/Content.Shared/_RMC14/Medical/CPR/CPRSystem.cs
+++ b/Content.Shared/_RMC14/Medical/CPR/CPRSystem.cs
@@ -180,10 +180,10 @@ public sealed class CPRSystem : EntitySystem
         if (!CanCPRPopup(performer, target, true, out _))
             return false;
 
-        EnsureComp<ReceivingCPRComponent>(target);
+        var cprComp = EnsureComp<ReceivingCPRComponent>(target);
 
         // If the performer has skills in medical their CPR time will be reduced.
-        var delay = TimeSpan.FromSeconds(4 * _skills.GetSkillDelayMultiplier(performer, SkillType));
+        var delay = TimeSpan.FromSeconds(cprComp.CPRPerformingTime * _skills.GetSkillDelayMultiplier(performer, SkillType));
 
         var doAfter = new DoAfterArgs(EntityManager, performer, delay, new CPRDoAfterEvent(), performer, target)
         {

--- a/Content.Shared/_RMC14/Medical/CPR/ReceivingCPRComponent.cs
+++ b/Content.Shared/_RMC14/Medical/CPR/ReceivingCPRComponent.cs
@@ -1,7 +1,12 @@
-﻿using Robust.Shared.GameStates;
+using Robust.Shared.GameStates;
 
 namespace Content.Shared._RMC14.Medical.CPR;
 
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 [Access(typeof(CPRSystem))]
-public sealed partial class ReceivingCPRComponent : Component;
+public sealed partial class ReceivingCPRComponent : Component
+{
+    // The time it takes to perform CPR pre skill modification.
+    [DataField, AutoNetworkedField]
+    public int CPRPerformingTime = 4;
+}

--- a/Resources/Prototypes/_RMC14/Entities/skills.yml
+++ b/Resources/Prototypes/_RMC14/Entities/skills.yml
@@ -97,6 +97,9 @@
   id: RMCSkillMedical
   name: Medical
   categories: [ HideSpawnMenu ]
+  components:
+  - type: SkillDefinition
+    delayMultipliers: [1, 1, 1, 0.75, 0.35]
 
 - type: entity
   parent: RMCSkillBase


### PR DESCRIPTION
Medical skills now impact the time it takes to perform CPR.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Made the Medical skill impact CPR timer.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity.
Solves: #5730

## Technical details
<!-- Summary of code changes for easier review. -->
Added a if/else check to test against the performers medical skill to decide the time it takes to perform CPR.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
None.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: CPR time now depends medical skill.
