### PR TITLE
Liaison Safe

### DIFF
--- a/Resources/Prototypes/_RMC14/Catalog/Fills/Lockers/misc.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Fills/Lockers/misc.yml
@@ -80,9 +80,9 @@
   - type: StorageFill
     contents:
     - id: RMCArmorVest #should be bulletproof vest from CM13.
-    - id: RMCSynthResetKey
-      # todo: 2 WeYa ration packs
-      # todo: Platinum Coin
+    - id: RMCSynthResetKeySMART
+      # ToDo: RMC14 2 WeYa ration packs
+      # ToDo: RMC14 Platinum Coin
     - id: RMCSpaceCash1000
     - id: RMCSpaceCash1000
     - id: CMWebbingHolster

--- a/Resources/Prototypes/_RMC14/Catalog/Fills/Lockers/misc.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Fills/Lockers/misc.yml
@@ -71,3 +71,21 @@
       - id: RMCHeadsetMarineCommand
       - id: CMBeltMarine
       - id: CMBeltMarine
+
+- type: entity
+  parent: RMCLockerSecureSafeLiaison
+  id: RMCLockerSecureSafeLiaisonFilled
+  suffix: Corporate Liaison, Filled
+  components:
+  - type: StorageFill
+    contents:
+    - id: RMCArmorVest #should be bulletproof vest from CM13.
+    - id: RMCSynthResetKey
+      # todo: 2 WeYa ration packs
+      # todo: Platinum Coin
+    - id: RMCSpaceCash1000
+    - id: RMCSpaceCash1000
+    - id: CMWebbingHolster
+    - id: RMCWeaponPistolPK7
+    - id: RMCMagazinePistolPK7
+    - id: RMCMagazinePistolPK7

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Medical/defib.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Medical/defib.yml
@@ -179,3 +179,13 @@
   - type: Tag
     tags:
     - RMCSynthResetKey
+
+- type: entity
+  parent: RMCSynthResetKey
+  id: RMCSynthResetKeySMART
+  name: SMART WeYa synthetic reset key
+  description: This device can fix major glitches or programming errors of synthetic units, as well as being able to restart a synthetic that has suffered critical failure. It can only be used once before being reset. This one has a microfunction AI and can be operated by anyone.
+  components:
+  - type: RequiresSkill
+    skills:
+      RMCSkillEngineer: 0

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Storage/lockers.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Storage/lockers.yml
@@ -76,6 +76,17 @@
     access: [["CMAccessColonyCommand"]]
 
 - type: entity
+  parent: RMCLockerSecureSafe
+  id: RMCLockerSecureSafeLiaison
+  description: A huge chunk of metal with a dial embedded in it. Fine print on the dial reads "Scarborough Arms - 2 tumbler safe, guaranteed thermite resistant, explosion resistant, and assistant resistant."
+  suffix: Corporate Liaison
+  components:
+  - type: Sprite
+    sprite: _RMC14/Structures/Storage/Lockers/safe.rsi
+  - type: AccessReader
+    access: [["RMCAccessWeYa"]]
+
+- type: entity
   parent: CMLockerBase
   id: CMLockerStaff
   name: staff officer's locker

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Storage/lockers.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Storage/lockers.yml
@@ -78,7 +78,7 @@
 - type: entity
   parent: RMCLockerSecureSafe
   id: RMCLockerSecureSafeLiaison
-  description: A huge chunk of metal with a dial embedded in it. Fine print on the dial reads "Scarborough Arms - 2 tumbler safe, guaranteed thermite resistant, explosion resistant, and assistant resistant."
+  description: A huge chunk of metal with a dial embedded in it. Fine print on the dial reads "Scarborough Arms - 2 tumbler safe, guaranteed thermite resistant, and explosion resistant."
   suffix: Corporate Liaison
   components:
   - type: Sprite


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds the Liaison safe and it's filled variant, containing the PK-7 stun pistol, two mags, a shoulder holster, a SMART synthetic reset key, $2000, and an armour vest.

Also adds the SMART synth reset key which can be used by anyone.
## Why / Balance
Parity content

## Technical details
yml

## Media
<img width="235" height="224" alt="image" src="https://github.com/user-attachments/assets/b46024fa-e902-4908-aa8b-fa60db32f4ed" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Added the CL safe and it's filled variant.
- add: Added the SMART WeYa Synthetic Reset Key
