### PR TITLE
Show transfer direction when examining reagent tanks.

### DIFF
--- a/Content.Shared/_RMC14/Chemistry/RMCToggleableSolutionTransferComponent.cs
+++ b/Content.Shared/_RMC14/Chemistry/RMCToggleableSolutionTransferComponent.cs
@@ -8,4 +8,11 @@ public sealed partial class RMCToggleableSolutionTransferComponent : Component
 {
     [DataField(required: true), AutoNetworkedField]
     public string Solution;
+
+    [DataField, AutoNetworkedField]
+    public SolutionTransferDirection Direction = SolutionTransferDirection.Input;
+}
+public enum SolutionTransferDirection
+{
+    Input, Output,
 }

--- a/Content.Shared/_RMC14/Chemistry/SharedRMCChemistrySystem.cs
+++ b/Content.Shared/_RMC14/Chemistry/SharedRMCChemistrySystem.cs
@@ -96,6 +96,17 @@ public abstract class SharedRMCChemistrySystem : EntitySystem
 
                 args.PushText($"Total volume: {solution.Volume} / {solution.MaxVolume}.");
             }
+            if (EntityManager.TryGetComponent<RMCToggleableSolutionTransferComponent>(ent.Owner, out var transferComp))
+            {
+                var directionText = transferComp.Direction switch
+                {
+                    SolutionTransferDirection.Input => "Transfer mode: Drawing",
+                    SolutionTransferDirection.Output => "Transfer mode: Dispensing",
+                    _ => string.Empty,
+                };
+                if (!string.IsNullOrEmpty(directionText))
+                    args.PushText(directionText);
+            }
         }
     }
 
@@ -106,6 +117,7 @@ public abstract class SharedRMCChemistrySystem : EntitySystem
 
     private void OnToggleableSolutionTransferMapInit(Entity<RMCToggleableSolutionTransferComponent> ent, ref MapInitEvent args)
     {
+        ent.Comp.Direction = SolutionTransferDirection.Input;
         RemCompDeferred<DrainableSolutionComponent>(ent);
         var refillable = EnsureComp<RefillableSolutionComponent>(ent);
         refillable.Solution = ent.Comp.Solution;
@@ -130,6 +142,7 @@ public abstract class SharedRMCChemistrySystem : EntitySystem
                     RemCompDeferred<DrainableSolutionComponent>(ent);
                     var refillable = EnsureComp<RefillableSolutionComponent>(ent);
                     refillable.Solution = ent.Comp.Solution;
+                    ent.Comp.Direction = SolutionTransferDirection.Input;
                     Dirty(ent, refillable);
                     _popup.PopupClient("Now drawing", ent, user, PopupType.Medium);
                 }
@@ -138,6 +151,7 @@ public abstract class SharedRMCChemistrySystem : EntitySystem
                     RemCompDeferred<RefillableSolutionComponent>(ent);
                     var drainable = EnsureComp<DrainableSolutionComponent>(ent);
                     drainable.Solution = ent.Comp.Solution;
+                    ent.Comp.Direction = SolutionTransferDirection.Output;
                     Dirty(ent, drainable);
                     _popup.PopupClient("Now dispensing", ent, user, PopupType.Medium);
                 }

--- a/Content.Shared/_RMC14/Chemistry/SharedRMCChemistrySystem.cs
+++ b/Content.Shared/_RMC14/Chemistry/SharedRMCChemistrySystem.cs
@@ -96,17 +96,15 @@ public abstract class SharedRMCChemistrySystem : EntitySystem
 
                 args.PushText($"Total volume: {solution.Volume} / {solution.MaxVolume}.");
             }
-            if (EntityManager.TryGetComponent<RMCToggleableSolutionTransferComponent>(ent.Owner, out var transferComp))
+            var transferComp = EntityManager.GetComponent<RMCToggleableSolutionTransferComponent>(ent.Owner);
+            var directionText = transferComp.Direction switch
             {
-                var directionText = transferComp.Direction switch
-                {
-                    SolutionTransferDirection.Input => "Transfer mode: Drawing",
-                    SolutionTransferDirection.Output => "Transfer mode: Dispensing",
-                    _ => string.Empty,
-                };
-                if (!string.IsNullOrEmpty(directionText))
-                    args.PushText(directionText);
-            }
+                SolutionTransferDirection.Input => "Transfer mode: Drawing",
+                SolutionTransferDirection.Output => "Transfer mode: Dispensing",
+                _ => string.Empty,
+            };
+            if (!string.IsNullOrEmpty(directionText))
+                args.PushText(directionText);
         }
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity QoL
## Technical details
<!-- Summary of code changes for easier review. -->
Adds transfer direction text on examine.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1920" height="1080" alt="Screenshot (228)" src="https://github.com/user-attachments/assets/b2325c32-346d-435e-8b0f-18cb725b48c8" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Transfer directions on reagent tanks are now visible when you examine them. No more guessing games.