### PR TITLE
Shotgun choke increases range

### DIFF
--- a/Content.Shared/_RMC14/Attachable/AttachableData.cs
+++ b/Content.Shared/_RMC14/Attachable/AttachableData.cs
@@ -55,7 +55,8 @@ public record struct AttachableWeaponRangedModifierSet(
     float RecoilFlat, // How much the camera shakes when you shoot.
     double ScatterFlat, // Scatter in degrees. This is how far bullets go from where you aim. Conversion to RMC: CM_SCATTER * 2
     float FireDelayFlat, // The delay between each shot. Conversion to RMC: CM_FIRE_DELAY / 10
-    float ProjectileSpeedFlat // How fast the projectiles move. Conversion to RMC: CM_PROJECTILE_SPEED * 10
+    float ProjectileSpeedFlat, // How fast the projectiles move. Conversion to RMC: CM_PROJECTILE_SPEED * 10
+    float RangeFlat // The distance in tiles at which the damage of the projectiles starts to drop off. Conversion to RMC: projectile_max_range_mod
 );
 
 [DataRecord, Serializable, NetSerializable]

--- a/Content.Shared/_RMC14/Attachable/Systems/AttachableModifiersSystem.Ranged.cs
+++ b/Content.Shared/_RMC14/Attachable/Systems/AttachableModifiersSystem.Ranged.cs
@@ -1,7 +1,6 @@
 using Content.Shared._RMC14.Attachable.Components;
 using Content.Shared._RMC14.Attachable.Events;
 using Content.Shared._RMC14.Weapons.Ranged;
-using Content.Shared.Projectiles;
 using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Weapons.Ranged.Events;
 
@@ -75,6 +74,10 @@ public sealed partial class AttachableModifiersSystem : EntitySystem
             result.Add(Loc.GetString("rmc-attachable-examine-ranged-damage-falloff",
                 ("colour", modifierExamineColour), ("sign", modSet.DamageFalloffAddMult > 0 ? '+' : ""), ("falloff", modSet.DamageFalloffAddMult)));
 
+        if (modSet.RangeFlat != 0)
+            result.Add(Loc.GetString("rmc-attachable-examine-ranged-range",
+                ("colour", modifierExamineColour), ("sign", modSet.RangeFlat > 0 ? '+' : ""), ("falloff", modSet.RangeFlat)));
+
         return result;
     }
 
@@ -147,6 +150,7 @@ public sealed partial class AttachableModifiersSystem : EntitySystem
                 continue;
 
             args.Args.FalloffMultiplier += modSet.DamageFalloffAddMult;
+            args.Args.Range += modSet.RangeFlat;
         }
     }
 
@@ -169,6 +173,7 @@ public sealed partial class AttachableModifiersSystem : EntitySystem
                 continue;
 
             args.Args.AccuracyMultiplier += modSet.AccuracyAddMult;
+            args.Args.Range += modSet.RangeFlat;
         }
     }
 

--- a/Content.Shared/_RMC14/Projectiles/RMCProjectileSystem.cs
+++ b/Content.Shared/_RMC14/Projectiles/RMCProjectileSystem.cs
@@ -160,7 +160,7 @@ public sealed class RMCProjectileSystem : EntitySystem
         if (!_examine.InRangeUnOccluded(_transform.ToMapCoordinates(projectile.Comp.ShotFrom.Value), _transform.ToMapCoordinates(targetCoords), distance, null))
             accuracy += (int) AccuracyModifiers.TargetOccluded;
 
-        if (!projectile.Comp.IgnoreFriendlyEvasion && IsProjectileTargetFriendly(projectile.Owner, args.OtherEntity))//
+        if (!projectile.Comp.IgnoreFriendlyEvasion && IsProjectileTargetFriendly(projectile.Owner, args.OtherEntity))
             accuracy -= evasionComponent.ModifiedEvasionFriendly;
 
         accuracy -= evasionComponent.ModifiedEvasion;

--- a/Content.Shared/_RMC14/Projectiles/RMCProjectileSystem.cs
+++ b/Content.Shared/_RMC14/Projectiles/RMCProjectileSystem.cs
@@ -1,7 +1,6 @@
 using System.Numerics;
 using Content.Shared._RMC14.Evasion;
 using Content.Shared._RMC14.Random;
