### PR TITLE
Fix Xeno Mice Chatsan

### DIFF
--- a/Resources/Prototypes/_RMC14/Accents/cm_word_replacements.yml
+++ b/Resources/Prototypes/_RMC14/Accents/cm_word_replacements.yml
@@ -126,7 +126,7 @@
     cm-chatsan-word-rat: cm-chatsan-replacement-rat
     cm-chatsan-word-rats: cm-chatsan-replacement-rats
     cm-chatsan-word-mouse: cm-chatsan-replacement-mouse
-    cm-chatsan-word-mice: cm-chatsan-replacement-
+    cm-chatsan-word-mice: cm-chatsan-replacement-mice
     cm-chatsan-word-feroxi: cm-chatsan-replacement-feroxi
     cm-chatsan-word-feroxis: cm-chatsan-replacement-feroxi
     cm-chatsan-word-shark: cm-chatsan-replacement-shark


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes the word "mice" being changed to "cm-chatsan-replacement-" instead of "squeaking hosts" for xenos

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

:cl:
- fix: Fixed mice being replaced incorrectly in chat when said by xenos.