### PR TITLE
Fireteam Radio prefix + Automatic tracker change on fireteam assignment

### DIFF
--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -6,6 +6,7 @@ using Content.Server.Radio.Components;
 using Content.Shared._RMC14.Chat;
 using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.Marines.Squads;
+using Content.Shared._RMC14.Tracker.SquadLeader;
 using Content.Shared._RMC14.Radio;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared.Chat;
@@ -115,6 +116,10 @@ public sealed class RadioSystem : EntitySystem
             }
             else
             {
+                if (TryComp(messageSource, out FireteamMemberComponent? fireteamMember) && fireteamMember.Fireteam >= 0)
+                {
+                    prefixText += $" FT-{fireteamMember.Fireteam + 1}" + (TryComp(messageSource, out FireteamLeaderComponent? fireteamLeader) ? "L" : "");
+                }
                 name = $"({prefixText}) {name}";
             }
         }

--- a/Content.Shared/_RMC14/Tracker/SquadLeader/SquadLeaderTrackerSystem.cs
+++ b/Content.Shared/_RMC14/Tracker/SquadLeader/SquadLeaderTrackerSystem.cs
@@ -415,6 +415,22 @@ public sealed class SquadLeaderTrackerSystem : EntitySystem
 
             if (_fireteamLeaderQuery.HasComp(member))
                 fireteam.Leader = marine;
+
+            if (_squadLeaderTrackerQuery.TryComp(member, out var tempTracker))
+            {
+                if (fireteam.Leader != null)
+                {
+                    if (TryGetEntity(fireteam?.Leader?.Id, out var fireteamLeaderUid))
+                    {
+                        if (fireteamLeaderUid != member)
+                        {
+                            ProtoId<TrackerModePrototype> mode = "FireteamLeader";
+                            SetTarget((member, tempTracker), fireteamLeaderUid);
+                            SetMode((member, tempTracker), mode);
+                        }
+                    }
+                }
+            }
         }
         else
         {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Marines, in squad comms, will include their fireteam and if they're a leader or not (L).

Marines assigned to a fireteam with an FTL (not the role) in said fireteam will have their tracker set to that FTL (again, not the role).



## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

parity + feature request [link to forum](url)

> Automatic FTL change isn't parity but it's also a huge QoL.

## Technical details
<!-- Summary of code changes for easier review. -->

`SendRadioMessage` now checks if the message source has `FireteamMemberComponent` @ `Content.Server/Radio/EntitySystems/RadioSystem.cs`

`AddFireteamMember` now updates the marine's tracker using a hardcoded "FireteamLeader" protoId as the trackermode. It checks the networked entity to make sure things are accurate. Things don't desync :) @ `Content.Shared/_RMC14/Tracker/SquadLeader/SquadLeaderTrackerSystem.cs`


## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="525" height="177" alt="image" src="https://github.com/user-attachments/assets/f8b4c3e2-3ccd-44bc-ae53-d89251017269" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Spaghetti
- add: Added fireteam prefixes to squad comms.
- tweak: Marines assigned to fireteams with an already existing FTL will have their tracker set to the FTL.