-using Content.Shared._RMC14.Weapons.Ranged.Prediction;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared.Examine;
 using Content.Shared.FixedPoint;
@@ -99,8 +98,16 @@ public sealed class RMCProjectileSystem : EntitySystem
         }
     }
 
-    public void SetProjectileFalloffWeaponMult(Entity<RMCProjectileDamageFalloffComponent> projectile, FixedPoint2 mult)
+    public void SetProjectileFalloffWeaponMult(Entity<RMCProjectileDamageFalloffComponent> projectile, FixedPoint2 mult, float range)
     {
+        var count = 0;
+        while (projectile.Comp.Thresholds.Count > count)
+        {
+            var threshold = projectile.Comp.Thresholds[count];
+            projectile.Comp.Thresholds[count] = threshold with { Range = threshold.Range + range };
+            count++;
+        }
+
         projectile.Comp.WeaponMult = mult;
         Dirty(projectile);
     }
@@ -153,7 +160,7 @@ public sealed class RMCProjectileSystem : EntitySystem
         if (!_examine.InRangeUnOccluded(_transform.ToMapCoordinates(projectile.Comp.ShotFrom.Value), _transform.ToMapCoordinates(targetCoords), distance, null))
             accuracy += (int) AccuracyModifiers.TargetOccluded;
 
-        if (!projectile.Comp.IgnoreFriendlyEvasion && IsProjectileTargetFriendly(projectile.Owner, args.OtherEntity))
+        if (!projectile.Comp.IgnoreFriendlyEvasion && IsProjectileTargetFriendly(projectile.Owner, args.OtherEntity))//
             accuracy -= evasionComponent.ModifiedEvasionFriendly;
 
         accuracy -= evasionComponent.ModifiedEvasion;

--- a/Content.Shared/_RMC14/Weapons/Ranged/CMGunSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/CMGunSystem.cs
@@ -228,10 +228,11 @@ public sealed class CMGunSystem : EntitySystem
 
     private void OnWeaponDamageFalloffRefreshModifiers(Entity<RMCWeaponDamageFalloffComponent> weapon, ref GunRefreshModifiersEvent args)
     {
-        var ev = new GetDamageFalloffEvent(weapon.Comp.FalloffMultiplier);
+        var ev = new GetDamageFalloffEvent(weapon.Comp.FalloffMultiplier, weapon.Comp.RangeFlat);
         RaiseLocalEvent(weapon.Owner, ref ev);
 
         weapon.Comp.ModifiedFalloffMultiplier = FixedPoint2.Max(ev.FalloffMultiplier, 0);
+        weapon.Comp.RangeFlatModified = ev.Range;
 
         Dirty(weapon);
     }
@@ -243,7 +244,7 @@ public sealed class CMGunSystem : EntitySystem
             if (!TryComp(projectile, out RMCProjectileDamageFalloffComponent? falloffComponent))
                 continue;
 
-            _rmcProjectileSystem.SetProjectileFalloffWeaponMult((projectile, falloffComponent), weapon.Comp.ModifiedFalloffMultiplier);
+            _rmcProjectileSystem.SetProjectileFalloffWeaponMult((projectile, falloffComponent), weapon.Comp.ModifiedFalloffMultiplier, weapon.Comp.RangeFlatModified);
         }
     }
 
@@ -276,10 +277,11 @@ public sealed class CMGunSystem : EntitySystem
         if (TryComp(weapon.Owner, out WieldableComponent? wieldableComponent) && wieldableComponent.Wielded)
             baseMult = weapon.Comp.AccuracyMultiplier;
 
-        var ev = new GetWeaponAccuracyEvent(baseMult);
+        var ev = new GetWeaponAccuracyEvent(baseMult, weapon.Comp.RangeFlat);
         RaiseLocalEvent(weapon.Owner, ref ev);
 
         weapon.Comp.ModifiedAccuracyMultiplier = Math.Max(0.1, (double) ev.AccuracyMultiplier);
+        weapon.Comp.RangeFlatModified = ev.Range;
 
         Dirty(weapon);
     }
