### PR TITLE
Make the command pouch no longer corrodible by xenos.

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Pouches/storage.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Pouches/storage.yml
@@ -149,6 +149,8 @@
     whitelist:
       tags:
       - Sidearm
+  - type: Corrodible
+    isCorrodible: false
 
 #Filled Command Pouch
 - type: entity


### PR DESCRIPTION
## About the PR
Title, command pouch can no longer be melted by xeno acid.

## Why / Balance
Doublechecked this with warcat in deadchat, but this pouch is designed to contain a CO's sidearm and the Command Tablet, both of which are key items that are not intended to be corrodible by xenos. The fact that the pouch itself IS corrodible seems like a bug/oversight.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl: BramvanZijp
- fix: The Commanding Officer's Command Pouch is no longer corrodible/meltable by Xenos.
