### PR TITLE
Fix the bipod's scatter and slow values.

### DIFF
--- a/Content.Shared/_RMC14/Attachable/Components/AttachableTemporarySpeedModsComponent.cs
+++ b/Content.Shared/_RMC14/Attachable/Components/AttachableTemporarySpeedModsComponent.cs
@@ -16,10 +16,10 @@ public sealed partial class AttachableTemporarySpeedModsComponent : Component
     public List<TemporarySpeedModifierSet> Modifiers = new();
 
     [DataField, AutoNetworkedField]
-    public TimeSpan SlowDuration = TimeSpan.FromSeconds(2);
+    public TimeSpan SlowDuration = TimeSpan.FromSeconds(4);
 
     [DataField, AutoNetworkedField]
-    public TimeSpan SuperSlowDuration = TimeSpan.FromSeconds(1);
+    public TimeSpan SuperSlowDuration = TimeSpan.FromSeconds(2);
 }
 
 

--- a/Content.Shared/_RMC14/Attachable/Components/AttachableTemporarySpeedModsComponent.cs
+++ b/Content.Shared/_RMC14/Attachable/Components/AttachableTemporarySpeedModsComponent.cs
@@ -14,6 +14,12 @@ public sealed partial class AttachableTemporarySpeedModsComponent : Component
 
     [DataField, AutoNetworkedField]
     public List<TemporarySpeedModifierSet> Modifiers = new();
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan SlowDuration = TimeSpan.FromSeconds(2);
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan SuperSlowDuration = TimeSpan.FromSeconds(1);
 }
 
 

--- a/Content.Shared/_RMC14/Attachable/Systems/AttachableModifiersSystem.Ranged.cs
+++ b/Content.Shared/_RMC14/Attachable/Systems/AttachableModifiersSystem.Ranged.cs
@@ -90,10 +90,7 @@ public sealed partial class AttachableModifiersSystem : EntitySystem
                 _cmGunSystem.RefreshGunDamageMultiplier(args.Holder);
 
                 if (attachable.Comp.FireModeMods != null)
-                {
                     _rmcSelectiveFireSystem.RefreshFireModes(args.Holder, true);
-                    break;
-                }
 
                 _rmcSelectiveFireSystem.RefreshModifiableFireModeValues(args.Holder);
                 break;

--- a/Content.Shared/_RMC14/Attachable/Systems/AttachableTemporarySpeedModsSystem.cs
+++ b/Content.Shared/_RMC14/Attachable/Systems/AttachableTemporarySpeedModsSystem.cs
@@ -1,13 +1,13 @@
 using Content.Shared._RMC14.Attachable.Components;
 using Content.Shared._RMC14.Attachable.Events;
-using Content.Shared._RMC14.Movement;
+using Content.Shared._RMC14.Slow;
 
 namespace Content.Shared._RMC14.Attachable.Systems;
 
 public sealed class AttachableTemporarySpeedModsSystem : EntitySystem
 {
-    [Dependency] private readonly TemporarySpeedModifiersSystem _temporarySpeedModifiersSystem = default!;
     [Dependency] private readonly AttachableHolderSystem _attachableHolderSystem = default!;
+    [Dependency] private readonly RMCSlowSystem _slow = default!;
 
     public override void Initialize()
     {
@@ -19,6 +19,7 @@ public sealed class AttachableTemporarySpeedModsSystem : EntitySystem
         if ((attachable.Comp.Alteration & args.Alteration) != attachable.Comp.Alteration || !_attachableHolderSystem.TryGetUser(attachable.Owner, out var userUid))
             return;
 
-        _temporarySpeedModifiersSystem.ModifySpeed(userUid.Value, attachable.Comp.Modifiers);
+        _slow.TrySlowdown(userUid.Value, attachable.Comp.SlowDuration);
+        _slow.TrySuperSlowdown(userUid.Value, attachable.Comp.SuperSlowDuration);
     }
 }

