### PR TITLE
Prevent pylon duplication

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Construction/ReplaceWeedSourceOnWeedingComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/ReplaceWeedSourceOnWeedingComponent.cs
@@ -24,4 +24,6 @@ public sealed partial class ReplaceWeedSourceOnWeedingComponent : Component
     /// </summary>
     [DataField]
     public Dictionary<EntProtoId, EntProtoId> ReplacementPairs;
+
+    public bool HasReplaced = false;
 }

--- a/Content.Shared/_RMC14/Xenonids/Weeds/SharedXenoWeedsSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Weeds/SharedXenoWeedsSystem.cs
@@ -481,7 +481,8 @@ public abstract class SharedXenoWeedsSystem : EntitySystem
         if (!TryComp(ent, out XenoWeedsComponent? weedComp) ||
             Prototype(weededEntity) is not { } weededEntityProto ||
             !comp.ReplacementPairs.TryGetValue(weededEntityProto.ID, out var replacementId) ||
-            TerminatingOrDeleted(weedSource))
+            TerminatingOrDeleted(weedSource) ||
+            comp.HasReplaced)
         {
             return;
         }
@@ -505,6 +506,7 @@ public abstract class SharedXenoWeedsSystem : EntitySystem
         }
         curWeeds.Clear();
         RemComp<XenoWeedsSpreadingComponent>(newWeedSource);
+        comp.HasReplaced = true;
         QueueDel(ent);
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Hive clusters don't turned into 2 pylons during weeding of a comms tower

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
So little code is changed that I believe media is unnecessary
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: blueDev2
- fix: Hive clusters turn into only 1 pylon on weeding of the comms tower