### PR TITLE
Remove 'case' from xeno chatsan

### DIFF
--- a/Resources/Locale/en-US/_RMC14/cm-chatsan.ftl
+++ b/Resources/Locale/en-US/_RMC14/cm-chatsan.ftl
@@ -680,13 +680,11 @@ cm-chatsan-word-light-bulbs = light bulbs
 cm-chatsan-word-lightbulbs = lightbulbs
 cm-chatsan-replacement-light-bulbs = glow orbs
 
-cm-chatsan-word-case = case
 cm-chatsan-word-crate = crate
-cm-chatsan-replacement-case = containment box
+cm-chatsan-replacement-crate = containment box
 
-cm-chatsan-word-cases = cases
 cm-chatsan-word-crates = crates
-cm-chatsan-replacement-cases = containment boxes
+cm-chatsan-replacement-crates = containment boxes
 
 cm-chatsan-word-gunshot = gunshot
 cm-chatsan-replacement-gunshot = spit burst

--- a/Resources/Prototypes/_RMC14/Accents/cm_word_replacements.yml
+++ b/Resources/Prototypes/_RMC14/Accents/cm_word_replacements.yml
@@ -249,10 +249,8 @@
     cm-chatsan-word-lightbulb: cm-chatsan-replacement-light-bulb
     cm-chatsan-word-light-bulbs: cm-chatsan-replacement-light-bulbs
     cm-chatsan-word-lightbulbs: cm-chatsan-replacement-light-bulbs
-    cm-chatsan-word-case: cm-chatsan-replacement-case
-    cm-chatsan-word-crate: cm-chatsan-replacement-case
-    cm-chatsan-word-cases: cm-chatsan-replacement-cases
-    cm-chatsan-word-crates: cm-chatsan-replacement-cases
+    cm-chatsan-word-crate: cm-chatsan-replacement-crate
+    cm-chatsan-word-crates: cm-chatsan-replacement-crates
     cm-chatsan-word-gunshot: cm-chatsan-replacement-gunshot
     cm-chatsan-word-gunshots: cm-chatsan-replacement-gunshots
     cm-chatsan-word-paper: cm-chatsan-replacement-paper


### PR DESCRIPTION
## About the PR
Removes the word "case" from xeno chatsan list.

## Why / Balance
See below.

## Media
<img width="360" height="188" alt="case8" src="https://github.com/user-attachments/assets/2603a472-4de7-4a46-a979-d5607b18e9a9" />
<img width="339" height="89" alt="case7" src="https://github.com/user-attachments/assets/e54833ad-d012-43c8-a02b-cce1bca3ac19" />
<img width="366" height="194" alt="case6" src="https://github.com/user-attachments/assets/f44b1793-ce75-4a88-a9c7-d251bd391f77" />
<img width="361" height="193" alt="case5" src="https://github.com/user-attachments/assets/f0d20411-ea2f-4b6b-8ac1-d0c848fabd62" />
<img width="416" height="161" alt="case4" src="https://github.com/user-attachments/assets/1cf2eceb-0ec9-46cc-a22f-b6e6f607a941" />
<img width="355" height="140" alt="case3" src="https://github.com/user-attachments/assets/fa95652d-8b24-4cee-99f1-5339eaa6b688" />
<img width="384" height="244" alt="case2" src="https://github.com/user-attachments/assets/a1bfc095-72d9-4663-94c1-8dde33aad161" />
<img width="350" height="260" alt="case" src="https://github.com/user-attachments/assets/fe4e6334-e7c3-48fc-810d-85cdd5a4c419" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
- remove: Removed 'case' from xeno chat san list
