### PR TITLE
Allow HAR to be in full auto without a bipod

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m54c_heavy_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m54c_heavy_rifle.yml
@@ -16,19 +16,20 @@
   - type: Tag
     tags:
     - WeaponRifleM54CE2
-    - RMCGunBipodFullAuto
   - type: Gun
     shotsPerBurst: 5
-    selectedMode: SemiAuto
+    selectedMode: FullAuto
     availableModes:
     - SemiAuto
     - Burst
+    - FullAuto
     soundGunshot:
       collection: CMM54CShoot
   - type: RMCSelectiveFire
     baseFireModes:
     - SemiAuto
     - Burst
+    - FullAuto
     recoilUnwielded: 5
     scatterWielded: 10
     scatterUnwielded: 20
@@ -82,7 +83,6 @@
           - RMCAttachmentS5RedDotSight
           - RMCAttachmentS6ReflexSight
       rmc-aslot-underbarrel:
-        startingAttachable: RMCAttachmentBipod
         whitelist:
           tags:
           - RMCAttachmentAngledGrip


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Parity
https://github.com/cmss13-devs/cmss13/pull/9807

makes no bipod HAR actually usable because you dont need to break your finger
HAR no longer spawns with a bipod

:cl:
- fix: Fixed the M54CE2 HAR not having full auto without a bipod
- fix: Fixed the M54CE2 HAR spawning with a bipod attached