### PR TITLE
[Fix] corrects CBS having wrong attachment whitelists 

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/custombuilt.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/custombuilt.yml
@@ -27,8 +27,6 @@
     modifiers:
       Burst:
         fireDelay: 0.1665
-  - type: GunDamageModifier
-    multiplier: 1
   - type: BallisticAmmoProvider
     cycleable: false
     whitelist:
@@ -41,20 +39,6 @@
         whitelist:
           tags:
           - RMCAttachmentRecoilCompensator
-          - RMCM5Bayonet
-      rmc-aslot-rail:
-        whitelist:
-          tags:
-          - RMCAttachmentRailFlashlight
-          - RMCAttachmentMagneticHarness
-      rmc-aslot-underbarrel:
-        whitelist:
-          tags:
-          - RMCAttachmentGyroscopicStabilizer
-          - RMCAttachmentFlashlightGrip
-          - RMCAttachmentAngledGrip
-          - RMCAttachmentVerticalGrip
-          - RMCAttachmentLaserSight
   - type: AttachableHolderVisuals
     offsets:
       rmc-aslot-barrel: 0.780, 0.06


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
1. removed none parity attachments
   - whispers from discord members caused me to look into this, people have known about this mistake, but haven't made any bug reports from what i can see
   - source: https://github.com/cmss13-devs/cmss13/blob/5cbae54b94ab9f3c1c71df07cb23607ef7b936d7/code/modules/projectiles/guns/shotguns.dm#L198
3. removed the GunDamageMultiplier component
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
1. parity
3. the GunDamageMultiplier component doesn't seem to actually do anything since none of the CBS parents touch or even have the component, couldn't find a reason for it to be there in my testing.
<!-- ## Technical details -->
<!-- Summary of code changes for easier review. -->

<!-- ## Media -->
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed the Custom barrel shotgun having an incorrect list of attachment whitelists.
