### PR TITLE
Fix LACN mention in MRE cig mini packs.

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Smokeables/cigarettes.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Smokeables/cigarettes.yml
@@ -2,7 +2,7 @@
   parent: CigPackBase
   id: CMCigarettePackLuckySlothsMini
   name: lucky sloths mini packet
-  description: These four-packs of Luckies come in every MRE. They're not as good as the Habana Reals that come in the LACN MREs, but at least they're free.
+  description: These four-packs of Luckies come in every MRE. They're not as good as the Embassy Crowns found in some TSE MREs, but at least they're free.
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Consumable/Smokeables/Cigarettes/lucky_sloths_4.rsi


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
As far as I am aware LACN does not exist in RMC lore. As soon as I was made aware of this GAMEBREAKING bug, I rushed to fix it. Changes the description of the lucky sloth mini packs from:
"These four-packs of Luckies come in every MRE. They're not as good as the Habana Reals that come in the LACN MREs, but at least they're free."
To: 
"These four-packs of Luckies come in every MRE. They're not as good as the Embassy Crowns found in some TSE MREs, but at least they're free."
Embassy Crowns being a made up brand based on the real-life Embassy King cigarettes brand, popular in the UK in the 70's. There is a parity TSE cig brand, but it has its base in official aliens media so I figure its better to go full original.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
fixes a HORRIBLE lore mistake in a description.
## Technical details
<!-- Summary of code changes for easier review. -->
YML
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed LACN mention in lucky strike mini pack description.
