### PR TITLE
Tackling nested + nest retargeting

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared._RMC14.Chat;
 using Content.Shared._RMC14.Ghost;
 using Content.Shared._RMC14.Inventory;
 using Content.Shared._RMC14.Map;
+using Content.Shared._RMC14.Weapons.Melee;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Parasite;
 using Content.Shared._RMC14.Xenonids.Weeds;
@@ -230,14 +231,14 @@ public sealed class XenoNestSystem : EntitySystem
         var nestCoordinates = ent.Owner.ToCoordinates();
         var offset = direction switch
         {
-            Direction.South => new Vector2(0, -0.25f),
-            Direction.East => new Vector2(0.5f, 0),
-            Direction.North => new Vector2(0, 0.5f),
-            Direction.West => new Vector2(-0.5f, 0),
+            Direction.South => new Vector2(0, -0.52f),
+            Direction.East => new Vector2(0.52f, 0),
+            Direction.North => new Vector2(0, 0.52f),
+            Direction.West => new Vector2(-0.52f, 0),
             _ => Vector2.Zero,
         };
 
-        var nest = SpawnAttachedTo(ent.Comp.Nest, nestCoordinates);
+        var nest = SpawnAttachedTo(ent.Comp.Nest, nestCoordinates, rotation: direction.Value.ToAngle());
         _transform.SetCoordinates(nest, nestCoordinates.Offset(offset));
 
         _hive.SetSameHive(args.User, nest);
@@ -255,7 +256,7 @@ public sealed class XenoNestSystem : EntitySystem
         Dirty(victim, nestedComp);
 
         _transform.SetCoordinates(victim, nest.ToCoordinates());
-        _transform.SetLocalRotation(victim, direction.Value.ToAngle());
+        _transform.SetLocalRotation(victim, Angle.Zero);
 
         _standing.Stand(victim, force: true);
 

--- a/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
@@ -9,6 +9,7 @@ using Content.Shared._RMC14.NightVision;
 using Content.Shared._RMC14.Rules;
 using Content.Shared._RMC14.Tackle;
 using Content.Shared._RMC14.Vendors;
+using Content.Shared._RMC14.Weapons.Melee;
 using Content.Shared._RMC14.Xenonids.Construction.Nest;
 using Content.Shared._RMC14.Xenonids.Devour;
 using Content.Shared._RMC14.Xenonids.Egg;
@@ -119,6 +120,7 @@ public sealed partial class XenoSystem : EntitySystem
         SubscribeLocalEvent<XenoComponent, HealthScannerAttemptTargetEvent>(OnXenoHealthScannerAttemptTarget);
         SubscribeLocalEvent<XenoComponent, GetDefaultRadioChannelEvent>(OnXenoGetDefaultRadioChannel);
         SubscribeLocalEvent<XenoComponent, AttackAttemptEvent>(OnXenoAttackAttempt);
+        SubscribeLocalEvent<XenoComponent, MeleeAttackAttemptEvent>(OnXenoMeleeAttackAttempt);
         SubscribeLocalEvent<XenoComponent, UserOpenActivatableUIAttemptEvent>(OnXenoOpenActivatableUIAttempt);
         SubscribeLocalEvent<XenoComponent, GetMeleeDamageEvent>(OnXenoGetMeleeDamage);
         SubscribeLocalEvent<XenoComponent, DamageModifyEvent>(OnXenoDamageModify);
@@ -217,9 +219,29 @@ public sealed partial class XenoSystem : EntitySystem
         }
 
         if (_xenoNestedQuery.HasComp(target) &&
-            _victimInfectedQuery.HasComp(target))
+            _victimInfectedQuery.HasComp(target) && !args.Disarm)
         {
             args.Cancel();
+        }
+    }
+
+    private void OnXenoMeleeAttackAttempt(Entity<XenoComponent> xeno, ref MeleeAttackAttemptEvent args)
+    {
+        if (!TryComp<XenoNestComponent>(GetEntity(args.Target), out var nest) || nest.Nested == null)
+            return;
+
+        var attacker = GetNetEntity(xeno);
+        args.Target = GetNetEntity(nest.Nested.Value);
+
+        switch (args.Attack)
+        {
+            case LightAttackEvent attack:
+                args.Attack = new LightAttackEvent(args.Target, attacker, attack.Coordinates);
+                break;
+
+            case DisarmAttackEvent disarm:
+                args.Attack = new DisarmAttackEvent(args.Target, disarm.Coordinates);
+                break;
         }
     }
 

--- a/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
@@ -227,7 +227,8 @@ public sealed partial class XenoSystem : EntitySystem
 
     private void OnXenoMeleeAttackAttempt(Entity<XenoComponent> xeno, ref MeleeAttackAttemptEvent args)
     {
-        if (!TryComp<XenoNestComponent>(GetEntity(args.Target), out var nest) || nest.Nested == null)
+        if (!TryComp<XenoNestComponent>(GetEntity(args.Target), out var nest) || nest.Nested == null
+            || !_hive.FromSameHive(xeno.Owner, GetEntity(args.Target)))
             return;
 
         var attacker = GetNetEntity(xeno);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Told it's Parity + to make it work with clicks.

## Technical details
<!-- Summary of code changes for easier review. -->
You can now tackle nested/nested & infected hosts. The attackattempt func in the xeno system no longer stops disarmed attacks.

To make this easier, if a xeno attacks a xeno nest, it will try to redirect the attack to it's occupant, both disarms and attacks. Ofc at this point the xeno attack code will cancel it if they're infected. To make this work however I had to move the nest offsets slightly, and make the south offset inline with the others, so they're farther down the wall now, because they were being counted as being obstructed. But as a bonus I fixed nests not rotating on creations so.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
(nested sprites fix + where the front goes now)
<img width="197" height="163" alt="image" src="https://github.com/user-attachments/assets/dafb53a1-a57f-4704-8d1e-061641ee8ad2" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed not being able to tackle nested hosts. Trying to attack/tackle a nest will also now redirect the attack to the occupant, if it's from a xeno.
- fix: Fixed nest sprites always using the south sprite.
