### PR TITLE
fix: overfull pods now get ejected correctly

### DIFF
--- a/Content.Server/_RMC14/Evacuation/EvacuationSystem.cs
+++ b/Content.Server/_RMC14/Evacuation/EvacuationSystem.cs
@@ -18,6 +18,7 @@ public sealed class EvacuationSystem : SharedEvacuationSystem
     [Dependency] private readonly ShuttleSystem _shuttle = default!;
 
     private EntityQuery<EvacuationDoorComponent> _evacuationDoorQuery;
+    private EntityQuery<EvacuationComputerComponent> _evacuationComputerQuery;
 
     private readonly HashSet<Entity<EvacuationDoorComponent>> _doors = new();
 
@@ -25,6 +26,7 @@ public sealed class EvacuationSystem : SharedEvacuationSystem
     {
         base.Initialize();
         _evacuationDoorQuery = GetEntityQuery<EvacuationDoorComponent>();
+        _evacuationComputerQuery = GetEntityQuery<EvacuationComputerComponent>();
     }
 
     protected override void LaunchEvacuationFTL(EntityUid grid, float crashLandChance, SoundSpecifier? launchSound)
@@ -67,6 +69,11 @@ public sealed class EvacuationSystem : SharedEvacuationSystem
                 {
                     door.Locked = false;
                     Dirty(child, door);
+                }
+                if (_evacuationComputerQuery.TryComp(child, out var computer))
+                {
+                    computer.Mode = EvacuationComputerMode.Crashed;
+                    Dirty(child, computer);
                 }
             }
 


### PR DESCRIPTION
## About the PR

This PR fixes overfull pods not being launched.

## Why / Balance

Bugfix. Fixes #6609, fixes #4448.

## Technical details

The code early returned and it never launched.

## Media

https://github.com/user-attachments/assets/21a46b0b-7a0f-4287-a451-264c0d60fcd0

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Overfull pods no longer get struck on the ship.