@@ -306,6 +308,14 @@ public sealed class CMGunSystem : EntitySystem
 
             accuracyComponent.Accuracy *= weapon.Comp.ModifiedAccuracyMultiplier;
             accuracyComponent.Accuracy += orderAccuracy;
+
+            var count = 0;
+            while (accuracyComponent.Thresholds.Count > count)
+            {
+                var threshold = accuracyComponent.Thresholds[count];
+                accuracyComponent.Thresholds[count] = threshold with { Range = threshold.Range + weapon.Comp.RangeFlatModified };
+                count++;
+            }
 
             if (orderAccuracyPerTile != 0)
                 accuracyComponent.Thresholds.Add(new AccuracyFalloffThreshold(0f, -orderAccuracyPerTile, false));

--- a/Content.Shared/_RMC14/Weapons/Ranged/GetDamageFalloffEvent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/GetDamageFalloffEvent.cs
@@ -4,5 +4,6 @@ namespace Content.Shared._RMC14.Weapons.Ranged;
 
 [ByRefEvent]
 public record struct GetDamageFalloffEvent(
-    FixedPoint2 FalloffMultiplier
+    FixedPoint2 FalloffMultiplier,
+    float Range
 );

--- a/Content.Shared/_RMC14/Weapons/Ranged/GetWeaponAccuracyEvent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/GetWeaponAccuracyEvent.cs
@@ -4,5 +4,6 @@ namespace Content.Shared._RMC14.Weapons.Ranged;
 
 [ByRefEvent]
 public record struct GetWeaponAccuracyEvent(
-    FixedPoint2 AccuracyMultiplier
+    FixedPoint2 AccuracyMultiplier,
+    float Range
 );

--- a/Content.Shared/_RMC14/Weapons/Ranged/RMCWeaponAccuracyComponent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/RMCWeaponAccuracyComponent.cs
@@ -23,4 +23,10 @@ public sealed partial class RMCWeaponAccuracyComponent : Component
 
     [DataField, AutoNetworkedField]
     public FixedPoint2 ModifiedAccuracyMultiplier = 1;
+
+    [DataField, AutoNetworkedField]
+    public float RangeFlat;
+
+    [DataField, AutoNetworkedField]
+    public float RangeFlatModified;
 }

--- a/Content.Shared/_RMC14/Weapons/Ranged/RMCWeaponDamageFalloffComponent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/RMCWeaponDamageFalloffComponent.cs
@@ -16,4 +16,10 @@ public sealed partial class RMCWeaponDamageFalloffComponent : Component
 
     [DataField, AutoNetworkedField]
     public FixedPoint2 ModifiedFalloffMultiplier = 1;
+
+    [DataField, AutoNetworkedField]
+    public float RangeFlat;
+
+    [DataField, AutoNetworkedField]
+    public float RangeFlatModified;
 }

--- a/Content.Shared/_RMC14/Weapons/Ranged/ShootUseDelaySystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/ShootUseDelaySystem.cs
@@ -1,6 +1,5 @@
 ﻿using Content.Shared.Timing;
 using Content.Shared.Weapons.Ranged.Components;
-using Content.Shared.Weapons.Ranged.Events;
 using Content.Shared.Weapons.Ranged.Systems;
 
 namespace Content.Shared._RMC14.Weapons.Ranged;
@@ -9,7 +8,7 @@ public sealed class ShootUseDelaySystem : EntitySystem
 {
     [Dependency] private readonly UseDelaySystem _useDelay = default!;
 
-    private const string shootUseDelayId = "CMShootUseDelay";
+    private const string ShootUseDelayId = "CMShootUseDelay";
 
     public override void Initialize()
     {
@@ -21,7 +20,7 @@ public sealed class ShootUseDelaySystem : EntitySystem
         if (!TryComp(ent, out UseDelayComponent? delayComponent) || !TryComp(ent, out GunComponent? gunComponent))
             return;
 
-        _useDelay.SetLength((ent.Owner, delayComponent), TimeSpan.FromSeconds(1f / gunComponent.FireRate), shootUseDelayId);
-        _useDelay.TryResetDelay((ent.Owner, delayComponent), true, id: shootUseDelayId);
+        _useDelay.SetLength((ent.Owner, delayComponent), TimeSpan.FromSeconds(1f / gunComponent.FireRateModified), ShootUseDelayId);
+        _useDelay.TryResetDelay((ent.Owner, delayComponent), true, id: ShootUseDelayId);
     }
 }

