### PR TITLE
Adds M1984 AP to dropship crew weapon vendors

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/pilot.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/pilot.yml
@@ -222,8 +222,8 @@
         amount: 20
       - id: CMMagazinePistolM1984
         amount: 20
-      #- id: CMMagazinePistolM1984AP # TODO RMC14 Pistol AP varieties
-      # amount: 14
+      - id: RMCMagazinePistolM1984AP 
+        amount: 14
       #- id: CMMagazinePistolMK80HP # TODO RMC14 Pistol AP varieties
       # amount: 14
       - id: CMMagazinePistolMK80


### PR DESCRIPTION
Does what it says on the tin. 84 AP mags were in the code, just commented out due to being unimplemented at the time.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds AP ammunition for the M1984 Service Pistol to dropship crew weapon vendors.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity.

## Technical details
<!-- Summary of code changes for easier review. -->
Uncomments out M1984 AP magazines under the sidearm ammunition portion of the vendor for PO/DCC weapons (and also properly names them; 84 AP mags use the RMC naming scheme rather than CM) 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://drive.google.com/file/d/1rxrqm5ioQ0U3wyeUsC56iu898ojR7uX6/view?usp=sharing

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: added M1984 AP mags to dropship crew weapon vendors.
