### PR TITLE
Fix apprehend being removed on first hit and turning tackles into attacks

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Crippling/XenoActiveCripplingStrikeComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Crippling/XenoActiveCripplingStrikeComponent.cs
@@ -30,4 +30,10 @@ public sealed partial class XenoActiveCripplingStrikeComponent : Component
 
     [DataField, AutoNetworkedField]
     public float? Speed;
+
+    [DataField, AutoNetworkedField]
+    public bool RemoveOnHit;
+
+    [DataField, AutoNetworkedField]
+    public bool PreventTackle;
 }

--- a/Content.Shared/_RMC14/Xenonids/Crippling/XenoCripplingStrikeComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Crippling/XenoCripplingStrikeComponent.cs
@@ -34,4 +34,10 @@ public sealed partial class XenoCripplingStrikeComponent : Component
 
     [DataField, AutoNetworkedField]
     public float? Speed;
+
+    [DataField, AutoNetworkedField]
+    public bool RemoveOnHit;
+
+    [DataField, AutoNetworkedField]
+    public bool PreventTackle;
 }

--- a/Content.Shared/_RMC14/Xenonids/Crippling/XenoCripplingStrikeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Crippling/XenoCripplingStrikeSystem.cs
@@ -59,6 +59,8 @@ public sealed class XenoCripplingStrikeSystem : EntitySystem
         active.DeactivateText = xeno.Comp.DeactivateText;
         active.ExpireText = xeno.Comp.ExpireText;
         active.Speed = xeno.Comp.Speed;
+        active.RemoveOnHit = xeno.Comp.RemoveOnHit;
+        active.PreventTackle = xeno.Comp.PreventTackle;
 
         Dirty(xeno, active);
 
@@ -102,7 +104,8 @@ public sealed class XenoCripplingStrikeSystem : EntitySystem
             break;
         }
 
-        RemCompDeferred<XenoActiveCripplingStrikeComponent>(xeno);
+        if (xeno.Comp.RemoveOnHit)
+            RemCompDeferred<XenoActiveCripplingStrikeComponent>(xeno);
     }
 
     private void OnActiveCripplingRefreshSpeed(Entity<XenoActiveCripplingStrikeComponent> xeno, ref RefreshMovementSpeedModifiersEvent args)
@@ -127,6 +130,9 @@ public sealed class XenoCripplingStrikeSystem : EntitySystem
 
     private void OnActiveCripplingStrikeMeleeAttempt(Entity<XenoActiveCripplingStrikeComponent> ent, ref MeleeAttackAttemptEvent args)
     {
+        if (!ent.Comp.PreventTackle)
+            return;
+
         var netAttacker = GetNetEntity(ent);
         switch (args.Attack)
         {

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lurker.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lurker.yml
@@ -114,6 +114,8 @@
     unrootOnMelee: true
   - type: XenoTurnInvisible
   - type: XenoCripplingStrike
+    removeOnHit: true
+    preventTackle: true
   - type: XenoTailStab
     tailDamage:
       groups:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Apprehend doesn't get removed on first hit and doesn't turn tackles into attacks.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fix for a bug that is not live yet

## Technical details
<!-- Summary of code changes for easier review. -->
Apprehend is also a crippling strike

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
No CL
