### PR TITLE
Fixes rotations on tents and vehicles

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Tools/tents.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Tools/tents.yml
@@ -17,7 +17,6 @@
     sprite: _RMC14/Objects/tents.rsi
     offset: 1,0
     drawdepth: OverMobs
-    noRot: true
     layers:
     - state: standard_frame
     - state: standard_canvas
@@ -91,7 +90,6 @@
     sprite: _RMC14/Objects/tents.rsi
     drawdepth: Overdoors
     offset: 1,0
-    noRot: true
     layers:
     - state: standard_roof
       map: [ "enum.ItemCamouflageLayers.Layer" ]

--- a/Resources/Prototypes/_RMC14/Entities/Structures/prop_vehicles.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/prop_vehicles.yml
@@ -58,7 +58,6 @@
   - type: Sprite
     sprite: _RMC14/Structures/Vehicles/vehicles.rsi
     offset: 0.5, 0.5
-    noRot: true
   - type: DeleteOnExplosion
   - type: Damageable
     damageContainer: Inorganic


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Removes "norot" from tents and vehicles so sprites dont move when rotating camera, leading to the appearance of incorrect collisions because camera rotation is stupid.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I hate camera rotation

## Technical details
<!-- Summary of code changes for easier review. -->
yaml

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no cl