### PR TITLE
Requisition vendors parity changes

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
@@ -19,7 +19,7 @@
   parent: ColMarTechCargo
   id: ColMarTechCargoGuns
   name: ASRS automated armaments vendor
-  description: An automated supply rack hooked up to a big storage of various firearms and explosives. Can be accessed by the Requisitions Officer and Requisitions Technicians.
+  description: An automated supply rack hooked up to a big storage of various firearms, explosives, load carrying equipment, and other miscellaneous items. Can be accessed by the Logistics Officer and Requisitions Technicians.
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/requisitions_wall/guns.rsi
@@ -238,22 +238,8 @@
         amount: 1
       - id: RMCPouchShotgunLarge
         amount: 1
-    - name: Miscellaneous
+    - name: Essential Devices
       entries:
-      - id: RMCFlashlight # Combat Flashlight
-        amount: 5
-      - id: CMEntrenchingTool
-        amount: 4
-      - id: CMMaskGas
-        amount: 10
-      - id: RMCPackFlareCAS
-        amount: 2
-      - id: CMPackFlare
-        amount: 10
-      - id: RMCScabbardMacheteFilled
-        amount: 6
-      #- id: MB-6 Folding Barricades (x3)
-      #   amount: 3
       - id: RMCMotionDetector
         amount: 4
       - id: RMCIntelDetector
@@ -264,28 +250,48 @@
         amount: 1
       - id: RMCLaserDesignator
         amount: 1
+      - id: RMCFulton20
+        amount: 1
+      #- id: Sentry Gun Network Laptop
+      #   amount: 4
+      #- id: Spare PDT/L Battle Buddy Kit
+      #  amount: 4
+    - name: Flare and Light
+      entries:
+      - id: RMCFlashlight # Combat Flashlight
+        amount: 8
+      - id: RMCPackFlareCAS
+        amount: 2
+      - id: CMPackFlare
+        amount: 10
+    - name: Miscellaneous
+      entries:
+      - id: CMEntrenchingTool
+        amount: 4
+      - id: CMMaskGas
+        amount: 10
+      - id: RMCScabbardMacheteFilled
+        amount: 6
+      #- id: MB-6 Folding Barricades (x3)
+      #   amount: 3
       #- id: Welding Goggles
       #  amount: 3
       - id: CMFireExtinguisherPortable
         amount: 3
       - id: RMCPowerCellHigh
         amount: 1
-      - id: RMCFulton20
-        amount: 1
-      #- id: Sentry Gun Network Laptop
-      #   amount: 4
+      - id: RMCPowerCellCrap
+        amount: 10
+      - id: RMCMagazineSMGNailgun
+        amount: 4
+    - name: Pamphlets
+      entries:
       - id: CMPamphletJTAC
         amount: 1
       - id: CMPamphletEngineer
         amount: 1
       #- id: Powerloader Certification
       #  amount: 1
-      #- id: Spare PDT/L Battle Buddy Kit
-      #  amount: 4
-      - id: RMCPowerCellCrap
-        amount: 10
-      - id: RMCMagazineSMGNailgun
-        amount: 4
     - name: Explosive Boxes
       hasBoxes: true
       entries:
@@ -345,7 +351,7 @@
   parent: ColMarTechCargo
   id: ColMarTechCargoAmmo
   name: ASRS automated munition vendor
-  description: An automated supply rack hooked up to a big storage of various ammunition types. Can be accessed by the Requisitions Officer and Requisitions Technicians.
+  description: An automated supply rack hooked up to a big storage of various ammunition types. Can be accessed by the Logistics Officer and Requisitions Technicians.
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/requisitions_wall/ammo.rsi
@@ -569,7 +575,7 @@
   parent: ColMarTechCargo
   id: ColMarTechCargoAttachments
   name: AEGIS Armaments attachments vendor
