### PR TITLE
Xeno announcement upon expiration of queen death cooldown and hive core cooldowns

### DIFF
--- a/Content.Server/_RMC14/Xenonids/Construction/XenoPylonSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Construction/XenoPylonSystem.cs
@@ -53,7 +53,14 @@ public sealed class XenoPylonSystem : SharedXenoPylonSystem
     {
         if (_hive.GetHive(ent.Owner) is {} hive &&
             _gameTicker.RoundDuration() > hive.Comp.PreSetupCutoff)
+        {
             hive.Comp.NewCoreAt = _timing.CurTime + hive.Comp.NewCoreCooldown;
+            Dirty(hive);
+
+            var ev = new HiveCoreDestroyedEvent(hive.Owner);
+            RaiseLocalEvent(hive.Owner, ref ev);
+        }
+            
     }
 
     private void OnXenoSpawnerUsed(Entity<XenoComponent> xeno, ref GhostRoleSpawnerUsedEvent args)

--- a/Content.Shared/_RMC14/Xenonids/Hive/HiveComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hive/HiveComponent.cs
@@ -29,12 +29,6 @@ public sealed partial class HiveComponent : Component
     public Dictionary<TimeSpan, List<EntProtoId>> Unlocks = new();
 
     [DataField, AutoNetworkedField]
-    public HashSet<EntProtoId> AnnouncedUnlocks = new();
-
-    [DataField, AutoNetworkedField]
-    public List<TimeSpan> AnnouncementsLeft = [];
-
-    [DataField, AutoNetworkedField]
     public SoundSpecifier AnnounceSound = new SoundPathSpecifier("/Audio/_RMC14/Xeno/alien_distantroar_3.ogg", AudioParams.Default.WithVolume(-6));
 
     [DataField, AutoNetworkedField]

--- a/Content.Shared/_RMC14/Xenonids/Hive/SharedXenoHiveSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hive/SharedXenoHiveSystem.cs
@@ -91,9 +91,7 @@ public abstract class SharedXenoHiveSystem : EntitySystem
 
     private void OnMapInit(Entity<HiveComponent> ent, ref MapInitEvent args)
     {
-        ent.Comp.AnnouncedUnlocks.Clear();
         ent.Comp.Unlocks.Clear();
-        ent.Comp.AnnouncementsLeft.Clear();
 
         foreach (var prototype in _prototypes.EnumeratePrototypes<EntityPrototype>())
         {
@@ -104,17 +102,14 @@ public abstract class SharedXenoHiveSystem : EntitySystem
                 continue;
 
             ent.Comp.Unlocks.GetOrNew(xeno.UnlockAt).Add(prototype.ID);
-
-            if (!ent.Comp.AnnouncementsLeft.Contains(xeno.UnlockAt))
-                ent.Comp.AnnouncementsLeft.Add(xeno.UnlockAt);
         }
 
-        foreach (var unlock in ent.Comp.Unlocks)
+        foreach (var (time, castes) in ent.Comp.Unlocks)
         {
-            unlock.Value.Sort();
+            castes.Sort();
+            var ev = new CasteUnlockScheduleAnnouncement(time, castes);
+            RaiseLocalEvent(ent.Owner, ref ev);
         }
-
-        ent.Comp.AnnouncementsLeft.Sort();
     }
 
     /// <summary>
@@ -398,3 +393,10 @@ public readonly record struct QueenDeathEvent(EntityUid Hive);
 /// </summary>
 [ByRefEvent]
 public readonly record struct HiveCoreDestroyedEvent(EntityUid Hive);
+
+/// <summary>
+/// Raised on a hive entity during map init to schedule a timed message
+/// for when new xeno castes become available during evolution.
+/// </summary>
+[ByRefEvent]
+public readonly record struct CasteUnlockScheduleAnnouncement(TimeSpan UnlockAt, List<EntProtoId> Castes);

--- a/Content.Shared/_RMC14/Xenonids/Hive/SharedXenoHiveSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hive/SharedXenoHiveSystem.cs
@@ -72,17 +72,21 @@ public abstract class SharedXenoHiveSystem : EntitySystem
         }
     }
 
