### PR TITLE
Fix corporate colonist icon and headset,

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/distress_headsets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/distress_headsets.yml
@@ -46,11 +46,12 @@
   id: RMCHeadsetDistressWeYa
   name: WeYa corporate headset
   description: A headset commonly worn by WeYa corporate personnel.
+  suffix: WeYa, Colony
   components:
   - type: ContainerFill
     containers:
       key_slots:
-      - CMEncryptionKeyWEYA
+      - CMEncryptionKeyWEYAColony
 
 # For WeYa PMC
 - type: entity

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/ert_headsets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/ert_headsets.yml
@@ -1,18 +1,8 @@
 ﻿- type: entity
   parent: RMCHeadsetLiaison
-  id: RMCHeadsetDistressWeYaColony
-  suffix: WeYa, Colony
-  components:
-  - type: ContainerFill
-    containers:
-      key_slots:
-      - CMEncryptionKeyWEYAColony
-
-- type: entity
-  parent: RMCHeadsetLiaison
   id: RMCHeadsetDistressICBLiaison
   name: ICB liaison headset
-  suffix: WeYa, Colony
+  suffix: ICB, Colony
   components:
   - type: ContainerFill
     containers:

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Corpses/civilians.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Corpses/civilians.yml
@@ -362,7 +362,7 @@
     shoes: RMCBootsPMCFilled
     mask: RMCMaskBalaclava
     id: RMCIDCardPMC
-    ears: RMCHeadsetDistressWeYaColony
+    ears: RMCHeadsetDistressWeYa
     pocket1: RMCPouchFirstAidPMCFill
     pocket2: RMCPouchToolsFill
   storage:
@@ -386,7 +386,7 @@
 - type: startingGear
   id: RMCGearCorpseWeYaManager # TODO RMC14 manager jacket, jumpsuit and hat, lockable satchel
   equipment:
-    ears: RMCHeadsetDistressWeYaColony
+    ears: RMCHeadsetDistressWeYa
     back: CMSatchel
     jumpsuit: CMJumpsuitLiaisonBlack
     outerClothing: RMCJacketCorporateBlack

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/corporate_executives.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/corporate_executives.yml
@@ -51,7 +51,7 @@
 - type: startingGear
   id: RMCGearCorporateExecutiveSupervisor
   equipment:
-    ears: RMCHeadsetDistressWeYaColony # TODO RMC14 tape recorder
+    ears: RMCHeadsetDistressWeYa # TODO RMC14 tape recorder
     back: CMSatchel
     jumpsuit: CMJumpsuitLiaisonBlack
     outerClothing: RMCJacketCorporateBlack
@@ -120,7 +120,7 @@
 - type: startingGear
   id: RMCGearCorporateExecutiveSpecialist
   equipment:
-    ears: RMCHeadsetDistressWeYaColony # TODO RMC14 tape recorder
+    ears: RMCHeadsetDistressWeYa # TODO RMC14 tape recorder
     back: CMSatchel
     jumpsuit: CMJumpsuitLiaisonBlue
     outerClothing: RMCJacketCorporateBlue

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/corporate_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/corporate_survivor.yml
@@ -4,6 +4,8 @@
   name: cm-job-name-survivor-corporate
   description: cm-job-description-survivor
   playTimeTracker: CMJobSurvivorCorporate
+  icon: "CMJobIconLiaison"
+  hasIcon: true
   ranks:
     RMCRankWeYaExecutiveSpecialist:
     - !type:RoleTimeRequirement
@@ -45,7 +47,7 @@
 - type: startingGear
   id: RMCGearSurvivorCorporate
   equipment:
-    ears: RMCHeadsetDistressWeYaColony
+    ears: RMCHeadsetDistressWeYa
     jumpsuit: CMJumpsuitLiaisonField
     outerClothing: RMCArmorVest
     shoes: RMCShoesLaceup


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changes the corporate colonists headset
Removes the RMCHeadsetDistressWeYaColony since it's useless. Every WeYa headset is supposed to have colony comms
Adds colony comms to RMCHeadsetDistressWeYa

Give corporate colonists an icon. It's the same as the shipside liaison's in parity, but only WeYa faction members can see it

## Why / Balance
Parity
![image](https://github.com/user-attachments/assets/46cec382-78bd-4b8c-b0b9-bf6977500fc5)

:cl:
- fix: Fixed corporate colonist headset having UNMC faction HUD.
