### PR TITLE
Smokables loadout category

### DIFF
--- a/Resources/Locale/en-US/_RMC14/roles/loadouts.ftl
+++ b/Resources/Locale/en-US/_RMC14/roles/loadouts.ftl
@@ -9,6 +9,7 @@ rmc-loadout-group-recreational = Recreational
 rmc-loadout-group-weapons = Weapons
 rmc-loadout-group-canned-drinks = Canned Drinks
 rmc-loadout-group-flasks = Flasks
+rmc-loadout-group-smokables = Smokables
 rmc-loadout-group-foods-sweets = Food (sweets)
 rmc-loadout-group-foods-packaged = Food (packaged)
 rmc-loadout-group-foods-healthy = Food (healthy)

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Smokeables/cigarettes.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Smokeables/cigarettes.yml
@@ -194,6 +194,16 @@
     state: unlit-icon
 
 - type: entity
+  parent: Cigarette
+  id: RMCJoint
+  name: joint
+  description: A roll of dried plant matter wrapped in thin paper.
+  components:
+  - type: Sprite
+    sprite: Objects/Consumable/Smokeables/Cannabis/joint.rsi
+    state: unlit-icon
+
+- type: entity
   id: RMCCigaretteSpent
   parent: RMCCigarette
   suffix: spent

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Smokeables/cigarettes.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Smokeables/cigarettes.yml
@@ -194,16 +194,6 @@
     state: unlit-icon
 
 - type: entity
-  parent: Cigarette
-  id: RMCJoint
-  name: joint
-  description: A roll of dried plant matter wrapped in thin paper.
-  components:
-  - type: Sprite
-    sprite: Objects/Consumable/Smokeables/Cannabis/joint.rsi
-    state: unlit-icon
-
-- type: entity
   id: RMCCigaretteSpent
   parent: RMCCigarette
   suffix: spent

--- a/Resources/Prototypes/_RMC14/Roles/Loadouts/Items/smokables.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Loadouts/Items/smokables.yml
@@ -1,0 +1,85 @@
+# Smokables
+- type: loadout
+  id: LuckySlothsPackRMC
+  cost: 1
+  storage:
+    back:
+    - RMCCigarettePackLuckySloths
+
+- type: loadout
+  id: WeYaGoldPackRMC
+  cost: 1
+  storage:
+    back:
+    - RMCCigarettePackWeYaGold
+
+- type: loadout
+  id: ExecutiveSelectPackRMC
+  cost: 1
+  storage:
+    back:
+    - RMCCigarettePackExecutiveSelect
+
+- type: loadout
+  id: TarbackTubeRMC
+  cost: 2
+  storage:
+    back:
+    - RMCTarbackTube
+
+- type: loadout
+  id: TarbacksCaseRMC
+  cost: 6
+  storage:
+    back:
+    - RMCTarbackCase
+
+- type: loadout
+  id: PremiumCigarRMC
+  cost: 2
+  storage:
+    back:
+    - Cigar
+
+- type: loadout
+  id: JointRMC
+  cost: 2
+  storage:
+    back:
+    - RMCJoint
+
+- type: loadout
+  id: ZippoRMC
+  cost: 1
+  storage:
+    back:
+    - RMCZippo
+
+- type: loadout
+  id: ZippoExecRMC
+  cost: 3
+  storage:
+    back:
+    - RMCZippoExec
+
+- type: loadout
+  id: ZippoGoldRMC
+  cost: 3
+  storage:
+    back:
+    - RMCZippoGold
+
+- type: loadout
+  id: CheapLighterRMC
+  cost: 1
+  storage:
+    back:
+    - RMCLighter
+
+- type: loadout
+  id: MatchboxRMC
+  cost: 1
+  storage:
+    back:
+    - RMCMatchboxFull
+

--- a/Resources/Prototypes/_RMC14/Roles/Loadouts/Items/smokables.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Loadouts/Items/smokables.yml
@@ -42,13 +42,6 @@
     - Cigar
 
 - type: loadout
-  id: JointRMC
-  cost: 2
-  storage:
-    back:
-    - RMCJoint
-
-- type: loadout
   id: ZippoRMC
   cost: 1
   storage:

--- a/Resources/Prototypes/_RMC14/Roles/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Loadouts/loadout_groups.yml
@@ -256,6 +256,25 @@
   - CanteenRMC
   - MetalFlaskRMC
 
