### PR TITLE
Fix health analyzers not showing permadead marines as permadead

### DIFF
--- a/Content.Client/_RMC14/Medical/Scanner/HealthScannerBui.cs
+++ b/Content.Client/_RMC14/Medical/Scanner/HealthScannerBui.cs
@@ -11,7 +11,6 @@ using Content.Shared._RMC14.Medical.Scanner;
 using Content.Shared._RMC14.Medical.Unrevivable;
 using Content.Shared._RMC14.Medical.Wounds;
 using Content.Shared._RMC14.Xenonids.Parasite;
-using Content.Shared.Atmos.Rotting;
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;

--- a/Content.Client/_RMC14/Medical/Scanner/HealthScannerBui.cs
+++ b/Content.Client/_RMC14/Medical/Scanner/HealthScannerBui.cs
@@ -8,6 +8,7 @@ using Content.Shared._RMC14.Medical.HUD;
 using Content.Shared._RMC14.Medical.HUD.Components;
 using Content.Shared._RMC14.Medical.HUD.Systems;
 using Content.Shared._RMC14.Medical.Scanner;
+using Content.Shared._RMC14.Medical.Unrevivable;
 using Content.Shared._RMC14.Medical.Wounds;
 using Content.Shared._RMC14.Xenonids.Parasite;
 using Content.Shared.Atmos.Rotting;
@@ -41,7 +42,7 @@ public sealed class HealthScannerBui : BoundUserInterface
     private readonly ShowHolocardIconsSystem _holocardIcons;
     private readonly SkillsSystem _skills;
     private readonly SharedWoundsSystem _wounds;
-    private readonly SharedRottingSystem _rot;
+    private readonly RMCUnrevivableSystem _unrevivable;
     private readonly MobStateSystem _mob;
 
     private Dictionary<EntProtoId<SkillDefinitionComponent>, int> BloodPackSkill = new() { ["RMCSkillSurgery"] = 1 };
@@ -53,7 +54,7 @@ public sealed class HealthScannerBui : BoundUserInterface
         _holocardIcons = _entities.System<ShowHolocardIconsSystem>();
         _skills = _entities.System<SkillsSystem>();
         _wounds = _entities.System<SharedWoundsSystem>();
-        _rot = _entities.System<SharedRottingSystem>();
+        _unrevivable = _entities.System<RMCUnrevivableSystem>();
         _mob = _entities.System<MobStateSystem>();
     }
 
@@ -115,8 +116,9 @@ public sealed class HealthScannerBui : BoundUserInterface
             _window.HealthBar.MinValue = 0;
             _window.HealthBar.MaxValue = 100;
 
