### PR TITLE
Added and Changed Liaison/WeYa stuff

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Drinks/alcohol.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Drinks/alcohol.yml
@@ -260,7 +260,7 @@
 - type: entity
   parent: RMCDrinkAlcoholBase
   id: RMCDrinkAlcoholSake
-  name: weston-yamada sake
+  name: Pure Platinum Sake
   description: Sake made with ancient techniques passed down for thousands of years. Fermented in Iowa by the Weston-Yamada Corporation.
   components:
   - type: Sprite

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Drinks/cans.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Drinks/cans.yml
@@ -272,8 +272,8 @@
 - type: entity
   parent: CMDrinkCanBase
   id: CMDrinkCanBeerLite
-  name: We-Ya Lite
-  description: Beer. You've dialed in your target. Time to fire for effect.
+  name: Alder Lite
+  description: Beer. You've dialed in your target. Time to fire for effect. Canned by the Weston-Yamada Corporation
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Consumable/Drinks/beer.rsi
@@ -290,8 +290,8 @@
 - type: entity
   parent: CMDrinkCanBase
   id: CMDrinkCanAle
-  name: We-Ya IPA
-  description: Beer's misunderstood cousin.
+  name: Larch IPA
+  description: Beer's misunderstood cousin. Canned by the Weston-Yamada Corporation.
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Consumable/Drinks/ale.rsi

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Devices/portable_vendor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Devices/portable_vendor.yml
@@ -52,17 +52,21 @@
         points: 5
     - name: Smokables
       entries:
-      - id: CigarGoldCase # TODO RMC14
+      - id: RMCCigarCase
         points: 5
-      - id: CMCigarettePackLuckySlothsMini # TODO RMC14 WeYa cigarettes
+      - id: RMCCigarettePackWeYaGold
         points: 5
-      - id: FlippoEngravedLighter # TODO RMC14
+      - id: RMCZippoExec
+        points: 5
+      - id: RMCZippoGold
         points: 5
     - name: Drinkables
       entries:
-      - id: DrinkSakeBottleFull
+      - id: RMCDrinkAlcoholSake
         points: 5
-      - id: CMDrinkCanAle # TODO RMC14 Aspen Beer
+      - id: CMDrinkCanAle
+        points: 5
+      - id: CMDrinkCanBeerLite
         points: 5
       - id: DrinkGlass
         points: 1

--- a/Resources/Prototypes/_RMC14/Roles/Loadouts/Items/RoleSpecific/liaison.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Loadouts/Items/RoleSpecific/liaison.yml
@@ -1,0 +1,14 @@
+﻿# Corporate Liaison
+- type: loadout
+  id: CMPenClicky
+  cost: 1
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: CMJobLiaison
+      time: 90000 # 25 hours
+  storage:
+    back:
+    - CMPenClicky
+

--- a/Resources/Prototypes/_RMC14/Roles/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Loadouts/loadout_groups.yml
@@ -354,6 +354,15 @@
   - ColIDCardRMC
   - ColNormalIDCardRMC
 
+# Corporate Liaison
+- type: loadoutGroup
+  id: LiaisonRoleSpecificRMC
+  name: rmc-loadout-group-role-specific
+  minLimit: 0
+  maxLimit: 1
+  loadouts:
+  - CMPenClicky
+
 # Chief MP
 - type: loadoutGroup
   id: ChiefMPRoleSpecificRMC

--- a/Resources/Prototypes/_RMC14/Roles/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Loadouts/role_loadouts.yml
@@ -562,6 +562,7 @@
   points: 7
   groups:
   - MarineLeatherBackpack
+  - LiaisonRoleSpecificRMC
   - HeadwearRMC
   - EyewearRMC
   - MasksRMC


### PR DESCRIPTION

## About the PR
Changed the name of the We-Ya IPA, We-Ya Lite, and We-Ya Sake to Larch IPA, Alder Lite, and Pure Platinum Sake be more branded and accurate to the naming scheme of the drinks they are based off of. Replaced upstream and incorrect items in the Weston-Yamada Automated Storage Briefcase for parity. Added a Corporate Liaison-exclusive loadout menu, with a WeYa pen accessible at 25 hours (Executive Rank), intended for cosmetic items.

## Why / Balance
Some content is parity, such as the briefcase items being intended to have Weston-Yamada brands. Giving the drinks brand names also feels more immersive and detailed. Having a Liaison-Exclusive loadout menu will potentially allow for future WeYa items to be accessible for people who have spent a significant amount of time playing as the role.

## Technical details
All yml changes, with one yml addition

## Media
![image](https://github.com/user-attachments/assets/a85b3a1c-c7e5-4bd2-acff-3d0a61e21e02)
![image](https://github.com/user-attachments/assets/4a8b3ab8-8134-4a66-b323-4d56ee5afc18)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Added a Liaison role-specific loadout section
- tweak: Changed the name of the WeYa alcoholic drinks to be more distinctly branded
- tweak: Adjusted the items in the Liaison's Automated Briefcase to match parity and no longer use upstream items
