### PR TITLE
Tail stab daze

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Stab/XenoTailStabComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Stab/XenoTailStabComponent.cs
@@ -15,19 +15,34 @@ public sealed partial class XenoTailStabComponent : Component
     public EntProtoId TailAnimationId = "WeaponArcThrust";
 
     [DataField, AutoNetworkedField]
+    public EntProtoId HitAnimationId = "RMCEffectExtraSlash";
+
+    [DataField, AutoNetworkedField]
     public FixedPoint2 TailRange = 2;
 
     [DataField]
     public DamageSpecifier TailDamage = new();
 
     [DataField, AutoNetworkedField]
-    public SoundSpecifier SoundHit = new SoundCollectionSpecifier("XenoBite", AudioParams.Default.WithVolume(-3));
+    public SoundSpecifier SoundHit = new SoundCollectionSpecifier("XenoBite")
+    {
+        Params = AudioParams.Default.WithVariation(0.15f).WithVolume(-3),
+    };
 
     [DataField, AutoNetworkedField]
-    public SoundSpecifier SoundMiss = new SoundCollectionSpecifier("XenoTailSwipe");
+    public SoundSpecifier SoundMiss = new SoundCollectionSpecifier("XenoTailSwipe")
+    {
+        Params = AudioParams.Default.WithVariation(0.15f),
+    };
 
     [DataField, AutoNetworkedField]
     public float ChargeTime = 1; // TODO RMC14 implement this
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan DazeTime = TimeSpan.FromSeconds(1);
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan BigDazeTime = TimeSpan.FromSeconds(3);
 
     [DataField, AutoNetworkedField]
     public Dictionary<ProtoId<ReagentPrototype>, FixedPoint2>? Inject;

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/defender.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/defender.yml
@@ -68,6 +68,12 @@
     tailDamage:
       groups:
         Brute: 36
+    soundHit:
+        collection: Punch
+        params:
+          variation: 0.15
+    hitAnimationId: RMCEffectSlam
+
   - type: Tackle
     max: 4
   - type: Fixtures


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Parity, adds the tail stab daze and new tailstab effects
Make defenders tailstab effects parity

## Media
Soon

:cl:
- add: Tail stabs will now blind marines. New effects have also been added for tail stabs.
