### PR TITLE
Put the CO's M59a Prototype Rifle in a case with 3 AP magazines.

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/gun_cases.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/gun_cases.yml
@@ -521,6 +521,26 @@
 
 - type: entity
   parent: RMCGunCaseBase
+  id: RMCM59ACaseAP
+  name: M59A prototype rifle AP case
+  description: A gun case containing the M59A prototype rifle loaded with AP rounds. Experimental and back issue only, built to outperform the standard M54C. While this case contains MK1 rifle magazines, the weapon also supports MK2 rifle magazines.
+  components:
+  - type: Storage
+    maxItemSize: Huge
+    grid:
+    - 0,0,5,1
+    whitelist:
+      tags:
+      - RMCWeaponRifleM59A
+      - CMMagazineRifleM54CMK1AP
+  - type: StorageFill
+    contents:
+    - id: RMCWeaponRifleM59A
+    - id: CMMagazineRifleM54CMK1AP
+    - id: CMMagazineRifleM54CMK1AP
+
+- type: entity
+  parent: RMCGunCaseBase
   id: RMCM54CMK2Case
   name: M54C assault rifle MK2 case
   description: A gun case containing the M54C assault rifle MK2.

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m59a_prototype_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m59a_prototype_rifle.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   parent: [ CMBaseWeaponRifle, RMCBaseWeaponMagazineVisuals ]
   name: M59A prototype rifle
   id: RMCWeaponRifleM59A
@@ -75,7 +75,7 @@
           - CMMagazineRifleM54CMK1AP
           - RMCMagazineRifleM54CIncendiary
           - RMCMagazineRifleM54CMK1Incendiary
-        startingItem: CMMagazineRifleM54CMK1
+        startingItem: CMMagazineRifleM54CMK1AP
   - type: GunDamageModifier
     multiplier: 1.1
   - type: RMCMagneticItem
@@ -127,3 +127,9 @@
       Snow: _RMC14/Objects/Weapons/Guns/Rifles/m59a/snow.rsi
       Classic: _RMC14/Objects/Weapons/Guns/Rifles/m59a/classic.rsi
       Urban: _RMC14/Objects/Weapons/Guns/Rifles/m59a/urban.rsi
+  - type: Tag
+    tags:
+    - RMCWeaponRifleM59A
+
+- type: Tag
+  id: RMCWeaponRifleM59A

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/command.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/command.yml
@@ -553,7 +553,7 @@
     - name: Commander's Primary
       takeOne: CMProtagGun
       entries:
-      - id: RMCWeaponRifleM59A
+      - id: RMCM59ACaseAP
         name: M59A Prototype Rifle
       - id: CMCOSmartGunOperatorEquipmentCaseBelt
         name: Commander's Smartgun


### PR DESCRIPTION
## About the PR
The M59a Prototype Rifle now starts with an AP mk1 magazine instead of a regular mk1 magazine.
Furthermore, the COs vendor will now provide an m59a case, containing this weapon and 2 additional mk1 AP mags.

## Why / Balance
Discussed here: https://discord.com/channels/1168210010233376858/1427611577447612417
TLDR: The XO gets this for their Mk1, but the CO previously only got a single regular mk1 mag.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl: BramvanZijp
- tweak: The Commanding Officer's M59a Prototype Rifle now comes in a case alongside 3 MK1 AP Magazines instead of one regular MK1 Magazine.