### PR TITLE
remove walter white

### DIFF
--- a/Resources/IgnoredPrototypes/cm_ignoredPrototypes.yml
+++ b/Resources/IgnoredPrototypes/cm_ignoredPrototypes.yml
@@ -3,3 +3,11 @@
 - /Prototypes/Traits/quirks.yml
 - /Prototypes/Traits/disabilities.yml
 - /Prototypes/game_presets.yml
+- /Prototypes/Recipes/Reactions/fun.yml
+- /Prototypes/Recipes/Reactions/biological.yml
+- /Prototypes/Recipes/Reactions/chemicals.yml
+- /Prototypes/Recipes/Reactions/cleaning.yml
+- /Prototypes/Recipes/Reactions/gas.yml
+- /Prototypes/Recipes/Reactions/medicine.yml
+- /Prototypes/Recipes/Reactions/pyrotechnic.yml
+- /Prototypes/Recipes/Reactions/single_reagent.yml

--- a/Resources/Prototypes/Recipes/Reactions/drinks.yml
+++ b/Resources/Prototypes/Recipes/Reactions/drinks.yml
@@ -829,6 +829,8 @@
 - type: reaction
   id: Mead
   reactants:
+    RMCBlackGoo: # TODO RMC14 remove this later
+      amount: 0.5
     Sugar:
       amount: 1
       # TODO replace Sugar with Honey once added

--- a/Resources/Prototypes/Recipes/Reactions/food.yml
+++ b/Resources/Prototypes/Recipes/Reactions/food.yml
@@ -240,15 +240,15 @@
     Mayo: 15
 
 # Gas not included
-- type: reaction
-  id: CookingMustard
-  reactants:
-    Bleach:
-      amount: 1
-    Ammonia:
-      amount: 1
-  products:
-    Mustard: 2
+#- type: reaction # RMC14
+#  id: CookingMustard
+#  reactants:
+#    Bleach:
+#      amount: 1
+#    Ammonia:
+#      amount: 1
+#  products:
+#    Mustard: 2
 
 - type: reaction
   id: CookingKetchunaise
@@ -328,17 +328,17 @@
   products:
     Vinaigrette: 3
 
-- type: reaction
-  id: BananaBreakdown
-  source: true
-  requiredMixerCategories:
-  - Centrifuge
-  reactants:
-    JuiceBanana:
-      amount: 10
-  products:
-    Sugar: 5
-    Potassium: 5
+#- type: reaction # RMC14
+#  id: BananaBreakdown
+#  source: true
+#  requiredMixerCategories:
+#  - Centrifuge
+#  reactants:
+#    JuiceBanana:
+#      amount: 10
+#  products:
+#    Sugar: 5
+#    Potassium: 5
 
 - type: reaction
   id: OilBreakdown
@@ -364,87 +364,87 @@
 #    Oxygen: 1
 #    Hydrogen: 2
 
-- type: reaction
-  id: AllicinBreakdown
-  source: true
-  requiredMixerCategories:
-  - Centrifuge
-  reactants:
-    Allicin:
-      amount: 4
-  products:
-    Sulfur: 2
-    Carbon: 1
-    Water: 1
+#- type: reaction # rmc14
+#  id: AllicinBreakdown
+#  source: true
+#  requiredMixerCategories:
+#  - Centrifuge
+#  reactants:
+#    Allicin:
+#      amount: 4
+#  products:
+#    Sulfur: 2
+#    Carbon: 1
+#    Water: 1
 
-- type: reaction
-  id: NutrimentBreakdown
-  source: true
-  requiredMixerCategories:
-  - Centrifuge
-  reactants:
-    Nutriment:
-      amount: 5
-  products:
-    Water: 2
-    Carbon: 2
-    Sugar: 1
+#- type: reaction # RMC14
+#  id: NutrimentBreakdown
+#  source: true
+#  requiredMixerCategories:
+#  - Centrifuge
+#  reactants:
+#    Nutriment:
+#      amount: 5
+#  products:
+#    Water: 2
+#    Carbon: 2
+#    Sugar: 1
 
-- type: reaction
-  id: FatBreakdown
-  source: true
-  requiredMixerCategories:
-  - Electrolysis
-  reactants:
-    Fat:
-      amount: 15
-  products:
-    Carbon: 5
-    Hydrogen: 10
-    Oxygen: 1
+#- type: reaction # RMC14
+#  id: FatBreakdown
+#  source: true
+#  requiredMixerCategories:
+#  - Electrolysis
+#  reactants:
+#    Fat:
+#      amount: 15
+#  products:
+#    Carbon: 5
+#    Hydrogen: 10
+#    Oxygen: 1
 
