### PR TITLE
Fixed scouts not actually needing their armor to use their cloak

### DIFF
--- a/Content.Shared/_RMC14/Clothing/ClothingRequireEquippedComponent.cs
+++ b/Content.Shared/_RMC14/Clothing/ClothingRequireEquippedComponent.cs
@@ -14,5 +14,5 @@ public sealed partial class ClothingRequireEquippedComponent : Component
     public string DenyReason = "rmc-wear-smart-gun-required";
 
     [DataField, AutoNetworkedField]
-    public bool AutoUnequip = true;
+    public bool AutoUnequip = false;
 }

--- a/Content.Shared/_RMC14/Clothing/ClothingRequireEquippedComponent.cs
+++ b/Content.Shared/_RMC14/Clothing/ClothingRequireEquippedComponent.cs
@@ -12,4 +12,7 @@ public sealed partial class ClothingRequireEquippedComponent : Component
 
     [DataField, AutoNetworkedField]
     public string DenyReason = "rmc-wear-smart-gun-required";
+
+    [DataField, AutoNetworkedField]
+    public bool AutoUnequip = true;
 }

--- a/Content.Shared/_RMC14/Clothing/RMCClothingSystem.cs
+++ b/Content.Shared/_RMC14/Clothing/RMCClothingSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared._RMC14.UniformAccessories;
+using Content.Shared.Clothing.Components;
 using Content.Shared.Clothing.EntitySystems;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Inventory;
@@ -32,6 +33,10 @@ public sealed class RMCClothingSystem : EntitySystem
         SubscribeLocalEvent<ClothingLimitComponent, BeingEquippedAttemptEvent>(OnClothingLimitBeingEquippedAttempt);
 
         SubscribeLocalEvent<ClothingRequireEquippedComponent, BeingEquippedAttemptEvent>(OnRequireEquippedBeingEquippedAttempt);
+
+        // this is for clothing with ClothingRequireEquipped, so they can drop when required clothing is unequipped
+        // ex: scout cloak should not stay on when they take off the armor required for it
+        SubscribeLocalEvent<InventoryComponent, DidUnequipEvent>(OnUnequipped);
 
         SubscribeLocalEvent<NoClothingSlowdownComponent, ComponentStartup>(OnNoClothingSlowUpdate);
         SubscribeLocalEvent<NoClothingSlowdownComponent, DidEquipEvent>(OnNoClothingSlowUpdate);
@@ -96,6 +101,11 @@ public sealed class RMCClothingSystem : EntitySystem
 
         args.Cancel();
         args.Reason = ent.Comp.DenyReason;
+    }
+
+    private void OnUnequipped(Entity<InventoryComponent> ent, ref DidUnequipEvent args)
+    {
+        // todo
     }
 
     private void AddFoldVerb(Entity<RMCClothingFoldableComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Back/satchels.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Back/satchels.yml
@@ -102,7 +102,6 @@
     whitelist:
       tags:
       - RMCScoutArmor
-      - PlushieLizard
     denyReason: rmc-wear-scout-armor-required
   - type: ThermalCloak
     opacity: 0.03 # Put to 0.03 for testing

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Back/satchels.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Back/satchels.yml
@@ -102,6 +102,7 @@
     whitelist:
       tags:
       - RMCScoutArmor
+      - PlushieLizard
     denyReason: rmc-wear-scout-armor-required
   - type: ThermalCloak
     opacity: 0.03 # Put to 0.03 for testing

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Back/satchels.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Back/satchels.yml
@@ -98,6 +98,7 @@
     grid:
     - 0,0,20,1 # 21, Satchel but with backpack capacity
   - type: ClothingRequireEquipped
+    autoUnequip: true
     whitelist:
       tags:
       - RMCScoutArmor


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
With this PR scouts will actually need to at least have their armor on them in order to use their cloak. There was already a check for when equipping the cloak, but players could easily just unequip and ditch the armor after equipping it solely to wear the cloak. 

Now when the armor is dropped; the cloak will fall off along with it.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Resolves #5501

## Technical details
<!-- Summary of code changes for easier review. -->
`ClothingRequireEquippedComponent` now has an `autoUnequip` field, if this is set to `true` then the clothing will drop when something within it's whitelist is dropped.

This field is false by default so that it doesn't affect anything else that's also using the component.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Scouts will now drop their cloak when dropping their required armor.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
