### PR TITLE
Fix some xeno abilities having too much range

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Headbutt/XenoHeadbuttComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Headbutt/XenoHeadbuttComponent.cs
@@ -18,7 +18,7 @@ public sealed partial class XenoHeadbuttComponent : Component
     public DamageSpecifier Damage = new();
 
     [DataField, AutoNetworkedField]
-    public float Range = 3;
+    public float Range = 2;
 
     [DataField, AutoNetworkedField]
     public float ThrowForce = 1;

--- a/Content.Shared/_RMC14/Xenonids/SpitToggle/XenoToggleSpitComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/SpitToggle/XenoToggleSpitComponent.cs
@@ -20,5 +20,5 @@ public sealed partial class XenoToggleSpitComponent : Component
     public EntProtoId NeuroProto = "XenoQueenNeuroSpitProjectile";
 
     [DataField, AutoNetworkedField]
-    public EntProtoId AcidProto = "XenoChargedSpitProjectile";
+    public EntProtoId AcidProto = "XenoChargedSpitProjectileQueen";
 }

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/burrower.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/burrower.yml
@@ -61,7 +61,7 @@
   - type: XenoStomp
     selfEffect: CMEffectSelfStomp
     shortRange: 0
-    range: 4
+    range: 3
     plasmaCost: 100
     paralyzeTime: 2
     slowBigInsteadOfStun: true

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_projectiles.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_projectiles.yml
@@ -89,7 +89,14 @@
       components:
       - Marine
   - type: ProjectileMaxRange
-    max: 6
+    max: 4
+
+  - type: entity
+    parent: XenoChargedSpitProjectile
+    id: XenoChargedSpitProjectileQueen
+    components:
+    - type: ProjectileMaxRange
+      max: 5
 
 - type: entity
   id: XenoSlowingSpitProjectile
@@ -108,7 +115,7 @@
     deleteOnFriendlyXeno: true
   - type: DrainOnHit
   - type: ProjectileMaxRange
-    max: 6
+    max: 5
 
 - type: entity
   id: XenoQueenNeuroSpitProjectile
@@ -131,7 +138,6 @@
     max: 4
   - type: RMCProjectileAccuracy
     accuracy: 125
-
 
 - type: entity
   id: XenoScatteredSpitProjectile
@@ -325,7 +331,7 @@
   - type: RMCProjectileAccuracy
     accuracy: 160
   - type: ProjectileMaxRange
-    max: 7
+    max: 6
 
 - type: entity
   parent: XenoSpitProjectile


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I adjusted the range of some xeno abilities.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity.
Abilities that have their range reduced, the number is the range in tiles:

- Defender's Headbutt: 3 > 2
- Burrower's Tremor: 4 > 3
- Spitter's Charged Spit: 6 > 4
- Queen's Acid(not neuro) Spit: 6 > 5
- Sentinel's Slowing Spit: 6 > 5
- Praetorian's Acid Spit: 7 > 6


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Dygon
- fix: Reduced the range of the Defender's Headbutt, Burrower's Tremor, Queen's Acid Spit, Sentinel's Slowing Spit and Praetorian's Acid spit by 1 tile. Reduced the range of the Spitter's Charged Spit by 2 tiles.

