### PR TITLE
PK-7 Description fix

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/pk7.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/pk7.yml
@@ -2,7 +2,7 @@
   parent: CMWeaponPistolBase
   id: RMCWeaponPistolPK7
   name: PK-7 electrostatic pistol
-  description: A Weston-Yamada manufactured less-than-lethal pistol. Originally manufactured in the 2080s, the ES-4 electrostatic pistol fires electrically-charged bullets with high accuracy, though its cost and constant need for cleaning makes it a rare sight.
+  description: A Weston-Yamada manufactured less-than-lethal pistol. Originally manufactured in the 2080s, the PK-7 electrostatic pistol fires electrically-charged bullets with high accuracy, though its cost and constant need for cleaning makes it a rare sight.
   components:
   - type: Tag
     tags:


### PR DESCRIPTION
## About the PR
gun name is wrong in description, fixed.

## Why / Balance
error fixing, fixes https://github.com/RMC-14/RMC-14/issues/8088

## Technical details
yml

## Media
not needed

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed PK-7 description having the wrong gun name.