### PR TITLE
Revert "Make corporate survivor rank up from the sum of both corpo surv and corporate liaison."

### DIFF
--- a/Resources/Locale/en-US/_RMC14/job/cm-role-timers.ftl
+++ b/Resources/Locale/en-US/_RMC14/job/cm-role-timers.ftl
@@ -3,7 +3,6 @@ role-timer-medical-roles = any medical roles
 role-timer-engineering-roles = any engineering roles
 role-timer-dropship-roles = any dropship roles
 role-timer-dropship-pilot-roles = any dropship pilot roles
-role-timer-corporate-roles = any corporate roles
 role-timer-survivor-roles = any survivor roles
 
 role-timer-total-department-insufficient = You require [color=yellow]{TOSTRING($time, "0")}[/color] more minutes as [color={$rolesColor}]{$roles}[/color] to play this role.

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Departments/human_job_groups.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Departments/human_job_groups.yml
@@ -72,18 +72,6 @@
     - CMPilotGunship
 
 - type: entity
-  id: RMCJobsCorporate
-  categories:
-  - HideSpawnMenu
-  components:
-  - type: JobGroup
-    name: role-timer-corporate-roles
-    color: "#78ec0b"
-    jobs:
-    - CMLiaison
-    - CMSurvivorCorporate
-    
-- type: entity
   id: RMCJobsSurvivor
   categories:
   - HideSpawnMenu

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/corporate_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/corporate_survivor.yml
@@ -6,16 +6,16 @@
   playTimeTracker: CMJobSurvivorCorporate
   ranks:
     RMCRankWeYaExecutiveSpecialist:
-    - !type:TotalJobsTimeRequirement
-      group: RMCJobsCorporate
+    - !type:RoleTimeRequirement
+      role: CMJobLiaison
       time: 630000 # 175 hours
     RMCRankWeYaSeniorExecutive:
-    - !type:TotalJobsTimeRequirement
-      group: RMCJobsCorporate
+    - !type:RoleTimeRequirement
+      role: CMJobLiaison
       time: 252000 # 70 hours
     RMCRankWeYaExecutive:
-    - !type:TotalJobsTimeRequirement
-      group: RMCJobsCorporate
+    - !type:RoleTimeRequirement
+      role: CMJobLiaison
       time: 90000 # 25 hours
     RMCRankWeYaJuniorExecutive: []
   startingGear: RMCGearSurvivorCorporate


### PR DESCRIPTION
Reverts RMC-14/RMC-14#6550

I believe anyone who actually played the role for the medal ranks should be rewarded for doing so.

We have these for account progression, they don't mean anything - the whole point is to play the roles they belong to obtain them, otherwise we may as well do this for all similar roles. 

Doing this removes long term account progression otherwise, and is not something I want to see pushed to the other roles because it was done in this one.