### PR TITLE
Fix forecon rifleman not having medical skill

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/rifleman.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/rifleman.yml
@@ -16,6 +16,7 @@
         RMCSkillCqc: 1
         RMCSkillFireman: 1
         RMCSkillFirearms: 1
+        RMCSkillMedical: 1
         RMCSkillJtac: 1
         RMCSkillEndurance: 2
         RMCSkillLeadership: 0


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c8f195c6-f6b2-41e3-ab4f-9db32a377f5d)

accident


:cl:
- fix: Fixed FORECON rifleman not having medical skill of 1