### PR TITLE
Fix light combat pack size being too small

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Back/satchels.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Back/satchels.yml
@@ -28,9 +28,9 @@
   parent: CMSatchel
   id: CMSatchelFillColonySynthetic
   suffix: Survivor
-  components: 
+  components:
   - type: StorageFill
-    contents: 
+    contents:
     - id: CMDefibrillator
 
 
@@ -530,6 +530,9 @@
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Back/Satchels/Other/lightpack.rsi
+  - type: Storage
+    grid:
+    - 0,0,19,1 # 20
 
 - type: entity
   parent: RMCSatchelLightpack


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Parity, supposed to have same storage space has the intel backpacks

:cl:
- fix: Fixed the lightweight combat pack (the PMC one) having less storage space than intended.
