### PR TITLE
Fix xenos not being able to add plasma to hive structures

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
@@ -661,7 +661,7 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
     {
         var user = args.User;
         var plasmaLeft = xenoStructure.Comp.PlasmaCost - xenoStructure.Comp.StoredPlasma;
-        if (!TryComp(user, out XenoConstructionComponent? xeno) ||
+        if (!TryComp(user, out XenoCanAddPlasmaToConstructComponent? xeno) ||
             plasmaLeft < FixedPoint2.Zero ||
             !TryComp(xenoStructure, out TransformComponent? xenoStructureTransform) ||
             !TryComp(user, out XenoPlasmaComponent? plasma) ||
@@ -677,7 +677,7 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
             return;
         }
 
-        if (!InRangePopup(user, xenoStructureTransform.Coordinates, xeno.OrderConstructionRange.Float()))
+        if (!InRangePopup(user, xenoStructureTransform.Coordinates, xeno.Range.Float()))
             return;
 
         if (plasma.Plasma < 1)

--- a/Content.Shared/_RMC14/Xenonids/Construction/XenoCanAddPlasmaToConstructComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/XenoCanAddPlasmaToConstructComponent.cs
@@ -1,0 +1,13 @@
+using Content.Shared._RMC14.Xenonids.Construction.ResinWhisper;
+using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.Construction;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true)]
+[Access(typeof(SharedXenoConstructionSystem), typeof(ResinWhispererSystem))]
+public sealed partial class XenoCanAddPlasmaToConstructComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 Range = 1.75;
+}

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
@@ -470,6 +470,7 @@
     stacks: -5
   - type: RMCHandEmotes
   - type: XenoToggleChargingKnockback
+  - type: XenoCanAddPlasmaToConstruct
 
 - type: entity
   abstract: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
In CM13 any xeno with a plasma bar can repair structures, not just builders

## Media


:cl:
- fix: Fix some xenos not being able to add plasma to hive structures