### PR TITLE
Prevent parasites from leaping, or being thrown, through doors.

### DIFF
--- a/Content.Server/_RMC14/Xenonids/Parasite/XenoParasiteThrowerSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Parasite/XenoParasiteThrowerSystem.cs
@@ -107,7 +107,7 @@ public sealed partial class XenoParasiteThrowerSystem : SharedXenoParasiteThrowe
             }
 
             _rmcObstacleSlamming.MakeImmune(heldEntity);
-            _throw.TryThrow(heldEntity, target, user: xeno, compensateFriction: true);
+            _throw.TryThrow(heldEntity, target, user: xeno);
 
             // Not parity but should help the ability be more consistent/not look weird since para AI goes rest on idle.
             // Should amount to about 10 seconds before they attempt a leap (10 seconds stunned)

--- a/Content.Shared/_RMC14/Xenonids/Leap/XenoLeapSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Leap/XenoLeapSystem.cs
@@ -235,6 +235,9 @@ public sealed class XenoLeapSystem : EntitySystem
 
     private void OnXenoLeapingRemove(Entity<XenoLeapingComponent> ent, ref ComponentRemove args)
     {
+        var ev = new XenoLeapStoppedEvent();
+        RaiseLocalEvent(ent, ref ev);
+
         StopLeap(ent);
     }
 
@@ -538,8 +541,11 @@ public sealed class XenoLeapSystem : EntitySystem
             if (_size.TryGetSize(leaping, out var size) && size > RMCSizes.SmallXeno)
                 collisionGroup = (int)leaping.Comp.IgnoredCollisionGroupLarge;
 
-            var fixture = fixtures.Fixtures.First();
-            _physics.SetCollisionMask(leaping, fixture.Key, fixture.Value, fixture.Value.CollisionMask | collisionGroup);
+            if (size >= RMCSizes.SmallXeno)
+            {
+                var fixture = fixtures.Fixtures.First();
+                _physics.SetCollisionMask(leaping, fixture.Key, fixture.Value, fixture.Value.CollisionMask | collisionGroup);
+            }
         }
 
         RemCompDeferred<XenoLeapingComponent>(leaping);
@@ -575,3 +581,6 @@ public sealed class XenoLeapSystem : EntitySystem
 
 [ByRefEvent]
 public record struct XenoLeapHitAttempt(EntityUid Leaper, bool Cancelled = false);
+
+[ByRefEvent]
+public record struct XenoLeapStoppedEvent;

--- a/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
@@ -1,9 +1,10 @@
+using System.Linq;
 using Content.Shared._RMC14.Atmos;
 using Content.Shared._RMC14.Damage;
-using Content.Shared._RMC14.Deafness;
 using Content.Shared._RMC14.Hands;
 using Content.Shared._RMC14.Stun;
 using Content.Shared._RMC14.Xenonids.Construction.Nest;
+using Content.Shared._RMC14.Xenonids.Construction.ResinWhisper;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Leap;
 using Content.Shared._RMC14.Xenonids.Pheromones;
@@ -12,6 +13,7 @@ using Content.Shared.Atmos.Rotting;
 using Content.Shared.Chat.Prototypes;
 using Content.Shared.Damage;
 using Content.Shared.DoAfter;
+using Content.Shared.Doors.Components;
 using Content.Shared.DragDrop;
 using Content.Shared.Examine;
 using Content.Shared.Ghost;
@@ -27,17 +29,19 @@ using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Pulling.Events;
+using Content.Shared.Physics;
 using Content.Shared.Popups;
 using Content.Shared.Rejuvenate;
 using Content.Shared.Standing;
 using Content.Shared.StatusEffect;
-using Content.Shared.Stunnable;
 using Content.Shared.Tag;
 using Content.Shared.Throwing;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Network;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Systems;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
@@ -57,9 +61,9 @@ public abstract partial class SharedXenoParasiteSystem : EntitySystem
     [Dependency] private readonly InventorySystem _inventory = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly StandingStateSystem _standing = default!;
-    [Dependency] private readonly SharedStunSystem _stun = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
@@ -69,8 +73,10 @@ public abstract partial class SharedXenoParasiteSystem : EntitySystem
     [Dependency] private readonly StatusEffectsSystem _status = default!;
     [Dependency] private readonly SharedRottingSystem _rotting = default!;
     [Dependency] private readonly TagSystem _tagSystem = default!;
-    [Dependency] private readonly SharedDeafnessSystem _deafen = default!;
     [Dependency] private readonly RMCSizeStunSystem _size = default!;
