### PR TITLE
Fix Ship Security Camera Console's draw depth

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Wallmounts/surveillance_camera.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Wallmounts/surveillance_camera.yml
@@ -73,6 +73,7 @@
     sprite: _RMC14/Structures/Machines/computer.rsi
     state: security_cam
     layers: []
+    drawdepth: SmallObjects
   - type: InteractionOutline
   - type: ActivatableUI
     key: enum.RMCCameraUiKey.Key


### PR DESCRIPTION
title

:cl:
- fix: Fixed the draw depth of the 'ship security camera' console.
