### PR TITLE
Missing Loc.GetString for rmc-medevac-stretcher-failure

### DIFF
--- a/Content.Shared/_RMC14/Dropship/Utility/Systems/SharedMedevacSystem.cs
+++ b/Content.Shared/_RMC14/Dropship/Utility/Systems/SharedMedevacSystem.cs
@@ -73,7 +73,7 @@ public abstract class SharedMedevacSystem : EntitySystem
         }
         else
         {
-            _popup.PopupClient("rmc-medevac-stretcher-failure", targetCoord, args.User);
+            _popup.PopupClient(Loc.GetString("rmc-medevac-stretcher-failure"), targetCoord, args.User);
         }
     }
 


### PR DESCRIPTION
## About the PR

rmc-medevac-stretcher-failure

## Why / Balance

Bugfix

## Technical details

Added a Loc.GetString

## Media

Before:
<img width="288" height="203" alt="Screenshot From 2025-08-05 14-42-53" src="https://github.com/user-attachments/assets/5aec492d-e7a5-40b1-b891-005029c0acde" />

After:
<img width="288" height="203" alt="Screenshot From 2025-08-05 15-41-39" src="https://github.com/user-attachments/assets/7a1ca5a1-2992-4ede-adf6-29450664891f" />

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

No