### PR TITLE
link to the new communications guide

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Back/satchels.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Back/satchels.yml
@@ -577,6 +577,13 @@
           Ring: { state: ring }
           Ear: { state: ear }
   - type: Undisposable
+  - type: GuideHelp
+    guides:
+    - RMCGuideMarineCommunications
+    - RMCLanguage
+    - RMCGuideCommunicationsTowers
+    - RMCGuideRoleCombatTechnician
+    - RMCGuideRoleMaintenanceTechnician
 
 - type: entity
   parent: CMSatchel

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/ship_headsets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/ship_headsets.yml
@@ -33,6 +33,13 @@
     tags:
     - RMCHeadset
   - type: RMCHeadset
+  - type: GuideHelp
+    guides:
+    - RMCGuideMarineCommunications
+    - RMCLanguage
+    - RMCGuideCommunicationsTowers
+    - RMCGuideRoleCombatTechnician
+    - RMCGuideRoleMaintenanceTechnician
 
 - type: entity
   parent: RMCHeadsetIconsUNMC

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Devices/EncryptionKeys/ship.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Devices/EncryptionKeys/ship.yml
@@ -13,6 +13,13 @@
   - type: Sprite
     sprite: _RMC14/Objects/Devices/encryption_keys.rsi
     state: cypherkey
+  - type: GuideHelp
+    guides:
+    - RMCGuideMarineCommunications
+    - RMCLanguage
+    - RMCGuideCommunicationsTowers
+    - RMCGuideRoleCombatTechnician
+    - RMCGuideRoleMaintenanceTechnician
 
 
 # Common

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/rmc_communications_console.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/rmc_communications_console.yml
@@ -117,6 +117,10 @@
   - type: GuideHelp
     guides:
     - RMCGuideMarineCommunications
+    - RMCLanguage
+    - RMCGuideCommunicationsTowers
+    - RMCGuideRoleCombatTechnician
+    - RMCGuideRoleMaintenanceTechnician
 
 - type: entity
   parent: RMCOverwatchConsole
@@ -152,6 +156,10 @@
   - type: GuideHelp
     guides:
     - RMCGuideMarineCommunications
+    - RMCLanguage
+    - RMCGuideCommunicationsTowers
+    - RMCGuideRoleCombatTechnician
+    - RMCGuideRoleMaintenanceTechnician
 
 - type: entity
   parent: RMCTacticalMapTable

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/rmc_communications_console.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/rmc_communications_console.yml
@@ -52,6 +52,13 @@
   - type: OverwatchConsole
     canMessageSquad: false
   - type: TacticalMapComputer
+  - type: GuideHelp
+    guides:
+    - RMCGuideMarineCommunications
+    - RMCLanguage
+    - RMCGuideCommunicationsTowers
+    - RMCGuideRoleCombatTechnician
+    - RMCGuideRoleMaintenanceTechnician
 
 - type: entity
   parent: RMCCommunicationsConsoleBase
@@ -107,6 +114,9 @@
   - type: OverwatchConsole
   - type: TacticalMapComputer
   - type: SupplyDropComputer
+  - type: GuideHelp
+    guides:
+    - RMCGuideMarineCommunications
 
 - type: entity
   parent: RMCOverwatchConsole
@@ -139,6 +149,9 @@
   - type: TacticalMapComputer
   - type: EmitSoundOnUIOpen
     sound: null
+  - type: GuideHelp
+    guides:
+    - RMCGuideMarineCommunications
 
 - type: entity
   parent: RMCTacticalMapTable

--- a/Resources/Prototypes/_RMC14/Entities/Structures/rotary_phone.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/rotary_phone.yml
@@ -38,6 +38,13 @@
           Ear: { state: rotary_phone_ear }
   - type: WallMount
     arc: 360
+  - type: GuideHelp
+    guides:
+    - RMCGuideMarineCommunications
+    - RMCLanguage
+    - RMCGuideCommunicationsTowers
+    - RMCGuideRoleCombatTechnician
+    - RMCGuideRoleMaintenanceTechnician
 
 - type: entity
   parent: RMCRotaryPhone

--- a/Resources/Prototypes/_RMC14/Entities/Structures/rotary_phone.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/rotary_phone.yml
@@ -80,3 +80,10 @@
     isCorrodible: false
   - type: BlockEntityStorage
   - type: Undisposable
+  - type: GuideHelp
+    guides:
+    - RMCGuideMarineCommunications
+    - RMCLanguage
+    - RMCGuideCommunicationsTowers
+    - RMCGuideRoleCombatTechnician
+    - RMCGuideRoleMaintenanceTechnician


### PR DESCRIPTION
## About the PR

This PR adds a guidebook link to telephones, telephone packs, radios, map tables, overwatch consoles and the groudside  operations console.

## Why / Balance

<img width="786" height="89" alt="image" src="https://github.com/user-attachments/assets/adbc2239-b076-4a1f-aa12-87b50c6ac67f" />

## Technical details

Also included everything that the guide links to and what those link to.

## Media

<img width="488" height="267" alt="Screenshot From 2025-08-22 15-02-29" src="https://github.com/user-attachments/assets/e1205576-28d5-4ad3-90e0-fc9a600da90c" />
<img width="669" height="221" alt="Screenshot From 2025-08-22 15-02-38" src="https://github.com/user-attachments/assets/4f1cb380-8faf-4b2f-92bc-b0b1be3e4253" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- tweak: Everything communications related now has link to the relevant guide.
