### PR TITLE
Removes being able to get nutriment

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Food/bar.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Food/bar.yml
@@ -15,8 +15,6 @@
   - type: Item
     size: Tiny
     sprite: _RMC14/Objects/Consumable/Food/bar.rsi
-  - type: Extractable
-    grindableSolutionName: food
   - type: InjectableSolution
     solution: food
   - type: DrawableSolution

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Food/donuts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Food/donuts.yml
@@ -98,8 +98,6 @@
   - type: FlavorProfile
     flavors:
       - bread
-  - type: Extractable
-    grindableSolutionName: food
   - type: InjectableSolution
     solution: food
   - type: DrawableSolution

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Food/prepared.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Food/prepared.yml
@@ -15,8 +15,6 @@
   - type: Item
     size: Small
     sprite: _RMC14/Objects/Consumable/Food/prepared.rsi
-  - type: Extractable
-    grindableSolutionName: food
   - type: InjectableSolution
     solution: food
   - type: DrawableSolution

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Food/snacks.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Food/snacks.yml
@@ -20,8 +20,6 @@
     sprite: _RMC14/Objects/Consumable/Food/packaged.rsi
     heldPrefix: packet
     size: Tiny
-  - type: Extractable
-    grindableSolutionName: food
   - type: InjectableSolution
     solution: food
   - type: DrawableSolution


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
title, no longer can you grind food to get nutriment. you're not able to do this in cm13 and it's pretty LRP.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: noctyrnal
- fix: You can no longer grind foods for nutriment.
