### PR TITLE
Fixes the accursed hybrisa windows

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Windows/hybrisa_windows.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Windows/hybrisa_windows.yml
@@ -81,6 +81,10 @@
   - type: Construction
     graph: RMCWindowHybrisa
     node: windowHybrisa
+  - type: DestroyOnXenoPierceScissor
+    spawnPrototype: RMCWindowFrameHybrisa
+    sound:
+      collection: WindowShatter
 
 - type: entity
   parent: CMBaseWindow
@@ -126,12 +130,16 @@
                 min: 1
                 max: 1
           - !type:ChangeConstructionNodeBehavior
-            node: windowFrameHybrisa
+            node: windowFrameHybrisaReinforced
   - type: RMCWallExplosionDeletable
   - type: DestroyedByExplosionType
   - type: Construction
-    graph: RMCWindowHybrisa
-    node: windowHybrisa
+    graph: RMCWindowHybrisaReinforced
+    node: windowHybrisaReinforced
+  - type: DestroyOnXenoPierceScissor
+    spawnPrototype: RMCWindowFrameHybrisa
+    sound:
+      collection: WindowShatter
 
 - type: entity
   parent: CMBaseWindowIndestructible
@@ -139,6 +147,8 @@
   name: hull window
   description: A glass window. Light refracts incorrectly when looking through. It looks rather strong. No way to get through here.
   components:
+  - type: Corrodible
+    isCorrodible: false
   - type: Sprite
     sprite: _RMC14/Structures/Windows/hybrisa_window.rsi
     state: strata_window0
@@ -186,6 +196,34 @@
     key: walls
     base: strata_window
     mode: CardinalFlags
+  - type: Destructible
+    thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 600 # excessive damage destroys window and frame
+        behaviors:
+          - !type:PlaySoundBehavior
+            sound:
+              collection: WindowShatter
+          - !type:DoActsBehavior
+            acts: ["Destruction"]
+      - trigger:
+          !type:DamageTrigger
+          damage: 100
+        behaviors:
+          - !type:PlaySoundBehavior
+            sound:
+              collection: WindowShatter
+          - !type:SpawnEntitiesBehavior
+            spawn:
+              CMShardGlass:
+                min: 1
+                max: 1
+              CMRodMetal:
+                min: 1
+                max: 1
+          - !type:ChangeConstructionNodeBehavior
+            node: windowFrameHybrisaMedicalReinforced
   - type: Construction
     graph: RMCWindowHybrisaMedicalReinforced
     node: windowHybrisaMedicalReinforced
@@ -226,6 +264,34 @@
     key: walls
     base: strata_window
     mode: CardinalFlags
+  - type: Destructible
+    thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 600 # excessive damage destroys window and frame
+        behaviors:
+          - !type:PlaySoundBehavior
+            sound:
+              collection: WindowShatter
+          - !type:DoActsBehavior
+            acts: ["Destruction"]
+      - trigger:
+          !type:DamageTrigger
+          damage: 100
+        behaviors:
+          - !type:PlaySoundBehavior
+            sound:
+              collection: WindowShatter
+          - !type:SpawnEntitiesBehavior
+            spawn:
+              CMShardGlass:
+                min: 1
+                max: 1
+              CMRodMetal:
+                min: 1
+                max: 1
+          - !type:ChangeConstructionNodeBehavior
+            node: windowFrameHybrisaEngiReinforced
   - type: Construction
     graph: RMCWindowHybrisaEngiReinforced
     node: windowHybrisaEngiReinforced
@@ -266,6 +332,34 @@
     key: walls
     base: strata_window
     mode: CardinalFlags
+  - type: Destructible
+    thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 600 # excessive damage destroys window and frame
+        behaviors:
+          - !type:PlaySoundBehavior
+            sound:
+              collection: WindowShatter
+          - !type:DoActsBehavior
+            acts: ["Destruction"]
+      - trigger:
+          !type:DamageTrigger
+          damage: 100
+        behaviors:
+          - !type:PlaySoundBehavior
+            sound:
+              collection: WindowShatter
+          - !type:SpawnEntitiesBehavior
+            spawn:
+              CMShardGlass:
+                min: 1
+                max: 1
+              CMRodMetal:
+                min: 1
+                max: 1
+          - !type:ChangeConstructionNodeBehavior
+            node: windowFrameHybrisaOfficeReinforced
   - type: Construction
     graph: RMCWindowHybrisaOfficeReinforced
     node: windowHybrisaOfficeReinforced
