### PR TITLE
Zombies no longer drop their headsets and gloves on turn

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -207,9 +207,9 @@ public sealed partial class ZombieSystem
         _bloodstream.ChangeBloodReagent(target, zombiecomp.NewBloodReagent);
 
         //This is specifically here to combat insuls, because frying zombies on grilles is funny as shit.
-        _inventory.TryUnequip(target, "gloves", true, true);
+        // _inventory.TryUnequip(target, "gloves", true, true); RMC14
         //Should prevent instances of zombies using comms for information they shouldnt be able to have.
-        _inventory.TryUnequip(target, "ears", true, true);
+        // _inventory.TryUnequip(target, "ears", true, true); RMC14
 
         //popup
         _popup.PopupEntity(Loc.GetString("zombie-transform", ("target", target)), target, PopupType.LargeCaution);


### PR DESCRIPTION
title, simple PR

makes spawning zombies en masse x1000 easier as GMs / Admins no longer have to delete dropped gloves and headsets for each spawned zombie.