### PR TITLE
new command to hopefully fix power for development/pve/events

### DIFF
--- a/Content.Server/_RMC14/Admin/RMCFixPower.cs
+++ b/Content.Server/_RMC14/Admin/RMCFixPower.cs
@@ -5,7 +5,7 @@ using Robust.Shared.Console;
 
 namespace Content.Server._RMC14.Admin;
 
-[AdminCommand(AdminFlags.Admin), AdminCommand(AdminFlags.Debug)]
+[AdminCommand(AdminFlags.Debug)]
 public sealed class RMCFixPower : LocalizedEntityCommands
 {
     [Dependency] private readonly SharedRMCPowerSystem _power = default!;

--- a/Content.Server/_RMC14/Admin/RMCFixPower.cs
+++ b/Content.Server/_RMC14/Admin/RMCFixPower.cs
@@ -5,12 +5,12 @@ using Robust.Shared.Console;
 
 namespace Content.Server._RMC14.Admin;
 
-[AdminCommand(AdminFlags.Admin)]
-public sealed class RMCRecalculatePower : LocalizedEntityCommands
+[AdminCommand(AdminFlags.Admin), AdminCommand(AdminFlags.Debug)]
+public sealed class RMCFixPower : LocalizedEntityCommands
 {
     [Dependency] private readonly SharedRMCPowerSystem _power = default!;
 
-    public override string Command => "rmcrecalcualtepower";
+    public override string Command => "fixpower";
 
     public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {

--- a/Content.Server/_RMC14/Admin/RMCRecalculatePower.cs
+++ b/Content.Server/_RMC14/Admin/RMCRecalculatePower.cs
@@ -1,0 +1,19 @@
+using Content.Server.Administration;
+using Content.Shared._RMC14.Power;
+using Content.Shared.Administration;
+using Robust.Shared.Console;
+
+namespace Content.Server._RMC14.Admin;
+
+[AdminCommand(AdminFlags.Admin)]
+public sealed class RMCRecalculatePower : LocalizedEntityCommands
+{
+    [Dependency] private readonly SharedRMCPowerSystem _power = default!;
+
+    public override string Command => "rmcrecalcualtepower";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        _power.RecalculatePower();
+    }
+}

--- a/Resources/Locale/en-US/_RMC14/commands/rmc-entity-commands.ftl
+++ b/Resources/Locale/en-US/_RMC14/commands/rmc-entity-commands.ftl
@@ -1,2 +1,2 @@
-cmd-rmcrecalcualtepower-desc = Force the RMCPowerSystem to recalculate all power related entities.
-cmd-rmcrecalcualtepower-help = Usage: rmcrecalcualtepower
+cmd-fixpower-desc = Force the RMCPowerSystem to recalculate all power related entities.
+cmd-fixpower-help = Usage: fixpower

--- a/Resources/Locale/en-US/_RMC14/commands/rmc-entity-commands.ftl
+++ b/Resources/Locale/en-US/_RMC14/commands/rmc-entity-commands.ftl
@@ -1,0 +1,2 @@
+cmd-rmcrecalcualtepower-desc = Force the RMCPowerSystem to recalculate all power related entities.
+cmd-rmcrecalcualtepower-help = Usage: rmcrecalcualtepower


### PR DESCRIPTION
## About the PR

This PR adds a new command `rmcrecalcualtepower` that admins can use to fix the power system on certain maps.

## Why / Balance

Sometimes the power system fails during PVE or development. This command forces it to recalculate all power related entities, which should fix it.

## Technical details

A simple command that just calls a preexisting method. That method is also used by CMDistressSignal which i had been using to fix the power during development.

## Media

https://github.com/user-attachments/assets/84553a27-1b48-46c1-8774-2e333d1fe7f4

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- add: Admin only command "rmcrecalcualtepower" for fixing the power system.
