### PR TITLE
Giving PMC+SPP PVE roles smartgun, powerloader, and special weapons skills.

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/PMC/corpsman.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/PMC/corpsman.yml
@@ -31,9 +31,16 @@
         RMCSkillSurgery: 1
         RMCSkillEndurance: 1
         RMCSkillPilot: 1
+        RMCSkillPowerLoader: 1
+        RMCSkillSmartGun: 1
     - type: SquadArmorWearer
     - type: JobPrefix
       prefix: rmc-job-prefix-pmc-medic
+    - type: DemoSpecWhitelist
+    - type: GrenadeSpecWhitelist
+    - type: ScoutWhitelist
+    - type: SniperWhitelist
+    - type: PyroWhitelist
   hidden: true
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/PMC/force_lead.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/PMC/force_lead.yml
@@ -34,12 +34,19 @@
         RMCSkillMedical: 1
         RMCSkillJtac: 1
         RMCSkillPilot: 1
+        RMCSkillPowerLoader: 1
+        RMCSkillSmartGun: 1
     - type: SquadArmorWearer
     - type: JobPrefix
       prefix: rmc-job-prefix-pmc-standard
     - type: MarineOrders
     - type: RMCPointing
     - type: RMCTrackable
+    - type: DemoSpecWhitelist
+    - type: GrenadeSpecWhitelist
+    - type: ScoutWhitelist
+    - type: SniperWhitelist
+    - type: PyroWhitelist
   hidden: true
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/PMC/operator.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/PMC/operator.yml
@@ -29,9 +29,16 @@
         RMCSkillEngineer: 2
         RMCSkillEndurance: 1
         RMCSkillPilot: 1
+        RMCSkillPowerLoader: 1
+        RMCSkillSmartGun: 1
     - type: SquadArmorWearer
     - type: JobPrefix
       prefix: rmc-job-prefix-pmc-standard
+    - type: DemoSpecWhitelist
+    - type: GrenadeSpecWhitelist
+    - type: ScoutWhitelist
+    - type: SniperWhitelist
+    - type: PyroWhitelist
   hidden: true
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/PMC/overwatch.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/PMC/overwatch.yml
@@ -34,12 +34,19 @@
         RMCSkillJtac: 4
         RMCSkillExecution: 1
         RMCSkillPilot: 1
+        RMCSkillPowerLoader: 1
+        RMCSkillSmartGun: 1
     - type: SquadArmorWearer
     - type: JobPrefix
       prefix: rmc-job-prefix-pmc-standard
     - type: MarineOrders
     - type: RMCPointing
     - type: RMCTrackable
+    - type: DemoSpecWhitelist
+    - type: GrenadeSpecWhitelist
+    - type: ScoutWhitelist
+    - type: SniperWhitelist
+    - type: PyroWhitelist
   hidden: true
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/PMC/support_gunner.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/PMC/support_gunner.yml
@@ -32,9 +32,15 @@
         RMCSkillEndurance: 1
         RMCSkillJtac: 1
         RMCSkillPilot: 1
+        RMCSkillPowerLoader: 1
     - type: SquadArmorWearer
     - type: JobPrefix
       prefix: rmc-job-prefix-pmc-gunner
+    - type: DemoSpecWhitelist
+    - type: GrenadeSpecWhitelist
+    - type: ScoutWhitelist
+    - type: SniperWhitelist
+    - type: PyroWhitelist
   hidden: true
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/PMC/team_lead.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/PMC/team_lead.yml
@@ -33,12 +33,19 @@
         RMCSkillMedical: 1
         RMCSkillJtac: 1
         RMCSkillPilot: 1
+        RMCSkillPowerLoader: 1
+        RMCSkillSmartGun: 1
     - type: SquadArmorWearer
     - type: JobPrefix
       prefix: rmc-job-prefix-pmc-standard
     - type: MarineOrders
     - type: RMCPointing
     - type: RMCTrackable
+    - type: DemoSpecWhitelist
+    - type: GrenadeSpecWhitelist
+    - type: ScoutWhitelist
+    - type: SniperWhitelist
+    - type: PyroWhitelist
   hidden: true
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/SPPoverwatch.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/SPPoverwatch.yml
@@ -35,12 +35,19 @@
         RMCSkillJtac: 4
         RMCSkillExecution: 1
         RMCSkillPilot: 1
