### PR TITLE
Add announcements for queen death cooldown and hive core cooldown

### DIFF
--- a/Content.Server/_RMC14/Xenonids/Construction/XenoPylonSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Construction/XenoPylonSystem.cs
@@ -53,7 +53,11 @@ public sealed class XenoPylonSystem : SharedXenoPylonSystem
     {
         if (_hive.GetHive(ent.Owner) is {} hive &&
             _gameTicker.RoundDuration() > hive.Comp.PreSetupCutoff)
+        {
             hive.Comp.NewCoreAt = _timing.CurTime + hive.Comp.NewCoreCooldown;
+            hive.Comp.AnnouncedHiveCoreCooldownOver = false;
+        }
+
     }
 
     private void OnXenoSpawnerUsed(Entity<XenoComponent> xeno, ref GhostRoleSpawnerUsedEvent args)

--- a/Content.Server/_RMC14/Xenonids/Hive/XenoHiveSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Hive/XenoHiveSystem.cs
@@ -139,12 +139,29 @@ public sealed class XenoHiveSystem : SharedXenoHiveSystem
                 }
             }
 
-            if (_announce.Count == 0)
-                continue;
+            if (_announce.Count > 0)
+            {
+                var popup = Loc.GetString("rmc-hive-supports-castes", ("castes", string.Join(", ", _announce)));
+                _xenoAnnounce.AnnounceToHive(EntityUid.Invalid, hiveId, popup, hive.AnnounceSound, PopupType.Large);
+                EvoScreech(hive);
+            }
 
-            var popup = Loc.GetString("rmc-hive-supports-castes", ("castes", string.Join(", ", _announce)));
-            _xenoAnnounce.AnnounceToHive(EntityUid.Invalid, hiveId, popup, hive.AnnounceSound, PopupType.Large);
-            EvoScreech(hive);
+            if (!hive.AnnouncedQueenDeathCooldownOver && hive.CurrentQueen == null && hive.NewQueenAt.HasValue && roundTime >= hive.NewQueenAt.Value)
+            {
+                var queenPopup = Loc.GetString("rmc-queen-death-cooldown-over");
+                _xenoAnnounce.AnnounceToHive(EntityUid.Invalid, hiveId, queenPopup, hive.AnnounceSound);
+                hive.AnnouncedQueenDeathCooldownOver = true;
+                Dirty(hiveId, hive);
+            }
+
+            if (!hive.AnnouncedHiveCoreCooldownOver && hive.NewCoreAt.HasValue && roundTime >= hive.NewCoreAt)
+            {
+                var corePopup = Loc.GetString("rmc-hive-core-cooldown-over");
+                _xenoAnnounce.AnnounceToHive(EntityUid.Invalid, hiveId, corePopup, hive.AnnounceSound);
+                hive.AnnouncedHiveCoreCooldownOver = true;
+                Dirty(hiveId, hive);
+            }
+
         }
 
         var time = _timing.CurTime;

--- a/Content.Shared/_RMC14/Xenonids/Hive/HiveComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hive/HiveComponent.cs
@@ -35,6 +35,12 @@ public sealed partial class HiveComponent : Component
     public List<TimeSpan> AnnouncementsLeft = [];
 
     [DataField, AutoNetworkedField]
+    public bool AnnouncedQueenDeathCooldownOver;
+
+    [DataField, AutoNetworkedField]
+    public bool AnnouncedHiveCoreCooldownOver;
+
+    [DataField, AutoNetworkedField]
     public SoundSpecifier AnnounceSound = new SoundPathSpecifier("/Audio/_RMC14/Xeno/alien_distantroar_3.ogg", AudioParams.Default.WithVolume(-6));
 
     [DataField, AutoNetworkedField]
@@ -62,7 +68,10 @@ public sealed partial class HiveComponent : Component
     public TimeSpan PreSetupCutoff = TimeSpan.FromMinutes(20);
 
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
-    public TimeSpan NewCoreAt;
+    public TimeSpan? NewCoreAt;
+
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
+    public TimeSpan? NewQueenAt;
 
     [DataField, AutoNetworkedField]
     public bool HijackSurged;

--- a/Content.Shared/_RMC14/Xenonids/Hive/SharedXenoHiveSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hive/SharedXenoHiveSystem.cs
@@ -81,6 +81,8 @@ public abstract class SharedXenoHiveSystem : EntitySystem
         {
             hive.Comp.LastQueenDeath = _timing.CurTime;
             hive.Comp.CurrentQueen = null;
+            hive.Comp.AnnouncedQueenDeathCooldownOver = false;
+            hive.Comp.NewQueenAt = _timing.CurTime + hive.Comp.NewQueenCooldown;
             Dirty(hive);
         }
     }

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-chat.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-chat.ftl
@@ -1,6 +1,6 @@
 ﻿rmc-no-queen-hivemind-chat = There is no Queen. You are alone.
 rmc-new-queen = A new Queen has risen to lead the Hive! Rejoice!
-rmc-queen-death-cooldown-over = The Hive stirs in anticipation. A new Queen must now evolve to sustain her children!
+rmc-queen-death-cooldown-over = The Hive is ready for a new Queen to evolve. The hive can only survive for a limited time without a queen!
 rmc-hive-core-cooldown-over = The Hive has recovered from the destruction of its previous core. A new Hive Core can now be placed.
 
 rmc-hive-supports-castes = The Hive can now support: {$castes}

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-chat.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-chat.ftl
@@ -1,5 +1,7 @@
 ﻿rmc-no-queen-hivemind-chat = There is no Queen. You are alone.
 rmc-new-queen = A new Queen has risen to lead the Hive! Rejoice!
+rmc-queen-death-cooldown-over = The Hive stirs in anticipation. A new Queen must now evolve to sustain her children!
+rmc-hive-core-cooldown-over = The Hive has recovered from the destruction of its previous core. A new Hive Core can now be placed.
 
 rmc-hive-supports-castes = The Hive can now support: {$castes}
 rmc-hive-supports-castes-human = You hear a distant screech and feel your insides freeze up...  something new is with you in this colony.


### PR DESCRIPTION
## About the PR
Adds an announcement for when the queen death cooldown is over and a new queen can evolve.
Adds an announcement for when the hive core destruction cooldown is over and a new hive core can be placed.

## Why / Balance
There is no existing announcement and the only way to check is to try and evolve / try and place a new hive core.

## Technical details
Cooldowns + announcement status are now kept track of by the hive component and checked in the update loop alongside xeno caste unlock announcements.

## Media
<img width="482" height="277" alt="image" src="https://github.com/user-attachments/assets/69d1f5db-4ea4-4d9b-8eba-c356adec4ac0" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Xeno announcements for queen death cooldown and hive core destruction cooldown
