### PR TITLE
Fixes mag repacking leaving floating ammo

### DIFF
--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
@@ -229,7 +229,7 @@ public abstract partial class SharedGunSystem
         }
 
         List<(EntityUid? Entity, IShootable Shootable)> ammo = new();
-        var evTakeAmmo = new TakeAmmoEvent(Math.Min(20, target.Capacity - (target.Entities.Count + target.UnspawnedCount)), ammo, Transform(uid).Coordinates, args.User); // RMC14
+        var evTakeAmmo = new TakeAmmoEvent(Math.Clamp(target.Capacity - target.Count, 0, 20), ammo, Transform(uid).Coordinates, args.User); // RMC14
         RaiseLocalEvent(uid, evTakeAmmo);
 
         foreach (var (ent, _) in ammo)


### PR DESCRIPTION
## About the PR
The logic no longer takes 20 ammo no matter what and takes less if the target mag is missing less than 20 pieces of ammo.

## Why / Balance
fixes #8089
fixes #8219 (Possibly, remove this line if you as a maintainer thing that is an unrelated issue)

## Technical details
See commit descriptions, it uses the humble Math.Min

## Media
N/A, this is a small fix

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed mag to mag repacking leaving floating ammo around unfortunate marines.
