### PR TITLE
LV-624 Surv fixes + headset fixes

### DIFF
--- a/Resources/Locale/en-US/_RMC14/job/survivor.ftl
+++ b/Resources/Locale/en-US/_RMC14/job/survivor.ftl
@@ -28,9 +28,6 @@ CMSurvivorScientist = Scientist Colonist
 rmc-job-name-survivor-cmb-deputy = CMB Deputy
 CMSurvivorCMBDeputy = CMB Deputy
 
-cm-job-name-survivor-goon = We-Ya Corporate Security
-CMSurvivorGoon = We-Ya Corporate Security
-
 rmc-job-greeting-survivor = You are a survivor of the attack on the colony. You worked or lived in the colony, and managed to avoid the alien attacks... until now.
 
   You are fully aware of the xenonid threat and are able to use this knowledge as you see fit.

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/distress_headsets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/distress_headsets.yml
@@ -36,6 +36,9 @@
   name: bureau earpiece
   description: A sleek headset used by The Colonial Marshal Bureau, crafted in Sol. Low profile and comfortable. No one is above the law.
   components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Clothing/headsets.rsi
+    state: cmb_headset
   - type: ContainerFill
     containers:
       key_slots:
@@ -43,7 +46,7 @@
 
 # For CMB and ICB survivors.
 - type: entity
-  parent: RMCHeadsetIconsCMB
+  parent: RMCHeadsetDistressBureau
   id: RMCHeadsetDistressBureauDamaged
   name: damaged bureau earpiece
   description: A sleek headset used by The Colonial Marshal Bureau, crafted in Sol. Low profile and comfortable. No one is above the law. This one is pretty beat up, and seems to be missing a few frequencies.
@@ -202,6 +205,7 @@
   - type: RMCHeadset
     radioTextIncrease: 3
 
+# Survivor SOF/FORECON
 - type: entity
   parent: RMCHeadsetMarine
   id: RMCHeadsetForecon
@@ -240,7 +244,7 @@
 
 # For MARSOC
 - type: entity
-  parent: RMCHeadsetIcons
+  parent: RMCHeadsetForecon
   id: RMCHeadsetMARSOC
   name: UNMC SOF headset
   description: Issued exclusively to Marine Raiders and members of the UNMC's Force Reconnaissance.

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/distress_headsets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/distress_headsets.yml
@@ -248,6 +248,7 @@
   id: RMCHeadsetMARSOC
   name: UNMC SOF headset
   description: Issued exclusively to Marine Raiders and members of the UNMC's Force Reconnaissance.
+  suffix: ERT
   components:
   - type: ContainerFill
     containers:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m54c_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m54c_rifle.yml
@@ -174,7 +174,18 @@
   - type: ItemSlots
     slots:
       gun_magazine:
+        name: Magazine
         startingItem: CMMagazineRifleM54C
+        insertSound: /Audio/_RMC14/Weapons/Guns/Reload/m41_reload.ogg
+        ejectSound: /Audio/_RMC14/Weapons/Guns/Reload/m41_unload.ogg
+        priority: 2
+        whitelist:
+          tags:
+          - CMMagazineRifleM54C
+          - CMMagazineRifleM54CAP
+          - CMMagazineRifleM54CExt
+          - RMCMagazineRifleM54CIncendiary
+          - RMCMagazineRifleM54CHEAP
   - type: AttachableHolder
     slots:
       rmc-aslot-stock:
@@ -192,7 +203,18 @@
   - type: ItemSlots
     slots:
       gun_magazine:
+        name: Magazine
         startingItem: CMMagazineRifleM54C
+        insertSound: /Audio/_RMC14/Weapons/Guns/Reload/m41_reload.ogg
+        ejectSound: /Audio/_RMC14/Weapons/Guns/Reload/m41_unload.ogg
+        priority: 2
+        whitelist:
+          tags:
+          - CMMagazineRifleM54C
+          - CMMagazineRifleM54CAP
+          - CMMagazineRifleM54CExt
+          - RMCMagazineRifleM54CIncendiary
+          - RMCMagazineRifleM54CHEAP
 
 - type: entity
   parent: RMCWeaponRifleM54CSemiStripped

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Base_Survs/cmb_deputy_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Base_Survs/cmb_deputy_survivor.yml
@@ -11,6 +11,8 @@
     RMCRankCMBDeputy: []
   startingGear: RMCGearSurvivorCMBDeputy
   spawnMenuRoleName: CMB Deputy (Survivor)
