### PR TITLE
Make 175 hour DCC rank Warrant Officer

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/dropship_crew_chief.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/dropship_crew_chief.yml
@@ -12,7 +12,7 @@
     group: CMJobsMedical
     time: 3600 # 1 hours
   ranks:
-    RMCRankChiefWarrantOfficer:
+    RMCRankWarrantOfficer:
     - !type:RoleTimeRequirement
       role: CMJobDropshipCrewChief
       time: 630000 # 175 hours


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This seems like a mistake, especially considering it shared the pilot playtime tracker before (but then was fixed)
Currently, a 175 hour DCC can outrank a <25 hour pilot, which is strange considering the DCC are the subordinate to the pilots

So now it's
Corporal -> Sergeant -> Staff Sergeant -> Warrant Officer

**Changelog**
update not live yet
