### PR TITLE
Aciders no longer gain acid from attacking training dummies

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/AciderGeneration/XenoAciderGenerationSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/AciderGeneration/XenoAciderGenerationSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared._RMC14.Xenonids.Energy;
 using Content.Shared._RMC14.Xenonids.Rest;
+using Content.Shared._RMC14.TrainingDummy;
 using Content.Shared.Mobs;
 using Content.Shared.StatusEffect;
 using Content.Shared.Stunnable;
@@ -28,6 +29,9 @@ public sealed class XenoAciderGenerationSystem : EntitySystem
         {
             if (!_xeno.CanAbilityAttackTarget(xeno, hit))
                 continue;
+
+            if (HasComp<RMCTrainingDummyComponent>(hit))
+                return;
 
             startGenerating = true;
             break;

--- a/Content.Shared/_RMC14/Xenonids/Energy/XenoEnergySystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Energy/XenoEnergySystem.cs
@@ -1,6 +1,7 @@
 using Content.Shared._RMC14.Actions;
 using Content.Shared._RMC14.Xenonids.Parasite;
 using Content.Shared._RMC14.Xenonids.Projectile;
+using Content.Shared._RMC14.TrainingDummy;
 using Content.Shared.Alert;
 using Content.Shared.Rounding;
 using Content.Shared.Mobs.Systems;
@@ -62,6 +63,9 @@ public sealed class XenoEnergySystem : EntitySystem
 
             if (xeno.Comp.IgnoreLateInfected && TryComp<VictimInfectedComponent>(hit, out var infect) && infect.CurrentStage >= infect.FinalSymptomsStart)
                 continue;
+            
+            if (HasComp<RMCTrainingDummyComponent>(hit))
+                return;
 
             isHit = true;
             if (_stand.IsDown(hit))


### PR DESCRIPTION
## About the PR
Slashing anything that has a training dummy component no longer gives the runner acider strain any acid gain. Both the instant acid gain and passive acid gain accounted for.

## Why / Balance
To address my own bug report I made here: https://github.com/RMC-14/RMC-14/issues/8156
Basically, training dummies can now be spawned in medbay by admins without worrying about people exploiting them during hijack as acider.

## Technical details
When hitting an entity, checks if the entity has a "RMCTrainingDummyComponent" and doesn't grant acid gain if it does.

## Media
https://github.com/user-attachments/assets/6fc61843-7803-407c-8203-e8adc611d3d4

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

:cl:
- fix: Fixed acider runners gaining acid from hitting training dummies.