### PR TITLE
Fix liaison gear, make weya headsets use the correct sprite

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/distress_headsets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/distress_headsets.yml
@@ -61,6 +61,9 @@
   description: A headset commonly worn by WeYa corporate personnel.
   suffix: WeYa, Colony
   components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Clothing/headsets.rsi
+    state: we_ya_headset
   - type: ContainerFill
     containers:
       key_slots:
@@ -68,7 +71,7 @@
 
 # For WeYa PMC
 - type: entity
-  parent: RMCHeadsetIconsWeYa
+  parent: RMCHeadsetDistressWeYa
   id: RMCHeadsetDistressPMC
   name: PMC headset
   description: A special headset used by corporate personnel.
@@ -98,7 +101,7 @@
     radioTextIncrease: 2
 
 - type: entity
-  parent: RMCHeadsetIconsWeYa
+  parent: RMCHeadsetDistressWeYa
   id: RMCHeadsetDistressPMCDirector
   name: PMC headset
   description: A special headset used by corporate personnel.
@@ -121,7 +124,7 @@
 
 # For WeYa lawyers
 - type: entity
-  parent: RMCHeadsetIcons
+  parent: RMCHeadsetDistressWeYa
   id: RMCHeadsetDistressGoon
   name: We-Ya headset
   description: A special headset used by corporate personnel.
@@ -153,7 +156,7 @@
     radioTextIncrease: 2
 
 - type: entity
-  parent: RMCHeadsetIcons
+  parent: RMCHeadsetDistressWeYa
   id: RMCHeadsetDistressLawyerWeYa
   name: We-Ya headset
   description: A special headset used by corporate personnel.

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/liaison.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/liaison.yml
@@ -59,7 +59,7 @@
 - type: startingGear
   id: CMGearLiaison
   equipment:
-    jumpsuit: CMJumpsuitLiaisonBlack
+    jumpsuit: CMJumpsuitLiaisonIvy
     shoes: RMCShoesLaceup
     id: CMIDCardLiaison
     ears: RMCHeadsetLiaison

--- a/Resources/Prototypes/_RMC14/Roles/Ranks/We-Ya/corporate.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Ranks/We-Ya/corporate.yml
@@ -2,67 +2,67 @@
   id: RMCRankWeYaTrainee
   name: Trainee
   prefix: Trn.
-  paygrade: WEYAC1
+  paygrade: WYC1
 
 - type: rank
   id: RMCRankWeYaJuniorExecutive
   name: Junior Executive
   prefix: Jr. Exec.
-  paygrade: WEYAC2
+  paygrade: WYC2
 
 - type: rank
   id: RMCRankWeYaExecutive
   name: Executive
   prefix: Exec.
-  paygrade: WEYAC3
+  paygrade: WYC3
 
 - type: rank
   id: RMCRankWeYaSeniorExecutive
   name: Senior Executive
   prefix: Sr. Exec.
-  paygrade: WEYAC4
+  paygrade: WYC4
 
 - type: rank
   id: RMCRankWeYaExecutiveSpecialist
   name: Executive Specialist
   prefix: Exec. Spc.
-  paygrade: WEYAC5
+  paygrade: WYC5
 
 - type: rank
   id: RMCRankWeYaExecutiveSupervisor
   name: Executive Supervisor
   prefix: Exec. Spvsr.
-  paygrade: WEYAC6
+  paygrade: WYC6
 
 - type: rank
   id: RMCRankWeYaAssistantManager
   name: Assistant Manager
   prefix: Assis. Mng.
-  paygrade: WEYAC7
+  paygrade: WYC7
 
 - type: rank
   id: RMCRankWeYaDivisionManager
   name: Division Manager
   prefix: Div. Mng.
-  paygrade: WEYAC8
+  paygrade: WYC8
 
 - type: rank
   id: RMCRankWeYaChiefExecutive
   name: Chief Executive
   prefix: Chief. Exec.
-  paygrade: WEYAC9
+  paygrade: WYC9
 
 - type: rank
   id: RMCRankWeYaDeputyDirector
   name: Deputy Director
   prefix: Dep. Director
-  paygrade: WEYAC10
+  paygrade: WYC10
 
 - type: rank
   id: RMCRankWeYaDirector
   name: Director
   prefix: Director
-  paygrade: WEYAC11
+  paygrade: WYC11
 
 # Lawyers
 - type: rank
@@ -80,4 +80,4 @@
   id: RMCRankWeYaPilotOfficer
   name: Captain
   prefix: Capt
-  paygrade: WEYAPO2
+  paygrade: WYPO2

--- a/Resources/Prototypes/_RMC14/Roles/Ranks/We-Ya/corporate.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Ranks/We-Ya/corporate.yml
@@ -1,54 +1,68 @@
 - type: rank
+  id: RMCRankWeYaTrainee
+  name: Trainee
+  prefix: Trn.
+  paygrade: WEYAC1
+
+- type: rank
   id: RMCRankWeYaJuniorExecutive
   name: Junior Executive
   prefix: Jr. Exec.
+  paygrade: WEYAC2
 
 - type: rank
   id: RMCRankWeYaExecutive
   name: Executive
   prefix: Exec.
+  paygrade: WEYAC3
 
 - type: rank
   id: RMCRankWeYaSeniorExecutive
   name: Senior Executive
   prefix: Sr. Exec.
+  paygrade: WEYAC4
 
 - type: rank
   id: RMCRankWeYaExecutiveSpecialist
   name: Executive Specialist
   prefix: Exec. Spc.
-  paygrade: WYC5
+  paygrade: WEYAC5
 
 - type: rank
   id: RMCRankWeYaExecutiveSupervisor
   name: Executive Supervisor
   prefix: Exec. Spvsr.
-  paygrade: WYC6
+  paygrade: WEYAC6
 
 - type: rank
   id: RMCRankWeYaAssistantManager
   name: Assistant Manager
   prefix: Assis. Mng.
+  paygrade: WEYAC7
 
 - type: rank
   id: RMCRankWeYaDivisionManager
   name: Division Manager
   prefix: Div. Mng.
+  paygrade: WEYAC8
 
 - type: rank
   id: RMCRankWeYaChiefExecutive
   name: Chief Executive
   prefix: Chief. Exec.
+  paygrade: WEYAC9
 
 - type: rank
   id: RMCRankWeYaDeputyDirector
   name: Deputy Director
   prefix: Dep. Director
+  paygrade: WEYAC10
 
 - type: rank
   id: RMCRankWeYaDirector
   name: Director
   prefix: Director
+  paygrade: WEYAC11
 
 # Lawyers
 - type: rank
@@ -60,3 +74,10 @@
   id: RMCRankWeYaLegalSupervisor
   name: Legal Supervisor
   prefix: Legal Spvsr.
+
+# Pilots
+- type: rank
+  id: RMCRankWeYaPilotOfficer
+  name: Captain
+  prefix: Capt
+  paygrade: WEYAPO2


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Parity
Liaisons should spawn with the country club outfit
Also makes the WeYa headsets use the weya sprite

adds some missing weya ranks and paygrades

:cl:
- tweak: Liaisons now spawn with the country club outfit instead of the black suit pants.
- fix: Fixed WeYA PMC headsets having the incorrect sprite.
