### PR TITLE
Adds External Webbing to the flight crew prep vendor

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/pilot.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/pilot.yml
@@ -34,6 +34,7 @@
       entries:
       - id: CMArmorM3VLFlakVest
       - id: CMArmorM3VLBallistics
+      - id: RMCOuterClothingExternalWebbing
     - name: Personal Sidearm
       choices: { CMSidearm: 1 }
       entries:


### PR DESCRIPTION
## About the PR
Adds External Webbing to the flight crew prep vendors as an additional option for armor

(Forgive me if I'm doing this wrong, first time editing on github. Please give any feedback if I need to do something differently!)
## Why / Balance
Flight crew are practically the only roles who go groundside consistently and can wear external webbing without being arrested for it. Adding for ease of access since it's a common, legal practice

## Technical details
Changes YML

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Flight crew prep vendors now have external webbing as an option for armor
