### PR TITLE
Disabler Rework + Melee stun

### DIFF
--- a/Content.Shared/_RMC14/Stamina/RMCStaminaSystem.cs
+++ b/Content.Shared/_RMC14/Stamina/RMCStaminaSystem.cs
@@ -13,6 +13,7 @@ using Content.Shared.StatusEffect;
 using Content.Shared.Throwing;
 using Content.Shared.Weapons.Melee.Events;
 using Content.Shared.Wieldable.Components;
+using Content.Shared.Damage.Events;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Timing;
@@ -159,6 +160,11 @@ public sealed partial class RMCStaminaSystem : EntitySystem
         {
             return;
         }
+
+        var ev = new StaminaDamageOnHitAttemptEvent();
+        RaiseLocalEvent(ent, ref ev);
+        if (ev.Cancelled)
+        return;
 
         var stamQuery = GetEntityQuery<RMCStaminaComponent>();
         var toHit = new List<(EntityUid Entity, RMCStaminaComponent Component)>();

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Energy/taser.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Energy/taser.yml
@@ -20,11 +20,11 @@
       path: /Audio/Weapons/Guns/Gunshots/taser.ogg
   - type: Wieldable
   - type: Battery
-    maxCharge: 10000
-    startingCharge: 10000
+    maxCharge: 800
+    startingCharge: 800
   - type: ProjectileBatteryAmmoProvider
     proto: RMCProjectileTaser
-    fireCost: 625
+    fireCost: 50
   - type: MagazineVisuals
     magState: mag
     steps: 5
@@ -38,5 +38,20 @@
   - type: GunDualWielding
     weaponGroup: Handgun
   - type: GunRequiresSkills
+    skills:
+      RMCSkillPolice: 2
+  - type: AltFireMelee
+  - type: MeleeWeapon
+    attackRate: 1
+    damage:
+      types:
+        Blunt: 5
+    soundHit:
+      path: /Audio/Weapons/Guns/Hits/taser_hit.ogg
+  - type: Stunbaton
+    energyPerUse: 50
+  - type: RMCStaminaDamageOnHit
+    damage: 100
+  - type: MeleeRequiresSkill
     skills:
       RMCSkillPolice: 2


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I used components from the stun baton and existing rifles to add a right click melee function to the disabler. I also edited the stamina system slightly to make melee hits call an event to actually drain battery (they were not before)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This is a purely stylistic choice, as I find the large batons to be somewhat silly. in real life tasers can often be used to "drive stun" a suspect. This is done by the front of the taser being pushed into the individual rather than shot.
<img width="278" height="181" alt="image" src="https://github.com/user-attachments/assets/6e5d9215-e468-421d-b322-9450681bb255" />
The Stun baton is already a one hit stun, so this is not any better. But due to the fact there is now less equipment to carry, I ended up with the disabler have 5 less charges than the baton to try and balance that fact out at least a little. MPs can still carry whichever they wish or both.

## Technical details
<!-- Summary of code changes for easier review. -->
- In the RMCStaminaCystem.Cs I Added a callout for event when using the "RMCStaminaDamageComponent". Currently stun batons do not use charge due to the lack of an event callout.
- In the Taser.yml I added multiple components related to Alt click melee stun functionality.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/7effe9e9-c3ac-42da-b4f7-0dc55a2e35f2

https://github.com/user-attachments/assets/1df24299-20a7-4bca-add4-13645c2de17e



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [ X ] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Disabler's now have a melee stun function similar to Drive Stunning!
-->
