### PR TITLE
Podlocks can be pried, xeno pry sounds, xenos cant pry closed doors.

### DIFF
--- a/Content.Shared/Doors/Components/DoorComponent.cs
+++ b/Content.Shared/Doors/Components/DoorComponent.cs
@@ -297,6 +297,12 @@ public sealed partial class DoorComponent : Component
 
     [DataField(customTypeSerializer: typeof(ConstantSerializer<DrawDepthTag>))]
     public int ClosedDrawDepth = (int) DrawDepth.DrawDepth.Doors;
+
+    /// <summary>
+    /// What sound to play when a xeno is prying the door (RMC14)
+    /// </summary>
+    [DataField]
+    public SoundSpecifier XenoPrySound = new SoundPathSpecifier("/Audio/Machines/airlock_creaking.ogg");
 }
 
 [Serializable, NetSerializable]
@@ -327,4 +333,12 @@ public enum DoorVisualLayers : byte
     BaseUnlit,
     BaseBolted,
     BaseEmergencyAccess,
+}
+
+[ByRefEvent] /// RMC14
+public record struct DoorPryEvent(EntityUid User)
+{
+    public readonly EntityUid User = User;
+
+    public bool Cancelled;
 }

--- a/Content.Shared/Doors/Components/DoorComponent.cs
+++ b/Content.Shared/Doors/Components/DoorComponent.cs
@@ -297,12 +297,6 @@ public sealed partial class DoorComponent : Component
 
     [DataField(customTypeSerializer: typeof(ConstantSerializer<DrawDepthTag>))]
     public int ClosedDrawDepth = (int) DrawDepth.DrawDepth.Doors;
-
-    /// <summary>
-    /// What sound to play when a xeno is prying the door (RMC14)
-    /// </summary>
-    [DataField]
-    public SoundSpecifier XenoPrySound = new SoundPathSpecifier("/Audio/Machines/airlock_creaking.ogg");
 }
 
 [Serializable, NetSerializable]
@@ -333,12 +327,4 @@ public enum DoorVisualLayers : byte
     BaseUnlit,
     BaseBolted,
     BaseEmergencyAccess,
-}
-
-[ByRefEvent] /// RMC14
-public record struct DoorPryEvent(EntityUid User)
-{
-    public readonly EntityUid User = User;
-
-    public bool Cancelled;
 }

--- a/Content.Shared/Prying/Components/PryingComponent.cs
+++ b/Content.Shared/Prying/Components/PryingComponent.cs
@@ -29,7 +29,7 @@ public sealed partial class PryingComponent : Component
     /// What sound to play when prying is finished.
     /// </summary>
     [DataField]
-    public SoundSpecifier UseSound = new SoundPathSpecifier("/Audio/Items/crowbar.ogg");
+    public SoundSpecifier? UseSound = new SoundPathSpecifier("/Audio/Items/crowbar.ogg"); // RMC14 - Nullable
 
     /// <summary>
     /// Whether the entity can currently pry things.

--- a/Content.Shared/Prying/Systems/PryingSystem.cs
+++ b/Content.Shared/Prying/Systems/PryingSystem.cs
@@ -162,8 +162,8 @@ public sealed class PryingSystem : EntitySystem
             _adminLog.Add(LogType.Action, LogImpact.Low, $"{ToPrettyString(user)} is prying {ToPrettyString(target)}");
         }
 
-        var podlockpry = new PodlockPryEvent(user); // RMC14
-        RaiseLocalEvent(target, ref podlockpry); // RMC14
+        var doorpry = new DoorPryEvent(user); // RMC14
+        RaiseLocalEvent(target, ref doorpry); // RMC14
 
         return _doAfterSystem.TryStartDoAfter(doAfterArgs, out id);
     }

--- a/Content.Shared/Prying/Systems/PryingSystem.cs
+++ b/Content.Shared/Prying/Systems/PryingSystem.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Content.Shared._RMC14.Prying;
 using Content.Shared._RMC14.Doors;
+using Content.Shared._RMC14.Xenonids;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
 using Content.Shared.DoAfter;
@@ -133,6 +134,14 @@ public sealed class PryingSystem : EntitySystem
 
             canev = new BeforePryEvent(user, false, false, false);
         }
+
+        // RMC14 - Disable xenos being able to pry closed doors
+        if (HasComp<XenoComponent>(user) && TryComp(target, out DoorComponent? door) && door.State != DoorState.Closed)
+        {
+            message = null;
+            return false;
+        }
+
         RaiseLocalEvent(target, ref canev);
 
         message = canev.Message;

