### PR TITLE
spec and  job pamphlets now update your role in tracker and OW

### DIFF
--- a/Content.Client/_RMC14/Overwatch/OverwatchConsoleBui.cs
+++ b/Content.Client/_RMC14/Overwatch/OverwatchConsoleBui.cs
@@ -22,6 +22,7 @@ namespace Content.Client._RMC14.Overwatch;
 public sealed class OverwatchConsoleBui : RMCPopOutBui<OverwatchConsoleWindow>
 {
     [Dependency] private readonly IPrototypeManager _prototypes = default!;
+    [Dependency] private readonly ILocalizationManager _localization = default!;
 
     private const string GreenColor = "#229132";
     private const string RedColor = "#A42625";
@@ -283,7 +284,9 @@ public sealed class OverwatchConsoleBui : RMCPopOutBui<OverwatchConsoleWindow>
                 string? rankName = null;
                 if (marine.Role != null)
                 {
-                    if (_prototypes.TryIndex(marine.Role, out var job))
+                    if (marine.RoleOverride is { } roleOverride && _localization.TryGetString(roleOverride, out var localizedName))
+                        roleName = localizedName;
+                    else if (_prototypes.TryIndex(marine.Role, out var job))
                         roleName = job.LocalizedName;
 
                     var role = roles.GetOrNew(marine.Role.Value, out var present);

--- a/Content.Client/_RMC14/Overwatch/OverwatchConsoleBui.cs
+++ b/Content.Client/_RMC14/Overwatch/OverwatchConsoleBui.cs
@@ -21,8 +21,8 @@ namespace Content.Client._RMC14.Overwatch;
 [UsedImplicitly]
 public sealed class OverwatchConsoleBui : RMCPopOutBui<OverwatchConsoleWindow>
 {
-    [Dependency] private readonly IPrototypeManager _prototypes = default!;
     [Dependency] private readonly ILocalizationManager _localization = default!;
+    [Dependency] private readonly IPrototypeManager _prototypes = default!;
 
     private const string GreenColor = "#229132";
     private const string RedColor = "#A42625";

--- a/Content.Client/_RMC14/Tracker/SquadLeader/SquadInfoBui.cs
+++ b/Content.Client/_RMC14/Tracker/SquadLeader/SquadInfoBui.cs
@@ -164,7 +164,9 @@ public sealed class SquadInfoBui : BoundUserInterface
         if (member.Role is { } role &&
             _prototype.TryIndex(role, out var job))
         {
-            if (_prototype.TryIndex(job.Icon, out var icon))
+            if (member.IconOverride != null)
+                row.RoleIcon.Texture = _sprite.Frame0(member.IconOverride);
+            else if (_prototype.TryIndex(job.Icon, out var icon))
                 row.RoleIcon.Texture = _sprite.Frame0(icon.Icon);
 
             row.RoleBackground.Texture = background;

--- a/Content.Server/_RMC14/Ghost/GhostRoleApplySpecialSystem.cs
+++ b/Content.Server/_RMC14/Ghost/GhostRoleApplySpecialSystem.cs
@@ -58,14 +58,6 @@ public sealed partial class GhostRoleApplySpecialSystem : EntitySystem
         foreach (var special in job.Special)
             special.AfterEquip(ent);
 
-        if (ent.Comp.Squad is { } squadProto && _squad.TryEnsureSquad(squadProto, out var squad))
-        {
-            if (_squad.TryGetSquadLeader(squad, out _))
-                RemComp<SquadLeaderComponent>(ent);
-
-            _squad.AssignSquad(ent, squad.Owner, jobProto);
-        }
-
         if (job.Ranks is { } ranks)
         {
             foreach (var rank in ranks)
@@ -76,6 +68,14 @@ public sealed partial class GhostRoleApplySpecialSystem : EntitySystem
                     break;
                 }
             }
+        }
+
+        if (ent.Comp.Squad is { } squadProto && _squad.TryEnsureSquad(squadProto, out var squad))
+        {
+            if (_squad.TryGetSquadLeader(squad, out _))
+                RemComp<SquadLeaderComponent>(ent);
+
+            _squad.AssignSquad(ent, squad.Owner, jobProto);
         }
 
         if (HasComp<MarineComponent>(ent) &&

--- a/Content.Shared/_RMC14/Overwatch/OverwatchConsoleUI.cs
+++ b/Content.Shared/_RMC14/Overwatch/OverwatchConsoleUI.cs
@@ -167,5 +167,6 @@ public readonly record struct OverwatchMarine(
     OverwatchLocation Location,
     string AreaName,
     Vector2? LeaderDistance,
-    ProtoId<RankPrototype>? Rank
+    ProtoId<RankPrototype>? Rank,
+    LocId? RoleOverride
 );

--- a/Content.Shared/_RMC14/Overwatch/SharedOverwatchConsoleSystem.cs
+++ b/Content.Shared/_RMC14/Overwatch/SharedOverwatchConsoleSystem.cs
@@ -6,12 +6,14 @@ using Content.Shared._RMC14.Chat;
 using Content.Shared._RMC14.Dialog;
 using Content.Shared._RMC14.Marines.Announce;
 using Content.Shared._RMC14.Marines.Roles.Ranks;
+using Content.Shared._RMC14.Marines.Skills.Pamphlets;
 using Content.Shared._RMC14.Marines.Squads;
 using Content.Shared._RMC14.OrbitalCannon;
 using Content.Shared._RMC14.Roles;
 using Content.Shared._RMC14.Rules;
 using Content.Shared._RMC14.SupplyDrop;
 using Content.Shared._RMC14.TacticalMap;
+using Content.Shared._RMC14.Vendors;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Chat;
@@ -663,6 +665,7 @@ public abstract class SharedOverwatchConsoleSystem : EntitySystem
                             ? areaProto.Name
                             : string.Empty;
                         var netMember = GetNetEntity(member);
+                        var roleOverride = CompOrNull<RMCVendorRoleOverrideComponent>(member)?.GiveSquadRoleName ?? CompOrNull<UsedSkillPamphletComponent>(member)?.JobTitle;
 
                         Vector2? leaderDistance = null;
                         if (member != leader.Owner &&
@@ -685,7 +688,8 @@ public abstract class SharedOverwatchConsoleSystem : EntitySystem
                             location,
                             areaName,
                             leaderDistance,
-                            rank
+                            rank,
+                            roleOverride
                         );
                     }
 

--- a/Content.Shared/_RMC14/Tracker/SquadLeader/SquadLeaderTrackerMarine.cs
+++ b/Content.Shared/_RMC14/Tracker/SquadLeader/SquadLeaderTrackerMarine.cs
@@ -1,8 +1,9 @@
 ﻿using Content.Shared.Roles;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
+using Robust.Shared.Utility;
 
 namespace Content.Shared._RMC14.Tracker.SquadLeader;
 
 [Serializable, NetSerializable]
-public readonly record struct SquadLeaderTrackerMarine(NetEntity Id, ProtoId<JobPrototype>? Role, string Name);
+public readonly record struct SquadLeaderTrackerMarine(NetEntity Id, ProtoId<JobPrototype>? Role, string Name, SpriteSpecifier.Rsi? IconOverride);

--- a/Content.Shared/_RMC14/Tracker/SquadLeader/SquadLeaderTrackerSystem.cs
+++ b/Content.Shared/_RMC14/Tracker/SquadLeader/SquadLeaderTrackerSystem.cs
@@ -1,7 +1,9 @@
 ﻿using Content.Shared._RMC14.Dialog;
 using Content.Shared._RMC14.Marines.Roles.Ranks;
+using Content.Shared._RMC14.Marines.Skills.Pamphlets;
 using Content.Shared._RMC14.Marines.Squads;
 using Content.Shared._RMC14.Roles;
+using Content.Shared._RMC14.Vendors;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Alert;
 using Content.Shared.Database;
@@ -64,6 +66,7 @@ public sealed class SquadLeaderTrackerSystem : EntitySystem
         SubscribeLocalEvent<SquadLeaderTrackerComponent, SquadLeaderTrackerClickedEvent>(OnSquadLeaderTrackerClicked);
         SubscribeLocalEvent<SquadLeaderTrackerComponent, SquadLeaderTrackerChangeModeEvent>(OnSquadLeaderTrackerChangeMode);
         SubscribeLocalEvent<SquadLeaderTrackerComponent, LeaderTrackerSelectTargetEvent>(OnLeaderTrackerSelectTargetEvent);
+        SubscribeLocalEvent<SquadLeaderTrackerComponent, GetMarineSquadNameEvent>(OnRoleChange, after: [typeof(SkillPamphletSystem), typeof(VendorRoleOverrideSystem)]);
 
         Subs.BuiEvents<SquadLeaderTrackerComponent>(SquadLeaderTrackerUI.Key,
             subs =>
@@ -292,7 +295,8 @@ public sealed class SquadLeaderTrackerSystem : EntitySystem
 
         var netMember = GetNetEntity(marineId.Value);
         var job = _originalRoleQuery.CompOrNull(marineId.Value)?.Job;
-        var marine = new SquadLeaderTrackerMarine(netMember, job, _rank.GetSpeakerRankName(marineId.Value) ?? Name(marineId.Value));
+        var iconOverride = CompOrNull<RMCVendorRoleOverrideComponent>(marineId)?.GiveIcon ?? CompOrNull<UsedSkillPamphletComponent>(marineId)?.Icon;
+        var marine = new SquadLeaderTrackerMarine(netMember, job, _rank.GetSpeakerRankName(marineId.Value) ?? Name(marineId.Value), iconOverride);
         ref var fireteam = ref ent.Comp.Fireteams.Fireteams[member.Fireteam];
         fireteam ??= new SquadLeaderTrackerFireteam();
 
@@ -398,7 +402,8 @@ public sealed class SquadLeaderTrackerSystem : EntitySystem
     {
         var netMember = GetNetEntity(member);
         var job = _originalRoleQuery.CompOrNull(member)?.Job;
-        var marine = new SquadLeaderTrackerMarine(netMember, job, _rank.GetSpeakerRankName(member) ?? Name(member));
+        var iconOverride = CompOrNull<RMCVendorRoleOverrideComponent>(member)?.GiveIcon ?? CompOrNull<UsedSkillPamphletComponent>(member)?.Icon;
+        var marine = new SquadLeaderTrackerMarine(netMember, job, _rank.GetSpeakerRankName(member) ?? Name(member), iconOverride);
         if (_fireteamMemberQuery.TryComp(member, out var fireteamMember) &&
             fireteamMember.Fireteam >= 0 &&
             fireteamMember.Fireteam < fireteamData.Fireteams.Length)
@@ -486,13 +491,18 @@ public sealed class SquadLeaderTrackerSystem : EntitySystem
         Dirty(ent);
     }
 
+    private void OnRoleChange(Entity<SquadLeaderTrackerComponent> ent, ref GetMarineSquadNameEvent _)
+    {
+        SyncMemberFireteams(ent.Owner);
+    }
+
     public bool TryFindTargets(ProtoId<TrackerModePrototype> mode, out List<DialogOption> options, out List<EntityUid> trackingOptions)
     {
         options = new List<DialogOption>();
         trackingOptions = new List<EntityUid>();
 
         _prototypeManager.TryIndex(mode, out var trackerMode);
-        if(trackerMode == null)
+        if (trackerMode == null)
             return false;
 
         // Try to find all entities that fit the selected role.
@@ -531,7 +541,7 @@ public sealed class SquadLeaderTrackerSystem : EntitySystem
                 originalRole = original.Job;
 
             if (originalRole != trackerMode.Job &&
-                (mode != SquadLeaderMode||
+                (mode != SquadLeaderMode ||
                  !HasComp<SquadLeaderComponent>(trackableUid)))
                 continue;
 


### PR DESCRIPTION
## About the PR

This PR makes it so that after reading a role pamphlet (loader/spotter/mortar/etc...) or choosing a weapons spec the icon and role name are updates in the squad tracker and inside overwatch.

## Why / Balance

More clarity.

## Technical details

Override the icon and role if the marine has the RMCVendorRoleOverrideComponent or UsedSkillPamphletComponent component.

Also fixed a bug where ghost roles had no rank in the squad tracker. (found while testing)

## Media


https://github.com/user-attachments/assets/1f81670b-b04c-4749-87bb-bbc3427a8bfd



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- tweak: Choosing a weapons spec and reading a job pamphlet now update your role and icon in the squad tracker and overwatch.
