### PR TITLE
Fixed disabled playtime benefits not working

### DIFF
--- a/Content.Server/_RMC14/Xenonids/XenoRoleSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/XenoRoleSystem.cs
@@ -134,7 +134,9 @@ public sealed class XenoRoleSystem : EntitySystem
         }
 
         int rank;
-        if (time > _rankFiveTime)
+        if (!profile.PlaytimePerks)
+            rank = 1;
+        else if (time > _rankFiveTime)
             rank = 5;
         else if (time > _rankFourTime)
             rank = 4;
@@ -142,8 +144,6 @@ public sealed class XenoRoleSystem : EntitySystem
             rank = 3;
         else if (time > _rankTwoTime)
             rank = 2;
-        else if (!profile.PlaytimePerks)
-            rank = 1;
         else
             rank = 0;
 

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/parasite.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/parasite.yml
@@ -117,7 +117,6 @@
   - type: XenoRankNames #TODO change ranks based on total hugs done
     rankNames:
       0: rmc-xeno-young
-      1: rmc-xeno-young
       2: rmc-xeno-mature-parasite
       3: rmc-xeno-elder-parasite
       4: rmc-xeno-ancient-parasite


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
If you click the button in character customization called "disable playtime benefits", you'd expect the prefixes "young/mature/elder/ancient/prime" to not show, but it only worked for young xenos cause the logic was silly. Now no matter what age, it'll remove your prefix
Fixes #5849

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: shibechef
- fix: Turning off playtime benefits now works for all xeno ages
