### PR TITLE
Parity Vendors: Mags and Googles

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/engineer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/engineer.yml
@@ -22,10 +22,10 @@
     - name: Handheld Defense
       takeOne: CMHandheldDefense
       entries:
+      - id: RMCTesla
     #    CMJIMAPlantedFlag
     #    CMUA42FSentryFlamer
       - id: RMCSentry
-      - id: RMCTesla
     - name: Handheld Defense Upgrade
       choices: { CMHandheldDefenseUpgrade: 1 }
       entries:
@@ -35,8 +35,8 @@
       entries:
     #- id: CMAirlockCircuitBoard
     #  points: 2
-    #- id: CMAPCCircuitBoard
-    #  points: 2
+      - id: CMAPCCircuitBoard
+        points: 2
       - id: CMEntrenchingTool
         points: 2
       - id: RMCPowerCellHigh
@@ -98,8 +98,18 @@
         points: 6
     - name: Sidearm Ammunition
       entries:
+      - id: RMCMagazinePistolM13Ext
+        points: 10
+      - id: RMCMagazinePistolM13Drum
+        points: 15
+      # - id: RMCSpeedLoader44Heavy
+      #   points: 6
       - id: RMCSpeedLoader44Marksman
         points: 6
+      # - id: RMCMagazinePistolM1984HP
+      #   points: 3
+      - id: RMCMagazinePistolM1984AP
+        points: 3
       - id: CMMagazinePistolMK80
         points: 3
       - id: RMCMagazinePistolSU6
@@ -152,6 +162,8 @@
         points: 8
       - id: RMCWhistle
         points: 3
+      - id: RMCSynthResetKey
+        points: 10
     - name: Binoculars
       entries:
       - id: RMCBinoculars
@@ -319,12 +331,14 @@
     sections:
     - name: Equipment
       entries:
+      - id: CMHandsInsulated
+        amount: 2
       - id: CMBeltUtility
         name: utility tool belt
         amount: 4
       - id: RMCCableCoil
         amount: 4
-      - id: ClothingEyesGlassesMeson # TODO RMC14 welding goggles
+      - id: RMCWeldingGoggles
         amount: 2
       - id: RMCEngineerKit
         amount: 2
@@ -344,3 +358,11 @@
         amount: 4
       - id: CMWelderSmall
         amount: 2
+      - id: CMLightReplacer
+        amount: 4
+    # - name: Utility
+    #   entries:
+    #   - id: Sentry Gun Network Laptop
+    #     amount: 4
+    #   - id: Sentry Gun Network Encryption KEy
+    #     amount: 4

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/leader.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/leader.yml
@@ -103,8 +103,8 @@
         points: 7
       - id: RMCPouchToolsFill
         points: 5
-    #- id: CMWeldingGoggles
-    #  points: 5
+      - id: RMCWeldingGoggles
+        points: 5
     - name: Explosives
       entries:
       - id: CMPacketGrenadeHighExplosiveFilled
@@ -159,6 +159,8 @@
       entries:
       - id: CMMagazineRifleM4SPRAP
         points: 6
+      - id: CMMagazineRifleM4SPRExt
+        points: 6
       - id: CMMagazineSMGM63AP
         points: 6
       - id: CMMagazineSMGM63Ext
@@ -169,8 +171,18 @@
         points: 6
     - name: Sidearm Ammunition
       entries:
+      - id: RMCMagazinePistolM13Ext
+        points: 10
+      - id: RMCMagazinePistolM13Drum
+        points: 15
+      # - id: RMCSpeedLoader44Heavy
+      #  points: 6
       - id: RMCSpeedLoader44Marksman
         points: 6
+      # - id: RMCMagazinePistolM1984HP
+      #   points: 3
+      - id: RMCMagazinePistolM1984AP
+        points: 3
       - id: CMMagazinePistolMK80
         points: 3
       - id: RMCMagazinePistolSU6

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/medic.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/medic.yml
@@ -23,10 +23,10 @@
       entries:
       - id: CMBurnKit10
         points: 2
-#        recommended: true
+        recommended: true
       - id: CMTraumaKit10
         points: 2
-#        recommended: true
+        recommended: true
     #    CMMedicalSplints: 1P
 #        recommended: true
       - id: CMBloodPackFull # TODO RMC14 O-
@@ -36,7 +36,7 @@
       entries:
       - id: CMAdvFirstAidKitFilled
         points: 12
-#        recommended: true
+        recommended: true
       - id: CMFirstAidKitFilled
         points: 5
       - id: CMBurnAidKitFilled
@@ -115,6 +115,8 @@
       entries:
       - id: CMMagazineRifleM4SPRAP
         points: 6
