### PR TITLE
battlefield executions can now be used in PvE

### DIFF
--- a/Content.Shared/_RMC14/Weapons/Ranged/RMCBattleExecuteSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/RMCBattleExecuteSystem.cs
@@ -88,7 +88,7 @@ public sealed class RMCBattleExecuteSystem : EntitySystem
         RMCBattleExecuteComponent executionComponent,
         EntityUid handHeldItem)
     {
-        if (HasComp<RMCBattleExecutedComponent>(target) || HasComp<UnrevivableComponent>(target))
+        if (_mobState.IsDead(target) && _unrevivable.IsUnrevivable(target))
         {
             var cancelledMessage = $"You decide to not Execute {Name(target)}, as they are already far beyond revival.";
             _popup.PopupClient(cancelledMessage, user, PopupType.MediumCaution);


### PR DESCRIPTION
## About the PR

This PR enables BEs in PVE.

## Why / Balance

Fixes #7841

## Technical details

- Also check if dead.
- Replaced `HasComp` with appropriate methods.
  - It always sets `UnrevivableComponent`, so checking for `RMCBattleExecutedComponent` is unnecessary.

## Media


https://github.com/user-attachments/assets/994da134-63c3-4d3e-b350-ab6170508485



## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

- fix: battlefield executions can now be used in PvE
