### PR TITLE
Fix certain entities blocking resin structure construction while they shouldn't

### DIFF
--- a/Content.Shared/Foldable/FoldableComponent.cs
+++ b/Content.Shared/Foldable/FoldableComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared._RMC14.Folded;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared.Foldable;
@@ -9,7 +10,7 @@ namespace Content.Shared.Foldable;
 /// Will prevent any insertions into containers while this item is unfolded.
 /// </remarks>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true)]
-[Access(typeof(FoldableSystem))]
+[Access(typeof(FoldableSystem), typeof(RMCFoldableSystem))]
 public sealed partial class FoldableComponent : Component
 {
     [DataField("folded"), AutoNetworkedField]

--- a/Content.Shared/_RMC14/Folded/RMCFoldableComponent.cs
+++ b/Content.Shared/_RMC14/Folded/RMCFoldableComponent.cs
@@ -1,0 +1,9 @@
+// ReSharper disable CheckNamespace
+namespace Content.Shared.Foldable;
+// ReSharper enable CheckNamespace
+
+public sealed partial class FoldableComponent
+{
+    [DataField, AutoNetworkedField]
+    public bool AnchorOnUnfold;
+}

--- a/Content.Shared/_RMC14/Folded/RMCFoldableSystem.cs
+++ b/Content.Shared/_RMC14/Folded/RMCFoldableSystem.cs
@@ -1,0 +1,26 @@
+using Content.Shared.Foldable;
+
+namespace Content.Shared._RMC14.Folded;
+
+public sealed class RMCFoldableSystem : EntitySystem
+{
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<FoldableComponent, FoldAttemptEvent>(OnFolded);
+    }
+
+    private void OnFolded(Entity<FoldableComponent> ent, ref FoldAttemptEvent args)
+    {
+        if (!ent.Comp.AnchorOnUnfold || args.Cancelled)
+            return;
+
+        if (args.Comp.IsFolded)
+            _transform.AnchorEntity(ent);
+        else
+        {
+            _transform.Unanchor(ent);
+        }
+    }
+}

--- a/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
@@ -2,6 +2,7 @@ using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Content.Shared._RMC14.Areas;
+using Content.Shared._RMC14.Entrenching;
 using Content.Shared._RMC14.Map;
 using Content.Shared._RMC14.Sentry;
 using Content.Shared._RMC14.Xenonids.Announce;
@@ -18,12 +19,14 @@ using Content.Shared.Actions.Events;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Atmos;
 using Content.Shared.Buckle.Components;
+using Content.Shared.Climbing.Components;
 using Content.Shared.Coordinates;
 using Content.Shared.Coordinates.Helpers;
 using Content.Shared.Damage;
 using Content.Shared.Database;
 using Content.Shared.Destructible;
 using Content.Shared.DoAfter;
+using Content.Shared.Doors.Components;
 using Content.Shared.Examine;
 using Content.Shared.FixedPoint;
 using Content.Shared.Interaction;
@@ -95,6 +98,7 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
 
     private static readonly ProtoId<TagPrototype> AirlockTag = "Airlock";
     private static readonly ProtoId<TagPrototype> StructureTag = "Structure";
+    private static readonly ProtoId<TagPrototype> PlatformTag = "Platform";
 
     public override void Initialize()
     {
@@ -510,7 +514,7 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
         }
 
         args.Handled = true;
-        
+
         // TODO RMC14 stop collision for mobs until they move off
         if (_net.IsServer)
         {
@@ -1068,13 +1072,6 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
             return false;
         }
 
-        if (!CanPlaceXenoStructure(xeno, target, out var popupType))
-        {
-            popupType += "-structure";
-            _popup.PopupClient(Loc.GetString(popupType), xeno, xeno, PopupType.SmallCaution);
-            return false;
-        }
-
         var ev = new XenoConstructionRangeEvent(xeno.Comp.BuildRange);
         RaiseLocalEvent(xeno, ref ev);
 
@@ -1102,6 +1099,19 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
             {
                 _popup.PopupClient(Loc.GetString("cm-xeno-construction-failed-cant-build"), target, xeno);
                 return false;
+            }
+
+            if (!HasComp<BarricadeComponent>(uid))
+            {
+                if ((_tags.HasAnyTag(uid.Value, StructureTag) || HasComp<StrapComponent>(uid) || HasComp<ClimbableComponent>(uid))  &&
+                    !_tags.HasTag(uid.Value, PlatformTag) &&
+                    !HasComp<DoorComponent>(uid) ||
+                    TryComp(uid, out DoorComponent? door) &&
+                    door.State != DoorState.Open)
+                {
+                    _popup.PopupClient(Loc.GetString("rmc-xeno-construction-blocked-structure"), xeno, xeno, PopupType.SmallCaution);
+                    return false;
+                }
             }
         }
 

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Furniture/beds.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Furniture/beds.yml
@@ -5,7 +5,7 @@
   description: A mattress seated on a rectangular metallic frame. This is used to support a lying person in a comfortable manner, notably for regular sleep. Ancient technology, but still useful.
   components:
   - type: Transform
-    anchored: false
+    anchored: true
   - type: Physics
     bodyType: Static
   - type: Sprite

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Furniture/chairs.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Furniture/chairs.yml
@@ -24,6 +24,10 @@
   name: chair
   description: A rectangular metallic frame sitting on four legs with a back panel. Designed to fit the sitting position, more or less comfortably.
   components:
+  - type: Transform
+    anchored: true
+  - type: Foldable
+    anchorOnUnfold: true
   - type: Sprite
     sprite: _RMC14/Structures/Furniture/folding_chair.rsi
     layers:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/base.yml
@@ -8,6 +8,7 @@
     mode: SnapgridCenter
   components:
   - type: Transform
+    anchored: true
     noRot: true
   - type: Clickable
   - type: InteractionOutline

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Platforms/platform.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Platforms/platform.yml
@@ -12,6 +12,9 @@
   - type: Clickable
   - type: Climbable
     delay: 0.25
+  - type: Tag
+    tags:
+    - Platform
 
 - type: entity
   abstract: true
@@ -574,7 +577,7 @@
   components:
   - type: Sprite
     state: stone_deco
-    
+
 - type: entity
   parent: CMPlatform
   id: RMCPlatformSandstone
@@ -608,7 +611,7 @@
   - type: Sprite
     state: stone_deco
     color: "#b29082"
-    
+
 - type: entity
   parent: CMPlatform
   id: RMCPlatformSandstoneStairRight
@@ -626,3 +629,6 @@
   - type: Sprite
     state: stone_stair_alt
     color: "#b29082"
+
+- type: Tag
+  id: Platform


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Platforms, barricades and open doors no longer block resin structures.
Beds, vendors and foldable chairs are now anchored.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Dygon
- fix: Platforms, barricades and open doors/shutters/podlocks no longer block resin structures.