+      - id: CMMagazineRifleM4SPRExt
+        points: 6
       - id: CMMagazineSMGM63AP
         points: 6
       - id: CMMagazineSMGM63Ext
@@ -125,8 +127,18 @@
         points: 6
     - name: Sidearm Ammunition
       entries:
+      - id: RMCMagazinePistolM13Ext
+        points: 10
+      - id: RMCMagazinePistolM13Drum
+        points: 15
+      # - id: RMCSpeedLoader44Heavy
+      #  points: 6
       - id: RMCSpeedLoader44Marksman
         points: 6
+      # - id: RMCMagazinePistolM1984HP
+      #   points: 3
+      - id: RMCMagazinePistolM1984AP
+        points: 3
       - id: CMMagazinePistolMK80
         points: 3
       - id: RMCMagazinePistolSU6
@@ -150,7 +162,8 @@
         points: 8
       - id: RMCBackpackRTO
         points: 15
-    #    CMWeldingGoggles: 3P
+      - id: RMCWeldingGoggles
+        points: 3
     - name: Utilities
       entries:
       - id: CMFireExtinguisherPortable

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/prep.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/prep.yml
@@ -328,9 +328,15 @@
         amount: 3
     - name: Extended Ammunition
       entries:
+      - id: CMMagazineRifleM4SPRExt
+        amount: 2
       - id: CMMagazineSMGM63Ext
         amount: 2
       - id: CMMagazineRifleM54CExt
+        amount: 2
+      - id: RMCMagazinePistolM13Ext
+        amount: 2
+      - id: RMCMagazinePistolM13Drum
         amount: 2
     - name: Special Ammunition
       entries:
@@ -403,7 +409,7 @@
         amount: 5
       - id: CMMultitool
         amount: 1
-      - id: CMWelder
+      - id: CMWelderSmall
         amount: 1
     - name: Flare and light
       entries:
@@ -477,18 +483,20 @@
         amount: 3
       - id: RMCAttachmentSuppressor
         amount: 3
+      # - id: RMCAttachmentShotgunChoke
+      #   amount: 2
     - name: Rail
       entries:
       - id: RMCAttachmentB8SmartScope
         amount: 2
       - id: RMCAttachmentMagneticHarness
-        amount: 5
+        amount: 4
       - id: RMCAttachmentS42xTelescopicMiniscope
         amount: 2
       - id: RMCAttachmentS5RedDotSight
-        amount: 4
+        amount: 3
       - id: RMCAttachmentS6ReflexSight
-        amount: 4
+        amount: 3
       - id: RMCAttachmentS84xTelescopicScope
         amount: 2
     - name: Underbarrel

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/rifleman.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/rifleman.yml
@@ -127,6 +127,8 @@
       entries:
       - id: CMMagazineRifleM4SPRAP
         points: 10
+      - id: CMMagazineRifleM4SPRExt
+        points: 10
       - id: CMMagazineSMGM63AP
         points: 10
       - id: CMMagazineSMGM63Ext
@@ -137,6 +139,10 @@
         points: 10
     - name: Sidearm Ammunition
       entries:
+      - id: RMCMagazinePistolM13Ext
+        points: 10
+      - id: RMCMagazinePistolM13Drum
+        points: 15
       #- id: M44 Heavy Speedloader
       #  points: 10
       - id: RMCSpeedLoader44Marksman
@@ -177,8 +183,8 @@
         points: 15
       - id: RMCPouchFuelTank
         points: 5
-    #- id: CMWeldingGoggles
-    #  points: 5
+      - id: RMCWeldingGoggles
+        points: 5
     #- id: CMSlingPouch
     #  points: 15
       - id: RMCPouchGeneralLarge

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/smart_gun_operator.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/smart_gun_operator.yml
@@ -47,6 +47,18 @@
     #  points: 20
     - name: Sidearm Ammunitions
       entries:
+      - id: RMCMagazinePistolM13Ext
+        points: 10
+      - id: RMCMagazinePistolM13Drum
+        points: 15
+      # - id: RMCSpeedLoader44Heavy
+      #  points: 10
+      - id: RMCSpeedLoader44Marksman
+        points: 10
+      # - id: RMCMagazinePistolM1984HP
+      #   points: 5
+      - id: RMCMagazinePistolM1984AP
+        points: 5
       - id: CMMagazinePistolMK80
         points: 5
       - id: RMCMagazinePistolSU6

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/specialist.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/specialist.yml
@@ -256,8 +256,18 @@
         points: 15
     - name: Sidearm Ammunition
       entries:
+      - id: RMCMagazinePistolM13Ext
+        points: 10
+      - id: RMCMagazinePistolM13Drum
+        points: 15
+      # - id: RMCSpeedLoader44Heavy
+      #  points: 10
       - id: RMCSpeedLoader44Marksman
         points: 10
