### PR TITLE
Changes to shard gained numbers on slash and damage recieved, also fix a potentional lag causer

### DIFF
--- a/Content.Server/Explosion/EntitySystems/RMCProjectileGrenadeSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/RMCProjectileGrenadeSystem.cs
@@ -118,7 +118,7 @@ public sealed class RMCProjectileGrenadeSystem : EntitySystem
                 continue;
 
             _hitEntities.Add(entity);
-            limit.HitBy.Add(new Hit(GetNetEntity(ent.Owner), _timing.CurTime + limit.Expire));
+            limit.HitBy.Add(new Hit(GetNetEntity(ent.Owner), _timing.CurTime + limit.Expire, null));
             Dirty(entity,limit);
 
             if(projectileCount == 0)

--- a/Content.Shared/_RMC14/Explosion/CMClusterGrenadeSystem.cs
+++ b/Content.Shared/_RMC14/Explosion/CMClusterGrenadeSystem.cs
@@ -47,7 +47,7 @@ public sealed class CMClusterGrenadeSystem : EntitySystem
             return;
         }
 
-        limit.HitBy.Add(new Hit(GetNetEntity(ent.Comp.OriginEntity), _timing.CurTime + limit.Expire));
+        limit.HitBy.Add(new Hit(GetNetEntity(ent.Comp.OriginEntity), _timing.CurTime + limit.Expire, ent.Comp.ExtraId));
         Dirty(args.Target, limit);
     }
 
@@ -74,8 +74,11 @@ public sealed class CMClusterGrenadeSystem : EntitySystem
                 !projectile.Comp.IgnoredEntities.Contains(user))
                 continue;
 