+  icon: "RMCJobIconBureauDeputy"
+  hasIcon: true
   special:
   - !type:AddComponentSpecial
     components:
@@ -35,6 +37,13 @@
     - type: RMCAllowSuitStorage
     - type: EquipSurvivorPreset
       preset: RMCGearSurvivorPresetCMBDeputy
+    - type: TacticalMapIcon
+      icon:
+        sprite: _RMC14/Interface/map_blips.rsi
+        state: deputy
+      background:
+        sprite: _RMC14/Interface/map_blips.rsi
+        state: background_cmb
 
 - type: startingGear
   parent: RMCGearSurvivorSecurity
@@ -44,7 +53,7 @@
     id: RMCIDCardDeputySurvivor
     jumpsuit: RMCMarshalCMBUniform
     outerClothing: RMCCoatBureauDeputy
-    ears: RMCHeadsetDistressBureau
+    ears: RMCHeadsetDistressBureauDamaged
     pocket2: RMCPouchMagazineLarge
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/LV624/cargo_technician_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/LV624/cargo_technician_survivor.yml
@@ -1,5 +1,5 @@
 - type: job
-  parent: CMSurvivorDoctor
+  parent: CMSurvivorEngineer
   id: CMSurvivorLV624CargoTechnician
   name: rmc-job-name-survivor-lv624-cargo-technician
   description: cm-job-description-survivor

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/LV624/corporate_liaison.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/LV624/corporate_liaison.yml
@@ -5,8 +5,6 @@
   description: cm-job-description-survivor
   playTimeTracker: CMJobSurvivorLV624CorporateLiaison
   spawnMenuRoleName: Corporate Liaison (LV624 Survivor)
-  ranks:
-    RMCRankICBCorporateLiaison: []
   startingGear: RMCGearSurvivorLV624CorporateLiaison
   special:
   - !type:AddComponentSpecial

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Multi_Map/goon_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Multi_Map/goon_survivor.yml
@@ -1,11 +1,13 @@
 - type: job
   parent: CMSurvivorSecurity
   id: CMSurvivorGoon
-  name: cm-job-name-survivor-goon
+  name: rmc-job-name-pmc-corporate-goon
   description: cm-job-description-survivor
   playTimeTracker: CMJobSurvivorGoon
   startingGear: RMCGearSurvivorGoon
   spawnMenuRoleName: We-Ya Goon (Survivor)
+  icon: "RMCJobIconPMCGoonStandard"
+  hasIcon: true
   special:
   - !type:AddComponentSpecial
     components:
@@ -40,7 +42,7 @@
     shoes: RMCBootsPMCFilled
     back: RMCSatchelLightpack
     belt: CMM77BeltFilled # TODO RMC14: PMC re-sprite
-    suitstorage: RMCWeaponRifleM54CWhite # TODO RMC14: Corporate semi-stripped (white)
+    suitstorage: RMCWeaponRifleM54CWhite
     pocket1: RMCPouchSurvivalFill
     pocket2: RMCPouchFirstAidPMCFill
   storage:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/New_Varadero/new_varadero_researcher.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/New_Varadero/new_varadero_researcher.yml
@@ -5,6 +5,7 @@
   description: cm-job-description-survivor
   playTimeTracker: RMCJobSurvivorNewVaraderoResearcher
   startingGear: RMCGearSurvivorNewVaraderoResearcher
+  spawnMenuRoleName: New Varadero Researcher (NV Survivor)
   accessGroups:
   - ColonistMedical
   useLoadoutOfJob: CMSurvivorScientist


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- Makes the CMB survivor have an icon and tacmap icon, from CM13
- Fixes the CMB headset having an incorrect sprite, also fixes the CMB surv having the normal CMB headset and not the damaged one
- Fixes MARSOC headset not having SOF channel and wrong sprite
- Fixes the Corporate M54C having the wrong magazine whitelist and insert/eject sounds
- Fixes the LV-624 weya goon not having an icon
- Fixes LV-624 inheriting from the wrong job, and fixes the LV-624 liaison ranks

**Changelog**
:cl:
- fix: Fixed LV-624 CMB Deputy Survivor not having a tacmap icon.
- fix: Fixed LV-624 CMB Deputy survivor headset having marine channels.