--- a/Resources/Locale/en-US/_RMC14/attachable/attachable.ftl
+++ b/Resources/Locale/en-US/_RMC14/attachable/attachable.ftl
@@ -61,6 +61,7 @@ rmc-attachable-examine-ranged-damage = [color={$colour}]{$sign}{$damage}[/color]
 rmc-attachable-examine-ranged-projectile-speed = [color={$colour}]{$sign}{$projectileSpeed}[/color] projectile speed.
 rmc-attachable-examine-ranged-damage-falloff = [color={$colour}]{$sign}{$falloff}[/color] falloff multiplier.
 rmc-attachable-examine-ranged-range = [color={$colour}]{$sign}{$falloff}[/color] projectile range.
+rmc-attachable-examine-ranged-projectile-stun-duration = [color={$colour}]{$sign}{$stunDurationMult}[/color] stun duration multiplier.
 
 rmc-attachable-examine-melee-damage = [color={$colour}]{$sign}{$damage}[/color] melee damage.
 

--- a/Resources/Locale/en-US/_RMC14/attachable/attachable.ftl
+++ b/Resources/Locale/en-US/_RMC14/attachable/attachable.ftl
@@ -60,7 +60,7 @@ rmc-attachable-examine-ranged-recoil = [color={$colour}]{$sign}{$recoil}[/color]
 rmc-attachable-examine-ranged-damage = [color={$colour}]{$sign}{$damage}[/color] ranged damage multiplier.
 rmc-attachable-examine-ranged-projectile-speed = [color={$colour}]{$sign}{$projectileSpeed}[/color] projectile speed.
 rmc-attachable-examine-ranged-damage-falloff = [color={$colour}]{$sign}{$falloff}[/color] falloff multiplier.
-rmc-attachable-examine-ranged-range = [color={$colour}]{$sign}{$falloff}[/color] range.
+rmc-attachable-examine-ranged-range = [color={$colour}]{$sign}{$falloff}[/color] projectile range.
 
 rmc-attachable-examine-melee-damage = [color={$colour}]{$sign}{$damage}[/color] melee damage.
 

--- a/Resources/Locale/en-US/_RMC14/attachable/attachable.ftl
+++ b/Resources/Locale/en-US/_RMC14/attachable/attachable.ftl
@@ -60,6 +60,7 @@ rmc-attachable-examine-ranged-recoil = [color={$colour}]{$sign}{$recoil}[/color]
 rmc-attachable-examine-ranged-damage = [color={$colour}]{$sign}{$damage}[/color] ranged damage multiplier.
 rmc-attachable-examine-ranged-projectile-speed = [color={$colour}]{$sign}{$projectileSpeed}[/color] projectile speed.
 rmc-attachable-examine-ranged-damage-falloff = [color={$colour}]{$sign}{$falloff}[/color] falloff multiplier.
+rmc-attachable-examine-ranged-range = [color={$colour}]{$sign}{$falloff}[/color] range.
 
 rmc-attachable-examine-melee-damage = [color={$colour}]{$sign}{$damage}[/color] melee damage.
 

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/barrel_attachments.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/barrel_attachments.yml
@@ -135,6 +135,7 @@
     - accuracyAddMult: 0.25
       damageFalloffAddMult: -0.3
       damageAddMult: -0.2
+      rangeFlat: 1
     - conditions:
         wieldedOnly: true
       recoilFlat: 2


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

The shotgun choke now increases the range of any shot projectiles by 1.
Attachments now show their stun duration multiplier in their description.
The shoot delay visual(the cooldown circle on the gun after shooting) now uses the modified fire rate instead of the base fire rate.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity and bug fix.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Dygon
- fix: Fixed the shotgun choke not increasing the range of any shot projectiles by 1.
- tweak: The attachment effect examine now shows the stun duration multiplier if the attachment applies one.
- fix: Weapons with a modified fire rate show the correct use delay visual.

