### PR TITLE
Make unrevivable not use perishable + medical actions

### DIFF
--- a/Content.Client/_RMC14/Medical/HUD/CMHealthIconsSystem.cs
+++ b/Content.Client/_RMC14/Medical/HUD/CMHealthIconsSystem.cs
@@ -1,9 +1,7 @@
 ﻿using Content.Shared._RMC14.Connection;
-using Content.Shared._RMC14.Medical.Defibrillator;
 using Content.Shared._RMC14.Medical.HUD.Components;
-using Content.Shared._RMC14.Xenonids;
+using Content.Shared._RMC14.Medical.Unrevivable;
 using Content.Shared._RMC14.Xenonids.Parasite;
-using Content.Shared.Atmos.Rotting;
 using Content.Shared.Damage;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.StatusIcon;
@@ -15,6 +13,7 @@ public sealed class CMHealthIconsSystem : EntitySystem
 {
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly RMCUnrevivableSystem _unrevivable = default!;
 
     private static readonly ProtoId<HealthIconPrototype> BaseDeadIcon = "CMHealthIconDead";
 
@@ -31,11 +30,7 @@ public sealed class CMHealthIconsSystem : EntitySystem
         if (!TryComp<RMCHealthIconsComponent>(damageable, out var iconsComp))
             return icons;
 
-        // TODO RMC14 don't use perishable
-        if (HasComp<CMDefibrillatorBlockedComponent>(damageable)
-            || HasComp<VictimBurstComponent>(damageable)
-            || TryComp(damageable, out PerishableComponent? perishable)
-            && perishable.Stage >= 4)
+        if (_unrevivable.IsUnrevivable(damageable))
         {
             icon = RMCHealthIconTypes.Dead;
             if (iconsComp.Icons.TryGetValue(icon, out var deadIcon))
@@ -46,11 +41,12 @@ public sealed class CMHealthIconsSystem : EntitySystem
 
         if (_mobState.IsDead(damageable))
         {
-            if (perishable == null || perishable.Stage <= 1)
+            var stage = _unrevivable.GetUnrevivableStage(damageable.Owner, 3);
+            if (stage <= 1)
                 icon = RMCHealthIconTypes.DeadDefib;
-            else if (perishable.Stage == 2)
+            else if (stage == 2)
                 icon = RMCHealthIconTypes.DeadClose;
-            else if (perishable.Stage == 3)
+            else if (stage == 3)
                 icon = RMCHealthIconTypes.DeadAlmost;
 
             if (TryComp<MindCheckComponent>(damageable, out var mind) && !mind.ActiveMindOrGhost)

--- a/Content.Client/_RMC14/Medical/HUD/CMHealthIconsSystem.cs
+++ b/Content.Client/_RMC14/Medical/HUD/CMHealthIconsSystem.cs
@@ -41,7 +41,7 @@ public sealed class CMHealthIconsSystem : EntitySystem
 
         if (_mobState.IsDead(damageable))
         {
-            var stage = _unrevivable.GetUnrevivableStage(damageable.Owner, 3);
+            var stage = _unrevivable.GetUnrevivableStage(damageable.Owner, 4);
             if (stage <= 1)
                 icon = RMCHealthIconTypes.DeadDefib;
             else if (stage == 2)

--- a/Content.Server/Atmos/Rotting/RottingSystem.cs
+++ b/Content.Server/Atmos/Rotting/RottingSystem.cs
@@ -43,10 +43,6 @@ public sealed class RottingSystem : SharedRottingSystem
     {
         if (args.Handled)
             return;
-
-        if (TryComp<PerishableComponent>(uid, out var perishable) && perishable.IgnoreTemperature)
-            return;
-
         args.Handled = component.CurrentTemperature < Atmospherics.T0C + 0.85f;
     }
 

--- a/Content.Shared/Atmos/Rotting/PerishableComponent.cs
+++ b/Content.Shared/Atmos/Rotting/PerishableComponent.cs
@@ -52,12 +52,6 @@ public sealed partial class PerishableComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public bool ForceRotProgression;
-
-    /// <summary>
-    /// If true, it ignores human body temperature.
-    /// </summary>
-    [DataField, AutoNetworkedField]
-    public bool IgnoreTemperature;
 }
 
 

--- a/Content.Shared/Body/Systems/SharedBloodstreamSystem.cs
+++ b/Content.Shared/Body/Systems/SharedBloodstreamSystem.cs
@@ -272,6 +272,7 @@ public abstract class SharedBloodstreamSystem : EntitySystem
     /// </summary>
     private void OnHealthBeingExamined(Entity<BloodstreamComponent> ent, ref HealthBeingExaminedEvent args)
     {
+        return; // RMC14
         // Shows massively bleeding at 0.75x the max bleed rate.
         if (ent.Comp.BleedAmount > ent.Comp.MaxBleedAmount * 0.75f)
         {

--- a/Content.Shared/Mind/SharedMindSystem.cs
+++ b/Content.Shared/Mind/SharedMindSystem.cs
@@ -174,8 +174,8 @@ public abstract partial class SharedMindSystem : EntitySystem
             args.PushMarkup($"[color=mediumpurple]{Loc.GetString("comp-mind-examined-dead-and-irrecoverable", ("ent", uid))}[/color]");
         else if (dead && !hasActiveSession)
             args.PushMarkup($"[color=yellow]{Loc.GetString("comp-mind-examined-dead-and-ssd", ("ent", uid))}[/color]");
-        else if (dead)
-            args.PushMarkup($"[color=red]{Loc.GetString("comp-mind-examined-dead", ("ent", uid))}[/color]");
+        // RMC14 else if (dead)vf
+            // args.PushMarkup($"[color=red]{Loc.GetString("comp-mind-examined-dead", ("ent", uid))}[/color]");
         else if (hasUserId == null)
             args.PushMarkup($"[color=mediumpurple]{Loc.GetString("comp-mind-examined-catatonic", ("ent", uid))}[/color]");
         else if (!hasActiveSession)

--- a/Content.Shared/_RMC14/Medical/CPR/CPRSystem.cs
+++ b/Content.Shared/_RMC14/Medical/CPR/CPRSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.Marines.Skills;
+using Content.Shared._RMC14.Medical.Unrevivable;
 using Content.Shared.Atmos.Rotting;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
@@ -25,7 +26,7 @@ public sealed class CPRSystem : EntitySystem
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly SharedPopupSystem _popups = default!;
-    [Dependency] private readonly SharedRottingSystem _rotting = default!;
+    [Dependency] private readonly RMCUnrevivableSystem _unrevivable = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SkillsSystem _skills = default!;
 
@@ -77,9 +78,7 @@ public sealed class CPRSystem : EntitySystem
 
         args.Handled = true;
 
-        // TODO RMC14 make this not use rotting
-        if (_net.IsServer)
-            _rotting.ReduceAccumulator(target, TimeSpan.FromSeconds(7));
+        _unrevivable.AddRevivableTime(target, TimeSpan.FromSeconds(7));
 
         if (!TryComp(target, out DamageableComponent? damageable) ||
             !damageable.Damage.DamageDict.TryGetValue(HealType, out damage))
@@ -146,7 +145,7 @@ public sealed class CPRSystem : EntitySystem
         if (args.Cancelled)
             return;
 
-        if (_mobState.IsAlive(ent) || _rotting.IsRotten(ent))
+        if (_mobState.IsAlive(ent) || _unrevivable.IsUnrevivable(ent))
             args.Cancelled = true;
     }
 

--- a/Content.Shared/_RMC14/Medical/Defibrillator/CMDefibrillatorBlockedComponent.cs
+++ b/Content.Shared/_RMC14/Medical/Defibrillator/CMDefibrillatorBlockedComponent.cs
@@ -13,5 +13,5 @@ public sealed partial class CMDefibrillatorBlockedComponent : Component
     public LocId Examine = "rmc-defib-suicide";
 
     [DataField, AutoNetworkedField]
-    public bool ShowOnExamine = true;
+    public bool ShowOnExamine = false;
 }

--- a/Content.Shared/_RMC14/Medical/Defibrillator/CMDefibrillatorBlockedComponent.cs
+++ b/Content.Shared/_RMC14/Medical/Defibrillator/CMDefibrillatorBlockedComponent.cs
@@ -7,10 +7,10 @@ namespace Content.Shared._RMC14.Medical.Defibrillator;
 public sealed partial class CMDefibrillatorBlockedComponent : Component
 {
     [DataField]
-    public LocId Popup = "defibrillator-unrevivable";
+    public LocId Popup = "rmc-defibrillator-unrevivable";
 
     [DataField]
-    public LocId Examine = "rmc-defib-suicide";
+    public LocId Examine = "rmc-defibrillator-unrevivable";
 
     [DataField, AutoNetworkedField]
     public bool ShowOnExamine = false;

--- a/Content.Shared/_RMC14/Medical/Examine/RMCBlockMedicalExamineComponent.cs
+++ b/Content.Shared/_RMC14/Medical/Examine/RMCBlockMedicalExamineComponent.cs
@@ -1,0 +1,7 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Medical.Examine;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(RMCMedicalExamineSystem))]
+public sealed partial class RMCBlockMedicalExamineComponent : Component;

--- a/Content.Shared/_RMC14/Medical/Examine/RMCMedicalExamineComponent.cs
+++ b/Content.Shared/_RMC14/Medical/Examine/RMCMedicalExamineComponent.cs
@@ -1,0 +1,26 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Medical.Examine;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(RMCMedicalExamineSystem))]
+public sealed partial class RMCMedicalExamineComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public LocId UnrevivableText = "rmc-medical-examine-unrevivable";
+
+    [DataField, AutoNetworkedField]
+    public LocId AliveText = "rmc-medical-examine-alive";
+
+    [DataField, AutoNetworkedField]
+    public LocId DeadText = "rmc-medical-examine-dead";
+
+    [DataField, AutoNetworkedField]
+    public LocId CritText = "rmc-medical-examine-unconscious";
+
+    [DataField, AutoNetworkedField]
+    public LocId BleedText = "rmc-medical-examine-bleeding";
+
+    [DataField, AutoNetworkedField]
+    public bool Simple = false;
+}

