### PR TITLE
Defenders can tailslam while fortified again.

### DIFF
--- a/Content.Shared/_RMC14/Actions/RMCActionsSystem.cs
+++ b/Content.Shared/_RMC14/Actions/RMCActionsSystem.cs
@@ -164,8 +164,7 @@ public sealed class RMCActionsSystem : EntitySystem
         if (args.Target is not { } target)
             return;
 
-        EntityUid userUid = args.User;
-        if (!_interaction.InRangeUnobstructed(ent.Owner, target, ent.Comp.Range, predicate: entity => entity == userUid))
+        if (!_interaction.InRangeUnobstructed(args.User, target, ent.Comp.Range))
             args.Cancelled = true;
     }
 

--- a/Content.Shared/_RMC14/Actions/RMCActionsSystem.cs
+++ b/Content.Shared/_RMC14/Actions/RMCActionsSystem.cs
@@ -164,7 +164,8 @@ public sealed class RMCActionsSystem : EntitySystem
         if (args.Target is not { } target)
             return;
 
-        if (!_interaction.InRangeUnobstructed(ent.Owner, target, ent.Comp.Range))
+        EntityUid userUid = args.User;
+        if (!_interaction.InRangeUnobstructed(ent.Owner, target, ent.Comp.Range, predicate: entity => entity == userUid))
             args.Cancelled = true;
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Fixes defenders being too chunky for their own good, allowing them to tail slam while fortified again.



## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

bug fix.

## Technical details
<!-- Summary of code changes for easier review. -->

Actions that check for "InRangeUnObstructed" are no longer blocked by the user's collision.
A basic predicate was added to the function in `OnInRangeUnobstructedUseAttempt` of `RMCActionsSystem.c`
> Is user entity and obstructed? No? Obstructed. Is user entity and obstructed? Yes? Unobstructed. 



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed defenders being unable to tail slam while fortified.
