### PR TITLE
[Bug Fix] Fix the pills being made with the wrong pill colour selected.

### DIFF
--- a/Content.Client/Chemistry/EntitySystems/PillSystem.cs
+++ b/Content.Client/Chemistry/EntitySystems/PillSystem.cs
@@ -19,6 +19,6 @@ public sealed class PillSystem : EntitySystem
         if (!sprite.TryGetLayer(0, out var layer))
             return;
 
-        layer.SetState($"pill{component.PillType + 1}");
+        layer.SetState($"pill{component.PillType}");
     }
 }


### PR DESCRIPTION
## About the PR
Stopped pills being made with the next pill colour up in the list, rather than the one selected.

## Why / Balance
Bug fix - https://github.com/RMC-14/RMC-14/issues/6714

## Technical details
Stopped the pill making process adding a 1 to the selected sprite.

## Media
Before

https://github.com/user-attachments/assets/69c57203-8712-406e-8c7b-98d967a364a1

After

https://github.com/user-attachments/assets/9847c22c-86ab-441d-96b4-0536b73f589a


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Pills are now created with the correct colour selected
