### PR TITLE
Disables being able to place glass tiles

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Materials/Sheets/glass.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Materials/Sheets/glass.yml
@@ -16,10 +16,41 @@
   maxCount: 50
 
 - type: entity
-  parent: SheetGlassBase
+  parent: BaseItem
   id: CMSheetGlassBase
   abstract: true
   components:
+  - type: Material
+    damageContainer: Inorganic
+    damageModifierSet: Glass
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
+        damage: 50
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: GlassBreak
+          params:
+            volume: -4
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          ShardGlass:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: SolutionContainerManager
+    solutions:
+      glass:
+        canReact: false
   - type: Stack
     count: 50
   - type: Sprite


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Makes CMSheetGlassBase no longer parent from SheetGlassBase and instead BaseItem with the needed components added. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Prevents players from being able to place glass floors which were immersion breaking (why can i see space through the floor of the 2nd deck of the Almayer). Upstream tiles are also bad.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: noctyrnal
- fix: Glass sheets no longer let you place upstream glass tiles.
