### PR TITLE
Make warriors unable to tackle their lunge victim

### DIFF
--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Numerics;
 using Content.Shared._RMC14.CCVar;
+using Content.Shared._RMC14.Weapons.Melee;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Administration.Logs;
 using Content.Shared.CombatMode;
@@ -381,6 +382,29 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
 
                 if (!Blocker.CanAttack(user, target, (weaponUid, weapon), true))
                     return false;
+
+                // RMC14
+                if (target != null)
+                {
+                    var targetPosition = TransformSystem.GetMoverCoordinates(target.Value).Position;
+                    var userPosition = TransformSystem.GetMoverCoordinates(user).Position;
+                    var entities = GetNetEntityList(ArcRayCast(userPosition,
+                            (targetPosition -
+                             userPosition).ToWorldAngle(),
+                            0,
+                            1.5f,
+                            TransformSystem.GetMapId(user),
+                            user)
+                        .ToList());
+
+                    var meleeEv = new MeleeAttackAttemptEvent(GetNetEntity(target.Value),
+                        attack,
+                        disarm.Coordinates,
+                        entities);
+                    RaiseLocalEvent(user, ref meleeEv);
+
+                    attack = meleeEv.Attack;
+                }
                 break;
             default:
                 if (!Blocker.CanAttack(user, weapon: (weaponUid, weapon)))

--- a/Content.Shared/_RMC14/Weapons/Melee/MeleeAttackAttemptEvent.cs
+++ b/Content.Shared/_RMC14/Weapons/Melee/MeleeAttackAttemptEvent.cs
@@ -1,0 +1,9 @@
+using Content.Shared.Weapons.Melee.Events;
+using Robust.Shared.Map;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Weapons.Melee;
+
+[ByRefEvent]
+[Serializable, NetSerializable]
+public record struct MeleeAttackAttemptEvent(NetEntity Target, AttackEvent Attack, NetCoordinates Coordinates , List<NetEntity> PotentialTargets,NetEntity? Weapon = null);

--- a/Content.Shared/_RMC14/Xenonids/Lunge/XenoLungeStunnedComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Lunge/XenoLungeStunnedComponent.cs
@@ -14,4 +14,7 @@ public sealed partial class XenoLungeStunnedComponent : Component
 
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
     public TimeSpan ExpireAt;
+
+    [DataField, AutoNetworkedField]
+    public NetEntity? Stunner;
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
If a Warrior attempts to tackle their lunge target while it is still stunned by the lunge, the tackle will be replaced with a light attack

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Dygon
- tweak: Warriors can no longer tackle targets that are stunned by their own lunge effect.

