### PR TITLE
Add X17 riot charge

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Explosives/breaching_charge.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Explosives/breaching_charge.yml
@@ -58,6 +58,20 @@
     - state: icon
       map: ["base"]
   # TODO Shrapnel volume 20
+  - type: RequiresSkill
+    skills:
+      RMCSkillPolice: 1
+
+# TSEPA variant
+- type: entity
+  parent: RMCExplosiveBreachingChargeRubber
+  id: RMCExplosiveBreachingChargeRubberTSEPA
+  name: TSEPA X17 riot charge
+  components:
+  - type: RequiresSkill
+    skills:
+      RMCSkillPolice: 0
+      RMCSkillEngineer: 1
 
 - type: entity
   parent: RMCExplosiveBreachingCharge

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/vending_machines.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/vending_machines.yml
@@ -480,7 +480,7 @@
     RMCMagazineRifleM54CRubber: 40
     RMCMagazineRifleM4SPRRubber: 40
     CMArmorHelmetM10MP: 8
-    RMCExplosiveBreachingCharge: 6 #Replace with Riot Breaching Charges
+    RMCExplosiveBreachingChargeRubber: 6 #Replace with Riot Breaching Charges
     RMCSunglasses: 2 #Contraband - inherited from SecTech
     RMCBoxDonut: 2 #Contraband
 

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Hybrisa_Prospera/tsepa_constable.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Hybrisa_Prospera/tsepa_constable.yml
@@ -69,7 +69,7 @@
     randomOutfits:
     - [ RMCHeadCapTSEPAPeaked, RMCCoatTSEPA, RMCPouchMagazineFilledMP5, WeaponSMGMP5 ]
     - [ RMCHeadCapTSEPAPeaked, RMCCoatTSEPAFormal, RMCPouchMagazineFilledMP5, WeaponSMGMP5 ]
-    - [ RMCHeadCapTSEPAPeaked, RMCArmorVestTSEPA, RMCPouchShotgunFilledConstable, RMCWeaponShotgunHG3712, RMCExplosiveBreachingChargeRubber ]
+    - [ RMCHeadCapTSEPAPeaked, RMCArmorVestTSEPA, RMCPouchShotgunFilledConstable, RMCWeaponShotgunHG3712, RMCExplosiveBreachingChargeRubberTSEPA ]
     - [ RMCHeadCapTSEPAPeaked, RMCCoatTSEPAHighVis, RMCPouchMagazineFilledMP5, WeaponSMGMP5, RMCHandsCombat ]
     - [ RMCHeadCapTSEPAPeakedGoldSilver, RMCCoatTSEPAHighVisVest, RMCPouchShotgunFilledConstable, RMCWeaponShotgunHG3712, RMCHandsCombat ]
     - [ RMCHeadCapTSEPAPeakedGold, RMCCoatTSEPAFormal, RMCPouchShotgunFilledConstable, RMCHandsCombat ]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Replaces the explosive breaching charge (which can't be used by MPs) with the X17 riot breaching charge for parity and practical reason. Creates TSEPA variant as TSEPA survivors don't have police skills. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity and current breaching charges unusable by regular MPs

## Technical details
<!-- Summary of code changes for easier review. -->
yml

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- add: Added X17 riot breaching charges to Riot Tech.
