### PR TITLE
Fix oppressor abilities going through things they shouldn't

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_projectiles.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_projectiles.yml
@@ -417,4 +417,16 @@
   - type: RMCProjectileAccuracy
     accuracy: 185
   - type: XenoHookOnHit
+  - type: Fixtures
+    fixtures:
+      projectile:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.1,-0.1,0.1,0.1"
+        hard: false
+        mask:
+        - Impassable
+        - BulletImpassable
+        - XenoProjectileImpassable
+        - BarricadeImpassable
 

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Base/base_structure.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Base/base_structure.yml
@@ -183,6 +183,7 @@
   - type: Tag
     tags:
     - SpreaderIgnore
+    - Wall
   - type: XenoToggleChargingDamage
     stop: true
     damage:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The Oppressor's Tail Seize projectile doesn't go over barricades anymore, it hits the barricade instead.
The Oppressor's Abduct ability doesn't go through resin walls anymore.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity

## Technical details
<!-- Summary of code changes for easier review. -->
The resin wall's "wall" tag inherited from BaseXenoStructure was overwritten and not applied.
The Oppressor's Tail Seize projectile now also has the BarricadeImpassable collision mask.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Dygon
- fix: Fixed Oppressor's Tail Seize ability going over barricades.
- fix: Fixed Oppressor's Abduct ability going through resin walls.

