### PR TITLE
Fix HIDP packets not being filled.

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -287,8 +287,8 @@
 
 - type: entity
   parent:
-  - CMGrenadeBase
   - RMCM40DPTags
+  - CMGrenadeBase
   id: RMCGrenadeIncendiary
   name: M40 HIDP incendiary grenade
   description: The M40 HIDP is a small, but deceptively strong incendiary grenade designed to disrupt enemy mobility with long-lasting Type B napalm. It is set to detonate in 4 seconds.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
HIDP packets now contain 3 grenades again.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Buf fix.

## Technical details
<!-- Summary of code changes for easier review. -->
Inheritance issue, swapping the parenting order fixed it.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Dygon
- fix: HIDP grenade packets now contain HIDP grenades again.

