### PR TITLE
Fix the TSEPA Synth faction

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/TSE/TSEPA/tsepa_synthetic.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/TSE/TSEPA/tsepa_synthetic.yml
@@ -35,6 +35,9 @@
         RMCSkillJtac: 1
         RMCSkillIntel: 1
         RMCSkillDomestics: 2
+    - type: NpcFactionMember
+      factions:
+      - TSE
     - type: DemoSpecWhitelist
     - type: GrenadeSpecWhitelist
     - type: ScoutWhitelist


### PR DESCRIPTION
## About the PR
Fixes #7392. Adding the faction fixed both issues.

## Why / Balance
Correct factions are important for clarity.

## Technical details
YAML.

## Media
N/A - I do not believe it is needed, but I have verified this works ingame.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: The TSEPA Synthetic is now apart of the TSE faction.