--- a/Content.Shared/Prying/Systems/PryingSystem.cs
+++ b/Content.Shared/Prying/Systems/PryingSystem.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Content.Shared._RMC14.Prying;
+using Content.Shared._RMC14.Doors;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
 using Content.Shared.DoAfter;
@@ -132,7 +133,6 @@ public sealed class PryingSystem : EntitySystem
 
             canev = new BeforePryEvent(user, false, false, false);
         }
-
         RaiseLocalEvent(target, ref canev);
 
         message = canev.Message;
@@ -161,6 +161,10 @@ public sealed class PryingSystem : EntitySystem
         {
             _adminLog.Add(LogType.Action, LogImpact.Low, $"{ToPrettyString(user)} is prying {ToPrettyString(target)}");
         }
+
+        var podlockpry = new PodlockPryEvent(user); // RMC14
+        RaiseLocalEvent(target, ref podlockpry); // RMC14
+
         return _doAfterSystem.TryStartDoAfter(doAfterArgs, out id);
     }
 

--- a/Content.Shared/Prying/Systems/PryingSystem.cs
+++ b/Content.Shared/Prying/Systems/PryingSystem.cs
@@ -171,7 +171,7 @@ public sealed class PryingSystem : EntitySystem
             _adminLog.Add(LogType.Action, LogImpact.Low, $"{ToPrettyString(user)} is prying {ToPrettyString(target)}");
         }
 
-        var doorpry = new DoorPryEvent(user); // RMC14
+        var doorpry = new RMCDoorPryEvent(user); // RMC14
         RaiseLocalEvent(target, ref doorpry); // RMC14
 
         return _doAfterSystem.TryStartDoAfter(doAfterArgs, out id);

--- a/Content.Shared/_RMC14/Doors/CMDoorSystem.cs
+++ b/Content.Shared/_RMC14/Doors/CMDoorSystem.cs
@@ -43,6 +43,8 @@ public sealed class CMDoorSystem : EntitySystem
         SubscribeLocalEvent<RMCDoorButtonComponent, ActivateInWorldEvent>(OnButtonActivateInWorld);
 
         SubscribeLocalEvent<RMCPodDoorComponent, BeforePryEvent>(OnPodDoorBeforePry);
+
+        SubscribeLocalEvent<RMCPodDoorComponent, GetPryTimeModifierEvent>(OnPodDoorGetPryTimeModifier);
     }
 
     private void OnDoorStateChanged(Entity<CMDoubleDoorComponent> door, ref DoorStateChangedEvent args)
@@ -121,9 +123,17 @@ public sealed class CMDoorSystem : EntitySystem
         if (_rmcPower.IsPowered(ent))
             args.Cancelled = true;
 
-        if (HasComp<XenoComponent>(args.User))
+        if (HasComp<XenoComponent>(args.User) && _net.IsServer)
         {
             _audioSystem.PlayPredicted(ent.Comp.XenoPodlockUseSound, ent.Owner, args.User);
+        }
+    }
+
+    private void OnPodDoorGetPryTimeModifier(Entity<RMCPodDoorComponent> ent, ref GetPryTimeModifierEvent args)
+    {
+        if (HasComp<XenoComponent>(args.User))
+        {
+            args.PryTimeModifier *= ent.Comp.XenoPodlockPryMultiplier;
         }
     }
 

--- a/Content.Shared/_RMC14/Doors/CMDoorSystem.cs
+++ b/Content.Shared/_RMC14/Doors/CMDoorSystem.cs
@@ -45,6 +45,8 @@ public sealed class CMDoorSystem : EntitySystem
         SubscribeLocalEvent<RMCPodDoorComponent, BeforePryEvent>(OnPodDoorBeforePry);
 
         SubscribeLocalEvent<RMCPodDoorComponent, GetPryTimeModifierEvent>(OnPodDoorGetPryTimeModifier);
+
+        SubscribeLocalEvent<RMCPodDoorComponent, PodlockPryEvent>(OnPodDoorPry);
     }
 
     private void OnDoorStateChanged(Entity<CMDoubleDoorComponent> door, ref DoorStateChangedEvent args)
@@ -123,9 +125,13 @@ public sealed class CMDoorSystem : EntitySystem
         if (_rmcPower.IsPowered(ent))
             args.Cancelled = true;
 
-        if (HasComp<XenoComponent>(args.User) && _net.IsServer)
+    }
+
+    private void OnPodDoorPry(Entity<RMCPodDoorComponent> ent, ref PodlockPryEvent args)
+    {
+        if (HasComp<XenoComponent>(args.User) && _net.IsServer && !args.Cancelled)
         {
-            _audioSystem.PlayPredicted(ent.Comp.XenoPodlockUseSound, ent.Owner, args.User);
+            _audioSystem.PlayPvs(ent.Comp.XenoPodlockUseSound, ent);
         }
     }
 

