### PR TITLE
Add the AGM-227 'Banshee', AGM-184 'Harpoon II', and BLU-200 'Dragon's Breath' missiles

### DIFF
--- a/Content.Shared/_RMC14/Atmos/RMCFire.cs
+++ b/Content.Shared/_RMC14/Atmos/RMCFire.cs
@@ -14,6 +14,12 @@ public sealed partial class RMCFire
     public int Range;
 
     [DataField]
+    public int CardinalRange;
+
+    [DataField]
+    public int OrdinalRange;
+
+    [DataField]
     public int? Intensity;
 
     [DataField]

--- a/Content.Shared/_RMC14/Atmos/SharedRMCFlammableSystem.cs
+++ b/Content.Shared/_RMC14/Atmos/SharedRMCFlammableSystem.cs
@@ -437,6 +437,28 @@ public abstract class SharedRMCFlammableSystem : EntitySystem
         SpawnFires(spawn, center, range, chain, intensity, duration);
     }
 
+    public void SpawnFireLines(EntProtoId spawn, EntityCoordinates center, int cardinalRange, int ordinalRange, int? intensity = null, int? duration = null)
+    {
+        var chain = _onCollide.SpawnChain();
+        var spawned = new HashSet<EntityCoordinates>();
+        foreach (var direction in DirectionExtensions.AllDirections)
+        {
+            var range = _rmcMap.CardinalDirections.Contains(direction) ? cardinalRange : ordinalRange;
+            var nextRange = range;
+            var target = center.Offset(direction);
+            while (nextRange > 0)
+            {
+                if (!spawned.Add(target))
+                    continue;
+
+                nextRange = SpawnFire(target, spawn, chain, nextRange, intensity, duration, out var cont);
+                target = target.Offset(direction);
+                if (cont)
+                    break;
+            }
+        }
+    }
+
     public int SpawnFire(EntityCoordinates target, EntProtoId spawn, EntityUid chain, int range, int? intensity, int? duration, out bool cont)
     {
         cont = false;
@@ -539,7 +561,6 @@ public abstract class SharedRMCFlammableSystem : EntitySystem
     /// </summary>
     /// <param name="ent">The entity creating the fire</param>
     /// <param name="target">The tile the fire is being spawned from</param>
-    /// <param name="direction">The direction the entity is facing</param>
     /// <param name="initialShot">If </param>
     /// <returns>Returns a list of potential targets for a fire to be spawned on</returns>
     private HashSet<EntityCoordinates> AddTarget(Entity<DirectionalTileFireOnTriggerComponent> ent, EntityCoordinates target, bool initialShot)

--- a/Content.Shared/_RMC14/Dropship/Weapon/AmmoInFlightComponent.cs
+++ b/Content.Shared/_RMC14/Dropship/Weapon/AmmoInFlightComponent.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Shared._RMC14.Atmos;
 using Content.Shared._RMC14.Explosion;
+using Content.Shared._RMC14.Explosion.Implosion;
 using Content.Shared.Damage;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
@@ -72,6 +73,9 @@ public sealed partial class AmmoInFlightComponent : Component
 
     [DataField, AutoNetworkedField]
     public RMCExplosion? Explosion;
+
+    [DataField, AutoNetworkedField]
+    public RMCImplosion? Implosion;
 
     [DataField, AutoNetworkedField]
     public RMCFire? Fire;

--- a/Content.Shared/_RMC14/Dropship/Weapon/DropshipAmmoComponent.cs
+++ b/Content.Shared/_RMC14/Dropship/Weapon/DropshipAmmoComponent.cs
@@ -1,5 +1,6 @@
 using Content.Shared._RMC14.Atmos;
 using Content.Shared._RMC14.Explosion;
+using Content.Shared._RMC14.Explosion.Implosion;
 using Content.Shared.Damage;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
@@ -65,6 +66,9 @@ public sealed partial class DropshipAmmoComponent : Component
 
     [DataField, AutoNetworkedField]
     public RMCExplosion? Explosion;
+
+    [DataField, AutoNetworkedField]
+    public RMCImplosion? Implosion;
 
     [DataField, AutoNetworkedField]
     public RMCFire? Fire;

--- a/Content.Shared/_RMC14/Dropship/Weapon/SharedDropshipWeaponSystem.cs
+++ b/Content.Shared/_RMC14/Dropship/Weapon/SharedDropshipWeaponSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared._RMC14.Dropship.AttachmentPoint;
 using Content.Shared._RMC14.Dropship.Utility.Components;
 using Content.Shared._RMC14.Dropship.Utility.Systems;
 using Content.Shared._RMC14.Explosion;
+using Content.Shared._RMC14.Explosion.Implosion;
 using Content.Shared._RMC14.Map;
 using Content.Shared._RMC14.Marines.Skills;
 using Content.Shared._RMC14.Marines.Squads;
@@ -78,6 +79,7 @@ public abstract class SharedDropshipWeaponSystem : EntitySystem
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly SharedRMCFlammableSystem _rmcFlammable = default!;
     [Dependency] private readonly SharedRMCExplosionSystem _rmcExplosion = default!;
+    [Dependency] private readonly RMCImplosionSystem _rmcImplosion = default!;
     [Dependency] private readonly SkillsSystem _skills = default!;
     [Dependency] private readonly SquadSystem _squad = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
@@ -612,6 +614,7 @@ public abstract class SharedDropshipWeaponSystem : EntitySystem
             SoundImpact = ammo.Comp.SoundImpact,
             ImpactEffect = ammo.Comp.ImpactEffect,
             Explosion = ammo.Comp.Explosion,
+            Implosion = ammo.Comp.Implosion,
             Fire = ammo.Comp.Fire,
             SoundEveryShots = ammo.Comp.SoundEveryShots,
         };
