### PR TITLE
Synth Key resize, Belt whitelists, Synth Vendor Changes

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
@@ -156,6 +156,7 @@
       - RMCNailgunCompact
       - RMCNailgunTactical
       - RMCCircuitboard
+      - RMCSynthResetKey
       components:
       - Welder
       - PowerCell
@@ -199,6 +200,7 @@
       - RMCNailgunCompact
       - RMCNailgunTactical
       - RMCCircuitboard
+      - RMCSynthResetKey
       # TODO stock parts
       components:
       - Welder
@@ -265,6 +267,7 @@
       - RMCShellShotgun
       - RMCNailgunCompact
       - RMCNailgunTactical
+      - RMCSynthResetKey
       #      - # TODO analyzer
       components:
       - Welder

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Pouches/storage.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Pouches/storage.yml
@@ -455,7 +455,7 @@
       # - TODO RMC14 RMCAssembly
       # - TODO RMC14 RMCStockParts
       - RMCExplosiveBreachingCharge
-      # - TODO RMC14 RMCSynthResetKey
+      - RMCSynthResetKey
       components:
       - TrayScanner
       - ComputerBoard
@@ -475,7 +475,7 @@
         # - TODO RMC14 RMCAssembly
         # - TODO RMC14 RMCStockParts
         - RMCExplosiveBreachingCharge
-        # - TODO RMC14 RMCSynthResetKey
+        - RMCSynthResetKey
         components:
         - TrayScanner
         - ComputerBoard

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Medical/defib.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Medical/defib.yml
@@ -173,6 +173,9 @@
       components:
         - Marine
   - type: Item
-    size: Normal
+    size: Small
     sprite: _RMC14/Objects/Devices/reset_key.rsi
     heldPrefix: null
+  - type: Tag
+    tags:
+    - RMCSynthResetKey

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Misc/engineerkit.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Misc/engineerkit.yml
@@ -28,7 +28,7 @@
       # - TODO RMC14 RMCAssembly
       # - TODO RMC14 RMCStockParts,
       - RMCExplosiveBreachingCharge
-      # - TODO RMC14 RMCSynthResetKey
+      - RMCSynthResetKey
       components:
       - TrayScanner
   - type: FixedItemSizeStorage

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/synthetic.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/synthetic.yml
@@ -18,6 +18,7 @@
       entries:
       # /obj/item/coin/marine/synth
       # /obj/item/device/defibrillator/synthetic
+      - id: RMCSynthResetKey
       - id: RMCHeadsetSynth
     - name: Uniform
       choices: { CMUniform: 1 }

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/synthetic.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/synthetic.yml
@@ -273,10 +273,6 @@
         points: 4
       - id: CMSynthGraft
         points: 4
-      - id: CMWebbingSurgicalBlue
-        points: 15
-      - id: CMWebbingSurgicalGreen
-        points: 15
     - name: Other Supplies
       entries:
       - id: RMCBinoculars
@@ -306,10 +302,6 @@
         points: 2
       - id: RMCFlashlightPen
         points: 2
-      - id: CMSatchelMarineLogistics
-        points: 15
-      - id: RMCSatchelMarineIntelChestrig
-        points: 15
         
 
 - type: entity
@@ -344,6 +336,14 @@
       # maintenance jack - 15 Points
       # portable dialysis machine - 15 Points
       - id: RMCTelescopicBaton
+        points: 15
+      - id: CMWebbingSurgicalBlue
+        points: 15
+      - id: CMWebbingSurgicalGreen
+        points: 15
+      - id: CMSatchelMarineLogistics
+        points: 15
+      - id: RMCSatchelMarineIntelChestrig
         points: 15
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/synthetic.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/synthetic.yml
@@ -41,8 +41,6 @@
       - id: CMWebbing
       - id: RMCWebbingBlackSmall
       - id: CMWebbingHolster
-      - id: CMWebbingSurgicalBlue
-      - id: CMWebbingSurgicalGreen
     - name: Shoes
       choices: { RMCShoes: 1 }
       entries:
@@ -275,6 +273,10 @@
         points: 4
       - id: CMSynthGraft
         points: 4
+      - id: CMWebbingSurgicalBlue
+        points: 15
+      - id: CMWebbingSurgicalGreen
+        points: 15
     - name: Other Supplies
       entries:
       - id: RMCBinoculars
@@ -304,6 +306,11 @@
         points: 2
       - id: RMCFlashlightPen
         points: 2
+      - id: CMSatchelMarineLogistics
+        points: 15
+      - id: RMCSatchelMarineIntelChestrig
+        points: 15
+        
 
 - type: entity
   parent: ColMarTechBase

--- a/Resources/Prototypes/_RMC14/rmc_tags.yml
+++ b/Resources/Prototypes/_RMC14/rmc_tags.yml
@@ -123,3 +123,6 @@
   
 - type: Tag
   id: RMCPinpointer
+
+- type: Tag
+  id: RMCSynthResetKey


### PR DESCRIPTION
## About the PR
Resized the synth reset key to be the same size as CM13
Added the synth reset key to the whitelists of the various belts it should be in based on #7635 and Code TODO's
Added Synth Reset key to essential on Synth Vendor from #7633
Moved Surgical webbing from one vendor to the experimental vendor #7634, and added the IMP/Expedition chest rigs from the screen shot as i didnt see them in there either.

## Why / Balance
Parity, Synth Gameplay

## Technical details
Mostly moved YML Code around, and added a tag.

## Media

Size of synth key + Added to whitelists for all these belts and pouches.

https://github.com/user-attachments/assets/2f858774-0a71-43f5-8c8f-47763cfb54ee

Synth Reset key in essentials:
<img width="731" height="322" alt="image" src="https://github.com/user-attachments/assets/95cb9214-d469-4b69-8f85-f6f6114b32ac" />

Webbing and chest rigs added to Experimental Vendor:
<img width="733" height="641" alt="image" src="https://github.com/user-attachments/assets/45bb7882-d583-4b94-a412-7fd9705d9bcc" />



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed synth reset key being normal size instead of small.
- fix: Fixed the synth vendor not having synth reset keys, marine logistics IMP backpack, or the UNMC expedition chestrig.
- fix: Fixed engineer belts not being able to hold synth reset keys.
