### PR TITLE
Made OB Console uninteractable for xenos, and added Warhead Descriptions

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/orbital_cannon.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/orbital_cannon.yml
@@ -96,7 +96,7 @@
 - type: entity
   parent: RMCOrbitalCannonWarheadBase
   id: RMCOrbitalCannonWarheadExplosive
-  description: "An orbital warhead designed to be fired from the UNMC Orbital Cannon system, after sufficient solid fuel has been inserted. This particular model is designed for use in open areas and causes a large circular explosion if it manages to reach the ground."
+  description: "An orbital warhead designed to be fired from the UNMC Orbital Cannon system, after sufficient solid fuel has been inserted. This particular model is designed for use in heavily-fortified areas, and causes a large circular explosion if it manages to reach the ground."
   name: HE orbital warhead
   components:
   - type: Sprite


### PR DESCRIPTION
## About the PR
Made xenos unable to interact with the Orbital Bombardment Console, and added some original descriptions for the 3 basic warheads, which had none. The descriptions were reviewed and approved by @t0wnshark before being comitted.

## Why / Balance
Xenos interacting with this Console is unintended behavior, and if it were intended, they'd have a different way to sabotage it rather than opening the normal window and chambering the warhead. And the warheads need descriptions both to hint at how they are meant to be used, and to not look bad when examined. Made the descriptions original because parity has none.

## Technical details
Only changes orbital_cannon.yml. Uses InteractedBlacklist for forbidding xeno interaction.

## Media
![ClusterWarheadDesc](https://github.com/user-attachments/assets/cde815b0-d1da-4b73-93b2-cc894c21e81e)
![HEWarheadDesc](https://github.com/user-attachments/assets/49d6e96a-7ca1-48c3-a48d-1e160e693cd4)
![IncendiaryWarheadDesc](https://github.com/user-attachments/assets/cdb8813e-be26-4e62-b417-9e441e6ceaa3)
All warhead descriptions, the console just doesn't open when a xeno clicks it.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Xenonids can no longer interact with the Orbital Bombardment Console.
- tweak: HE, Incendiary and Cluster Orbital Warheads now have descriptions.