--- a/Content.Shared/_RMC14/Medical/Examine/RMCMedicalExamineSystem.cs
+++ b/Content.Shared/_RMC14/Medical/Examine/RMCMedicalExamineSystem.cs
@@ -1,0 +1,87 @@
+﻿using Content.Shared._RMC14.Medical.Unrevivable;
+using Content.Shared._RMC14.Stun;
+using Content.Shared.Body.Components;
+using Content.Shared.Examine;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.Verbs;
+using Robust.Shared.Timing;
+using Robust.Shared.Utility;
+
+namespace Content.Shared._RMC14.Medical.Examine;
+
+public sealed class RMCMedicalExamineSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly RMCUnrevivableSystem _unrevivable = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
+    [Dependency] private readonly ExamineSystemShared _examine = default!;
+    [Dependency] private readonly RMCSizeStunSystem _sizeStun = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<RMCMedicalExamineComponent, ExaminedEvent>(OnExamined);
+        SubscribeLocalEvent<RMCMedicalExamineComponent, GetVerbsEvent<ExamineVerb>>(OnGetExamineVerbs);
+    }
+
+    private void OnExamined(Entity<RMCMedicalExamineComponent> ent, ref ExaminedEvent args)
+    {
+        if (!ent.Comp.Simple || !_mobState.IsDead(ent.Owner))
+            return;
+
+        using (args.PushGroup(nameof(RMCMedicalExamineSystem), 1))
+        {
+            args.PushMarkup(Loc.GetString(ent.Comp.DeadText));
+        }
+    }
+
+    private void OnGetExamineVerbs(Entity<RMCMedicalExamineComponent> ent, ref GetVerbsEvent<ExamineVerb> args)
+    {
+        if (ent.Comp.Simple)
+            return;
+
+        var user = args.User;
+
+        if (HasComp<RMCBlockMedicalExamineComponent>(user))
+            return;
+
+        var detailsRange = _examine.IsInDetailsRange(user, ent.Owner);
+
+        var verb = new ExamineVerb()
+        {
+            Act = () =>
+            {
+                var text = GetExamineText(ent);
+                _examine.SendExamineTooltip(user, ent, text, false, false);
+            },
+            Text = Loc.GetString("rmc-medical-examine-verb"),
+            Category = VerbCategory.Examine,
+            Disabled = !detailsRange,
+            Message = detailsRange ? null : Loc.GetString("health-examinable-verb-disabled"),
+            Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/rejuvenate.svg.192dpi.png"))
+        };
+
+        args.Verbs.Add(verb);
+    }
+
+    public FormattedMessage GetExamineText(Entity<RMCMedicalExamineComponent> ent)
+    {
+        var msg = new FormattedMessage();
+
+        if (TryComp<BloodstreamComponent>(ent, out var bloodstream) && bloodstream.BleedAmount > 0)
+        {
+            msg.AddMarkupOrThrow(Loc.GetString(ent.Comp.BleedText, ("victim", ent.Owner)));
+            msg.PushNewline();
+        }
+
+        var stateText = ent.Comp.AliveText;
+
+        if (_mobState.IsDead(ent))
+            stateText = _unrevivable.IsUnrevivable(ent) ? ent.Comp.UnrevivableText : ent.Comp.DeadText;
+        else if (_mobState.IsCritical(ent) || _sizeStun.IsKnockedOut(ent))
+            stateText = ent.Comp.CritText;
+
+        msg.AddMarkupOrThrow(Loc.GetString(stateText, ("victim", ent.Owner)));
+
+        return msg;
+    }
+}

