### PR TITLE
Scientist survivor skill fixes

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Hybrisa_Prospera/xenoarchaeologist.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Hybrisa_Prospera/xenoarchaeologist.yml
@@ -13,11 +13,11 @@
       skills:
         RMCSkillConstruction: 1
         RMCSkillEndurance: 2
-        RMCSkillFireman: 2
+        RMCSkillFireman: 1
         RMCSkillFirearms: 1
         RMCSkillMedical: 3
         RMCSkillSurgery: 2
-        RMCSkillVehicles: 1
+        RMCSkillResearch: 1
     - type: EquipSurvivorPreset
       preset: RMCGearSurvivorPresetHybrisaXenoarchaeologist
     - type: RMCSurvivor

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Hybrisa_Prospera/xenobiologist.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Hybrisa_Prospera/xenobiologist.yml
@@ -13,11 +13,11 @@
       skills:
         RMCSkillConstruction: 1
         RMCSkillEndurance: 2
-        RMCSkillFireman: 2
+        RMCSkillFireman: 1
         RMCSkillFirearms: 1
         RMCSkillMedical: 3
         RMCSkillSurgery: 2
-        RMCSkillVehicles: 1
+        RMCSkillResearch: 1
     - type: EquipSurvivorPreset
       preset: RMCGearSurvivorPresetHybrisaXenobiologist
     - type: RMCSurvivor

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/cosmos_exploration_corps.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/cosmos_exploration_corps.yml
@@ -13,7 +13,10 @@
     components:
     - type: Skills
       skills:
+        RMCSkillConstruction: 1
+        RMCSkillEndurance: 2
         RMCSkillFireman: 1
+        RMCSkillFirearms: 1
         RMCSkillMedical: 3
         RMCSkillSurgery: 2
         RMCSkillResearch: 1


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed the hybrisa scientists having the incorrect skills
Fixed sorokyne survivors not having firearms/endurance/construction skill

:cl:
- fix: Fixed scientist survivor variants not having firearms skill.