### PR TITLE
Fix xeno hud stun overlay not going away when unconscious wearsoff

### DIFF
--- a/Content.Shared/_RMC14/Slow/RMCSlowSystem.cs
+++ b/Content.Shared/_RMC14/Slow/RMCSlowSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.StatusEffect;
 using Content.Shared.Stunnable;
 using Robust.Shared.Network;
 using Robust.Shared.Timing;
+using System.Linq;
 
 namespace Content.Shared._RMC14.Slow;
 
@@ -222,10 +223,10 @@ public sealed class RMCSlowSystem : EntitySystem
 
     private void OnModifierEffectEnd(Entity<RMCSpeciesSlowdownModifierComponent> ent, ref StatusEffectEndedEvent args)
     {
-        if (args.Key != "Stun" && args.Key != "KnockedDown")
+        if (!ent.Comp.StatusesToUpdateOn.Contains(args.Key))
             return;
 
-        if (args.Key == "Stun" && !HasComp<RMCRootedComponent>(ent))
+        if (args.Key != "KnockedDown" && !HasComp<RMCRootedComponent>(ent))
             RemCompDeferred<XenoImmobileVisualsComponent>(ent);
         else if ((args.Key == "KnockedDown" || !_standing.IsDown(ent)) && HasComp<StunnedComponent>(ent))
             EnsureComp<XenoImmobileVisualsComponent>(ent);

--- a/Content.Shared/_RMC14/Slow/RMCSpeciesSlowdownModifierComponent.cs
+++ b/Content.Shared/_RMC14/Slow/RMCSpeciesSlowdownModifierComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared.StatusEffect;
 using Robust.Shared.GameStates;
 namespace Content.Shared._RMC14.Slow;
 
@@ -19,4 +20,7 @@ public sealed partial class RMCSpeciesSlowdownModifierComponent : Component
 
     [DataField]
     public float DurationMultiplier = 1.0f;
+
+    [DataField]
+    public string[] StatusesToUpdateOn = { "Stun", "KnockedDown", "Unconscious" };
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug.

## Technical details
<!-- Summary of code changes for easier review. -->
SlowSystem was only taking into account stun and knockeddown, never unconscious. Now it does by storing all the stuff it checks in an array.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed xeno stun indicator not going away when unconscious goes away.
