### PR TITLE
Change crosshair if underbarrel weapons are toggled

### DIFF
--- a/Content.Shared/_RMC14/CombatMode/RMCCombatModeSystem.cs
+++ b/Content.Shared/_RMC14/CombatMode/RMCCombatModeSystem.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared.Wieldable.Components;
+using Content.Shared._RMC14.Attachable.Components;
+using Content.Shared.Wieldable.Components;
 using Robust.Shared.Utility;
 
 namespace Content.Shared._RMC14.CombatMode;
@@ -7,12 +8,26 @@ public sealed class RMCCombatModeSystem : EntitySystem
 {
     public SpriteSpecifier.Rsi? GetCrosshair(Entity<WieldedCrosshairComponent?, WieldableComponent?> crosshair)
     {
+        // Require the held item to be wielded (this keeps existing behavior).
         if (!Resolve(crosshair, ref crosshair.Comp1, ref crosshair.Comp2, false))
             return null;
 
-        if (!crosshair.Comp2.Wielded)
+        if (crosshair.Comp2 is not { Wielded: true })
             return null;
 
-        return crosshair.Comp1.Rsi;
+        var heldUid = crosshair.Owner;
+
+        // Prefer the superceding attachable (e.g., the underbarrel) if present.
+        if (TryComp<AttachableHolderComponent>(heldUid, out var holder) &&
+            holder.SupercedingAttachable is { } active &&
+            TryComp<WieldedCrosshairComponent>(active, out var ubXhair) &&
+            ubXhair.Rsi is { } ubSpec)
+        {
+            // Underbarrel is active and defines a crosshair — use it.
+            return ubSpec;
+        }
+
+        // Fallback to the held item’s own crosshair (your normal rifle behavior).
+        return crosshair.Comp1?.Rsi;
     }
 }

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/under_attachments.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/under_attachments.yml
@@ -279,6 +279,10 @@
       state: flamethrower-on
   - type: AttachableVisuals
     offset: -0.125, 0.245
+  - type: WieldedCrosshair
+    rsi:
+      sprite: _RMC14/Interface/MousePointer/flamer_mouse.rsi
+      state: all
 
 - type: entity
   parent: RMCUnderAttachmentBase
@@ -358,6 +362,10 @@
       sprite: _RMC14/Objects/Weapons/Guns/Attachments/under.rsi
       state: masterkey-on
   - type: AttachableVisuals
+  - type: WieldedCrosshair
+    rsi:
+      sprite: _RMC14/Interface/MousePointer/shotgun_mouse.rsi
+      state: all
 
 - type: entity
   parent: RMCUnderAttachmentBase
@@ -423,6 +431,10 @@
   - type: SolutionTransfer
     maxTransferAmount: 60
     transferAmount: 60
+  - type: WieldedCrosshair
+    rsi:
+      sprite: _RMC14/Interface/MousePointer/shotgun_mouse.rsi
+      state: all
 
 - type: entity
   parent: [ RMCUnderAttachmentBase, RMCAttachableToggleableBase ]
@@ -509,6 +521,10 @@
     tags:
     - RMCAttachmentUnderbarrel
     - RMCAttachmentU1GrenadeLauncher
+  - type: WieldedCrosshair
+    rsi:
+      sprite: _RMC14/Interface/MousePointer/explosive_mouse.rsi
+      state: all
 
 - type: entity
   parent: RMCAttachmentU1GrenadeLauncher
@@ -548,6 +564,10 @@
     tags:
     - RMCAttachmentUnderbarrel
     - RMCAttachmentMK1GrenadeLauncher
+  - type: WieldedCrosshair
+    rsi:
+      sprite: _RMC14/Interface/MousePointer/explosive_mouse.rsi
+      state: all
 
 - type: entity
   parent: RMCAttachmentU1GrenadeLauncher
@@ -587,6 +607,10 @@
     tags:
     - RMCAttachmentUnderbarrel
     - RMCAttachmentM203GrenadeLauncher
+  - type: WieldedCrosshair
+    rsi:
+      sprite: _RMC14/Interface/MousePointer/explosive_mouse.rsi
+      state: all
 
 - type: entity
   parent: RMCUnderAttachmentBase


### PR DESCRIPTION
## About the PR
When the user activates an underbarrel weapon attachment, the crosshair switches to the appropriate type (UBS -> shotgun crosshair, etc..)

## Why / Balance
This is a nice QoL change that will help avoid confusion on what weapon you're using, and may result in less horrific friendly fire accidents when the underbarrel extinguisher is used.

## Technical details
First, I added a WieldedCrosshair component to the UBS, the 3 UGs, the UBE, and the UBF pointing to the existing crosshairs. Any other attachment will be unaffected.
Next, I changed the GetCrosshair() function in RMCCombatModeSystem.cs to check for a superceding underbarrel attachment kind of how it was done in SharedGunSystem. 

## Media

https://github.com/user-attachments/assets/f3b05108-3674-4da2-9f43-7df5c41e9526

I will say it'd be nice to have an extinguisher cursor but making a new one with a license is a job for someone else.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- tweak: Crosshairs will now change when using the underbarrel flamer, shotgun, and grenade launcher(z). 


