### PR TITLE
Added WeYa Stompers and WeYa black patch to to the Corporate Liaison's automated storage briefcase

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Devices/portable_vendor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Devices/portable_vendor.yml
@@ -84,6 +84,12 @@
       entries: []
       #- id: Hollow cane
       #  points: 15
+    - name: Wearables
+      entries:
+      - id: RMCPatchWeYaBlack
+        points: 5
+      - id: RMCShoesWeYaStompers
+        points: 50
     - name: Ammo
       entries: []
       #- id: ES-4 stun mag


### PR DESCRIPTION
## About the PR
Added the WeYa Stompers and the WeYa black patch to the Corporate Liaison's automated storage briefcase.

## Why / Balance
Material incentives can go a long way towards goodwill with the troops on behalf of WeYa; something as simple as a mug, pen, or cigar can build rapport both with members of command and the marines. In fact, given the status of WeYa Stompers as a highly sought-after clothing item, it can be used as an incentive for the Corporate Liaison, in turn for favors or other remuneration.

## Technical details
Added both items via the .YML for the automated storage.

## Media
<img width="477" height="134" alt="image" src="https://github.com/user-attachments/assets/2ef7e48e-5ca0-4c4a-9c2c-e9f82e8e2d7f" />

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- add: Added the Weston-Yamada Stompers and Weston-Yamada patch to the Corporate Liaison's automated storage briefcase.

