### PR TITLE
add flare holster to req

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
@@ -179,8 +179,8 @@
         amount: 2
       - id: RMCBeltHolsterRevolver
         amount: 5
-      #- id: M276 M82F Holster Rig
-      #  amount: 2
+      - id: RMCM82FHolster
+        amount: 2
       - id: RMCM276ShotgunShellLoadingRig
         amount: 10
       - id: CMBeltMortar


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
There was a commented line looking to add the flaregun holster to the req vendor. Now that the flaregun holster exists I have updated that line to correctly add the flaregun holster.

## Why / Balance
I'm assuming it was always supposed to be there.

## Technical details
updated a commented id reference to match the real id for the item.

## Media
I believe this change is exempt from media requests.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!--
:cl:
- add: Requisitions can now dispense flare gun holsters from their vendors.
-->
