### PR TITLE
Actually fix escape pods

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/rmc_communications_console.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/rmc_communications_console.yml
@@ -236,12 +236,6 @@
     blacklist:
       components:
       - Xeno
-  - type: Explosive
-    explosionType: RMC
-    totalIntensity: 100
-    intensitySlope: 20
-    maxIntensity: 75
-    canCreateVacuum: false
 
 - type: entity
   parent: RMCEscapePodController


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Makes it queue an explosion on a valid unblocked tile
currently it'll explode inside a wall

changes the door incorrectly referencing the escape pod computer instead of the grid's child
