### PR TITLE
Requisitions Chair Automatic Dispense

### DIFF
--- a/Content.Shared/_RMC14/Vendors/RMCRequisitionsChairComponent.cs
+++ b/Content.Shared/_RMC14/Vendors/RMCRequisitionsChairComponent.cs
@@ -1,0 +1,14 @@
+using System.Numerics;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Vendors;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class RMCRequisitionsChairComponent : Component
+{
+    /// <summary>
+    /// The Offset that the item will be placed at from the marker.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public Vector2 OffsetItem { get; set; }
+}

--- a/Content.Shared/_RMC14/Vendors/RMCRequisitionsVendorComponent.cs
+++ b/Content.Shared/_RMC14/Vendors/RMCRequisitionsVendorComponent.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Vendors;
+
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class RMCRequisitionsVendorComponent : Component
+{
+    /// <summary>
+    /// Determines if the auto dispense to the table is enabled, this is just a toggle and still requires the Requisitions Chair Marker to exist.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool Enabled { get; set; } = true;
+}

--- a/Content.Shared/_RMC14/Vendors/SharedCMAutomatedVendorSystem.cs
+++ b/Content.Shared/_RMC14/Vendors/SharedCMAutomatedVendorSystem.cs
@@ -16,6 +16,7 @@ using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Clothing.Components;
+using Content.Shared.Coordinates;
 using Content.Shared.Database;
 using Content.Shared.DoAfter;
 using Content.Shared.Examine;
@@ -85,10 +86,11 @@ public abstract class SharedCMAutomatedVendorSystem : EntitySystem
         SubscribeLocalEvent<RMCRecentlyVendedComponent, GotEquippedHandEvent>(OnRecentlyGotEquipped);
         SubscribeLocalEvent<RMCRecentlyVendedComponent, GotEquippedEvent>(OnRecentlyGotEquipped);
 
-        Subs.BuiEvents<CMAutomatedVendorComponent>(CMAutomatedVendorUI.Key, subs =>
-        {
-            subs.Event<CMVendorVendBuiMsg>(OnVendBui);
-        });
+        Subs.BuiEvents<CMAutomatedVendorComponent>(CMAutomatedVendorUI.Key,
+            subs =>
+            {
+                subs.Event<CMVendorVendBuiMsg>(OnVendBui);
+            });
     }
 
     private void OnMarineScaleChanged(ref MarineScaleChangedEvent ev)
@@ -111,7 +113,7 @@ public abstract class SharedCMAutomatedVendorSystem : EntitySystem
                         continue;
                     }
 
-                    var newMax = (int) Math.Round(ev.New * multiplier);
+                    var newMax = (int)Math.Round(ev.New * multiplier);
                     var toAdd = newMax - max;
                     if (toAdd <= 0)
                         continue;
@@ -351,6 +353,7 @@ public abstract class SharedCMAutomatedVendorSystem : EntitySystem
 
             Dirty(actor, user);
         }
+
         if (section.TakeOne is { } takeOne)
         {
             user = EnsureComp<CMVendorUserComponent>(actor);
@@ -426,7 +429,8 @@ public abstract class SharedCMAutomatedVendorSystem : EntitySystem
                 var thisSpecVendor = Comp<RMCVendorSpecialistComponent>(vendor);
 
                 // If the vendor's own value is at or above the capacity, immediately return.
-                if (thisSpecVendor.GlobalSharedVends.TryGetValue(args.Entry, out var vendCount) && vendCount >= section.SharedSpecLimit)
+                if (thisSpecVendor.GlobalSharedVends.TryGetValue(args.Entry, out var vendCount) &&
+                    vendCount >= section.SharedSpecLimit)
                 {
                     // FIXME
                     ResetChoices();
@@ -466,6 +470,7 @@ public abstract class SharedCMAutomatedVendorSystem : EntitySystem
                     }
                     else // Does not exist on the currently checked vendor
                         specVendorComponent.GlobalSharedVends.Add(args.Entry, maxAmongVendors);
+
                     Dirty(vendorId, specVendorComponent);
                 }
 
@@ -487,7 +492,8 @@ public abstract class SharedCMAutomatedVendorSystem : EntitySystem
         {
             if (user == null)
             {
-                Log.Error($"{ToPrettyString(actor)} tried to buy {entry.Id} for {entry.Points} points without having points.");
+                Log.Error(
+                    $"{ToPrettyString(actor)} tried to buy {entry.Id} for {entry.Points} points without having points.");
                 return;
             }
 
@@ -496,7 +502,8 @@ public abstract class SharedCMAutomatedVendorSystem : EntitySystem
                 : user.ExtraPoints?.GetValueOrDefault(vendor.Comp.PointsType) ?? 0;
             if (userPoints < entry.Points)
             {
-                Log.Error($"{ToPrettyString(actor)} with {user.Points} tried to buy {entry.Id} for {entry.Points} points without having enough points.");
+                Log.Error(
+                    $"{ToPrettyString(actor)} with {user.Points} tried to buy {entry.Id} for {entry.Points} points without having enough points.");
                 return;
             }
 
@@ -614,7 +621,25 @@ public abstract class SharedCMAutomatedVendorSystem : EntitySystem
             }
         }
 
