### PR TITLE
Better Fax/ERT map spawning

### DIFF
--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
@@ -168,7 +168,6 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
     private float _marinesPerSurvivor;
     private float _maximumSurvivors;
     private float _minimumSurvivors;
-    private string _adminFaxAreaMap = string.Empty;
     private int _mapVoteExcludeLast;
     private bool _useCarryoverVoting;
     private readonly TimeSpan _hijackStunTime = TimeSpan.FromSeconds(5);
@@ -244,7 +243,6 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
         Subs.CVar(_config, RMCCVars.RMCMarinesPerSurvivor, v => _marinesPerSurvivor = v, true);
         Subs.CVar(_config, RMCCVars.RMCSurvivorsMaximum, v => _maximumSurvivors = v, true);
         Subs.CVar(_config, RMCCVars.RMCSurvivorsMinimum, v => _minimumSurvivors = v, true);
-        Subs.CVar(_config, RMCCVars.RMCAdminFaxAreaMap, v => _adminFaxAreaMap = v, true);
         Subs.CVar(_config, RMCCVars.RMCPlanetMapVoteExcludeLast, v => _mapVoteExcludeLast = v, true);
         Subs.CVar(_config, RMCCVars.RMCUseCarryoverVoting, v => _useCarryoverVoting = v, true);
         Subs.CVar(_config, RMCCVars.RMCLandingZoneMiasmaEnabled, v => _landingZoneMiasmaEnabled = v, true);
@@ -1864,13 +1862,17 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
             }
             catch (Exception e)
             {
-                Log.Error($"Error loading admin fax area:\n{e}");
+                Log.Error($"Error loading {path} map:\n{e}");
             }
 
             return false;
         }
 
-        SpawnMap(new ResPath(_adminFaxAreaMap), out _);
+        foreach (string _map in comp.AuxiliaryMaps)
+        {
+            SpawnMap(new ResPath(_map), out _);
+        }
+
         if (SpawnMap(comp.Thunderdome, out var mapEnt))
             EnsureComp<ThunderdomeMapComponent>(mapEnt.Value);
     }

--- a/Content.Shared/_RMC14/CCVar/RMCCVars.cs
+++ b/Content.Shared/_RMC14/CCVar/RMCCVars.cs
@@ -126,9 +126,6 @@ public sealed partial class RMCCVars : CVars
     public static readonly CVarDef<bool> RMCActiveInputMoverEnabled =
         CVarDef.Create("rmc.active_input_mover_enabled", true, CVar.REPLICATED | CVar.SERVER);
 
-    public static readonly CVarDef<string> RMCAdminFaxAreaMap =
-        CVarDef.Create("rmc.admin_fax_area_map", "Maps/_RMC14/admin_fax.yml", CVar.REPLICATED | CVar.SERVER);
-
     public static readonly CVarDef<int> RMCBioscanInitialDelaySeconds =
         CVarDef.Create("rmc.bioscan_initial_delay_seconds", 300, CVar.REPLICATED | CVar.SERVER);
 

--- a/Content.Shared/_RMC14/Rules/CMDistressSignalRuleComponent.cs
+++ b/Content.Shared/_RMC14/Rules/CMDistressSignalRuleComponent.cs
@@ -163,6 +163,11 @@ public sealed partial class CMDistressSignalRuleComponent : Component
     [DataField]
     public ResPath Thunderdome = new("/Maps/_RMC14/thunderdome.yml");
 
+    public List<string> AuxiliaryMaps = new() {
+        "/Maps/_RMC14/OCP-583.yml",
+        "/Maps/_RMC14/admin_fax.yml"
+    };
+
     [DataField]
     public ProtoId<JobPrototype> XenoSurvivorCorpseJob = "CMSurvivor";
 


### PR DESCRIPTION
## About the PR

Changed logic of Fax Map spawning
Now it uses string list in DistressSignal Rule component, and not CCVar.

Creating a new CCVar for every new fax/ert map or hardcoding them - **sucks**. And **sucks** a lot.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
