### PR TITLE
Make X17 riot charge no longer require police skill.

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Explosives/breaching_charge.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Explosives/breaching_charge.yml
@@ -58,9 +58,6 @@
     - state: icon
       map: ["base"]
   # TODO Shrapnel volume 20
-  - type: RequiresSkill
-    skills:
-      RMCSkillPolice: 1
 
 - type: entity
   parent: RMCExplosiveBreachingCharge


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This breaching charge spawns on TSEPA constables survivors aswell in the Hybrisa armory. Since it's impossible for survivors (Hybrisa security variants no longer have police skill due to a recent change) to use this item, the police skill requirement has been removed, now is engineering 1 like the other breaching charges.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

:cl:
- tweak: The X17 riot charge no longer requires police skill to use.
