### PR TITLE
Fix for dead things rendering behind rollerbeds

### DIFF
--- a/Content.Client/_RMC14/Buckle/RMCBuckleVisualsSystem.cs
+++ b/Content.Client/_RMC14/Buckle/RMCBuckleVisualsSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Client._RMC14.Sprite;
+using Content.Client._RMC14.Sprite;
 using Content.Client._RMC14.Xenonids;
 using Content.Shared._RMC14.Buckle;
 using Content.Shared._RMC14.Sprite;
@@ -36,20 +36,23 @@ public sealed class RMCBuckleVisualsSystem : EntitySystem
     private int? GetDrawDepth(Entity<BuckleComponent> buckle, Entity<StrapComponent> strap)
     {
         var buckleDepth = (int?) CompOrNull<RMCBuckleDrawDepthComponent>(buckle)?.BuckleDepth;
-        if (HasComp<RMCStrapNoDrawDepthChangeComponent>(strap) &&
-            buckleDepth == null)
-        {
-            return null;
-        }
 
         if (!TryComp(strap, out SpriteComponent? strapSprite))
             return null;
+
+        if (HasComp<RMCStrapNoDrawDepthChangeComponent>(strap) &&
+            buckleDepth == null)
+        {
+            buckleDepth = strapSprite.DrawDepth + 1;
+        }
 
         if (buckleDepth == null)
         {
             var isNorth = Transform(strap).LocalRotation.GetCardinalDir() == Direction.North;
             if (isNorth)
                 buckleDepth = strapSprite.DrawDepth - 1;
+            else
+                buckleDepth = strapSprite.DrawDepth + 1;
         }
 
         return buckleDepth;


### PR DESCRIPTION
## About the PR
dead things get their draw depth set to be above whatever they are buckled to if the buckle doesn't face north. Things on rollerbeds are always drawn on top.

## Technical details
BuckleVisualSystem now sets the draw depth of dead things to draw above the strap. Rollerbed buckles now get set to always be drawn above. 

This might not work if GetDrawDepthEvent is given to CMMobStateSystem before BuckleVisualSystem. I don't know what controls the order these activate in, and I am afraid of refactoring the buckling draw depth system, so I just went with the quick fix. Also there's another draw depth system in BuckleSystem that I think is being overridden?

This still doesn't fix draw depth ignoring camera rotation

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X ] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
- 
:cl:
- fix: Fixed dead things rendering behind rollerbeds.