### PR TITLE
Prevent airburst grenade projectiles from colliding with dead bodies

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m74_airburst_grenades.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m74_airburst_grenades.yml
@@ -326,6 +326,14 @@
 
 - type: entity
   parent: RMCBaseBullet
+  id: RMCBaseAirburstRound
+  categories: [ HideSpawnMenu ]
+  abstract: true
+  components:
+  - type: PreventCollideWithDead
+
+- type: entity
+  parent: RMCBaseAirburstRound
   id: RMCHornetRound
   name: .22 Hornet Round
   categories: [ HideSpawnMenu ]
@@ -347,7 +355,7 @@
     amount: 25
 
 - type: entity
-  parent: RMCBaseBullet
+  parent: RMCBaseAirburstRound
   id: RMCShrapnelJagged
   name: Jagged Shrapnel
   categories: [ HideSpawnMenu ]
@@ -377,7 +385,7 @@
       falloff: 33
 
 - type: entity
-  parent: RMCBaseBullet
+  parent: RMCBaseAirburstRound
   id: RMCShrapnelIncendiary
   name: Flaming Shrapnel
   categories: [ HideSpawnMenu ]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Airburst grenade projectiles now don't hit dead bodies anymore.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug fix

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix: Fixed Airburst grenade projectiles hitting corpses.

