### PR TITLE
Dim flower SOF surgery

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/m1984_pistol.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/m1984_pistol.yml
@@ -199,7 +199,7 @@
     proto: RMCBulletPistol9mmHP
 
 - type: entity
-  parent: CMBulletPistol9mm
+  parent: CMBulletBase
   id: RMCBulletPistol9mmHP
   name: bullet (9mm HP)
   components:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/m1984_pistol.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/m1984_pistol.yml
@@ -199,7 +199,7 @@
     proto: RMCBulletPistol9mmHP
 
 - type: entity
-  parent: CMBulletBase
+  parent: CMBulletPistol9mm
   id: RMCBulletPistol9mmHP
   name: bullet (9mm HP)
   components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/SOF/sof_leader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/SOF/sof_leader.yml
@@ -24,6 +24,7 @@
         RMCSkillFirearms: 2
         RMCSkillLeadership: 1
         RMCSkillMedical: 2
+        RMCSkillSurgery: 1
         RMCSkillMeleeWeapons: 1
         RMCSkillEndurance: 5
         RMCSkillJtac: 1

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/SOF/sof_raider.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/SOF/sof_raider.yml
@@ -23,6 +23,7 @@
         RMCSkillConstruction: 2
         RMCSkillFirearms: 2
         RMCSkillMedical: 2
+        RMCSkillSurgery: 1
         RMCSkillMeleeWeapons: 1
         RMCSkillEndurance: 5
         RMCSkillJtac: 1


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Gives both SOF/MARSOC Jobs RMCSkillSurgery 1 to better align with other roles 

## Why / Balance
SOF Leader and SOF Raider did not have RMCSkillSurgery 1, unlike every single other job in the game that has RMCSkillMedical 2. While this allows them to do almost everything a corpsman can do, it leaves out one single bit of importance. They cannot use Bloodpacks, and do not naturally have any way of regaining blood. 

## Technical details
Added RMCSkillSurgery 1 to both SOF Leader and SOF Raider

## Media
None Used

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Added Surgery 1 to MARSOC jobs
