### PR TITLE
tweak: dogtags can now be worn around the neck

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/IdCards/cm_base_id.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/IdCards/cm_base_id.yml
@@ -131,6 +131,9 @@
           22: { state: "dogtag_22" }
           23: { state: "dogtag_23" }
           24: { state: "dogtag_24" }
+  - type: Clothing
+    slots:
+    - neck
 
 - type: entity
   id: RMCDogtagProp


### PR DESCRIPTION
## About the PR

This PR makes it so that collected dogtags can be work around the neck (in the neck slot).

## Why / Balance

Soul; Also HM currently store them in their helmet where they get lost or forgotten.

## Technical details

Just added the ClothingComponent to it with only the neck slot.

## Media

https://github.com/user-attachments/assets/47512c36-7a43-4288-a163-a4d031fc4447

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- tweak: dogtags can now be worn around the neck
