### PR TITLE
Tests fix for pill0 issue

### DIFF
--- a/Content.Client/Chemistry/EntitySystems/PillSystem.cs
+++ b/Content.Client/Chemistry/EntitySystems/PillSystem.cs
@@ -19,6 +19,6 @@ public sealed class PillSystem : EntitySystem
         if (!sprite.TryGetLayer(0, out var layer))
             return;
 
-        layer.SetState($"pill{component.PillType}");
+        layer.SetState($"pill{component.PillType + 1}");
     }
 }

--- a/Content.Shared/_RMC14/Chemistry/ChemMaster/SharedRMCChemMasterSystem.cs
+++ b/Content.Shared/_RMC14/Chemistry/ChemMaster/SharedRMCChemMasterSystem.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Content.Shared._RMC14.Chemistry.SmartFridge;
 using Content.Shared._RMC14.IconLabel;
@@ -386,7 +386,7 @@ public abstract class SharedRMCChemMasterSystem : EntitySystem
                 }
 
                 var pillComp = EnsureComp<PillComponent>(pill);
-                pillComp.PillType = ent.Comp.SelectedType;
+                pillComp.PillType = ent.Comp.SelectedType - 1;
                 Dirty(pill, pillComp);
 
                 if (label != null)


### PR DESCRIPTION
## About the PR
The last pills fix i made broke the upstream chemmaster, which was causing pill0 errors in the intergration tests. So moved the type selection change into the RMC chemmaster itself, and gave it a -1 to select the right pill type, while reverting the original change.

## Why / Balance
Fix for Tests

## Technical details
moved the old fix to SharedRMCChemMasterSystem.cs, and reverted the change to PillSystem.cs

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Pill0 intergration  test bugfix
