### PR TITLE
Enhanced spitter acid is now harder to remove

### DIFF
--- a/Content.Shared/_RMC14/OnCollide/DamageOnCollideComponent.cs
+++ b/Content.Shared/_RMC14/OnCollide/DamageOnCollideComponent.cs
@@ -59,6 +59,9 @@ public sealed partial class DamageOnCollideComponent : Component
     public TimeSpan AcidComboParalyze;
 
     [DataField]
+    public int AcidComboResists;
+
+    [DataField]
     public TimeSpan Paralyze;
 
     [DataField]

--- a/Content.Shared/_RMC14/OnCollide/SharedOnCollideSystem.cs
+++ b/Content.Shared/_RMC14/OnCollide/SharedOnCollideSystem.cs
@@ -89,7 +89,7 @@ public abstract class SharedOnCollideSystem : EntitySystem
             _damageable.TryChangeDamage(other, damage, ent.Comp.IgnoreResistances);
         }
 
-        _xenoSpit.SetAcidCombo(other, ent.Comp.AcidComboDuration, ent.Comp.AcidComboDamage, ent.Comp.AcidComboParalyze);
+        _xenoSpit.SetAcidCombo(other, ent.Comp.AcidComboDuration, ent.Comp.AcidComboDamage, ent.Comp.AcidComboParalyze, ent.Comp.AcidComboResists);
 
         if (ent.Comp.Paralyze > TimeSpan.Zero && !_standing.IsDown(other) && (!_size.TryGetSize(other, out var size) || size < RMCSizes.Big))
         {

--- a/Content.Shared/_RMC14/Xenonids/Projectile/Spit/Charge/UserAcidedComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/Spit/Charge/UserAcidedComponent.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Damage;
+using Content.Shared.Damage;
 using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
@@ -32,6 +32,15 @@ public sealed partial class UserAcidedComponent : Component
 
     [DataField, AutoNetworkedField]
     public TimeSpan ResistDuration = TimeSpan.FromSeconds(3);
+
+    [DataField, AutoNetworkedField]
+    public int ResistsNeeded = 1;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan AllowVaporHitAfter;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan ExtinguishGracePeriod = TimeSpan.FromSeconds(1);
 }
 
 [Serializable, NetSerializable]

--- a/Resources/Locale/en-US/_RMC14/acid/rmc-acid.ftl
+++ b/Resources/Locale/en-US/_RMC14/acid/rmc-acid.ftl
@@ -1,4 +1,5 @@
 ﻿rmc-acid-resist = You stop, drop, and roll, getting rid of the acid.
+rmc-acid-resist-partial = You stop, drop, and roll, getting rid of some of the acid... but it's still melting you!
 
 rmc-glob-start-self = We begin to spit glob of acid gas!
 rmc-glob-start-others = {$user} prepares to spit a massive glob!

--- a/Resources/Prototypes/_RMC14/Effects/xeno_acid.yml
+++ b/Resources/Prototypes/_RMC14/Effects/xeno_acid.yml
@@ -57,6 +57,7 @@
   - type: DamageOnCollide
     acidic: true
     acidComboDuration: 40
+    acidComboResists: 2
     acidComboDamage:
       types:
         Heat: 3


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title. Enhanced acid now takes 2 rolls and/or 2 extinguish attempts to get rid of.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity.

## Technical details
<!-- Summary of code changes for easier review. -->
ResistsNeeded added to UserAcidedComp, defaults to 1 ofc. Base acid combo sets this to 2. Resisting or getting extinguished removes a stack, and only removes the component if it hits 0 (or is under, somehow).

Extinguishing acid now has a grace period where further vapor hits won't count, otherwise extinguishing instantly removes all resist stacks.

Enhancing setting the resist might need to be changed to adding to the existing resist later, if despoiler becomes real cause that would matter, but its an easy change to make later.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/8929f46c-f2d5-44a4-835d-d6f0c1d290a7


https://github.com/user-attachments/assets/76960fd9-bc1c-4bf3-a751-014de183f7e5



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed enhanced spitter acid not taking 2 rolls and/or extinguisher hits to get rid of.
