### PR TITLE
fix: mateba barrel sprites

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Revolvers/mateba.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Revolvers/mateba.yml
@@ -84,6 +84,7 @@
           - RMCAttachmentS6ReflexSight
   - type: AttachableHolderVisuals
     offsets:
+      rmc-bslot-barrel: 0.215, 0.19
       rmc-aslot-barrel: 0.215, 0.19
       rmc-aslot-rail: -0.11, 0.22
   - type: ItemCamouflage
@@ -133,6 +134,7 @@
           - RMCAttachmentS6ReflexSight
   - type: AttachableHolderVisuals
     offsets:
+      rmc-bslot-barrel: 0.215, 0.19
       rmc-aslot-barrel: 0.215, 0.19
       rmc-aslot-rail: -0.11, 0.22
   - type: ItemCamouflage


### PR DESCRIPTION
## About the PR

This PR fixes the icon sprite of the mateba.

## Why / Balance

Fixes #7241 

## Technical details

The barrel was simply lacking an offset in the `AttachableHolderVisualsComponent`.

## Media


https://github.com/user-attachments/assets/52d17ec2-76cf-4392-904e-83c6e66cb0e9

Forgot to record without:

<img width="294" height="154" alt="Screenshot From 2025-07-27 17-21-33" src="https://github.com/user-attachments/assets/ce55f065-7ea2-4b2e-84f2-fb747dc9df72" />

## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: The barrel of the mateba is now visible again.
