### PR TITLE
Adds surgical case to the medilathe

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Lathe/medilathe.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Lathe/medilathe.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   parent: BaseMachinePowered
   id: RMCMedilathe
   name: medilathe
@@ -157,6 +157,7 @@
   - CMFirstAidO2Kit
   - RMCRadiationAidKit
   - RMCSyringeCase
+  - CMSurgicalCase
   - RMCSurgicalTrayEmpty
   - RMCVialBox
   - RMCPouchReagentCanister

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Lathe/medilathe_recipes.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Lathe/medilathe_recipes.yml
@@ -1,4 +1,4 @@
-﻿# Divide original costs by 37.5 each - except plastic which is 20
+# Divide original costs by 37.5 each - except plastic which is 20
 - type: latheRecipe
   id: CMSyringe
   result: CMSyringe
@@ -108,6 +108,13 @@
 - type: latheRecipe
   id: RMCSyringeCase
   result: RMCSyringeCase
+  completetime: 4
+  materials:
+    RMCPlastic: 50 # 1000
+
+- type: latheRecipe
+  id: CMSurgicalCase
+  result: CMSurgicalCase
   completetime: 4
   materials:
     RMCPlastic: 50 # 1000


### PR DESCRIPTION
## About the PR
Added the recipe for the surgical case to the medilathe 

## Why / Balance
Parity apparently

## Technical details
Added the recipe based on the cm13 costs and added to the medilathe itself

## Media
Added to the medilathe
![image](https://github.com/user-attachments/assets/c080c490-cdbf-4e9f-a692-e2f6a4ec9e06)

it being in the medilathe list on cm13
![medilathe surgicalcase](https://github.com/user-attachments/assets/3fb4d51c-4cc4-44f4-a5fe-45a01fc5bc84)

and its cost in cm13 (this is the same as the syringe case)
![image](https://github.com/user-attachments/assets/7d6893df-f7cf-4000-8a16-f9d9426238d2)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Added surgical case to the medilathe.
