### PR TITLE
LZ Detector name fix

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/PowerLoader/Dropship/rmc_dropship_electronic_systems.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/PowerLoader/Dropship/rmc_dropship_electronic_systems.yml
@@ -54,7 +54,7 @@
 - type: entity
   parent: RMCDropshipAttachmentElectronicSystem
   id: RMCDropShipLZDetector
-  name: AN/AVD-60 LZ detector.
+  name: AN/AVD-60 LZ detector
   description: An electronic device linked to the dropship's camera system that lets you observe your landing zone mid-flight
   components:
   - type: Sprite


### PR DESCRIPTION
## About the PR
Removed fullstop after the LZ Detector Name

## Why / Balance
Its incorrect, none of the other systems have a fullstop

## Technical details
Removed fullstop in the yml

## Media
<img width="485" height="233" alt="image" src="https://github.com/user-attachments/assets/e14a5f3c-2866-4885-b0ff-3ea4b3219936" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: AN/AVD-60 LZ Detector name fullstop removed.