### PR TITLE
Clicking the hive tracker alert now watches the current target

### DIFF
--- a/Content.Shared/_RMC14/Tracker/Xeno/HiveTrackerSystem.cs
+++ b/Content.Shared/_RMC14/Tracker/Xeno/HiveTrackerSystem.cs
@@ -1,12 +1,10 @@
 ﻿using Content.Shared._RMC14.Dialog;
 using Content.Shared._RMC14.Tracker.SquadLeader;
 using Content.Shared._RMC14.Xenonids;
-using Content.Shared._RMC14.Xenonids.Evolution;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Watch;
 using Content.Shared.Alert;
 using Content.Shared.Mobs;
-using Content.Shared.Mobs.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
@@ -60,16 +58,11 @@ public sealed class HiveTrackerSystem : EntitySystem
         if (_hive.GetHive(ent.Owner) is not {} hive)
             return;
 
-        args.Handled = true;
-        // TODO: if queen gets stored on the hive entity just use that instead of searching for it
-        var granters = EntityQueryEnumerator<XenoEvolutionGranterComponent, HiveMemberComponent, XenoComponent>();
-        while (granters.MoveNext(out var uid, out var granter, out var member, out var xeno))
-        {
-            if (member.Hive != hive.Owner)
-                continue;
+        if (!TryComp(ent.Comp.Target, out HiveMemberComponent? targetHive) || targetHive.Hive != hive.Owner)
+            return;
 
-            _xenoWatch.Watch(ent.Owner, (uid, member));
-        }
+        args.Handled = true;
+        _xenoWatch.Watch(ent.Owner, ent.Comp.Target.Value);
     }
 
     private void OnAltClickedAlert(Entity<HiveTrackerComponent> ent, ref HiveTrackerAltClickedAlertEvent args)

--- a/Resources/Prototypes/_RMC14/Trackers/Trackers.yml
+++ b/Resources/Prototypes/_RMC14/Trackers/Trackers.yml
@@ -151,9 +151,9 @@
 - type: trackerMode
   id: HiveLeader
   component: HiveLeader
-  alert: HiveTracker
+  alert: LeaderTracker
 
 - type: trackerMode
   id: Tunnel
   component: XenoTunnel
-  alert: HiveTracker
+  alert: TunnelTracker


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Clicking the hive tracker now watches the entity being tracked instead of the queen.
The hive tracker now shows the correct description when not tracking the queen.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity.
Resolves #7227
Resolves #7229 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Dygon
- fix: Clicking the hive tracker now watches the current tracking target.

