### PR TITLE
Allows office chairs to spin

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Furniture/chairs.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Furniture/chairs.yml
@@ -242,6 +242,8 @@
   components:
   - type: Sprite
     state: officechair_dark
+  - type: Rotatable
+    rotateWhileAnchored: true
   - type: Construction
     graph: CMSeat
     node: chairOfficeDark


### PR DESCRIPTION
## About the PR
Allows office chairs to spin

## Why / Balance
Parity, reported in #7637 

## Technical details
Just added rotatable tag to the dark office chair (the light one inherits from the dark one.)

## Media

https://github.com/user-attachments/assets/a529b336-8dbe-4c70-a837-c665bd559f84



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Office chairs spin
