### PR TITLE
add: training dummy

### DIFF
--- a/Content.Shared/_RMC14/TrainingDummy/RMCTrainingDummyComponent.cs
+++ b/Content.Shared/_RMC14/TrainingDummy/RMCTrainingDummyComponent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._RMC14.TrainingDummy;
+
+[RegisterComponent]
+public sealed partial class RMCTrainingDummyComponent : Component
+{
+    [DataField]
+    public ComponentRegistry? RemoveComponents;
+}

--- a/Content.Shared/_RMC14/TrainingDummy/RMCTrainingDummySystem.cs
+++ b/Content.Shared/_RMC14/TrainingDummy/RMCTrainingDummySystem.cs
@@ -1,0 +1,27 @@
+using Robust.Shared.Enums;
+using Robust.Shared.GameObjects.Components.Localization;
+
+namespace Content.Shared._RMC14.TrainingDummy;
+
+public sealed partial class RMCTrainingDummySystem : EntitySystem
+{
+    [Dependency] private readonly GrammarSystem _grammarSystem = default!;
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<RMCTrainingDummyComponent, ComponentStartup>(OnStartup);
+    }
+
+    private void OnStartup(Entity<RMCTrainingDummyComponent> ent, ref ComponentStartup args)
+    {
+        if (ent.Comp.RemoveComponents != null)
+            EntityManager.RemoveComponents(ent.Owner, ent.Comp.RemoveComponents);
+
+        // Can't set gender via component as it gets overwritten on spawn.
+        if (TryComp<GrammarComponent>(ent.Owner, out var grammar))
+        {
+            _grammarSystem.SetGender((ent.Owner, grammar), Gender.Neuter);
+            _grammarSystem.SetProperNoun((ent.Owner, grammar), false);
+        }
+    }
+}

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/training_dummy.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/training_dummy.yml
@@ -1,0 +1,41 @@
+- type: entity
+  parent: CMBaseMobSpeciesOrganic
+  id: RMCTrainingDummy
+  name: training dummy
+  description: A training dummy used by the UNMC to simulate a humanoid body. Feels almost too lifelike.
+  suffix: RMC14
+  components:
+  - type: Loadout
+    prototypes: [ RMCGearTrainingDummy ]
+  - type: FixedIdentity
+    name: cm-chatsan-replacement-synthetic
+  - type: RMCTrainingDummy
+    removeComponents:
+    - type: Hunger
+    - type: Infectable
+    - type: NewPlayerLabel
+    - type: Perishable
+    - type: SSDIndicator
+    - type: TacticalMapTracked
+    - type: Thirst
+    - type: Vocal
+
+- type: startingGear
+  id: RMCGearTrainingDummy
+  equipment:
+    jumpsuit: JumpsuitMarine
+    shoes: RMCShoesJackboots
+
+- type: entity
+  parent: MarkerBase
+  id: SpawnRMCTrainingDummy
+  name: RMC Training Dummy Spawner
+  components:
+  - type: Sprite
+    layers:
+    - state: green
+    - sprite: Mobs/Species/Human/parts.rsi
+      state: full
+  - type: ConditionalSpawner
+    prototypes:
+    - RMCTrainingDummy


### PR DESCRIPTION
## About the PR

This PR adds a training dummy that can be used to teach mechanics to new players.

## Why / Balance

I have seen admins spawn in the test dummy to tech nurses. This entity is more "streamline" in that id does not come with an SO id and headset or any other superfluous items and cannot be infected.

## Technical details

Basically a copy of the test dummy with some changes. Maybe map one into medical and one into the brig for training.

Please inform me if you know how to (correctly) remove the catatonic text or of any other desired changes.

## Media

<img width="49%" height="355" alt="Screenshot From 2025-07-25 17-39-09" src="https://github.com/user-attachments/assets/ce97681d-d18f-40a2-acc2-ddae7f2de9f1" />

<img width="49%" height="273" alt="Screenshot From 2025-07-25 17-39-31" src="https://github.com/user-attachments/assets/9fa54338-5c5e-4c04-b04a-86d1b787ed1e" />

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
ADMIN:
- add: Training dummy.
