### PR TITLE
Remove ERT badges from CMB corpses

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Corpses/civilians.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Corpses/civilians.yml
@@ -205,7 +205,7 @@
     shoes: CMBootsBlackFilled
     head: RMCHeadCapBureau
     eyes: CMGlassesSecurity
-    id: RMCIDCardCMBDeputy
+    id: RMCIDCardDeputySurvivor
     ears: CMHeadsetColony
     belt: RMCBeltHolsterPistolHandcannonFilled
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The CMB corpses have ERT badges on them with full all access. The badges in question have been replaced with survivor variants,
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Prevents bad actors from using the AA badges.
Partially (if not completely) fixes  #8131 
## Technical details
<!-- Summary of code changes for easier review. -->
yml

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: CMB corpses no longer spawn with all access badges.