-    private void OnGranterMobStateChanged(Entity<XenoEvolutionGranterComponent> ent, ref MobStateChangedEvent args)
+    protected virtual void OnGranterMobStateChanged(Entity<XenoEvolutionGranterComponent> ent, ref MobStateChangedEvent args)
     {
         if (args.NewMobState != MobState.Dead)
             return;
 
-        if (GetHive(ent.Owner) is {} hive)
-        {
-            hive.Comp.LastQueenDeath = _timing.CurTime;
-            hive.Comp.CurrentQueen = null;
-            Dirty(hive);
-        }
+        if (GetHive(ent.Owner) is not { } hive)
+            return;
+
+        hive.Comp.LastQueenDeath = _timing.CurTime;
+        hive.Comp.CurrentQueen = null;
+
+        Dirty(hive);
+
+        var ev = new QueenDeathEvent(hive.Owner);
+        RaiseLocalEvent(hive.Owner, ref ev);
     }
 
     private void OnMapInit(Entity<HiveComponent> ent, ref MapInitEvent args)
@@ -382,3 +386,15 @@ public abstract class SharedXenoHiveSystem : EntitySystem
 /// </summary>
 [ByRefEvent]
 public record struct HiveChangedEvent(Entity<HiveComponent>? Hive, EntityUid? OldHive);
+
+/// <summary>
+/// Raised when a hive's Queen has died.
+/// </summary>
+[ByRefEvent]
+public readonly record struct QueenDeathEvent(EntityUid Hive);
+
+/// <summary>
+/// Raised when a Hive Core has been destroyed.
+/// </summary>
+[ByRefEvent]
+public readonly record struct HiveCoreDestroyedEvent(EntityUid Hive);

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-chat.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-chat.ftl
@@ -1,5 +1,7 @@
-﻿rmc-no-queen-hivemind-chat = There is no Queen. You are alone.
+rmc-no-queen-hivemind-chat = There is no Queen. You are alone.
 rmc-new-queen = A new Queen has risen to lead the Hive! Rejoice!
+rmc-queen-cooldown-over = The Hive stirs with anticipation. A new Queen must now evolve to guide her children.
+rmc-core-cooldown-over = The Hive's connection with Queen Mother has stabilized. A new Hive Core can now be constructed.
 
 rmc-hive-supports-castes = The Hive can now support: {$castes}
 rmc-hive-supports-castes-human = You hear a distant screech and feel your insides freeze up...  something new is with you in this colony.

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-chat.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-chat.ftl
@@ -1,7 +1,7 @@
 rmc-no-queen-hivemind-chat = There is no Queen. You are alone.
 rmc-new-queen = A new Queen has risen to lead the Hive! Rejoice!
 rmc-queen-cooldown-over = The Hive stirs with anticipation. A new Queen must now evolve to guide her children.
-rmc-core-cooldown-over = The Hive's connection with Queen Mother has stabilized. A new Hive Core can now be constructed.
+rmc-core-cooldown-over = The Hive has recovered from the previous core's destruction. A new Hive Core can now be placed.
 
 rmc-hive-supports-castes = The Hive can now support: {$castes}
 rmc-hive-supports-castes-human = You hear a distant screech and feel your insides freeze up...  something new is with you in this colony.


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Adds support for scheduled xeno announcements, including a message when the queen death cooldown has ended as well as when a new hive core can be built. To support this cleanly, the existing xeno caste unlock announcements were folded into the same timed scheduling system, avoiding redundant polling logic in the update method. Future time-based announcements can now be easily added.

## Why / Balance
The 5-minute cooldown after a queen dies is only visible/checkable by attempting to evolve into a queen. Same goes for the 5 minute cooldown on making a new hive core after the previous one is destroyed, you can only check it by trying to place a hive core. This adds new announcements for both via a simple announcement scheduler. Xeno caste unlock announcements were moved to the same scheduler.

## Technical details
New local events for queen death, hive core destruction, and caste unlock. These events are raised from SharedXenoHiveSystem and XenoPylonSystem. XenoHiveSystem subscribes to these events and handles them server-side by setting the appropriate announcement to be scheduled.

## Media
<img width="492" height="386" alt="msgs" src="https://github.com/user-attachments/assets/d6c06631-da98-47cc-9857-03a96be95a15" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Queen death cooldown announcement
- add: Hive core destruction cooldown announcement
- tweak: Moved existing caste unlock announcements to use the same time scheduling system
-->
