### PR TITLE
Comtech Sentry recommended change

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/engineer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/engineer.yml
@@ -20,11 +20,12 @@
       entries:
       - id: CMVendorBundleCombatTechnicianEssentials
     - name: Handheld Defense
-      takeOne: CMHandheldDefense
+      choices:  { CMHandheldDefense : 1 }
       entries:
     #    CMJIMAPlantedFlag
     #    CMUA42FSentryFlamer
       - id: RMCSentry
+        recommended: true
       - id: RMCTesla
       - id: RMCSentryFire
     - name: Handheld Defense Upgrade


### PR DESCRIPTION
## About the PR
Added the 571-C sentry gun (the standard one) as the recommended option in the comtech menu

## Why / Balance
This is similar to my other recent PR https://github.com/RMC-14/RMC-14/pull/8022 and has similar logic to it, recommended options are useful for newer players and comtech is a role that someone could be playing as their second ever role after rifleman - it is handy for these newer players to have pointers to what are good options to take and I believe that the standard sentry gun is much more likely to be useful for a newer comtech player than the other two options, especially the tesla. 

## Technical details
simple yml. changed from "takeOne" to "choices" to allow the recommended option highlight.

## Media
old
<img width="479" height="153" alt="image" src="https://github.com/user-attachments/assets/f609d091-bdce-49e6-b7e6-44310d2f19f4" />

new
<img width="474" height="150" alt="image" src="https://github.com/user-attachments/assets/32b49871-1ca0-4c61-ba91-0507fc173e34" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: The 571-C sentry gun is now highlighted as a recommended option in the combat technician vendor.