### PR TITLE
some id console related fixes

### DIFF
--- a/Content.Server/_RMC14/Ghost/GhostRoleApplySpecialSystem.cs
+++ b/Content.Server/_RMC14/Ghost/GhostRoleApplySpecialSystem.cs
@@ -49,6 +49,7 @@ public sealed partial class GhostRoleApplySpecialSystem : EntitySystem
                 if (TryComp<IdCardComponent>(item, out var card))
                 {
                     card.FullName = metaData.EntityName;
+                    card.OriginalOwner = ent.Owner;
                     _meta.SetEntityName(item, $"{metaData.EntityName} ({job.LocalizedName})");
                 }
             }

--- a/Content.Shared/_RMC14/Marines/Access/IdModificationConsoleSystem.cs
+++ b/Content.Shared/_RMC14/Marines/Access/IdModificationConsoleSystem.cs
@@ -1,5 +1,6 @@
 using System.Collections.Frozen;
 using Content.Shared._RMC14.Marines.Roles.Ranks;
+using Content.Shared._RMC14.Marines.Squads;
 using Content.Shared._RMC14.Weapons.Ranged.IFF;
 using Content.Shared.Access;
 using Content.Shared.Access.Components;
@@ -25,6 +26,7 @@ public sealed class IdModificationConsoleSystem : EntitySystem
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly SharedRankSystem _rank = default!;
     [Dependency] private readonly ISerializationManager _serialization = default!;
+    [Dependency] private readonly SquadSystem _squad = default!;
 
     private FrozenDictionary<string, AccessGroupPrototype> _accessGroup =
         FrozenDictionary<string, AccessGroupPrototype>.Empty;
@@ -77,6 +79,13 @@ public sealed class IdModificationConsoleSystem : EntitySystem
             access.Tags.Add(tag);
         }
 
+        if (accessGroupPrototype.Name is { } accessName && TryComp(uid, out IdCardComponent? idCard))
+        {
+            idCard._jobTitle = accessName;
+            Dirty(uid.Value, idCard);
+            _metaData.SetEntityName(uid.Value, $"{idCard.FullName} ({accessName})");
+        }
+
         _adminLogger.Add(LogType.RMCIdModify,
             LogImpact.Low,
             $"{ToPrettyString(args.Actor):player} has changed the accesses of {ToPrettyString(uid):entity} to {accessGroupPrototype.Name}");
@@ -106,10 +115,12 @@ public sealed class IdModificationConsoleSystem : EntitySystem
         }
 
         idCard._jobTitle = "Civilian";
+        Dirty(uid.Value, idCard);
         if (idCard.OriginalOwner != null)
         {
             _rank.SetRank(idCard.OriginalOwner.Value, "RMCRankCivilian");
-            _metaData.SetEntityName(uid.Value, $"{MetaData(idCard.OriginalOwner.Value).EntityName} (Civilian)");
+            _squad.RemoveSquad(idCard.OriginalOwner.Value, null);
+            _metaData.SetEntityName(uid.Value, $"{MetaData(idCard.OriginalOwner.Value).EntityName} ({idCard._jobTitle})");
         }
 
         _adminLogger.Add(LogType.RMCIdModify,


### PR DESCRIPTION
## About the PR

This PR fixes and tweaks some thing related to the new ID computer.

## Why / Balance

Mostly fixes and stuff that makes sense in my view.

## Technical details

- Method to just remove the assigned squad.
- Sync fireteams when removing.

## Media


https://github.com/user-attachments/assets/f82ee974-72d5-41c6-b641-7e5126690063


https://github.com/user-attachments/assets/23e2270c-faad-45f6-abf9-abd7cdff5c85



## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- tweak: Changing the job now also changes the title on the ID.
- fix: The ID of ghost roles are now linked to their original owner.
- fix: ID termination now also removes the target from the squad.
