### PR TITLE
Removes SO job scaling nearly entirely.

### DIFF
--- a/Resources/Prototypes/_RMC14/rmc_job_slot_scaling.yml
+++ b/Resources/Prototypes/_RMC14/rmc_job_slot_scaling.yml
@@ -22,9 +22,9 @@
         min: 4
         max: 8
       CMStaffOfficer:
-        factor: 40
+        factor: 160
         c: 1
-        min: 2
+        min: 4
         max: 5
       CMDoctor:
         factor: 25


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Removed the job scaling for staff officers. Now by default you start with 4 available, and a 5th one will be available if there are 160+ marines.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
No matter the pop. There will be multiple squads.

As of now, moves members are limited (SLs, WSes, SGOs) and encryption key do not automatically transfer. Squad merging is not reliable for low pop.

Staff officer is best enjoyed when you can focus on one squad to overwatch. Not having to manage three squad comms because it's 70 pop and the other SO is dedicated on alpha.


The cap makes CIC lacking in staff that it needs. It makes the role less enjoyable due to forcing it to do extra work load.

Consequently, it makes XO worse to play because you do not have proper relay (the SO enacting the plan to respective squads) between you and squads. And as such makes CIC less reliable for marines as a whole.

See feature post for community discussion/opinion: "Remove SO cap"
https://discord.com/channels/1168210010233376858/1382468386214379530

## Technical details
<!-- Summary of code changes for easier review. -->
yml soup
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:

- remove: Removed SO job scaling. CIC will now have 4 SO slots at any pop, up to 5 at 160+ pop.
