### PR TITLE
Paraisites have faster laying-down infect delay

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
@@ -332,6 +332,9 @@ public abstract partial class SharedXenoParasiteSystem : EntitySystem
         var ev = new AttachParasiteDoAfterEvent();
         var delay = parasite.Comp.ManualAttachDelay;
 
+        if (parasite.Owner == user)
+            delay = parasite.Comp.SelfAttachDelay;
+
         if (HasComp<TrapParasiteComponent>(parasite))
             delay = TimeSpan.Zero;
 

--- a/Content.Shared/_RMC14/Xenonids/Parasite/XenoParasiteComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Parasite/XenoParasiteComponent.cs
@@ -11,6 +11,9 @@ public sealed partial class XenoParasiteComponent : Component
     public TimeSpan ManualAttachDelay = TimeSpan.FromSeconds(2);
 
     [DataField, AutoNetworkedField]
+    public TimeSpan SelfAttachDelay = TimeSpan.FromSeconds(1);
+
+    [DataField, AutoNetworkedField]
     public TimeSpan ParalyzeTime = TimeSpan.FromMinutes(1.5);
 
     [DataField, AutoNetworkedField]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Just a small change from CM13
Makes infecting hosts that are laying down only take a second instead of 2, parity
![image](https://github.com/user-attachments/assets/387632b5-4bf6-46e2-afa9-2a0cb06374f7)


:cl:
- add: Parasites now infect prone targets faster if they went on manually