### PR TITLE
Fix most xeno spit cooldowns being 0.5 secs too short

### DIFF
--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
@@ -341,10 +341,17 @@
       sprite: _RMC14/Actions/xeno_actions.rsi
       state: xeno_spit
     event: !type:XenoSpitActionEvent
-    useDelay: 2
+    useDelay: 2.5
     range: 15
     checkCanAccess: false
   - type: ActionBlockIfResting
+
+- type: entity
+  id: ActionXenoSpitPraetorian
+  parent: ActionXenoSpit
+  components:
+  - type: EntityWorldTargetAction
+    useDelay: 2
 
 - type: entity
   parent: CMGuidebookActionXenoBase

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/praetorian.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/praetorian.yml
@@ -33,7 +33,7 @@
     - ActionXenoWatch
     - ActionXenoTailStab
     - ActionXenoAcidNormal
-    - ActionXenoSpit
+    - ActionXenoSpitPraetorian
     - ActionXenoDash
     - ActionXenoAcidBall
     - ActionXenoSprayAcidPraetorian


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity. Was just fixed.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed all xeno spit abilities (except praetorian's)'s cooldown being 0.5 seconds too short.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!

-->
