### PR TITLE
allow storing shotgun magazines where rifle magazines are allowed

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Accessory/webbing.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Accessory/webbing.yml
@@ -61,6 +61,7 @@
       - CMMagazineSmg
       - CMMagazinePistol
       - CMMagazineRifle
+      - RMCMagazineShotgun
       - CMMagazineSniper
       - MRE
       - PillPacket
@@ -80,6 +81,7 @@
         - CMMagazineSmg
         - CMMagazinePistol
         - CMMagazineRifle
+        - RMCMagazineShotgun
         - CMMagazineSniper
         - MRE
         - PillPacket

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
@@ -34,6 +34,7 @@
       - CMMagazinePistol
       - RMCMagazineRevolver
       - CMMagazineRifle
+      - RMCMagazineShotgun
       - CMMagazineSmg
       - CMMagazineSniper
       - Grenade
@@ -48,6 +49,7 @@
     items:
       tags:
       - CMMagazineRifle
+      - RMCMagazineShotgun
       - CMMagazineSmg
   - type: FixedItemSizeStorage
   - type: ItemCamouflage
@@ -88,6 +90,7 @@
     items:
       tags:
       - CMMagazineRifle
+      - RMCMagazineShotgun
       - CMMagazineSmg
   - type: FixedItemSizeStorage
   - type: ItemCamouflage
@@ -461,6 +464,7 @@
       tags:
       - CMMagazinePistol
       - CMMagazineRifle
+      - RMCMagazineShotgun
       - CMMagazineSmg
       - CMMagazineSniper
       - RMCMagazineSmartGun
@@ -1434,6 +1438,7 @@
     items:
       tags:
       - CMMagazineRifle
+      - RMCMagazineShotgun
       - CMMagazineSmg
       - RMCShellShotgun
   - type: FixedItemSizeStorage

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/base_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/base_armor.yml
@@ -124,6 +124,7 @@
       - CMMagazineSmg
       - CMMagazinePistol
       - CMMagazineRifle
+      - RMCMagazineShotgun
       - CMMagazineSniper
 
 - type: entity
@@ -210,6 +211,7 @@
     items:
       tags:
       - CMMagazineRifle
+      - RMCMagazineShotgun
       - CMMagazineSmg
       - CMMagazineSniper
       - CMMagazinePistol

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Pouches/storage.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Pouches/storage.yml
@@ -179,6 +179,7 @@
       - CMMagazinePistol
       - RMCMagazineRevolver
       - CMMagazineRifle
+      - RMCMagazineShotgun
       - CMMagazineSmg
       - CMMagazineSniper
       - RMCShellShotgun


### PR DESCRIPTION
## About the PR

This PR expands the whitelist of everything that allows rifle magazines to also allow shotgun magazines.

## Why / Balance

Fixes #7833

References for reviewers:

- https://github.com/cmss13-devs/cmss13/blob/master/code/modules/projectiles/magazines/rifles.dm#L689
- https://github.com/cmss13-devs/cmss13/blob/master/code/modules/clothing/under/ties.dm#L815-L826

There is no distinction between rifle and shotgun magazines.

## Technical details

Searched for `CMMagazineRifle`, added `RMCMagazineShotgun` when relevant.

## Media

https://github.com/user-attachments/assets/e870b4f2-7f25-4c95-ab67-1d124bc5b8ed

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: XM51 magazines can now be stored in armor, webbing, magazine pouches and belts.
