### PR TITLE
Added the option to buy parachutes in the cargo department

### DIFF
--- a/Resources/Prototypes/_RMC14/Catalog/Cargo/requisitions_catalog.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Cargo/requisitions_catalog.yml
@@ -233,6 +233,8 @@
         crate: RMCCrateGearPackFlareCAS
       - cost: 2000
         crate: RMCCrateGearFulton
+      - cost: 4000
+        crate: RMCCrateGearParachute
     - name: Medical
       entries:
       - cost: 3200

--- a/Resources/Prototypes/_RMC14/Catalog/Fills/Crates/gear.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Fills/Crates/gear.yml
@@ -51,3 +51,13 @@
     contents:
     - id: RMCFulton20
       amount: 4
+
+- type: entity
+  parent: RMCCrateSupply
+  id: RMCCrateGearParachute
+  name: parachute crate (x20)
+  components:
+  - type: StorageFill
+    contents:
+    - id: RMCParachute
+      amount: 20


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added the option to buy behind 4k parachute crate containing 20 parachutes in the gear section of the cargo catalog.

## Why / Balance
Parity

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: A parachute crate in the cargo catalog