-            if (_entities.HasComponent<VictimBurstComponent>(target) || _rot.IsRotten(target) ||
-                _entities.HasComponent<CMDefibrillatorBlockedComponent>(target) && _mob.IsDead(target))
+            if (_unrevivable.IsUnrevivable(target) ||
+                _entities.HasComponent<CMDefibrillatorBlockedComponent>(target) &&
+                _mob.IsDead(target))
             {
                 isPermaDead = true;
                 _window.HealthBar.Value = 100;

--- a/Resources/Locale/en-US/_RMC14/medical/examine.ftl
+++ b/Resources/Locale/en-US/_RMC14/medical/examine.ftl
@@ -11,6 +11,8 @@ rmc-medical-examine-dead = [color=red]{CAPITALIZE(SUBJECT($victim))} {CONJUGATE-
 
 rmc-medical-examine-dead-simple-mob = [color=red]{CAPITALIZE(SUBJECT($victim))} {CONJUGATE-BE($victim)} DEAD. Kicked the bucket.[/color]
 
+rmc-medical-examine-dead-xeno = [color=red]{CAPITALIZE(SUBJECT($victim))} {CONJUGATE-BE($victim)} DEAD. Kicked the bucket. Off to that great hive in the sky.[/color]
+
 rmc-medical-examine-alive = [color=green]{CAPITALIZE(SUBJECT($victim))} {CONJUGATE-BE($victim)} alive and breathing.[/color]
 
 rmc-medical-examine-bleeding = [color=#d10a0a]{CAPITALIZE(SUBJECT($victim))} {CONJUGATE-HAVE($victim)} bleeding wounds on {POSS-ADJ($victim)} body.[/color]

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/NPCs/animals.yml
@@ -1,4 +1,16 @@
 - type: entity
+  id: RMCSimpleMob
+  name: abstract simple mob
+  abstract: true
+  components:
+  - type: ShortExamine
+  - type: RMCRevivable
+  - type: RMCMedicalExamine
+    simple: true
+    deadText: rmc-medical-examine-dead-simple-mob
+  - type: CrashLandable
+
+- type: entity
   id: RMCSmallHost
   name: abstract small host
   abstract: true
@@ -9,7 +21,6 @@
   - type: XenoNestable
   - type: RMCNightVisionVisible
   - type: InfectStopOnDeath
-  - type: CrashLandable
   - type: PressureImmunity
   - type: Respirator
     minSaturation: 5.0
@@ -19,7 +30,7 @@
     coldDamageThreshold: 0
 
 - type: entity
-  parent: [MobMonkey, RMCSmallHost]
+  parent: [RMCSimpleMob, MobMonkey, RMCSmallHost]
   id: CMMobMonkey
   suffix: CM
   components:
@@ -27,7 +38,7 @@
     prob: 0
 
 - type: entity
-  parent: [MobKobold, RMCSmallHost]
+  parent: [RMCSimpleMob, MobKobold, RMCSmallHost]
   id: CMMobKobold
   suffix: CM
   components:
@@ -35,7 +46,7 @@
     prob: 0
 
 - type: entity
-  parent: MobMouse
+  parent: [RMCSimpleMob, MobMouse]
   id: CMMobMouse
   suffix: CM
   components:
@@ -50,7 +61,7 @@
     coldDamageThreshold: 0
 
 - type: entity
-  parent: MobMouse1
+  parent: [RMCSimpleMob, MobMouse1]
   id: CMMobMouse1
   suffix: CM
   components:
@@ -64,7 +75,7 @@
     coldDamageThreshold: 0
 
 - type: entity
-  parent: MobMouse2
+  parent: [RMCSimpleMob, MobMouse2]
   id: CMMobMouse2
   suffix: CM
   components:
@@ -85,7 +96,7 @@
 
 - type: entity
   name: rat
-  parent: SimpleMobBase
+  parent: [RMCSimpleMob, SimpleMobBase]
   id: RMCMobRat
   description: It's a small laboratory rat.
   suffix: RMC
@@ -295,7 +306,7 @@
         Base: splat-3
 
 - type: entity
-  parent: MobCorgiPuppy
+  parent: [RMCSimpleMob, MobCorgiPuppy]
   id: CMMobWiggles
   name: Mister Wiggles
   description: It's a corgi puppy. MISTER WIGGLES!! HE IS THE GREATEST!
@@ -312,7 +323,7 @@
     coldDamageThreshold: 0
 
 - type: entity
-  parent: MobCatCalico
+  parent: [RMCSimpleMob, MobCatCalico]
   id: CMMobJones
   name: Jones
   description: A tough, old stray whose origin no one seems to know.
@@ -329,7 +340,7 @@
     coldDamageThreshold: 0
 
 - type: entity
-  parent: MobCatCalico
+  parent: [RMCSimpleMob, MobCatCalico]
   id: RMCMobOrion
   name: Orion
   description: A domesticated, feline pet. The collar says 'Orion'.
@@ -346,7 +357,7 @@
     coldDamageThreshold: 0
 
 - type: entity
-  parent: MobCat
+  parent: [RMCSimpleMob, MobCat]
   id: RMCMobGarry
   name: Garry
   description: Her fur has the look and feel of velvet, and her tail quivers occasionally.

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
@@ -39,7 +39,7 @@
     thresholds: []
   - type: RMCMedicalExamine
     simple: true
-    deadText: rmc-medical-examine-dead-simple-mob
+    deadText: rmc-medical-examine-dead-xeno
   - type: RMCBlockMedicalExamine
   - type: MobState
     allowedStates:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Bugfix

Also adds RMC Revivable to simple mobs

:cl:
- fix: Fixed health analyzers not showing permadead marines as permadead