### PR TITLE
fix: overfull pods now bolt open after exploding

### DIFF
--- a/Content.Shared/_RMC14/Evacuation/SharedEvacuationSystem.cs
+++ b/Content.Shared/_RMC14/Evacuation/SharedEvacuationSystem.cs
@@ -338,16 +338,14 @@ public abstract class SharedEvacuationSystem : EntitySystem
 
             if (mobs.Count > maxMobs)
             {
-                ent.Comp.Mode = EvacuationComputerMode.Crashed;
                 _popup.PopupPredicted("The evacuation pod is overloaded with this many people inside!", ent, null, PopupType.LargeCaution);
+                ent.Comp.Mode = EvacuationComputerMode.Crashed;
+                Dirty(ent);
 
                 var time = _timing.CurTime;
                 var detonating = EnsureComp<DetonatingEvacuationComputerComponent>(ent);
                 detonating.DetonateAt = time + ent.Comp.DetonateDelay;
                 detonating.EjectAt = time + ent.Comp.EjectDelay;
-
-                Dirty(ent);
-                return;
             }
         }
 

--- a/Content.Shared/_RMC14/Evacuation/SharedEvacuationSystem.cs
+++ b/Content.Shared/_RMC14/Evacuation/SharedEvacuationSystem.cs
@@ -308,39 +308,22 @@ public abstract class SharedEvacuationSystem : EntitySystem
         var gridTransform = Transform(gridId);
         if (ent.Comp.MaxMobs is { } maxMobs)
         {
-            var mobs = 0;
+            var mobs = new HashSet<EntityUid>();
             var children = gridTransform.ChildEnumerator;
             while (children.MoveNext(out var uid))
             {
-                var mob = _mobStateQuery.HasComp(uid);
-                if (!mob)
+                if (_mobStateQuery.HasComp(uid))
                 {
-                    if (TryComp(uid, out ContainerManagerComponent? containerManager))
-                    {
-                        foreach (var container in _container.GetAllContainers(uid, containerManager))
-                        {
-                            if (container.ContainedEntities.Any(_mobStateQuery.HasComp))
-                            {
-                                mob = true;
-                                break;
-                            }
-                        }
-                    }
+                    mobs.Add(uid);
                 }
-
-                if (mob)
+                else if (TryComp(uid, out ContainerManagerComponent? containerManager))
                 {
-                    mobs++;
-
-                    if (mobs > maxMobs && ent.Comp.Mode != EvacuationComputerMode.Crashed)
+                    foreach (var container in _container.GetAllContainers(uid, containerManager))
                     {
-                        ent.Comp.Mode = EvacuationComputerMode.Crashed;
-                        _popup.PopupClient("The evacuation pod is overloaded with this many people inside!", ent, user, PopupType.LargeCaution);
-
-                        var time = _timing.CurTime;
-                        var detonating = EnsureComp<DetonatingEvacuationComputerComponent>(ent);
-                        detonating.DetonateAt = time + ent.Comp.DetonateDelay;
-                        detonating.EjectAt = time + ent.Comp.EjectDelay;
+                        foreach (var mob in container.ContainedEntities.Where(_mobStateQuery.HasComp).ToList())
+                        {
+                            mobs.Add(mob);
+                        }
                     }
                 }
 
@@ -351,6 +334,20 @@ public abstract class SharedEvacuationSystem : EntitySystem
                     Dirty(uid, evacuationDoor);
                     _door.TryClose(uid, door);
                 }
+            }
+
+            if (mobs.Count > maxMobs)
+            {
+                ent.Comp.Mode = EvacuationComputerMode.Crashed;
+                _popup.PopupPredicted("The evacuation pod is overloaded with this many people inside!", ent, null, PopupType.LargeCaution);
+
+                var time = _timing.CurTime;
+                var detonating = EnsureComp<DetonatingEvacuationComputerComponent>(ent);
+                detonating.DetonateAt = time + ent.Comp.DetonateDelay;
+                detonating.EjectAt = time + ent.Comp.EjectDelay;
+
+                Dirty(ent);
+                return;
             }
         }
 
@@ -691,7 +688,9 @@ public abstract class SharedEvacuationSystem : EntitySystem
                         var evacuationDoor = EnsureComp<EvacuationDoorComponent>(child);
                         evacuationDoor.Locked = false;
                         Dirty(child, evacuationDoor);
-                        _door.TryOpenAndBolt(child, door);
+
+                        // Bypass the checks in TryOpenAndBolt:
+                        _door.SetState(child, DoorState.Emagging, door);
                     }
                 }
             }


### PR DESCRIPTION
## About the PR

Second try for #7381.

## Why / Balance

Bugfix. Fixes #6609. Not sure if #4448 is related.

## Technical details

1. The console was not dirtied, causing the client to think it didn't crash.
2. The door could have been open, causing it to not get bolted open.
3. The popup was only send to the one using the console, causing confusion for everyone else in the pod.
4. Mobs could have been counted twice.
5. Containers with more than one mob inside only counted as one.

## Media

https://github.com/user-attachments/assets/a0b7db93-507c-4fbe-8405-79b186e4826e

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- fix: Overfull pods now bolt open after exploding