### PR TITLE
Fix xenos being unable to pry powered doors

### DIFF
--- a/Content.Shared/_RMC14/Doors/CMDoorSystem.cs
+++ b/Content.Shared/_RMC14/Doors/CMDoorSystem.cs
@@ -171,7 +171,7 @@ public sealed class CMDoorSystem : EntitySystem
                 args.Cancelled = true;
         }
 
-        if (_rmcPower.IsPowered(ent))
+        if (_rmcPower.IsPowered(ent) && !HasComp<XenoComponent>(args.User))
             args.Cancelled = true;
 
     }


### PR DESCRIPTION
fixes #8190
title

:cl:
- fix: Fixed xenos not being able to pry powered doors.