### PR TITLE
Fix for buckled objects colliding with walls

### DIFF
--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -26,6 +26,8 @@ using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
+using Robust.Shared.Physics;
+using System.Linq;
 
 namespace Content.Shared.Buckle;
 
@@ -409,8 +411,14 @@ public abstract partial class SharedBuckleSystem
         var gotEv = new BuckledEvent(strap, buckle);
         RaiseLocalEvent(buckle, ref gotEv, true);
 
-        if (TryComp<PhysicsComponent>(buckle, out var physics))
+        if (TryComp<PhysicsComponent>(buckle, out var physics) && TryComp<FixturesComponent>(buckle, out var fixtures))
+        {
             _physics.ResetDynamics(buckle, physics);
+            // RMC14
+            var fixture = fixtures.Fixtures.First();
+            _physics.SetHard(buckle, fixture.Value, false);
+            // RMC14
+        }
 
         DebugTools.AssertEqual(xform.ParentUid, strap.Owner);
     }
@@ -476,6 +484,14 @@ public abstract partial class SharedBuckleSystem
 
         var buckleXform = Transform(buckle);
         var oldBuckledXform = Transform(strap);
+
+        // RMC14
+        if (TryComp<FixturesComponent>(buckle, out var fixtures))
+        {
+            var fixture = fixtures.Fixtures.First();
+            _physics.SetHard(buckle, fixture.Value, true);
+        }
+        // RMC14
 
         if (buckleXform.ParentUid == strap.Owner && !Terminating(oldBuckledXform.ParentUid))
         {


### PR DESCRIPTION
## About the PR
Buckling now sets physics to soft, preventing movement altering collisions

## Why / Balance
This fixes buckling into chairs getting pushed out when the chair is close to a wall, canceling the buckle. Most noticeable on the dropship edge chairs. Also prevents objects like water tanks from colliding with buckled objects as a side effect.

## Technical details
Buckling sets physics of the buckle to soft, and unbuckling sets physics to hard. I avoided modifying collision masks, since it seems easy to lose track of the original mask when multiple systems are modifying collision. It seems a little hacky but it was the simplest solution I could come up with

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X ] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

:cl:
fix: Fixed being kicked out of chairs by walls
