### PR TITLE
Fix fire immune xenos from taking fire cross damage

### DIFF
--- a/Content.Shared/_RMC14/OnCollide/DamageOnCollideComponent.cs
+++ b/Content.Shared/_RMC14/OnCollide/DamageOnCollideComponent.cs
@@ -41,7 +41,10 @@ public sealed partial class DamageOnCollideComponent : Component
     public ProtoId<EmotePrototype>? XenoEmote = "Hiss";
 
     [DataField]
-    public bool Acidic = true;
+    public bool Acidic = false;
+
+    [DataField]
+    public bool Fire = false;
 
     [DataField]
     public CollisionGroup Collision = CollisionGroup.FullTileLayer;

--- a/Content.Shared/_RMC14/OnCollide/SharedOnCollideSystem.cs
+++ b/Content.Shared/_RMC14/OnCollide/SharedOnCollideSystem.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared._RMC14.Armor.ThermalCloak;
+using Content.Shared._RMC14.Armor.ThermalCloak;
+using Content.Shared._RMC14.Atmos;
 using Content.Shared._RMC14.Stun;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared._RMC14.Xenonids.Hive;
@@ -59,6 +60,9 @@ public abstract class SharedOnCollideSystem : EntitySystem
             return;
 
         if (_hive.FromSameHive(ent.Owner, other))
+            return;
+
+        if (ent.Comp.Fire && HasComp<RMCImmuneToFireTileDamageComponent>(other))
             return;
 
         if (HasComp<UncloakOnHitComponent>(ent.Owner))

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
@@ -255,6 +255,7 @@
   - type: XenoToggleChargingStop
   - type: FixedIdentity
     name: cm-job-name-xeno-queen
+  - type: RMCImmuneToFireTileDamage
 
 - type: entity
   parent: RMCXenoQueenBase

--- a/Resources/Prototypes/_RMC14/Entities/Tiles/tile_fire.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Tiles/tile_fire.yml
@@ -41,6 +41,7 @@
         Heat: 0.5
   - type: DamageOnCollide
     damageDead: false
+    fire: true
     damage:
       types:
         Heat: 45


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug. Also fixes xenos possibly taking over double damage from crossing fire (whoops). Fixes #6786
Open

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed fire immune xenos taking damage when crossing fire tiles
- fix: Fixed fire tiles doing more damage on cross than intended
