### PR TITLE
Fixes Smartgun Harness allowing other weapons on suit slot storage.

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/base_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/base_armor.yml
@@ -111,7 +111,6 @@
   - type: AllowSuitStorage
     whitelist:
       components:
-      - BallisticAmmoProvider #Note should get all maganizes
       - SmartGun
       - CassettePlayer
       tags:
@@ -121,6 +120,11 @@
       - RMCG8Pouch
       #TODO mines
       - RMCDetector
+      #Note should get all magazines and ignore guns
+      - CMMagazineSmg
+      - CMMagazinePistol
+      - CMMagazineRifle
+      - CMMagazineSniper
 
 - type: entity
   abstract: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Stops the SGO armor from being able to store weapons that aren't smartguns.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity, tested in 13 and is already implemented in RMC via the Smartgun Suit Slot whitelist, RMC substitutes the Magazine whitelist in 13 with a component that's used for both magazines and shotguns, so I removed the component and added tags for magazines, this prevents the storage slot from being used for shotguns and rifles.

## Technical details
<!-- Summary of code changes for easier review. -->
1 yaml file, modifies RMCAllowSuitStorageClothingSmartgunner

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Max_Power
- fix: Fixed smartgunner armor letting you store weapons that aren't smartguns in their suit storage.