### PR TITLE
Fix close queen scream stacking with far scream effects

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Screech/SharedXenoScreechSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Screech/SharedXenoScreechSystem.cs
@@ -26,6 +26,7 @@ public sealed class XenoScreechSystem : EntitySystem
     [Dependency] private readonly XenoSystem _xeno = default!;
 
     private readonly HashSet<Entity<MobStateComponent>> _mobs = new();
+    private readonly HashSet<Entity<MobStateComponent>> _closeMobs = new();
     private readonly HashSet<Entity<XenoParasiteComponent>> _parasites = new();
 
     public override void Initialize()
@@ -57,10 +58,8 @@ public sealed class XenoScreechSystem : EntitySystem
         if (_net.IsServer)
             _audio.PlayPvs(xeno.Comp.Sound, xeno);
 
-        _mobs.Clear();
-        _entityLookup.GetEntitiesInRange(xform.Coordinates, xeno.Comp.ParalyzeRange, _mobs);
-
-        HashSet<Entity<MobStateComponent>> closeTargets = _mobs.ToHashSet(); //Duplicate
+        _closeMobs.Clear();
+        _entityLookup.GetEntitiesInRange(xform.Coordinates, xeno.Comp.ParalyzeRange, _closeMobs);
 
         foreach (var receiver in _mobs)
         {
@@ -79,7 +78,7 @@ public sealed class XenoScreechSystem : EntitySystem
             if (!_xeno.CanAbilityAttackTarget(xeno, receiver))
                 continue;
 
-            if (closeTargets.Contains(receiver))
+            if (_closeMobs.Contains(receiver))
                 continue;
 
             Stun(xeno, receiver, xeno.Comp.StunTime, true);

--- a/Content.Shared/_RMC14/Xenonids/Screech/SharedXenoScreechSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Screech/SharedXenoScreechSystem.cs
@@ -57,19 +57,9 @@ public sealed class XenoScreechSystem : EntitySystem
             _audio.PlayPvs(xeno.Comp.Sound, xeno);
 
         _mobs.Clear();
-        _entityLookup.GetEntitiesInRange(xform.Coordinates, xeno.Comp.StunRange, _mobs);
-
-        foreach (var receiver in _mobs)
-        {
-            if (!_xeno.CanAbilityAttackTarget(xeno, receiver))
-                continue;
-
-            Stun(xeno, receiver, xeno.Comp.StunTime, true);
-            Deafen(xeno, receiver, xeno.Comp.FarDeafTime);
-        }
-
-        _mobs.Clear();
         _entityLookup.GetEntitiesInRange(xform.Coordinates, xeno.Comp.ParalyzeRange, _mobs);
+
+        List<EntityUid> closeTargets = new();
 
         foreach (var receiver in _mobs)
         {
@@ -78,6 +68,22 @@ public sealed class XenoScreechSystem : EntitySystem
 
             Stun(xeno, receiver, xeno.Comp.ParalyzeTime, false);
             Deafen(xeno, receiver, xeno.Comp.CloseDeafTime);
+            closeTargets.Add(receiver);
+        }
+
+        _mobs.Clear();
+        _entityLookup.GetEntitiesInRange(xform.Coordinates, xeno.Comp.StunRange, _mobs);
+
+        foreach (var receiver in _mobs)
+        {
+            if (!_xeno.CanAbilityAttackTarget(xeno, receiver))
+                continue;
+
+            if (closeTargets.Contains(receiver))
+                continue;
+
+            Stun(xeno, receiver, xeno.Comp.StunTime, true);
+            Deafen(xeno, receiver, xeno.Comp.FarDeafTime);
         }
 
         _parasites.Clear();

--- a/Content.Shared/_RMC14/Xenonids/Screech/SharedXenoScreechSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Screech/SharedXenoScreechSystem.cs
@@ -9,6 +9,7 @@ using Content.Shared.Mobs.Systems;
 using Content.Shared.Stunnable;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Network;
+using System.Linq;
 
 namespace Content.Shared._RMC14.Xenonids.Screech;
 
@@ -59,7 +60,7 @@ public sealed class XenoScreechSystem : EntitySystem
         _mobs.Clear();
         _entityLookup.GetEntitiesInRange(xform.Coordinates, xeno.Comp.ParalyzeRange, _mobs);
 
-        List<EntityUid> closeTargets = new();
+        HashSet<Entity<MobStateComponent>> closeTargets = _mobs.ToHashSet(); //Duplicate
 
         foreach (var receiver in _mobs)
         {
@@ -68,7 +69,6 @@ public sealed class XenoScreechSystem : EntitySystem
 
             Stun(xeno, receiver, xeno.Comp.ParalyzeTime, false);
             Deafen(xeno, receiver, xeno.Comp.CloseDeafTime);
-            closeTargets.Add(receiver);
         }
 
         _mobs.Clear();

--- a/Content.Shared/_RMC14/Xenonids/Screech/SharedXenoScreechSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Screech/SharedXenoScreechSystem.cs
@@ -61,7 +61,7 @@ public sealed class XenoScreechSystem : EntitySystem
         _closeMobs.Clear();
         _entityLookup.GetEntitiesInRange(xform.Coordinates, xeno.Comp.ParalyzeRange, _closeMobs);
 
-        foreach (var receiver in _mobs)
+        foreach (var receiver in _closeMobs)
         {
             if (!_xeno.CanAbilityAttackTarget(xeno, receiver))
                 continue;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug. CM checks range and doesn't stack those.

## Technical details
<!-- Summary of code changes for easier review. -->
Moved the close effects to check first, dupe the set to a temp hashset and don't do far effects if it was in the set.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed close Queen scream stacking with far queen scream effects.