@@ -1156,6 +1159,11 @@ public abstract class SharedDropshipWeaponSystem : EntitySystem
                     }
                 }
 
+                if (flight.Implosion != null)
+                {
+                    _rmcImplosion.Implode(flight.Implosion, target);
+                }
+
                 if (flight.Explosion != null)
                 {
                     _rmcExplosion.QueueExplosion(target,
@@ -1200,6 +1208,13 @@ public abstract class SharedDropshipWeaponSystem : EntitySystem
                     }
                     else
                     {
+                        _rmcFlammable.SpawnFireLines(flight.Fire.Type,
+                            flight.Target,
+                            flight.Fire.CardinalRange,
+                            flight.Fire.OrdinalRange,
+                            flight.Fire.Intensity,
+                            flight.Fire.Duration);
+
                         for (var x = -flight.Fire.Range; x <= flight.Fire.Range; x++)
                         {
                             for (var y = -flight.Fire.Range; y <= flight.Fire.Range; y++)

--- a/Content.Shared/_RMC14/Explosion/Implosion/RMCImplosion.cs
+++ b/Content.Shared/_RMC14/Explosion/Implosion/RMCImplosion.cs
@@ -1,0 +1,20 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Explosion.Implosion;
+
+[DataDefinition]
+[Serializable, NetSerializable]
+public sealed partial class RMCImplosion
+{
+    [DataField]
+    public float PullRange;
+
+    [DataField]
+    public float PullDistance;
+
+    [DataField]
+    public float PullSpeed;
+
+    [DataField]
+    public bool IgnoreSize = true;
+}

--- a/Content.Shared/_RMC14/Explosion/Implosion/RMCImplosionSystem.cs
+++ b/Content.Shared/_RMC14/Explosion/Implosion/RMCImplosionSystem.cs
@@ -1,0 +1,19 @@
+using Content.Shared._RMC14.Stun;
+using Robust.Shared.Map;
+
+namespace Content.Shared._RMC14.Explosion.Implosion;
+
+public sealed class RMCImplosionSystem : EntitySystem
+{
+    [Dependency] private readonly RMCSizeStunSystem _sizeStun = default!;
+    [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
+
+    public void Implode(RMCImplosion implosion, MapCoordinates origin)
+    {
+        var nearbyEntities = _entityLookup.GetEntitiesInRange(origin, implosion.PullRange, LookupFlags.Uncontained);
+        foreach (var entity in nearbyEntities)
+        {
+            _sizeStun.KnockBack(entity, origin, -implosion.PullDistance, -implosion.PullDistance, implosion.PullSpeed, implosion.IgnoreSize);
+        }
+    }
+}

--- a/Resources/Prototypes/_RMC14/Entities/Objects/PowerLoader/Dropship/rmc_dropship_ammo.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/PowerLoader/Dropship/rmc_dropship_ammo.yml
@@ -160,9 +160,9 @@
   - type: DropshipAmmo
     travelTime: 2
     explosion:
-      total: 905
-      slope: 15
-      max: 45
+      total: 1500
+      slope: 40
+      max: 115
 
 - type: entity
   parent: RMCDropshipAttachmentAmmoRocket
@@ -178,10 +178,74 @@
     cost: 500
   - type: DropshipAmmo # TODO RMC14 not usable in fire mission, only direct bombardment
     travelTime: 6
-    explosion:
-      total: 1780
-      slope: 7.2
-      max: 50
     fire:
       type: RMCTileFireNapalm
       range: 3
+      cardinalRange: 5
+
+- type: entity
+  parent: RMCDropshipAttachmentAmmoRocket
+  id: RMCDropshipAttachmentAmmoRocketHarpoon
+  name: AGM-184 'Harpoon II'
+  description: The AGM-184 Harpoon II is an Anti-Ship Missile, designed and used to effectively take down enemy ships with a huge blast wave with low explosive power. This one is modified to use ground signals and can be seen as a cheaper alternative to conventional ordnance. Can be loaded into the LAU-444 Guided Missile Launcher.
+  components:
+  - type: Sprite
+    layers:
+    - state: harpoon
+      map: [ "enum.DropshipAmmoVisuals.Fill"]
+  - type: DropshipFabricatorPrintable
+    cost: 200
+  - type: DropshipAmmo
+    travelTime: 5
+    explosion:
+      total: 850
+      slope: 5.5
+      max: 30
+
+- type: entity
+  parent: RMCDropshipAttachmentAmmoRocket
+  id: RMCDropshipAttachmentAmmoRocketThermobaric
+  name: BLU-200 'Dragon's Breath'
+  description: The BLU-200 'Dragon's Breath' is a thermobaric fuel-air bomb. The aerosolized fuel mixture creates a vacuum when ignited causing serious damage to those in its way. Can be loaded into the LAU-444 Guided Missile Launcher.
+  components:
+  - type: Sprite
+    layers:
+    - state: fatty
+      map: [ "enum.DropshipAmmoVisuals.Fill"]
+  - type: DropshipFabricatorPrintable
+    cost: 300
+  - type: DropshipAmmo
+    travelTime: 5
+    implosion:
+      pullRange: 5.5
+      pullDistance: 3.5
+      pullSpeed: 15
+    fire:
+      type: RMCTileFireThermobaric
+      range: 1
+      cardinalRange: 3
+      ordinalRange: 3
+
+- type: entity
+  parent: RMCDropshipAttachmentAmmoRocket
+  id: RMCDropshipAttachmentAmmoRocketBanshee
+  name: AGM-227 'Banshee'
+  description: The AGM-227 missile is a mainstay of the overhauled dropship fleet against any mobile or armored ground targets. It's earned the nickname of 'Banshee' from the sudden wail that it emits right before hitting a target. Useful to clear out large areas. Can be loaded into the LAU-444 Guided Missile Launcher.
+  components:
+  - type: Sprite
+    layers:
+    - state: banshee
+      map: [ "enum.DropshipAmmoVisuals.Fill"]
+  - type: DropshipFabricatorPrintable
+    cost: 300
+  - type: DropshipAmmo
+    travelTime: 6
+    explosion:
+      total: 950
+      slope: 6.25
+      max: 40
+    fire:
+      type: RMCTileFireBanshee
+      range: 1
+      cardinalRange: 3
+      ordinalRange: 3

--- a/Resources/Prototypes/_RMC14/Entities/Tiles/tile_fire.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Tiles/tile_fire.yml
@@ -221,4 +221,56 @@
     duration: 30
   - type: RMCIgniteOnCollide
     maxStacks: 60
-    intensity: 60
+    intensity: 30
+
+- type: entity
+  parent: RMCTileFireLaser
+  id: RMCTileFireBanshee
+  components:
+  - type: Sprite
+    color: "#00b8ff"
+    layers:
+    - map: [ "base" ]
+      state: blue_4
+  - type: TileFire
+    duration: 15
+  - type: RMCIgniteOnCollide
+    maxStacks: 15
+    intensity: 50
+    duration: 15
+  - type: PointLight
+    color: "#00b8ff"
+  - type: GenericVisualizer
+    visuals:
+      enum.TileFireLayers.Base:
+        base:
+          One: { state: blue_1 }
+          Two: { state: blue_2 }
+          Three: { state: blue_3 }
+          Four: { state: blue_4 }
+
+- type: entity
+  parent: RMCTileFireLaser
+  id: RMCTileFireThermobaric
+  components:
+  - type: Sprite
+    color: White
+    layers:
+    - map: [ "base" ]
+      state: red_4
+  - type: TileFire
+    duration: 25
+  - type: RMCIgniteOnCollide
+    maxStacks: 25
+    intensity: 50
+    duration: 25
+  - type: PointLight
+    color: "#c96500"
+  - type: GenericVisualizer
+    visuals:
+      enum.TileFireLayers.Base:
+        base:
+          One: { state: red_1 }
+          Two: { state: red_2 }
+          Three: { state: red_3 }
+          Four: { state: red_4 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

- The dropship part fabricator can now print the  AGM-227 'Banshee', AGM-184 'Harpoon II', and BLU-200 'Dragon's Breath'.
- The AGM-99 'Napalm' now creates a slightly larger fire area.
- The GBU-67 'Keeper II' deals more damage.
- Fix fires created by the AGM-99 'Napalm'' having too much intensity.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity.

- The AGM-227 'Banshee' costs 300 points to print and has a 6-second travel time. It creates a medium-sized explosion and a star-shaped area of high-intensity fire, which lasts 15 seconds.
- The AGM-184 'Harpoon II' costs 200 points to print and has a 5-second travel time. It produces a medium-sized explosion with low damage.
- The BLU-200 'Dragon's Breath' costs 300 points to print and has a 5-second travel time. It creates a medium-sized, non-damaging implosion that pulls nearby objects toward its epicenter, along with a star-shaped area of high-intensity fire that lasts 25 seconds.
- The GBU-67 'Keeper II' now deals significantly more damage near its epicenter. It can kill a base Praetorian in one hit within a 3x3 area and severely damage one within a 5x5 area.
- The AGM-99 'Napalm' creates two additional tiles of fire in each cardinal direction.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Banshee fire area:

<img width="684" height="659" alt="image" src="https://github.com/user-attachments/assets/1bf679f5-4ec6-42ad-9e54-5cab629b6a1f" />

Dragon's Breath fire area:

<img width="678" height="670" alt="image" src="https://github.com/user-attachments/assets/b1965937-77a3-45e3-9198-643dce46cbf2" />

Napalm fire area:

<img width="757" height="703" alt="image" src="https://github.com/user-attachments/assets/b10e46e1-37e8-4db8-bfc2-1eeebdea077a" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Dygon
- add: The Dropship part fabricator can now print the AGM-227 'Banshee' for 300 points, the AGM-184 'Harpoon II' for 200 points, and the  BLU-200 'Dragon's Breath' for 300 points. The Banshee creates a medium-sized explosion and a short lasting, star-shaped area of high-intensity fire. The Harpoon creates a medium sized explosion with low damage. The Dragon's Breath creates an area of high-intensity fire and a non-damaging implosion that pulls nearby entities towards it's epicenter.
- tweak: The GBU-67 'Keeper II' now deals significantly more damage near it's epicenter.
- fix: Fire created by the AGM-99 'Napalm' now deals less damage per second.