### PR TITLE
Smoke nades no longer detonate when deleted

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -109,9 +109,8 @@
     delay: 2
   - type: Sprite
     sprite: _RMC14/Objects/Weapons/Grenades/m40smoke.rsi
-  - type: SpawnOnTerminate
-    spawn: RMCSmoke
-    projectileAdjust: false
+  - type: SpawnOnTrigger
+    proto: RMCSmoke
   - type: SoundOnTrigger
     sound: /Audio/Effects/smoke.ogg
   - type: DeleteOnTrigger


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The m40 smoke grenade now uses `SpawnOnTrigger` instead of `SpawnOnTerminate` to spawn it's effect. This doesn't affect the grenades behavior aside from it no longer detonating when deleted by other means. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #6622

## Technical details
<!-- Summary of code changes for easier review. -->
None.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
