### PR TITLE
Tail Jab now breaks windows

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Actions/XenoActionsSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Actions/XenoActionsSystem.cs
@@ -19,7 +19,7 @@ public sealed class XenoActionsSystem : EntitySystem
         if (GetEntity(args.Input.EntityTarget) is not { } target)
             return;
 
-        if (!_xeno.CanAbilityAttackTarget(args.User, target))
+        if (!_xeno.CanAbilityAttackTarget(args.User, target, false, true))
             args.Invalid = true;
     }
 }

--- a/Content.Shared/_RMC14/Xenonids/ScissorCut/XenoScissorCutSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/ScissorCut/XenoScissorCutSystem.cs
@@ -75,7 +75,7 @@ public sealed class XenoScissorCutSystem : EntitySystem
                 continue;
             }
 
-            if (!_xeno.CanAbilityAttackTarget(xeno, ent))
+            if (!_xeno.CanAbilityAttackTarget(xeno, ent, false, true))
                 continue;
             mobs.Add(ent);
         }

--- a/Content.Shared/_RMC14/Xenonids/TailJab/XenoTailJabSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/TailJab/XenoTailJabSystem.cs
@@ -13,6 +13,7 @@ using Robust.Shared.Audio.Systems;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Content.Shared._RMC14.Stun;
+using Content.Shared._RMC14.Xenonids.ScissorCut;
 
 namespace Content.Shared._RMC14.Xenonids.TailJab;
 
@@ -31,6 +32,9 @@ public sealed class XenoTailJabSystem : EntitySystem
     [Dependency] private readonly RMCSizeStunSystem _size = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly XenoSystem _xeno = default!;
+
+    private const string WindowBonusDamageType = "Structural";
+    private const int WindowDamageBonus = 100;
 
     public override void Initialize()
     {
@@ -56,6 +60,9 @@ public sealed class XenoTailJabSystem : EntitySystem
         var ev = new RMCGetTailStabBonusDamageEvent(new DamageSpecifier());
         RaiseLocalEvent(xeno, ref ev);
         damage += ev.Damage;
+
+        if (HasComp<DestroyOnXenoPierceScissorComponent>(target))
+            damage.DamageDict.TryAdd(WindowBonusDamageType, WindowDamageBonus);
 
         var damageTaken = _damage.TryChangeDamage(target, _xeno.TryApplyXenoSlashDamageMultiplier(target, damage), origin: xeno, tool: xeno);
         if (damageTaken?.GetTotal() > FixedPoint2.Zero)

--- a/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
@@ -20,6 +20,7 @@ using Content.Shared._RMC14.Xenonids.Parasite;
 using Content.Shared._RMC14.Xenonids.Pheromones;
 using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared._RMC14.Xenonids.Rest;
+using Content.Shared._RMC14.Xenonids.ScissorCut;
 using Content.Shared._RMC14.Xenonids.Weeds;
 using Content.Shared.Access.Components;
 using Content.Shared.Actions;
@@ -421,7 +422,7 @@ public sealed partial class XenoSystem : EntitySystem
         _damageable.TryChangeDamage(xeno, heal, true, origin: xeno);
     }
 
-    public bool CanAbilityAttackTarget(EntityUid xeno, EntityUid target, bool canAttackBarricades = false)
+    public bool CanAbilityAttackTarget(EntityUid xeno, EntityUid target, bool canAttackBarricades = false, bool canAttackWindows = false)
     {
         if (xeno == target)
             return false;
@@ -440,6 +441,9 @@ public sealed partial class XenoSystem : EntitySystem
             return false;
 
         if (canAttackBarricades && HasComp<BarricadeComponent>(target))
+            return true;
+
+        if (canAttackWindows && HasComp<DestroyOnXenoPierceScissorComponent>(target))
             return true;
 
         return HasComp<MarineComponent>(target) || HasComp<XenoComponent>(target);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Vampire Lurker's Tail Jab action can now be used on windows to destroy them in one hit.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Dygon
- fix: Vampire Lurker's Tail Jab can now be used on windows.

