### PR TITLE
Lizard Emotes Tweaks

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/reptilian.yml
@@ -18,7 +18,7 @@
   - type: Speech
     speechSounds: Lizard
     speechVerb: Reptilian
-    allowedEmotes: ['Thump', 'Hiss', 'Purr', 'RMCReptileRattle']
+    allowedEmotes: ['Thump', 'Hiss', 'Growl']
   - type: BodyEmotes
     soundsId: RMCReptilianBodyEmotes
   - type: TypingIndicator

--- a/Resources/Prototypes/_RMC14/SoundCollections/reptile.yml
+++ b/Resources/Prototypes/_RMC14/SoundCollections/reptile.yml
@@ -1,9 +1,6 @@
 - type: soundCollection
   id: RMCReptilianScreams
   files:
-  - /Audio/_RMC14/Voice/Reptilian/lizard_scream_1.ogg
-  - /Audio/_RMC14/Voice/Reptilian/lizard_scream_2.ogg
-  - /Audio/_RMC14/Voice/Reptilian/lizard_scream_3.ogg
   - /Audio/Voice/Reptilian/reptilian_scream.ogg
 
 - type: soundCollection

--- a/Resources/Prototypes/_RMC14/Voice/Reptilian/reptilian_emote_sounds.yml
+++ b/Resources/Prototypes/_RMC14/Voice/Reptilian/reptilian_emote_sounds.yml
@@ -13,7 +13,7 @@
       collection: RMCReptilianHisses
       params:
         variation: 0.125
-    Purr:
+    Growl:
       path: /Audio/_RMC14/Voice/Reptilian/lizard_purr.ogg
       params:
         variation: 0.125


### PR DESCRIPTION
Disables a couple of sounds and uses a more fitting emote icon on the wheel.

## About the PR
Default Lizard scream is back (ported sounds are still in files, just disabled via code pending reassignment)
Disabled Tail Rattle for now as current selection of lizard tails cannot feasibly make that sound.
Parented new Lizard Purr so it shows up as Growl on the emote wheel. The growl is soul.
New Hiss emote left as is because it just works.

## Technical details
<!-- Summary of code changes for easier review. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: Sounds of Lizards, they can now Growl & Hiss.

