### PR TITLE
Disable Civilian Access to the CLF Patch in Loadouts

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Loadouts/loadout_groups.yml
@@ -493,7 +493,7 @@
   - CorporateBrownJacketRMC
   - CorporateBlueJacketRMC
   - JacketWindbreakerRMC
-  
+
 - type: loadoutGroup
   id: SynthUniformAccessoriesRMC
   name: rmc-loadout-group-synthetic-accessories
@@ -559,7 +559,7 @@
   - PatchWeYaRMCFury161
   - PatchTSERMC
   - PatchCECRMC
-  - PatchCLFRMC
+  # - PatchCLFRMC # RMC14 - Disabled intentionally to reduce admin burden.
   # TODO Halcyon Dynamics patch
   # TODO cowboy hat
   # white cowboy hat TODO


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Remove `PatchCLFRMC` from the Civilian loadout group (the one survivors get, and a few other roles). I've disabled it, but with a comment, instead of removing it. So someone doesn't accidentally re-enable it for parity reasons.

## Why / Balance
This patch being accessible is setting *someone* up for a rule violation (Survivors or MPs or Civi roles, etc). It is an actively hostile faction's patch. Survivors may get the wrong idea that by wearing it they can be even remotely antagonistic (then causing a rule violation) or an MP will see someone with it and get the wrong idea they they are a proper CLF and kill them (then causing a rule violation). By outright removing it, we aren't encouraging players to break the rules anymore. It just reduces admin workload outright.

## Technical details
YAML

## Media
N/A - But I have verified this functions ingame.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: Civilians can no longer access the CLF Patch through loadouts.