+# Smokables
+- type: loadoutGroup
+  id: SmokablesRMC
+  name: rmc-loadout-group-smokables
+  minLimit: 0
+  maxLimit: 11
+  loadouts:
+  - LuckySlothsPackRMC
+  - WeYaGoldPackRMC
+  - ExecutiveSelectPackRMC
+  - TarbackTubeRMC
+  - TarbacksCaseRMC
+  - PremiumCigarRMC
+  - JointRMC
+  - ZippoRMC
+  - ZippoExecRMC
+  - ZippoGoldRMC
+  - MatchboxRMC
+
 # Food (sweets)
 - type: loadoutGroup
   id: FoodSweetsRMC

--- a/Resources/Prototypes/_RMC14/Roles/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Loadouts/role_loadouts.yml
@@ -21,6 +21,7 @@
   - FoodPackagedRMC
   - FoodHealthyRMC
   - RMCLoadoutGroupPins
+  - SmokablesRMC
 
 - type: roleLoadout
   id: JobCMDropshipCrewChief
@@ -41,6 +42,7 @@
   - FoodPackagedRMC
   - FoodHealthyRMC
   - RMCLoadoutGroupPins
+  - SmokablesRMC
 
 - type: roleLoadout
   id: JobCMPilotDropship
@@ -61,6 +63,7 @@
   - FoodPackagedRMC
   - FoodHealthyRMC
   - RMCLoadoutGroupPins
+  - SmokablesRMC
 
 - type: roleLoadout
   id: JobCMPilotGunship
@@ -81,6 +84,7 @@
   - FoodPackagedRMC
   - FoodHealthyRMC
   - RMCLoadoutGroupPins
+  - SmokablesRMC
 
 - type: roleLoadout
   id: JobCMIntelOfficer
@@ -101,6 +105,7 @@
   - FoodPackagedRMC
   - FoodHealthyRMC
   - RMCLoadoutGroupPins
+  - SmokablesRMC
 
 # Command
 - type: roleLoadout
@@ -124,6 +129,7 @@
   - FoodPackagedRMC
   - FoodHealthyRMC
   - RMCLoadoutGroupPins
+  - SmokablesRMC
 
 - type: roleLoadout
   id: JobCMExecutiveOfficer
@@ -144,6 +150,7 @@
   - FoodPackagedRMC
   - FoodHealthyRMC
   - RMCLoadoutGroupPins
+  - SmokablesRMC
 
 - type: roleLoadout
   id: JobCMStaffOfficer
@@ -164,6 +171,7 @@
   - FoodPackagedRMC
   - FoodHealthyRMC
   - RMCLoadoutGroupPins
+  - SmokablesRMC
 
 # Engineering
 - type: roleLoadout
@@ -185,6 +193,7 @@
   - FoodPackagedRMC
   - FoodHealthyRMC
   - RMCLoadoutGroupPins
+  - SmokablesRMC
 
 - type: roleLoadout
   id: JobCMMaintTech
@@ -205,6 +214,7 @@
   - FoodPackagedRMC
   - FoodHealthyRMC
   - RMCLoadoutGroupPins
+  - SmokablesRMC
 
 - type: roleLoadout
   id: JobCMOrdnanceTech
@@ -225,6 +235,7 @@
   - FoodPackagedRMC
   - FoodHealthyRMC
   - RMCLoadoutGroupPins
+  - SmokablesRMC
 
 # Squad Roles
 - type: roleLoadout
@@ -246,6 +257,7 @@
   - FoodPackagedRMC
   - FoodHealthyRMC
   - RMCLoadoutGroupPins
+  - SmokablesRMC
 
 - type: roleLoadout
   id: JobCMFireteamLeader
@@ -266,6 +278,7 @@
   - FoodPackagedRMC
   - FoodHealthyRMC
   - RMCLoadoutGroupPins
+  - SmokablesRMC
 
 - type: roleLoadout
   id: JobCMHospitalCorpsman
@@ -286,6 +299,7 @@
   - FoodPackagedRMC
   - FoodHealthyRMC
   - RMCLoadoutGroupPins
+  - SmokablesRMC
 
 - type: roleLoadout
   id: JobCMRifleman
@@ -306,6 +320,7 @@
   - FoodPackagedRMC
   - FoodHealthyRMC
   - RMCLoadoutGroupPins
