### PR TITLE
Allowed Syringe Cases in CMWebbing, CMWebbingBlack and CMWebbingBrown

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/webbing.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/webbing.yml
@@ -66,6 +66,7 @@
       - PillPacket
       - PillCanister
       - CMSurgicalCase
+      - RMCSyringeCase
   - type: Webbing
     components:
     - type: Storage
@@ -84,6 +85,7 @@
         - PillPacket
         - PillCanister
         - CMSurgicalCase
+        - RMCSyringeCase
     - type: RMCStorageEjectHand
       state: Open
     - type: ExplosionResistance
@@ -115,6 +117,7 @@
       - PillPacket
       - PillCanister
       - CMSurgicalCase
+      - RMCSyringeCase
   - type: Webbing
     playerSprite:
       sprite: _RMC14/Objects/Clothing/Webbing/webbing_black.rsi
@@ -134,6 +137,7 @@
         - PillPacket
         - PillCanister
         - CMSurgicalCase
+        - RMCSyringeCase
     - type: FixedItemSizeStorage
     - type: RMCStorageEjectHand
       state: Open
@@ -170,6 +174,7 @@
         - PillPacket
         - PillCanister
         - CMSurgicalCase
+        - RMCSyringeCase
     - type: FixedItemSizeStorage
     - type: RMCStorageEjectHand
       state: Open


### PR DESCRIPTION
## About the PR
Allowed Syringe Cases in CMWebbing, CMWebbingBlack and CMWebbingBrown

## Why / Balance
Parity... or so im told on medcord, i coudln't tell from the code, and i dont have cm13 setup to check. Dont see why it wouldnt be.

## Technical details
Added to the IgnoreContentsSize lists for those 3 webbings.

## Media

https://github.com/user-attachments/assets/f839bff2-9447-47eb-886d-c6c1ea9aa47b


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed syringe cases not fitting into the 3-slot and 5-slot webbings.
