### PR TITLE
Giving UNMC Synths MP comms access

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/ship_headsets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/ship_headsets.yml
@@ -505,7 +505,7 @@
   - type: ContainerFill
     containers:
       key_slots:
-      - RMCEncryptionKeyMarineCommand
+      - RMCEncryptionKeySeniorCommand
   - type: HeadsetMultiBroadcast
     cooldown: 60
   - type: GrantSquadLeaderTracker


### PR DESCRIPTION
## About the PR
Changed synth comms key from command to senior command to give them MP comms.

## Why / Balance
Parity. Fixes https://github.com/RMC-14/RMC-14/issues/7834

## Technical details
yml

## Media
<img width="351" height="461" alt="image" src="https://github.com/user-attachments/assets/eb54421f-b6b6-421f-9293-a73554d6332f" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Added MP comms to the UNMC Synthetic headset