### PR TITLE
Cargo Tech renaming to Req Tech

### DIFF
--- a/Resources/Locale/en-US/_RMC14/chat/highlights.ftl
+++ b/Resources/Locale/en-US/_RMC14/chat/highlights.ftl
@@ -13,7 +13,7 @@ highlights-staff-officer = Staff Officer, "SO", Combat Information Center, "CIC"
 
 # Requisitions
 highlights-quartermaster = Quartermaster, "QM", Requisitions, "Req", Command, Supply, "Drop", Crate, Budget, Ammo
-highlights-cargo-technician = Cargo Technician, Cargo Tech, "CT" Requisitions, "Req", Supply, "Drop", Crate, Budget, Ammo
+highlights-cargo-technician = Requisitions Technician, Req Technician, Requisitions Tech, Req Tech, "RT", Requisitions, "Req", Supply, "Drop", Crate, Budget, Ammo
 
 # Engineering
 highlights-chief-engineer = Chief Engineer, "CE", Engineering, Engineer, "Engi", Command, "OB", "OT"

--- a/Resources/Locale/en-US/_RMC14/job/requisitions.ftl
+++ b/Resources/Locale/en-US/_RMC14/job/requisitions.ftl
@@ -4,10 +4,10 @@ cm-job-description-quartermaster = Your job is to dispense supplies to the marin
 cm-job-prefix-quartermaster = QM
 CMJobQuartermaster = Quartermaster
 
-cm-job-name-cargotech = Cargo Technician
+cm-job-name-cargotech = Requisitions Technician
 cm-job-description-cargotech = Your job is to dispense supplies to the marines, including weapon attachments.
-cm-job-prefix-cargotech = CT
-CMJobCargoTech = Cargo Technician
+cm-job-prefix-cargotech = RT
+CMJobCargoTech = Requisitions Technician
 
 cm-job-name-messtech = Mess Technician
 cm-job-description-messtech = Your job is to service the marines with excellent food, drinks and entertaining the shipside crew when needed.

--- a/Resources/Prototypes/_RMC14/Access/Groups/requisition_access_groups.yml
+++ b/Resources/Prototypes/_RMC14/Access/Groups/requisition_access_groups.yml
@@ -16,7 +16,7 @@
 - type: accessGroup
   id: CMCargoTech
   parent: RMCBaseRequisitionsJob
-  name: Cargo Technician
+  name: Requisitions Technician
   tags:
   - CMAccessRequisitions
 

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/ship_headsets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/ship_headsets.yml
@@ -132,8 +132,8 @@
 - type: entity
   parent: RMCHeadsetShip
   id: CMHeadsetRequisition
-  name: supply radio headset
-  description: Used by the lowly Cargo Technicians of the Marine, light weight and portable.
+  name: requisitions radio headset
+  description: Used by the Requisitions Technicians, lightweight and portable.
   components:
   - type: Sprite
     state: req_headset

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/marines.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/marines.yml
@@ -168,12 +168,12 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Uniforms/Supply/ro.rsi
 
-# Cargotech
+# ReqTech / RT
 - type: entity
   parent: [RMCMarineUniformBase, RMCFoldableUniformBase]
   id: CMJumpsuitCargoTech
-  name: cargo technician uniform
-  description: A standard-issue cargo tech uniform.
+  name: requisitions technician uniform
+  description: A standard-issue req tech uniform.
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Uniforms/Supply/cargo_tech.rsi

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Devices/EncryptionKeys/ship.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Devices/EncryptionKeys/ship.yml
@@ -377,7 +377,7 @@
 - type: entity
   parent: CMEncryptionKey
   id: RMCEncryptionKeyCargotech
-  name: cargo tech encryption key
+  name: req tech encryption key
   components:
   - type: EncryptionKey
     channels:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/IdCards/cm_id_requisitions.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/IdCards/cm_id_requisitions.yml
@@ -9,7 +9,7 @@
 - type: entity
   parent: CMIDCardBase
   id: CMIDCardCargoTech
-  name: cargo tech's ID card
+  name: req tech's ID card
   components:
   - type: PresetIdCard
     job: CMCargoTech

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
@@ -19,7 +19,7 @@
   parent: ColMarTechCargo
   id: ColMarTechCargoGuns
   name: ColMarTech automated armaments vendor
