### PR TITLE
Dupe overwatch roles fix

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/UNMC/corpsman.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/UNMC/corpsman.yml
@@ -1,6 +1,8 @@
 - type: job
-  parent: CMHospitalCorpsman
+  parent: CMJobSquadBase
   id: CMPVEHospitalCorpsman
+  name: cm-job-name-hospital-corpsman
+  description: cm-job-description-hospital-corpsman
   playTimeTracker: CMJobPVEHospitalCorpsman
   requirements:
   - !type:TotalJobsTimeRequirement
@@ -10,7 +12,13 @@
     RMCRankLanceCorporal: []
   spawnMenuRoleName: Sun Rider Hospital Corpsman (PVE)
   startingGear: RMCGearPVEHospitalCorpsman
+  dummyStartingGear: CMGearHospitalCorpsmanEquipped
+  icon: "CMJobIconHospitalCorpsman"
+  joinNotifyCrew: false
+  marineAuthorityLevel: 1
   supervisors: cm-job-supervisors-secserg
+  accessGroups:
+  - HospitalCorpsman
   special:
   - !type:AddComponentSpecial
     components:
@@ -26,6 +34,8 @@
     - type: ScoutWhitelist
     - type: SniperWhitelist
     - type: PyroWhitelist
+    - type: JobPrefix
+      prefix: cm-job-prefix-hospital-corpsman
     - type: TacticalMapIcon
       icon:
         sprite: /Textures/_RMC14/Interface/map_blips.rsi

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/UNMC/section_sergeant.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/UNMC/section_sergeant.yml
@@ -15,9 +15,6 @@
   marineAuthorityLevel: 2
   accessGroups:
   - SquadLeader
-  overwatchSortPriority: -6
-  overwatchShowName: true
-  overwatchRoleName: Squad Leader
   roleWeight: 1
   special:
   - !type:AddComponentSpecial

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/UNMC/smart_gun_operator.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/UNMC/smart_gun_operator.yml
@@ -13,7 +13,6 @@
   icon: "CMJobIconSmartGunOperator"
   joinNotifyCrew: false
   marineAuthorityLevel: 1
-  supervisors: cm-job-supervisors-secserg
   accessGroups:
   - SmartGunOperator
   special:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/UNMC/smart_gun_operator.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/UNMC/smart_gun_operator.yml
@@ -1,12 +1,21 @@
 - type: job
-  parent: CMSmartGunOperator
+  parent: CMJobSquadBase
   id: CMPVESmartGunOperator
+  name: cm-job-name-smart-gun-operator
+  description: cm-job-description-smart-gun-operator
   playTimeTracker: CMJobPVESmartGunOperator
   ranks:
     RMCRankCorporal: []
   spawnMenuRoleName: Sun Rider Smart Gun Operator (PVE)
   supervisors: cm-job-supervisors-secserg
   startingGear: RMCGearPVESmartGunOperator
+  dummyStartingGear: CMGearSmartGunOperatorEquipped
+  icon: "CMJobIconSmartGunOperator"
+  joinNotifyCrew: false
+  marineAuthorityLevel: 1
+  supervisors: cm-job-supervisors-secserg
+  accessGroups:
+  - SmartGunOperator
   special:
   - !type:AddComponentSpecial
     components:
@@ -30,6 +39,8 @@
       icon:
         sprite: /Textures/_RMC14/Interface/map_blips.rsi
         state: smartgunner
+    - type: JobPrefix
+      prefix: cm-job-prefix-gun-operator
   hidden: true
 
 - type: playTimeTracker

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/UNMC/squad_leader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/UNMC/squad_leader.yml
@@ -15,8 +15,6 @@
   marineAuthorityLevel: 1
   accessGroups:
   - FTL
-  overwatchSortPriority: -5
-  overwatchRoleName: Squad Leaders
   roleWeight: 1
   special:
   - !type:AddComponentSpecial


### PR DESCRIPTION
fixes #8007 
title
PVE roles dont display at all in the overwatch squad info area which sucks but better than current issue