### PR TITLE
FTLs now get an RTO in their essential bundle

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/team_leader.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/team_leader.yml
@@ -83,9 +83,6 @@
         points: 30
     - name: Clothing Items
       entries:
-      - id: RMCBackpackRTO
-        recommended: true
-        points: 5
       - id: RMCScabbardMacheteFilled
         name: machete scabbard (Full)
         points: 5
@@ -241,7 +238,7 @@
   parent: CMVendorBundleRiflemanApparel
   id: RMCVendorBundleCrewFireteamLeader
   name: essential fireteam leader utilities
-  description: Contains a laser designator and two packs of signal flares.
+  description: Contains a laser designator, two packs of signal flares and a Radio Telephone pack.
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Devices/binoculars.rsi
@@ -253,3 +250,4 @@
     - RMCPackFlareCAS
     - RMCPackFlareCAS
     - RMCLaserDesignator
+    - RMCBackpackRTO


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title, request of hosts and FTL mains. Not parity but giga fucking good. Removes RTO as a point buy for FTLs as a counter-piece (redundant).

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: noctyrnal
- add: FTLs now get an RTO for free with their essential bundle.
- remove: FTLs can no longer purchase an RTO from their equipment vendor.