-            if (GetEntity(hit.Id) == projectile.Comp.OriginEntity ||
-                hit.Id == GetNetEntity(projectile.Owner)&&
+            // TODO RMC14 save me from this if statement
+            if (GetEntity(hit.Id) == projectile.Comp.OriginEntity &&
+                (hit.ExtraId == null || hit.ExtraId == projectile.Comp.ExtraId) ||
+                hit.Id == GetNetEntity(projectile.Owner) &&
+                (hit.ExtraId == null || hit.ExtraId == projectile.Comp.ExtraId) &&
                 hit.ExpireAt > time)
             {
                 count++;

--- a/Content.Shared/_RMC14/Explosion/ProjectileLimitHitsComponent.cs
+++ b/Content.Shared/_RMC14/Explosion/ProjectileLimitHitsComponent.cs
@@ -6,11 +6,14 @@ namespace Content.Shared._RMC14.Explosion;
 public sealed partial class ProjectileLimitHitsComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public List<EntityUid> IgnoredEntities = new ();
+    public List<EntityUid> IgnoredEntities = new();
 
     [DataField, AutoNetworkedField]
     public EntityUid OriginEntity;
 
     [DataField, AutoNetworkedField]
     public int Limit = 1;
+
+    [DataField, AutoNetworkedField]
+    public int? ExtraId;
 }

--- a/Content.Shared/_RMC14/Explosion/UserLimitHitsComponent.cs
+++ b/Content.Shared/_RMC14/Explosion/UserLimitHitsComponent.cs
@@ -19,5 +19,6 @@ public sealed partial class UserLimitHitsComponent : Component
 public partial record struct Hit(
     NetEntity Id,
     [field: DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
-    TimeSpan ExpireAt
+    TimeSpan ExpireAt,
+    int? ExtraId
 );

--- a/Content.Shared/_RMC14/Shields/XenoShieldSystem.cs
+++ b/Content.Shared/_RMC14/Shields/XenoShieldSystem.cs
@@ -25,7 +25,7 @@ public sealed partial class XenoShieldSystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popup = default!;
 
     private static readonly ProtoId<DamageTypePrototype> ShieldSoundDamageType = "Piercing";
-    private static readonly EntProtoId HedgehogSpikeProjectile = "XenoHedgehogShieldSpikeProjectile";
+
     public enum ShieldType
     {
         Generic,
@@ -85,17 +85,20 @@ public sealed partial class XenoShieldSystem : EntitySystem
                 _audio.PlayPredicted(ent.Comp.ShieldImpact, ent, null);
 
                 // Fire hedgehog spikes when shield is hit
-                if (ent.Comp.Shield == ShieldType.Hedgehog && TryComp<XenoSpikeShieldComponent>(ent, out var spikeShield) && spikeShield.Active)
+                if (ent.Comp.Shield == ShieldType.Hedgehog &&
+                    TryComp<XenoSpikeShieldComponent>(ent, out var spikeShield) &&
+                    spikeShield.Active)
                 {
                     _xenoProjectile.TryShoot(
                         ent.Owner,
                         new EntityCoordinates(ent, Vector2.UnitX * 2.5f),
                         FixedPoint2.Zero,
-                        HedgehogSpikeProjectile,
+                        spikeShield.Projectile,
                         null,
-                        9, // 9 spikes like CM13
+                        spikeShield.ProjectileCount,
                         new Angle(2 * Math.PI), // Full circle
                         15f,
+                        projectileHitLimit: spikeShield.ProjectileHitLimit,
                         predicted: false
                     );
 

--- a/Content.Shared/_RMC14/Xenonids/Hedgehog/XenoFireSpikesComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hedgehog/XenoFireSpikesComponent.cs
@@ -34,4 +34,7 @@ public sealed partial class XenoFireSpikesComponent : Component
 
     [DataField, AutoNetworkedField]
     public int ProjectileCount = 8;
+
+    [DataField, AutoNetworkedField]
+    public int? ProjectileHitLimit = 6;
 }

--- a/Content.Shared/_RMC14/Xenonids/Hedgehog/XenoShardComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hedgehog/XenoShardComponent.cs
@@ -22,7 +22,10 @@ public sealed partial class XenoShardComponent : Component
     public float ShardGrowthRate = 5f; // shard_gain_onlife = 5
 
     [DataField, AutoNetworkedField]
-    public int ShardsOnDamage = 15; // shards_per_slash = 15
+    public int ShardsOnDamage = 10; // shards gained when hit by projectiles
+
+    [DataField, AutoNetworkedField]
+    public int ShardsPerSlash = 15; // shards gained when dealing melee damage
 
 
 

--- a/Content.Shared/_RMC14/Xenonids/Hedgehog/XenoShardSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hedgehog/XenoShardSystem.cs
@@ -11,6 +11,9 @@ using Robust.Shared.Map;
 using System.Numerics;
 using Content.Shared.Popups;
 using Robust.Shared.Network;
+using Content.Shared._RMC14.Xenonids;
+using Content.Shared.Weapons.Melee.Events;
+using Content.Shared.Rejuvenate;
 
 namespace Content.Shared._RMC14.Xenonids.Hedgehog;
 
@@ -25,18 +28,21 @@ public sealed class XenoShardSystem : EntitySystem
     [Dependency] private readonly XenoProjectileSystem _xenoProjectile = default!;
     [Dependency] private readonly XenoShieldSystem _xenoShield = default!;
     [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly XenoSystem _xeno = default!;
 
     public override void Initialize()
     {
         SubscribeLocalEvent<XenoShardComponent, DamageChangedEvent>(OnDamageChanged);
         SubscribeLocalEvent<XenoShardComponent, CMGetArmorEvent>(OnShardGetArmor);
         SubscribeLocalEvent<XenoShardComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<XenoShardComponent, MeleeHitEvent>(OnMeleeHit);
 
         SubscribeLocalEvent<XenoFireSpikesComponent, ActionXenoFireSpikesEvent>(OnFireSpikes);
         SubscribeLocalEvent<XenoSpikeShedComponent, ActionXenoSpikeShedEvent>(OnSpikeShed);
         SubscribeLocalEvent<XenoSpikeShieldComponent, ActionXenoSpikeShieldEvent>(OnSpikeShield);
 
         SubscribeLocalEvent<XenoSpikeShieldComponent, RemovedShieldEvent>(OnShieldRemoved);
+        SubscribeLocalEvent<XenoShardComponent, RejuvenateEvent>(OnRejuvenate);
     }
 
     public override void Update(float frameTime)
@@ -82,6 +88,18 @@ public sealed class XenoShardSystem : EntitySystem
             return;
 
         AddShards(ent, ent.Comp.ShardsOnDamage);
+    }
+
+    private void OnMeleeHit(Entity<XenoShardComponent> ent, ref MeleeHitEvent args)
+    {
+        foreach (var target in args.HitEntities)
+        {
+            if (_xeno.CanAbilityAttackTarget(ent, target))
+            {
+                AddShards(ent, ent.Comp.ShardsPerSlash);
+                break; // Only gain shards once per attack
+            }
+        }
     }
 
     public void AddShards(Entity<XenoShardComponent> ent, int amount)
@@ -288,5 +306,32 @@ public sealed class XenoShardSystem : EntitySystem
 
         ent.Comp.Active = false;
         Dirty(ent, ent.Comp);
+    }
+
+    private void OnRejuvenate(Entity<XenoShardComponent> ent, ref RejuvenateEvent args)
+    {
+        // Reset shard cooldown
+        ent.Comp.SpikeShedCooldownEnd = TimeSpan.Zero;
+        ent.Comp.SpikeShedCooldownMessageShown = false;
+        
+        // Set shards to 150
+        ent.Comp.Shards = 150;
+        
+        // Reset ability cooldowns
+        if (TryComp<XenoFireSpikesComponent>(ent, out var fireSpikes))
+        {
+            fireSpikes.CooldownExpireAt = TimeSpan.Zero;
+            Dirty(ent, fireSpikes);
+        }
+        
+        if (TryComp<XenoSpikeShieldComponent>(ent, out var spikeShield))
+        {
+            spikeShield.CooldownExpireAt = TimeSpan.Zero;
+            Dirty(ent, spikeShield);
+        }
+        
+        Dirty(ent);
+        _armor.UpdateArmorValue(ent.Owner);
+        UpdateHedgehogSprite(ent);
     }
 }

--- a/Content.Shared/_RMC14/Xenonids/Hedgehog/XenoShardSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hedgehog/XenoShardSystem.cs
@@ -176,7 +176,8 @@ public sealed class XenoShardSystem : EntitySystem
             ent.Comp.ProjectileCount,
             new Angle(Math.PI / 4), // 45 degrees
             20f,
-            target: args.Entity
+            target: args.Entity,
+            projectileHitLimit: ent.Comp.ProjectileHitLimit
         );
     }
 
