### PR TITLE
Fix EZs having a doafter

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Medical/auto_injectors.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Medical/auto_injectors.yml
@@ -503,7 +503,6 @@
   - type: RMCEmptySolution
   - type: SolutionStorageFillable
     solution: pen
-  - type: MedicallyUnskilledDoAfter
 
 - type: entity
   parent: RMCMedicAutoInjectorBase
@@ -525,9 +524,10 @@
         maxVol: 15
   - type: Hypospray
     transferAmount: 5
+  - type: MedicallyUnskilledDoAfter
 
 - type: entity
-  parent: RMCMedicAutoInjectorBase
+  parent: RMCMedicAutoInjectorCS5
   id: RMCMedicAutoInjectorCS15
   name: autoinjector (C-M)
   components:
@@ -547,7 +547,7 @@
     transferAmount: 15
 
 - type: entity
-  parent: RMCMedicAutoInjectorBase
+  parent: RMCMedicAutoInjectorCS5
   id: RMCMedicAutoInjectorCS30
   name: autoinjector (C-XL)
   components:
@@ -567,7 +567,7 @@
     transferAmount: 30
 
 - type: entity
-  parent: RMCMedicAutoInjectorBase
+  parent: RMCMedicAutoInjectorCS5
   id: RMCMedicAutoInjectorCS60
   name: autoinjector (C-XXL)
   components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug.

## Technical details
<!-- Summary of code changes for easier review. -->
Last PR put the doafter on the base medic injector, it was only supposed to be on the CS line, with every injector inheriting from the 5 u one.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
no cl not live