+  - SmokablesRMC
 
 - type: roleLoadout
   id: JobCMSmartGunOperator
@@ -326,6 +341,7 @@
   - FoodPackagedRMC
   - FoodHealthyRMC
   - RMCLoadoutGroupPins
+  - SmokablesRMC
 
 - type: roleLoadout
   id: JobCMSquadLeader
@@ -346,6 +362,7 @@
   - FoodPackagedRMC
   - FoodHealthyRMC
   - RMCLoadoutGroupPins
+  - SmokablesRMC
 
 - type: roleLoadout
   id: JobCMWeaponsSpecialist
@@ -366,6 +383,7 @@
   - FoodPackagedRMC
   - FoodHealthyRMC
   - RMCLoadoutGroupPins
+  - SmokablesRMC
 
 # Medical
 - type: roleLoadout
@@ -387,6 +405,7 @@
   - FoodPackagedRMC
   - FoodHealthyRMC
   - RMCLoadoutGroupPins
+  - SmokablesRMC
 
 - type: roleLoadout
   id: JobCMDoctor
@@ -407,6 +426,7 @@
   - FoodPackagedRMC
   - FoodHealthyRMC
   - RMCLoadoutGroupPins
+  - SmokablesRMC
 
 - type: roleLoadout
   id: JobCMNurse
@@ -427,6 +447,7 @@
   - FoodPackagedRMC
   - FoodHealthyRMC
   - RMCLoadoutGroupPins
+  - SmokablesRMC
 
 - type: roleLoadout
   id: JobCMResearcher
@@ -447,6 +468,7 @@
   - FoodPackagedRMC
   - FoodHealthyRMC
   - RMCLoadoutGroupPins
+  - SmokablesRMC
 
 # Military Police
 - type: roleLoadout
@@ -468,6 +490,7 @@
   - FoodPackagedRMC
   - FoodHealthyRMC
   - RMCLoadoutGroupPins
+  - SmokablesRMC
 
 - type: roleLoadout
   id: JobCMMilitaryPolice
@@ -488,6 +511,7 @@
   - FoodPackagedRMC
   - FoodHealthyRMC
   - RMCLoadoutGroupPins
+  - SmokablesRMC
 
 - type: roleLoadout
   id: JobCMMilitaryWarden
@@ -508,6 +532,7 @@
   - FoodPackagedRMC
   - FoodHealthyRMC
   - RMCLoadoutGroupPins
+  - SmokablesRMC
 
 # Other
 - type: roleLoadout
@@ -529,6 +554,7 @@
   - FoodPackagedRMC
   - FoodHealthyRMC
   - RMCLoadoutGroupPins
+  - SmokablesRMC
 
 - type: roleLoadout
   id: JobCMLiaison
@@ -549,6 +575,7 @@
   - FoodPackagedRMC
   - FoodHealthyRMC
   - RMCLoadoutGroupPins
+  - SmokablesRMC
 
 - type: roleLoadout
   id: JobCMMessTech
@@ -569,6 +596,7 @@
   - FoodPackagedRMC
   - FoodHealthyRMC
   - RMCLoadoutGroupPins
+  - SmokablesRMC
 
 - type: roleLoadout
   id: JobCMSeniorEnlistedAdvisor
@@ -589,6 +617,7 @@
   - FoodPackagedRMC
   - FoodHealthyRMC
   - RMCLoadoutGroupPins
+  - SmokablesRMC
 
 - type: roleLoadout
   id: JobRMCJobSynthetic
@@ -605,6 +634,7 @@
   - RecreationalRMC
   - PlushiesRMC
   - RMCLoadoutGroupPins
+  - SmokablesRMC
 
 # Requsitions
 - type: roleLoadout
@@ -626,6 +656,7 @@
   - FoodPackagedRMC
   - FoodHealthyRMC
   - RMCLoadoutGroupPins
+  - SmokablesRMC
 
 - type: roleLoadout
   id: JobCMQuartermaster
@@ -646,3 +677,4 @@
   - FoodPackagedRMC
   - FoodHealthyRMC
   - RMCLoadoutGroupPins
+  - SmokablesRMC


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
made a new loadout category for smokables.

## Why / Balance
parity, plus more loadout variety is always nice

## Technical details
entirely yaml.

## Media
![image](https://github.com/user-attachments/assets/30839a7d-ba52-4e23-b700-172cfc00c328)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added the smokables loadout category.