--- a/Content.Shared/_RMC14/Medical/Examine/RMCMedicalExamineSystem.cs
+++ b/Content.Shared/_RMC14/Medical/Examine/RMCMedicalExamineSystem.cs
@@ -30,7 +30,7 @@ public sealed class RMCMedicalExamineSystem : EntitySystem
 
         using (args.PushGroup(nameof(RMCMedicalExamineSystem), 1))
         {
-            args.PushMarkup(Loc.GetString(ent.Comp.DeadText));
+            args.PushMarkup(Loc.GetString(ent.Comp.DeadText, ("victim", ent.Owner)));
         }
     }
 

--- a/Content.Shared/_RMC14/Medical/Unrevivable/RMCRevivableComponent.cs
+++ b/Content.Shared/_RMC14/Medical/Unrevivable/RMCRevivableComponent.cs
@@ -8,9 +8,6 @@ namespace Content.Shared._RMC14.Medical.Unrevivable;
 public sealed partial class RMCRevivableComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public int Stage = 0;
-
-    [DataField, AutoNetworkedField]
     public TimeSpan UnrevivableDelay = TimeSpan.FromMinutes(5);
 
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]

--- a/Content.Shared/_RMC14/Medical/Unrevivable/RMCRevivableComponent.cs
+++ b/Content.Shared/_RMC14/Medical/Unrevivable/RMCRevivableComponent.cs
@@ -1,0 +1,21 @@
+﻿using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Shared._RMC14.Medical.Unrevivable;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
+[Access(typeof(RMCUnrevivableSystem))]
+public sealed partial class RMCRevivableComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public int Stage = 0;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan UnrevivableDelay = TimeSpan.FromMinutes(5);
+
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
+    public TimeSpan UnrevivableAt = TimeSpan.Zero;
+
+    [DataField, AutoNetworkedField]
+    public LocId UnrevivableReasonMessage = "rmc-defibrillator-unrevivable";
+}