-  description: An automated supply rack hooked up to a big storage of weapons attachments. Can be accessed by the Requisitions Officer and Requisitions Technicians.
+  description: An automated supply rack hooked up to a big storage of weapons attachments. Can be accessed by the Logistics Officer and Requisitions Technicians.
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/requisitions_wall/attachments.rsi
@@ -630,6 +636,8 @@
         amount: 5
       - id: RMCAttachmentUnderbarrelExtinguisher
         amount: 5
+      - id: RMCAttachmentFlashlightGrip
+        amount: 10
       - id: RMCAttachmentU1GrenadeLauncher
         amount: 10
       - id: RMCAttachmentVerticalGrip
@@ -656,7 +664,7 @@
   parent: ColMarTechBase
   id: ColMarTechCargoUniform
   name: ASRS surplus uniform vendor
-  description: An automated supply rack hooked up to a big storage of standard marine uniforms. Can be accessed by the Requisitions Officer and Requisitions Technicians.
+  description: An automated supply rack hooked up to a big storage of standard marine uniforms. Can be accessed by the Logistics Officer and Requisitions Technicians.
   suffix: Requisitions
   components:
   - type: AccessReader
@@ -668,18 +676,34 @@
     sections:
     - name: Uniform
       entries:
-      - id: CMBackpackMarine
-        amount: 20
-      - id: CMBootsBlack
-        amount: 20
-      - id: CMBeltMarine
-        amount: 10
-      - id: RMCM276ShotgunShellLoadingRig
-        amount: 10
-      - id: CMSatchelMarine
-        amount: 20
       - id: JumpsuitMarine
         amount: 20
+      - id: CMJumpsuitMarineEngineer
+        amount: 5
+      - id: CMJumpsuitMarineMedic
+        amount: 5
+    - name: Boots
+      entries:
+      - id: CMBootsBlack
+        amount: 20
+      - id: CMBootsBrown
+        amount: 5
+      - id: CMBootsGrey
+        amount: 5
+    - name: Backpacks
+      entries:
+      - id: CMBackpackMarine
+        amount: 20
+      - id: CMSatchelMarine
+        amount: 20
+      - id: CMBackpackMarineTech
+        amount: 10
+      - id: CMSatchelMarineTech
+        amount: 10
+      - id: CMBackpackMarineMedic
+        amount: 10
+      - id: CMSatchelMarineMedic
+        amount: 10
     - name: Armor
       entries:
       - id: ArmorHelmetM10
@@ -748,12 +772,26 @@
         amount: 10
       - id: RMCMaskRebreather
         amount: 20
+    - name: Goggles
+      entries:
+      - id: RMCGogglesBallistic
+        amount: 10
+      - id: RMCGogglesM1A1Ballistic
+        amount: 10
+      - id: RMCGogglesPrescriptionBallistic
+        amount: 10
+      - id: RMCGlassesMarineRpg
+        amount: 10
     - name: Miscellaneous
       entries:
       - id: BedrollFolded
         amount: 30
       - id: RMCM5CameraGear
-        amount: 3
+        amount: 5
+      - id: RMCHelmetGarbNetting
+        amount: 10
+      - id: RMCHelmetGarbRainCover
+        amount: 10
       - id: RMCPatchFallingFalcons
         amount: 15
       - id: RMCPatchFallingFalconsAlt


### PR DESCRIPTION
## About the PR
Making changes to the req vendors to match parity. I did not add welding goggles, powerloader certification, or flare holster because there are other PRs open to do that.

## Why / Balance
Parity.

## Technical details
yml

## Media
uniform
<img width="490" height="692" alt="image" src="https://github.com/user-attachments/assets/14c5e383-a907-4381-8030-83ade1186036" />

armament
<img width="490" height="896" alt="image" src="https://github.com/user-attachments/assets/a5805ea7-88d0-4817-a8bb-4f30d72b2d5d" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed the requisitions uniform vendor missing some uniforms, boots, backpacks, goggles, and helmet accessories, and the requisitions attachment vendor missing flashlight grips.
- tweak: Changed the order of items in the requisitions armament and uniform vendors, with new categories.
- fix: Fixed the requisitions vendor descriptions to now mention the LO.