### PR TITLE
make implosions ignore ghosts

### DIFF
--- a/Content.Shared/_RMC14/Explosion/Implosion/RMCImplosionSystem.cs
+++ b/Content.Shared/_RMC14/Explosion/Implosion/RMCImplosionSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared._RMC14.Stun;
+using Content.Shared.Ghost;
 using Robust.Shared.Map;
 
 namespace Content.Shared._RMC14.Explosion.Implosion;
@@ -8,11 +9,22 @@ public sealed class RMCImplosionSystem : EntitySystem
     [Dependency] private readonly RMCSizeStunSystem _sizeStun = default!;
     [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
 
+    private EntityQuery<GhostComponent> _ghostQuery;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        _ghostQuery = GetEntityQuery<GhostComponent>();
+    }
+
     public void Implode(RMCImplosion implosion, MapCoordinates origin)
     {
         var nearbyEntities = _entityLookup.GetEntitiesInRange(origin, implosion.PullRange, LookupFlags.Uncontained);
         foreach (var entity in nearbyEntities)
         {
+            if (_ghostQuery.HasComp(entity))
+                continue;
+
             _sizeStun.KnockBack(entity, origin, -implosion.PullDistance, -implosion.PullDistance, implosion.PullSpeed, implosion.IgnoreSize);
         }
     }


### PR DESCRIPTION
## About the PR

This PR makes it so that implosions (cause by the BLU-200 for example) do not affect ghosts.

## Why / Balance

Makes no sense really.

Was just spectating a game and the entity I was orbiting got hit by a BLU-200. This caused my ghost to then orbit at an offset.

## Technical details

Check for `GhostComponent` and continue.

## Media


https://github.com/user-attachments/assets/23e1d954-2078-427b-83e2-f5bb78d4b626



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

No