### PR TITLE
Fixed the rank of TSEPA support synth from Master Sergeant to Constable

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/TSE/TSEPA/tsepa_synthetic.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/TSE/TSEPA/tsepa_synthetic.yml
@@ -6,7 +6,7 @@
   description: rmc-job-description-tsepa-synth
   playTimeTracker: RMCJobTSEPASynthetic
   ranks:
-    RMCRankMasterSergeant: [ ]
+    RMCRankTSEPAConstable: [ ]
   startingGear: RMCGearTSEPASynthetic
   icon: "RMCJobIconTSEPASynth"
   joinNotifyCrew: false


### PR DESCRIPTION
## About the PR
Fixed the incorrect rank for the TSEPA support synth. Used to be Master Sergeant, is now Constable

Fixes #7602 

## Why / Balance
Clarity.

## Technical details
Changed the rank from RMCRankMasterSergeant in tsepa_synthetic.yml to RMCRankTSEPAConstable

## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!--
:cl:
- fix: Gave the TSEPA Support Synthetic the correct rank.
-->
