### PR TITLE
Nutrimax vendor plant bag fix

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/vending_machines.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/vending_machines.yml
@@ -552,7 +552,7 @@
     ChemistryBottleRobustHarvest: 15
     PestSpray: 20
     Syringe: 5
-    PlantBag: 5
+    RMCStoragePlantBag: 5
     RMCToolSpade: 3
     RMCToolHatchet: 3
     # AmmoniaBottle: 10 #Premium


### PR DESCRIPTION
## About the PR
Fixing the Nutrimax vendor using the upstream plant bags rather than our own

## Why / Balance
Fix

## Technical details
yml

## Media
Old
<img width="536" height="314" alt="image" src="https://github.com/user-attachments/assets/d24a23f8-2803-4882-b4b0-531bc8a470a3" />

New
<img width="452" height="274" alt="image" src="https://github.com/user-attachments/assets/b8d04188-54c0-4525-9eac-73154944fd7a" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: The Nutrimax vendor now stocks the correct RMC plant bag.