### PR TITLE
XM51 Stock gives Burst

### DIFF
--- a/Content.Client/_RMC14/Weapons/Ranged/PumpActionSystem.cs
+++ b/Content.Client/_RMC14/Weapons/Ranged/PumpActionSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared._RMC14.Weapons.Ranged;
 using Content.Shared.Examine;
 using Content.Shared.Popups;
 using Content.Shared.Weapons.Ranged.Systems;
+using Content.Shared.Weapons.Ranged.Components;
 using Robust.Client.Input;
 
 namespace Content.Client._RMC14.Weapons.Ranged;
@@ -27,7 +28,7 @@ public sealed class PumpActionSystem : SharedPumpActionSystem
 
         base.OnAttemptShoot(ent, ref args);
 
-        if (!ent.Comp.Pumped)
+        if (!ent.Comp.Pumped && TryComp<GunComponent>(ent.Owner, out var gun) && !gun.BurstActivated)
         {
             var message = _input.TryGetKeyBinding(CMKeyFunctions.CMUniqueAction, out var bind)
                 ? Loc.GetString(ent.Comp.PopupKey, ("key", bind.GetKeyString()))

--- a/Content.Shared/_RMC14/Weapons/Ranged/SharedPumpActionSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/SharedPumpActionSystem.cs
@@ -74,7 +74,6 @@ public abstract class SharedPumpActionSystem : EntitySystem
     {
         if (TryComp<GunComponent>(ent.Owner, out var gun) && gun.BurstActivated)
         {
-            _popup.PopupClient($"BurstActivated: {gun.BurstActivated}", user, user);
             return true;
         }
 

--- a/Content.Shared/_RMC14/Weapons/Ranged/SharedPumpActionSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/SharedPumpActionSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared.Examine;
 using Content.Shared.Popups;
 using Content.Shared.Weapons.Ranged.Events;
 using Content.Shared.Weapons.Ranged.Systems;
+using Content.Shared.Weapons.Ranged.Components;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 
@@ -32,6 +33,12 @@ public abstract class SharedPumpActionSystem : EntitySystem
     {
         if (args.Cancelled)
             return;
+
+        if (TryComp<GunComponent>(ent.Owner, out var gun) &&
+            gun.BurstActivated)
+        {
+            return;
+        }
 
         if (!ent.Comp.Pumped)
             args.Cancelled = true;
@@ -65,6 +72,12 @@ public abstract class SharedPumpActionSystem : EntitySystem
 
     public bool Pump(Entity<PumpActionComponent> ent, EntityUid user)
     {
+        if (TryComp<GunComponent>(ent.Owner, out var gun) && gun.BurstActivated)
+        {
+            _popup.PopupClient($"BurstActivated: {gun.BurstActivated}", user, user);
+            return true;
+        }
+
         var ammo = new GetAmmoCountEvent();
         RaiseLocalEvent(ent.Owner, ref ammo);
 

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/stock_attachments.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/stock_attachments.yml
@@ -171,7 +171,7 @@
 
 - type: entity
   parent: RMCStockAttachmentBase
-  id: RMCAttachmentXM51Stock # TODO RMC14 burst
+  id: RMCAttachmentXM51Stock
   name: XM51 stock
   description: A specialized stock designed for XM51 breaching shotguns. Helps the user absorb the recoil of the weapon while also reducing scatter. Integrated mechanisms inside the stock allow use of a devastating two-shot burst. This comes at a cost of the gun becoming too unwieldy to holster, worse handling and mobility.
   components:
@@ -199,6 +199,12 @@
         types:
           Blunt: 10
   - type: AttachableWeaponRangedMods
+    fireModeMods:
+    - conditions:
+        whitelist:
+          tags:
+          - RMCXM51StockBurst
+      extraFireModes: Burst
     modifiers:
     - conditions:
         wieldedOnly: true
@@ -925,6 +931,9 @@
 
 - type: Tag
   id: RMCAttachmentM42A2WoodenStock
+
+- type: Tag
+  id: RMCXM51StockBurst
 
 - type: Tag
   id: RMCAttachmentXM51Stock

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/xm51_shotgun.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/xm51_shotgun.yml
@@ -18,7 +18,7 @@
       gun_magazine: !type:ContainerSlot
       gun_chamber: !type:ContainerSlot
   - type: Gun
-    shotsPerBurst: 1
+    shotsPerBurst: 2
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto
@@ -85,6 +85,7 @@
     tags:
     - RMCWeaponShotgun
     - RMCWeaponShotgunXM51
+    - RMCXM51StockBurst
   - type: GunDamageMultipliers
     multipliers:
       Turf: 30

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/xm51_shotgun.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/xm51_shotgun.yml
@@ -18,6 +18,7 @@
       gun_magazine: !type:ContainerSlot
       gun_chamber: !type:ContainerSlot
   - type: Gun
+    burstCooldown: 0.625
     shotsPerBurst: 2
     selectedMode: SemiAuto
     availableModes:
@@ -34,6 +35,7 @@
     scatterWielded: 10
     scatterUnwielded: 30
     baseFireRate: 0.625
+    burstFireRateMultiplier: 15
   - type: RMCExtraProjectilesDamageMods
     damageMultiplier:  0.18
   - type: RMCWeaponAccuracy


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The XM51 stock now allows for a 2 shot burst. Fixes #6861 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity

## Technical details
<!-- Summary of code changes for easier review. -->
`OnAttemptShoot` in `SharedPumpActionSystem` returns if `BurstActivated` is true in the gun component of the parent entity, allowing for multiple shots from a pump action shotgun in a burst without having to pump for each shot in said burst.
`Pump` in `SharedPumpActionSystem` returns true if `BurstActivated` is true too, same logic as `OnAttemptShoot` - This is done to prevent pumping mid burst.
Added the same logic as the other two mentioned functions to `OnAttemptShoot` in `PumpActionSystem` so the client wont get a popup telling them they need to pump to shoot when the gun is doing a burst shot.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://github.com/user-attachments/assets/f6c39a11-c7f7-4e92-a498-e673817a19be

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: noctyrnal
- add: The XM51 can now do a two shot burst when the stock is attached.