### PR TITLE
Admeme dropship and mortar explosions

### DIFF
--- a/Content.Shared/_RMC14/Dropship/Weapon/ActivateDropshipWeaponOnSpawnComponent.cs
+++ b/Content.Shared/_RMC14/Dropship/Weapon/ActivateDropshipWeaponOnSpawnComponent.cs
@@ -1,0 +1,6 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Dropship.Weapon;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ActivateDropshipWeaponOnSpawnComponent : Component;

--- a/Content.Shared/_RMC14/Mortar/ActivateMortarShellOnSpawnComponent.cs
+++ b/Content.Shared/_RMC14/Mortar/ActivateMortarShellOnSpawnComponent.cs
@@ -1,0 +1,6 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Mortar;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ActivateMortarShellOnSpawnComponent : Component;

--- a/Resources/Prototypes/_RMC14/Entities/Structures/explosions.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/explosions.yml
@@ -1,0 +1,273 @@
+## Mortar Shells
+
+- type: entity
+  parent: MarkerBase
+  id: RMCMortarExplosionHE
+  name: he mortar explosion
+  suffix: Fires a mortar shell!
+  placement:
+    mode: SnapgridCenter
+  components:
+  - type: Explosive
+    explosionType: RMCMortar
+    maxIntensity: 30.1 # max 150 brute, 150 burn
+    intensitySlope: 5
+    totalIntensity: 800
+    canCreateVacuum: false
+  - type: CMExplosionEffect
+  - type: RMCScorchEffect
+  - type: MortarShell
+  - type: ActivateMortarShellOnSpawn
+
+- type: entity
+  parent: MarkerBase
+  id: RMCMortarExplosionIncendiary
+  name: incendiary mortar explosion
+  suffix: Fires a mortar shell!
+  placement:
+    mode: SnapgridCenter
+  components:
+  - type: Explosive
+    explosionType: RMCMortar
+    maxIntensity: 0
+    intensitySlope: 0
+    totalIntensity: 0
+    canCreateVacuum: false
+  - type: TileFireOnTrigger
+    spawn: RMCTileFireGreen
+    range: 5
+  - type: RMCScorchEffect
+  - type: MortarShell
+  - type: ActivateMortarShellOnSpawn
+
+- type: entity
+  parent: MarkerBase
+  id: RMCMortarExplosionFlare
+  name: mortar flare/camera
+  suffix: Fires a mortar shell!
+  placement:
+    mode: SnapgridCenter
+  components:
+  - type: MortarShell
+  - type: MortarCameraShell
+  - type: ActivateMortarShellOnSpawn
+
+## Dropship Weapons
+
+- type: entity
+  parent: MarkerBase
+  id: RMCDropshipGauBurst
+  name: dropship Multi-Purpose GAU burst
+  suffix: Fires a GAU burst!
+  placement:
+    mode: SnapgridCenter
+  components:
+  - type: ActivateDropshipWeaponOnSpawn
+  - type: DropshipAmmo
+    rounds: 400
+    maxRounds: 400
+    roundsPerShot: 40
+    damage:
+      groups:
+        Brute: 105
+    armorPiercing: 10
+    weapon: RMCDropshipAttachmentGau21Cannon
+    soundCockpit: /Audio/_RMC14/Dropship/gau_incockpit.ogg
+    soundGround: /Audio/_RMC14/Dropship/gau.ogg
+    soundImpact:
+      path: /Audio/_RMC14/Dropship/gauimpact.ogg
+      params:
+        volume: -6
+    impactEffects:
+    - RMCEffectExplosionParticle
+
+- type: entity
+  parent: RMCDropshipGauBurst
+  id: RMCDropshipGauBurstAntiTank
+  name: dropship Anti-Tank GAU burst
+  suffix: Fires a GAU burst!
+  placement:
+    mode: SnapgridCenter
+  components:
+  - type: DropshipAmmo
+    bulletSpread: 4
+    damage:
+      groups:
+        Brute: 80
+    armorPiercing: 40
+    travelTime: 6
+
+- type: entity
+  parent: MarkerBase
+  id: RMCDropshipLaserFire
+  name: dropship laser
+  suffix: Fires a laser!
+  placement:
+    mode: SnapgridCenter
+  components:
+  - type: ActivateDropshipWeaponOnSpawn
+  - type: DropshipAmmo
+    rounds: 100
+    maxRounds: 100
+    roundsPerShot: 10
+    shotsPerVolley: 10
+    targetSpread: 1
+    bulletSpread: 0
+    travelTime: 1
+    weapon: RMCDropshipAttachmentLaserCannon
+    soundEveryShots: 1
+    soundCockpit: /Audio/Machines/phasein.ogg
+    soundMarker: /Audio/_RMC14/Binoculars/nightvision.ogg
+    soundImpact:
+      path: /Audio/_RMC14/Effects/laser_cannon.ogg
+      params:
+        volume: -6
+    fire:
+      type: RMCTileFireLaser
+      range: 3
+      total: 16
+
+- type: entity
+  parent: MarkerBase
+  id: RMCDropshipMissileExplosionBase
+  suffix: Fires a missle!
+  abstract: true
+  components:
+  - type: ActivateDropshipWeaponOnSpawn
+  - type: DropshipAmmo
+    rounds: 1
+    maxRounds: 1
+    roundsPerShot: 1
+    targetSpread: 3
+    bulletSpread: 0
+    travelTime: 6
+    weapon: RMCDropshipAttachmentGuidedMissileLauncher
+    soundCockpit: /Audio/_RMC14/Effects/rocketpod_fire.ogg
+    soundMarker: /Audio/_RMC14/Effects/rocketpod_fire.ogg
+
+- type: entity
+  parent: RMCDropshipMissileExplosionBase
+  id: RMCDropshipMissileExplosionWidowmaker
+  name: AIM-224B 'Widowmaker' explosion
+  components:
+  - type: DropshipAmmo
+    travelTime: 3
+    explosion:
+      total: 3000
+      slope: 5.5
+      max: 55
+
+- type: entity
+  parent: RMCDropshipMissileExplosionBase
+  id: RMCDropshipMissileExplosionKeeper
+  name: GBU-67 'Keeper II' explosion
+  components:
+  - type: DropshipAmmo
+    travelTime: 2
+    explosion:
+      total: 905
+      slope: 15
+      max: 45
+
+- type: entity
+  parent: RMCDropshipMissileExplosionBase
+  id: RMCDropshipMissileExplosionNapalm
+  name: AGM-99 'Napalm' explosion
+  components:
+  - type: DropshipAmmo
+    travelTime: 6
+    explosion:
+      total: 1780
+      slope: 7.2
+      max: 50
+    fire:
+      type: RMCTileFireNapalm
+      range: 3
+      cardinalRange: 5
+
+- type: entity
+  parent: RMCDropshipMissileExplosionBase
+  id: RMCDropshipMissileExplosionHarpoon
+  name: AGM-184 'Harpoon II' explosion
+  components:
+  - type: DropshipAmmo
+    travelTime: 5
+    explosion:
+      total: 1850
+      slope: 3.2
+      max: 32
+
+- type: entity
+  parent: RMCDropshipMissileExplosionBase
+  id: RMCDropshipMissileExplosionThermobaric
+  name: BLU-200 'Dragon's Breath' explosion
+  components:
+  - type: DropshipAmmo
+    travelTime: 5
+    implosion:
+      pullRange: 5.5
+      pullDistance: 3.5
+      pullSpeed: 15
+    fire:
+      type: RMCTileFireThermobaric
+      range: 1
+      cardinalRange: 3
+      ordinalRange: 3
+
+- type: entity
+  parent: RMCDropshipMissileExplosionBase
+  id: RMCDropshipMissileExplosionBanshee
+  name: AGM-227 'Banshee' explosion
+  components:
+  - type: DropshipAmmo
+    travelTime: 6
+    explosion:
+      total: 2000
+      slope: 5.5
+      max: 40
+    fire:
+      type: RMCTileFireBanshee
+      range: 1
+      cardinalRange: 3
+      ordinalRange: 3
+
+- type: entity
+  parent: MarkerBase
+  id: RMCDropshipMiniRocketExplosionBase
+  abstract: true
+  suffix: Fires a mini rocket!
+  components:
+  - type: ActivateDropshipWeaponOnSpawn
+  - type: DropshipAmmo
+    rounds: 6
+    maxRounds: 6
+    roundsPerShot: 1
+    bulletSpread: 0
+    travelTime: 8
+    weapon: RMCDropshipAttachmentRocketPod
+    soundCockpit: /Audio/_RMC14/Effects/rocketpod_fire.ogg
+    soundMarker: /Audio/_RMC14/Effects/rocketpod_fire.ogg
+
+- type: entity
+  parent: RMCDropshipMiniRocketExplosionBase
+  id: RMCDropshipMiniRocketExplosionMiniMike
+  name: AGR-59 'Mini-Mike' explosion
+  components:
+  - type: DropshipAmmo
+    explosion:
+      total: 850
+      slope: 8
+      max: 40
+    impactEffects:
+    - RMCEffectExplosionParticle
+    - RMCSmokeExplosionProofSmall
+
+- type: entity
+  parent: RMCDropshipMiniRocketExplosionMiniMike
+  id: RMCDropshipMiniRocketExplosionMiniMikeIncindiary
+  name: AGR-59-I 'Mini-Mike' explosion
+  components:
+  - type: DropshipAmmo
+    fire:
+      type: RMCTileFireMiniMike
+      range: 1


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
For PVE and admeme funnies.

## Technical details
<!-- Summary of code changes for easier review. -->
Components that cause dropship ammo and mortar (sep ones) to instantly fire at the location on spawn pretty much. Note I Copied over the stats instead of inheriting the shells/ammo so sprites etc doesn't show. Otherwise it just goes through most of the dropship/mortar logic

Atm mortar always hit 100% accurate while dropship stuff is still in a random range. It's easy to make the dropship stuff 100% too but wasn't sure if I should.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/47be98c1-8d4f-4ef1-b7f5-8878a4844fb0

(explosion fail cause of bug on live, they should be fixed with the live fix like the actual ammo)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
no cl just funny admeme