@@ -306,6 +400,34 @@
     key: walls
     base: prison_window
     mode: CardinalFlags
+  - type: Destructible
+    thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 600 # excessive damage destroys window and frame
+        behaviors:
+          - !type:PlaySoundBehavior
+            sound:
+              collection: WindowShatter
+          - !type:DoActsBehavior
+            acts: ["Destruction"]
+      - trigger:
+          !type:DamageTrigger
+          damage: 100
+        behaviors:
+          - !type:PlaySoundBehavior
+            sound:
+              collection: WindowShatter
+          - !type:SpawnEntitiesBehavior
+            spawn:
+              CMShardGlass:
+                min: 1
+                max: 1
+              CMRodMetal:
+                min: 1
+                max: 1
+          - !type:ChangeConstructionNodeBehavior
+            node: windowFrameHybrisaSpacePort
   - type: Construction
     graph: RMCWindowHybrisaSpacePort
     node: windowHybrisaSpacePort
@@ -344,6 +466,34 @@
     key: walls
     base: prison_window
     mode: CardinalFlags
+  - type: Destructible
+    thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 600 # excessive damage destroys window and frame
+        behaviors:
+          - !type:PlaySoundBehavior
+            sound:
+              collection: WindowShatter
+          - !type:DoActsBehavior
+            acts: ["Destruction"]
+      - trigger:
+          !type:DamageTrigger
+          damage: 100
+        behaviors:
+          - !type:PlaySoundBehavior
+            sound:
+              collection: WindowShatter
+          - !type:SpawnEntitiesBehavior
+            spawn:
+              CMShardGlass:
+                min: 1
+                max: 1
+              CMRodMetal:
+                min: 1
+                max: 1
+          - !type:ChangeConstructionNodeBehavior
+            node: windowFrameHybrisaSpacePortReinforced
   - type: Construction
     graph: RMCWindowHybrisaSpacePortReinforced
     node: windowHybrisaSpacePortReinforced
@@ -382,6 +532,34 @@
     key: walls
     base: prison_window
     mode: CardinalFlags
+  - type: Destructible
+    thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 600 # excessive damage destroys window and frame
+        behaviors:
+          - !type:PlaySoundBehavior
+            sound:
+              collection: WindowShatter
+          - !type:DoActsBehavior
+            acts: ["Destruction"]
+      - trigger:
+          !type:DamageTrigger
+          damage: 100
+        behaviors:
+          - !type:PlaySoundBehavior
+            sound:
+              collection: WindowShatter
+          - !type:SpawnEntitiesBehavior
+            spawn:
+              CMShardGlass:
+                min: 1
+                max: 1
+              CMRodMetal:
+                min: 1
+                max: 1
+          - !type:ChangeConstructionNodeBehavior
+            node: windowFrameHybrisaSpacePortCell
   - type: Construction
     graph: RMCWindowHybrisaSpacePortCell
     node: windowHybrisaSpacePortCell
@@ -422,6 +600,34 @@
     key: walls
     base: strata_window
     mode: CardinalFlags
+  - type: Destructible
+    thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 600 # excessive damage destroys window and frame
+        behaviors:
+          - !type:PlaySoundBehavior
+            sound:
+              collection: WindowShatter
+          - !type:DoActsBehavior
+            acts: ["Destruction"]
+      - trigger:
+          !type:DamageTrigger
+          damage: 100
+        behaviors:
+          - !type:PlaySoundBehavior
+            sound:
+              collection: WindowShatter
+          - !type:SpawnEntitiesBehavior
+            spawn:
+              CMShardGlass:
+                min: 1
+                max: 1
+              CMRodMetal:
+                min: 1
+                max: 1
+          - !type:ChangeConstructionNodeBehavior
+            node: windowFrameHybrisaResearchReinforced
   - type: Construction
     graph: RMCWindowHybrisaResearchReinforced
     node: windowHybrisaResearchReinforced


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Hybrisa windows now properly become frames when broken, and the hull windows cannot be corroded.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I waited like 6 months for literally anyone to fix this while I tried to do other projects but no one fixed it yet so I have to fix it. Bugs are bad, I fix.

## Technical details
<!-- Summary of code changes for easier review. -->
yaml

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: noctyrnal
- fix: Fixed Hybrisa windows not becoming frames when destroyed.
- fix: Fixed Hybrisa hull windows being corrodible.
