### PR TITLE
PVE SGO Locker Fill Fix

### DIFF
--- a/Resources/Prototypes/_RMC14/Catalog/Fills/Lockers/marine.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Fills/Lockers/marine.yml
@@ -18,7 +18,7 @@
   id: RMCClosetGoldenArrowSGOFill
   table: !type:AllSelector
     children:
-    - id: RMCSmartGunUNMC
+    - id: RMCSmartGunPVE
     - id: RMCPowerCellSmartgun
     - id: CMArmorSmartGunCombatHarness
     - id: RMCBeltSmartGunOperatorPistolFilled


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds the PVE Smartgun to the PVE SGO Locker Fill

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
No IFF is a preferred default to IFF, Im pretty sure I gave them this before and it got replaced, regardless better for this to be the default in the locker and let GMs give them IFF smart guns if wanted.
