### PR TITLE
Minor warrior tackle fix.

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Lunge/XenoLungeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Lunge/XenoLungeSystem.cs
@@ -13,7 +13,6 @@ using Content.Shared.Throwing;
 using Content.Shared.Weapons.Melee;
 using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.Network;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Timing;
@@ -42,8 +41,6 @@ public sealed class XenoLungeSystem : EntitySystem
 
     private EntityQuery<PhysicsComponent> _physicsQuery;
     private EntityQuery<ThrownItemComponent> _thrownItemQuery;
-
-    private static readonly ProtoId<StatusEffectPrototype> Stun = "Stun";
 
     public override void Initialize()
     {

--- a/Content.Shared/_RMC14/Xenonids/Lunge/XenoLungeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Lunge/XenoLungeSystem.cs
@@ -181,6 +181,8 @@ public sealed class XenoLungeSystem : EntitySystem
         {
             _statusEffects.TryRemoveStatusEffect(ent, effect);
         }
+
+        RemCompDeferred<XenoLungeStunnedComponent>(ent.Owner);
     }
 
     private void OnAttackAttempt(Entity<XenoLungeComponent> ent, ref MeleeAttackAttemptEvent args)
@@ -203,7 +205,7 @@ public sealed class XenoLungeSystem : EntitySystem
         var query = EntityQueryEnumerator<XenoLungeStunnedComponent>();
         while (query.MoveNext(out var uid, out var stunned))
         {
-            if (time < stunned.ExpireAt && _statusEffects.HasStatusEffect(uid, Stun))
+            if (time < stunned.ExpireAt)
                 continue;
 
             RemCompDeferred<XenoLungeStunnedComponent>(uid);

--- a/Content.Shared/_RMC14/Xenonids/Lunge/XenoLungeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Lunge/XenoLungeSystem.cs
@@ -13,6 +13,7 @@ using Content.Shared.Throwing;
 using Content.Shared.Weapons.Melee;
 using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.Network;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Timing;
@@ -41,6 +42,8 @@ public sealed class XenoLungeSystem : EntitySystem
 
     private EntityQuery<PhysicsComponent> _physicsQuery;
     private EntityQuery<ThrownItemComponent> _thrownItemQuery;
+
+    private static readonly ProtoId<StatusEffectPrototype> Stun = "Stun";
 
     public override void Initialize()
     {
@@ -200,7 +203,7 @@ public sealed class XenoLungeSystem : EntitySystem
         var query = EntityQueryEnumerator<XenoLungeStunnedComponent>();
         while (query.MoveNext(out var uid, out var stunned))
         {
-            if (time < stunned.ExpireAt)
+            if (time < stunned.ExpireAt && _statusEffects.HasStatusEffect(uid, Stun))
                 continue;
 
             RemCompDeferred<XenoLungeStunnedComponent>(uid);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Simple fix to warrior lunge always causing tackles to be converted into light attacks if the target was let go early.

Link to bug report: ["Warrior Leap forces Slash no matter what"](https://discordapp.com/channels/1168210010233376858/1410552909757939794)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

fix

## Technical details
<!-- Summary of code changes for easier review. -->

Fully removes the XenoLungeStunned Component the moment they're no longer being pulled.

In `OnXenoLungeStunnedPullStopped` function; removes the component `XenoLungeStunned` component from the owner.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Spaghetti
- fix: Fixed warrior lunge always slashing a target even if they were let go early.