### PR TITLE
Make `setlooc` permission require +ADMIN not +SERVER

### DIFF
--- a/Content.Server/Chat/Commands/SetLOOCCommand.cs
+++ b/Content.Server/Chat/Commands/SetLOOCCommand.cs
@@ -6,7 +6,7 @@ using Robust.Shared.Console;
 
 namespace Content.Server.Chat.Commands;
 
-[AdminCommand(AdminFlags.Admin)]
+[AdminCommand(AdminFlags.Admin)] //RMC14 +ADMIN not +SERVER
 public sealed class SetLoocCommand : LocalizedCommands
 {
     [Dependency] private readonly IConfigurationManager _configManager = default!;

--- a/Content.Server/Chat/Commands/SetLOOCCommand.cs
+++ b/Content.Server/Chat/Commands/SetLOOCCommand.cs
@@ -6,7 +6,7 @@ using Robust.Shared.Console;
 
 namespace Content.Server.Chat.Commands;
 
-[AdminCommand(AdminFlags.Server)]
+[AdminCommand(AdminFlags.Admin)]
 public sealed class SetLoocCommand : LocalizedCommands
 {
     [Dependency] private readonly IConfigurationManager _configManager = default!;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
`setlooc` is now useable inherently with the +Admin flag rather than being restricted to +SERVER.

## Why / Balance
This feels much more suitable and is consistent with the OOC and DChat toggles. Doesn't make sense for admins to have only 2/3 (Esp when the other two are much more serious and the outlier is less severe imo). Restricting +SERVER is important, but we can give this to +ADMIN without causing issues imo.

Whisper semi-approval via discord.

## Technical details
Changed a permission flag.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
- tweak: Setlooc is now useable with the +ADMIN permission instead of the +SERVER permission.
