### PR TITLE
Fix being able to pry powered podlocks

### DIFF
--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -15,6 +15,7 @@ using Content.Shared.Prying.Systems;
 using Content.Shared.Stunnable;
 using Content.Shared.Tag;
 using Content.Shared.Tools.Systems;
+using Content.Shared._RMC14.Doors;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map.Components;
@@ -224,6 +225,14 @@ public abstract partial class SharedDoorSystem : EntitySystem
     {
         if (door.State == DoorState.Welded || !door.CanPry)
             args.Cancelled = true;
+
+         // RMC14
+        var beforepry = new RMCBeforePryEvent(args.User);
+        RaiseLocalEvent(uid, ref beforepry);
+
+        if (beforepry.Cancelled)
+            args.Cancelled = true;
+        // RMC14
     }
 
     /// <summary>

--- a/Content.Shared/_RMC14/Doors/CMDoorSystem.cs
+++ b/Content.Shared/_RMC14/Doors/CMDoorSystem.cs
@@ -52,7 +52,7 @@ public sealed class CMDoorSystem : EntitySystem
 
         SubscribeLocalEvent<DoorComponent, RMCDoorPryEvent>(OnDoorPry);
 
-        SubscribeLocalEvent<DoorComponent, BeforePryEvent>(OnBeforePry);
+        SubscribeLocalEvent<DoorComponent, RMCBeforePryEvent>(OnBeforePry);
 
         SubscribeLocalEvent<RMCPodDoorComponent, GetPryTimeModifierEvent>(OnPodDoorGetPryTimeModifier);
 
@@ -163,7 +163,7 @@ public sealed class CMDoorSystem : EntitySystem
         RaiseNetworkEvent(new RMCPodDoorButtonPressedEvent(GetNetEntity(button), animState), Filter.PvsExcept(button));
     }
 
-    private void OnBeforePry(Entity<DoorComponent> ent, ref BeforePryEvent args)
+    private void OnBeforePry(Entity<DoorComponent> ent, ref RMCBeforePryEvent args)
     {
         if (TryComp(ent, out DoorComponent? door) && door.State != DoorState.Closed)
         {

--- a/Content.Shared/_RMC14/Doors/RMCDoorComponent.cs
+++ b/Content.Shared/_RMC14/Doors/RMCDoorComponent.cs
@@ -48,3 +48,10 @@ public record struct RMCDoorPryEvent(EntityUid User)
 
     public bool Cancelled;
 }
+
+[ByRefEvent]
+public record struct RMCBeforePryEvent(EntityUid User)
+{
+    public readonly EntityUid User = User;
+    public bool Cancelled;
+}


### PR DESCRIPTION
Fixes #8086
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
rmcdoorcomponent got changed and i didnt update my function properly to accomodate for it so basically it just didnt run, fixed it

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
bug bad no more podlocks to space

## Technical details
<!-- Summary of code changes for easier review. -->
new event that we run on OnBeforePry because otherwise dupe event sub, we cancel this event in OnBeforePry in CMDoorSystem if our criterias are met which then cancels OnBeforePry in SharedDoorSystem

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: noctynral
- fix: Fixed being able to pry open powered podlocks and shutters.
- fix: Fixed Xenos being able to pry doors closed.
