### PR TITLE
Fix crash land audio playing twice

### DIFF
--- a/Content.Shared/_RMC14/CrashLand/SharedCrashLandSystem.cs
+++ b/Content.Shared/_RMC14/CrashLand/SharedCrashLandSystem.cs
@@ -276,7 +276,9 @@ public abstract partial class SharedCrashLandSystem : EntitySystem
             var ev = new CrashLandedEvent(crashLanding.DoDamage);
             RaiseLocalEvent(uid, ref ev);
 
-            _audio.PlayPvs(crashLandable.CrashSound, uid);
+            if (_net.IsServer)
+                _audio.PlayPvs(crashLandable.CrashSound, uid);
+
             RemComp<CrashLandingComponent>(uid);
             Blocker.UpdateCanMove(uid);
         }

--- a/Content.Shared/_RMC14/CrashLand/SharedCrashLandSystem.cs
+++ b/Content.Shared/_RMC14/CrashLand/SharedCrashLandSystem.cs
@@ -276,8 +276,7 @@ public abstract partial class SharedCrashLandSystem : EntitySystem
             var ev = new CrashLandedEvent(crashLanding.DoDamage);
             RaiseLocalEvent(uid, ref ev);
 
-            if (_net.IsServer)
-                _audio.PlayPvs(crashLandable.CrashSound, uid);
+            _audio.PlayPredicted(crashLandable.CrashSound, uid, uid);
 
             RemComp<CrashLandingComponent>(uid);
             Blocker.UpdateCanMove(uid);

--- a/Content.Shared/_RMC14/CrashLand/SharedCrashLandSystem.cs
+++ b/Content.Shared/_RMC14/CrashLand/SharedCrashLandSystem.cs
@@ -276,7 +276,8 @@ public abstract partial class SharedCrashLandSystem : EntitySystem
             var ev = new CrashLandedEvent(crashLanding.DoDamage);
             RaiseLocalEvent(uid, ref ev);
 
-            _audio.PlayPredicted(crashLandable.CrashSound, uid, uid);
+            if (_net.IsServer)
+                _audio.PlayPvs(crashLandable.CrashSound, uid);
 
             RemComp<CrashLandingComponent>(uid);
             Blocker.UpdateCanMove(uid);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The sound now only plays once.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
No CL