-        var spawn = SpawnNextToOrDrop(toVend, vendor);
+        if (TryComp(vendor, out RMCRequisitionsVendorComponent? vendorComponent) && vendorComponent.Enabled &&
+            _rmcMap.HasAnchoredEntityEnumerator<RMCRequisitionsChairComponent>(player.ToCoordinates(),
+                out var requisitionsChair))
+        {
+            var itemPlacementOffset = requisitionsChair.Comp.OffsetItem;
+            var finalPlacementCoordinates = requisitionsChair.Owner.ToCoordinates().Offset(itemPlacementOffset);
+            var spawn = SpawnAtPosition(toVend, finalPlacementCoordinates);
+
+            AfterVend(spawn, player, vendor, offset, true);
+        }
+        else
+        {
+            var spawn = SpawnNextToOrDrop(toVend, vendor);
+            AfterVend(spawn, player, vendor, offset);
+        }
+    }
+
+    private void AfterVend(EntityUid spawn, EntityUid player, EntityUid vendor, Vector2 offset, bool vended = false)
+    {
         var recently = EnsureComp<RMCRecentlyVendedComponent>(spawn);
         var anchored = _rmcMap.GetAnchoredEntitiesEnumerator(spawn);
         while (anchored.MoveNext(out var uid))
@@ -628,14 +653,18 @@ public abstract class SharedCMAutomatedVendorSystem : EntitySystem
         mount.Arc = Angle.FromDegrees(360);
         Dirty(spawn, mount);
 
-        var grabbed = Grab(player, spawn);
-        if (!grabbed && TryComp(spawn, out TransformComponent? xform))
-            _transform.SetLocalPosition(spawn, xform.LocalPosition + offset, xform);
+        if (!vended)
+        {
+            var grabbed = Grab(player, spawn);
+            if (!grabbed && TryComp(spawn, out TransformComponent? xform))
+                _transform.SetLocalPosition(spawn, xform.LocalPosition + offset, xform);
+        }
 
         var ev = new RMCAutomatedVendedUserEvent(spawn);
         RaiseLocalEvent(player, ref ev);
 
-        _adminLog.Add(LogType.RMCVend, $"{ToPrettyString(player)} vended {ToPrettyString(spawn)} from vendor {ToPrettyString(vendor)}");
+        _adminLog.Add(LogType.RMCVend,
+            $"{ToPrettyString(player)} vended {ToPrettyString(spawn)} from vendor {ToPrettyString(vendor)}");
     }
 
     private bool Grab(EntityUid player, EntityUid item)

--- a/Resources/Prototypes/_RMC14/Entities/Markers/rmc_requisitions_markers.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Markers/rmc_requisitions_markers.yml
@@ -1,0 +1,41 @@
+- type: entity
+  parent: MarkerBase
+  id: RMCRequisitionsChairMarker
+  name: requisitions chair marker
+  suffix: RMC14
+  components:
+  - type: Sprite
+    state: pink
+  - type: RMCRequisitionsChair
+
+- type: entity
+  parent: RMCRequisitionsChairMarker
+  id: RMCRequisitionsChairMarkerNorth
+  suffix: RMC14, North
+  components:
+  - type: RMCRequisitionsChair
+    offsetItem: 0,1
+
+- type: entity
+  parent: RMCRequisitionsChairMarker
+  id: RMCRequisitionsChairMarkerEast
+  suffix: RMC14, East
+  components:
+  - type: RMCRequisitionsChair
+    offsetItem: 1,0
+
+- type: entity
+  parent: RMCRequisitionsChairMarker
+  id: RMCRequisitionsChairMarkerSouth
+  suffix: RMC14, South
+  components:
+  - type: RMCRequisitionsChair
+    offsetItem: 0,-1
+
+- type: entity
+  parent: RMCRequisitionsChairMarker
+  id: RMCRequisitionsChairMarkerWest
+  suffix: RMC14, West
+  components:
+  - type: RMCRequisitionsChair
+    offsetItem: -1,0

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
@@ -18,11 +18,12 @@
 - type: entity
   parent: ColMarTechCargo
   id: ColMarTechCargoGuns
-  name: ColMarTech automated armaments vendor
+  name: ASRS automated armaments vendor
   description: An automated supply rack hooked up to a big storage of various firearms and explosives. Can be accessed by the Requisitions Officer and Cargo Techs.
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/requisitions_wall/guns.rsi
+  - type: RMCRequisitionsVendor
   - type: CMAutomatedVendor
     baseSprite:
       sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/requisitions_wall/guns.rsi
@@ -341,11 +342,12 @@
 - type: entity
   parent: ColMarTechCargo
   id: ColMarTechCargoAmmo
-  name: ColMarTech automated munition vendor
+  name: ASRS automated munition vendor
   description: An automated supply rack hooked up to a big storage of various ammunition types. Can be accessed by the Requisitions Officer and Cargo Techs.
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/requisitions_wall/ammo.rsi
+  - type: RMCRequisitionsVendor
   - type: CMAutomatedVendor
     baseSprite:
       sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/requisitions_wall/ammo.rsi
@@ -569,6 +571,7 @@
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/requisitions_wall/attachments.rsi
+  - type: RMCRequisitionsVendor
   - type: CMAutomatedVendor
     baseSprite:
       sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/requisitions_wall/attachments.rsi
@@ -650,7 +653,7 @@
 - type: entity
   parent: ColMarTechBase
   id: ColMarTechCargoUniform
-  name: ColMarTech surplus uniform vendor
+  name: ASRS surplus uniform vendor
   description: An automated supply rack hooked up to a big storage of standard marine uniforms. Can be accessed by the Requisitions Officer and Cargo Techs.
   suffix: Requisitions
   components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Standing in the requisitions chair tile will now automatically dispense to the table

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/e9e14e23-3e0d-4510-a66f-63248a73bc85


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [ x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Dispensing Requisitions items while manning the line now places those items on the table automatically.