### PR TITLE
Fix staff officer loadout

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Command/staff_officer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Command/staff_officer.yml
@@ -61,7 +61,7 @@
   equipment:
     jumpsuit: CMJumpsuitBO
     shoes: RMCShoesLaceup
-    head: RMCHeadCapFlippable
+    head: CMHeadCapOfficer
     id: CMIDCardStaffOfficer
     ears: RMCHeadsetMarineCommand
     pocket1: RMCPouchGeneralLarge


### PR DESCRIPTION
They're supposed to spawn with an officer cap not a normal one