### PR TITLE
sorokyne survivor rank fixes

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/cosmos_exploration_corps.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/cosmos_exploration_corps.yml
@@ -4,6 +4,8 @@
   name: rmc-job-name-survivor-cec-researcher
   description: cm-job-description-survivor
   playTimeTracker: CMJobSurvivorCECResearcher
+  ranks:
+    RMCRankCivilianDoctor: []
   startingGear: RMCGearSurvivorCECResearcher
   accessGroups:
   - ColonistMedical

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/doctor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/doctor.yml
@@ -4,6 +4,8 @@
   name: rmc-job-name-survivor-moh-doctor
   description: cm-job-description-survivor
   playTimeTracker: CMJobSurvivorMoHDoctor
+  ranks:
+    RMCRankCivilianDoctor: []
   startingGear: RMCGearSurvivorMoHDoctor
   accessGroups:
   - ColonistMedical

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/liaison.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/liaison.yml
@@ -1,11 +1,9 @@
 - type: job
-  parent: CMSurvivor
+  parent: CMSurvivorCorporate
   id: CMJobSurvivorHalcyonDynamicsLiaison
   name: rmc-job-name-survivor-halcyon-dynamics-liaison
   description: cm-job-description-survivor
   playTimeTracker: CMJobSurvivorHalcyonDynamicsLiaison
-  ranks:
-    RMCRankWeYaExecutive: []
   startingGear: RMCGearSurvivorHalcyonDynamicsLiaison
   accessGroups:
   - ColonistCorporate


### PR DESCRIPTION
fixes the survivors having the incorrect ranks

:cl:
- fix: Fixed Sorokyne Strata survivors having the wrong ranks.