--- a/Content.Shared/_RMC14/Doors/CMDoorSystem.cs
+++ b/Content.Shared/_RMC14/Doors/CMDoorSystem.cs
@@ -127,11 +127,15 @@ public sealed class CMDoorSystem : EntitySystem
 
     }
 
-    private void OnDoorPry(Entity<DoorComponent> ent, ref DoorPryEvent args)
+    private void OnDoorPry(Entity<RMCDoorComponent> ent, ref DoorPryEvent args)
     {
+        if (args.Cancelled)
+        {
+            _audioSystem.Stop(ent.Comp.SoundEntity);
+        }
         if (HasComp<XenoComponent>(args.User) && _net.IsServer && !args.Cancelled)
         {
-            _audioSystem.PlayPvs(ent.Comp.XenoPrySound, ent);
+            ent.Comp.SoundEntity = _audioSystem.PlayPredicted(ent.Comp.XenoPrySound, ent.Owner, ent.Owner)?.Entity;
         }
     }
 

--- a/Content.Shared/_RMC14/Doors/CMDoorSystem.cs
+++ b/Content.Shared/_RMC14/Doors/CMDoorSystem.cs
@@ -46,7 +46,7 @@ public sealed class CMDoorSystem : EntitySystem
 
         SubscribeLocalEvent<RMCPodDoorComponent, GetPryTimeModifierEvent>(OnPodDoorGetPryTimeModifier);
 
-        SubscribeLocalEvent<RMCPodDoorComponent, PodlockPryEvent>(OnPodDoorPry);
+        SubscribeLocalEvent<DoorComponent, DoorPryEvent>(OnDoorPry);
     }
 
     private void OnDoorStateChanged(Entity<CMDoubleDoorComponent> door, ref DoorStateChangedEvent args)
@@ -127,11 +127,11 @@ public sealed class CMDoorSystem : EntitySystem
 
     }
 
-    private void OnPodDoorPry(Entity<RMCPodDoorComponent> ent, ref PodlockPryEvent args)
+    private void OnDoorPry(Entity<DoorComponent> ent, ref DoorPryEvent args)
     {
         if (HasComp<XenoComponent>(args.User) && _net.IsServer && !args.Cancelled)
         {
-            _audioSystem.PlayPvs(ent.Comp.XenoPodlockUseSound, ent);
+            _audioSystem.PlayPvs(ent.Comp.XenoPrySound, ent);
         }
     }
 

--- a/Content.Shared/_RMC14/Doors/CMDoorSystem.cs
+++ b/Content.Shared/_RMC14/Doors/CMDoorSystem.cs
@@ -8,11 +8,13 @@ using Content.Shared.Doors.Systems;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
 using Content.Shared.Prying.Components;
+using Content.Shared.Prying.Systems;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Map.Enumerators;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Timing;
+using Robust.Shared.Audio.Systems;
 
 namespace Content.Shared._RMC14.Doors;
 
@@ -25,6 +27,7 @@ public sealed class CMDoorSystem : EntitySystem
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly SharedRMCPowerSystem _rmcPower = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
 
     private EntityQuery<DoorComponent> _doorQuery;
     private EntityQuery<CMDoubleDoorComponent> _doubleQuery;
@@ -117,6 +120,11 @@ public sealed class CMDoorSystem : EntitySystem
 
         if (_rmcPower.IsPowered(ent))
             args.Cancelled = true;
+
+        if (HasComp<XenoComponent>(args.User))
+        {
+            _audioSystem.PlayPredicted(ent.Comp.XenoPodlockUseSound, ent.Owner, args.User);
+        }
     }
 
     private AnchoredEntitiesEnumerator? GetAdjacentEnumerator(Entity<CMDoubleDoorComponent> ent)

--- a/Content.Shared/_RMC14/Doors/CMDoorSystem.cs
+++ b/Content.Shared/_RMC14/Doors/CMDoorSystem.cs
@@ -46,7 +46,7 @@ public sealed class CMDoorSystem : EntitySystem
 
         SubscribeLocalEvent<RMCPodDoorComponent, GetPryTimeModifierEvent>(OnPodDoorGetPryTimeModifier);
 