@@ -216,7 +217,8 @@ public sealed class XenoShardSystem : EntitySystem
             null,
             ent.Comp.ProjectileCount,
             new Angle(2 * Math.PI), // Full circle
-            20f
+            20f,
+            projectileHitLimit: ent.Comp.ProjectileHitLimit
         );
 
         // Apply speed boost (remove armor bonus, gain speed)
@@ -313,23 +315,23 @@ public sealed class XenoShardSystem : EntitySystem
         // Reset shard cooldown
         ent.Comp.SpikeShedCooldownEnd = TimeSpan.Zero;
         ent.Comp.SpikeShedCooldownMessageShown = false;
-        
+
         // Set shards to 150
         ent.Comp.Shards = 150;
-        
+
         // Reset ability cooldowns
         if (TryComp<XenoFireSpikesComponent>(ent, out var fireSpikes))
         {
             fireSpikes.CooldownExpireAt = TimeSpan.Zero;
             Dirty(ent, fireSpikes);
         }
-        
+
         if (TryComp<XenoSpikeShieldComponent>(ent, out var spikeShield))
         {
             spikeShield.CooldownExpireAt = TimeSpan.Zero;
             Dirty(ent, spikeShield);
         }
-        
+
         Dirty(ent);
         _armor.UpdateArmorValue(ent.Owner);
         UpdateHedgehogSprite(ent);

--- a/Content.Shared/_RMC14/Xenonids/Hedgehog/XenoSpikeShedComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hedgehog/XenoSpikeShedComponent.cs
@@ -37,4 +37,7 @@ public sealed partial class XenoSpikeShedComponent : Component
 
     [DataField, AutoNetworkedField]
     public int ProjectileCount = 40;
+
+    [DataField, AutoNetworkedField]
+    public int? ProjectileHitLimit = 6;
 }

--- a/Content.Shared/_RMC14/Xenonids/Hedgehog/XenoSpikeShieldComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hedgehog/XenoSpikeShieldComponent.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Damage;
 using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared._RMC14.Xenonids.Hedgehog;
 
