### PR TITLE
Fix xenos that hibernate due to being deleted by hijack not being able to instantly become a burrowed

### DIFF
--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
@@ -59,6 +59,7 @@ using Content.Shared._RMC14.Xenonids.Construction.Nest;
 using Content.Shared._RMC14.Xenonids.Construction.Tunnel;
 using Content.Shared._RMC14.Xenonids.Evolution;
 using Content.Shared._RMC14.Xenonids.Hive;
+using Content.Shared._RMC14.Xenonids.JoinXeno;
 using Content.Shared._RMC14.Xenonids.Parasite;
 using Content.Shared.Actions;
 using Content.Shared.CCVar;
@@ -975,7 +976,6 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
                 if (TryComp(xeno, out ActorComponent? actor))
                 {
                     var session = actor.PlayerSession;
-
                     Entity<MindComponent> mind;
 
                     if (_mind.TryGetMind(session, out var mindId, out var mindComp))
@@ -984,11 +984,13 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
                         mind = _mind.CreateMind(session.UserId);
 
                     var ghost = _ghost.SpawnGhost((mind.Owner, mind.Comp), xeno);
+                    if (ghost != null)
+                        EnsureComp<JoinXenoCooldownIgnoreComponent>(ghost.Value);
 
                     var origin = _transform.GetMoverCoordinates(xeno);
-
                     _popup.PopupCoordinates(Loc.GetString("rmc-xeno-hibernation"), origin, Filter.SinglePlayer(session), true, PopupType.MediumXeno);
                 }
+
                 QueueDel(xeno);
             }
             else

--- a/Content.Shared/_RMC14/Xenonids/JoinXeno/JoinXenoCooldownIgnoreComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/JoinXeno/JoinXenoCooldownIgnoreComponent.cs
@@ -1,0 +1,7 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.JoinXeno;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(JoinXenoSystem))]
+public sealed partial class JoinXenoCooldownIgnoreComponent : Component;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Parity, xenos should be able to instantly rejoin

## Technical details
``JoinXenoCooldownIgnoreComponent`` makes it so they can ignore the join xeno action death cooldown
This component is added to the ghost when the xeno hibernates

:cl:
- fix: Fixed xenos that hibernate when the queen launches the hijack shuttle not being able to instantly become a burrowed larva