### PR TITLE
Tailstab can hit folding barricades again

### DIFF
--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
@@ -123,6 +123,7 @@
     range: 2.5
     checkCanAccess: false
   - type: EntityTargetAction
+    targetCheckCanInteract: false
   - type: WorldTargetAction
     event: !type:XenoTailStabEvent
   - type: XenoTailStabAction


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Tail stab is able to hit folding barricades again.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug fix

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.

:cl: Dygon
- fix: Tail Stab can hit folding barricades again.

