### PR TITLE
Fix Integration Tests + small Sorokyne Update

### DIFF
--- a/Content.Client/_RMC14/Roadmap/RoadmapWindow.xaml
+++ b/Content.Client/_RMC14/Roadmap/RoadmapWindow.xaml
@@ -47,6 +47,7 @@
                     <controls:RoadmapItem ItemState="Partial" HeaderText="Firearms skill" Text="Each marine role has a different firearms skill. This impacts how accurate they are with guns" />
                     <controls:RoadmapItem ItemState="Partial" HeaderText="Medical skill" Text="Allows more advanced medical procedures and increases their overall speed" />
                     <controls:RoadmapItem ItemState="Partial" HeaderText="Xeno Queen" Text="Head caste of the xenonids" />
+                    <controls:RoadmapItem ItemState="Complete" HeaderText="Sorokyne Strata" Text="Planet map, ported by Tunguso4ka and Noctyrn" />
                     <controls:RoadmapItem ItemState="Complete" HeaderText="Construction skill" Text="Allows you to build more advanced constructs" />
                     <controls:RoadmapItem ItemState="Complete" HeaderText="Charger Crusher strain" />
                     <controls:RoadmapItem ItemState="Complete" HeaderText="Berserker Ravager strain" />
@@ -105,7 +106,6 @@
                 <BoxContainer Name="ThirdVersion" Access="Public" Orientation="Vertical"  HorizontalExpand="True" Margin="0 0 20 0">
                     <controls:RoadmapVersionHeader Text="Future versions" />
                     <controls:RoadmapItem ItemState="Planned" HeaderText="More lobby art and music" Text="We are always looking for people to contribute more lobby art and music!" />
-                    <controls:RoadmapItem ItemState="Planned" HeaderText="Sorokyne Strata planet map" />
                     <controls:RoadmapItem ItemState="Planned" HeaderText="Clone damage and cryo cells" Text="Clone damage is rarely caused by some chemicals, cryo cells treats this kind of damage." />
                     <controls:RoadmapItem ItemState="Planned" HeaderText="Autodoc and body scanners" Text="Automatically but very inefficiently treats marines in the medbay." />
                     <controls:RoadmapItem ItemState="Planned" HeaderText="Vehicles, the tank and the ARC" Text="Driveable vehicles such as the colony van, which can be repaired. The tank unlocks at 200 players for the marines." />

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magazine_boxes.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magazine_boxes.yml
@@ -660,7 +660,7 @@
   components:
   - type: Construction
     graph: RMCBoxMagazine
-    node: RMCBoxMagazineRifleAK4047
+    node: RMCBoxMagazineRifleAK4047Empty
   - type: Sprite
     layers:
     - state: rifle_box

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Wallmounts/fireaxe_cabinet.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Wallmounts/fireaxe_cabinet.yml
@@ -3,6 +3,9 @@
   parent: FireAxeCabinet
   id: RMCFireAxeCabinet
   suffix: RMC
+  components:
+  - type: AccessReader
+    access: []
 
 - type: entity
   parent: RMCFireAxeCabinet

--- a/Resources/Prototypes/_RMC14/Recipes/Construction/magazine_box_crafting.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Construction/magazine_box_crafting.yml
@@ -588,6 +588,7 @@
       - material: RMCSheetCardboard
         amount: 1
         doAfter: 0.25
+
     # AK4047
     - to: RMCBoxMagazineRifleAK4047Empty
       steps:


### PR DESCRIPTION
## About the PR
- Moved Sorokyne Strata to Completed in Roadmap.

- Fixed AK4047 mag box node id.
- Fixed accidentally activated flashlights, desk lamps and hard hats.
- Removed access requirements from FireAxe locker (parity)
- Added more fire axe lockers to Sorokyne
- Renamed bar at mining canteen to Cheeki Breeki (parity)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.