### PR TITLE
Resin Whisper Tunnel Fix

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Construction/Tunnel/XenoTunnelSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/Tunnel/XenoTunnelSystem.cs
@@ -12,6 +12,7 @@ using Content.Shared._RMC14.Xenonids.Weeds;
 using Content.Shared._RMC14.Xenonids.Construction.ResinWhisper;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Actions;
+using Content.Shared.Actions.Components;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Coordinates;
 using Content.Shared.Coordinates.Helpers;
@@ -730,8 +731,11 @@ public sealed class XenoTunnelSystem : EntitySystem
 
     private void OnInTunnel(Entity<InXenoTunnelComponent> tunneledXeno, ref ComponentInit args)
     {
-        // Don't disable abilities for resin whisperers to prevent tunnel UI issues
-        if (!HasComp<ResinWhispererComponent>(tunneledXeno.Owner))
+        if (HasComp<ResinWhispererComponent>(tunneledXeno.Owner))
+        {
+            DisableAllExceptResinWhispererAbilities(tunneledXeno.Owner);
+        }
+        else
         {
             DisableAllAbilities(tunneledXeno.Owner);
         }
@@ -739,11 +743,7 @@ public sealed class XenoTunnelSystem : EntitySystem
 
     private void OnOutTunnel(Entity<InXenoTunnelComponent> tunneledXeno, ref ComponentRemove args)
     {
-        // Only re-enable abilities if they were disabled (i.e., not for resin whisperers)
-        if (!HasComp<ResinWhispererComponent>(tunneledXeno.Owner))
-        {
-            EnableAllAbilities(tunneledXeno.Owner);
-        }
+        EnableAllAbilities(tunneledXeno.Owner);
     }
 
     private void OnTryDropInTunnel(Entity<InXenoTunnelComponent> tunneledXeno, ref DropAttemptEvent args)
@@ -828,6 +828,19 @@ public sealed class XenoTunnelSystem : EntitySystem
         foreach (var action in actions)
         {
             _action.SetEnabled(action.AsNullable(), newStatus);
+        }
+    }
+
+    private void DisableAllExceptResinWhispererAbilities(EntityUid ent)
+    {
+        var actions = _action.GetActions(ent);
+        foreach (var action in actions)
+        {
+            var actionName = Name(action);
+            if (!actionName.Contains("resin", StringComparison.OrdinalIgnoreCase))
+            {
+                _action.SetEnabled(action.AsNullable(), false);
+            }
         }
     }
 

--- a/Content.Shared/_RMC14/Xenonids/Construction/Tunnel/XenoTunnelSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/Tunnel/XenoTunnelSystem.cs
@@ -9,6 +9,7 @@ using Content.Shared._RMC14.Xenonids.Devour;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared._RMC14.Xenonids.Weeds;
+using Content.Shared._RMC14.Xenonids.Construction.ResinWhisper;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Actions;
 using Content.Shared.Administration.Logs;
@@ -729,12 +730,20 @@ public sealed class XenoTunnelSystem : EntitySystem
 
     private void OnInTunnel(Entity<InXenoTunnelComponent> tunneledXeno, ref ComponentInit args)
     {
-        DisableAllAbilities(tunneledXeno.Owner);
+        // Don't disable abilities for resin whisperers to prevent tunnel UI issues
+        if (!HasComp<ResinWhispererComponent>(tunneledXeno.Owner))
+        {
+            DisableAllAbilities(tunneledXeno.Owner);
+        }
     }
 
     private void OnOutTunnel(Entity<InXenoTunnelComponent> tunneledXeno, ref ComponentRemove args)
     {
-        EnableAllAbilities(tunneledXeno.Owner);
+        // Only re-enable abilities if they were disabled (i.e., not for resin whisperers)
+        if (!HasComp<ResinWhispererComponent>(tunneledXeno.Owner))
+        {
+            EnableAllAbilities(tunneledXeno.Owner);
+        }
     }
 
     private void OnTryDropInTunnel(Entity<InXenoTunnelComponent> tunneledXeno, ref DropAttemptEvent args)

--- a/Content.Shared/_RMC14/Xenonids/Construction/Tunnel/XenoTunnelSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/Tunnel/XenoTunnelSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared._RMC14.Stun;
 using Content.Shared._RMC14.TacticalMap;
 using Content.Shared._RMC14.Xenonids.Devour;
 using Content.Shared._RMC14.Xenonids.Hive;
+using Content.Shared._RMC14.Xenonids.Rest;
 using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared._RMC14.Xenonids.Weeds;
 using Content.Shared._RMC14.Xenonids.Construction.ResinWhisper;
@@ -833,18 +834,16 @@ public sealed class XenoTunnelSystem : EntitySystem
 
     private void DisableSpecificAbilities(EntityUid ent)
     {
-        var actions = _action.GetActions(ent);
-        foreach (var action in actions)
+        foreach (var action in _rmcActions.GetActionsWithEvent<XenoRestActionEvent>(ent))
         {
-            var actionName = Name(action).ToLower();
-            if (actionName.Contains("rest") || actionName.Contains("regurgitate"))
-            {
-                _action.SetEnabled(action.AsNullable(), false);
-            }
+            _action.SetEnabled((action, action), false);
+        }
+        
+        foreach (var action in _rmcActions.GetActionsWithEvent<XenoRegurgitateActionEvent>(ent))
+        {
+            _action.SetEnabled((action, action), false);
         }
     }
-
-
 
     private bool TryPlaceTunnel(Entity<HiveMemberComponent?> builder, string? name, [NotNullWhen(true)] out EntityUid? tunnelEnt)
     {

--- a/Content.Shared/_RMC14/Xenonids/Construction/Tunnel/XenoTunnelSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/Tunnel/XenoTunnelSystem.cs
@@ -733,7 +733,7 @@ public sealed class XenoTunnelSystem : EntitySystem
     {
         if (HasComp<ResinWhispererComponent>(tunneledXeno.Owner))
         {
-            DisableAllExceptResinWhispererAbilities(tunneledXeno.Owner);
+            DisableSpecificAbilities(tunneledXeno.Owner);
         }
         else
         {
@@ -831,18 +831,20 @@ public sealed class XenoTunnelSystem : EntitySystem
         }
     }
 
-    private void DisableAllExceptResinWhispererAbilities(EntityUid ent)
+    private void DisableSpecificAbilities(EntityUid ent)
     {
         var actions = _action.GetActions(ent);
         foreach (var action in actions)
         {
-            var actionName = Name(action);
-            if (!actionName.Contains("resin", StringComparison.OrdinalIgnoreCase))
+            var actionName = Name(action).ToLower();
+            if (actionName.Contains("rest") || actionName.Contains("regurgitate"))
             {
                 _action.SetEnabled(action.AsNullable(), false);
             }
         }
     }
+
+
 
     private bool TryPlaceTunnel(Entity<HiveMemberComponent?> builder, string? name, [NotNullWhen(true)] out EntityUid? tunnelEnt)
     {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
https://github.com/RMC-14/RMC-14/issues/6548#issue-3087423980

Fixes this issue

## Why / Balance
n/a

## Technical details
When xenos enter a tunnel it disables all their abilities, I changed the OnInTunnel and OnOutTunnel to skip the caste specific abilities of resin whisperer while still disabling the base. They are still unable to build in the tunnel though.

I tried one by one disabling them and it didn't work until I let all through, I have no idea why it reacts to the map ui actions but oh well.

## Media
https://github.com/user-attachments/assets/7769b3ba-a402-402b-9991-d1a1a35872da

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed not being able to use tunnels as resin whisperer hivelord.