### PR TITLE
Change some corpse's loadouts

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Corpses/civilians.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Corpses/civilians.yml
@@ -152,12 +152,14 @@
   id: RMCGearCorpseSecurity
   equipment:
     jumpsuit: ClothingUniformJumpsuitSec
-    back: CMBackpackSecurity
+    back: CMSatchelSecurity
+    head: RMCArmorHelmetSecurity
+    outerClothing: RMCArmorSecurity
     shoes: RMCShoesJackboots
     eyes: CMGlassesSecurity
     gloves: CMHandsBlackMarine
     id: CMIDCardColonist
-    ears: CMHeadsetColony
+    ears: CMIDCardColonistSecurity
     belt: CMBeltSecurityMPFilled
   storage:
     back:

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Corpses/civilians.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Corpses/civilians.yml
@@ -158,8 +158,8 @@
     shoes: RMCShoesJackboots
     eyes: CMGlassesSecurity
     gloves: CMHandsBlackMarine
-    id: CMIDCardColonist
-    ears: CMIDCardColonistSecurity
+    id: CMIDCardColonistSecurity
+    ears: CMHeadsetColony
     belt: CMBeltSecurityMPFilled
   storage:
     back:

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Corpses/civilians.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Corpses/civilians.yml
@@ -151,7 +151,7 @@
 - type: startingGear
   id: RMCGearCorpseSecurity
   equipment:
-    jumpsuit: ClothingUniformJumpsuitSec
+    jumpsuit: RMCJumpsuitCivilianSecurity
     back: CMSatchelSecurity
     head: RMCArmorHelmetSecurity
     outerClothing: RMCArmorSecurity
@@ -194,22 +194,45 @@
   id: RMCCorpseLiaison
   components:
   - type: Loadout
-    prototypes: [ RMCGearCorpseLiaison ]
+    prototypes:
+    - RMCGearCorpseLiaison
+    - RMCGearCorpseLiaisonBlue
+    - RMCGearCorpseLiaisonBrown
+    - RMCGearCorpseLiaisonWhite
   - type: VictimBurst
 
 - type: startingGear
   id: RMCGearCorpseLiaison
   equipment:
-    jumpsuit: CMJumpsuitLiaisonField
+    jumpsuit: CMJumpsuitLiaisonBlack
+    outerClothing: RMCArmorVest
     back: CMSatchel
     shoes: RMCShoesLaceup
     eyes: RMCGlassesAviators
     id: CMIDCardLiaisonColony
     ears: RMCHeadsetDistressWeYa
-#    belt: /obj/item/storage/belt/gun/m4a3/mod88
+    belt: CMM77BeltFilled
   storage:
     back:
     - RMCRadioHandheldColonyOff
+
+- type: startingGear
+  parent: RMCGearCorpseLiaison
+  id: RMCGearCorpseLiaisonBlue
+  equipment:
+    jumpsuit: CMJumpsuitLiaisonBlue
+
+- type: startingGear
+  parent: RMCGearCorpseLiaison
+  id: RMCGearCorpseLiaisonBrown
+  equipment:
+    jumpsuit: CMJumpsuitLiaisonBrown
+
+- type: startingGear
+  parent: RMCGearCorpseLiaison
+  id: RMCGearCorpseLiaisonWhite
+  equipment:
+    jumpsuit: CMJumpsuitLiaisonCorporateFormal
 
 # Prison Guard
 - type: randomHumanoidSettings


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
also updated corpo colonist corpse and other corpses
updated security colonist CORPSE to parity so they have a satchel, armor vest, and helmet
![image](https://github.com/user-attachments/assets/c21024b3-dffc-4e96-9cd1-0c2e76cbe97c)
![image](https://github.com/user-attachments/assets/5387dbcf-d574-41b2-ba2a-f43d6b2de661)



:cl:
- fix: Fixed security colonist corpse not spawning with an armor vest and helmet
- tweak: Corporate colonist corpse now spawns with random outfits
