### PR TITLE
Dropships can now independently lock or unlock doors on the Aft, Port, or Starboard sides.

### DIFF
--- a/Content.Client/_RMC14/Dropship/DropshipNavigationBui.cs
+++ b/Content.Client/_RMC14/Dropship/DropshipNavigationBui.cs
@@ -145,16 +145,7 @@ public sealed class DropshipNavigationBui : BoundUserInterface
             _window.DestinationsContainer.AddChild(button);
         }
 
-        var locked = destinations.DoorLockStatus;
-        locked.TryGetValue(DoorLocation.Aft, out var aftStatus);
-        locked.TryGetValue(DoorLocation.Port, out var portStatus);
-        locked.TryGetValue(DoorLocation.Starboard, out var starboardStatus);
-        var lockdownStatus = aftStatus && portStatus && starboardStatus;
-
-        _window.LockdownButton.Text = lockdownStatus ? "Lift Lockdown" : "Lockdown";
-        _window.LockdownButtonAft.Text = aftStatus ? "Unlock Aft" : "Lock Aft";
-        _window.LockdownButtonPort.Text = portStatus ? "Unlock Port" : "Lock Port";
-        _window.LockdownButtonStarboard.Text = starboardStatus ? "Unlock Starboard" : "Lock Starboard";
+        RefreshDoorLockStatus(destinations.DoorLockStatus);
     }
 
     private void Set(DropshipNavigationTravellingBuiState travelling)
@@ -207,6 +198,8 @@ public sealed class DropshipNavigationBui : BoundUserInterface
             default:
                 return;
         }
+
+        RefreshDoorLockStatus(travelling.DoorLockStatus);
 
         var startEndTime = travelling.Time;
         _window.ProgressBar.MinValue = 0;
@@ -274,6 +267,22 @@ public sealed class DropshipNavigationBui : BoundUserInterface
             return;
 
         SendPredictedMessage(new DropshipNavigationCancelMsg());
+    }
+
+    private void RefreshDoorLockStatus(Dictionary<DoorLocation, bool> dooorLockStatus)
+    {
+        if (_window == null)
+            return;
+
+        dooorLockStatus.TryGetValue(DoorLocation.Aft, out var aftStatus);
+        dooorLockStatus.TryGetValue(DoorLocation.Port, out var portStatus);
+        dooorLockStatus.TryGetValue(DoorLocation.Starboard, out var starboardStatus);
+        var lockdownStatus = aftStatus && portStatus && starboardStatus;
+
+        _window.LockdownButton.Text = lockdownStatus ? "Lift Lockdown" : "Lockdown";
+        _window.LockdownButtonAft.Text = aftStatus ? "Unlock Aft" : "Lock Aft";
+        _window.LockdownButtonPort.Text = portStatus ? "Unlock Port" : "Lock Port";
+        _window.LockdownButtonStarboard.Text = starboardStatus ? "Unlock Starboard" : "Lock Starboard";
     }
 
     public void Update()

--- a/Content.Client/_RMC14/Dropship/DropshipNavigationBui.cs
+++ b/Content.Client/_RMC14/Dropship/DropshipNavigationBui.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Client.Message;
 using Content.Shared._RMC14.Dropship;
+using Content.Shared.Doors.Components;
 using Content.Shared.Shuttles.Systems;
 using JetBrains.Annotations;
 using Robust.Client.UserInterface;
@@ -53,7 +54,7 @@ public sealed class DropshipNavigationBui : BoundUserInterface
         _window = this.CreateWindow<DropshipNavigationWindow>();
         _window.OnClose += OnClose;
         SetFlightHeader("Flight Controls");
-        SetDoorHeader("Lockdown");
+        SetDoorHeader("Door Controls");
 
         if (_entities.TryGetComponent(Owner, out TransformComponent? transform) &&
             _entities.TryGetComponent(transform.ParentUid, out MetaDataComponent? metaData))
@@ -80,7 +81,10 @@ public sealed class DropshipNavigationBui : BoundUserInterface
             ResetDestinationButtons();
         };
 
-        _window.LockdownButton.Button.OnPressed += _ => SendPredictedMessage(new DropshipLockdownMsg());
+        _window.LockdownButton.Button.OnPressed += _ => SendPredictedMessage(new DropshipLockdownMsg(DoorLocation.None));
+        _window.LockdownButtonAft.Button.OnPressed += _ => SendPredictedMessage(new DropshipLockdownMsg(DoorLocation.Aft));
+        _window.LockdownButtonPort.Button.OnPressed += _ => SendPredictedMessage(new DropshipLockdownMsg(DoorLocation.Port));
+        _window.LockdownButtonStarboard.Button.OnPressed += _ => SendPredictedMessage(new DropshipLockdownMsg(DoorLocation.Starboard));
         _entities.System<DropshipSystem>().Uis.Add(this);
     }
 
