### PR TITLE
Adding Squad Chair construction

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Materials/Sheets/metal.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Materials/Sheets/metal.yml
@@ -55,7 +55,7 @@
       # Bed
       # Chair
       - RMCComfyChairList
-      # squad chairs
+      - RMCSquadChairList
       # office chairs
       # stool
       - RMCDividerConstruction

--- a/Resources/Prototypes/_RMC14/Recipes/Materials/metal.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Materials/metal.yml
@@ -158,28 +158,28 @@
 
 - type: rmcConstruction
   id: RMCComfyChairAlphaBuild
-  name: alpha comfy chair
+  name: alpha squad chair
   prototype: CMChairComfyAlpha
   materialCost: 2
   restrictedTags: [RMCSeat]
 
 - type: rmcConstruction
   id: RMCComfyChairBravoBuild
-  name: bravo comfy chair
+  name: bravo squad chair
   prototype: CMChairComfyBravo
   materialCost: 2
   restrictedTags: [RMCSeat]
 
 - type: rmcConstruction
   id: RMCComfyChairCharlieBuild
-  name: charlie comfy chair
+  name: charlie squad chair
   prototype: CMChairComfyCharlie
   materialCost: 2
   restrictedTags: [RMCSeat]
 
 - type: rmcConstruction
   id: RMCComfyChairDeltaBuild
-  name: delta comfy chair
+  name: delta squad chair
   prototype: CMChairComfyDelta
   materialCost: 2
   restrictedTags: [RMCSeat]

--- a/Resources/Prototypes/_RMC14/Recipes/Materials/metal.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Materials/metal.yml
@@ -145,6 +145,45 @@
   materialCost: 2
   restrictedTags: [RMCSeat]
 
+# Squad Chairs
+- type: rmcConstruction
+  id: RMCSquadChairList
+  name: squad chairs
+  prototype: CMChairComfy
+  listed:
+  - RMCComfyChairAlphaBuild
+  - RMCComfyChairBravoBuild
+  - RMCComfyChairCharlieBuild
+  - RMCComfyChairDeltaBuild
+
+- type: rmcConstruction
+  id: RMCComfyChairAlphaBuild
+  name: alpha comfy chair
+  prototype: CMChairComfyAlpha
+  materialCost: 2
+  restrictedTags: [RMCSeat]
+
+- type: rmcConstruction
+  id: RMCComfyChairBravoBuild
+  name: bravo comfy chair
+  prototype: CMChairComfyBravo
+  materialCost: 2
+  restrictedTags: [RMCSeat]
+
+- type: rmcConstruction
+  id: RMCComfyChairCharlieBuild
+  name: charlie comfy chair
+  prototype: CMChairComfyCharlie
+  materialCost: 2
+  restrictedTags: [RMCSeat]
+
+- type: rmcConstruction
+  id: RMCComfyChairDeltaBuild
+  name: delta comfy chair
+  prototype: CMChairComfyDelta
+  materialCost: 2
+  restrictedTags: [RMCSeat]
+
 - type: rmcConstruction
   id: RMCMachineFrameBuild
   name: machine frame


### PR DESCRIPTION
# About the PR
Added the ability to construct squad chairs

## Why / Balance
Parity. Lets people use metal to construct the squad chairs.

## Technical details
Added the squad chairs to the metal recipe yml with their own list, and linked said list in the metal construction yml.

## Media
https://github.com/user-attachments/assets/abd4354d-72c7-4915-9b63-cacf6a1cab8a

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Added the four squad chairs as constructable furniture.