@@ -35,5 +36,14 @@ public sealed partial class XenoSpikeShieldComponent : Component
     public TimeSpan LastProcTime = TimeSpan.Zero;
 
     [DataField, AutoNetworkedField]
-    public float AccumulatedDamage = 0f;
+    public float AccumulatedDamage;
+
+    [DataField, AutoNetworkedField]
+    public EntProtoId Projectile = "XenoHedgehogShieldSpikeProjectile";
+
+    [DataField, AutoNetworkedField]
+    public int ProjectileCount = 9;
+
+    [DataField, AutoNetworkedField]
+    public int? ProjectileHitLimit = 6;
 }

--- a/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
@@ -124,9 +124,6 @@ public sealed class XenoProjectileSystem : EntitySystem
 
     private void OnShotRemove<T>(Entity<XenoProjectileShotComponent> ent, ref T args)
     {
-        if (_timing.ApplyingState)
-            return;
-            
         if (ent.Comp.ShooterEnt is not { } shooter)
             return;
 

--- a/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
@@ -142,7 +142,6 @@ public sealed class XenoProjectileSystem : EntitySystem
         if (!TryComp(ent, out XenoProjectileShotComponent? shot))
             return;
 
-        Log.Info(_timing.CurTick.ToString());
         var ev = new XenoProjectilePredictedHitEvent(
             shot.Id,
             GetNetEntity(args.OtherEntity),
@@ -216,7 +215,8 @@ public sealed class XenoProjectileSystem : EntitySystem
         float speed,
         float? stopAtDistance = null,
         EntityUid? target = null,
-        bool predicted = true)
+        bool predicted = true,
+        int? projectileHitLimit = null)
     {
         if (!predicted && _net.IsClient)
             return false;
@@ -281,6 +281,14 @@ public sealed class XenoProjectileSystem : EntitySystem
                 var targeted = EnsureComp<TargetedProjectileComponent>(projectile);
                 targeted.Target = target.Value;
                 Dirty(projectile, targeted);
+            }
+
+            if (projectileHitLimit != null)
+            {
+                var limitHits = EnsureComp<ProjectileLimitHitsComponent>(projectile);
+                limitHits.Limit = projectileHitLimit.Value;
+                limitHits.OriginEntity = xeno;
+                Dirty(projectile, limitHits);
             }
 
             shooter ??= EnsureComp<XenoProjectileShooterComponent>(xeno);

--- a/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
@@ -309,26 +309,4 @@ public sealed class XenoProjectileSystem : EntitySystem
         RaiseLocalEvent(xeno, ammoShotEvent);
         return true;
     }
-
-    public override void Update(float frameTime)
-    {
-        // Clean up invalid projectile references to prevent networking errors
-        var query = EntityQueryEnumerator<XenoProjectileShooterComponent>();
-        while (query.MoveNext(out var uid, out var comp))
-        {
-            var toRemove = new List<EntityUid>();
-            foreach (var shot in comp.Shot)
-            {
-                if (Deleted(shot) || TerminatingOrDeleted(shot))
-                    toRemove.Add(shot);
-            }
-            
-            if (toRemove.Count > 0)
-            {
-                foreach (var shot in toRemove)
-                    comp.Shot.Remove(shot);
-                Dirty(uid, comp);
-            }
-        }
-    }
 }

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_spike_projectiles.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_spike_projectiles.yml
@@ -25,6 +25,8 @@
     slow: 3
     paralyze: 0
     armorResistsKnockdown: true
+  - type: TimedDespawn
+    lifetime: 1.0
 
 - type: entity
   parent: XenoHedgehogSpikeProjectile


### PR DESCRIPTION
## About the PR
The numbers were a bit off for shard gain, I've since corrected them.

I have also specified a rejuv method for the handler that properly resets hedgehog rav's abilities, shard gain and sets shards to 150 to be enable easier testing going forward.

## Why / Balance
n/a

## Technical details
Reinforced timedespawn, even if clean up isn't needed just as a fallback.

XenoProjectileShooterComponent kept references to already deleted projectiles, so when trying to sync the comp state, it tried to reference deleted entities causing mass "Can't resolve MetaDataComponent" errors which caused huge amount of lag with every added rav spike used.

Uncertain if this could be happening with other projectiles but glad I have seemingly fixed this, I might be completely wrong but who knows, it isn't my strong suit.

## Media
n/a

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
