### PR TITLE
Update m1984_pistol.yml

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/m1984_pistol.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/m1984_pistol.yml
@@ -199,7 +199,7 @@
     proto: RMCBulletPistol9mmHP
 
 - type: entity
-  parent: CMBulletPistol9mm
+  parent: CMBulletBase
   id: RMCBulletPistol9mmHP
   name: bullet (9mm HP)
   components:


### PR DESCRIPTION
1984 Hollow point ammunition was inheriting from the wrong source

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
9mm hollow point damage inheritance
## Why / Balance
9mm Hollowpoint for the 1984 was inheriting the Armor piercing value of standard 9mm, where it shouldn't have!

## Technical details
Parent: CMBulletPistol9mm -> CMBulletBase

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- fix: Fixed 1984 Hollowpoint AP Values