### PR TITLE
Fix xeno tailstab not being 2.5 range

### DIFF
--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
@@ -120,7 +120,7 @@
       state: tail_attack
     useDelay: 10
   - type: TargetAction
-    range: 2
+    range: 2.5
     checkCanAccess: false
   - type: EntityTargetAction
   - type: WorldTargetAction


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
https://github.com/RMC-14/RMC-14/pull/5973
A PR was made to increase this range to 2.5, but due a recent change requiring sprite clicking, the range was mistakenly made 2 instead of 2.5

**Changelog**
:cl:
- fix: Fixed xeno tailstab not having a range of 2.5 (2 > 2.5)
