### PR TITLE
Fix scattered spit projectile spread

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Projectile/Spit/Scattered/XenoScatteredSpitComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/Spit/Scattered/XenoScatteredSpitComponent.cs
@@ -25,5 +25,5 @@ public sealed partial class XenoScatteredSpitComponent : Component
     public int MaxProjectiles = 5;
 
     [DataField, AutoNetworkedField]
-    public Angle MaxDeviation = Angle.FromDegrees(45);
+    public Angle MaxDeviation = Angle.FromDegrees(90);
 }

--- a/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
@@ -140,14 +140,15 @@ public sealed class XenoProjectileSystem : EntitySystem
             target = null;
 
         var originalDiff = targetMap.Position - origin.Position;
+        var halfDeviation = deviation / 2;
         for (var i = 0; i < shots; i++)
         {
-            var projTarget = targetMap;
-            if (deviation != Angle.Zero)
-            {
-                var angle = _random.NextAngle(-deviation / 2, deviation / 2);
-                projTarget = new MapCoordinates(origin.Position + angle.RotateVec(originalDiff), targetMap.MapId);
-            }
+            // center projectile has no deviation; others are randomly offset within deviation
+            var angleOffset = Angle.Zero;
+            if (i > 0 && deviation != Angle.Zero)
+                angleOffset = _random.NextAngle(-halfDeviation, halfDeviation);
+
+            var projTarget = new MapCoordinates(origin.Position + angleOffset.RotateVec(originalDiff), targetMap.MapId);
 
             var diff = projTarget.Position - origin.Position;
             var xenoVelocity = _physics.GetMapLinearVelocity(xeno);


### PR DESCRIPTION
## About the PR
Fixes the Sentinel caste's Scattered Spit ability to match parity mechanics.

## Why / Balance
This PR widens the projectile spread to match the parity value of 90 degrees (currently only 45) but exempts the first projectile from deviating, resulting in a wider and more unpredictable spread but more consistent knockdowns due to the base projectile always being accurate. See Media for clips showing how the current projectile spread can often result in near-point-blank misses, and how the updated spread is larger but better due to the accurate base projectile.

## Technical details
Currently, Scattered Spit shoots 5 projectiles within a 45 degree cone. The center of the cone is positioned where the player clicks, and then all 5 projectiles independently roll an angle within +-22.5 degrees (for a 45 degree envelope). In CM13, one projectile, the "base pellet", always goes center line, and then the remaining projectiles, or "bonus pellets", independently roll a deviation angle within +-45 degrees (for a 90 degree envelope). We update the Scattered Spit component's MaxDeviation value from 45 to 90, and edit the TryShoot method's for() loop to use a deviation of 0 for the first projectile.

## Media
Actual gameplay clip showing current behavior and drawbacks
https://github.com/user-attachments/assets/c25d7ec1-51a5-4ddc-b3ea-95fe32e4a074

Test clip showing larger, updated spread but with accurate base projectile
https://github.com/user-attachments/assets/216a424b-76be-4213-a3ba-3850d9916c04


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
- tweak: Scattered Spit deviation changed to 90, first projectile exempt from deviation