-        SubscribeLocalEvent<DoorComponent, DoorPryEvent>(OnDoorPry);
+        SubscribeLocalEvent<RMCDoorComponent, RMCDoorPryEvent>(OnDoorPry);
     }
 
     private void OnDoorStateChanged(Entity<CMDoubleDoorComponent> door, ref DoorStateChangedEvent args)
@@ -127,7 +127,7 @@ public sealed class CMDoorSystem : EntitySystem
 
     }
 
-    private void OnDoorPry(Entity<RMCDoorComponent> ent, ref DoorPryEvent args)
+    private void OnDoorPry(Entity<RMCDoorComponent> ent, ref RMCDoorPryEvent args)
     {
         if (args.Cancelled)
         {

--- a/Content.Shared/_RMC14/Doors/RMCDoorComponent.cs
+++ b/Content.Shared/_RMC14/Doors/RMCDoorComponent.cs
@@ -1,0 +1,34 @@
+using Content.Shared.Damage;
+using Content.Shared.Doors.Systems;
+using Content.Shared.Tools;
+using JetBrains.Annotations;
+using Robust.Shared.Audio;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+using Robust.Shared.Timing;
+using DrawDepthTag = Robust.Shared.GameObjects.DrawDepth;
+
+namespace Content.Shared._RMC14.Doors;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true)]
+public sealed partial class RMCDoorComponent : Component
+{
+    /// <summary>
+    /// What sound to play when a xeno is prying the door
+    /// </summary>
+    [DataField]
+    public SoundSpecifier XenoPrySound = new SoundPathSpecifier("/Audio/Machines/airlock_creaking.ogg");
+
+    [DataField, AutoNetworkedField]
+    public EntityUid? SoundEntity;
+}
+
+[ByRefEvent]
+public record struct DoorPryEvent(EntityUid User)
+{
+    public readonly EntityUid User = User;
+
+    public bool Cancelled;
+}

--- a/Content.Shared/_RMC14/Doors/RMCDoorComponent.cs
+++ b/Content.Shared/_RMC14/Doors/RMCDoorComponent.cs
@@ -26,7 +26,7 @@ public sealed partial class RMCDoorComponent : Component
 }
 
 [ByRefEvent]
-public record struct DoorPryEvent(EntityUid User)
+public record struct RMCDoorPryEvent(EntityUid User)
 {
     public readonly EntityUid User = User;
 

--- a/Content.Shared/_RMC14/Doors/RMCPodDoorComponent.cs
+++ b/Content.Shared/_RMC14/Doors/RMCPodDoorComponent.cs
@@ -10,22 +10,8 @@ public sealed partial class RMCPodDoorComponent : Component
     public string? Id;
 
     /// <summary>
-    /// What sound to play when a xeno is prying a podlock
-    /// </summary>
-    [DataField]
-    public SoundSpecifier XenoPodlockUseSound = new SoundPathSpecifier("/Audio/Machines/airlock_creaking.ogg");
-
-    /// <summary>
     /// The doafter time multiplier for when a xeno is prying a podlock
     /// </summary>
     [DataField]
     public float XenoPodlockPryMultiplier = 4.0f;
-}
-
-[ByRefEvent]
-public record struct PodlockPryEvent(EntityUid User)
-{
-    public readonly EntityUid User = User;
-
-    public bool Cancelled;
 }

