### PR TITLE
Tightens M13 scatter to be more accurate

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/m13_auto_pistol.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/m13_auto_pistol.yml
@@ -13,8 +13,8 @@
     availableModes:
     - FullAuto
   - type: RMCSelectiveFire
-    scatterWielded: 14
-    scatterUnwielded: 16
+    scatterWielded: 12
+    scatterUnwielded: 13
     baseFireRate: 10
     burstScatterMult: 4
     modifiers:


### PR DESCRIPTION
## About the PR
Adjusted M13 scatter to reduce both wielded and unwielded scatter.

## Why / Balance
Parity(tm) for now; there is another PR to more dramatically change how the M10 in CM13 operates, but this is current parity.

## Technical details


## Media

https://github.com/user-attachments/assets/b059243e-d1bc-4e31-aae7-20a76517c34d



## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:

- tweak: Adjusted the M13 to be slightly more accurate, both wielded and unwielded.

