### PR TITLE
Bug fix: Space drug conservation of mass

### DIFF
--- a/Resources/Prototypes/_RMC14/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Reactions/medicine.yml
@@ -191,7 +191,7 @@
     RMCHydrogen:
       amount: 1
   products:
-    RMCMethylphenidate: 3
+    RMCMethylphenidate: 2
 
 - type: reaction
   id: RMCCitalopram
@@ -201,7 +201,7 @@
     RMCCarbon:
       amount: 1
   products:
-    RMCCitalopram: 3
+    RMCCitalopram: 2
 
 - type: reaction
   id: RMCParoxetine


### PR DESCRIPTION
## About the PR
Something something conservation of mass, something something insert witty comment here.

## Why / Balance
While looking at the new stuff i noticed a couple of the chems in the Space drugs merge, created more chems than input. This seems wrong.

## Technical details
Corrected the two chems to only produce the correct amount based on input chems.

## Media
https://github.com/user-attachments/assets/6b8ff1bf-ccf7-4d6b-9860-ba296bbec7de



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed space drug Conservation of Mass
