### PR TITLE
SL Pyro Kit description fix

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/leader.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/leader.yml
@@ -383,7 +383,7 @@
   parent: RMCKitBase
   id: RMCKitPyroMini
   name: m34 pyrotechnician support kit
-  description: Contains a M34 Incinerator Unit, a G4-1 Fuel Tank, 3 incinerator tanks, and a portable fire extinguisher. Flame on!
+  description: Contains a M34 Incinerator Unit, a G4-1 Fuel Tank, 3 incinerator tanks, and a portable fire extinguisher.
   components:
   - type: Storage
     maxItemSize: Huge

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/leader.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/leader.yml
@@ -383,6 +383,7 @@
   parent: RMCKitBase
   id: RMCKitPyroMini
   name: m34 pyrotechnician support kit
+  description: Contains a M34 Incinerator Unit, a G4-1 Fuel Tank, 3 incinerator tanks, and a portable fire extinguisher. Flame on!
   components:
   - type: Storage
     maxItemSize: Huge


### PR DESCRIPTION
## About the PR
Added description to the SL vendor "M3 Pyrotechnician support kit".

## Why / Balance
It needs a description, currently SLs don't know what's in the kit

## Technical details
yml.

## Media
<img width="1197" height="281" alt="Screenshot 2025-09-27 152512" src="https://github.com/user-attachments/assets/9fb608d5-ce73-40b4-a938-8b50044ace70" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Squad Leader vendor: m34 pyrotehcnician support kit now has a description