--- a/Content.Shared/_RMC14/Doors/RMCPodDoorComponent.cs
+++ b/Content.Shared/_RMC14/Doors/RMCPodDoorComponent.cs
@@ -4,6 +4,7 @@ using Robust.Shared.GameStates;
 namespace Content.Shared._RMC14.Doors;
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(CMDoorSystem))]
 public sealed partial class RMCPodDoorComponent : Component
 {
     [DataField, AutoNetworkedField]

--- a/Content.Shared/_RMC14/Doors/RMCPodDoorComponent.cs
+++ b/Content.Shared/_RMC14/Doors/RMCPodDoorComponent.cs
@@ -1,4 +1,5 @@
-﻿using Robust.Shared.GameStates;
+﻿using Robust.Shared.Audio;
+using Robust.Shared.GameStates;
 
 namespace Content.Shared._RMC14.Doors;
 
@@ -8,4 +9,10 @@ public sealed partial class RMCPodDoorComponent : Component
 {
     [DataField, AutoNetworkedField]
     public string? Id;
+
+    /// <summary>
+    /// What sound to play when a xeno is prying a podlock
+    /// </summary>
+    [DataField]
+    public SoundSpecifier XenoPodlockUseSound = new SoundPathSpecifier("/Audio/Machines/airlock_creaking.ogg");
 }

--- a/Content.Shared/_RMC14/Doors/RMCPodDoorComponent.cs
+++ b/Content.Shared/_RMC14/Doors/RMCPodDoorComponent.cs
@@ -4,7 +4,6 @@ using Robust.Shared.GameStates;
 namespace Content.Shared._RMC14.Doors;
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-[Access(typeof(CMDoorSystem))]
 public sealed partial class RMCPodDoorComponent : Component
 {
     [DataField, AutoNetworkedField]
@@ -21,4 +20,12 @@ public sealed partial class RMCPodDoorComponent : Component
     /// </summary>
     [DataField]
     public float XenoPodlockPryMultiplier = 4.0f;
+}
+
+[ByRefEvent]
+public record struct PodlockPryEvent(EntityUid User)
+{
+    public readonly EntityUid User = User;
+
+    public bool Cancelled;
 }

--- a/Content.Shared/_RMC14/Doors/RMCPodDoorComponent.cs
+++ b/Content.Shared/_RMC14/Doors/RMCPodDoorComponent.cs
@@ -15,4 +15,10 @@ public sealed partial class RMCPodDoorComponent : Component
     /// </summary>
     [DataField]
     public SoundSpecifier XenoPodlockUseSound = new SoundPathSpecifier("/Audio/Machines/airlock_creaking.ogg");
+
+    /// <summary>
+    /// The doafter time multiplier for when a xeno is prying a podlock
+    /// </summary>
+    [DataField]
+    public float XenoPodlockPryMultiplier = 4.0f;
 }

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
@@ -380,8 +380,7 @@
   - type: Prying
     pryPowered: true
     speedModifier: 2.7
-    useSound:
-      path: /Audio/Items/crowbar.ogg
+    useSound: null
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Doors/Shutters/poddoor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Doors/Shutters/poddoor.yml
@@ -22,7 +22,7 @@
         - FullTileLayer
   - type: AccessReader
   - type: Door
-    canPry: false # TODO RMC14
+    canPry: false
     crushDamage:
       types:
         Blunt: 25 # yowch
@@ -69,7 +69,7 @@
         - FullTileLayer
   - type: AccessReader
   - type: Door
-    canPry: false # TODO RMC14
+    canPry: false
     crushDamage:
       types:
         Blunt: 25 # yowch
@@ -98,7 +98,7 @@
   description: That looks like it doesn't open easily. Maybe look for a button or use a breaching charge?
   components:
   - type: Door
-    canPry: false # TODO RMC14
+    canPry: true
   - type: XenoCrusherChargable
     instantDestroy: true
 
@@ -128,7 +128,7 @@
     sprite: _RMC14/Structures/Doors/Shutters/Hybrisa/redpoddoor.rsi
   - type: MinimapColor
     color: "#451e5eb8"
-    
+
 - type: entity
   parent: RMCPodDoorHybrisaRed
   id: RMCPodDoorHybrisaRedOpen

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Doors/Shutters/shutters.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Doors/Shutters/shutters.yml
@@ -73,6 +73,7 @@
     activeLoad: 20
     channel: Environment
   - type: RMCOpenOnAlertLevel
+  - type: RMCDoor
 
 - type: entity
   parent: RMCShutterBaseIndestructible

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Doors/cm_door.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Doors/cm_door.yml
@@ -164,6 +164,7 @@
     percentageDamage: 0.25
   - type: XenoCrusherChargable
     instantDestroy: true
+  - type: RMCDoor
 
 - type: entity
   abstract: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Podlocks can now be pried open while unpowered. Xenos take 4 seconds to pry open podlocks and shutters, while marines take the same time as before. Xenos can no longer pry closed doors.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity

## Technical details
<!-- Summary of code changes for easier review. -->
Adds `RMCDoorComponent` which contains an event for when Doors are pried along with the time multiplier for Xenonid podlock prying and the sound for them prying things open. Adds `OnDoorPry` and `OnPodDoorGetPryTimeModifier` to `CMDoorSystem` which handles the audio and do-after time for Xenos prying, with xeno's prying sound being set to null so we can play a sound at the start of the do-after opposed to at the end. Adds a check to `PryingSystem` that prevents xenos from prying closed doors, along with calling the `RMCDoorPryEvent` when the do-after starts. Makes `UseSound ` in `PryingComponent` nullable.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://github.com/user-attachments/assets/7ed0a39b-bed5-4247-946e-0586886c3030

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Podlocks can now be pried open when unpowered.
- fix: Xenonids now take 4 seconds to pry open podlocks and shutters.
- fix: Xenonids now have a unique sound when prying open things.
- fix: Xenonids cannot pry doors closed anymore.
