### PR TITLE
CMB jacket fixes

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/faction_coats.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/faction_coats.yml
@@ -26,7 +26,7 @@
 - type: entity
   parent: [RMCAllowSuitStorageClothingJacketMB, RMCBaseJacket]
   id: RMCCoatBureauDeputy
-  name: bureau deputy jacket
+  name: CMB deputy jacket
   description: A thick and stylish black leather jacket with a Marshal's Deputy badge pinned to it. The back is enscribed with the powerful letters of 'DEPUTY' representing justice, authority, and protection in the outer rim. The laws of the Earth stretch beyond the Sol.
   components:
   - type: Sprite
@@ -40,9 +40,9 @@
     explosionArmor: 10
 
 - type: entity
-  parent: RMCBaseJacket
+  parent: RMCCoatBureauDeputy
   id: RMCCoatBureauMarshal
-  name: bureau marshal jacket
+  name: CMB marshal jacket
   description: A thick and stylish black leather jacket with a Marshal's badge pinned to it. The back is enscribed with the powerful letters of 'MARSHAL' representing justice, authority, and protection in the outer rim. The laws of the Earth stretch beyond the Sol.
   components:
   - type: Sprite


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- Fixes CMB marshal jacket not having armor
- Renames the 'bureau' part to 'CMB', to be more clear, it's also the parity name

:cl:
- fix: Fixed CMB Marshal jacket not having armor
