### PR TITLE
SPP Type 71 Buff for PVE!

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/type71PVE.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/type71PVE.yml
@@ -10,4 +10,4 @@
     - RMCWeaponRifleType71PVE
 
 - type: Tag
-  id: RMCMagazineRifleType71PVE
+  id: RMCWeaponRifleType71PVE

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/type71PVE.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/type71PVE.yml
@@ -5,6 +5,9 @@
   components:
   - type: RMCSelectiveFire
     baseFireRate: 3.5
+  - type: Tag
+    tags:
+    - RMCWeaponRifleType71PVE
 
 - type: Tag
   id: RMCMagazineRifleType71PVE

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/type71PVE.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/type71PVE.yml
@@ -1,0 +1,7 @@
+- type: entity
+  parent: RMCWeaponRifleType71
+  id: RMCWeaponRifleType71PVE
+  suffix: PVE
+  components:
+  - type: RMCSelectiveFire
+    baseFireRate: 3.5

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/type71PVE.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/type71PVE.yml
@@ -5,3 +5,6 @@
   components:
   - type: RMCSelectiveFire
     baseFireRate: 3.5
+
+- type: Tag
+  id: RMCMagazineRifleType71PVE

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/GunRacks/rifles.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/GunRacks/rifles.yml
@@ -390,3 +390,100 @@
       - RMCWeaponRifleType71
       item_6:
       - RMCWeaponRifleType71
+
+# Type 71, PVE
+
+- type: entity
+  parent: RMCGunRackBase
+  id: RMCGunRackType71EmptyPVE
+  name: Type 71 gun rack
+  suffix: Type 71, Empty, PVE
+  description: Some off-branded gun rack. Per SOF and SPPA regulations, weapons should be stored in secure safes and only given out when necessary. Of course, most (but not all!) units overlook this regulation, only storing their firearms in safes when inspection arrives.
+
+  components:
+  - type: Sprite
+    sprite: _RMC14/Structures/Machines/VendingMachines/GunRacks/t71_rack.rsi
+  - type: ItemSlots
+    slots:
+      item_1:
+        name: Type 71
+        whitelist:
+          tags:
+          - RMCWeaponRifleType71PVE
+      item_2:
+        name: Type 71
+        whitelist:
+          tags:
+          - RMCWeaponRifleType71PVE
+      item_3:
+        name: Type 71
+        whitelist:
+          tags:
+          - RMCWeaponRifleType71PVE
+      item_4:
+        name: Type 71
+        whitelist:
+          tags:
+          - RMCWeaponRifleType71PVE
+      item_5:
+        name: Type 71
+        whitelist:
+          tags:
+          - RMCWeaponRifleType71PVE
+      item_6:
+        name: Type 71
+        whitelist:
+          tags:
+          - RMCWeaponRifleType71PVE
+  - type: ItemMapper
+    mapLayers:
+      fill_1:
+        minCount: 1
+        whitelist:
+          tags:
+          - RMCWeaponRifleType71PVE
+      fill_2:
+        minCount: 2
+        whitelist:
+          tags:
+          - RMCWeaponRifleType71PVE
+      fill_3:
+        minCount: 3
+        whitelist:
+          tags:
+          - RMCWeaponRifleType71PVE
+      fill_4:
+        minCount: 4
+        whitelist:
+          tags:
+          - RMCWeaponRifleType71PVE
+      fill_5:
+        minCount: 5
+        whitelist:
+          tags:
+          - RMCWeaponRifleType71PVE
+      fill_6:
+        minCount: 6
+        whitelist:
+          tags:
+          - RMCWeaponRifleType71PVE
+
+- type: entity
+  parent: RMCGunRackType71Empty
+  id: RMCGunRackType71FilledPVE
+  suffix: Type 71, Filled, PVE
+  components:
+  - type: ContainerFill
+    containers:
+      item_1:
+      - RMCWeaponRifleType71PVE
+      item_2:
+      - RMCWeaponRifleType71PVE
+      item_3:
+      - RMCWeaponRifleType71PVE
+      item_4:
+      - RMCWeaponRifleType71PVE
+      item_5:
+      - RMCWeaponRifleType71PVE
+      item_6:
+      - RMCWeaponRifleType71PVE


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
the guns were a bit weak for the job they needed to do in pve, so i boosted the firerate by one, which basically puts it on par with the mk1.

## Why / Balance
the spp seemed really squishy during the last spp pve round, constantly getting their asses beat by three runners, and i checked the armor, seemed to be fine, so i figure the only other explanation is that the guns werent performing well enough to make sure the xenos dont survive after getting shot at for three seconds while they murderize someone.

tested it, seems like one mag of regular t71 takes out six drones as good as a mag of regular mk1 takes six drones out. bit of a uh, poor test though i spose. will need some more testin in actual rounds.

## Technical details
bit of yaml

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Shromply
- add: Buffed the Type 71s firerate by one for PVE only, hopefully making it just about on par with the Mk1.
