### PR TITLE
make mutany:end also remove the leader component

### DIFF
--- a/Content.Server/_RMC14/Marines/Mutiny/MutinyCommand.cs
+++ b/Content.Server/_RMC14/Marines/Mutiny/MutinyCommand.cs
@@ -20,6 +20,7 @@ public sealed class MutinyCommand : ToolshedCommand
 
         while (mutineers.MoveNext(out var mutineer, out var comp))
         {
+            RemComp<MutineerLeaderComponent>(mutineer);
             RemComp<MutineerComponent>(mutineer);
             numMutineers++;
             if (!HasComp<ActorComponent>(mutineer))


### PR DESCRIPTION
## About the PR

Title

## Why / Balance

Fixes #8238

## Technical details

Remove `MutineerLeaderComponent` before `MutineerComponent` as it adds `MutineerComponent`.

## Media


https://github.com/user-attachments/assets/fec9f8f4-f103-4ced-b4b9-88377c21f221



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

No