--- a/Content.Shared/_RMC14/Medical/Unrevivable/RMCUnrevivableSystem.cs
+++ b/Content.Shared/_RMC14/Medical/Unrevivable/RMCUnrevivableSystem.cs
@@ -1,0 +1,94 @@
+﻿using Content.Shared.Mobs;
+using Content.Shared.Traits.Assorted;
+using Robust.Shared.Timing;
+
+namespace Content.Shared._RMC14.Medical.Unrevivable;
+
+public sealed class RMCUnrevivableSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<RMCRevivableComponent, MobStateChangedEvent>(OnMobstateChanged);
+    }
+
+    private void OnMobstateChanged(Entity<RMCRevivableComponent> ent, ref MobStateChangedEvent args)
+    {
+        if (args.NewMobState == MobState.Dead)
+            ent.Comp.UnrevivableAt = _timing.CurTime + ent.Comp.UnrevivableDelay;
+        else
+            ent.Comp.UnrevivableAt = TimeSpan.Zero;
+
+        Dirty(ent);
+    }
+
+    public void AddRevivableTime(EntityUid uid, TimeSpan time)
+    {
+        if (!TryComp<RMCRevivableComponent>(uid, out var revivable))
+            return;
+
+        if (revivable.UnrevivableAt == TimeSpan.Zero)
+            return;
+
+        revivable.UnrevivableAt += time;
+        Dirty(uid, revivable);
+    }
+
+    public bool IsUnrevivable(EntityUid uid)
+    {
+        return HasComp<UnrevivableComponent>(uid);
+    }
+
+    public void MakeUnrevivable(Entity<RMCRevivableComponent?> ent)
+    {
+        if (!Resolve(ent.Owner, ref ent.Comp, false))
+            return;
+
+        var unrevivable = EnsureComp<UnrevivableComponent>(ent);
+        unrevivable.Analyzable = false;
+        unrevivable.Cloneable = false;
+        unrevivable.ReasonMessage = ent.Comp.UnrevivableReasonMessage;
+        Dirty(ent);
+    }
+
+    public int GetUnrevivableStage(Entity<RMCRevivableComponent?> ent, int maxStages)
+    {
+        if (!Resolve(ent.Owner, ref ent.Comp, false))
+            return 0;
+
+        if (ent.Comp.UnrevivableAt == TimeSpan.Zero)
+            return 0;
+
+        var now = _timing.CurTime;
+        var end = ent.Comp.UnrevivableAt;
+        var start = ent.Comp.UnrevivableAt - ent.Comp.UnrevivableDelay;
+
+        var progress = (now - start) / (end - start);
+        progress = Math.Clamp(progress, 0, 1);
+
+        return (int)(progress * maxStages);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var revivableQuery = EntityQueryEnumerator<RMCRevivableComponent>();
+        while (revivableQuery.MoveNext(out var uid, out var revivable))
+        {
+            if (IsUnrevivable(uid))
+                continue;
+
+            if (revivable.UnrevivableAt == TimeSpan.Zero)
+                continue;
+
+            if (_timing.CurTime < revivable.UnrevivableAt)
+                continue;
+
+            MakeUnrevivable((uid, revivable));
+        }
+    }
+}

