### PR TITLE
Increase to medical playtime requirements.

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/hospital_corpsman.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/hospital_corpsman.yml
@@ -7,7 +7,7 @@
   requirements:
   - !type:TotalJobsTimeRequirement
     group: CMJobsMedical
-    time: 3600 # 1 hours
+    time: 7200 # 2 hours
   - !type:DepartmentTimeRequirement
     department: CMSquad
     time: 3600 # 1 hour

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Medical/doctor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Medical/doctor.yml
@@ -1,4 +1,4 @@
-﻿- type: job
+- type: job
   parent: CMJobBase
   id: CMDoctor
   name: cm-job-name-doctor
@@ -7,7 +7,7 @@
   requirements:
   - !type:RoleTimeRequirement
     role: CMJobNurse
-    time: 18000 # 5 hours
+    time: 10800 # 3 hours
   ranks:
     RMCRankSecondLT: []
   startingGear: CMGearDoctor

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Medical/doctor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Medical/doctor.yml
@@ -5,8 +5,8 @@
   description: cm-job-description-doctor
   playTimeTracker: CMJobDoctor
   requirements:
-  - !type:TotalJobsTimeRequirement
-    group: CMJobsMedical
+  - !type:RoleTimeRequirement
+    role: CMJobNurse
     time: 18000 # 5 hours
   ranks:
     RMCRankSecondLT: []

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Medical/doctor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Medical/doctor.yml
@@ -7,7 +7,7 @@
   requirements:
   - !type:TotalJobsTimeRequirement
     group: CMJobsMedical
-    time: 3600 # 1 hour
+    time: 18000 # 5 hours
   ranks:
     RMCRankSecondLT: []
   startingGear: CMGearDoctor

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Base_Survs/doctor_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Base_Survs/doctor_survivor.yml
@@ -16,7 +16,7 @@
     time: 18000 # 5 hours
   - !type:RoleTimeRequirement
     role: CMJobDoctor
-    time: 18000 # 5 hours
+    time: 7200 # 2 hours
   ranks:
     RMCRankCivilianDoctor: []
   startingGear: RMCGearSurvivorDoctor

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Base_Survs/doctor_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Base_Survs/doctor_survivor.yml
@@ -4,6 +4,19 @@
   name: cm-job-name-survivor-doctor
   description: cm-job-description-survivor
   playTimeTracker: CMJobSurvivorDoctor
+  requirements:
+  - !type:DepartmentTimeRequirement
+    department: CMSquad
+    time: 18000 # 5 hours
+  - !type:RoleTimeRequirement
+    role: CMJobCombatTech
+    time: 18000 # 5 hours
+  - !type:RoleTimeRequirement
+    role: CMJobHospitalCorpsman
+    time: 18000 # 5 hours
+  - !type:RoleTimeRequirement
+    role: CMJobDoctor
+    time: 18000 # 5 hours
   ranks:
     RMCRankCivilianDoctor: []
   startingGear: RMCGearSurvivorDoctor


### PR DESCRIPTION
![Training FAILED](https://github.com/user-attachments/assets/627d1ef6-8212-4f67-a0cf-be19a2713e0f)

## About the PR
The medical review board has deemed the lack of training amongst the medical staff of the almayer to be a detriment to its crews health, and is lifting its policy of scraping the barrel for recruits.

## Why / Balance
From discussions on Medicord we were supprised at the lack of training requirements for doctor. With new med looming soon(tm), an untrained doctor is a dangerous thing, and hopefully this will help encourage more training amongst medical players. If this is to much, or to little, please share your thoughts.

## Technical details
Increased doctor playtime requiremint to 5hrs Nurse.
Doctor Survivor requires 5hr doctor.
Corpsman required time increased to 2hr medical.

## Media
Doc playtime
![image](https://github.com/user-attachments/assets/fe57b9b6-bf4b-4033-a332-806afbdd03ad)

Docsurv playtime
![Docsurv](https://github.com/user-attachments/assets/6c495fbd-b935-4040-9e65-d7494876fbd6)

HC Playtime
![HC Playtime](https://github.com/user-attachments/assets/150a49d1-b883-4826-a6e0-b627dd98cfff)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: Increased medical related playtime requirements.
