### PR TITLE
Maybe fix baton slug perma blindness

### DIFF
--- a/Content.Shared/_RMC14/Stun/RMCSizeStunSystem.cs
+++ b/Content.Shared/_RMC14/Stun/RMCSizeStunSystem.cs
@@ -118,20 +118,6 @@ public sealed class RMCSizeStunSystem : EntitySystem
         if (distance > bullet.Comp.MaxRange || _stand.IsDown(args.Target))
             return;
 
-
-        // Multiply daze duration based on the size of the target
-        var dazeMultiplier = 1.0;
-        if(TryComp(args.Target, out RMCSizeComponent? targetSize))
-        {
-            if (targetSize.Size >= RMCSizes.Big)
-                dazeMultiplier = DazedMultiplierBigXeno;
-            else if (targetSize.Size <= RMCSizes.SmallXeno && IsXenoSized((args.Target, targetSize)))
-                dazeMultiplier = DazedMultiplierSmallXeno;
-        }
-
-        //Try to daze before the big size check, because big xenos can still be dazed.
-        _dazed.TryDaze(args.Target, bullet.Comp.DazeTime * dazeMultiplier);
-
         if (!TryComp<RMCSizeComponent>(args.Target, out var size))
             return;
 
@@ -139,6 +125,16 @@ public sealed class RMCSizeStunSystem : EntitySystem
 
         if (_net.IsClient)
             return;
+
+        // Multiply daze duration based on the size of the target
+        var dazeMultiplier = 1.0;
+        if (size.Size >= RMCSizes.Big)
+            dazeMultiplier = DazedMultiplierBigXeno;
+        else if (size.Size <= RMCSizes.SmallXeno && IsXenoSized((args.Target, size)))
+            dazeMultiplier = DazedMultiplierSmallXeno;
+
+        //Try to daze before the big size check, because big xenos can still be dazed.
+        _dazed.TryDaze(args.Target, bullet.Comp.DazeTime * dazeMultiplier);
 
         //Stun part
         if (IsXenoSized((args.Target, size)))


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Happens when the baton slug mispredicts and hits on the client but not the server, causing the blindness effect permanently
Just makes the daze effect serversided

:cl:
- fix: Fixed baton slugs permanently blinding xenos sometimes
