### PR TITLE
Parity channels for cargotechs

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/ship_headsets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/ship_headsets.yml
@@ -134,7 +134,7 @@
     containers:
       key_slots:
       - CMEncryptionKeyCommon
-      - CMEncryptionKeyRequisition
+      - RMCEncryptionKeyCargotech
   - type: GrantSquadLeaderTracker
     defaultMode: Quartermaster
     trackerModes:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Devices/EncryptionKeys/ship.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Devices/EncryptionKeys/ship.yml
@@ -367,6 +367,20 @@
   - type: Sprite
     state: req_key
 
+- type: entity
+  parent: CMEncryptionKey
+  id: RMCEncryptionKeyCargotech
+  name: cargo tech encryption key
+  components:
+  - type: EncryptionKey
+    channels:
+    - MarineRequisition
+    - MarineEngineer
+    - MarineCommand
+    defaultChannel: MarineRequisition
+  - type: Sprite
+    state: req_key
+
 # Quartermaster
 - type: entity
   parent: CMEncryptionKeyRequisition


### PR DESCRIPTION
For all my cargotech buddies. Hopefully improves the marine retail worker experience.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds engineering and command channel access to cargotech radio headsets, tuned out by default.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity. https://github.com/psyendrocronologicalwarfare/cmss13/blob/ac2f2e544ef11ad60596bc8cb9febc3b137a129f/code/game/objects/items/devices/radio/encryptionkey.dm

## Technical details
<!-- Summary of code changes for easier review. -->
Replaces the typical requisition encryption key in cargotech headsets with RMCEncryptionKeyCargotech, which also has command and engi channels so as to not affect normal req keys.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Difference between QM key, normal radio key, and the new cargotech key (I didn't delete the public radio key, I just forgot to put it back in when prepping the recording)
https://drive.google.com/file/d/1yihEFEpayqP-5LDkUnSNCeaf4OZs6cpM/view?usp=sharing

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed cargo tech headsets not having engi and command radio channels, tuned out by default.