@@ -140,6 +144,17 @@ public sealed class DropshipNavigationBui : BoundUserInterface
             _destinations[button] = name;
             _window.DestinationsContainer.AddChild(button);
         }
+
+        var locked = destinations.DoorLockStatus;
+        locked.TryGetValue(DoorLocation.Aft, out var aftStatus);
+        locked.TryGetValue(DoorLocation.Port, out var portStatus);
+        locked.TryGetValue(DoorLocation.Starboard, out var starboardStatus);
+        var lockdownStatus = aftStatus && portStatus && starboardStatus;
+
+        _window.LockdownButton.Text = lockdownStatus ? "Lift Lockdown" : "Lockdown";
+        _window.LockdownButtonAft.Text = aftStatus ? "Unlock Aft" : "Lock Aft";
+        _window.LockdownButtonPort.Text = portStatus ? "Unlock Port" : "Lock Port";
+        _window.LockdownButtonStarboard.Text = starboardStatus ? "Unlock Starboard" : "Lock Starboard";
     }
 
     private void Set(DropshipNavigationTravellingBuiState travelling)
@@ -169,24 +184,24 @@ public sealed class DropshipNavigationBui : BoundUserInterface
             case FTLState.Starting:
                 SetFlightHeader("Launch in progress");
                 _window.ProgressBarHeader.SetMarkup(Msg($"Launching in T-{time}s to {destination}"));
-                _window.LockdownButton.Disabled = false;
+                SetLockDownDisabled(false);
                 break;
             case FTLState.Travelling:
                 SetFlightHeader($"In flight: {destination}");
                 _window.ProgressBarHeader.SetMarkup(Msg($"Time until destination: T-{time}s"));
-                _window.LockdownButton.Disabled = true;
+                SetLockDownDisabled(true);
                 SetCancelDisabled(false);
                 break;
             case FTLState.Arriving:
                 SetFlightHeader($"Final Approach: {destination}");
                 _window.ProgressBarHeader.SetMarkup(Msg($"Time until landing: T-{time}s"));
-                _window.LockdownButton.Disabled = true;
+                SetLockDownDisabled(true);
                 SetCancelDisabled(true);
                 break;
             case FTLState.Cooldown:
                 SetFlightHeader("Refueling in progress");
                 _window.ProgressBarHeader.SetMarkup(Msg($"Ready to launch in T-{time}s"));
-                _window.LockdownButton.Disabled = false;
+                SetLockDownDisabled(false);
                 SetCancelDisabled(true);
                 break;
             default:
@@ -221,7 +236,19 @@ public sealed class DropshipNavigationBui : BoundUserInterface
     {
         if (_window == null)
             return;
+
         _window.CancelButton.Button.Disabled = disabled;
+    }
+
+    private void SetLockDownDisabled(bool disabled)
+    {
+        if (_window == null)
+            return;
+
+        _window.LockdownButton.Button.Disabled = disabled;
+        _window.LockdownButtonAft.Button.Disabled = disabled;
+        _window.LockdownButtonPort.Button.Disabled = disabled;
+        _window.LockdownButtonStarboard.Button.Disabled = disabled;
     }
 
     private void ResetDestinationButtons()

--- a/Content.Client/_RMC14/Dropship/DropshipNavigationWindow.xaml
+++ b/Content.Client/_RMC14/Dropship/DropshipNavigationWindow.xaml
@@ -32,6 +32,7 @@
                 <RichTextLabel Name="ProgressBarHeader" Access="Public" />
                 <ProgressBar Name="ProgressBar" Access="Public" />
             </BoxContainer>
+            <cc:HSeparator Color="#02E74E" />
             <BoxContainer Orientation="Horizontal" HorizontalExpand="True" Margin="5">
                 <RichTextLabel Name="DoorHeader" Access="Public" />
                 <Control HorizontalExpand="True" />
@@ -41,6 +42,23 @@
                                          Text="Lockdown" />
             </BoxContainer>
             <cc:HSeparator Color="#02E74E" />
+            <BoxContainer Orientation="Horizontal" HorizontalExpand="True" Margin="5">
+                <controls:DropshipButton Name="LockdownButtonAft" Access="Public"
+                                         Margin="1" BackgroundColor="#004E25"
+                                         BorderColor="#02E74E" BorderThickness="1"
+                                         Text="Lock Aft"
+                                         HorizontalExpand="True"/>
+                <controls:DropshipButton Name="LockdownButtonPort" Access="Public"
+                                         Margin="1" BackgroundColor="#004E25"
+                                         BorderColor="#02E74E" BorderThickness="1"
+                                         Text="Lock Port"
+                                         HorizontalExpand="True"/>
+                <controls:DropshipButton Name="LockdownButtonStarboard" Access="Public"
+                                         Margin="1" BackgroundColor="#004E25"
+                                         BorderColor="#02E74E" BorderThickness="1"
+                                         Text="Lock Starboard"
+                                         HorizontalExpand="True"/>
+            </BoxContainer>
         </BoxContainer>
     </PanelContainer>
 </controls:DropshipNavigationWindow>

