### PR TITLE
Normal crusher charge now instant destroys doors, racks, and lockers

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Doors/Airlocks/airlocks.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Doors/Airlocks/airlocks.yml
@@ -17,8 +17,6 @@
   - type: Occluder
   - type: PaintableAirlock
     department: CMSquad
-  - type: XenoCrusherChargable
-    instantDestroy: True
 
 - type: entity
   parent: CMAirlock

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Doors/cm_door.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Doors/cm_door.yml
@@ -163,7 +163,7 @@
     stageLoss: 2
     percentageDamage: 0.25
   - type: XenoCrusherChargable
-    instantDestroy: True
+    instantDestroy: true
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Doors/cm_door.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Doors/cm_door.yml
@@ -163,6 +163,7 @@
     stageLoss: 2
     percentageDamage: 0.25
   - type: XenoCrusherChargable
+    instantDestroy: True
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Storage/lockers.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Storage/lockers.yml
@@ -31,6 +31,8 @@
     stateDoorClosed: closed
   - type: AccessReader
   - type: Lock
+  - type: XenoCrusherChargable
+    instantDestroy: true
 
 - type: entity
   parent: CMLockerBase

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Storage/rack.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Storage/rack.yml
@@ -62,3 +62,5 @@
     spawnPrototype: CMSheetMetalBase
   - type: XenoToggleChargingDamage
     destroy: true
+  - type: XenoCrusherChargable
+    instantDestroy: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity. They weren't inherenting the property and are some of the instant destroying stuff.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed normal crusher charge not deleting doors, racks, or lockers.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!

-->
