### PR TITLE
synth vision to half

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/synth.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/synth.yml
@@ -79,7 +79,6 @@
           Shock: -15
           Cold: -15
       addComponents:
-      # TODO darksight instead of night vision
       - type: NightVision
         innate: true
         state: Half


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
synth vision to half
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
parity
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
🆑 Vixting
- tweak: Synth vision now uses half vision.
