### PR TITLE
move pill and injector icon label to the left

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Medical/auto_injectors.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Medical/auto_injectors.yml
@@ -40,7 +40,7 @@
     delay: 0.333
   - type: IconLabel
     textColor: White
-    storedOffset: 0, 12
+    storedOffset: -12, 12
   - type: RMCSmartFridgeInsertable
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Medical/pill_canisters.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Medical/pill_canisters.yml
@@ -65,7 +65,7 @@
     - PillCanister
   - type: IconLabel
     textColor: White
-    storedOffset: 3, 12
+    storedOffset: -12, 12
   - type: UserInterface
     interfaces:
       enum.StorageUiKey.Key:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Medical/pill_packets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Medical/pill_packets.yml
@@ -23,7 +23,7 @@
     - PillPacket
   - type: IconLabel
     textColor: White
-    storedOffset: 2, 12
+    storedOffset: -12, 12
   - type: InteractedBlacklist
     blacklist:
       components:


### PR DESCRIPTION
## About the PR

This PR moves the icon labels for pills and injectors to the left.

## Why / Balance

Fixes #7786

Also fixes the label being overdrawn by the item to the right.

## Technical details

Minor yaml edit.

## Media

<img width="543" height="165" alt="Screenshot From 2025-11-05 19-06-34" src="https://github.com/user-attachments/assets/3571414f-c04d-46e7-a800-c122a5ba2346" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- tweak: Moved the label on pills and injectors to the left.