--- a/Content.Server/_RMC14/Dropship/DropshipSystem.cs
+++ b/Content.Server/_RMC14/Dropship/DropshipSystem.cs
@@ -221,7 +221,8 @@ public sealed class DropshipSystem : SharedDropshipSystem
         }
 
         if (TryComp(grid, out FTLComponent? ftl) &&
-            ftl.State is FTLState.Travelling or FTLState.Arriving)
+            ftl.State is FTLState.Travelling or FTLState.Arriving &&
+            args.DoorLocation != DoorLocation.Aft)
         {
             return;
         }

--- a/Content.Shared/_RMC14/Dropship/DropshipComponent.cs
+++ b/Content.Shared/_RMC14/Dropship/DropshipComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Doors.Components;
 using Content.Shared.Shuttles.Systems;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
@@ -35,13 +36,10 @@ public sealed partial class DropshipComponent : Component
     public SoundSpecifier UnidentifledlifesignsSound = new SoundPathSpecifier("/Audio/_RMC14/Announcements/ARES/unidentified_lifesigns.ogg");
 
     [DataField, AutoNetworkedField]
-    public bool Locked;
-
-    [DataField, AutoNetworkedField]
     public TimeSpan LockCooldown = TimeSpan.FromSeconds(1);
 
-    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
-    public TimeSpan LastLocked;
+    [DataField, AutoNetworkedField]
+    public Dictionary<DoorLocation, TimeSpan> LastLocked = new ();
 
     [DataField, AutoNetworkedField]
     public HashSet<EntityUid> AttachmentPoints = new();

--- a/Content.Shared/_RMC14/Dropship/DropshipNavigationUI.cs
+++ b/Content.Shared/_RMC14/Dropship/DropshipNavigationUI.cs
@@ -14,12 +14,13 @@ public sealed class DropshipNavigationDestinationsBuiState(NetEntity? flyBy, Lis
 }
 
 [Serializable, NetSerializable]
-public sealed class DropshipNavigationTravellingBuiState(FTLState state, StartEndTime time, string destination, string departureLocation) : BoundUserInterfaceState
+public sealed class DropshipNavigationTravellingBuiState(FTLState state, StartEndTime time, string destination, string departureLocation, Dictionary<DoorLocation, bool> doorLockStatus) : BoundUserInterfaceState
 {
     public readonly FTLState State = state;
     public readonly StartEndTime Time = time;
     public readonly string Destination = destination;
     public readonly string DepartureLocation = departureLocation;
+    public readonly Dictionary<DoorLocation, bool> DoorLockStatus = doorLockStatus;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/_RMC14/Dropship/DropshipNavigationUI.cs
+++ b/Content.Shared/_RMC14/Dropship/DropshipNavigationUI.cs
@@ -1,14 +1,16 @@
-﻿using Content.Shared.Shuttles.Systems;
+﻿using Content.Shared.Doors.Components;
+using Content.Shared.Shuttles.Systems;
 using Content.Shared.Timing;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared._RMC14.Dropship;
 
 [Serializable, NetSerializable]
-public sealed class DropshipNavigationDestinationsBuiState(NetEntity? flyBy, List<Destination> destinations) : BoundUserInterfaceState
+public sealed class DropshipNavigationDestinationsBuiState(NetEntity? flyBy, List<Destination> destinations, Dictionary<DoorLocation, bool> doorLockStatus) : BoundUserInterfaceState
 {
     public readonly NetEntity? FlyBy = flyBy;
     public readonly List<Destination> Destinations = destinations;
+    public readonly Dictionary<DoorLocation, bool> DoorLockStatus = doorLockStatus;
 }
 
 [Serializable, NetSerializable]
@@ -32,7 +34,10 @@ public sealed class DropshipNavigationCancelMsg : BoundUserInterfaceMessage
 }
 
 [Serializable, NetSerializable]
-public sealed class DropshipLockdownMsg : BoundUserInterfaceMessage;
+public sealed class DropshipLockdownMsg(DoorLocation doorLocation) : BoundUserInterfaceMessage
+{
+    public readonly DoorLocation DoorLocation = doorLocation;
+}
 
 [Serializable, NetSerializable]
 public enum DropshipNavigationUiKey


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The dropship navigation computer now has 3 extra buttons to lock/unlock doors at a specific side of the ship.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="509" height="250" alt="image" src="https://github.com/user-attachments/assets/7c838dd4-f6d0-49f1-91d0-1a51e93efe42" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Dygon
- tweak: Dropships can now independently lock or unlock the aft port and starboard doors.
