### PR TITLE
Xeno drags no longer get stopped by being disarmed or tackled.

### DIFF
--- a/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
+++ b/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
@@ -9,6 +9,7 @@ using Content.Shared.Interaction;
 using Content.Shared.Interaction.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.MouseRotator;
+using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Events;
@@ -66,7 +67,7 @@ public sealed class RMCPullingSystem : EntitySystem
         SubscribeLocalEvent<InfectOnPullAttemptComponent, PullAttemptEvent>(OnInfectOnPullAttempt);
         SubscribeLocalEvent<MeleeWeaponComponent, PullAttemptEvent>(OnMeleePullAttempt);
 
-        SubscribeLocalEvent<XenoComponent, DisarmedEvent>(OnDisarmed);
+        SubscribeLocalEvent<XenoComponent, DisarmedEvent>(OnDisarmed, before: new[] { typeof(SharedHandsSystem) });
 
         SubscribeLocalEvent<SlowOnPullComponent, PullStartedMessage>(OnSlowPullStarted);
         SubscribeLocalEvent<SlowOnPullComponent, PullStoppedMessage>(OnSlowPullStopped);

--- a/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
+++ b/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared._RMC14.Fireman;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared._RMC14.Xenonids.Parasite;
 using Content.Shared.ActionBlocker;
+using Content.Shared.CombatMode;
 using Content.Shared.Coordinates;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Components;
@@ -64,6 +65,8 @@ public sealed class RMCPullingSystem : EntitySystem
         SubscribeLocalEvent<ParalyzeOnPullAttemptComponent, PullAttemptEvent>(OnParalyzeOnPullAttempt);
         SubscribeLocalEvent<InfectOnPullAttemptComponent, PullAttemptEvent>(OnInfectOnPullAttempt);
         SubscribeLocalEvent<MeleeWeaponComponent, PullAttemptEvent>(OnMeleePullAttempt);
+
+        SubscribeLocalEvent<XenoComponent, DisarmedEvent>(OnDisarmed);
 
         SubscribeLocalEvent<SlowOnPullComponent, PullStartedMessage>(OnSlowPullStarted);
         SubscribeLocalEvent<SlowOnPullComponent, PullStoppedMessage>(OnSlowPullStopped);
@@ -247,6 +250,13 @@ public sealed class RMCPullingSystem : EntitySystem
 
         if (ent.Comp.NextAttack > _timing.CurTime)
             args.Cancelled = true;
+    }
+
+    private void OnDisarmed(Entity<XenoComponent> ent, ref DisarmedEvent args)
+    {
+        if (TryComp(args.Target, out XenoComponent? xeno))
+            args.PopupPrefix = "disarm-action-shove-";
+            args.Handled = true;
     }
 
     private void OnXenoPullToggle(Entity<XenoComponent> ent, ref RMCPullToggleEvent args)

--- a/Content.Shared/_RMC14/Tackle/TackleSystem.cs
+++ b/Content.Shared/_RMC14/Tackle/TackleSystem.cs
@@ -1,6 +1,7 @@
 using Content.Shared._RMC14.Hands;
 using Content.Shared._RMC14.Marines.Skills;
 using Content.Shared._RMC14.Pulling;
+using Content.Shared._RMC14.Xenonids;
 using Content.Shared._RMC14.Xenonids.Parasite;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Buckle.Components;
@@ -144,8 +145,11 @@ public sealed class TackleSystem : EntitySystem
 
         DoDisarmEffects(user, target);
 
-        if (_net.IsClient)
+        if (!TryComp(target, out XenoComponent? xeno))
             return;
+
+        if (_net.IsClient)
+                return;
 
         var doPopups = true;
 

--- a/Content.Shared/_RMC14/Tackle/TackleSystem.cs
+++ b/Content.Shared/_RMC14/Tackle/TackleSystem.cs
@@ -145,7 +145,7 @@ public sealed class TackleSystem : EntitySystem
         DoDisarmEffects(user, target);
 
         if (_net.IsClient)
-                return;
+            return;
 
         var doPopups = true;
 

--- a/Content.Shared/_RMC14/Tackle/TackleSystem.cs
+++ b/Content.Shared/_RMC14/Tackle/TackleSystem.cs
@@ -1,7 +1,6 @@
 using Content.Shared._RMC14.Hands;
 using Content.Shared._RMC14.Marines.Skills;
 using Content.Shared._RMC14.Pulling;
-using Content.Shared._RMC14.Xenonids;
 using Content.Shared._RMC14.Xenonids.Parasite;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Buckle.Components;
@@ -144,9 +143,6 @@ public sealed class TackleSystem : EntitySystem
         args.Handled = true;
 
         DoDisarmEffects(user, target);
-
-        if (!TryComp(target, out XenoComponent? xeno))
-            return;
 
         if (_net.IsClient)
                 return;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Fixes https://github.com/RMC-14/RMC-14/issues/7769

Leadered xenos still bully non-leadered xenos, still have the same affect as before; knock them down, stun for a short time... which makes the non-leadered xeno lose their pull.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

bug fig

## Technical details
<!-- Summary of code changes for easier review. -->

`RMCPullingSystem` watches for the `DisarmedEvent` and handles it without doing anything else if the target has the `XenoComponent`

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Spaghetti
- fix: Xenos no longer lose their drag/pull when disarmed/tackled by others.

