### PR TITLE
Give IMP racks the ability to store empty and full sandbags, give IO headsets access to the req channel and fit the underbarrel extinguisher on more guns.

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Back/backpacks.yml
@@ -266,6 +266,8 @@
     whitelist:
       tags:
       - RMCAmmoBox
+      - EmptySandbag
+      - FullSandbag
   - type: CMStorageVisualizer
     storageClosed: null
     storageOpen: null

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Back/backpacks.yml
@@ -266,6 +266,7 @@
     whitelist:
       tags:
       - RMCAmmoBox
+      components:
       - EmptySandbag
       - FullSandbag
   - type: CMStorageVisualizer

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Devices/EncryptionKeys/ship.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Devices/EncryptionKeys/ship.yml
@@ -439,6 +439,7 @@
     - MarineCommand
     - MarineEngineer
     - MarineJTAC
+    - MarineRequisition
     - MarineMedical
     - MarineAlpha
     - MarineBravo

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m54c_heavy_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m54c_heavy_rifle.yml
@@ -88,6 +88,7 @@
           - RMCAttachmentAngledGrip
           - RMCAttachmentBipod
           - RMCAttachmentBurstFireAssembly
+          - RMCAttachmentExtinguisher
           - RMCAttachmentFlashlightGrip
           - RMCAttachmentVerticalGrip
   - type: AttachableHolderVisuals

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/m63_smg.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/m63_smg.yml
@@ -86,6 +86,7 @@
         whitelist:
           tags:
           - RMCAttachmentAngledGrip
+          - RMCAttachmentExtinguisher
           - RMCAttachmentFlashlightGrip
           - RMCAttachmentGyroscopicStabilizer
           - RMCAttachmentLaserSight

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/mp5_smg.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/mp5_smg.yml
@@ -85,6 +85,7 @@
           - RMCAttachmentLaserSight
           - RMCAttachmentBipod
           - RMCAttachmentM203GrenadeLauncher
+          - RMCAttachmentExtinguisher
         random:
         - RMCAttachmentM203GrenadeLauncher
   - type: AttachableHolderVisuals

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/mou53_shotgun.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/mou53_shotgun.yml
@@ -76,6 +76,7 @@
           - RMCAttachmentAngledGrip
           - RMCAttachmentVerticalGrip
           - RMCAttachmentLaserSight
+          - RMCAttachmentExtinguisher
   - type: AttachableHolderVisuals
     offsets:
       rmc-aslot-barrel: 0.8, 0.06

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/xm51_shotgun.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/xm51_shotgun.yml
@@ -75,6 +75,7 @@
           - RMCAttachmentAngledGrip
           - RMCAttachmentGyroscopicStabilizer
           - RMCAttachmentFlashlightGrip
+          - RMCAttachmentExtinguisher
   - type: AttachableHolderVisuals
     offsets:
       rmc-aslot-barrel: 0.75, 0.00


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
IMP racks can now store empty and full sandbags.
Intelligence officer headsets now have access to the requisitions channel.
Underbarrel extinguishers now fit on the M63, Xm51, M54CE2, MP5 and the MOU53

Since it's a small YAML change I put the unrelated changes in 1 PR.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Dygon
- tweak: IMP ammo racks can now store empty and full sandbags.
- tweak: IO headsets now have access to the requisitions channel.
- tweak: Underbarrel extinguishers now also fit on the following weapons: M54CE2, M63, MOU53, MP5, XM51.

