### PR TITLE
Fix Tumble, Lunge, Charge, and Headbutt not always hitting

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Charge/XenoChargeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Charge/XenoChargeSystem.cs
@@ -441,7 +441,7 @@ _thrownItemQuery.TryGetComponent(xeno, out var thrown))
         Dirty(xeno);
 
         _rmcObstacleSlamming.MakeImmune(xeno);
-        _throwing.TryThrow(xeno, diff, xeno.Comp.Strength, animated: false, compensateFriction: false);
+        _throwing.TryThrow(xeno, diff, xeno.Comp.Strength, animated: false);
     }
 
     private void OnXenoChargeStop(Entity<XenoChargeComponent> xeno, ref StopThrowEvent args)

--- a/Content.Shared/_RMC14/Xenonids/Charge/XenoChargeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Charge/XenoChargeSystem.cs
@@ -441,7 +441,7 @@ _thrownItemQuery.TryGetComponent(xeno, out var thrown))
         Dirty(xeno);
 
         _rmcObstacleSlamming.MakeImmune(xeno);
-        _throwing.TryThrow(xeno, diff, xeno.Comp.Strength, animated: false, compensateFriction: true);
+        _throwing.TryThrow(xeno, diff, xeno.Comp.Strength, animated: false, compensateFriction: false);
     }
 
     private void OnXenoChargeStop(Entity<XenoChargeComponent> xeno, ref StopThrowEvent args)

--- a/Content.Shared/_RMC14/Xenonids/Lunge/XenoLungeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Lunge/XenoLungeSystem.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using Content.Shared._RMC14.Damage.ObstacleSlamming;
 using Content.Shared._RMC14.Pulling;
 using Content.Shared._RMC14.Stun;
@@ -87,7 +88,7 @@ public sealed class XenoLungeSystem : EntitySystem
         Dirty(xeno);
 
         _rmcObstacleSlamming.MakeImmune(xeno, 0.5f);
-        _throwing.TryThrow(xeno, diff, 30, animated: false, compensateFriction: true);
+        _throwing.TryThrow(xeno, diff, 30, animated: false);
 
         if (!_physicsQuery.TryGetComponent(xeno, out var physics))
             return;
@@ -178,6 +179,7 @@ public sealed class XenoLungeSystem : EntitySystem
             Dirty(xeno, melee);
         }
 
+        StopLunge(xeno);
         _pulling.TryStartPull(xeno, targetId);
         return true;
     }
@@ -216,6 +218,15 @@ public sealed class XenoLungeSystem : EntitySystem
                 args.Attack = new LightAttackEvent(disarm.Target, netAttacker, disarm.Coordinates);
                 break;
         }
+    }
+
+    private void StopLunge(EntityUid lunging)
+    {
+        if (!_physicsQuery.TryGetComponent(lunging, out var physics))
+            return;
+
+        _physics.SetLinearVelocity(lunging, Vector2.Zero, body: physics);
+        _physics.SetBodyStatus(lunging, physics, BodyStatus.OnGround);
     }
 
     public override void Update(float frameTime)

--- a/Content.Shared/_RMC14/Xenonids/Tumble/XenoTumbleComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Tumble/XenoTumbleComponent.cs
@@ -10,7 +10,7 @@ namespace Content.Shared._RMC14.Xenonids.Tumble;
 public sealed partial class XenoTumbleComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public float Range = 1;
+    public float Range = 2;
 
     [DataField, AutoNetworkedField]
     public SoundSpecifier Sound = new SoundCollectionSpecifier("XenoTailSwipe");


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Lunge, Charge, Headbutt and Tumble will now consistently hit targets in range. Lunge was the most noticeable, the other actions only at the edge of their range.
Lunge, Tumble and Headbutt won't overshoot their target anymore, the xeno's velocity is set to 0 when they hit their target.
Charge and Tumble(only without hitting anything) still overshoot a single tile, but they only hit entities within their ability range.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug fix

## Technical details
<!-- Summary of code changes for easier review. -->
These actions throw the xeno at coordinates and apply their effect on throw hit. Friction made it so they would land before reaching their target.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Dygon
- fix: Lunge, Tumble, Headbutt and Charge consistently hit their target again.
- fix: Lunge, Tumble and Headbutt won't move past their target anymore after hitting them.

