### PR TITLE
Cancel Pickup/Drops/Using while in a vent

### DIFF
--- a/Content.Shared/_RMC14/Vents/SharedVentCrawlingSystem.cs
+++ b/Content.Shared/_RMC14/Vents/SharedVentCrawlingSystem.cs
@@ -22,6 +22,8 @@ using Content.Shared.Actions.Events;
 using Content.Shared.Actions;
 using Content.Shared.Examine;
 using Content.Shared._RMC14.Storage.Containers;
+using Content.Shared.Hands;
+using Content.Shared.Item;
 
 namespace Content.Shared._RMC14.Vents;
 public abstract class SharedVentCrawlingSystem : EntitySystem
@@ -57,6 +59,8 @@ public abstract class SharedVentCrawlingSystem : EntitySystem
         SubscribeLocalEvent<VentCrawlingComponent, MoveInputEvent>(OnVentCrawlingInput);
         SubscribeLocalEvent<VentCrawlingComponent, ComponentInit>(OnVentCrawlingStart);
         SubscribeLocalEvent<VentCrawlingComponent, ComponentRemove>(OnVentCrawlingEnd);
+        SubscribeLocalEvent<VentCrawlingComponent, DropAttemptEvent>(OnVentCrawlingTryDrop);
+        SubscribeLocalEvent<VentCrawlingComponent, PickupAttemptEvent>(OnVentCrawlingTryPickup);
 
         SubscribeLocalEvent<RMCTrayCrawlerComponent, GetVisMaskEvent>(OnTrayGetVis);
 
@@ -313,6 +317,16 @@ public abstract class SharedVentCrawlingSystem : EntitySystem
         {
             _actions.SetEnabled(action.AsNullable(), true);
         }
+    }
+
+    private void OnVentCrawlingTryDrop(Entity<VentCrawlingComponent> ent, ref DropAttemptEvent args)
+    {
+        args.Cancel();
+    }
+
+    private void OnVentCrawlingTryPickup(Entity<VentCrawlingComponent> ent, ref PickupAttemptEvent args)
+    {
+        args.Cancel();
     }
 
     public override void Update(float frameTime)

--- a/Content.Shared/_RMC14/Vents/SharedVentCrawlingSystem.cs
+++ b/Content.Shared/_RMC14/Vents/SharedVentCrawlingSystem.cs
@@ -24,6 +24,7 @@ using Content.Shared.Examine;
 using Content.Shared._RMC14.Storage.Containers;
 using Content.Shared.Hands;
 using Content.Shared.Item;
+using Content.Shared.Interaction.Events;
 
 namespace Content.Shared._RMC14.Vents;
 public abstract class SharedVentCrawlingSystem : EntitySystem
@@ -59,8 +60,9 @@ public abstract class SharedVentCrawlingSystem : EntitySystem
         SubscribeLocalEvent<VentCrawlingComponent, MoveInputEvent>(OnVentCrawlingInput);
         SubscribeLocalEvent<VentCrawlingComponent, ComponentInit>(OnVentCrawlingStart);
         SubscribeLocalEvent<VentCrawlingComponent, ComponentRemove>(OnVentCrawlingEnd);
-        SubscribeLocalEvent<VentCrawlingComponent, DropAttemptEvent>(OnVentCrawlingTryDrop);
-        SubscribeLocalEvent<VentCrawlingComponent, PickupAttemptEvent>(OnVentCrawlingTryPickup);
+        SubscribeLocalEvent<VentCrawlingComponent, DropAttemptEvent>(OnVentCrawlingCancel);
+        SubscribeLocalEvent<VentCrawlingComponent, PickupAttemptEvent>(OnVentCrawlingCancel);
+        SubscribeLocalEvent<VentCrawlingComponent, UseAttemptEvent>(OnVentCrawlingCancel);
 
         SubscribeLocalEvent<RMCTrayCrawlerComponent, GetVisMaskEvent>(OnTrayGetVis);
 
@@ -319,12 +321,7 @@ public abstract class SharedVentCrawlingSystem : EntitySystem
         }
     }
 
-    private void OnVentCrawlingTryDrop(Entity<VentCrawlingComponent> ent, ref DropAttemptEvent args)
-    {
-        args.Cancel();
-    }
-
-    private void OnVentCrawlingTryPickup(Entity<VentCrawlingComponent> ent, ref PickupAttemptEvent args)
+    private void OnVentCrawlingCancel<T>(Entity<VentCrawlingComponent> ent, ref T args) where T : CancellableEntityEventArgs
     {
         args.Cancel();
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity.

I checked dying in a vent and...well it is parity behavior you're just stuck in there dead. But yeah. Better to not have xenos try to store stuff in there or use stuff in there (I don't think anyone's tried but still)

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
no cl kinda obscure
