### PR TITLE
Signal flares get renamed to their CAS identifier

### DIFF
--- a/Content.Shared/_RMC14/Dropship/Weapon/SharedDropshipWeaponSystem.cs
+++ b/Content.Shared/_RMC14/Dropship/Weapon/SharedDropshipWeaponSystem.cs
@@ -30,6 +30,7 @@ using Content.Shared.IgnitionSource;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Item;
 using Content.Shared.Light.Components;
+using Content.Shared.NameModifier.EntitySystems;
 using Content.Shared.ParaDrop;
 using Content.Shared.Popups;
 using Content.Shared.Projectiles;
@@ -68,6 +69,7 @@ public abstract class SharedDropshipWeaponSystem : EntitySystem
     [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
     [Dependency] private readonly SharedEyeSystem _eye = default!;
     [Dependency] private readonly IMapManager _mapManager = default!;
+    [Dependency] private readonly NameModifierSystem _name = default!;
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly SharedOnCollideSystem _onCollide = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
@@ -102,8 +104,6 @@ public abstract class SharedDropshipWeaponSystem : EntitySystem
         SubscribeLocalEvent<FlareSignalComponent, StopThrowEvent>(OnFlareSignalStopThrow);
         SubscribeLocalEvent<FlareSignalComponent, ContainerGettingInsertedAttemptEvent>(OnFlareSignalContainerGettingInsertedAttempt);
 
-        SubscribeLocalEvent<ActiveFlareSignalComponent, ExaminedEvent>(OnActiveFlareExamined);
-
         SubscribeLocalEvent<DropshipTerminalWeaponsComponent, MapInitEvent>(OnTerminalMapInit);
         SubscribeLocalEvent<DropshipTerminalWeaponsComponent, BoundUIOpenedEvent>(OnTerminalBUIOpened);
         SubscribeLocalEvent<DropshipTerminalWeaponsComponent, BoundUIClosedEvent>(OnTerminalBUIClosed);
@@ -111,6 +111,9 @@ public abstract class SharedDropshipWeaponSystem : EntitySystem
         SubscribeLocalEvent<DropshipTargetComponent, MapInitEvent>(OnDropshipTargetMapInit);
         SubscribeLocalEvent<DropshipTargetComponent, ComponentRemove>(OnDropshipTargetRemove);
         SubscribeLocalEvent<DropshipTargetComponent, EntityTerminatingEvent>(OnDropshipTargetRemove);
+        SubscribeLocalEvent<DropshipTargetComponent, ExaminedEvent>(OnActiveFlareExamined);
+
+        SubscribeLocalEvent<ActiveFlareSignalComponent, RefreshNameModifiersEvent>(OnRefreshNameModifier);
 
         SubscribeLocalEvent<DropshipTargetEyeComponent, ComponentRemove>(OnDropshipTargetEyeRemove);
         SubscribeLocalEvent<DropshipTargetEyeComponent, EntityTerminatingEvent>(OnDropshipTargetEyeRemove);
@@ -252,7 +255,7 @@ public abstract class SharedDropshipWeaponSystem : EntitySystem
         MakeDropshipTarget(ent, abbreviation);
     }
 
-    private void OnActiveFlareExamined(Entity<ActiveFlareSignalComponent> ent, ref ExaminedEvent args)
+    private void OnActiveFlareExamined(Entity<DropshipTargetComponent> ent, ref ExaminedEvent args)
     {
         if (ent.Comp.Abbreviation is { } id)
             args.PushMarkup(Loc.GetString("rmc-laser-designator-signal-flare-examine-id", ("id", id)));
@@ -887,6 +890,14 @@ public abstract class SharedDropshipWeaponSystem : EntitySystem
         RefreshWeaponsUI(ent);
     }
 
+    private void OnRefreshNameModifier(Entity<ActiveFlareSignalComponent> ent, ref RefreshNameModifiersEvent args)
+    {
+        if (ent.Comp.Abbreviation == null)
+            return;
+
+        args.AddModifier(ent.Comp.Abbreviation);
+    }
+
     private void UpdateTarget(Entity<DropshipTerminalWeaponsComponent> ent, EntityUid target)
     {
         RemovePvsActors(ent);
@@ -1032,6 +1043,7 @@ public abstract class SharedDropshipWeaponSystem : EntitySystem
         AddComp(ent, target, true);
         Dirty(ent, target);
 
+        _name.RefreshNameModifiers(ent.Owner);
         _physics.SetBodyType(ent, BodyType.Static);
 
         return true;

--- a/Resources/Locale/en-US/_RMC14/rangefinder/rmc-rangefinder.ftl
+++ b/Resources/Locale/en-US/_RMC14/rangefinder/rmc-rangefinder.ftl
@@ -16,7 +16,7 @@ rmc-laser-designator-target-abbreviation-squad = {$letter}-{$id}
 rmc-laser-designator-target-abbreviation = {$id}
 rmc-laser-designator-examine-id = Tracking ID for CAS: {$id}.
 rmc-laser-designator-signal-flare-examine = [color=red]It cannot be picked back up while its burning.[/color]
-rmc-laser-designator-signal-flare-examine-id = This flare has the designator: [color=#ad3b98][bold]{$id}[/bold][/color]
+rmc-laser-designator-signal-flare-examine-id = This target has the designator: [color=#ad3b98][bold]{$id}[/bold][/color]
 rmc-laser-designator-switch-mode = Switch to {$mode} mode
 rmc-laser-designator-in-rangefinder-mode = {CAPITALIZE(THE($item))} is currently set to range finder mode.
 rmc-laser-designator-in-designator-mode = {CAPITALIZE(THE($item))} is currently set to CAS marking mode.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The name of a signal flare now becomes their CAS identifier when thrown.
Fix the CAS identifier not always showing in the examine window.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

- tweak: Signal flares get renamed to their CAS identifier.