### PR TITLE
Fix inaccuracy in oppressor guidebook (Previously Stated Tail Seize Delt No Damage) 

### DIFF
--- a/Resources/ServerInfo/Guidebook/_RMC14/Guides/RMCGuideRoleOppressor.xml
+++ b/Resources/ServerInfo/Guidebook/_RMC14/Guides/RMCGuideRoleOppressor.xml
@@ -21,6 +21,6 @@
   <GuideEntityEmbed Entity="RMCGuidebookActionXenoDislocate"/>
   - [bold]Tail Lash[/bold]: Knock hosts back in a 2x3 area in front of you and slow them. Take note that this ability has a wind up.
   <GuideEntityEmbed Entity="RMCGuidebookActionXenoTailLash"/>
-  - [bold]Tail Seize[/bold]: The Oppressor has a unique tail stab, instead called Tail Seize. It has a range of 3 tiles - however, it deals no damage, instead pulling the target in towards you and slowing them upon their arrival.
+  - [bold]Tail Seize[/bold]: The Oppressor has a unique tail stab, instead called Tail Seize. It has a range of 3 tiles - dealing 40 damage, pulling the target in towards you and slowing them upon their arrival.
   <GuideEntityEmbed Entity="RMCGuidebookActionXenoTailSeize"/>
 </Document>


### PR DESCRIPTION
## About the PR
The oppressor guidebook said tail seize dealt no damage, but it deals 40.

## Why / Balance
Resolves #6552 . Accurate guidebooks are important.

## Technical details
N/A

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
No CL required.
