### PR TITLE
Now the plasma is not transferred if the target has full plasma

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Plasma/XenoPlasmaSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Plasma/XenoPlasmaSystem.cs
@@ -119,7 +119,9 @@ public sealed class XenoPlasmaSystem : EntitySystem
         _popup.PopupEntity(Loc.GetString("cm-xeno-plasma-transferred-to-self", ("plasma", args.Amount), ("target", self.Owner), ("total", otherXeno.Plasma)), target, target);
 
         _audio.PlayPredicted(self.Comp.PlasmaTransferSound, self, self);
-        args.Repeat = true;
+
+        if (otherXeno.Plasma != otherXeno.MaxPlasma)
+            args.Repeat = true;
     }
 
     private void OnNewXenoEvolved(Entity<XenoPlasmaComponent> newXeno, ref NewXenoEvolvedEvent args)

--- a/Content.Shared/_RMC14/Xenonids/Plasma/XenoPlasmaSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Plasma/XenoPlasmaSystem.cs
@@ -100,6 +100,7 @@ public sealed class XenoPlasmaSystem : EntitySystem
         if (self.Owner == target ||
             HasComp<XenoAttachedOvipositorComponent>(args.Target) ||
             !TryComp(target, out XenoPlasmaComponent? otherXeno) ||
+            otherXeno.Plasma == otherXeno.MaxPlasma ||
             !TryRemovePlasma((self, self), args.Amount))
         {
             return;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Now the plasma is not transferred if the target has full plasma. DoAfter don't repeat if target has full plasma. You can still start transferring plasma if the target has full plasma.

## Why / Balance
As a lord, you have to play QTE in order not to reset your plasma by giving it to someone with almost full plasma. Now you don't have to worry that a significant part of the plasma will disappear into the void. Also, you can still start transmitting plasma in advance until the DoAfter of another xeno is completed, for example, being a drone, you can start transmitting plasma in advance to a boiler that wants to spit a ball

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed repeating plasma transmission when the target has full plasma
