### PR TITLE
Escape pod fixes

### DIFF
--- a/Content.Shared/_RMC14/Evacuation/SharedEvacuationSystem.cs
+++ b/Content.Shared/_RMC14/Evacuation/SharedEvacuationSystem.cs
@@ -677,9 +677,9 @@ public abstract class SharedEvacuationSystem : EntitySystem
                         if (_doorQuery.TryComp(uid, out var door))
                         {
                             var evacuationDoor = EnsureComp<EvacuationDoorComponent>(uid);
-                            evacuationDoor.Locked = true;
+                            evacuationDoor.Locked = false;
                             Dirty(uid, evacuationDoor);
-                            _door.TryClose(uid, door);
+                            _door.TryOpen(uid, door);
                         }
                     }
                 }

--- a/Content.Shared/_RMC14/Evacuation/SharedEvacuationSystem.cs
+++ b/Content.Shared/_RMC14/Evacuation/SharedEvacuationSystem.cs
@@ -351,10 +351,11 @@ public abstract class SharedEvacuationSystem : EntitySystem
             }
         }
 
+        _audio.PlayPredicted(ent.Comp.WarmupSound, ent, user);
+
         if (ent.Comp.Mode == EvacuationComputerMode.Crashed)
             return;
 
-        _audio.PlayPredicted(ent.Comp.WarmupSound, ent, user);
         ent.Comp.Mode = EvacuationComputerMode.Travelling;
         Dirty(ent);
 

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/rmc_communications_console.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/rmc_communications_console.yml
@@ -236,6 +236,12 @@
     blacklist:
       components:
       - Xeno
+  - type: Explosive
+    explosionType: RMC
+    totalIntensity: 100
+    intensitySlope: 20
+    maxIntensity: 75
+    canCreateVacuum: false
 
 - type: entity
   parent: RMCEscapePodController


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Makes the escape pod computer actually explode over the 3 person limit
Fixes the escape pod doors being locked shut when it crashes, in CM13 it just forces it unlocked

## Technical details
![image](https://github.com/user-attachments/assets/870fc66b-3dad-444d-b725-334745484e8c)
Trigger explosive is called, but the computer doesn't have an explosive component.

## CM13 Code
![image](https://github.com/user-attachments/assets/7ccd4e06-56fa-4217-921e-b7dae46f47bf)
![image](https://github.com/user-attachments/assets/e80d148d-2bc8-4e18-bdbd-89801d8f3ebe)
![image](https://github.com/user-attachments/assets/d2f00296-ffda-4fcf-850f-4fe5d7c2bd3f)


:cl:
- fix: Fixed escape pods not exploding when it's launched over the maximum occupancy, and not reopening the door.