### PR TITLE
Fix pylon and core roofs

### DIFF
--- a/Content.Shared/_RMC14/Areas/RoofingEntityComponent.cs
+++ b/Content.Shared/_RMC14/Areas/RoofingEntityComponent.cs
@@ -13,8 +13,26 @@ public sealed partial class RoofingEntityComponent : Component
     public bool CanCAS;
 
     [DataField, AutoNetworkedField]
-    public bool CanMortar;
+    public bool CanMortarPlace;
+
+    [DataField, AutoNetworkedField]
+    public bool CanMortarFire;
 
     [DataField, AutoNetworkedField]
     public bool CanOrbitalBombard;
+
+    [DataField, AutoNetworkedField]
+    public bool CanMedevac;
+
+    [DataField, AutoNetworkedField]
+    public bool CanFulton;
+
+    [DataField, AutoNetworkedField]
+    public bool CanSupplyDrop;
+
+    [DataField, AutoNetworkedField]
+    public bool CanLase;
+
+    [DataField, AutoNetworkedField]
+    public bool CanParadrop;
 }

--- a/Content.Shared/_RMC14/TacticalMap/AreaInfoSystem.cs
+++ b/Content.Shared/_RMC14/TacticalMap/AreaInfoSystem.cs
@@ -114,7 +114,7 @@ public sealed class AreaInfoSystem : EntitySystem
             ceilingLevel = 3;
             severityToUse = hasPylonProtection ? (short)6 : (short)4;
         }
-        else if (!_area.CanSupplyDrop(coordinates.ToMap(_entityManager, _transform)) || !_area.CanMortarFire(coordinates))
+        else if (!_area.CanSupplyDrop(_transform.ToMapCoordinates(coordinates)) || !_area.CanMortarFire(coordinates))
         {
             ceilingLevel = 2;
             severityToUse = (short)3;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title. Roof ents didn't account for all the new area stuff.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity.

## Technical details
<!-- Summary of code changes for easier review. -->
Added medevac, supplydrop, paradrop, lasing, fulton to the roofing ent. Also seperated out mortar place and mortar firing to be consistent.

Made a seperate IsRoof func that works with map coords just for supply drops, otherwise it's the same.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed hive core and pylons roofs not blocking medevac, fultoning, lasing, or supply drops.
