### PR TITLE
BE Adjustments

### DIFF
--- a/Content.Shared/_RMC14/Weapons/Ranged/RMCBattleExecuteComponent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/RMCBattleExecuteComponent.cs
@@ -9,12 +9,21 @@ namespace Content.Shared._RMC14.Weapons.Ranged;
 [Access(typeof(CMGunSystem))]
 public sealed partial class RMCBattleExecuteComponent : Component
 {
+    /// <summary>
+    ///     Skill requirement to perform a BE with this weapon
+    /// </summary>
     [DataField, AutoNetworkedField]
     public EntProtoId<SkillDefinitionComponent> Skill = "RMCSkillExecution";
 
+    /// <summary>
+    ///     The BE's Damage
+    /// </summary>
     [DataField, AutoNetworkedField]
     public DamageSpecifier Damage = new() { DamageDict = { ["Blunt"] = 200 } };
 
+    /// <summary>
+    ///     How long it takes to perform a BE Do-After
+    /// </summary>
     [DataField, AutoNetworkedField]
     public TimeSpan BattleExecuteTimeSeconds = TimeSpan.FromSeconds(1);
 }

--- a/Resources/Locale/en-US/_RMC14/rmc-execute.ftl
+++ b/Resources/Locale/en-US/_RMC14/rmc-execute.ftl
@@ -1,0 +1,2 @@
+﻿rmc-execute-start-self = You aim the {$gun} at {$target}'s head!
+rmc-execute-start-others = {$user} aims their {$gun} at {$target}'s head!

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/peregrine_handcannon.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/peregrine_handcannon.yml
@@ -141,6 +141,7 @@
     shakeAmount: 5
     requiredSkills:
       RMCSkillLeadership: 3
+  - type: RMCBattleExecute
 
 - type: entity
   parent: CMBaseMagazinePistol


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
BE now has a popup when starting, recoil when done one handed, commenting in the component and some spacing / minor adjustments to sections of the system.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Popup and recoil are parity, commenting and spacing make code easier to read, gunshot sound adjustment will cover for cases where gunshot sound is modified e.g a suppressor i believe.

## Technical details
<!-- Summary of code changes for easier review. -->
minor cs, recoil on do-after end, popup on do-after attempt.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://github.com/user-attachments/assets/8850bccd-3a00-4517-bcf0-5c2ed2dcce4a

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: noctyrnal
- tweak: Executing someone via the Mateba (or now the Winter Wyvern) will have recoil when one-handed, and a popup when starting.
