### PR TITLE
Flamethrowers now ignite the tile that blocks their fire spray

### DIFF
--- a/Content.Shared/_RMC14/Line/LineSystem.cs
+++ b/Content.Shared/_RMC14/Line/LineSystem.cs
@@ -37,7 +37,7 @@ public sealed class LineSystem : EntitySystem
         _mapGridQuery = GetEntityQuery<MapGridComponent>();
     }
 
-    public List<LineTile> DrawLine(EntityCoordinates start, EntityCoordinates end, TimeSpan delayPer, out EntityUid? blocker)
+    public List<LineTile> DrawLine(EntityCoordinates start, EntityCoordinates end, TimeSpan delayPer, out EntityUid? blocker, bool hitBlocker = false)
     {
         blocker = null;
         start = _mapSystem.AlignToGrid(_transform.GetMoverCoordinates(start));
@@ -70,13 +70,16 @@ public sealed class LineSystem : EntitySystem
 
             var direction = (entityCoords.Position - lastCoords.Position).ToWorldAngle();
             var blocked = IsTileBlocked(grid, entityCoords, direction, out blocker);
-            if (blocked)
+            if (blocked && !hitBlocker)
                 break;
 
             lastCoords = entityCoords;
             var mapCoords = _transform.ToMapCoordinates(entityCoords);
             tiles.Add(new LineTile(mapCoords, time + delayPer * delay));
             delay++;
+
+            if (blocked)
+                break;
         }
 
         return tiles;

--- a/Content.Shared/_RMC14/Weapons/Ranged/Flamer/SharedRMCFlamerSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/Flamer/SharedRMCFlamerSystem.cs
@@ -226,7 +226,6 @@ public abstract class SharedRMCFlamerSystem : EntitySystem
 
         _audio.PlayPredicted(gun.Comp.SoundGunshotModified, gun, user);
         var normalized = -delta.Normalized();
-        var originalCoordinates = fromCoordinates;
 
         // to prevent hitting yourself
         fromCoordinates = fromCoordinates.Offset(normalized * 0.23f);

--- a/Content.Shared/_RMC14/Weapons/Ranged/Flamer/SharedRMCFlamerSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/Flamer/SharedRMCFlamerSystem.cs
@@ -234,7 +234,7 @@ public abstract class SharedRMCFlamerSystem : EntitySystem
         if (delta.Length() > flamer.Comp.Range)
             toCoordinates = fromCoordinates.Offset(normalized * range);
 
-        var tiles = _line.DrawLine(fromCoordinates, toCoordinates, flamer.Comp.DelayPer, out _);
+        var tiles = _line.DrawLine(fromCoordinates, toCoordinates, flamer.Comp.DelayPer, out _, true);
         if (tiles.Count == 0 || !_interaction.InRangeUnobstructed(flamer, tiles[0].Coordinates, 3))
             return;
 

--- a/Content.Shared/_RMC14/Weapons/Ranged/Flamer/SharedRMCFlamerSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/Flamer/SharedRMCFlamerSystem.cs
@@ -229,14 +229,14 @@ public abstract class SharedRMCFlamerSystem : EntitySystem
         var originalCoordinates = fromCoordinates;
 
         // to prevent hitting yourself
-        fromCoordinates = fromCoordinates.Offset(normalized * 0.3f);
+        fromCoordinates = fromCoordinates.Offset(normalized * 0.23f);
 
         var range = Math.Min((volume / flamer.Comp.CostPer).Int(), flamer.Comp.Range);
         if (delta.Length() > flamer.Comp.Range)
             toCoordinates = fromCoordinates.Offset(normalized * range);
 
         var tiles = _line.DrawLine(fromCoordinates, toCoordinates, flamer.Comp.DelayPer, out _, true);
-        if (tiles.Count == 0 || !_transform.InRange(originalCoordinates, _transform.ToCoordinates(tiles[0].Coordinates), 1.5f))
+        if (tiles.Count == 0)
             return;
 
         ProtoId<ReagentPrototype>? reagent = null;

--- a/Content.Shared/_RMC14/Weapons/Ranged/Flamer/SharedRMCFlamerSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/Flamer/SharedRMCFlamerSystem.cs
@@ -226,16 +226,17 @@ public abstract class SharedRMCFlamerSystem : EntitySystem
 
         _audio.PlayPredicted(gun.Comp.SoundGunshotModified, gun, user);
         var normalized = -delta.Normalized();
+        var originalCoordinates = fromCoordinates;
 
         // to prevent hitting yourself
-        fromCoordinates = fromCoordinates.Offset(normalized * 0.37f);
+        fromCoordinates = fromCoordinates.Offset(normalized * 0.3f);
 
         var range = Math.Min((volume / flamer.Comp.CostPer).Int(), flamer.Comp.Range);
         if (delta.Length() > flamer.Comp.Range)
             toCoordinates = fromCoordinates.Offset(normalized * range);
 
         var tiles = _line.DrawLine(fromCoordinates, toCoordinates, flamer.Comp.DelayPer, out _, true);
-        if (tiles.Count == 0 || !_interaction.InRangeUnobstructed(flamer, tiles[0].Coordinates, 3))
+        if (tiles.Count == 0 || !_transform.InRange(originalCoordinates, _transform.ToCoordinates(tiles[0].Coordinates), 1.5f))
             return;
 
         ProtoId<ReagentPrototype>? reagent = null;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Flamethrower fire now ignites a wall and then stops instead of stopping in front of the wall.
Added flamethrowers, acid sprays and the Vanguards Pierce ability not going through resin walls anymore to the changelog, it got fixed by an already merged PR that is not live yet.

Reduced the offset range of where a flamer starts it's fire, this means that you're able to hug a wall and flame it without it being cancelled. The offset is now low enough to prevent the tile behind the wall being targeted, it's also still high enough to prevent igniting the tile you're standing on.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity.

## Technical details
<!-- Summary of code changes for easier review. -->
In #6991 resin walls not having a "wall" tag got fixed, this means that the LineSystem now properly counts them as an obstacle, preventing fire from going on the tile. DrawLine now has a new argument that, if set to true, includes the blocker tile as a valid target.
Apparently before that PR flamethrowers completely ignored resin walls too, which is why I was able to ignite walls while testing in the PR that added resin structures taking fire damage.

I removed the InRangeUnobstucted check since the new smaller offset won't target a tile behind a wall.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Dygon
- fix: Flamethrower fire, acid sprays, and the Vanguard's Pierce action no longer pass through resin walls.
- tweak: Flamethrowers now require slightly less range between the user and the first spawned fire tile.