### PR TITLE
Fix players seeing entity string

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Hedgehog/XenoShardSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hedgehog/XenoShardSystem.cs
@@ -273,7 +273,7 @@ public sealed class XenoShardSystem : EntitySystem
 
         // Show CM13-style messages
         var selfMsg = "We ruffle our bone-shard quills, forming a defensive shell!";
-        var othersMsg = $"{ent} ruffles its bone-shard quills, forming a defensive shell!";
+        var othersMsg = "The hedgehog ruffles its bone-shard quills, forming a defensive shell!";
         _popup.PopupPredicted(selfMsg, othersMsg, ent, ent);
         _aura.GiveAura(ent, Color.Blue, shield.ShieldDuration, 2);
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR


## Why / Balance


## Technical details


## Media


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl: 
fix: Entity text no longer leaking to other xenonids when ravager uses shield
