### PR TITLE
Fix New Varadero survivor faction assigment

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/New_Varadero/beachbum.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/New_Varadero/beachbum.yml
@@ -25,7 +25,7 @@
     - type: MotionDetectorTracked
     - type: NpcFactionMember
       factions:
-      - Survivor
+      - Civilian
     - type: IntelRescueSurvivorObjective
     - type: RMCAllowSuitStorage
     - type: RMCConditionalMarkings

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/New_Varadero/cargo_technician_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/New_Varadero/cargo_technician_survivor.yml
@@ -22,7 +22,7 @@
     - type: MotionDetectorTracked
     - type: NpcFactionMember
       factions:
-      - Survivor
+      - Civilian
     - type: IntelRescueSurvivorObjective
     - type: RMCAllowSuitStorage
     - type: EquipSurvivorPreset

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/New_Varadero/commander_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/New_Varadero/commander_survivor.yml
@@ -42,8 +42,8 @@
     - type: RMCAllowSuitStorage
     - type: NpcFactionMember
       factions:
-      - Survivor
       - UNMC
+      - Civilian
     - type: TacticalMapIcon
       icon:
         sprite: _RMC14/Interface/map_blips.rsi

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/New_Varadero/icb_liaison_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/New_Varadero/icb_liaison_survivor.yml
@@ -24,7 +24,7 @@
     - type: MotionDetectorTracked
     - type: NpcFactionMember
       factions:
-      - Survivor
+      - Civilian
     - type: IntelRescueSurvivorObjective
     - type: RMCAllowSuitStorage
     - type: JobPrefix

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/New_Varadero/medical_technician_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/New_Varadero/medical_technician_survivor.yml
@@ -22,7 +22,7 @@
     - type: MotionDetectorTracked
     - type: NpcFactionMember
       factions:
-      - Survivor
+      - Civilian
     - type: IntelRescueSurvivorObjective
     - type: RMCAllowSuitStorage
     - type: EquipSurvivorPreset

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/New_Varadero/technician_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/New_Varadero/technician_survivor.yml
@@ -23,7 +23,7 @@
     - type: MotionDetectorTracked
     - type: NpcFactionMember
       factions:
-      - Survivor
+      - Civilian
     - type: IntelRescueSurvivorObjective
     - type: RMCAllowSuitStorage
     - type: EquipSurvivorPreset

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/New_Varadero/un_peacekeeper_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/New_Varadero/un_peacekeeper_survivor.yml
@@ -25,7 +25,7 @@
     - type: MotionDetectorTracked
     - type: NpcFactionMember
       factions:
-      - Survivor
+      - Civilian
     - type: IntelRescueSurvivorObjective
     - type: RMCAllowSuitStorage
     - type: EquipSurvivorPreset


### PR DESCRIPTION
They're currently assigned to the survivor faction which was renamed to Civilian. This PR fixes it