### PR TITLE
examine text for shooting into the air

### DIFF
--- a/Content.Shared/_RMC14/Weapons/Ranged/RMCAirShotSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/RMCAirShotSystem.cs
@@ -129,6 +129,9 @@ public sealed class RMCAirShotSystem : EntitySystem
 
     private void OnAirShotExamined(Entity<RMCAirShotComponent> ent, ref ExaminedEvent args)
     {
+        if (ent.Comp.RequiredSkills == null || _skills.HasAllSkills(args.Examiner, ent.Comp.RequiredSkills))
+            args.PushMarkup(Loc.GetString("rmc-gun-shoot-air-examine", ("harm", ent.Comp.RequiresCombat)));
+
         if (ent.Comp.LastFlareId is { } id)
             args.PushMarkup(Loc.GetString("rmc-flare-gun-examine", ("id", id)));
     }

--- a/Content.Shared/_RMC14/Weapons/Ranged/RMCAirShotSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/RMCAirShotSystem.cs
@@ -129,11 +129,14 @@ public sealed class RMCAirShotSystem : EntitySystem
 
     private void OnAirShotExamined(Entity<RMCAirShotComponent> ent, ref ExaminedEvent args)
     {
-        if (ent.Comp.RequiredSkills == null || _skills.HasAllSkills(args.Examiner, ent.Comp.RequiredSkills))
-            args.PushMarkup(Loc.GetString("rmc-gun-shoot-air-examine", ("harm", ent.Comp.RequiresCombat)));
+        using (args.PushGroup(nameof(RMCAirShotComponent), 5))
+        {
+            if (ent.Comp.RequiredSkills == null || _skills.HasAllSkills(args.Examiner, ent.Comp.RequiredSkills))
+                args.PushMarkup(Loc.GetString("rmc-gun-shoot-air-examine", ("harm", ent.Comp.RequiresCombat)));
 
-        if (ent.Comp.LastFlareId is { } id)
-            args.PushMarkup(Loc.GetString("rmc-flare-gun-examine", ("id", id)));
+            if (ent.Comp.LastFlareId is { } id)
+                args.PushMarkup(Loc.GetString("rmc-flare-gun-examine", ("id", id)));
+        }
     }
 
     /// <summary>

--- a/Resources/Locale/en-US/_RMC14/weapons/guns.ftl
+++ b/Resources/Locale/en-US/_RMC14/weapons/guns.ftl
@@ -60,6 +60,10 @@ rmc-gun-stacks-reset = The {$weapon} beeps as it loses its targeting data, and r
 rmc-gun-shoot-air-self = YOU FIRE YOUR { CAPITALIZE($weapon) } INTO THE AIR!
 rmc-gun-shoot-air-other = { CAPITALIZE(THE($user)) } FIRES { CAPITALIZE(THE($weapon)) } INTO THE AIR!
 rmc-gun-shoot-air-blocked = The roof above you is too dense.
+rmc-gun-shoot-air-examine = [bold]Press your [color=cyan]unique action[/color] keybind (Spacebar by default){$harm ->
+    [true] {" while in harm mode"}
+    *[false] {""}
+    } to fire into the air.[/bold]
 
 rmc-flare-gun-examine = The last signal flare fired has the designation: [color=#ad3b98][bold]{$id}[/bold][/color]
 


### PR DESCRIPTION
## About the PR

This PR extends the examine text of guns that shoot into the air (flare gun and CO pistols).

## Why / Balance

Players currently have to guess how to use them.

## Technical details

New ftl that gets added if you can use it. Similar to the one on the shotgun.

Note: I did try to add `before: [typeof(SharedGunSystem)]`, but it did not move the text up.

## Media

With skill:

<img width="49%" height="auto" alt="Screenshot From 2025-07-23 13-57-49" src="https://github.com/user-attachments/assets/e5679465-67ba-4cae-aa74-f47483605d55" />

<img width="49%" height="auto" alt="Screenshot From 2025-07-23 13-57-22" src="https://github.com/user-attachments/assets/a11af28e-0cd9-474f-828c-985808856f47" />

Without skill:

<img width="467" height="350" alt="Screenshot From 2025-07-23 13-58-17" src="https://github.com/user-attachments/assets/3c516c4c-1739-4e27-a717-e1f4a7b2f009" />

Shotgun for comparison:

<img width="414" height="369" alt="Screenshot From 2025-07-22 22-03-16" src="https://github.com/user-attachments/assets/78846dbc-c48c-4495-a813-7f3f2b75c9cd" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- tweak: The examine text for the flare gun, winter wyvern handcannon and mateba now explains how to fire them into the air.
