### PR TITLE
Remove the User IFF setting in distress signal

### DIFF
--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
@@ -871,8 +871,6 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
                     _hunger.SetHunger(ev.SpawnResult.Value, 50.0f, hunger);
             }
 
-            var faction = HasComp<RMCSurvivorComponent>(ev.SpawnResult.Value) ? comp.SurvivorFaction : comp.MarineFaction;
-            _gunIFF.SetUserFaction(ev.SpawnResult.Value, faction);
             return;
         }
     }

--- a/Content.Shared/_RMC14/Communications/CommunicationsTowerSystem.cs
+++ b/Content.Shared/_RMC14/Communications/CommunicationsTowerSystem.cs
@@ -147,7 +147,7 @@ public sealed class CommunicationsTowerSystem : EntitySystem
         if (ent.Comp.State == CommunicationsTowerState.Broken)
             return;
 
-        if (_gunIFF.TryGetUserFaction(args.User, out var faction) &&
+        if (_gunIFF.TryGetFaction(args.User, out var faction) &&
             _prototypes.TryIndex(faction, out var factionProto) &&
             factionProto.TryGetComponent(out FactionFrequenciesComponent? frequencies, _compFactory))
         {

--- a/Content.Shared/_RMC14/Weapons/Ranged/IFF/GunIFFSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/IFF/GunIFFSystem.cs
@@ -94,6 +94,9 @@ public sealed class GunIFFSystem : EntitySystem
             args.Cancelled = true;
     }
 
+    /// <summary>
+    ///     Gets the UserIFF faction of the user.
+    /// </summary>
     public bool TryGetUserFaction(Entity<UserIFFComponent?> user, out EntProtoId<IFFFactionComponent> faction)
     {
         faction = default;
@@ -102,6 +105,25 @@ public sealed class GunIFFSystem : EntitySystem
             return false;
 
         faction = userFaction;
+        return true;
+    }
+
+    /// <summary>
+    ///     Gets the IFFFaction of the user. Includes the UserIFFComponent and any items on the given slot flags that have the ItemIFFComponent.
+    /// </summary>
+    public bool TryGetFaction(Entity<UserIFFComponent?> user, out EntProtoId<IFFFactionComponent> faction, SlotFlags slots = SlotFlags.IDCARD)
+    {
+        faction = default;
+        if (!_userIFFQuery.Resolve(user, ref user.Comp, false))
+            return false;
+
+        var ev = new GetIFFFactionEvent(null, slots);
+        RaiseLocalEvent(user, ref ev);
+
+        if (ev.Faction is not { } newFaction)
+            return false;
+
+        faction = newFaction;
         return true;
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This line of code is useless. Colonist IDs and Marine IDs already have their respective ItemIFF, so this just makes Corporate Colonists not have the WeYa faction (like intended). This also makes any new role forcibly set to the marine faction.

## Media
IFF still works

https://github.com/user-attachments/assets/9dc91bb7-9966-47ef-bb9c-91391a236e00





Note the summary
![image](https://github.com/user-attachments/assets/b0f7e84f-9045-4534-8943-87f0c2c0429a)

## Technical details
Changes the comms tower to get the Item IFF component of the  multitool user's ID rather than the UserIFF


**Changelog**
not player facing