### PR TITLE
Unloading unchambered warheads and fuel from the orbital cannon.

### DIFF
--- a/Content.Shared/_RMC14/OrbitalCannon/OrbitalCannonSystem.cs
+++ b/Content.Shared/_RMC14/OrbitalCannon/OrbitalCannonSystem.cs
@@ -103,15 +103,17 @@ public sealed class OrbitalCannonSystem : EntitySystem
         if (args.Handled)
             return;
 
+        if (ent.Comp.Status != OrbitalCannonStatus.Unloaded)
+            return;
+
         if (_container.TryGetContainer(ent, ent.Comp.FuelContainer, out var fuel) &&
             fuel.ContainedEntities.Count > 0)
         {
             args.ToGrab = fuel.ContainedEntities[^1];
             args.Handled = true;
         }
-
-        if (_container.TryGetContainer(ent, ent.Comp.WarheadContainer, out var warhead) &&
-            warhead.ContainedEntities.Count > 0)
+        else if (_container.TryGetContainer(ent, ent.Comp.WarheadContainer, out var warhead) &&
+                 warhead.ContainedEntities.Count > 0)
         {
             args.ToGrab = warhead.ContainedEntities[^1];
             args.Handled = true;

--- a/Content.Shared/_RMC14/PowerLoader/PowerLoaderGrabEvent.cs
+++ b/Content.Shared/_RMC14/PowerLoader/PowerLoaderGrabEvent.cs
@@ -4,7 +4,7 @@
 public record struct PowerLoaderGrabEvent(
     EntityUid PowerLoader,
     EntityUid Target,
-    List<EntityUid> Buckled,
-    EntityUid ToGrab,
+    HashSet<EntityUid> Buckled,
+    EntityUid? ToGrab = null,
     bool Handled = false
 );

--- a/Content.Shared/_RMC14/PowerLoader/PowerLoaderSystem.cs
+++ b/Content.Shared/_RMC14/PowerLoader/PowerLoaderSystem.cs
@@ -228,6 +228,18 @@ public sealed class PowerLoaderSystem : EntitySystem
 
     private void OnUserGrab(Entity<PowerLoaderComponent> ent, ref UserActivateInWorldEvent args)
     {
+        if (!TryComp(ent, out StrapComponent? strap))
+            return;
+
+        var grab = new PowerLoaderGrabEvent(ent, args.Target, strap.BuckledEntities);
+        RaiseLocalEvent(args.Target, ref grab);
+
+        if (grab.ToGrab != null)
+        {
+            PickUp(ent, grab.ToGrab.Value);
+            return;
+        }
+
         if (!CanPickupPopup(ent, args.Target, out var delay))
             return;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
You can now remove any loaded warhead or fuel from the orbital cannon, as long as the tray is open.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
#Resolves #6880

## Technical details
<!-- Summary of code changes for easier review. -->
The code for this already existed, the event was just never raised.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Dygon
- fix: You can unload unchambered warheads and fuel from the orbital cannon.

