### PR TITLE
Fix FORECON Radio

### DIFF
--- a/Resources/Locale/en-US/_RMC14/radio-channels.ftl
+++ b/Resources/Locale/en-US/_RMC14/radio-channels.ftl
@@ -16,7 +16,7 @@ chat-radio-marine-delta = Delta
 chat-radio-marine-echo = Echo
 chat-radio-marine-foxtrot = Foxtrot
 
-chat-radio-forecon = FORECON
+chat-radio-marine-sof = SOF
 
 chat-radio-colony = Colony
 chat-radio-WY = We-Ya

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/distress_headsets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/distress_headsets.yml
@@ -129,10 +129,13 @@
 - type: entity
   parent: RMCHeadsetMarine
   id: RMCHeadsetForecon
-  name: Force Recon headset
-  description: A headset given to FORECON marines.
+  name: UNMC SOF headset
+  description: Issued exclusively to Marine Raiders and members of the UNMC's Force Reconnaissance.
   suffix: Survivor
   components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Clothing/headsets.rsi
+    state: soc_headset
   - type: ContainerFill
     containers:
       key_slots:

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/distress_headsets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/distress_headsets.yml
@@ -15,6 +15,7 @@
   id: RMCHeadsetColonyIcons
   name: colony headset
   description: A standard headset used by colonists.
+  suffix: With HUD Icons
   components:
   - type: ContainerFill
     containers:
@@ -134,10 +135,10 @@
   - type: ContainerFill
     containers:
       key_slots:
-      - RMCEncryptionKeyFORECON
+      - CMEncryptionKeyColony
   - type: RMCHeadset
     channels:
-    - MarineForecon
+    - MarineSOF
 
 #for UNMC personnel
 - type: entity

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/distress_headsets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/distress_headsets.yml
@@ -131,6 +131,7 @@
   id: RMCHeadsetForecon
   name: Force Recon headset
   description: A headset given to FORECON marines.
+  suffix: Survivor
   components:
   - type: ContainerFill
     containers:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/IdCards/cm_base_id.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/IdCards/cm_base_id.yml
@@ -239,7 +239,7 @@
     - MarineRequisition
     - MarineJTAC
     - MarineIntel
-    - MarineForecon
+    - MarineSOF
     - WEYA
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/squads.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/squads.yml
@@ -269,7 +269,7 @@
     - Helmet
     - Goggles
     - Armor
-    radio: MarineForecon
+    radio: MarineSOF
     minimapBackground:
       sprite: _RMC14/Interface/map_blips.rsi
       state: background_forecon
@@ -292,7 +292,7 @@
     background:
       sprite: _RMC14/Interface/cm_job_icons.rsi
       state: empty
-    radio: null
+    radio: MarineSOF
     accessLevels: []
     minimapBackground:
       sprite: _RMC14/Interface/map_blips.rsi

--- a/Resources/Prototypes/_RMC14/radio_channels.yml
+++ b/Resources/Prototypes/_RMC14/radio_channels.yml
@@ -139,11 +139,11 @@
 
 # Marine Special Forces
 - type: radioChannel
-  id: MarineForecon
-  name: chat-radio-forecon
+  id: MarineSOF
+  name: chat-radio-marine-sof
   keycode: "k"
   frequency: 1724
-  color: "#32CD32"
+  color: "#400000"
   longRange: true
   tower: true
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Renames the FORECON radio channel to SOF
Correctly removes all the almayer comms from the survivor forecon headset and adds a colony comms instead
Parity

**Changelog**
:cl:
- fix: Fixed FORECON having almayer comms
- fix: Renamed FORECON radio channel to 'SOF'
