### PR TITLE
[fix]Add the name back to inap pills

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Medical/pill_canisters.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Medical/pill_canisters.yml
@@ -1,4 +1,4 @@
-﻿# TODO RMC14 text labels on the bottom right
+# TODO RMC14 text labels on the bottom right
 - type: entity
   parent: PillCanister
   id: RMCPillCanisterNoSkill
@@ -174,6 +174,7 @@
 - type: entity
   parent: RMCPillCanisterNoSkill
   id: RMCPillCanisterInaprovalineNoSkill
+  name: inaprovaline pill bottle
   suffix: Inaprovaline, 16, No Skill
   components:
   - type: Item


### PR DESCRIPTION
## About the PR
Put the name back on inap bottles which was removed accidentally in #6910 (i believe...)

## Why / Balance
names yo

## Technical details
returned name element to inap bottles

## Media


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Returned Inap pill bottle name
