### PR TITLE
Fix a client/server desync when re-assigning the owner of a locked weapon (such as the CO's primary) that resulted in pretty severe misprediction.

### DIFF
--- a/Content.Shared/_RMC14/Weapons/Ranged/GunIDLockSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/GunIDLockSystem.cs
@@ -141,6 +141,7 @@ public sealed class GunIDLockSystem : EntitySystem
     private void RegisterNewUser(Entity<GunIDLockComponent> ent, EntityUid user)
     {
         ent.Comp.User = user;
+        Dirty(ent);
         var popup = Loc.GetString("rmc-id-lock-authorization", ("gun", ent.Owner));
         _popup.PopupClient(popup, user, PopupType.Medium);
     }
@@ -148,6 +149,7 @@ public sealed class GunIDLockSystem : EntitySystem
     private void RegisterNewUserCombat(Entity<GunIDLockComponent> ent, EntityUid user)
     {
         ent.Comp.User = user;
+        Dirty(ent);
         var popup = Loc.GetString("rmc-id-lock-authorization-combat", ("gun", ent.Owner));
         _popup.PopupClient(popup, user, user, PopupType.Small);
     }


### PR DESCRIPTION
## About the PR
Title

## Why / Balance
I noticed this in a recent XO round where the CO bursted and then eventually rotted. When examining the item, it would briefly show the name of the person who picked it up after, and then flash over to the original CO's name. Later, presumably when that person also died, I picked it up, got the notification, and then my name briefly flashed before going back to Freya. This means that you cannot toggle the guns lock or IFF, but after testing in a local build, does allow you to fire it, just at a much slower firerate. This is, of course, a bug, confirmed by me noticing in a localbuild where I managed to replicate the issue that the client version of the component had a different user compared to the server version. (Shared components are simply a component that has a server AND client side component which share a name, and usually, the same values, assuming it is coded properly.)

## Technical details
There was already a Dirty() when un-assigning the owner, but not when re-assigning it, I added that.
Please note that during both the actual round and my testing, the CO character died via bursting and eventually rotted. This may be relevant for testing as when I gibbed the CO character with for example an OB, the re-assignment worked as intended.

## Media
Not needed.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl: BramvanZijp
- fix: Fixed not properly reassigning a new owner to a CO Primary Weapon's after they become unrevivable.
