### PR TITLE
Queen Gut improvements

### DIFF
--- a/Content.Shared/_RMC14/Gibbing/RMCGibSystem.cs
+++ b/Content.Shared/_RMC14/Gibbing/RMCGibSystem.cs
@@ -1,0 +1,46 @@
+using Content.Shared.Inventory;
+using Robust.Shared.Physics.Systems;
+using Robust.Shared.Random;
+
+namespace Content.Shared._RMC14.Gibbing;
+public sealed class RMCGibSystem : EntitySystem
+{
+    private const float ItemLaunchImpulse = 8f;
+    private const float ItemLaunchImpulseVariance = 3f;
+
+    [Dependency] private readonly InventorySystem _inventory = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    /// <summary>
+    /// Scatters all inventory items from a target entity with physics impulses,
+    /// similar to how body parts are launched during gibbing.
+    /// </summary>
+    /// <param name="target">The entity whose items should be scattered</param>
+    /// <param name="launchImpulse">Base impulse force for launching items</param>
+    /// <param name="launchImpulseVariance">Random variance added to the launch impulse</param>
+    public void ScatterInventoryItems(EntityUid target, float? launchImpulse = null, float? launchImpulseVariance = null)
+    {
+        if (!TryComp<InventoryComponent>(target, out var inventory))
+            return;
+
+        var impulse = launchImpulse ?? ItemLaunchImpulse;
+        var impulseVariance = launchImpulseVariance ?? ItemLaunchImpulseVariance;
+
+        var targetTransform = Transform(target);
+        foreach (var item in _inventory.GetHandOrInventoryEntities(target))
+        {
+            // Drop the item next to the target
+            _transform.DropNextTo(item, (target, targetTransform));
+
+            // Apply random launch impulse to scatter the item
+            var scatterAngle = _random.NextAngle();
+            var scatterVector = scatterAngle.ToVec() * (impulse + _random.NextFloat(impulseVariance));
+            _physics.ApplyLinearImpulse(item, scatterVector);
+
+            // Give the item a random rotation for visual effect
+            _transform.SetWorldRotation(item, _random.NextAngle());
+        }
+    }
+}

--- a/Content.Shared/_RMC14/Xenonids/Gut/SharedXenoGutSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Gut/SharedXenoGutSystem.cs
@@ -1,9 +1,13 @@
 ﻿using Content.Shared._RMC14.Actions;
+using Content.Shared._RMC14.Gibbing;
 using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared.Actions;
 using Content.Shared.Body.Components;
 using Content.Shared.Body.Systems;
 using Content.Shared.DoAfter;
+using Content.Shared.Jittering;
+using Content.Shared.Popups;
+using Content.Shared.StatusEffect;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Network;
 
@@ -16,7 +20,11 @@ public sealed class SharedXenoGutSystem : EntitySystem
     [Dependency] private readonly SharedBodySystem _bodySystem = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedJitteringSystem _jitter = default!;
     [Dependency] private readonly RMCActionsSystem _rmcActions = default!;
+    [Dependency] private readonly RMCGibSystem _rmcGib = default!;
+    [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
     [Dependency] private readonly XenoPlasmaSystem _xenoPlasma = default!;
 
     public override void Initialize()
@@ -58,13 +66,22 @@ public sealed class SharedXenoGutSystem : EntitySystem
             BlockDuplicate = true,
         };
 
+        var selfMsg = Loc.GetString("rmc-gut-start-self");
+        var othersMsg = Loc.GetString("rmc-gut-start-others", ("user", xeno.Owner), ("target", args.Target));
+        _popup.PopupPredicted(selfMsg, othersMsg, xeno.Owner, xeno.Owner, PopupType.LargeCaution);
+
         _doAfter.TryStartDoAfter(doAfter);
+        _jitter.DoJitter(args.Target, xeno.Comp.Delay, true, 14f, 5f, true);
     }
 
     private void OnXenoGutDoAfterEvent(Entity<XenoGutComponent> xeno, ref XenoGutDoAfterEvent args)
     {
         if (args.Cancelled || args.Handled || args.Target is not { } target)
+        {
+            if (args.Target is { } cancelledTarget)
+                _statusEffects.TryRemoveStatusEffect(cancelledTarget, "Jitter");
             return;
+        }
 
         if (target == xeno.Owner || HasComp<XenoComponent>(target))
             return;
@@ -78,9 +95,14 @@ public sealed class SharedXenoGutSystem : EntitySystem
         args.Handled = true;
         if (_net.IsServer)
         {
+            _rmcGib.ScatterInventoryItems(target);
             _bodySystem.GibBody(target, true, body);
             _audio.PlayPvs(xeno.Comp.Sound, xeno);
         }
+
+        var selfMsg = Loc.GetString("rmc-gut-finish-self");
+        var othersMsg = Loc.GetString("rmc-gut-finish-others", ("user", xeno.Owner), ("target", args.Target));
+        _popup.PopupPredicted(selfMsg, othersMsg, xeno.Owner, xeno.Owner, PopupType.LargeCaution);
 
         foreach (var action in _rmcActions.GetActionsWithEvent<XenoGutActionEvent>(xeno))
         {

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
@@ -376,3 +376,10 @@ rmc-xeno-eviscerate-windup-small = {$xeno} begins digging in for a strike!
 
 # Fling
 rmc-xeno-fling-too-big = {CAPITALIZE(THE($target))} is too big for us to fling!
+
+# Gut
+rmc-gut-start-self = We plunge our claws into the body of this unfortunate host, starting to tear them in half!
+rmc-gut-start-others = {$user} plunges their claws into the body of {$target}, starting to tear them in half!
+
+rmc-gut-finish-self = We tear this pathetic host in half!!
+rmc-gut-finish-others = {$user} tears {$target} in half!!


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Gutting as the queen now has a pop up for starting and finishing, shakes the target as they're being gibbed, and splatters their items rather than dropping them all in one neat pile.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Looks alot cooler and makes more sense (turning someone into organs shouldn't make all their items nicely pile up)

## Technical details
<!-- Summary of code changes for easier review. -->
Added `RMCGibSystem` which stores `ScatterInventoryItems` which will fling items off an entity. Designed to be used with gibbing.
`SharedXenoGutSystem` now has Locs for starting and finishing, uses `DoJitter` when starting the do-after on a target, will remove the Jitter effect when the do-after is cancelled and now calls `ScatterInventoryItems` when gibbing a target.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://github.com/user-attachments/assets/d0e2f3d2-0567-4256-8487-3e635f04568f

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: noctyrnal
- add: Gibbing a person as a queen will now pop up text, cause the target to shake and make their dropped items splatter out.
