### PR TITLE
[QOL/Fix] ChemMaster Eject Beaker

### DIFF
--- a/Content.Shared/_RMC14/Chemistry/ChemMaster/SharedRMCChemMasterSystem.cs
+++ b/Content.Shared/_RMC14/Chemistry/ChemMaster/SharedRMCChemMasterSystem.cs
@@ -206,10 +206,6 @@ public abstract class SharedRMCChemMasterSystem : EntitySystem
 
         _itemSlots.TryEjectToHands(ent, slot, args.Actor, true);
 
-        if (!_solution.TryGetSolution(ent.Owner, ent.Comp.BufferSolutionId, out var buffer))
-            return;
-
-        _solution.RemoveAllSolution(buffer.Value);
         Dirty(ent);
     }
 
@@ -301,6 +297,11 @@ public abstract class SharedRMCChemMasterSystem : EntitySystem
 
         if (!_solution.TryGetSolution(ent.Owner, ent.Comp.BufferSolutionId, out var buffer))
             return;
+
+        if (ent.Comp.BufferTransferMode == RMCChemMasterBufferMode.ToDisposal)
+        {
+            _solution.RemoveAllSolution(buffer.Value);
+        }
 
         _solutionTransfer.Transfer(args.Actor, ent, buffer.Value, beaker, beakerSolution, buffer.Value.Comp.Solution.Volume);
         Dirty(ent);

--- a/Resources/Locale/en-US/_RMC14/chemistry/rmc-chem-master.ftl
+++ b/Resources/Locale/en-US/_RMC14/chemistry/rmc-chem-master.ftl
@@ -1,4 +1,4 @@
-﻿rmc-chem-master-full-pill-bottles = Machine is fully loaded by pill bottles.
+rmc-chem-master-full-pill-bottles = Machine is fully loaded by pill bottles.
 
 rmc-chem-master-status = [bold]Status[/bold]
 rmc-chem-master-reagent-amount = {$name}, {$amount} units
@@ -19,7 +19,7 @@ rmc-chem-master-pill-bottle-eject = Eject
 rmc-chem-master-pill-bottle-window-title = Pill Bottle Color
 
 rmc-chem-master-beaker-title = [bold]Beaker[/bold]
-rmc-chem-master-beaker-eject = Eject and clear buffer
+rmc-chem-master-beaker-eject = Eject Beaker
 rmc-chem-master-beaker-empty = Beaker is empty.
 
 rmc-chem-master-buffer = [bold]Buffer[/bold]


### PR DESCRIPTION
Eject the beaker only button, and allows all regant button to dump to disposals

## About the PR
QoL - The eject and clear button is now only Eject Beaker button.
Fix - The all reagents button can now send everything to disposals.

## Why / Balance
If i have to baby sit another nurse as they dump all their chems when they hit eject, i swear to god....

## Technical details
Just moved some code around and changed some wording.

## Media
After:

https://github.com/user-attachments/assets/a4fc9f23-5458-482a-adab-3a2cb452c351

Before:

https://github.com/user-attachments/assets/5eff7a02-f0c5-41b9-8daa-071bbfe11531

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: The ChemMaster eject and clear button is now only Eject Beaker button.
- fix: The ChemMaster buffer side, all reagents button can now send everything to disposals.
