### PR TITLE
decrease minimum usable range by mortar, by taking from maximum range

### DIFF
--- a/Content.Shared/_RMC14/Mortar/MortarComponent.cs
+++ b/Content.Shared/_RMC14/Mortar/MortarComponent.cs
@@ -50,10 +50,10 @@ public sealed partial class MortarComponent : Component
     public int MaxDial = 10;
 
     [DataField, AutoNetworkedField]
-    public int MinimumRange = 25;
+    public int MinimumRange = 15;
 
     [DataField, AutoNetworkedField]
-    public int MaximumRange = 75;
+    public int MaximumRange = 65;
 
     [DataField, AutoNetworkedField]
     public string FixtureId = "mortar";


### PR DESCRIPTION
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
- Makes the mortar more usable at closer ranges, at the expense of longer ranges (by the same amount of tiles)
- This will no longer require you to be as far back from the front, but will require you to move up with the front.

**Changelog**

:cl: Whisper
- tweak: Decreased the minimum range required for mortars by 10 tiles in exchange for the maximum range reduction of 10 tiles. You will be able to shoot it closer but not as far by the same amount.
