### PR TITLE
new smite: chestburst into rifleman

### DIFF
--- a/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
@@ -30,6 +30,8 @@ using Content.Shared.Damage;
 using Content.Shared.Damage.Systems;
 using Content.Shared.Database;
 using Content.Shared.Electrocution;
+using Content.Shared.Humanoid.Prototypes;
+using Content.Server.Humanoid.Systems;
 using Content.Shared.Interaction.Components;
 using Content.Shared.Inventory;
 using Content.Shared.Mobs;
@@ -84,8 +86,10 @@ public sealed partial class AdminVerbSystem
     [Dependency] private readonly SuperBonkSystem _superBonkSystem = default!;
     [Dependency] private readonly SlipperySystem _slipperySystem = default!;
     [Dependency] private readonly SharedXenoParasiteSystem _xenoParasite = default!;
+    [Dependency] private readonly RandomHumanoidSystem _randomHumanoid = default!;
 
     private static readonly EntProtoId MouseProto = "CMMobMouse";
+    private static readonly ProtoId<RandomHumanoidSettingsPrototype> RiflemanProto = "RMCUnassignedRifleman";
 
     // All smite verbs have names so invokeverb works.
     private void AddSmiteVerbs(GetVerbsEvent<Verb> args)
@@ -961,5 +965,23 @@ public sealed partial class AdminVerbSystem
             Message = "Chestburst into mouse",
         };
         args.Verbs.Add(chestburstMouse);
+
+        Verb chestburstRifleman = new()
+        {
+            Text = "Chestburst into rifleman",
+            Category = VerbCategory.Smite,
+            Icon = new SpriteSpecifier.Rsi(new ResPath("/Textures/_RMC14/Effects/burst.rsi"), "bursted_stand"),
+            Act = () =>
+            {
+                var rifleman = _randomHumanoid.SpawnRandomHumanoid(RiflemanProto, _transformSystem.GetMoverCoordinates(args.Target), "");
+                var infected = EnsureComp<VictimInfectedComponent>(args.Target);
+                _xenoParasite.InsertLarva((args.Target, infected), rifleman);
+                _xenoParasite.SetBurstSound((args.Target, infected), new SoundPathSpecifier("/Audio/Voice/Human/wilhelm_scream.ogg"));
+                _xenoParasite.TryStartBurst((args.Target, infected));
+            },
+            Impact = LogImpact.Extreme,
+            Message = "Chestburst into rifleman",
+        };
+        args.Verbs.Add(chestburstRifleman);
     }
 }

--- a/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
@@ -956,7 +956,18 @@ public abstract partial class SharedXenoParasiteSystem : EntitySystem
     {
         var larvaContainer = _container.EnsureContainer<ContainerSlot>(victim.Owner, victim.Comp.LarvaContainerId);
         spawned = SpawnInContainerOrDrop(victim.Comp.BurstSpawn, victim.Owner, larvaContainer.ID);
+        LinkLarvaToVictim(victim, spawned);
+    }
 
