### PR TITLE
Fixes warriors being able to heal while on fire from lifesteal.

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/XenoHealAttemptEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/XenoHealAttemptEvent.cs
@@ -1,4 +1,4 @@
 ﻿namespace Content.Shared._RMC14.Xenonids;
 
 [ByRefEvent]
-public readonly record struct XenoHealAttemptEvent(bool Cancelled = false);
+public record struct XenoHealAttemptEvent(bool Cancelled = false);

--- a/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
@@ -122,6 +122,7 @@ public sealed partial class XenoSystem : EntitySystem
         SubscribeLocalEvent<XenoComponent, GetDefaultRadioChannelEvent>(OnXenoGetDefaultRadioChannel);
         SubscribeLocalEvent<XenoComponent, AttackAttemptEvent>(OnXenoAttackAttempt);
         SubscribeLocalEvent<XenoComponent, MeleeAttackAttemptEvent>(OnXenoMeleeAttackAttempt);
+        SubscribeLocalEvent<XenoComponent, XenoHealAttemptEvent>(OnHealAttempt);
         SubscribeLocalEvent<XenoComponent, UserOpenActivatableUIAttemptEvent>(OnXenoOpenActivatableUIAttempt);
         SubscribeLocalEvent<XenoComponent, GetMeleeDamageEvent>(OnXenoGetMeleeDamage);
         SubscribeLocalEvent<XenoComponent, DamageModifyEvent>(OnXenoDamageModify);
@@ -245,6 +246,12 @@ public sealed partial class XenoSystem : EntitySystem
                 args.Attack = new DisarmAttackEvent(args.Target, disarm.Coordinates);
                 break;
         }
+    }
+
+    private void OnHealAttempt(Entity<XenoComponent> ent, ref XenoHealAttemptEvent args)
+    {
+        if (_rmcFlammable.IsOnFire(ent.Owner))
+            args.Cancelled = true;
     }
 
     private void OnXenoOpenActivatableUIAttempt(Entity<XenoComponent> ent, ref UserOpenActivatableUIAttemptEvent args)
@@ -482,7 +489,7 @@ public sealed partial class XenoSystem : EntitySystem
     public int GetGroundXenosAlive()
     {
         var count = 0;
-        var xenos = EntityQueryEnumerator<ActorComponent, XenoComponent, MobStateComponent,  TransformComponent>();
+        var xenos = EntityQueryEnumerator<ActorComponent, XenoComponent, MobStateComponent, TransformComponent>();
         while (xenos.MoveNext(out _, out _, out var mobState, out var xform))
         {
             if (mobState.CurrentState == MobState.Dead)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Fixes warrior being able to heal through lifesteal whilst on fire.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

bug fix

## Technical details
<!-- Summary of code changes for easier review. -->

`XenoHealAttemptEvent` was raised in `CanHeal` but never watched/caught. `XenoSystem` now watches those events.
`XenoHealAttemptEvent` was previously set to readonly for something that should be cancelable, this was fixed. It can now be cancelled.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Spaghetti
- fix: Fixed warriors being able to heal through lifesteal while on fire.
