### PR TITLE
Floor resin, resin constructs and resin structures now take burn damage over time.

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Base/base_structure.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Base/base_structure.yml
@@ -59,7 +59,7 @@
   - type: DeletedByWeedKiller
   - type: Flammable
     fireSpread: false
-    MaximumFireStacks: 1
+    maximumFireStacks: 0.5
     damage:
       types:
         Heat: 4.8

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Base/base_structure.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Base/base_structure.yml
@@ -57,6 +57,12 @@
   - type: DamageMultiplierFlags
     flags: Breaching
   - type: DeletedByWeedKiller
+  - type: Flammable
+    fireSpread: false
+    MaximumFireStacks: 1
+    damage:
+      types:
+        Heat: 4.8
 
 - type: entity
   id: CMCorrodible

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/Hive/xeno_base_hive.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/Hive/xeno_base_hive.yml
@@ -33,7 +33,7 @@
   - type: DeletedByWeedKiller
   - type: Flammable
     fireSpread: false
-    MaximumFireStacks: 1
+    maximumFireStacks: 0.5
     damage:
       types:
         Heat: 3.8

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/Hive/xeno_base_hive.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/Hive/xeno_base_hive.yml
@@ -31,6 +31,12 @@
   - type: XenoAnnounceStructureDestruction
   - type: RequireProjectileTarget
   - type: DeletedByWeedKiller
+  - type: Flammable
+    fireSpread: false
+    MaximumFireStacks: 1
+    damage:
+      types:
+        Heat: 3.8
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_floor_resin.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_floor_resin.yml
@@ -57,6 +57,12 @@
         Slash: 45
   - type: StickyResinSurgeBlocker
   - type: DeletedByWeedKiller
+  - type: Flammable
+    fireSpread: false
+    MaximumFireStacks: 1
+    damage:
+      types:
+        Heat: 2
 
 - type: entity
   parent: XenoBaseFloorResin

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_floor_resin.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_floor_resin.yml
@@ -59,7 +59,7 @@
   - type: DeletedByWeedKiller
   - type: Flammable
     fireSpread: false
-    MaximumFireStacks: 1
+    maximumFireStacks: 0.5
     damage:
       types:
         Heat: 2

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_weeds.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_weeds.yml
@@ -107,7 +107,7 @@
     - XenoWeedTile
   - type: Flammable
     fireSpread: false
-    MaximumFireStacks: 1
+    maximumFireStacks: 0.5
     damage:
       types:
         Heat: 1

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_weeds.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_weeds.yml
@@ -105,6 +105,12 @@
   - type: Tag
     tags:
     - XenoWeedTile
+  - type: Flammable
+    fireSpread: false
+    MaximumFireStacks: 1
+    damage:
+      types:
+        Heat: 1
 #  - type: Physics
 #    bodyType: Static
 #  - type: FootstepModifier


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Floor resin, xeno strcuctures and xeno constructs now take fire damage over time.
This means that for example resin walls, sticky resin and egg morphers will burn down over time from fires, 

Their max fire stack is  set to 0.5 so they stop burning if they are not repeatedly reignited by an ignition source like a tile fire.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Dygon
- fix: Fixed floor resin, resin structures, and resin constructs not taking fire damage over time.
