### PR TITLE
Add handcannon belt, add handcannon belt visuals

### DIFF
--- a/Resources/Prototypes/_RMC14/Catalog/Fills/Clothing/belt.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Fills/Clothing/belt.yml
@@ -238,3 +238,14 @@
     contents:
     - id: RMCMagazineRifleMAR40
       amount: 5
+
+- type: entity
+  parent: RMCBeltHolsterPistol
+  id: RMCBeltHolsterPistolHandcannonFilled
+  suffix: Filled, Handcannon
+  components:
+  - type: StorageFill
+    contents:
+    - id: RMCMagazinePistolHandcannon
+      amount: 6
+    - id: RMCWeaponPistolHandcannon

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
@@ -658,6 +658,15 @@
     - sprite: _RMC14/Objects/Weapons/Guns/gun_underlays.rsi
       state: highpower
       map: [ "mk45_fill" ]
+    - sprite: _RMC14/Objects/Weapons/Guns/gun_underlays.rsi
+      state: deagle
+      map: [ "handcannon_fill" ]
+    - sprite: _RMC14/Objects/Weapons/Guns/gun_underlays.rsi
+      state: g_deagle
+      map: [ "g_handcannon_fill" ]
+    - sprite: _RMC14/Objects/Weapons/Guns/gun_underlays.rsi
+      state: c_deagle
+      map: [ "co_handcannon_fill" ]
     - state: icon-front
       map: [ "holstered" ]
     - state: half
@@ -710,6 +719,9 @@
     - b92fs_fill
     - mk45_fill
     - m13_fill
+    - handcannon_fill
+    - g_handcannon_fill
+    - co_handcannon_fill
     mapLayers:
       holstered:
         whitelist:
@@ -739,6 +751,18 @@
         whitelist:
           tags:
           - RMCWeaponPistolM13
+      handcannon_fill:
+        whitelist:
+          tags:
+          - RMCWeaponPistolHandcannon
+      g_handcannon_fill:
+        whitelist:
+          tags:
+          - RMCWeaponPistolHandcannonGold
+      co_handcannon_fill:
+        whitelist:
+          tags:
+          - RMCWeaponPistolHandcannonWyvern
   - type: ItemCamouflage
     camouflageVariations:
       Jungle: _RMC14/Objects/Clothing/Belt/holster_pistol/classic-jungle.rsi

--- a/Resources/Prototypes/_RMC14/Entities/Markers/Spawners/Random/guns.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Markers/Spawners/Random/guns.yml
@@ -35,7 +35,7 @@
     # TODO 3 KT-42 automag
     - CMWeaponPistolM1984: CMMagazinePistolM1984 # TODO M1911
     # TODO S&W revolver
-    # TODO desert eagle
+    - RMCWeaponPistolHandcannon: RMCMagazinePistolHandcannon
     # TODO CZ-81 machine pistol
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Corpses/civilians.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Corpses/civilians.yml
@@ -186,7 +186,7 @@
     eyes: CMGlassesSecurity
     id: RMCIDCardDeputy
     ears: CMHeadsetColony
-#    belt: /obj/item/storage/belt/gun/m4a3/heavy
+    belt: RMCBeltHolsterPistolHandcannonFilled
 
 # Corporate Liaison
 - type: randomHumanoidSettings

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/peregrine_handcannon.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/peregrine_handcannon.yml
@@ -69,6 +69,10 @@
       rmc-aslot-barrel: 0.75, 0.070
       rmc-aslot-rail: 0.090, 0.125
       rmc-aslot-underbarrel: 0.312, -0.25
+  - type: Tag
+    tags:
+    - Sidearm
+    - RMCWeaponPistolHandcannon
 
 - type: entity
   parent: RMCWeaponPistolHandcannon
@@ -110,6 +114,10 @@
           - RMCMagazinePistolHandcannonHI
           - RMCMagazinePistolHandcannonHIAP
         startingItem: RMCMagazinePistolHandcannonHI
+  - type: Tag
+    tags:
+    - Sidearm
+    - RMCWeaponPistolHandcannonGold
 
 - type: entity
   parent: RMCWeaponPistolHandcannonGold
@@ -121,6 +129,10 @@
     sprite: _RMC14/Objects/Weapons/Guns/Pistols/handcannon_winter.rsi
   - type: Clothing
     sprite: _RMC14/Objects/Weapons/Guns/Pistols/handcannon_winter.rsi
+  - type: Tag
+    tags:
+    - Sidearm
+    - RMCWeaponPistolHandcannonWyvern
 
 - type: entity
   parent: CMBaseMagazinePistol
@@ -284,6 +296,15 @@
     stunTime: 1
   - type: RMCProjectileAccuracy
     accuracy: 70
+
+- type: Tag
+  id: RMCWeaponPistolHandcannon
+
+- type: Tag
+  id: RMCWeaponPistolHandcannonGold
+
+- type: Tag
+  id: RMCWeaponPistolHandcannonWyvern
 
 - type: Tag
   id: RMCMagazinePistolHandcannon


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added the peregrine handcannon to the CMB deputy corpse
Adds belt visuals for the handcannon, also gave it its proper tags

**Changelog**
update not live yet