+    public void InsertLarva(Entity<VictimInfectedComponent> victim, EntityUid spawned)
+    {
+        var larvaContainer = _container.EnsureContainer<ContainerSlot>(victim.Owner, victim.Comp.LarvaContainerId);
+        _container.InsertOrDrop(spawned, larvaContainer);
+        LinkLarvaToVictim(victim, spawned);
+    }
+
+    private void LinkLarvaToVictim(Entity<VictimInfectedComponent> victim, EntityUid spawned)
+    {
         if (HasComp<XenoComponent>(spawned))
             _hive.SetHive(spawned, victim.Comp.Hive);
 

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/ghosts/unassigned.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/ghosts/unassigned.yml
@@ -1,0 +1,118 @@
+# combat technician
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidUnassignedCombatTech
+  name: unassigned ghost role combat technician
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCUnassignedCombatTech
+
+- type: randomHumanoidSettings
+  parent: [RMCCombatTech, RMCUnassignedBase]
+  id: RMCUnassignedCombatTech
+
+# fireteam leader
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidUnassignedFireteamLeader
+  name: unassigned ghost role fireteam leader
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCUnassignedFireteamLeader
+
+- type: randomHumanoidSettings
+  parent: [RMCFireteamLeader, RMCUnassignedBase]
+  id: RMCUnassignedFireteamLeader
+
+# hospital corpsman
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidUnassignedHospitalCorpsman
+  name: unassigned ghost role hospital corpsman
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCUnassignedHospitalCorpsman
+
+- type: randomHumanoidSettings
+  parent: [RMCHospitalCorpsman, RMCUnassignedBase]
+  id: RMCUnassignedHospitalCorpsman
+
+# rifleman
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidUnassignedRifleman
+  name: unassigned ghost role rifleman
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCUnassignedRifleman
+
+- type: randomHumanoidSettings
+  parent: [RMCRifleman, RMCUnassignedBase]
+  id: RMCUnassignedRifleman
+
+# smart gun operator
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidUnassignedSmartGunOperator
+  name: unassigned ghost role smart gun operator
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCUnassignedSmartGunOperator
+
+- type: randomHumanoidSettings
+  parent: [RMCSmartGunOperator, RMCUnassignedBase]
+  id: RMCUnassignedSmartGunOperator
+
+# squad leader
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidUnassignedSquadLeader
+  name: unassigned ghost role squad leader
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCUnassignedSquadLeader
+
+- type: randomHumanoidSettings
+  parent: [RMCSquadLeader, RMCUnassignedBase]
+  id: RMCUnassignedSquadLeader
+
+# weapons specialist
+- type: entity
+  parent: MarkerBase
+  id: RMCRandomHumanoidUnassignedWeaponsSpecialist
+  name: unassigned ghost role weapons specialist
+  suffix: Spawner, Player
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+  - type: RandomHumanoidSpawner
+    settings: RMCUnassignedWeaponsSpecialist
+
+- type: randomHumanoidSettings
+  parent: [RMCWeaponsSpecialist, RMCUnassignedBase]
+  id: RMCUnassignedWeaponsSpecialist

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/ghosts.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/ghosts.yml
@@ -142,3 +142,10 @@
   components:
   - type: GhostRoleApplySpecial
     squad: SquadIntel
+
+- type: randomHumanoidSettings
+  parent: RMCRandomHumanoidBase
+  id: RMCUnassignedBase
+  components:
+  - type: GhostRoleApplySpecial
+    squad: SquadUnassigned

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/squads.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/squads.yml
@@ -332,3 +332,23 @@
     leaderIcon:
       sprite: _RMC14/Interface/cm_job_icons.rsi
       state: clf_sl
+
+- type: entity
+  parent: SquadBase
+  id: SquadUnassigned
+  name: Unassigned
+  components:
+  - type: SquadTeam
+    color: "#000000"
+    radio: MarineCommon
+    accessLevels: [] # Get them assigned before gearing up.
+    minimapBackground:
+     sprite: _RMC14/Interface/map_blips.rsi
+     state: background
+    canSupplyDrop: false
+    blacklistedSquadArmor:
+    - Helmet
+    - Goggles
+    - Armor
+    - Gloves
+    maxRoles: {}


### PR DESCRIPTION
## About the PR

This PR adds a new admin smite, a "unassigned" squad (whose marines can be moved to a different squad) and related spawners.

## Why / Balance

Fun new smite. Kinda the opposite of "burst into larva".

Unassigned squad for the smite and events (as you have to be in a squad to be movable to a different one).

## Technical details

Clients can't predict a random spawn, so I had to create a method to take an existing entity as "larva".

## Media

https://github.com/user-attachments/assets/82093cc7-959b-47dd-bc47-aa7443f06b84

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- add: admin smite "Chestburst into rifleman"
- add: "unassigned" squad for admins to use
