### PR TITLE
Fix some obstacle slamming stuff

### DIFF
--- a/Content.Shared/_RMC14/Damage/ObstacleSlamming/RMCObstacleSlammingComponent.cs
+++ b/Content.Shared/_RMC14/Damage/ObstacleSlamming/RMCObstacleSlammingComponent.cs
@@ -13,9 +13,6 @@ namespace Content.Shared._RMC14.Damage.ObstacleSlamming;
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class RMCObstacleSlammingComponent : Component
 {
-    [DataField, AutoNetworkedField]
-    public float MinimumSpeed = 4.5f;
-
     /// <summary>
     /// MOB_SIZE_COEFF in CM
     /// </summary>

--- a/Content.Shared/_RMC14/Damage/ObstacleSlamming/RMCObstacleSlammingComponent.cs
+++ b/Content.Shared/_RMC14/Damage/ObstacleSlamming/RMCObstacleSlammingComponent.cs
@@ -29,7 +29,7 @@ public sealed partial class RMCObstacleSlammingComponent : Component
     public float ThrowSpeedCoefficient = 0.2f;
 
     [DataField, AutoNetworkedField]
-    public float KnockbackPower = 1;
+    public float KnockbackPower = 0.3f;
 
     [DataField, AutoNetworkedField]
     public float KnockBackSpeed = 3;

--- a/Content.Shared/_RMC14/Damage/ObstacleSlamming/RMCObstacleSlammingSystem.cs
+++ b/Content.Shared/_RMC14/Damage/ObstacleSlamming/RMCObstacleSlammingSystem.cs
@@ -75,9 +75,6 @@ public sealed class RMCObstacleSlammingSystem : EntitySystem
 
         var speed = body.LinearVelocity.Length();
 
-        if (speed < ent.Comp.MinimumSpeed)
-            return;
-
         if (ent.Comp.LastHit != null && _timing.CurTime - ent.Comp.LastHit.Value < ent.Comp.DamageCooldown)
             return;
 
@@ -105,7 +102,7 @@ public sealed class RMCObstacleSlammingSystem : EntitySystem
         var vec = _transform.GetMoverCoordinates(user).Position - _transform.GetMoverCoordinates(obstacle).Position;
         if (vec.Length() != 0)
         {
-            _size.KnockBack(user, _transform.GetMapCoordinates(obstacle), knockBackSpeed: ent.Comp.KnockBackSpeed);
+            _size.KnockBack(user, _transform.GetMapCoordinates(obstacle), ent.Comp.KnockbackPower, ent.Comp.KnockbackPower, knockBackSpeed: ent.Comp.KnockBackSpeed);
         }
 
         if (_timing.IsFirstTimePredicted)

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lurker.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lurker.yml
@@ -162,7 +162,6 @@
         Brute: 40
   - type: XenoTailJab
     attackEffect: RMCEffectTailHit
-    throwRange: 0.5
     damage:
       groups:
         Brute: 50


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Changed the range of the vampire lurker's tail jab from 0.5 to 1
Removed the minimum speed requirement for an obstacle slam to happen.
Obstacle slams now knock back less far.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
No CL since these issues aren't live yet.
