### PR TITLE
Make survivor job rolling more random

### DIFF
--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
@@ -686,6 +686,13 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
 
             if (comp.SpawnSurvivors)
             {
+                // Shuffle survivor jobs and ensure civilian survivor stays at the bottom, as civ survivor has infinite slots
+                comp.SurvivorJobs = comp.SurvivorJobs
+                    .Where(entry => entry.Job != comp.CivilianSurvivorJob)
+                    .OrderBy(_ => _random.Next())
+                    .Append(comp.SurvivorJobs.FirstOrDefault(entry => entry.Job == comp.CivilianSurvivorJob))
+                    .ToList();
+
                 var survivorCandidates = new Dictionary<ProtoId<JobPrototype>, List<NetUserId>[]>();
                 foreach (var job in comp.SurvivorJobs)
                 {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Currently, survivors are always rolled in a specific order:
- Engi
- Doctor
- Security
- Corporate
- Scientist
- Civilian

This PR changes it so the order of the jobs are shuffled every round. I believe this to be a good change as engi/doc rollers will have a way higher chance of rolling survivor than a security, corporate, scientist, or civilian player. This PR gives a fair chance for everybody, and is also parity, as jobs are rolled all together in CM13 rather than a specific order.

## Media
1st attempt: Player 1 rolled Corporate Colonist, and Player 2 rolled Engineer colonist. Player 1 got corpo
<img width="888" height="611" alt="image" src="https://github.com/user-attachments/assets/880f5423-ab83-4f62-80ef-25eab5f8208a" />

2nd attempt: Player 1 rolled Engineer Colonist, and Player 2 rolled Security colonist. Player 1 got engi.
<img width="1274" height="628" alt="image" src="https://github.com/user-attachments/assets/cd31da38-1a55-4b78-aa6f-5ffbabf5e186" />


:cl:
- tweak: Survivor jobs now roll more randomly, instead of rolling in a specific order every round.
