### PR TITLE
Barricades block weeds from spreading and adjust weed spread speed

### DIFF
--- a/Content.Server/_RMC14/Xenonids/Weeds/XenoWeedsSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Weeds/XenoWeedsSystem.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Numerics;
 using Content.Server.Atmos.Components;
 using Content.Server.Spreader;
@@ -9,9 +10,11 @@ using Content.Shared.Atmos;
 using Content.Shared.Coordinates;
 using Content.Shared.Damage;
 using Content.Shared.Maps;
+using Content.Shared.Physics;
 using Content.Shared.Tag;
 using Robust.Server.GameObjects;
 using Robust.Shared.Map.Components;
+using Robust.Shared.Physics;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
@@ -29,6 +32,7 @@ public sealed class XenoWeedsSystem : SharedXenoWeedsSystem
     [Dependency] private readonly AppearanceSystem _appearance = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly TurfSystem _turf = default!;
+    [Dependency] private readonly PhysicsSystem _physics = default!;
 
     private static readonly ProtoId<TagPrototype> IgnoredTag = "SpreaderIgnore";
 
@@ -114,6 +118,15 @@ public sealed class XenoWeedsSystem : SharedXenoWeedsSystem
                             weedsToReplace = anchoredId;
                     }
                 }
+
+                // Do a raycast to see if any entities with offset fixtures are blocking the spread
+                var weedPosition = _transform.GetMoverCoordinates(uid).Position;
+                var ray = new CollisionRay(weedPosition, cardinal.CardinalToIntVec(), (int)CollisionGroup.BarricadeImpassable);
+                var intersect = _physics.IntersectRayWithPredicate(Transform(uid).MapID, ray, 0.6f, e => !Transform(e).Anchored);
+                var results = intersect.Select(r => r.HitEntity).ToHashSet();
+
+                if (results.Count > 0)
+                    blocked = true;
 
                 if (blocked)
                     continue;

--- a/Content.Shared/_RMC14/Xenonids/Weeds/XenoWeedsSpreadingComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Weeds/XenoWeedsSpreadingComponent.cs
@@ -5,11 +5,11 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 namespace Content.Shared._RMC14.Xenonids.Weeds;
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
-[Access([typeof(SharedXenoWeedsSystem), typeof(SharedXenoConstructionSystem)])]
+[Access(typeof(SharedXenoWeedsSystem), typeof(SharedXenoConstructionSystem))]
 public sealed partial class XenoWeedsSpreadingComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public TimeSpan SpreadDelay = TimeSpan.FromSeconds(3);
+    public TimeSpan SpreadDelay = TimeSpan.FromSeconds(3.33f);
 
     [DataField, AutoNetworkedField]
     public TimeSpan RepairedSpreadDelay = TimeSpan.FromSeconds(15);

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_weeds.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_weeds.yml
@@ -196,6 +196,8 @@
     layers:
     - state: hive_weed0
   - type: HiveWeeds
+  - type: XenoWeedsSpreading
+    spreadDelay: 1.25
   - type: IconSmooth
     key: cm_xeno_weeds
     base: hive_weed
@@ -353,6 +355,8 @@
     fruitGrowthMultiplier: 0.8
     speedMultiplierOutsider: 0.508
     speedMultiplierOutsiderArmor: 0.6177
+  - type: XenoWeedsSpreading
+    spreadDelay: 3.125
   - type: Destructible
     thresholds:
     - trigger:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

- Weeds won't spread through barricades anymore.
- Adjusted the spread speed of all xeno weeds.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity.

- Hive weed spread speed increased by 140%
- Regular weed spread speed reduced by 11%
- Hardy weed spread speed reduced by 5.5%

## Technical details
<!-- Summary of code changes for easier review. -->
Before a weed spreads to another tile it does a raycast to see if any barricades are within range.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/954509a9-1a3c-40f0-a99b-28dedf7dbc8d


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Dygon
- fix: Barricades now prevent weeds from spreading.
- fix: Adjusted the spread delay of hive weeds (3s > 1.25s), hardy weeds(3s > 3.125s) and regular weeds(3s > 3.33s)