### PR TITLE
Mou53 breech toggling delay parity

### DIFF
--- a/Content.Shared/_RMC14/Weapons/Ranged/BreechLoadedComponent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/BreechLoadedComponent.cs
@@ -1,10 +1,12 @@
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared._RMC14.Weapons.Ranged;
 
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
 [Access(typeof(BreechLoadedSystem))]
 public sealed partial class BreechLoadedComponent : Component
 {
@@ -28,6 +30,12 @@ public sealed partial class BreechLoadedComponent : Component
 
     [DataField, AutoNetworkedField]
     public bool ShowBreechOpen = true;
+
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
+    public TimeSpan LastToggledAt;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan ToggleDelay = TimeSpan.FromSeconds(0);
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/_RMC14/Weapons/Ranged/BreechLoadedComponent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/BreechLoadedComponent.cs
@@ -2,11 +2,10 @@ using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared._RMC14.Weapons.Ranged;
 
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 [Access(typeof(BreechLoadedSystem))]
 public sealed partial class BreechLoadedComponent : Component
 {
@@ -31,8 +30,8 @@ public sealed partial class BreechLoadedComponent : Component
     [DataField, AutoNetworkedField]
     public bool ShowBreechOpen = true;
 
-    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
-    public TimeSpan LastToggledAt;
+    [DataField, AutoNetworkedField]
+    public string DelayId = "breech-toggle-delay";
 
     [DataField, AutoNetworkedField]
     public TimeSpan ToggleDelay = TimeSpan.FromSeconds(0);

--- a/Content.Shared/_RMC14/Weapons/Ranged/BreechLoadedSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/BreechLoadedSystem.cs
@@ -77,7 +77,7 @@ public sealed class BreechLoadedSystem : EntitySystem
             return;
         }
 
-        gun.Comp.LastToggledAt = _timing.CurTime;
+        gun.Comp.LastToggledAt = time;
         gun.Comp.Open = !gun.Comp.Open;
 
         if (!gun.Comp.Open)

--- a/Content.Shared/_RMC14/Weapons/Ranged/BreechLoadedSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/BreechLoadedSystem.cs
@@ -68,18 +68,12 @@ public sealed class BreechLoadedSystem : EntitySystem
 
         args.Handled = true;
 
-        if (TryComp<UseDelayComponent>(gun, out var useDelay))
+        if (TryComp<UseDelayComponent>(gun, out var useDelay) && _useDelay.IsDelayed((gun, useDelay), gun.Comp.DelayId))
         {
-            if (_useDelay.IsDelayed((gun, useDelay)))
-            {
-                var actionLocale = gun.Comp.Open ? Loc.GetString("rmc-breech-loaded-close") : Loc.GetString("rmc-breech-loaded-open");
-                var popup = Loc.GetString("rmc-breech-loaded-toggle-attempt-cooldown", ("action", actionLocale));
-                _popupSystem.PopupClient(popup, args.UserUid, args.UserUid, PopupType.Small);
-                return;
-            }
-
-            _useDelay.SetLength((gun, useDelay), gun.Comp.ToggleDelay, gun.Comp.DelayId);
-            _useDelay.TryResetDelay((gun, useDelay), id: gun.Comp.DelayId);
+            var actionLocale = gun.Comp.Open ? Loc.GetString("rmc-breech-loaded-close") : Loc.GetString("rmc-breech-loaded-open");
+            var popup = Loc.GetString("rmc-breech-loaded-toggle-attempt-cooldown", ("action", actionLocale));
+            _popupSystem.PopupClient(popup, args.UserUid, args.UserUid, PopupType.Small);
+            return;
         }
 
         gun.Comp.Open = !gun.Comp.Open;
@@ -89,6 +83,12 @@ public sealed class BreechLoadedSystem : EntitySystem
 
         if (gun.Comp.ShowBreechOpen && TryComp(gun.Owner, out AppearanceComponent? appearanceComponent))
             _appearanceSystem.SetData(gun, BreechVisuals.Open, gun.Comp.Open, appearanceComponent);
+
+        if (useDelay != null)
+        {
+            _useDelay.SetLength((gun, useDelay), gun.Comp.ToggleDelay, gun.Comp.DelayId);
+            _useDelay.TryResetDelay((gun, useDelay), id: gun.Comp.DelayId);
+        }
 
         Dirty(gun);
         var sound = gun.Comp.Open ? gun.Comp.OpenSound : gun.Comp.CloseSound;

--- a/Resources/Locale/en-US/_RMC14/weapons/guns.ftl
+++ b/Resources/Locale/en-US/_RMC14/weapons/guns.ftl
@@ -9,6 +9,9 @@ rmc-breech-loaded-open-shoot-attempt = You need to close the breech first!
 rmc-breech-loaded-not-ready-to-shoot = You need to open and close the breech first!
 rmc-breech-loaded-closed-load-attempt = You need to open the breech first!
 rmc-breech-loaded-closed-extract-attempt = You need to open the breech first!
+rmc-breech-loaded-toggle-attempt-cooldown = You must wait before {$action} the chamber again!
+rmc-breech-loaded-open = opening
+rmc-breech-loaded-close = closing
 
 rmc-wield-use-delay = You need to wait {$seconds} seconds before wielding {THE($wieldable)}!
 rmc-shoot-use-delay = You need to wait {$seconds} seconds before shooting {THE($wieldable)}!

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/mou53_shotgun.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/mou53_shotgun.yml
@@ -45,6 +45,7 @@
     containerID: ballistic-ammo
     ejectSound:
       path: /Audio/_RMC14/Weapons/Guns/Reload/gun_mou_reload.ogg
+  - type: UseDelay
   - type: BreechLoaded
     openSound:
       path: /Audio/_RMC14/Weapons/Guns/Breech/pkd_open_chamber.ogg

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/mou53_shotgun.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/mou53_shotgun.yml
@@ -50,6 +50,7 @@
       path: /Audio/_RMC14/Weapons/Guns/Breech/pkd_open_chamber.ogg
     closeSound:
       path: /Audio/_RMC14/Weapons/Guns/Breech/pkd_close_chamber.ogg
+    toggleDelay: 1.1
   - type: AttachableHolder
     slots:
       rmc-aslot-barrel:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds a breech toggling cooldown of 1.1 seconds for the mou53

## Why / Balance
parity... https://github.com/cmss13-devs/cmss13/pull/10411
before this change you could reload nearly instantly by using in game methods to bind several inputs to a single button, which players have admitted to doing and makes the gun overly effective

## Technical details
Adds an optional breech toggling delay to guns

## Media
https://github.com/user-attachments/assets/d33d4651-1d07-4cef-90f1-2727c47afbef



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: shibechef
- tweak: The mou53 has a delay of 1.1 seconds for toggling it's breech.
