### PR TITLE
QOL: New ChemMaster - Label Flexi Width

### DIFF
--- a/Content.Client/_RMC14/Chemistry/Master/RMCChemMasterPillBottleRow.xaml
+++ b/Content.Client/_RMC14/Chemistry/Master/RMCChemMasterPillBottleRow.xaml
@@ -1,4 +1,4 @@
-﻿<controls:RMCChemMasterPillBottleRow
+<controls:RMCChemMasterPillBottleRow
     xmlns="https://spacestation14.io"
     xmlns:controls="clr-namespace:Content.Client._RMC14.Chemistry.Master">
     <BoxContainer Orientation="Horizontal">
@@ -7,7 +7,7 @@
         <Label Name="PillAmountLabel" Access="Public" Margin="0 0 10 0" />
         <RichTextLabel Name="NameLabel" Access="Public" Margin="0 0 5 0"
                        MinWidth="60" />
-        <BoxContainer Orientation="Horizontal" MinWidth="100">
+        <BoxContainer Orientation="Horizontal" MinWidth="100" HorizontalExpand="True">
             <Control HorizontalExpand="True">
                 <LineEdit Name="LabelInput" Access="Public" />
             </Control>

--- a/Content.Client/_RMC14/Chemistry/Master/RMCChemMasterWindow.xaml
+++ b/Content.Client/_RMC14/Chemistry/Master/RMCChemMasterWindow.xaml
@@ -1,4 +1,4 @@
-﻿<controls:RMCChemMasterWindow
+<controls:RMCChemMasterWindow
     xmlns="https://spacestation14.io"
     xmlns:controls="clr-namespace:Content.Client._RMC14.Chemistry.Master"
     xmlns:ui="clr-namespace:Content.Client._RMC14.UserInterface"
@@ -17,7 +17,7 @@
                                Text="{Loc rmc-chem-master-pill-bottle}" Margin="0 0 5 0"
                                VerticalAlignment="Top" />
                 <BoxContainer Name="PillBottlesContainer" Access="Public"
-                              Orientation="Vertical">
+                              Orientation="Vertical" HorizontalExpand="True">
                     <RichTextLabel Name="PillBottlesNoneLabel" Access="Public"
                                    Text="{Loc rmc-chem-master-pill-bottle-none}" />
                 </BoxContainer>


### PR DESCRIPTION
## About the PR
The new chem master is great, but god damn give me some space to type

## Why / Balance
I need to label!

## Technical details
Minor ui changes to the new chemmaster to make the text label space expand horizontally

## Media
Before

https://github.com/user-attachments/assets/addfe9b1-14e4-4413-9e56-1aedde8fbb99

After 

https://github.com/user-attachments/assets/5cf81cb6-8b44-4ee9-b32e-dbb66f27bba3


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: ChemMaster Label text field now has a flexible scaling Width
