### PR TITLE
Allow Forecon spotter whitelist

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/commander.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/commander.yml
@@ -56,6 +56,7 @@
         - RMCSquadFORECON
     - type: EquipSurvivorPreset
       preset: RMCSurvivorPresetForeconNoPistol
+    - type: SpotterWhitelist
   hidden: true
 
 - type: startingGear

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/marksman.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/marksman.yml
@@ -41,6 +41,7 @@
     - type: ScoutWhitelist
     - type: JobPrefix
       prefix: rmc-job-prefix-forecon-marksman
+    - type: SpotterWhitelist
   hidden: true
 
 - type: playTimeTracker

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/rifleman.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/rifleman.yml
@@ -34,6 +34,7 @@
       prefix: cm-job-prefix-rifleman
     - type: EquipSurvivorPreset
       preset: RMCSurvivorPresetForecon
+    - type: SpotterWhitelist
   hidden: true
 
 - type: playTimeTracker

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/smart_gun_operator.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/smart_gun_operator.yml
@@ -40,6 +40,7 @@
       preset: RMCSurvivorPresetForeconNoPistol
     - type: JobPrefix
       prefix: cm-job-prefix-gun-operator
+    - type: SpotterWhitelist
   hidden: true
 
 - type: playTimeTracker

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/sniper.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/sniper.yml
@@ -35,6 +35,7 @@
     - type: EquipSurvivorPreset
       preset: RMCSurvivorPresetForeconNoPrimary
     - type: SniperWhitelist
+    - type: SpotterWhitelist
     - type: JobPrefix
       prefix: rmc-job-prefix-weapons-specialist-sniper
   hidden: true

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/sniper.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/sniper.yml
@@ -35,7 +35,6 @@
     - type: EquipSurvivorPreset
       preset: RMCSurvivorPresetForeconNoPrimary
     - type: SniperWhitelist
-    - type: SpotterWhitelist
     - type: JobPrefix
       prefix: rmc-job-prefix-weapons-specialist-sniper
   hidden: true

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/squad_leader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/squad_leader.yml
@@ -48,6 +48,7 @@
       prefix: cm-job-prefix-squad-leader
     - type: EquipSurvivorPreset
       preset: RMCSurvivorPresetForeconSquadLead
+    - type: SpotterWhitelist
   hidden: true
 
 - type: playTimeTracker

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/support_technician.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/support_technician.yml
@@ -46,6 +46,7 @@
       preset: RMCSurvivorPresetForeconSupportTech
     - type: JobPrefix
       prefix: rmc-job-prefix-forecon-support-tech
+    - type: SpotterWhitelist
   hidden: true
 
 - type: playTimeTracker


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This is in the code for the base FORECON surv, they should be all able to use the spotter whitelist
![Screenshot_20250704_070440](https://github.com/user-attachments/assets/b72523c6-8fc9-4f7c-9764-57cd2512e144)


**Changelog**
:cl:
- fix: Fixed FORECON not being able to use spotter equipment