-# Proteins are hydrocarbons
-- type: reaction
-  id: UncookedAnimalProteinBreakdown
-  source: true
-  requiredMixerCategories:
-  - Electrolysis
-  reactants:
-    UncookedAnimalProteins:
-      amount: 10
-  products:
-    Carbon: 2
-    Hydrogen: 4
-    Phosphorus: 3
-    Oxygen: 1
-
-- type: reaction
-  id: ProteinBreakdown
-  source: true
-  requiredMixerCategories:
-  - Electrolysis
-  reactants:
-    Protein:
-      amount: 10
-  products:
-    Carbon: 2
-    Hydrogen: 4
-    Phosphorus: 3
-    Oxygen: 1
-
-# Vitamin = Healthy = Green = Nitrogenous
-- type: reaction
-  id: VitaminBreakdown
-  source: true
-  requiredMixerCategories:
-  - Centrifuge
-  reactants:
-    Vitamin:
-      amount: 4
-  products:
-    Carbon: 1
-    Water: 1
-    Nitrogen: 2
+## Proteins are hydrocarbons # RMC14
+#- type: reaction
+#  id: UncookedAnimalProteinBreakdown
+#  source: true
+#  requiredMixerCategories:
+#  - Electrolysis
+#  reactants:
+#    UncookedAnimalProteins:
+#      amount: 10
+#  products:
+#    Carbon: 2
+#    Hydrogen: 4
+#    Phosphorus: 3
+#    Oxygen: 1
+#
+#- type: reaction
+#  id: ProteinBreakdown
+#  source: true
+#  requiredMixerCategories:
+#  - Electrolysis
+#  reactants:
+#    Protein:
+#      amount: 10
+#  products:
+#    Carbon: 2
+#    Hydrogen: 4
+#    Phosphorus: 3
+#    Oxygen: 1
+#
+## Vitamin = Healthy = Green = Nitrogenous
+#- type: reaction
+#  id: VitaminBreakdown
+#  source: true
+#  requiredMixerCategories:
+#  - Centrifuge
+#  reactants:
+#    Vitamin:
+#      amount: 4
+#  products:
+#    Carbon: 1
+#    Water: 1
+#    Nitrogen: 2
 
 - type: reaction
   id: ReduceMilk #makes Cream renewable

--- a/Resources/Prototypes/Recipes/Reactions/fun.yml
+++ b/Resources/Prototypes/Recipes/Reactions/fun.yml
@@ -162,6 +162,8 @@
 - type: reaction
   id: Laughter
   reactants:
+    RMCBlackGoo: # TODO RMC14 remove this later
+      amount: 0.5
     JuiceBanana:
       amount: 1
     Sugar:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/vending_machines.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/vending_machines.yml
@@ -598,7 +598,7 @@
     RiceSeeds: 3
     # LibertyMycelium: 1 #Contraband
     # MessaTearSeeds: 1 #Contraband
-    AmbrosiaVulgarisSeeds: 1 #Contraband
+    # AmbrosiaVulgarisSeeds: 1 #Contraband
     NettleSeeds: 1 #Contraband
     LingzhiSeeds: 1 #ReishiMycelium #Contraband
     # WaterFlower: 1 #Premium

--- a/Resources/Prototypes/_RMC14/Reagents/elements.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/elements.yml
@@ -435,7 +435,7 @@
       - !type:ChemVomit
         probability: 0
 
-- type: reagent
+- type: reagent # TODO rmc14
   parent: [RMCReagentElement, BaseAlcohol]
   id: RMCEthanol
   name: reagent-name-ethanol

--- a/Resources/Prototypes/_RMC14/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Reactions/medicine.yml
@@ -186,6 +186,8 @@
 - type: reaction
   id: RMCMethylphenidate
   reactants:
+    RMCBlackGoo: # TODO RMC14 remove this later
+      amount: 0.5
     RMCMindbreakerToxin:
       amount: 1
     RMCHydrogen:
@@ -196,6 +198,8 @@
 - type: reaction
   id: RMCCitalopram
   reactants:
+    RMCBlackGoo: # TODO RMC14 remove this later
+      amount: 0.5
     RMCMindbreakerToxin:
       amount: 1
     RMCCarbon:
@@ -206,6 +210,8 @@
 - type: reaction
   id: RMCParoxetine
   reactants:
+    RMCBlackGoo: # TODO RMC14 remove this later
+      amount: 0.5
     RMCMindbreakerToxin:
       amount: 1
     RMCOxygen:

--- a/Resources/Prototypes/_RMC14/Recipes/Reactions/narcotics.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Reactions/narcotics.yml
@@ -1,6 +1,8 @@
 - type: reaction
   id: RMCMindbreakerToxin
   reactants:
+    RMCBlackGoo: # TODO RMC14 remove this later
+      amount: 0.5
     RMCSilicon:
       amount: 1
     RMCHydrogen:
@@ -13,6 +15,8 @@
 - type: reaction
   id: RMCSpaceDrugs
   reactants:
+    RMCBlackGoo: # TODO RMC14 remove this later
+      amount: 0.5
     RMCMercury:
       amount: 1
     RMCSugar:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

The amount of bad faith usage was out of hand, this will need to be better designed to be allowed back in the game someday.

![walter-white-walter-white-falling](https://github.com/user-attachments/assets/39ec8461-1ba7-4ac8-be0d-1f07afe38589)

**Changelog**

:cl: Whisper

- remove: Following up on consistent issues and reports of bad faith usage, roleplaying chemicals and drugs have been disabled, until they can be better designed to fit RMC.