+      # - id: RMCMagazinePistolM1984HP
+      #   points: 5
+      - id: RMCMagazinePistolM1984AP
+        points: 5
       - id: CMMagazinePistolMK80
         points: 5
       - id: RMCMagazinePistolSU6
@@ -274,7 +284,8 @@
         points: 15
       - id: RMCPouchFuelTank
         points: 5
-    #- id: CMWeldingGoggles
+      - id: RMCWeldingGoggles
+        points: 3
       - id: RMCPouchGeneralLarge
         points: 10
       - id: CMBeltUtilityCombat

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/team_leader.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/team_leader.yml
@@ -41,6 +41,8 @@
       entries:
       - id: CMMagazineRifleM4SPRAP
         points: 10
+      - id: CMMagazineRifleM4SPRExt
+        points: 10
       - id: CMMagazineSMGM63AP
         points: 10
       - id: CMMagazineSMGM63Ext
@@ -51,18 +53,24 @@
         points: 10
     - name: Sidearm Ammunition
       entries:
+      - id: RMCMagazinePistolM13Ext
+        points: 10
+      - id: RMCMagazinePistolM13Drum
+        points: 15
+      # - id: RMCSpeedLoader44Heavy
+      #  points: 10
+      - id: RMCSpeedLoader44Marksman
+        points: 10
+      # - id: RMCMagazinePistolM1984HP
+      #   points: 5
+      - id: RMCMagazinePistolM1984AP
+        points: 5
       - id: RMCSpeedLoader44Marksman
         points: 10
       - id: CMMagazinePistolMK80
         points: 5
       - id: RMCMagazinePistolSU6
         points: 10
-    #- id: CMM44HeavySpeedLoader
-    #  points: 10
-    #- id: CMM1984HPMagazine
-    #  points: 5
-    #- id: CMM1984APMagazine
-    #  points: 5
     - name: Restricted Firearms
       entries:
       - id: RMCGunCasePistolMK80
@@ -86,8 +94,8 @@
       - id: RMCPouchMacheteFilled
         name: machete pouch (Full)
         points: 15
-      #- id: RMCWeldingGoggles
-      #  points: 3
+      - id: RMCWeldingGoggles
+        points: 3
       - id: CMBeltUtilityCombat
         points: 15
       - id: RMCPouchAutoinjectorFill

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/bundles.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/bundles.yml
@@ -94,7 +94,7 @@
     - RMCPowerCellHigh
     - CMEntrenchingTool
     - CMLightReplacer
-#    - CMAPCElectronics # TODO RMC14 uncomment when power
+    - CMAPCElectronics
     - RMCNailgunTactical
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/engineering.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/engineering.yml
@@ -34,7 +34,7 @@
         amount: 4
       - id: CMBeltUtility
         amount: 4
-      - id: ClothingEyesGlassesMeson
+      - id: RMCWeldingGoogles
         amount: 4
       - id: RMCHelmetWelding
         amount: 4


### PR DESCRIPTION
## About the PR

# Prep
Added M4SPR Ext, M13 Ext, M13 Drum, M1984 AP.
Replaced Blowtorch with ME-3
Reduced by 1 number of maghar, s5 and s6.

# Rifleman
Added M4SPR Ext, M13 Ext, M13 Drum, Welding Googles.

### FTL
Added M4SPR Ext, M13 Ext, M13 Drum, M1984 AP, Welding Googles.
Closes #1901
Closes #1920

### Medic
Adds M4SPR Ext, M13 Ext, M13 Drum, M1984 AP, Welding Googles.
(Vermidia closed M1984 AP, yet it wasnt actually done)
Closes #1778

### CT
Adds APC Circuit Board, M4SPR Ext, M13 Ext, M13 Drum, M1984 AP, Synth Reset Key, Welding Googles, Light Replacer.
Added APC Circuit Board to essential engineer set.

### Leader
Adds Welding Googles, M4SPR Ext, M13 Ext, M13 Drum, M1984 AP.
Closes `3P M4A3 AP Magazine` at #785

### SGO
Added M4SPR Ext, M13 Ext, M13 Drum, M1984 AP.

### Specialist
Added M4SPR Ext, M13 Ext, M13 Drum, M1984 AP, Welding Googles.
Closes #1605

### Tools vendor
Replaced upstream mesons with RMC Welding Googles

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl: Tunguso4ka
- add: Added M4SPR Extended, M1984 AP, M13 Extended, M13 Drum magazines to squad vendors
- add: Added welding googles to squad vendors.
- tweak: Reduced number of magnetic harness, S5 RedDot and S6 Reflex attachments in squad vendor.