### PR TITLE
[Fix] adds missing name to the green EMT paramedic uniform 

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/other.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/other.yml
@@ -422,6 +422,7 @@
 - type: entity
   parent: RMCMarineUniformBase
   id: RMCJumpsuitEMT
+  name: EMT - Paramedic uniform
   description: A set of EMT - Paramedic fatigues, this one is green.
   components:
   - type: Sprite


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
title, it was called item before this PR.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
parity.
fixes #7426
<!-- ## Technical details -->
<!-- Summary of code changes for easier review. -->

<!-- ## Media -->
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed the red EMT paramedic uniform being named "Item".
