### PR TITLE
Fix boilers neuro tailstab

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Stab/SharedXenoTailStabSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Stab/SharedXenoTailStabSystem.cs
@@ -94,6 +94,7 @@ public abstract class SharedXenoTailStabSystem : EntitySystem
 
         // TODO RMC14 sounds
         // TODO RMC14 lag compensation
+        var damaged = false;
         var damage = new DamageSpecifier(stab.Comp.TailDamage);
         var eve = new RMCGetTailStabBonusDamageEvent(new DamageSpecifier());
         RaiseLocalEvent(stab, ref eve);
@@ -154,7 +155,10 @@ public abstract class SharedXenoTailStabSystem : EntitySystem
                 var change = _damageable.TryChangeDamage(hit, _xeno.TryApplyXenoSlashDamageMultiplier(hit, modifiedDamage), origin: stab , tool: stab);
 
                 if (change?.GetTotal() > FixedPoint2.Zero)
+                {
+                    damaged = true;
                     _colorFlash.RaiseEffect(Color.Red, new List<EntityUid> { hit }, filter);
+                }
 
                 if (_net.IsServer)
                 {
@@ -241,7 +245,7 @@ public abstract class SharedXenoTailStabSystem : EntitySystem
                 _rotate.RotateXeno(stab, angle.GetDir());
             }
 
-            var sound = args.Entity != null && !TerminatingOrDeleted(args.Entity) && args.Entity != stab ? stab.Comp.SoundHit : stab.Comp.SoundMiss;
+            var sound = args.Entity != null && damaged && !TerminatingOrDeleted(args.Entity) && args.Entity != stab ? stab.Comp.SoundHit : stab.Comp.SoundMiss;
             _audio.PlayPvs(sound, stab);
         }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Boiler's tail stab was injecting acid even if with neuro gas selected, now it injects the correct chemical based on selected gas type.
Tail stabs now make the "miss" sound instead of "hit" sound if a target was selected that didn't receive any damage.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug fix

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Dygon
- fix: Boilers now inject neurotoxin again instead of acid while neuro gas is selected.
- fix: Using Tail Stab on an entity that didn't get hit by it now plays the correct sound effect.
