### PR TITLE
Mateba / WW can fire in the air while moving

### DIFF
--- a/Content.Shared/_RMC14/Weapons/Ranged/RMCAirShotComponent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/RMCAirShotComponent.cs
@@ -26,6 +26,12 @@ public sealed partial class RMCAirShotComponent : Component
     public bool RequiresCombat;
 
     /// <summary>
+    ///     If the do-after breaks when moving.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool DoAfterBreakOnMove = true;
+
+    /// <summary>
     ///     How many shakes
     /// </summary>
     [DataField, AutoNetworkedField]

--- a/Content.Shared/_RMC14/Weapons/Ranged/RMCAirShotSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/RMCAirShotSystem.cs
@@ -164,7 +164,7 @@ public sealed class RMCAirShotSystem : EntitySystem
         var ev = new AirShotDoAfterEvent(GetNetCoordinates(shooterCoordinates));
         var doAfter = new DoAfterArgs(EntityManager, shooter, ent.Comp.PreparationTime, ev, ent)
         {
-            BreakOnMove = true,
+            BreakOnMove = ent.Comp.DoAfterBreakOnMove,
             NeedHand = true,
             BreakOnHandChange = true,
             MovementThreshold = 0.5f,

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/peregrine_handcannon.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/peregrine_handcannon.yml
@@ -136,6 +136,7 @@
   - type: RMCAirShot
     preparationTime: 1.5
     requiresCombat: true
+    doAfterBreakOnMove: false
     ignoreRoof: true
     shakeAmount: 5
     requiredSkills:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Revolvers/mateba.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Revolvers/mateba.yml
@@ -97,6 +97,7 @@
   - type: RMCAirShot
     preparationTime: 1.5
     requiresCombat: true
+    doAfterBreakOnMove: false
     ignoreRoof: true
     shakeAmount: 5
     requiredSkills:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title, Do-After no longer breaks while moving. Flare gun do-after unchanged for air-shots.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Feels silly that a CO is forced to stand still to fire in the air, also prevents people moving them to stop the do-after.

## Technical details
<!-- Summary of code changes for easier review. -->
Added 1 variable to the `RMCAirShotComponent`, BreakOnMove is now tied to the variable which is true by default.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://github.com/user-attachments/assets/39e598cc-718d-42c6-b472-f8be1a2c928c

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: noctyrnal
- tweak: You can now move while firing the Mateba or Winter Wyvern in the air.
