### PR TITLE
Fix survivor rolling

### DIFF
--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
@@ -772,13 +772,10 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
                         if (!HasValidSurvivorCandidates())
                             break;
 
-                        if (selectedSurvivors >= totalSurvivors)
+                        if (!HasValidPrioritySurvivorCandidates(prio))
                             break;
 
                         if (survivorCandidates.Count <= 0)
-                            break;
-
-                        if (!HasValidPrioritySurvivorCandidates(prio))
                             break;
 
                         var (job, players) = _random.Pick(survivorCandidates);

--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
@@ -738,13 +738,27 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
                 bool HasValidSurvivorCandidates()
                 {
                     // Check that there are still valid candidates left
-                    foreach (var (_, otherPlayersLists) in survivorCandidates)
+                    foreach (var (_, playerList) in survivorCandidates)
                     {
-                        foreach (var otherPlayers in otherPlayersLists)
+                        foreach (var players in playerList)
                         {
-                            if (otherPlayers.Count > 0)
+                            if (players.Count > 0)
                                 return true;
                         }
+                    }
+
+                    return false;
+                }
+
+                bool HasValidPrioritySurvivorCandidates(int priority)
+                {
+                    // Check that there are still valid candidates left, with a certain priority
+                    foreach (var (_, playerList) in survivorCandidates)
+                    {
+                        var list = playerList[priority];
+
+                        if (list.Count > 0)
+                            return true;
                     }
 
                     return false;
@@ -762,6 +776,9 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
                             break;
 
                         if (survivorCandidates.Count <= 0)
+                            break;
+
+                        if (!HasValidPrioritySurvivorCandidates(prio))
                             break;
 
                         var (job, players) = _random.Pick(survivorCandidates);

--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
@@ -735,11 +735,29 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
                     }
                 }
 
+                bool HasValidSurvivorCandidates()
+                {
+                    // Check that there are still valid candidates left
+                    foreach (var (_, otherPlayersLists) in survivorCandidates)
+                    {
+                        foreach (var otherPlayers in otherPlayersLists)
+                        {
+                            if (otherPlayers.Count > 0)
+                                return true;
+                        }
+                    }
+
+                    return false;
+                }
+
                 var selectedSurvivors = 0;
                 for (var prio = priorities - 1; prio >= 0; prio--)
                 {
-                    for (var i = 0; i < totalSurvivors; i++)
+                    while (selectedSurvivors < totalSurvivors)
                     {
+                        if (!HasValidSurvivorCandidates())
+                            break;
+
                         if (selectedSurvivors >= totalSurvivors)
                             break;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changes surv rolling to a while loop instead of just running 7 times
Then it breaks if there arent any more players to give survivor
Also breaks if there aren't any players on that priority

Reason why we're doing this is because if a survivor roll had maximum slots and it'd pick that roll, it'd just continue and not roll anything, which is bad because you could have a round where there arent enough survivors (doesnt happen in a live game since itll do medium and then low priority and its pretty unlikely)

**Changelog**
:cl:
- fix: Fixed survivor rolling sometimes not respecting job priority.