+        RMCSkillPowerLoader: 1
+        RMCSkillSmartGun: 1
     - type: SquadArmorWearer
     - type: JobPrefix
       prefix: rmc-job-prefix-spp-overwatch
     - type: MarineOrders
     - type: RMCPointing
     - type: RMCTrackable
+    - type: DemoSpecWhitelist
+    - type: GrenadeSpecWhitelist
+    - type: ScoutWhitelist
+    - type: SniperWhitelist
+    - type: PyroWhitelist
   hidden: true
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/corpsman.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/corpsman.yml
@@ -30,9 +30,16 @@
         RMCSkillSurgery: 1
         RMCSkillEndurance: 1
         RMCSkillPilot: 1
+        RMCSkillPowerLoader: 1
+        RMCSkillSmartGun: 1
     - type: SquadArmorWearer
     - type: JobPrefix
       prefix: rmc-job-prefix-spp-corpsman
+    - type: DemoSpecWhitelist
+    - type: GrenadeSpecWhitelist
+    - type: ScoutWhitelist
+    - type: SniperWhitelist
+    - type: PyroWhitelist
   hidden: true
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/heavy_gunner.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/heavy_gunner.yml
@@ -30,9 +30,15 @@
         RMCSkillEndurance: 1
         RMCSkillJtac: 1
         RMCSkillPilot: 1
+        RMCSkillPowerLoader: 1
     - type: SquadArmorWearer
     - type: JobPrefix
       prefix: rmc-job-prefix-spp-gunner
+    - type: DemoSpecWhitelist
+    - type: GrenadeSpecWhitelist
+    - type: ScoutWhitelist
+    - type: SniperWhitelist
+    - type: PyroWhitelist
   hidden: true
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/rifleman.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/rifleman.yml
@@ -28,9 +28,16 @@
         RMCSkillEngineer: 2
         RMCSkillEndurance: 1
         RMCSkillPilot: 1
+        RMCSkillPowerLoader: 1
+        RMCSkillSmartGun: 1
     - type: SquadArmorWearer
     - type: JobPrefix
       prefix: rmc-job-prefix-spp-rifleman-pve
+    - type: DemoSpecWhitelist
+    - type: GrenadeSpecWhitelist
+    - type: ScoutWhitelist
+    - type: SniperWhitelist
+    - type: PyroWhitelist
   hidden: true
 
 

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/section_lead.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/section_lead.yml
@@ -33,12 +33,19 @@
         RMCSkillSurgery: 1
         RMCSkillJtac: 1
         RMCSkillPilot: 1
+        RMCSkillPowerLoader: 1
+        RMCSkillSmartGun: 1
     - type: SquadArmorWearer
     - type: JobPrefix
       prefix: rmc-job-prefix-spp-sectionsergeant
     - type: MarineOrders
     - type: RMCPointing
     - type: RMCTrackable
+    - type: DemoSpecWhitelist
+    - type: GrenadeSpecWhitelist
+    - type: ScoutWhitelist
+    - type: SniperWhitelist
+    - type: PyroWhitelist
   hidden: true
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/squad_lead.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/squad_lead.yml
@@ -32,12 +32,19 @@
         RMCSkillMedical: 1
         RMCSkillJtac: 1
         RMCSkillPilot: 1
+        RMCSkillPowerLoader: 1
+        RMCSkillSmartGun: 1
     - type: SquadArmorWearer
     - type: JobPrefix
       prefix: rmc-job-prefix-spp-squadlead
     - type: MarineOrders
     - type: RMCPointing
     - type: RMCTrackable
+    - type: DemoSpecWhitelist
+    - type: GrenadeSpecWhitelist
+    - type: ScoutWhitelist
+    - type: SniperWhitelist
+    - type: PyroWhitelist
   hidden: true
 
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
gave the pmc and spp roles the abillity to use powerloaders, smartguns, and the special weapons.

## Why / Balance
parity with cm13 pve godo, but the important bit is that no spp or pmc pve roles had powerloader skill before, and as for the smartgun and special weapons skills, special weapon whitelist shit makes it easier to give out special weapon kits for whenever gms want to use them, and smartgun skill is to keep spp and pmcs somewhat on par with the garrow marines.

## Technical details
handful of yaml

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Shromply
- tweak: Gave the SPP and PMC PVE roles powerloader skill.
- tweak: Gave the SPP and PMC PVE roles smartgun skill.
- tweak: Gave the SPP and PMC PVE roles the abillity to use special weapons.