--- a/Content.Shared/_RMC14/Attachable/Systems/AttachableToggleableSystem.cs
+++ b/Content.Shared/_RMC14/Attachable/Systems/AttachableToggleableSystem.cs
@@ -295,9 +295,6 @@ public sealed class AttachableToggleableSystem : EntitySystem
         if ((attachable.Comp.NeedHand || attachable.Comp.BreakOnDrop) && attachable.Comp.Active)
         {
             Toggle(attachable, args.Args.User, attachable.Comp.DoInterrupt);
-
-            if (attachable.Comp.SlowOnBreak)
-                BreakSlow(args.Args.User);
         }
 
         var removeEv = new RemoveAttachableActionsEvent(args.Args.User);
@@ -322,9 +319,6 @@ public sealed class AttachableToggleableSystem : EntitySystem
             return;
 
         Toggle(attachable, args.User);
-
-        if (attachable.Comp.SlowOnBreak)
-            BreakSlow(args.User);
     }
 
     private void OnDropped(Entity<AttachableToggleableComponent> attachable, ref AttachableRelayedEvent<DroppedEvent> args)
@@ -336,15 +330,6 @@ public sealed class AttachableToggleableSystem : EntitySystem
             return;
 
         Toggle(attachable, args.Args.User);
-
-        if (attachable.Comp.SlowOnBreak)
-            BreakSlow(args.Args.User);
-    }
-
-    private void BreakSlow(EntityUid user)
-    {
-        _slow.TrySlowdown(user, TimeSpan.FromSeconds(4));
-        _slow.TrySuperSlowdown(user, TimeSpan.FromSeconds(2));
     }
 
     private void OnAttachableMovementLockedMoveInput(Entity<AttachableMovementLockedComponent> user, ref MoveInputEvent args)
@@ -363,8 +348,6 @@ public sealed class AttachableToggleableSystem : EntitySystem
             }
 
             Toggle((attachableUid, toggleableComponent), user.Owner, toggleableComponent.DoInterrupt);
-            if (toggleableComponent.SlowOnBreak)
-                BreakSlow(user);
         }
     }
 
@@ -392,8 +375,6 @@ public sealed class AttachableToggleableSystem : EntitySystem
             }
 
             Toggle((attachableUid, toggleableComponent), user.Owner, toggleableComponent.DoInterrupt);
-            if (toggleableComponent.SlowOnBreak)
-                BreakSlow(user);
         }
     }
 
@@ -431,8 +412,6 @@ public sealed class AttachableToggleableSystem : EntitySystem
             }
 
             Toggle((attachableUid, toggleableComponent), user.Owner, toggleableComponent.DoInterrupt);
-            if (toggleableComponent.SlowOnBreak)
-                BreakSlow(user);
         }
     }
 #endregion

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/under_attachments.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/under_attachments.yml
@@ -80,13 +80,6 @@
     showActive: true
   - type: AttachableTemporarySpeedMods
     alteration: Interrupted
-    modifiers:
-    - duration: 1
-      walk: 0.5
-      sprint: 0.357
-    - duration: 2
-      walk: 0.66
-      sprint: 0.526
   - type: AttachableSizeMods
     modifiers:
     - size: 2


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The bipod now doesn't applies multiple stacking slows anymore, only a slow and a  superslow.(which don't stack)

The bipod now also refreshes the burst scatter multiplier when deployed or undeployed, this means that the scatter reduction when using a deployed bipod is now properly applied. Previously it would only apply if the weapon had at least one other attachment that would refresh the burst scatter multiplier, and if it was deployed before wielding.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity and bug fix.
Resolves #6761

## Technical details
<!-- Summary of code changes for easier review. -->
Previously a wielded M54CE2 with only a bipod would have a max scatter of 90 degrees in automatic mode with the bipod deployed and no other attachments, this is now 50 degrees because the burst scatter value gets refreshed upon deploying/undeploying the bipod.

If the M54CE2 was used with a bipod AND reflex sight, it would only apply the bipod scatter reduction if it was first deployed and then wielded, this is because the reflex sight would call a refresh for burst scatter multiplier upon wielding the gun. If the gun was first wielded(refresh burst scatter multiplier because of reflex) and then deployed the bipod, the scatter wouldn't change at all because the action of deploying the bipod would not refresh the burst scatter value.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Dygon
- fix: Improperly folding the bipod attachment now applies a weaker slowdown effect.
- fix: The bipod attachment now correctly applies it's scatter reduction effect when toggled.

