### PR TITLE
Increase High-Capacity Beaker max volume to 500u

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Medical/beaker.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Medical/beaker.yml
@@ -151,7 +151,7 @@
   parent: RMCBeakerBaseMetallic
   id: RMCBeakerHighCapacity
   name: high-capacity beaker
-  description: A beaker with an enlarged holding capacity, made with blue-tinted plexiglass in order to withstand greater pressure. Can hold up to 300 units.
+  description: A beaker with an enlarged holding capacity, made with blue-tinted plexiglass in order to withstand greater pressure. Can hold up to 500 units.
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Medical/high_capacity_beaker.rsi
@@ -168,13 +168,13 @@
   - type: SolutionContainerManager
     solutions:
       beaker:
-        maxVol: 300
+        maxVol: 500
   - type: SolutionContainerVisuals
     maxFillLevels: 5
     fillBaseName: beakerbluespace
   - type: SolutionTransfer
     transferAmount: 100
-    maxTransferAmount: 300
+    maxTransferAmount: 500
     canChangeTransferAmount: true
     transferAmounts:
     - 5
@@ -190,6 +190,7 @@
     - 120
     - 240
     - 300
+    - 500
   - type: Openable
     opened: true
     closeable: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Upped the High-Capacity Beaker max volume to 500u to match the jani bucket.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Same reason #6906, janitorial buckets are the default for chem making because of their large size, but they don't really fit for medical to be using. Per DrSmugleaf, would rather see High-Cap be increase as it already spawns on chem dispensers and it is also used by medical rather than making a new jug. Would like to see #6906 also be merged with this to give HMs a RP friendly alternative to the jani bucket.

<img width="920" height="240" alt="image" src="https://github.com/user-attachments/assets/9ffad5dd-a4bf-4514-a337-44b2a2151401" />


## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="460" height="383" alt="image" src="https://github.com/user-attachments/assets/2fe7b21a-32a0-474b-8f18-d18b91bb1d8b" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- tweak: High-Capacity Beakers now have 500u max volume instead of 300u