+
+    private const CollisionGroup LeapCollisionGroup = CollisionGroup.InteractImpassable;
+    private const CollisionGroup ThrownCollisionGroup = CollisionGroup.InteractImpassable | CollisionGroup.BarricadeImpassable;
 
     public override void Initialize()
     {
@@ -89,6 +95,11 @@ public abstract partial class SharedXenoParasiteSystem : EntitySystem
         SubscribeLocalEvent<XenoParasiteComponent, PullAttemptEvent>(OnParasiteTryPull);
         SubscribeLocalEvent<XenoParasiteComponent, GettingPickedUpAttemptEvent>(OnParasiteTryPickup);
         SubscribeLocalEvent<XenoParasiteComponent, BeforeDamageChangedEvent>(OnParasiteBeforeDamageChanged);
+        SubscribeLocalEvent<XenoParasiteComponent, XenoLeapAttemptEvent>(OnParasiteLeapAttempt);
+        SubscribeLocalEvent<XenoParasiteComponent, XenoLeapDoAfterEvent>(OnParasiteLeapDoAfter);
+        SubscribeLocalEvent<XenoParasiteComponent, XenoLeapStoppedEvent>(OnParasiteLeapStopped);
+        SubscribeLocalEvent<XenoParasiteComponent, ThrownEvent>(OnParasiteThrown);
+        SubscribeLocalEvent<XenoParasiteComponent, LandEvent>(OnParasiteLand);
 
         SubscribeLocalEvent<ParasiteSpentComponent, MapInitEvent>(OnParasiteSpentMapInit);
         SubscribeLocalEvent<ParasiteSpentComponent, UpdateMobStateEvent>(OnParasiteSpentUpdateMobState,
@@ -250,6 +261,69 @@ public abstract partial class SharedXenoParasiteSystem : EntitySystem
     {
         if (ent.Comp.InfectedVictim != null && !ent.Comp.FellOff) // cannot damage while infecting host
             args.Cancelled = true;
+    }
+
+    private void OnParasiteLeapAttempt(Entity<XenoParasiteComponent> ent, ref XenoLeapAttemptEvent args)
+    {
+        if (args.Cancelled)
+            return;
+
+        var contacts = _physics.GetContactingEntities(ent);
+        foreach (var contact in contacts)
+        {
+            // Unable to leap while underneath an airlock
+            if (HasComp<DoorComponent>(contact) && !HasComp<ResinDoorComponent>(contact))
+            {
+                _popup.PopupClient(Loc.GetString("cm-xeno-leap-blocked"), Transform(ent).Coordinates, ent);
+                args.Cancelled = true;
+                break;
+            }
+        }
+    }
+
+    private void OnParasiteLeapDoAfter(Entity<XenoParasiteComponent> ent, ref XenoLeapDoAfterEvent args)
+    {
+        if (args.Cancelled)
+            return;
+
+        if (TryComp(ent, out FixturesComponent? fixtures))
+        {
+            var fixture = fixtures.Fixtures.First();
+            _physics.SetCollisionMask(ent, fixture.Key, fixture.Value, fixture.Value.CollisionMask | (int) LeapCollisionGroup);
+        }
+    }
+
+    private void OnParasiteLeapStopped(Entity<XenoParasiteComponent> ent, ref XenoLeapStoppedEvent args)
+    {
+        if (TryComp(ent, out FixturesComponent? fixtures))
+        {
+            var fixture = fixtures.Fixtures.First();
+            if ((fixture.Value.CollisionMask & (int) CollisionGroup.AirlockLayer) == 0)
+                return;
+
+            _physics.SetCollisionMask(ent, fixture.Key, fixture.Value, fixture.Value.CollisionMask ^ (int) LeapCollisionGroup);
+        }
+    }
+
+    private void OnParasiteThrown(Entity<XenoParasiteComponent> ent, ref ThrownEvent args)
+    {
+        if (TryComp(ent, out FixturesComponent? fixtures))
+        {
+            var fixture = fixtures.Fixtures.First();
+            _physics.SetCollisionMask(ent, fixture.Key, fixture.Value, fixture.Value.CollisionMask | (int)ThrownCollisionGroup);
+        }
+    }
+
+    private void OnParasiteLand(Entity<XenoParasiteComponent> ent, ref LandEvent args)
+    {
+        if (TryComp(ent, out FixturesComponent? fixtures))
+        {
+            var fixture = fixtures.Fixtures.First();
+            if ((fixture.Value.CollisionMask & (int) CollisionGroup.AirlockLayer & (int) CollisionGroup.BarricadeImpassable) != 0)
+                return;
+
+            _physics.SetCollisionMask(ent, fixture.Key, fixture.Value, fixture.Value.CollisionMask ^ (int) ThrownCollisionGroup);
+        }
     }
 
     protected virtual void ParasiteLeapHit(Entity<XenoParasiteComponent> parasite)

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
@@ -64,6 +64,7 @@ cm-xeno-fortify-cant-toggle-crest = We can't lower our crest while fortifying!
 rmc-xeno-headbutt-too-far = We can't headbutt from this distance with our crest lowered!
 
 # Leap
+cm-xeno-leap-blocked = We cannot do that while squeezing and scuttling!
 cm-xeno-leap-cancelled = We cancel our leap!
 
 # Plant weeds


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Parasites won't pass through doors anymore during a leap, colliding with the door instead.
Parasites can't be thrown through doors anymore, colliding with the door instead.
Parasites can't start a leap while under an airlock, they can still start a leap while under a resin door.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity.

## Technical details
<!-- Summary of code changes for easier review. -->
When thrown or when starting a leap the collision mask of the parasite is changed, when they land the collision mask is set back to what it was below the throw/leap.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Dygon
- fix: Parasites will now collide with a door during their leap if the leap didn't start underneath it.
- fix: Parasites can't start a leap while underneath and airlock, they can still start a leap while underneath a resin door.
- fix: Thrown parasites will now collide with doors during the throw.
