### PR TITLE
adds .5 range to headbutt

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Headbutt/XenoHeadbuttComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Headbutt/XenoHeadbuttComponent.cs
@@ -18,7 +18,7 @@ public sealed partial class XenoHeadbuttComponent : Component
     public DamageSpecifier Damage = new();
 
     [DataField, AutoNetworkedField]
-    public float Range = 3;
+    public float Range = 3.5;
 
     [DataField, AutoNetworkedField]
     public float ThrowForce = 1;

--- a/Content.Shared/_RMC14/Xenonids/Headbutt/XenoHeadbuttComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Headbutt/XenoHeadbuttComponent.cs
@@ -18,7 +18,7 @@ public sealed partial class XenoHeadbuttComponent : Component
     public DamageSpecifier Damage = new();
 
     [DataField, AutoNetworkedField]
-    public float Range = 3.5;
+    public float Range = 3.5f;
 
     [DataField, AutoNetworkedField]
     public float ThrowForce = 1;

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
@@ -249,7 +249,7 @@
       sprite: _RMC14/Actions/xeno_actions.rsi
       state: headbutt
     event: !type:XenoHeadbuttActionEvent
-    range: 3
+    range: 3.5
     useDelay: 6
     deselectOnMiss: false
   - type: XenoOffensiveAction


### PR DESCRIPTION

## About the PR
ups the range of headbutt to make it consistent with the tailsweep combo

## Why / Balance
you can be just on the edge of the ability, use it, go through the entire animation, just for you to teleport back and you waste tailsweep

this is most common with headbutt but it was suggested every ability should get

also follows this PR's idea however they are a bit different
in essence, slugs buckshot and mateba stuns also have 0.5 extra range
https://github.com/RMC-14/RMC-14/pull/5114

## Media
It being silly,
https://github.com/user-attachments/assets/e7232e18-caad-4e83-95be-6709e1200bb8


## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: Headbutt ability now will activate 0.5 tiles further away.

