### PR TITLE
Head top marking layer is now above hats.

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -43,12 +43,12 @@
     - map: [ "enum.HumanoidVisualLayers.FacialHair" ]
     - map: [ "enum.HumanoidVisualLayers.Hair" ]
     - map: [ "enum.HumanoidVisualLayers.HeadSide" ]
-    - map: [ "enum.HumanoidVisualLayers.HeadTop" ]
     - map: [ "enum.HumanoidVisualLayers.Tail" ]
     - map: [ "mask" ]
     - map: [ "neck" ] # RMC14 re-arrange neck slot
     - map: [ "head" ]
     - map: [ "enum.SquadArmorLayers.Helmet" ]
+    - map: [ "enum.HumanoidVisualLayers.HeadTop" ] # RMC14 re-arrange headtop slot
     - map: [ "enum.VisorVisualLayers.Base" ]
     - map: [ "pocket1" ]
     - map: [ "pocket2" ]
@@ -359,7 +359,6 @@
     - map: [ "enum.HumanoidVisualLayers.FacialHair" ]
     - map: [ "enum.HumanoidVisualLayers.Hair" ]
     - map: [ "enum.HumanoidVisualLayers.HeadSide" ]
-    - map: [ "enum.HumanoidVisualLayers.HeadTop" ]
     - map: [ "enum.HumanoidVisualLayers.Tail" ]
     - map: [ "mask" ]
     - map: [ "neck" ] # RMC14 re-arrange neck slot
@@ -367,6 +366,7 @@
     - map: [ "pocket1" ]
     - map: [ "pocket2" ]
     - map: [ "enum.MedalVisualLayers.Base" ]
+    - map: [ "enum.HumanoidVisualLayers.HeadTop" ] # RMC14 re-arrange headtop slot
   - type: Appearance
   - type: HumanoidAppearance
     species: Human


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Makes head top markings go above the helmets/hats etc etc.
I will *note* that some species even by basic markings might look eh with the helmet so i could just make it that the helmets will be the same still while normal hats will have this. 
Instances of when the helmet would look really weird (this only really happens with skrella) I want to be fully honest and not just pretend that i checked everythin and its gonna look *chefs kiss*
<img width="189" height="160" alt="image" src="https://github.com/user-attachments/assets/27ff6189-41ae-41d1-9696-0cfcf9dcacae" />

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
So to be honest. It genuily icked me with the fact how hats at the front? looked fine, you can see ears (some of em) but then you look at the side and you see that there is *nothing there*, this incosistency is just killing me inside and ss13 has this. (ss13 isnt a good argument, i know but mostly the idea is comin from there)
Plus I believe it just makes species look better with horns/ears not being overlapped by hats, etc etc
## Technical details
<!-- Summary of code changes for easier review. -->
Pretty much simple YML
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="186" height="178" alt="Zrzut ekranu 2025-07-22 202550" src="https://github.com/user-attachments/assets/724e3f78-10da-4b0d-b2d9-c36cf114ca71" />

<img width="183" height="160" alt="image" src="https://github.com/user-attachments/assets/f8bac6bf-e775-4cda-b2a2-2bb24ad107b7" />

<img width="195" height="141" alt="image" src="https://github.com/user-attachments/assets/2b163960-dce0-484e-b925-044ea1514b21" />

<img width="164" height="124" alt="image" src="https://github.com/user-attachments/assets/e7be67b6-6e30-4ee7-9ff6-f320e4417797" />

<img width="184" height="222" alt="image" src="https://github.com/user-attachments/assets/2868e337-3303-4706-8d0d-2396a4c18e92" />

<img width="292" height="232" alt="image" src="https://github.com/user-attachments/assets/8caeefcb-1e7a-444f-9cc7-0e1606c73061" />

<img width="236" height="167" alt="image" src="https://github.com/user-attachments/assets/2b7c315d-5308-4021-8a8e-0c8ed195e66f" />

<img width="235" height="223" alt="image" src="https://github.com/user-attachments/assets/d3cb12ed-03e8-4847-830f-872f79b16354" />

<img width="186" height="167" alt="image" src="https://github.com/user-attachments/assets/dd637a1e-d5e2-4654-8a7e-1c97351c7955" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Changed layering of head top marking to be above hats. Ears/horns will be now visible.


