### PR TITLE
tweak: the headsets in surplus vendors now come with the public channel

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
@@ -678,7 +678,7 @@
         amount: 40
     - name: Radio
       entries:
-      - id: CMHeadset
+      - id: RMCHeadsetShip
         amount: 5
       - id: CMEncryptionKeyAlpha
         amount: 5

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/prep.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/prep.yml
@@ -112,7 +112,7 @@
         amount: 15
       - id: CMHandsBlackMarine
         amount: 15
-      - id: CMHeadset
+      - id: RMCHeadsetShip
         amount: 15
       - id: ArmorHelmetM10
         amount: 15


### PR DESCRIPTION
## About the PR

This PR changes the headsets in the surplus vendors to `RMCHeadsetShip`.

## Why / Balance

Parity; Also no other way to get access to the public channel.

## Technical details

```
// From code/game/machinery/vending/vendor_types/requisitions.dm:517
list("Marine Radio Headset", 5, /obj/item/device/radio/headset/almayer, VENDOR_ITEM_REGULAR),

// From code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm:112
list("Marine Radio Headset", floor(scale * 15), /obj/item/device/radio/headset/almayer, VENDOR_ITEM_REGULAR),

// From code/game/objects/items/devices/radio/headset.dm:424
/obj/item/device/radio/headset/almayer
	name = "marine radio headset"
	desc = "A standard military radio headset. Bulkier than combat models."
	icon_state = "generic_headset"
	item_state = "headset"
	frequency = PUB_FREQ
	has_hud = TRUE
```

## Media

Nah

## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- tweak: the headsets in surplus vendors now come with the public channel
