### PR TITLE
Fixed scoping facing incorrect direction while buckled

### DIFF
--- a/Content.Shared/_RMC14/Scoping/SharedScopeSystem.cs
+++ b/Content.Shared/_RMC14/Scoping/SharedScopeSystem.cs
@@ -1,4 +1,4 @@
-﻿using System.Numerics;
+using System.Numerics;
 using Content.Shared._RMC14.Attachable.Events;
 using Content.Shared.Actions;
 using Content.Shared.Camera;
@@ -29,6 +29,7 @@ public abstract partial class SharedScopeSystem : EntitySystem
     [Dependency] private readonly SharedHandsSystem _hands = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly PullingSystem _pulling = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
 
     public override void Initialize()
     {
@@ -238,9 +239,7 @@ public abstract partial class SharedScopeSystem : EntitySystem
         if (!CanScopePopup(scope, user))
             return null;
 
-        // TODO RMC14 make this work properly with rotations
-        var xform = Transform(user);
-        var cardinalDir = xform.LocalRotation.GetCardinalDir();
+        var cardinalDir = _transform.GetWorldRotation(user).GetCardinalDir();
         var ev = new ScopeDoAfterEvent(cardinalDir);
         var zoomLevel = GetCurrentZoomLevel(scope);
         var doAfter = new DoAfterArgs(EntityManager, user, zoomLevel.DoAfter, ev, scope, null, scope)


### PR DESCRIPTION
## About the PR
Fixed Scope System using an incorrect rotation function, causing scope to always face south when buckled
Fixes #3187

## Technical details
Scope System was using LocalRotation, which gives incorrect rotation data when the user is parented to another object while buckled. I switched it to use SharedTransformSystems's GetWorldRotation instead

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X ] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

:cl:
- fix: Fixed scoping not facing seat direction while buckled
