### PR TITLE
Make paras spawning from carriers collision immune

### DIFF
--- a/Content.Server/_RMC14/Xenonids/Parasite/XenoParasiteThrowerSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Parasite/XenoParasiteThrowerSystem.cs
@@ -324,8 +324,10 @@ public sealed partial class XenoParasiteThrowerSystem : SharedXenoParasiteThrowe
             return null;
 
         _hive.SetSameHive(xeno.Owner, para.Value);
+        _rmcObstacleSlamming.MakeImmune(para.Value);
         _transform.DropNextTo(para.Value, xeno.Owner);
         // Small throw
+
         _throw.TryThrow(para.Value, _random.NextAngle().RotateVec(Vector2.One), 3);
 
         return para;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Caused them to take damage if spawned in a tight space.

## Technical details
<!-- Summary of code changes for easier review. -->
Obstacleslamming system make immune on the spawn part.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed parasites spawning from carriers sometimes taking collision damage.
