### PR TITLE
Fix hive cluster and hive pylon repair times being too long

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
@@ -760,13 +760,15 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
         var (ent, comp) = weedsStructure;
 
         var spreaderComp = EnsureComp<XenoWeedsSpreadingComponent>(ent);
-        spreaderComp.SpreadAt = _timing.CurTime;
+        var spreadTime = _timing.CurTime + spreaderComp.RepairedSpreadDelay;
+
+        spreaderComp.SpreadAt = spreadTime;
         Dirty(ent, spreaderComp);
 
         foreach (var weed in comp.Spread)
         {
             spreaderComp = EnsureComp<XenoWeedsSpreadingComponent>(weed);
-            spreaderComp.SpreadAt = _timing.CurTime;
+            spreaderComp.SpreadAt = spreadTime;
             Dirty(weed, spreaderComp);
         }
     }

--- a/Content.Shared/_RMC14/Xenonids/Weeds/XenoWeedsSpreadingComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Weeds/XenoWeedsSpreadingComponent.cs
@@ -11,6 +11,9 @@ public sealed partial class XenoWeedsSpreadingComponent : Component
     [DataField, AutoNetworkedField]
     public TimeSpan SpreadDelay = TimeSpan.FromSeconds(3);
 
+    [DataField, AutoNetworkedField]
+    public TimeSpan RepairedSpreadDelay = TimeSpan.FromSeconds(15);
+
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
     public TimeSpan SpreadAt;
 }

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/Hive/xeno_hive_cluster.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/Hive/xeno_hive_cluster.yml
@@ -38,7 +38,7 @@
     id: HiveClusterXeno
   - type: RepairableXenoStructure
     plasmaCost: 300
-    repairLength: 15
+    repairLength: 4
   - type: XenoStructureMapTracked
   - type: TacticalMapTracked
   - type: TacticalMapIcon

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/Hive/xeno_hive_core.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/Hive/xeno_hive_core.yml
@@ -142,7 +142,7 @@
         acts: ["Destruction"]
   - type: RepairableXenoStructure
     plasmaCost: 1000
-    repairLength: 15
+    repairLength: 4
   - type: MeleeReceivedMultiplier
     xenoDamage:
       types:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/Hive/xeno_hive_core.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/Hive/xeno_hive_core.yml
@@ -41,7 +41,7 @@
         acts: ["Destruction"]
   - type: RepairableXenoStructure
     plasmaCost: 1000
-    repairLength: 15
+    repairLength: 4
   - type: MeleeReceivedMultiplier
     xenoDamage:
       types:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Resolves #6059

Makes it takes 4 seconds to repair
It only starts reweeding after 15 seconds

## Technical details
Changes RepairLength in the YML of the clusters
Adds a new ``RepairedSpreadDelay`` field to ``XenoWeedsSpreadingComponent``

## Media


https://github.com/user-attachments/assets/f99f593f-43a8-4c28-b4e8-2241aa17a033




:cl:
- fix: Fixed hive clusters and hive pylons taking too long to repair. They now take 4 seconds to repair, and only start reweeding after 15 seconds has passed.
