### PR TITLE
Training grenade fixes

### DIFF
--- a/Content.Server/_RMC14/Trigger/RMCTriggerSystem.cs
+++ b/Content.Server/_RMC14/Trigger/RMCTriggerSystem.cs
@@ -15,6 +15,7 @@ public sealed class RMCTriggerSystem : EntitySystem
     {
         SubscribeLocalEvent<OnShootTriggerAmmoTimerComponent, AmmoShotEvent>(OnTriggerTimerAmmoShot);
         SubscribeLocalEvent<TriggerOnThrowEndComponent, StopThrowEvent>(OnThrownAmmoStops);
+        SubscribeLocalEvent<TriggerOnThrowEndComponent, TriggerEvent>(OnTrigger);
 
         SubscribeLocalEvent<TriggerOnFixedDistanceStopComponent, ProjectileFixedDistanceStopEvent>(OnTriggerOnFixedDistanceStop);
     }
@@ -49,6 +50,11 @@ public sealed class RMCTriggerSystem : EntitySystem
     {
         var active = EnsureComp<ActiveTriggerOnThrowEndComponent>(ent);
         active.TriggerAt = _timing.CurTime + ent.Comp.Delay;
+    }
+
+    private void OnTrigger(Entity<TriggerOnThrowEndComponent> ent, ref TriggerEvent args)
+    {
+        RemCompDeferred<TriggerOnThrowEndComponent>(ent);
     }
 
     public override void Update(float frameTime)

--- a/Content.Shared/_RMC14/Item/ChangeItemSizeOnTimerTriggerComponent.cs
+++ b/Content.Shared/_RMC14/Item/ChangeItemSizeOnTimerTriggerComponent.cs
@@ -10,4 +10,7 @@ public sealed partial class ChangeItemSizeOnTimerTriggerComponent : Component
 {
     [DataField, AutoNetworkedField]
     public ProtoId<ItemSizePrototype> Size = "Ginormous";
+
+    [DataField, AutoNetworkedField]
+    public ProtoId<ItemSizePrototype>? OriginalSize;
 }

--- a/Content.Shared/_RMC14/Item/ItemSizeChangeSystem.cs
+++ b/Content.Shared/_RMC14/Item/ItemSizeChangeSystem.cs
@@ -20,6 +20,7 @@ public sealed partial class ItemSizeChangeSystem : EntitySystem
             before: new[] { typeof(AttachableHolderSystem) });
 
         SubscribeLocalEvent<ChangeItemSizeOnTimerTriggerComponent, RMCActiveTimerTriggerEvent>(OnChangeItemSizeOnTimerTrigger);
+        SubscribeLocalEvent<ChangeItemSizeOnTimerTriggerComponent, RMCTriggerEvent>(OnTriggered);
 
         InitItemSizes();
     }
@@ -40,7 +41,21 @@ public sealed partial class ItemSizeChangeSystem : EntitySystem
 
     private void OnChangeItemSizeOnTimerTrigger(Entity<ChangeItemSizeOnTimerTriggerComponent> ent, ref RMCActiveTimerTriggerEvent args)
     {
+        if (TryComp(ent, out ItemComponent? item))
+        {
+            ent.Comp.OriginalSize = item.Size;
+            Dirty(ent);
+        }
+
         _itemSystem.SetSize(ent, ent.Comp.Size);
+    }
+
+    private void OnTriggered(Entity<ChangeItemSizeOnTimerTriggerComponent> ent, ref RMCTriggerEvent args)
+    {
+        if (ent.Comp.OriginalSize == null)
+            return;
+
+        _itemSystem.SetSize(ent, ent.Comp.OriginalSize.Value);
     }
 
     private void InitItemSizes()


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Training grenades now become small sized again after they "explode".
A training grenade will no longer be primed automatically when thrown, if it has ever been shot from a grenade launcher.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug fix.

## Technical details
<!-- Summary of code changes for easier review. -->
An entity's original size is stored on the ChangeItemSizeOnTimerTriggerComponent before it gets changed, when a TriggerEvent happens the item size is set back to this stored original size.
The TriggerOnThrowEndComponent is now removed when a TriggerEvent happens.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Dygon
- fix: Training grenades no longer explode without priming when shot from a grenade launcher, and now regain their original size after 'exploding.

