### PR TITLE
Fix incorrect SPP Sapper Boots

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/SPP/sapper.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/SPP/sapper.yml
@@ -98,7 +98,7 @@
     jumpsuit: CMJumpsuitSPPEngi
     outerClothing: RMCArmorSPPRifleman
     gloves: RMCHandsVeteranInsulated
-    shoes: CMBootsBlackFilled
+    shoes: RMCBootsSPPFilled
     suitstorage: RMCWeaponRifleType71Flamer
     id: RMCIDSPP
     belt: RMCType71BeltFilled


### PR DESCRIPTION
## About the PR
The SPP Sapper now spawns with SPP boots instead of the default combat boots.

## Why / Balance
Consistency + why would the sappers not have the same boots as the others?
Resolves #7371

## Technical details
N/A

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: The SPP Sapper now spawns with the correct boots.