### PR TITLE
Fixes accuracy modifiers for M82F Flare Gun and Hunting Rifle

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/BoltAction/hunting_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/BoltAction/hunting_rifle.yml
@@ -30,8 +30,8 @@
     baseFireRate: 1.25
     burstScatterMult: 5
   - type: RMCWeaponAccuracy
-    accuracyMultiplier: 1
-    accuracyMultiplierUnwielded: 0.95
+    accuracyMultiplier: 1.35
+    accuracyMultiplierUnwielded: 0.35
   - type: UniqueAction
   - type: BreechLoaded
     needOpenClose: true

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/m82f.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/m82f.yml
@@ -56,8 +56,8 @@
       ballistic-ammo: !type:Container
         ents: [ ]
   - type: RMCWeaponAccuracy
-    accuracyMultiplier: 1.15
-    accuracyMultiplierUnwielded: 0.95
+    accuracyMultiplier: 1
+    accuracyMultiplierUnwielded: 0.5
   - type: Appearance
   - type: RMCNameItemOnVend
     item: Sidearm


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Changes flare gun's accuracy stat to 1 and 0.5 wielded and unwielded, and the hunting rifle's stat to 1.35 and 0.35 wielded and unwielded.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity! Flare Gun's modifier was taken from https://github.com/cmss13-devs/cmss13/blob/81b251863e2329bfc2ba604d4262e9dec5747e3e/code/modules/projectiles/guns/flare_gun.dm#L45 
and hunting rifle from https://github.com/cmss13-devs/cmss13/blob/81b251863e2329bfc2ba604d4262e9dec5747e3e/code/modules/projectiles/guns/boltaction.dm#L88

Accuracy modifiers are defined in: https://github.com/cmss13-devs/cmss13/blob/90eb062ea56f0a6561816e1bdabbc5825404133f/code/__DEFINES/weapon_stats.dm#L46

## Technical details
<!-- Summary of code changes for easier review. -->
Yaml, only touches two lines per file, the accuracy stats.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Max_Power
- fix: Fixed the M82F Flare Gun having a 1.15x wielded accuracy and 0.95x unwielded accuracy multiplier instead of 1x wielded and 0.5x unwielded.
- fix: Fixed the Basira-Armstrong rifle having a 1x wielded accuracy and 0.95x unwielded accuracy multiplier instead of 1.35x wielded and 0.35x unwielded.