### PR TITLE
Provost MP requirement fixes

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Provost/provost_enforcer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Provost/provost_enforcer.yml
@@ -54,6 +54,9 @@
     - !type:RoleTimeRequirement
       role: CMJobRifleman
       time: 18000 # 5 Hours
+    - !type:RoleTimeRequirement
+      role: CMJobMilitaryPolice
+      time: 18000 # 5 Hours
   - type: GhostRoleApplySpecial
     squad: SquadProvost
 

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Provost/provost_team_leader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Provost/provost_team_leader.yml
@@ -67,6 +67,9 @@
     - !type:RoleTimeRequirement
       role: CMJobSquadLeader
       time: 18000 # 5 Hours
+    - !type:RoleTimeRequirement
+      role: CMJobMilitaryPolice
+      time: 18000 # 5 Hours
   - type: GhostRoleApplySpecial
     squad: SquadProvost
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Provost enforcers and leaders now require MP time.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: noctyrnal
- fix: Provost Enforcers and Provost Team Leaders now require 5 hours of MP playtime.
