### PR TITLE
fix: tesla bullet targeting

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Sentries/tesla.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Sentries/tesla.yml
@@ -106,6 +106,7 @@
     setDamage:
       types:
         Blunt: 40
+  - type: RequireProjectileTarget
 
 - type: entity
   parent: RMCBaseTesla


### PR DESCRIPTION
## About the PR
Now, to hit the tesla, you have to mouse target at the tesla. Same as with the turrets, so that the marines don't just demolish all my teslas 99 of the time out of 100.

## Why / Balance
Parity.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed bullets hitting tesla coils when not being targeted directly, same as sentries.