### PR TITLE
Minor Map Edits & Fixes

### DIFF
--- a/Content.Shared/_RMC14/Rules/CMDistressSignalRuleComponent.cs
+++ b/Content.Shared/_RMC14/Rules/CMDistressSignalRuleComponent.cs
@@ -165,7 +165,8 @@ public sealed partial class CMDistressSignalRuleComponent : Component
 
     public List<string> AuxiliaryMaps = new() {
         "/Maps/_RMC14/OCP-583.yml",
-        "/Maps/_RMC14/admin_fax.yml"
+        "/Maps/_RMC14/admin_fax.yml",
+        "/Maps/_RMC14/Breakwater_Strand.yml"
     };
 
     [DataField]

--- a/Resources/Maps/_RMC14/OCP-583.yml
+++ b/Resources/Maps/_RMC14/OCP-583.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 264.0.0
   forkId: ""
   forkVersion: ""
-  time: 07/23/2025 17:58:02
-  entityCount: 5728
+  time: 08/11/2025 18:19:37
+  entityCount: 5733
 maps:
 - 1
 grids:
@@ -368,6 +368,10 @@ entities:
           tiles: AQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAACAAAAAAAAAgAAAAAAAAsAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAgAAAAAAAAIAAAAAAAALAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAIAAAAAAAACAAAAAAAACwAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAACAAAAAAAAAgAAAAAAAAsAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAA==
           version: 7
     - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      fixedRotation: False
+      bodyType: Dynamic
     - type: Fixtures
       fixtures: {}
     - type: OccluderTree
@@ -653,6 +657,11 @@ entities:
             204: -12,-11
             205: -9,-11
             206: -8,-11
+        - node:
+            color: '#0B0806FF'
+            id: splatter
+          decals:
+            323: 50.345585,-7.0037365
     - type: MapAtmosphere
       space: False
       mixture:
@@ -7954,6 +7963,13 @@ entities:
     - type: BecomesStation
       id: OCP-583
     - type: ImplicitRoof
+    - type: GridAtmosphere
+      version: 2
+      data:
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: Shuttle
+      dampingModifier: 0.25
 - proto: ArmorHelmetPMCCorporate
   entities:
   - uid: 936
@@ -9524,266 +9540,356 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 37.553154,0.6183548
+      pos: 37.5,0.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 273
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 37.584427,-0.3035202
+      pos: 37.5,-0.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 274
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 39.47646,0.5402298
+      pos: 39.5,0.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 275
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 39.47646,-0.3035202
+      pos: 39.5,-0.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 415
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 54.49159,-3.3508873
+      pos: 54.5,-3.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 437
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 52.569714,-3.3977623
+      pos: 52.5,-3.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 466
     components:
     - type: Transform
-      pos: 57.882027,-16.413452
+      pos: 57.5,-16.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 475
     components:
     - type: Transform
-      pos: 56.542313,-16.366577
+      pos: 56.5,-16.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 839
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 28.625778,5.621969
+      pos: 28.5,5.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 904
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -2.4508948,14.689644
+      pos: -2.5,14.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 905
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -0.52901983,14.689644
+      pos: -0.5,14.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 906
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -0.51339483,13.767769
+      pos: -0.5,13.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 907
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -2.4821448,13.720894
+      pos: -2.5,13.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 952
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -7.576277,13.590973
+      pos: -7.5,13.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 953
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -7.576277,12.747223
+      pos: -7.5,12.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 1337
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -32.5,-10.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 1339
     components:
     - type: Transform
       pos: -32.5,-8.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 1341
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -34.5,-5.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 1342
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -32.5,-5.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 1955
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 34.48,27.739792
+      pos: 34.5,27.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 1956
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 34.48,26.786667
+      pos: 34.5,26.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 1957
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 32.526875,27.692917
+      pos: 32.5,27.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 1958
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 32.495625,26.724167
+      pos: 32.5,26.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 1959
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 35.526875,27.692917
+      pos: 35.5,27.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 1960
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 35.5425,26.708542
+      pos: 35.5,26.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 1961
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 37.495625,27.708542
+      pos: 37.5,27.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 1962
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 37.48,26.771042
+      pos: 37.5,26.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 2205
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 39.64291,42.66373
+      pos: 39.5,42.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 2206
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 41.377285,42.679356
+      pos: 41.5,42.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 2315
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 30.285576,40.583458
+      pos: 30.5,40.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 2367
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 31.280304,45.672974
+      pos: 31.5,45.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 2368
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 29.592804,45.704224
+      pos: 29.5,45.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 2995
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 73.49307,20.762905
+      pos: 73.5,20.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 2996
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 73.52432,19.68478
+      pos: 73.5,19.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 2997
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 75.43057,20.71603
+      pos: 75.5,20.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 2998
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 75.46182,19.71603
+      pos: 75.5,19.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 3288
     components:
     - type: Transform
-      pos: 64.59573,51.473076
+      pos: 64.5,51.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 4969
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -12.5753355,30.707745
+      pos: -12.5,30.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 4970
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -9.4972105,31.56712
+      pos: -9.5,31.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 4971
     components:
     - type: Transform
-      pos: -5.5284605,31.56712
+      pos: -5.5,31.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 4972
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -0.6222105,30.62962
+      pos: -0.5,30.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 4973
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -1.52951,48.735466
+      pos: -1.5,48.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 4974
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -4.607635,49.641716
+      pos: -4.5,49.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 4975
     components:
     - type: Transform
-      pos: -8.537776,49.65734
+      pos: -8.5,49.5
       parent: 23
+    - type: Physics
+      bodyType: Static
   - uid: 4976
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -13.522184,48.735466
+      pos: -13.5,48.5
       parent: 23
+    - type: Physics
+      bodyType: Static
 - proto: CMChairComfy
   entities:
   - uid: 943
@@ -15704,6 +15810,26 @@ entities:
     components:
     - type: Transform
       pos: 40.5,68.5
+      parent: 23
+  - uid: 5730
+    components:
+    - type: Transform
+      pos: 22.5,22.5
+      parent: 23
+  - uid: 5731
+    components:
+    - type: Transform
+      pos: 28.5,19.5
+      parent: 23
+  - uid: 5732
+    components:
+    - type: Transform
+      pos: 50.5,11.5
+      parent: 23
+  - uid: 5733
+    components:
+    - type: Transform
+      pos: 45.5,29.5
       parent: 23
 - proto: CMRack
   entities:
@@ -22932,6 +23058,12 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 37.5,10.5
+      parent: 23
+  - uid: 5729
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,7.5
       parent: 23
 - proto: CMWallMetalAlmayerWhite
   entities:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed a wall on OCP-583 being missing, added a shuttle to Chance's Admin LZ. Also added breakwater strand to the map load.

## Why / Balance
Fixes, and the shuttle adds more atmosphere. Breakwater as an ERT map should probably be loaded in

## Technical details
C#, YML.

## Media
<img width="354" height="742" alt="image" src="https://github.com/user-attachments/assets/3f81c731-7adc-4d9d-b192-b354a7363716" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Added Breakwater Strand to the Distress Signal loading
- add: Added a shuttle to repaired chances
- fix: Fixed a wall in the site director's office
