### PR TITLE
Fix roles that have leadership skill not having move/focus/hold orders

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/CLF/clf_cell_commander.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/CLF/clf_cell_commander.yml
@@ -28,6 +28,7 @@
         RMCSkillJtac: 4
         RMCSkillSmartGun: 1
         RMCSkillExecution: 1
+    - type: MarineOrders
     - type: NpcFactionMember
       factions:
       - CLF

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/CLF/clf_cell_commander.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/CLF/clf_cell_commander.yml
@@ -28,7 +28,6 @@
         RMCSkillJtac: 4
         RMCSkillSmartGun: 1
         RMCSkillExecution: 1
-    - type: MarineOrders
     - type: NpcFactionMember
       factions:
       - CLF

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/CLF/clf_specialist.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/CLF/clf_specialist.yml
@@ -26,6 +26,7 @@
     - type: ScoutWhitelist
     - type: SniperWhitelist
     - type: PyroWhitelist
+    - type: MarineOrders
     - type: NpcFactionMember
       factions:
       - CLF

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/WeYa/goon_leader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/WeYa/goon_leader.yml
@@ -20,6 +20,7 @@
     - type: NpcFactionMember
       factions:
       - WeYa
+    - type: MarineOrders
     - type: Skills
       skills:
         RMCSkillCqc: 2

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/WeYa/site_director.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/WeYa/site_director.yml
@@ -34,6 +34,7 @@
         RMCSkillEndurance: 3
         RMCSkillJtac: 4
         RMCSkillExecution: 1
+    - type: MarineOrders
     - type: JobPrefix
       prefix: rmc-job-prefix-pmc-director
   hidden: true

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/priest_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/priest_survivor.yml
@@ -19,6 +19,7 @@
         RMCSkillLeadership: 1
     - type: EquipSurvivorPreset
       preset: RMCGearSurvivorPresetPriest
+    - type: MarineOrders
     - type: RMCSurvivor
     - type: RMCRibbon
     - type: MotionDetectorTracked


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Roles that have leadership skill are supposed to have move orders aswell, this is in CM13

:cl:
- fix: Fixed some roles that have leadership skill not having marine orders.
