### PR TITLE
Removed Marine Orders Component from RMCJobSynthetic in synth.yml

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/synth.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/synth.yml
@@ -44,7 +44,6 @@
     - type: CMVendorUser
       id: RMCJobSynthetic
       points: 45
-    - type: MarineOrders
     - type: DemoSpecWhitelist
     - type: GrenadeSpecWhitelist
     - type: ScoutWhitelist


### PR DESCRIPTION
## About the PR
Closes #7623 

## Why / Balance
Stated in Issue

## Technical details
Removed Marine Orders Component from RMCJobSynthetic in synth.yml

Synths now only get Orders when promoted to aSL
## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!--
:cl:
- remove: Removed UNMC synths having marine orders by default.
-->