--- a/Content.Shared/_RMC14/Medical/Unrevivable/RMCUnrevivableSystem.cs
+++ b/Content.Shared/_RMC14/Medical/Unrevivable/RMCUnrevivableSystem.cs
@@ -67,9 +67,7 @@ public sealed class RMCUnrevivableSystem : EntitySystem
         var start = ent.Comp.UnrevivableAt - ent.Comp.UnrevivableDelay;
 
         var progress = (now - start) / (end - start);
-        progress = Math.Clamp(progress, 0, 1);
-
-        return (int)(progress * maxStages);
+        return (int)(maxStages * progress);
     }
 
     public override void Update(float frameTime)

--- a/Content.Shared/_RMC14/Stun/RMCSizeStunSystem.cs
+++ b/Content.Shared/_RMC14/Stun/RMCSizeStunSystem.cs
@@ -183,7 +183,7 @@ public sealed class RMCSizeStunSystem : EntitySystem
         if (!TryComp<RMCSizeComponent>(target, out var size) || size.Size >= RMCSizes.Big && !ignoreSize)
             return;
 
-        if(knockedBackFrom == null)
+        if (knockedBackFrom == null)
             return;
 
         //TODO Camera Shake
@@ -332,7 +332,7 @@ public sealed class RMCSizeStunSystem : EntitySystem
 
     private void OnUnconsciousUpdate(Entity<RMCUnconsciousComponent> ent, ref StatusEffectEndedEvent args)
     {
-        if (!_status.HasStatusEffect(ent, KnockedOut))
+        if (!IsKnockedOut(ent))
             return;
 
         //Readd comps just in case they were removed by a status
@@ -345,7 +345,7 @@ public sealed class RMCSizeStunSystem : EntitySystem
 
     private void OnUnconsciousPointAttempt(Entity<RMCUnconsciousComponent> ent, ref PointAttemptEvent args)
     {
-        if (!_status.HasStatusEffect(ent, KnockedOut))
+        if (!IsKnockedOut(ent))
             return;
 
         args.Cancel();
@@ -359,5 +359,10 @@ public sealed class RMCSizeStunSystem : EntitySystem
     private void OnKnockOutCollideThrowHit(Entity<RMCKnockOutOnCollideComponent> ent, ref ThrowDoHitEvent args)
     {
         TryKnockOut(args.Target, ent.Comp.ParalyzeTime);
+    }
+
+    public bool IsKnockedOut(EntityUid uid)
+    {
+        return _status.HasStatusEffect(uid, KnockedOut);
     }
 }

--- a/Content.Shared/_RMC14/Suicide/RMCSuicideSystem.cs
+++ b/Content.Shared/_RMC14/Suicide/RMCSuicideSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared._RMC14.Medical.Defibrillator;
+﻿using Content.Shared._RMC14.Medical.Unrevivable;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Damage;
 using Content.Shared.Database;
@@ -27,6 +27,7 @@ public sealed class RMCSuicideSystem : EntitySystem
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly RMCUnrevivableSystem _unrevivable = default!;
 
     public override void Initialize()
     {
@@ -127,9 +128,9 @@ public sealed class RMCSuicideSystem : EntitySystem
         _admin.Add(LogType.RMCSuicide, LogImpact.High, $"{ToPrettyString(user)} suicided.");
         _damageable.TryChangeDamage(user, ent.Comp.Damage, true);
         _mobState.ChangeMobState(user, MobState.Dead);
-        EnsureComp<RMCHasSuicidedComponent>(user);
-        EnsureComp<CMDefibrillatorBlockedComponent>(user);
+        _unrevivable.MakeUnrevivable(user);
         _audio.PlayPredicted(gun.SoundGunshot, held, ent);
+        EnsureComp<RMCHasSuicidedComponent>(user);
     }
 
     private void OnHasSuicidedUpdateMobState(Entity<RMCHasSuicidedComponent> ent, ref UpdateMobStateEvent args)

--- a/Content.Shared/_RMC14/Synth/SharedSynthSystem.cs
+++ b/Content.Shared/_RMC14/Synth/SharedSynthSystem.cs
@@ -1,6 +1,7 @@
 ﻿using Content.Shared._RMC14.IdentityManagement;
 using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.Medical.HUD.Components;
+using Content.Shared._RMC14.Medical.Unrevivable;
 using Content.Shared._RMC14.Repairable;
 using Content.Shared._RMC14.StatusEffect;
 using Content.Shared.Bed.Sleep;
@@ -82,6 +83,7 @@ public abstract class SharedSynthSystem : EntitySystem
             Dirty(ent.Owner, healthIcons);
         }
 
