### PR TITLE
Make plastic explosives and breaching charges require engineer skill

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Explosives/breaching_charge.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Explosives/breaching_charge.yml
@@ -41,6 +41,9 @@
   - type: Tag
     tags:
     - RMCExplosiveBreachingCharge
+  - type: RequiresSkill
+    skills:
+      RMCSkillEngineer: 1
 
 - type: entity
   parent: RMCExplosiveBreachingCharge


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Makes C4 and Breaching charges require 1 engi skill, from CM13.


:cl:
- fix: Fixed breaching charges not requiring 1 engineering skill.
