### PR TITLE
Acid blood fix

### DIFF
--- a/Content.Server/_RMC14/Xenonids/AcidBloodSplash/AcidBloodSplashSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/AcidBloodSplash/AcidBloodSplashSystem.cs
@@ -86,8 +86,8 @@ public sealed class AcidBloodSplashSystem : EntitySystem
             if (_random.NextFloat() > hitProbability)
                 continue;
 
-            _damageable.TryChangeDamage(target, _xeno.TryApplyXenoAcidDamageMultiplier(target, comp.Damage), origin: uid, tool: uid);
             comp.NextSplashAvailable = _timing.CurTime + comp.SplashCooldown;
+            _damageable.TryChangeDamage(target, _xeno.TryApplyXenoAcidDamageMultiplier(target, comp.Damage));
             i++;
 
             _audio.PlayPvs(comp.AcidSplashSound, target);

--- a/Content.Server/_RMC14/Xenonids/AcidBloodSplash/AcidBloodSplashSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/AcidBloodSplash/AcidBloodSplashSystem.cs
@@ -86,7 +86,7 @@ public sealed class AcidBloodSplashSystem : EntitySystem
             if (_random.NextFloat() > hitProbability)
                 continue;
 
-            var damage = _damageable.TryChangeDamage(target, _xeno.TryApplyXenoSlashDamageMultiplier(target, comp.Damage), origin: uid, tool: uid);
+            _damageable.TryChangeDamage(target, comp.Damage, origin: uid, tool: uid);
             comp.NextSplashAvailable = _timing.CurTime + comp.SplashCooldown;
             i++;
 

--- a/Content.Server/_RMC14/Xenonids/AcidBloodSplash/AcidBloodSplashSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/AcidBloodSplash/AcidBloodSplashSystem.cs
@@ -86,7 +86,7 @@ public sealed class AcidBloodSplashSystem : EntitySystem
             if (_random.NextFloat() > hitProbability)
                 continue;
 
-            _damageable.TryChangeDamage(target, comp.Damage, origin: uid, tool: uid);
+            _damageable.TryChangeDamage(target, _xeno.TryApplyXenoAcidDamageMultiplier(target, comp.Damage), origin: uid, tool: uid);
             comp.NextSplashAvailable = _timing.CurTime + comp.SplashCooldown;
             i++;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed stack overflow and wrong multiplier for damage xeno vs xeno

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed stack overflow when two hiveless xeno damage each other with acid blood
- fix: Fixed wrong damage multiplier for acid blood splash in case xeno vs xeno
