### PR TITLE
Supply drop console: requisitions access requirement

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/supply_drop_computer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/supply_drop_computer.yml
@@ -17,6 +17,9 @@
   - type: SupplyDropComputer
     squad: SquadEcho
     cooldown: 300
+  - type: ActivatableUIRequiresAccess
+  - type: AccessReader
+    access: [ [ "CMAccessRequisitions" ] ]
   - type: ActivatableUIBlacklist
     blacklist:
       components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/SPPoverwatch.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/SPPoverwatch.yml
@@ -10,8 +10,7 @@
   icon: "CMJobIconEmpty"
   joinNotifyCrew: false
   accessGroups:
-  - SO
-  - Rifleman
+  - ShipMasterAccess
   spawnMenuRoleName: SPP Platoon Commander (PVE)
   special:
   - !type:AddComponentSpecial


### PR DESCRIPTION
## About the PR
The supply drop console will now have a requisitions access lock, only people with requisitions access will be able to use the console.
Gave SPP PvE PlatCo shipmaster access to match their UNMC PlatCo counterpart, so that they will be able to use the supply drop console.

## Why / Balance
Parity. Fixes https://github.com/RMC-14/RMC-14/issues/8098

## Technical details
yml

## Media
https://github.com/user-attachments/assets/9cf4db61-7567-4e29-b73d-4535e558139d

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed the echo supply drop console not having a requisitions access requirement.