### PR TITLE
Make RMCPopOutWindow use OSWindow instead

### DIFF
--- a/Content.Client/_RMC14/UserInterface/RMCPopOutWindow.xaml.cs
+++ b/Content.Client/_RMC14/UserInterface/RMCPopOutWindow.xaml.cs
@@ -18,7 +18,7 @@ public partial class RMCPopOutWindow : DefaultWindow
     public event Action? OnFinalClose;
     public event Action? OnPopout;
 
-    private IClydeWindow? _popOutWindow;
+    private OSWindow? _popOutWindow;
 
     public RMCPopOutWindow()
     {
@@ -40,30 +40,25 @@ public partial class RMCPopOutWindow : DefaultWindow
         button.OnPressed += _ =>
         {
             OnClose -= FinalClose;
-            var clyde = IoCManager.Resolve<IClyde>();
-            var monitor = clyde.EnumerateMonitors().First();
 
-            _popOutWindow = clyde.CreateWindow(new WindowCreateParameters
+            _popOutWindow = new OSWindow
             {
-                Maximized = false,
                 Title = Title ?? string.Empty,
-                Monitor = monitor,
-                Width = PixelWidth,
-                Height = PixelHeight,
-            });
+                SetWidth = PixelWidth,
+                SetHeight = PixelHeight,
+            };
 
             Control.Orphan();
             Close();
 
-            _popOutWindow.RequestClosed += _ => OnFinalClose?.Invoke();
-            _popOutWindow.DisposeOnClose = true;
+            _popOutWindow.Closed += () => OnFinalClose?.Invoke();
 
             var panel = new PanelContainer();
             panel.PanelOverride = new StyleBoxFlat(Color.FromHex("#25252A"));
             panel.AddChild(Control);
 
-            var root = IoCManager.Resolve<IUserInterfaceManager>().CreateWindowRoot(_popOutWindow);
-            root.AddChild(panel);
+            _popOutWindow.AddChild(panel);
+            _popOutWindow.Show();
 
             OnPopout?.Invoke();
         };
@@ -76,6 +71,6 @@ public partial class RMCPopOutWindow : DefaultWindow
 
     public void DisposePopOut()
     {
-        _popOutWindow?.Dispose();
+        _popOutWindow?.Close();
     }
 }


### PR DESCRIPTION
Removes manual usage of CreateWindowRoot. OSWindow is more convenient to use and is more future-proof.
