### PR TITLE
Mhelp message added to first time joining

### DIFF
--- a/Resources/Locale/en-US/game-ticking/game-ticker.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-ticker.ftl
@@ -7,7 +7,7 @@ game-ticker-unknown-role = Unknown
 game-ticker-delay-start = Round start has been delayed for {$seconds} seconds.
 game-ticker-pause-start = Round start has been paused.
 game-ticker-pause-start-resumed = Round start countdown is now resumed.
-game-ticker-player-join-game-message = Welcome to RMC14! If this is your first time playing, be sure to read the game rules, and don't be afraid to ask for help in LOOC (local OOC) or OOC (usually available only between rounds).
+game-ticker-player-join-game-message = Welcome to RMC14! If this is your first time playing, be sure to read the game rules, and don't be afraid to ask for help in LOOC (local OOC) or OOC (usually available only between rounds). You can also use Mhelp for ingame questions — mentors are there to guide you on roles, ranks, how to fight xenos, and much more.
 game-ticker-get-info-text = Hi and welcome to [color=white]RMC14![/color]
                             The current round is: [color=white]#{$roundId}[/color]
                             The current player count is: [color=white]{$playerCount}[/color]

--- a/Resources/Locale/en-US/game-ticking/game-ticker.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-ticker.ftl
@@ -7,7 +7,7 @@ game-ticker-unknown-role = Unknown
 game-ticker-delay-start = Round start has been delayed for {$seconds} seconds.
 game-ticker-pause-start = Round start has been paused.
 game-ticker-pause-start-resumed = Round start countdown is now resumed.
-game-ticker-player-join-game-message = Welcome to RMC14! If this is your first time playing, be sure to read the game rules, and don't be afraid to ask for help in LOOC (local OOC) or OOC (usually available only between rounds). You can also use Mhelp for ingame questions — mentors are there to guide you on roles, ranks, how to fight xenos, and much more.
+game-ticker-player-join-game-message = Welcome to RMC14! If this is your first time playing, be sure to read the game rules, and don't be afraid to ask for help in LOOC (local OOC) or OOC (usually available only between rounds). You can also use Mentor Help (F1) for ingame questions — mentors are there to guide you on roles, ranks, how to fight Xenonids, and much more.
 game-ticker-get-info-text = Hi and welcome to [color=white]RMC14![/color]
                             The current round is: [color=white]#{$roundId}[/color]
                             The current player count is: [color=white]{$playerCount}[/color]


### PR DESCRIPTION
## About the PR
Closes #7580 

I added some info for new comers about the use of MHelp

## Why / Balance
Clarity and better support for new comers.

## Technical details
I added some text in game-ticker.ftl for game-ticker-player-join-game-message

Whole message is as follows:
```
Welcome to RMC14! If this is your first time playing, be sure to read the game rules, and don't be afraid to ask for help in LOOC (local OOC) or OOC (usually available only between rounds). You can also use Mhelp for ingame questions — mentors are there to guide you on roles, ranks, how to fight xenos, and much more.
```

## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Added Mhelp information to the first time join message.
