### PR TITLE
Fix barricades sometimes blocking attacks that shouldn't be blocked

### DIFF
--- a/Content.Shared/_RMC14/Barricade/DirectionalAttackBlockerComponent.cs
+++ b/Content.Shared/_RMC14/Barricade/DirectionalAttackBlockerComponent.cs
@@ -10,4 +10,7 @@ public sealed partial class DirectionalAttackBlockerComponent : Component
 
     [DataField, AutoNetworkedField]
     public int MaxHealth;
+
+    [DataField, AutoNetworkedField]
+    public bool BlockMarineAttacks;
 }

--- a/Content.Shared/_RMC14/Barricade/SharedDirectionalAttackBlockSystem.cs
+++ b/Content.Shared/_RMC14/Barricade/SharedDirectionalAttackBlockSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.Random;
 using Content.Shared._RMC14.Weapons.Melee;
 using Content.Shared.Damage;
@@ -58,7 +59,10 @@ public abstract class SharedDirectionalAttackBlockSystem : EntitySystem
         if (!TryComp(target, out DirectionalAttackBlockerComponent? blocker) || !Transform(target).Anchored)
             return false;
 
-        if (!IsFacingTarget(attacker, target))
+        if (!blocker.BlockMarineAttacks && HasComp<MarineComponent>(attacker))
+            return false;
+
+        if (!IsFacingTarget(target, attacker))
             return false;
 
         var tick = _timing.CurTick.Value;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fix barricades sometimes blocking attacks made from the back.
Humanoids can now hit over cades, even from the front.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug fix: It was checking the direction of the attacker instead of the direction of the barricade.
Parity: humanoids are able to attack over barricades in CM.
Resolves #7198 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Dygon
- fix: Barricades no longer block humanoid melee attacks
- fix: Barricades no longer occasionally block attacks made from the back.

