### PR TITLE
Synth fixes

### DIFF
--- a/Content.Shared/_RMC14/Synth/SharedSynthSystem.cs
+++ b/Content.Shared/_RMC14/Synth/SharedSynthSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared._RMC14.Repairable;
 using Content.Shared._RMC14.StatusEffect;
 using Content.Shared.Bed.Sleep;
 using Content.Shared.Damage;
+using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.DoAfter;
 using Content.Shared.FixedPoint;
@@ -64,6 +65,7 @@ public abstract class SharedSynthSystem : EntitySystem
             _rmcStatusEffects.GiveStunResistance(ent.Owner, ent.Comp.StunResistance.Value);
 
         _mobThreshold.SetMobStateThreshold(ent.Owner, ent.Comp.CritThreshold, MobState.Critical);
+        RemCompDeferred<SlowOnDamageComponent>(ent.Owner);
     }
 
     private void OnMeleeAttempted(Entity<SynthComponent> ent, ref AttackAttemptEvent args)

--- a/Content.Shared/_RMC14/Synth/SharedSynthSystem.cs
+++ b/Content.Shared/_RMC14/Synth/SharedSynthSystem.cs
@@ -8,6 +8,8 @@ using Content.Shared.DoAfter;
 using Content.Shared.FixedPoint;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Systems;
 using Content.Shared.Popups;
 using Content.Shared.Stacks;
 using Content.Shared.Tools.Systems;
@@ -28,6 +30,7 @@ public abstract class SharedSynthSystem : EntitySystem
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly SharedStackSystem _stack = default!;
     [Dependency] private readonly RMCStatusEffectSystem _rmcStatusEffects = default!;
+    [Dependency] private readonly MobThresholdSystem _mobThreshold = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
 
     public override void Initialize()
@@ -59,6 +62,8 @@ public abstract class SharedSynthSystem : EntitySystem
 
         if (ent.Comp.StunResistance != null)
             _rmcStatusEffects.GiveStunResistance(ent.Owner, ent.Comp.StunResistance.Value);
+
+        _mobThreshold.SetMobStateThreshold(ent.Owner, ent.Comp.CritThreshold, MobState.Critical);
     }
 
     private void OnMeleeAttempted(Entity<SynthComponent> ent, ref AttackAttemptEvent args)

--- a/Content.Shared/_RMC14/Synth/SynthComponent.cs
+++ b/Content.Shared/_RMC14/Synth/SynthComponent.cs
@@ -2,6 +2,7 @@
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
+using Content.Shared.FixedPoint;
 using Content.Shared.Tools;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
@@ -68,6 +69,9 @@ public sealed partial class SynthComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public TimeSpan SelfRepairTime = TimeSpan.FromSeconds(30);
+
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 CritThreshold = FixedPoint2.New(200);
 
     /// <summary>
     /// The tool quality needed to repair the synth brute damage.

--- a/Content.Shared/_RMC14/Xenonids/Paralyzing/XenoParalyzingSlashSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Paralyzing/XenoParalyzingSlashSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared._RMC14.Actions;
 using Content.Shared._RMC14.Stun;
+using Content.Shared._RMC14.Synth;
 using Content.Shared._RMC14.Xenonids.Dodge;
 using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared.Actions;
@@ -77,6 +78,13 @@ public sealed class XenoParalyzingSlashSystem : EntitySystem
                 HasComp<VictimBeingParalyzedComponent>(entity) ||
                 HasComp<XenoComponent>(entity))
             {
+                continue;
+            }
+
+            if (HasComp<SynthComponent>(entity))
+            {
+                var immuneMsg = Loc.GetString("cm-xeno-paralyzing-slash-immune", ("target", entity));
+                _popup.PopupEntity(immuneMsg, entity, entity, PopupType.SmallCaution);
                 continue;
             }
 

--- a/Content.Shared/_RMC14/Xenonids/Projectile/Spit/XenoSpitSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/Spit/XenoSpitSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared._RMC14.Explosion;
 using Content.Shared._RMC14.OnCollide;
 using Content.Shared._RMC14.Shields;
 using Content.Shared._RMC14.Slow;
+using Content.Shared._RMC14.Synth;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Projectile.Spit.Ball;
 using Content.Shared._RMC14.Xenonids.Projectile.Spit.Charge;
@@ -224,6 +225,13 @@ public sealed class XenoSpitSystem : EntitySystem
         if (_hive.FromSameHive(spit.Owner, target) || HasComp<XenoComponent>(target))
         {
             QueueDel(spit);
+            return;
+        }
+
+        if (HasComp<SynthComponent>(target))
+        {
+            var immuneMsg = Loc.GetString("cm-xeno-paralyzing-slash-immune", ("target", target));
+            _popup.PopupEntity(immuneMsg, target, target, PopupType.SmallCaution);
             return;
         }
 

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
@@ -78,6 +78,7 @@ rmc-xeno-acid-structure-unmeltable = We can only melt barricades and items!
 cm-xeno-paralyzing-slash-activate = Our next slash will apply neurotoxin!
 cm-xeno-paralyzing-slash-expire = We have waited too long, your slash will no longer apply neurotoxin!
 cm-xeno-paralyzing-slash-hit = We add neurotoxin into your attack, {$target} is about to fall over paralyzed!
+cm-xeno-paralyzing-slash-immune = {$target} shrugs off the neurotoxin!
 
 # Crippling Strike
 cm-xeno-crippling-strike-activate = Our next slash will apply neurotoxin!


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removes synth's crit threshold (parity)
Removes their damage slowdown
Synths aren't affected by neurotoxin slash or spit/slowing spit

:cl:
ADMIN:
- fix: Fixed synths being affected by xeno neurotoxin spit and slashes
- fix: Fixed synths having a crit threshold
