### PR TITLE
Update Xeno DamageOverlay

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Hedgehog/XenoShardSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hedgehog/XenoShardSystem.cs
@@ -269,7 +269,7 @@ public sealed class XenoShardSystem : EntitySystem
 
 
         // Give overshield with very high HP so it blocks all damage but still triggers spike firing
-        _xenoShield.ApplyShield(ent, XenoShieldSystem.ShieldType.Hedgehog, FixedPoint2.New(500), shield.ShieldDuration);
+        _xenoShield.ApplyShield(ent, XenoShieldSystem.ShieldType.Hedgehog, FixedPoint2.New(9999), shield.ShieldDuration);
 
         // Show CM13-style messages
         var selfMsg = "We ruffle our bone-shard quills, forming a defensive shell!";


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
fixes https://github.com/RMC-14/RMC-14/issues/7963
made their damage overlay green

## Why / Balance
parity

down the line I would prefer if we could get separate overlays that are a bit better than just a damn faded circle though, like a collection of 6-7 image overlays that are show with damage taken - but that's a later time and I need to have a conversation with rmc artisté about that


## Technical details
simple change, made a checker for xeno comp and a separate case for xenos, would be easy to bring in upstream changes if needed

## Media
<img width="2020" height="1412" alt="image" src="https://github.com/user-attachments/assets/8601e788-8ec8-4e3c-9672-911a41546e6f" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Changed xeno damage overlay to green
