### PR TITLE
Add MP Combat toolbelt

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/police.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/police.yml
@@ -63,3 +63,66 @@
     maxItemSize: Normal
     grid:
     - 0,0,15,1 # 8 slots
+
+
+- type: entity
+  parent: CMBeltSecurityMP
+  id: RMCBeltSecurityMPCombat
+  name: M276 pattern combat military police rig
+  description: The M276 pattern combat military police rig is a special version of standard rig. It consists of a modular belt with various clips and pouches for tools along with a holster for a sidearm. Due to the bulk of the sidearm, it is unable to hold as many tools as its standard counterpart.
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Clothing/Belt/combat_utility.rsi
+    layers:
+    - state: icon
+      color: "#707070"
+    - sprite: _RMC14/Objects/Weapons/Guns/gun_underlays.rsi
+      state: m1984 # TODO RMC14 per-gun underlay
+      offset: -0.3125, -0.09375
+      map: [ "enum.CMHolsterLayers.Fill" ]
+      visible: false
+    - sprite: _RMC14/Objects/Clothing/Belt/combat_utility.rsi
+      state: icon-front
+      color: "#707070"
+    - state: half
+      map: [ "openLayer" ]
+      color: "#707070"
+    - state: full
+      map: [ "closedLayer" ]
+      color: "#707070"
+  - type: Clothing
+    sprite: _RMC14/Objects/Clothing/Belt/combat_utility.rsi
+  - type: Storage
+    whitelist:
+      tags:
+      - SecBeltEquip
+      - Taser
+      - Flashlight
+      - Taser
+      - CMMagazinePistol
+      - RMCShellShotgun
+      components:
+      - Handcuff
+      - Flash
+      - FlashOnTrigger
+      - Stunbaton
+      - ForensicScanner
+      - MeleeWeapon
+      - Gun
+  - type: FixedItemSizeStorage
+  - type: LimitedStorage
+    limits:
+    - popup: rmc-storage-limit-cant-fit
+      count: 2
+      whitelist:
+        tags:
+          - CMMagazinePistol
+          - RMCShellShotgun
+    - popup: rmc-storage-limit-one-gun
+      whitelist:
+        components:
+        - Gun
+  - type: CMHolster
+    whitelist:
+      components:
+      - Gun

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/command.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/command.yml
@@ -909,6 +909,7 @@
       - id: RMCBeltHolsterPistol
       - id: RMCBeltHolsterRevolver
       - id: RMCBeltUtilityGeneral
+      - id: RMCBeltSecurityMPCombat
     - name: Patches
       jobs:
       - CMChiefMP

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/police.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/police.yml
@@ -53,6 +53,7 @@
       - id: RMCBeltHolsterPistol
       - id: RMCBeltHolsterRevolver
       - id: RMCBeltUtilityGeneral
+      - id: RMCBeltSecurityMPCombat
     - name: Pouches
       choices: { RMCPouch: 2 }
       entries:
@@ -128,6 +129,7 @@
       - id: RMCBeltHolsterPistol
       - id: RMCBeltHolsterRevolver
       - id: RMCBeltUtilityGeneral
+      - id: RMCBeltSecurityMPCombat
     - name: Pouches
       choices: { RMCPouch: 2 }
       entries:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/vending_machines.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/vending_machines.yml
@@ -290,6 +290,7 @@
     CMStunbaton: 4
     RMCFlashlight: 4
     CMBeltSecurityMP: 10
+    RMCBeltSecurityMPCombat: 4
     CMFlash: 5
     RMCBoxDonut: 12
     # Evidence box 6


### PR DESCRIPTION
## About the PR

Was asked by many people to do that, since MP toolbelt cant hold pistols.
MP Combat rig have the same number of slots as standard one (6), but can only keep one gun, and only 2 ammo.

## Media
just recolored CT Combat belt.
<img width="259" height="272" alt="зображення" src="https://github.com/user-attachments/assets/b38446e7-c41b-45a8-b2cc-cbad042a70f2" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Added new security belt, for keeping your pistol and your police tools.
