### PR TITLE
Fix we-ya secguard survivor not having WeYa IFF

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/LV624/corporate_security_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/LV624/corporate_security_survivor.yml
@@ -39,6 +39,7 @@
     jumpsuit: RMCJumsuitWhiteService
     outerClothing: RMCArmorVestWeYa
     ears: RMCHeadsetDistressWeYa
+    id: CMIDCardLiaisonColony
 
 - type: entity
   parent: CMSpawnPointJobBase


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
They spawn with that ID in CM13

:cl:
- fix: Fixed the We-Ya security guard survivor on LV-624 not having We-YA IFF