-  description: An automated supply rack hooked up to a big storage of various firearms and explosives. Can be accessed by the Requisitions Officer and Cargo Techs.
+  description: An automated supply rack hooked up to a big storage of various firearms and explosives. Can be accessed by the Requisitions Officer and Requisitions Technicians.
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/requisitions_wall/guns.rsi
@@ -342,7 +342,7 @@
   parent: ColMarTechCargo
   id: ColMarTechCargoAmmo
   name: ColMarTech automated munition vendor
-  description: An automated supply rack hooked up to a big storage of various ammunition types. Can be accessed by the Requisitions Officer and Cargo Techs.
+  description: An automated supply rack hooked up to a big storage of various ammunition types. Can be accessed by the Requisitions Officer and Requisitions Technicians.
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/requisitions_wall/ammo.rsi
@@ -565,7 +565,7 @@
   parent: ColMarTechCargo
   id: ColMarTechCargoAttachments
   name: Aegis Armaments attachments vendor
-  description: An automated supply rack hooked up to a big storage of weapons attachments. Can be accessed by the Requisitions Officer and Cargo Techs.
+  description: An automated supply rack hooked up to a big storage of weapons attachments. Can be accessed by the Requisitions Officer and Requisitions Technicians.
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/requisitions_wall/attachments.rsi
@@ -651,7 +651,7 @@
   parent: ColMarTechBase
   id: ColMarTechCargoUniform
   name: ColMarTech surplus uniform vendor
-  description: An automated supply rack hooked up to a big storage of standard marine uniforms. Can be accessed by the Requisitions Officer and Cargo Techs.
+  description: An automated supply rack hooked up to a big storage of standard marine uniforms. Can be accessed by the Requisitions Officer and Requisitions Technicians.
   suffix: Requisitions
   components:
   - type: AccessReader

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Storage/lockers.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Storage/lockers.yml
@@ -231,7 +231,7 @@
 - type: entity
   parent: CMLockerBase
   id: CMLockerCargo
-  name: cargo technician's locker
+  name: requisitions technician's locker
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Storage/Lockers/cargo.rsi

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Requisitions/cargo_tech.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Requisitions/cargo_tech.yml
@@ -60,7 +60,7 @@
 - type: entity
   parent: CMSpawnPointJobBase
   id: CMSpawnPointCargoTech
-  name: cargo tech spawn point
+  name: req tech spawn point
   components:
   - type: SpawnPoint
     job_id: CMCargoTech

--- a/Resources/ServerInfo/Guidebook/_RMC14/Guides/RMCRequisitions.xml
+++ b/Resources/ServerInfo/Guidebook/_RMC14/Guides/RMCRequisitions.xml
@@ -19,7 +19,7 @@
 
   ##Acquisitions
 
-  This responsibility is often managed by the Quartermaster or Auxiliary Support Officer, your direct superiors, but inexpensive orders are often left for the Cargo Techs. If you’re ever unsure about a purchase, contact them across the Requisitions radio frequency.
+  This responsibility is often managed by the Quartermaster or Auxiliary Support Officer, your direct superiors, but inexpensive orders are often left for the Req Techs. If you’re ever unsure about a purchase, contact them across the Requisitions radio frequency.
 
   Acquisitions is handled using the ASRS console.
 


### PR DESCRIPTION
## About the PR
Renaming Cargo Technician to Requisitions Technician.

## Why / Balance
To prevent confusion between Combat Tech and Cargo Tech.

## Technical details
Changed instances of Cargo Technician to Requisitions Technician or Req Tech in item descriptions.
Changed chat prefix from "CT" to "RT"
Edited chat highlights and added new ones.

## Media
<img width="425" height="109" alt="image" src="https://github.com/user-attachments/assets/05e2be5c-5643-4d73-b109-9fe117483bdc" />
<img width="399" height="183" alt="image-1" src="https://github.com/user-attachments/assets/0e931e69-fe35-4a96-a203-c6cc4fd1264c" />
<img width="382" height="191" alt="image" src="https://github.com/user-attachments/assets/9110312c-97d9-46e1-a15c-1feb6586d5fc" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: Renamed Cargo Technician to Requisitions Technician.