+        RemCompDeferred<RMCRevivableComponent>(ent.Owner);
         RemCompDeferred<SlowOnDamageComponent>(ent.Owner);
     }
 

--- a/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using Content.Shared._RMC14.Atmos;
 using Content.Shared._RMC14.Damage;
 using Content.Shared._RMC14.Hands;
+using Content.Shared._RMC14.Medical.Unrevivable;
 using Content.Shared._RMC14.Stun;
 using Content.Shared._RMC14.Xenonids.Construction.Nest;
 using Content.Shared._RMC14.Xenonids.Construction.ResinWhisper;
@@ -74,6 +75,7 @@ public abstract partial class SharedXenoParasiteSystem : EntitySystem
     [Dependency] private readonly SharedRottingSystem _rotting = default!;
     [Dependency] private readonly TagSystem _tagSystem = default!;
     [Dependency] private readonly RMCSizeStunSystem _size = default!;
+    [Dependency] private readonly RMCUnrevivableSystem _unrevivable = default!;
 
     private const CollisionGroup LeapCollisionGroup = CollisionGroup.InteractImpassable;
     private const CollisionGroup ThrownCollisionGroup = CollisionGroup.InteractImpassable | CollisionGroup.BarricadeImpassable;
@@ -380,6 +382,7 @@ public abstract partial class SharedXenoParasiteSystem : EntitySystem
     private void OnVictimBurstMapInit(Entity<VictimBurstComponent> burst, ref MapInitEvent args)
     {
         _appearance.SetData(burst, BurstVisuals.Visuals, VictimBurstState.Burst);
+        _unrevivable.MakeUnrevivable(burst.Owner);
     }
 
     private void OnVictimUpdateMobState(Entity<VictimBurstComponent> burst, ref UpdateMobStateEvent args)

