### PR TITLE
Add Shuttle Spawners for PVE Dropships

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Markers/shuttle_spawners.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Markers/shuttle_spawners.yml
@@ -1,9 +1,9 @@
 - type: entity
   parent: MarkerBase
-  id: RMCSpawnerERTShuttle
-  name: ert shuttle spawner
+  id: RMCSpawnerShuttle
+  name: shuttle spawner
   suffix: Generic
-  description: Defines a location to spawn an ERT shuttle in.
+  description: Defines a location to spawn a shuttle in.
   placement:
     mode: SnapgridCenter
   components:
@@ -11,12 +11,36 @@
     state: green
   - type: GridSpawner
     spawn: "/Maps/_RMC14/Shuttles/ert_response_shuttle.yml"
+
+- type: entity
+  parent: RMCSpawnerShuttle
+  id: RMCSpawnerPVEAlamo
+  suffix: PVE Alamo
+  components:
+  - type: GridSpawner
+    spawn: "/Maps/_RMC14/Shuttles/dropship_alamo_pve.yml"
+
+- type: entity
+  parent: RMCSpawnerShuttle
+  id: RMCSpawnerPVENormandy
+  suffix: PVE Normandy
+  components:
+  - type: GridSpawner
+    spawn: "/Maps/_RMC14/Shuttles/dropship_normandy_pve.yml"
+
+- type: entity
+  parent: RMCSpawnerShuttle
+  id: RMCSpawnerERTShuttle
+  suffix: ERT Generic
+  components:
+  - type: GridSpawner
+    spawn: "/Maps/_RMC14/Shuttles/ert_response_shuttle.yml"
     offset: -0.5,-0.5
 
 - type: entity
   parent: RMCSpawnerERTShuttle
   id: RMCSpawnerERTShuttleWeYa
-  suffix: PMC
+  suffix: ERT PMC
   components:
   - type: GridSpawner
     spawn: "/Maps/_RMC14/Shuttles/ert_pmc_shuttle.yml"
@@ -24,7 +48,7 @@
 - type: entity
   parent: RMCSpawnerERTShuttle
   id: RMCSpawnerERTShuttleSPP
-  suffix: SPP
+  suffix: ERT SPP
   components:
   - type: GridSpawner
     spawn: "/Maps/_RMC14/Shuttles/ert_spp_shuttle.yml"
@@ -32,7 +56,7 @@
 - type: entity
   parent: RMCSpawnerERTShuttle
   id: RMCSpawnerERTShuttleTSE
-  suffix: TSE
+  suffix: ERT TSE
   components:
   - type: GridSpawner
     spawn: "/Maps/_RMC14/Shuttles/ert_tse_shuttle.yml"


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Easy PR, cant test on local because shuttles never want to spawn so idfk, but should work.
PVP Alamo and Norm can probably use this system instead of the current "FTL roundstart into the grid".

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I can have correctly shuttles on PVE now yay :)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no cl not player facing