### PR TITLE
Fix fire tiles on a shuttle's landing area igniting passengers

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -388,7 +388,7 @@ public sealed partial class ShuttleSystem
 
         // RMC14
         Dirty(entity.Owner, entity.Comp1);
-        var beforeFTL = new BeforeFTLStartedEvent(uid);
+        var beforeFTL = new BeforeFTLStartedEvent();
         RaiseLocalEvent(uid, ref beforeFTL);
 
         // Leave audio at the old spot
@@ -483,6 +483,10 @@ public sealed partial class ShuttleSystem
         _physics.SetAngularVelocity(uid, 0f, body: body);
 
         var target = entity.Comp1.TargetCoordinates;
+
+        //RMC14
+        var ev = new BeforeFTLFinishedEvent();
+        RaiseLocalEvent(entity, ref ev);
 
         MapId mapId;
 

--- a/Content.Server/_RMC14/Shuttles/RMCShuttleSystem.cs
+++ b/Content.Server/_RMC14/Shuttles/RMCShuttleSystem.cs
@@ -1,16 +1,20 @@
-﻿using Content.Server.Shuttles.Events;
+﻿using System.Numerics;
+using Content.Server.Shuttles.Events;
+using Content.Shared._RMC14.Atmos;
 using Content.Shared._RMC14.Shuttles;
+using Content.Shared.Shuttles.Components;
 using Robust.Server.Audio;
 using Robust.Server.GameObjects;
 using Robust.Shared.Map.Components;
-using Robust.Shared.Physics;
 
 namespace Content.Server._RMC14.Shuttles;
 
 public sealed class RMCShuttleSystem : SharedRMCShuttleSystem
 {
     [Dependency] private readonly AudioSystem _audio = default!;
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
     [Dependency] private readonly MapSystem _mapSystem = default!;
+    [Dependency] private readonly TransformSystem _transform = default!;
 
     public override void Initialize()
     {
@@ -19,6 +23,8 @@ public sealed class RMCShuttleSystem : SharedRMCShuttleSystem
 
         SubscribeLocalEvent<RMCSpawnEntityOnFTLStartComponent, BeforeFTLStartedEvent>(BeforeFTLStarted);
         SubscribeLocalEvent<RMCSpawnEntityOnFTLStartComponent, FTLStartedEvent>(OnSpawnEntityOnFTLStart);
+
+        SubscribeLocalEvent<FTLComponent, BeforeFTLFinishedEvent>(BeforeFTLFinished);
     }
 
     private void OnPlaySoundOnFTLStart(Entity<PlaySoundOnFTLStartComponent> ent, ref FTLStartedEvent args)
@@ -46,23 +52,53 @@ public sealed class RMCShuttleSystem : SharedRMCShuttleSystem
     /// </summary>
     private void BeforeFTLStarted(Entity<RMCSpawnEntityOnFTLStartComponent> ent, ref BeforeFTLStartedEvent args)
     {
-        var uid = args.FTLEntity;
-        var grid = args.Grid;
-
-        if (!Resolve(uid, ref grid))
+        if (!TryComp(ent, out MapGridComponent? grid))
             return;
 
-        var enumerator = _mapSystem.GetAllTilesEnumerator(uid, grid);
+        var enumerator = _mapSystem.GetAllTilesEnumerator(ent, grid);
         while (enumerator.MoveNext(out var tile))
         {
-            if(!TryComp(uid, out MapGridComponent? mapGrid))
+            if(!TryComp(ent, out MapGridComponent? mapGrid))
                 return;
 
-            var mapCoords = _mapSystem.GridTileToWorld(uid, mapGrid, tile.Value.GridIndices);
+            var mapCoords = _mapSystem.GridTileToWorld(ent, mapGrid, tile.Value.GridIndices);
             ent.Comp.Coordinates.Add(mapCoords);
+        }
+    }
+
+    private void BeforeFTLFinished(Entity<FTLComponent> ent, ref BeforeFTLFinishedEvent args)
+    {
+        var test = Transform(ent.Comp.TargetCoordinates.EntityId).GridUid;
+        if (test == null)
+            return;
+
+        // Create a box that has the width and height of the FTLing grid.
+        var shuttleAABB = Comp<MapGridComponent>(ent).LocalAABB;
+        var targetLocalAABB = Box2.CenteredAround(ent.Comp.TargetCoordinates.Position, Vector2.Zero);
+        var height = (float)Math.Floor(shuttleAABB.Height / 2f);
+        var width = (float)Math.Floor(shuttleAABB.Width / 2f);
+        var expansionHeight = shuttleAABB.Height % 2 == 0 ? height - 1 : height;
+        var expansionWidth = shuttleAABB.Width % 2 == 0 ? width - 1 : width;
+        var newBox = new Box2(targetLocalAABB.Left - expansionWidth,
+            targetLocalAABB.Bottom - expansionHeight,
+            targetLocalAABB.Right + expansionWidth,
+            targetLocalAABB.Top + expansionHeight);
+
+        // Delete all tile fires before landing
+        var targetAABB = _transform.GetWorldMatrix(Transform(test.Value)).TransformBox(newBox);
+        var lookupEnts = new HashSet<EntityUid>();
+        _lookup.GetLocalEntitiesIntersecting(test.Value, targetAABB, lookupEnts, LookupFlags.Uncontained);
+
+        foreach (var entity in lookupEnts)
+        {
+            if (HasComp<TileFireComponent>(entity))
+                Del(entity);
         }
     }
 }
 
 [ByRefEvent]
-public record struct BeforeFTLStartedEvent(EntityUid FTLEntity, MapGridComponent? Grid = null);
+public record struct BeforeFTLStartedEvent;
+
+[ByRefEvent]
+public record struct BeforeFTLFinishedEvent;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
You no longer get lit on fire if you're on a shuttle that lands on a fire tile.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug fix.

## Technical details
<!-- Summary of code changes for easier review. -->
A Box2, with the height and width of the FTLing grid is created on the destination, any tile fires within this area are deleted.
Because the area being checked is a box, any shuttles that are not square or rectangle shaped will delete more fire than they should.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Dygon
- fix: A shuttle landing on a fire tile will no longer ignite it's passengers.