--- a/Resources/Locale/en-US/_RMC14/medical/defib.ftl
+++ b/Resources/Locale/en-US/_RMC14/medical/defib.ftl
@@ -1,3 +1,4 @@
 cm-defib-take-off-armor = Take off {POSS-ADJ($target)} armor first!
 
-rmc-defib-suicide = [color=purple][italic]The light has faded from {POSS-ADJ($victim)} eyes...[/italic][/color]
+rmc-defibrillator-heart-damage = Defibrillation failed. Patient's heart is too damaged. Immediate surgery is advised.
+rmc-defibrillator-unrevivable = Defibrillation failed. Patient's general condition does not allow reviving.

--- a/Resources/Locale/en-US/_RMC14/medical/examine.ftl
+++ b/Resources/Locale/en-US/_RMC14/medical/examine.ftl
@@ -1,0 +1,18 @@
+rmc-medical-examine-unrevivable = [color=purple][italic]{CAPITALIZE(POSS-ADJ($victim))} eyes have gone blank, there are no signs of life.[/italic][/color]
+
+rmc-medical-examine-headless = [color=purple][italic]{CAPITALIZE(SUBJECT($victim))} {CONJUGATE-BE($victim)} definitely dead.[/italic][/color]
+
+rmc-medical-examine-unconscious = [color=lightblue]{ CAPITALIZE(SUBJECT($victim)) } { GENDER($victim) ->
+    [epicene] seem
+    *[other] seems
+  } to be unconscious.[/color]
+
+rmc-medical-examine-dead = [color=red]{CAPITALIZE(SUBJECT($victim))} {CONJUGATE-BE($victim)} not breathing.[/color]
+
+rmc-medical-examine-dead-simple-mob = [color=red]{CAPITALIZE(SUBJECT($victim))} {CONJUGATE-BE($victim)} DEAD. Kicked the bucket.[/color]
+
+rmc-medical-examine-alive = [color=green]{CAPITALIZE(SUBJECT($victim))} {CONJUGATE-BE($victim)} alive and breathing.[/color]
+
+rmc-medical-examine-bleeding = [color=#d10a0a]{CAPITALIZE(SUBJECT($victim))} {CONJUGATE-HAVE($victim)} bleeding wounds on {POSS-ADJ($victim)} body.[/color]
+
+rmc-medical-examine-verb = Show medical actions

--- a/Resources/Locale/en-US/disease/miasma.ftl
+++ b/Resources/Locale/en-US/disease/miasma.ftl
@@ -2,20 +2,20 @@ ammonia-smell = Something smells pungent!
 
 ## Perishable
 
-perishable-1 = [color=green]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-HAVE($target)} died recently.[/color]
-perishable-2 = [color=orangered]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-HAVE($target)} been dead for a while now.[/color]
-perishable-3 = [color=red]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-HAVE($target)} been dead for several minutes and may become unrevivable![/color]
+perishable-1 = [color=green]{ CAPITALIZE(POSS-ADJ($target)) } corpse still looks fresh.[/color]
+perishable-2 = [color=orangered]{ CAPITALIZE(POSS-ADJ($target)) } corpse looks somewhat fresh.[/color]
+perishable-3 = [color=red]{ CAPITALIZE(POSS-ADJ($target)) } corpse doesn't look very fresh.[/color]
 
