### PR TITLE
no shooting into the air while devoured

### DIFF
--- a/Content.Shared/_RMC14/Weapons/Ranged/RMCAirShotSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/RMCAirShotSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared._RMC14.Dropship.Weapon;
 using Content.Shared._RMC14.Marines.Skills;
 using Content.Shared._RMC14.Stun;
 using Content.Shared._RMC14.Weapons.Common;
+using Content.Shared._RMC14.Xenonids.Devour;
 using Content.Shared.CombatMode;
 using Content.Shared.DoAfter;
 using Content.Shared.Examine;
@@ -50,6 +51,9 @@ public sealed class RMCAirShotSystem : EntitySystem
             return;
 
         if (ent.Comp.RequiredSkills != null && !_skills.HasAllSkills(args.UserUid, ent.Comp.RequiredSkills))
+            return;
+
+        if (HasComp<DevouredComponent>(args.UserUid))
             return;
 
         AttemptAirShot(ent, args.UserUid);


### PR DESCRIPTION
## About the PR

This PR makes it so that one can no longer use the AirShot ability while devoured.

## Why / Balance

Fixes #8319.

## Technical details

Just check if `DevouredComponent`.

## Media

You have to believe me on this, but pressing space does nothing now:


https://github.com/user-attachments/assets/df63b148-659a-4d2c-80ae-2ec5a344d4d0



## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Flares can no longer be shot into the sky while devoured.
