### PR TITLE
Make CLF and the UNMC factions hostile to eachother

### DIFF
--- a/Content.Shared/_RMC14/Marines/MarineComponent.cs
+++ b/Content.Shared/_RMC14/Marines/MarineComponent.cs
@@ -19,6 +19,7 @@ public sealed partial class MarineComponent : Component
         { "SPP", new SpriteSpecifier.Rsi(new ("/Textures/_RMC14/Interface/faction_icons.rsi"), "spp") },
         { "WeYa", new SpriteSpecifier.Rsi(new ("/Textures/_RMC14/Interface/faction_icons.rsi"), "weya") },
         { "RoyalMarines", new SpriteSpecifier.Rsi(new("/Textures/_RMC14/Interface/faction_icons.rsi"), "tse") },
+        { "TSE", new SpriteSpecifier.Rsi(new("/Textures/_RMC14/Interface/faction_icons.rsi"), "tse") },
         { "CLF", new SpriteSpecifier.Rsi(new("/Textures/_RMC14/Interface/faction_icons.rsi"), "clf") },
     };
 }

--- a/Resources/Prototypes/_RMC14/Factions/rmc_factions.yml
+++ b/Resources/Prototypes/_RMC14/Factions/rmc_factions.yml
@@ -2,6 +2,7 @@
   id: UNMC
   hostile:
   - RMCXeno
+  - CLF
 
 - type: npcFaction
   id: RMCXeno
@@ -33,6 +34,7 @@
   id: CLF
   hostile:
   - RMCXeno
+  - UNMC
 
 - type: npcFaction
   id: WeYa


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
These two factions should almost always be hostile to eachother
This makes UNMC/CLF NPCs (turrets) hostile to eachother

Also adds the TSE faction icon to the marine hud icon list

:cl:
- fix: Fixed UNMC turrets not targeting CLF