-perishable-1-nonmob = [color=green]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-HAVE($target)} died recently.[/color]
-perishable-2-nonmob = [color=orangered]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-HAVE($target)} been dead for a while now.[/color]
-perishable-3-nonmob = [color=red]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-HAVE($target)} been dead for several minutes and may become unrevivable![/color]
+perishable-1-nonmob = [color=green]{ CAPITALIZE(SUBJECT($target)) } still looks fresh.[/color]
+perishable-2-nonmob = [color=orangered]{ CAPITALIZE(SUBJECT($target)) } looks somewhat fresh.[/color]
+perishable-3-nonmob = [color=red]{ CAPITALIZE(SUBJECT($target)) } doesn't look very fresh.[/color]
 
 ## Rotting
 
-rotting-rotting = [color=orange]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} unrevivable.[/color]
-rotting-bloated = [color=orange]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} unrevivable.[/color]
-rotting-extremely-bloated = [color=orange]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} unrevivable.[/color]
+rotting-rotting = [color=orange]{ CAPITALIZE(POSS-ADJ($target)) } corpse is rotting![/color]
+rotting-bloated = [color=orangered]{ CAPITALIZE(POSS-ADJ($target)) } corpse is bloated![/color]
+rotting-extremely-bloated = [color=red]{ CAPITALIZE(POSS-ADJ($target)) } corpse is extremely bloated![/color]
 
-rotting-rotting-nonmob = [color=orange]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} unrevivable.[/color]
-rotting-bloated-nonmob = [color=orange]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} unrevivable.[/color]
-rotting-extremely-bloated-nonmob = [color=orange]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} unrevivable.[/color]
+rotting-rotting-nonmob = [color=orange]{ CAPITALIZE(SUBJECT($target)) } is rotting![/color]
+rotting-bloated-nonmob = [color=orangered]{ CAPITALIZE(SUBJECT($target)) } is bloated![/color]
+rotting-extremely-bloated-nonmob = [color=red]{ CAPITALIZE(SUBJECT($target)) } is extremely bloated![/color]

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
@@ -112,6 +112,8 @@
     damage:
       types:
         Heat: 1
+  - type: RMCRevivable
+  - type: RMCMedicalExamine
   - type: FireVisuals
     sprite: Mobs/Effects/onfire.rsi
     normalState: Generic_mob_burning
@@ -159,9 +161,6 @@
   - type: ShortExamine
   - type: MaxDamage
     max: 719 # TODO RMC14 this should be per part and smaller
-  - type: Perishable
-    rotAfter: 300
-    ignoreTemperature: true
   - type: AtmosExposed
   - type: Temperature
     heatDamageThreshold: 325

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
@@ -37,6 +37,10 @@
     damageContainer: Xeno
   - type: Destructible
     thresholds: []
+  - type: RMCMedicalExamine
+    simple: true
+    deadText: rmc-medical-examine-dead-simple-mob
+  - type: RMCBlockMedicalExamine
   - type: MobState
     allowedStates:
     - Alive


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds medical actions verb from CM13, and splits off becoming braindead from perishable

## Technical details
Just adds a new system for tracking the unrevivable time and then adds the upstream unrevivable component when its complete
Reverts some upstream perishable stuff to minimize conflicts

new RMCUnrevivableSystem.MakeUnrevivable() method, parasites and suicide uses this now

## Media
<img width="371" height="95" alt="image" src="https://github.com/user-attachments/assets/a0d4a5f0-2aae-49fd-8a16-21a829d11aa5" />

<img width="360" height="71" alt="image" src="https://github.com/user-attachments/assets/dddc99dd-a456-4b42-9af0-1ee5fca78ea2" />


https://github.com/user-attachments/assets/c070255e-553a-4e0c-aa84-b4d62b959103


https://github.com/user-attachments/assets/5d4c7adf-08ce-450d-8ab8-c798484f518f



:cl:
- add: Added medical action examine button. This can be used to see the status of a marine, such as if they're unrevivable, dead, bleeding, or unconscious.