### PR TITLE
Intel Support crate, Enabled a couple of other crates

### DIFF
--- a/Resources/Prototypes/_RMC14/Catalog/Cargo/requisitions_catalog.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Cargo/requisitions_catalog.yml
@@ -24,8 +24,8 @@
         crate: RMCCrateBoxMagazineRifleM54CAP
       - cost: 3000
         crate: RMCCrateBoxMagazineRifleM54CExt
-#      - cost: 2000
-#        crate: RMCCrateMagazineRifleM54CE2
+      - cost: 2000
+        crate: RMCCrateMagazineRifleM54CE2
       - cost: 3000
         crate: RMCCrateMagazineRifleM54CE2HT
       - cost: 2000
@@ -84,8 +84,8 @@
         crate: RMCCrateAttachmentSmartScope
       - cost: 2000
         crate: RMCCrateAttachmentRailFlashlight
-#      - cost: 3000
-#        crate: RMCCrateAttachmentRedDot
+      - cost: 3000
+        crate: RMCCrateAttachmentRedDot
       - cost: 3000
         crate: RMCCrateAttachmentTelescopicScope
       - cost: 3000
@@ -106,10 +106,10 @@
         crate: RMCCrateAttachmentBipod
       - cost: 3000
         crate: RMCCrateAttachmentUnderbarrelShotgun
-#      - cost: 3000
-#        crate: RMCCrateAttachmentUnderbarrelExtinguisher
-#      - cost: 3000
-#        crate: RMCCrateAttachmentUnderbarrelFlamer
+      - cost: 3000
+        crate: RMCCrateAttachmentUnderbarrelExtinguisher
+      - cost: 3000
+        crate: RMCCrateAttachmentUnderbarrelFlamer
       - cost: 3000
         crate: RMCCrateAttachmentBurstfire
       - cost: 6000
@@ -279,6 +279,8 @@
         crate: RMCCrateRestrictedEquipmentArmorM4
       - cost: 2000
         crate: RMCCrateRestrictedEquipmentArmorB12
+      - cost: 2000
+        crate: RMCCrateRestrictedEquipmentIntelSupportKit
     - name: Supplies
       entries:
       - cost: 2000
@@ -341,7 +343,6 @@
         crate: RMCCrateMagazineM4SPRCustomImpact
       - cost: 3000
         crate: RMCCrateMagazineM4SPRCustomIncendiary
-#      - cost: 4000
 
 
 

--- a/Resources/Prototypes/_RMC14/Catalog/Fills/Crates/restricted_equipment.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Fills/Crates/restricted_equipment.yml
@@ -17,8 +17,6 @@
     contents:
     - id: CMArmorB12
     - id: CMArmorHelmetM11
-
-
 - type: entity
   id: RMCCrateRestrictedEquipmentIntelSupportKit
   parent: RMCCrateBase

--- a/Resources/Prototypes/_RMC14/Catalog/Fills/Crates/restricted_equipment.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Fills/Crates/restricted_equipment.yml
@@ -17,3 +17,13 @@
     contents:
     - id: CMArmorB12
     - id: CMArmorHelmetM11
+
+
+- type: entity
+  id: RMCCrateRestrictedEquipmentIntelSupportKit
+  parent: RMCCrateBase
+  name: Field Intelligence Support Kit crate (x1 fulton, x1 data detector, 1x intel pamphlet, 1x large document pouch, 1x intel radio key)
+  components:
+  - type: StorageFill
+    contents:
+    - id: RMCKitIntel


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added the interl support crate, 
Enabled Red dot and HAR ammo crates as they were in there and just commented out
If they are meant to be disabled, let me know and ill remove it.
From issue: #7712

## Why / Balance
Parity, more stuff

## Technical details
See code, faily simple

## Media
<img width="766" height="385" alt="image" src="https://github.com/user-attachments/assets/36d81d2d-0fc7-4bff-9e05-6feb0ce466a1" />

<img width="727" height="114" alt="image" src="https://github.com/user-attachments/assets/27a708c1-ed2e-4206-af58-dd898a7d80ea" />

<img width="723" height="113" alt="image" src="https://github.com/user-attachments/assets/e829ed3f-4a43-400a-81c8-854b4a0d5b47" />

<img width="941" height="1417" alt="image" src="https://github.com/user-attachments/assets/dfa8467e-2203-4ab0-9eeb-e7d95f5c5a3b" />



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Added Intel support crate to req.
- fix: Enabled Red dot attachment crate and HAR ammo crate.
