### PR TITLE
increase default tacmap size

### DIFF
--- a/Content.Client/_RMC14/TacticalMap/TacticalMapWindow.xaml
+++ b/Content.Client/_RMC14/TacticalMap/TacticalMapWindow.xaml
@@ -1,6 +1,6 @@
 ﻿<controls:TacticalMapWindow
     xmlns="https://spacestation14.io"
     xmlns:controls="clr-namespace:Content.Client._RMC14.TacticalMap"
-    Title="Map" SetSize="600 600">
+    Title="Map" SetSize="1000 800">
     <controls:TacticalMapWrapper Name="Wrapper" Access="Public" />
 </controls:TacticalMapWindow>


### PR DESCRIPTION
<img width="1135" height="876" alt="image" src="https://github.com/user-attachments/assets/7e7d6c46-3e3b-4d9c-b4e8-5752b17fd300" />
just makes its 1000 by 800 now instead of 600 by 600