### PR TITLE
Sorokyne strata survivor fixes

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/armed_police_officer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/armed_police_officer.yml
@@ -51,11 +51,9 @@
     head: CMHeadCapSPPPeakedPolice
     eyes: CMGlassesSecurity
     jumpsuit: RMCJumpsuitSPPPaP
-    belt: RMCBeltHolsterPistolSPPT73
     outerClothing: RMCCoatPaP
     gloves: RMCHandsVeteran
     shoes: CMBootsBlackFilled
-    mask: RMCMaskGasSPP
     pocket2: RMCPouchMagazine
     id: RMCIDCardPaP
     back: RMCSatchelBlack
@@ -63,6 +61,7 @@
   storage:
     back:
     - CMSheetMetal20
+    - RMCMaskGasSPP
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/army_reservist.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/army_reservist.yml
@@ -67,10 +67,10 @@
 - type: entity
   parent: CMSpawnPointJobBase
   id: RMCSpawnPointSurvivorArmyReservist
-  name: people's armed police officer spawn point
+  name: army reservist spawn point
   components:
   - type: SpawnPoint
-    job_id: CMSurvivor
+    job_id: CMJobSurvivorArmyReservist
   - type: Sprite # TODO: Replace with landmark sprite
     layers:
     - sprite: Markers/jobs.rsi

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/civilian.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/civilian.yml
@@ -33,7 +33,6 @@
   parent: RMCGearSurvivorBase
   id: RMCGearSurvivorSoroCivilian
   equipment:
-    mask: RMCMaskGasSPP
     head: RMCHeadCapSPPCivilianPlantWorker
     ears: RMCHeadsetDistressSPP
 
@@ -109,3 +108,6 @@
       - RMCShoesJackboots
       - RMCBootsSPPBlackFilled
       - RMCBootsSPPFilled
+    randomGearOther:
+    -
+      - [ CMSheetMetal20, RMCMaskGasSPP ]

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/doctor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/doctor.yml
@@ -35,12 +35,12 @@
   parent: RMCGearSurvivorBase
   id: RMCGearSurvivorMoHDoctor
   equipment:
-    mask: RMCMaskGasSPP
     head: RMCHeadCapSPPCivilianPlantWorker
     ears: RMCHeadsetDistressSPP
   storage:
     back:
     - CMSheetMetal20
+    - RMCMaskGasSPP
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/fire_protection_specialist.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/fire_protection_specialist.yml
@@ -39,7 +39,6 @@
     back: RMCSatchelLightpack
     head: RMCArmorHelmetSPPFirefighter
     outerClothing: RMCArmorSPPFirefighter
-    mask: RMCMaskGasSPP
     ears: RMCHeadsetDistressSPP
   storage:
     back:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/infrastructure_engineer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/infrastructure_engineer.yml
@@ -41,12 +41,12 @@
     head: RMCHardhatOrange
     outerClothing: RMCHazardVest
     gloves: CMHandsInsulated
-    mask: RMCMaskGasSPP
     ears: RMCHeadsetDistressSPP
     pocket2: RMCWelderIndustrial
   storage:
     back:
     - CMSheetMetal20
+    - RMCMaskGasSPP
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/liaison.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/liaison.yml
@@ -46,6 +46,7 @@
   storage:
     back:
     - CMSheetMetal20
+    - RMCMaskGasSPP
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/miner.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/miner.yml
@@ -33,7 +33,6 @@
   parent: RMCGearSurvivorBase
   id: RMCGearSurvivorSoroMiner
   equipment:
-    mask: RMCMaskGasSPP
     head: RMCHardhatWhiteAlt
     jumpsuit: RMCJumpsuitSPPCiv5
     back: CMSatchelEngineer
@@ -45,6 +44,7 @@
   storage:
     back:
     - CMSheetMetal20
+    - RMCMaskGasSPP
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/reactor_technician.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/reactor_technician.yml
@@ -42,6 +42,7 @@
   storage:
     back:
     - CMSheetMetal20
+    - RMCMaskGasSPP
 
 - type: entity
   parent: CMSpawnPointJobBase
@@ -68,6 +69,6 @@
   components:
   - type: SurvivorPreset
     randomOutfits:
-    - [ RMCHeadCapSPPCivilianPlantWorker, RMCLabcoatShort, CMSatchel, RMCShoesWhite, RMCMaskGasSPP ]
-    - [ RMCLabcoatShort, CMSatchel, RMCShoesLaceupBrown, RMCMaskGasSPP ]
-    - [ RMCHeadRadiationHood, RMCSuitRadiation, CMSatchel, RMCShoesLaceupBrown, RMCMaskGasSPP ]
+    - [ RMCHeadCapSPPCivilianPlantWorker, RMCLabcoatShort, CMSatchel, RMCShoesWhite ]
+    - [ RMCLabcoatShort, CMSatchel, RMCShoesLaceupBrown ]
+    - [ RMCHeadRadiationHood, RMCSuitRadiation, CMSatchel, RMCShoesLaceupBrown ]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- Fixes the survivors spawning with the gas mask on their mask. This is not how it works in cm13; they spawn with it in their bag.
- Fixes the police officer spawning with a pistol belt. In CM13, the primary weapon with the belt overrides the pistol belt.
- Fixes the civilian not spawning with metal.

**Changelog**
update not live yet