### PR TITLE
Fix the default mode for the underbarrel flamer attachment being stronger than intended

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/under_attachments.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/under_attachments.yml
@@ -255,6 +255,8 @@
         - ReagentId: RMCNapalmUT
           Quantity: 40
   - type: RMCFlamerAmmoProvider
+    maxIntensity: 10
+    maxDuration: 10
   - type: RMCFlamerTank
   - type: AttachableToggleable
     userOnly: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- fix: Fixed the default mode (the only one we have right now) for the underbarrel flamer attachment being stronger than intended. Intensity 20 > 10, duration 24 > 10.
