### PR TITLE
Adds a weedkiller aura

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Weeds/WeedKillerAuraComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Weeds/WeedKillerAuraComponent.cs
@@ -1,0 +1,44 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+using Robust.Shared.ViewVariables;
+
+namespace Content.Shared._RMC14.Xenonids.Weeds;
+
+/// <summary>
+/// Blocks weeds from being placed within a certain radius around this entity.
+/// Can be configured with a timer or be permanent.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
+[Access(typeof(WeedKillerAuraSystem))]
+public sealed partial class WeedKillerAuraComponent : Component
+{
+    /// <summary>
+    /// Radius in tiles around the entity where weeds cannot be placed
+    /// </summary>
+    [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]
+    public int BlockRadius = 2;
+
+    /// <summary>
+    /// Duration that the weed blocking is active. Zero means lasts forever.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public TimeSpan BlockDuration;
+
+    /// <summary>
+    /// Time when the weed blocking will expire. Zero means never expires (calculated on MapInit from BlockDuration).
+    /// </summary>
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
+    public TimeSpan ExpireAt;
+
+    /// <summary>
+    /// Whether the blocker is currently active
+    /// </summary>
+    [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]
+    public bool Active = true;
+
+    /// <summary>
+    /// List of blocker entities spawned around this entity
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadOnly)]
+    public List<EntityUid> BlockerEntities = new();
+}

--- a/Content.Shared/_RMC14/Xenonids/Weeds/WeedKillerAuraEvents.cs
+++ b/Content.Shared/_RMC14/Xenonids/Weeds/WeedKillerAuraEvents.cs
@@ -1,0 +1,9 @@
+namespace Content.Shared._RMC14.Xenonids.Weeds;
+
+/// <summary>
+/// Raised by WeedKillerAuraSystem when an aura expires naturally.
+/// Listeners can react (e.g., schedule corruption checks).
+/// </summary>
+public readonly struct WeedKillerAuraExpiredEvent
+{
+}

--- a/Content.Shared/_RMC14/Xenonids/Weeds/WeedKillerAuraSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Weeds/WeedKillerAuraSystem.cs
@@ -1,0 +1,206 @@
+using Content.Shared._RMC14.Map;
+using Content.Shared._RMC14.Xenonids.ResinSurge;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Network;
+using Robust.Shared.Timing;
+
+namespace Content.Shared._RMC14.Xenonids.Weeds;
+
+/// <summary>
+/// System that manages weed killer auras around entities.
+/// Creates invisible anchored entities with BlockWeedsComponent in a radius.
+/// Automatically updates blocker positions when parent entity moves.
+/// Also destroys existing weeds and resin walls in the radius.
+/// </summary>
+public sealed class WeedKillerAuraSystem : EntitySystem
+{
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly SharedMapSystem _mapSystem = default!;
+    [Dependency] private readonly RMCMapSystem _rmcMap = default!;
+
+    private EntityQuery<XenoWeedsComponent> _weedsQuery;
+    private EntityQuery<ResinSurgeReinforcableComponent> _resinWallQuery;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        
+        _weedsQuery = GetEntityQuery<XenoWeedsComponent>();
+        _resinWallQuery = GetEntityQuery<ResinSurgeReinforcableComponent>();
+        
+        SubscribeLocalEvent<WeedKillerAuraComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<WeedKillerAuraComponent, ComponentShutdown>(OnShutdown);
+        SubscribeLocalEvent<WeedKillerAuraComponent, MoveEvent>(OnParentMoved);
+    }
+
+    private void OnMapInit(Entity<WeedKillerAuraComponent> ent, ref MapInitEvent args)
+    {
+        if (_net.IsClient)
+            return;
+
+        var blocker = ent.Comp;
+
+        // Calculate expiration time if duration is set
+        if (blocker.BlockDuration > TimeSpan.Zero && blocker.ExpireAt == TimeSpan.Zero)
+        {
+            blocker.ExpireAt = _timing.CurTime + blocker.BlockDuration;
+            Dirty(ent, blocker);
+        }
+
+        // Destroy existing weeds and resin walls in the radius
+        DestroyWeedsInRadius(ent);
+
+        // Spawn weed blocker entities in a radius around this entity
+        CreateWeedBlockers(ent);
+    }
+
+    private void OnParentMoved(Entity<WeedKillerAuraComponent> ent, ref MoveEvent args)
+    {
+        if (_net.IsClient)
+            return;
+
+        if (!ent.Comp.Active)
+            return;
+
+        // Only update if we actually moved to a different tile or grid
+        Vector2i oldTile, newTile;
+        var oldGridUid = args.OldPosition.EntityId;
+        var newGridUid = args.NewPosition.EntityId;
+
+        if (TryComp<MapGridComponent>(oldGridUid, out var oldGrid) &&
+            TryComp<MapGridComponent>(newGridUid, out var newGrid))
+        {
+            oldTile = _mapSystem.CoordinatesToTile(oldGridUid, oldGrid, args.OldPosition);
+            newTile = _mapSystem.CoordinatesToTile(newGridUid, newGrid, args.NewPosition);
+
+            if (oldGridUid == newGridUid && oldTile == newTile)
+                return;
+        }
+
+        // Recreate the blocker entities at the new position
+        RemoveWeedBlockers(ent);
+        DestroyWeedsInRadius(ent);
+        CreateWeedBlockers(ent);
+    }
+
+    private void OnShutdown(Entity<WeedKillerAuraComponent> ent, ref ComponentShutdown args)
+    {
+        // Clean up blocker entities when component is removed or entity is deleted
+        RemoveWeedBlockers(ent);
+    }
+
+    private void CreateWeedBlockers(Entity<WeedKillerAuraComponent> ent)
+    {
+        var gridId = _transform.GetGrid(ent.Owner);
+        if (gridId == null || !TryComp<MapGridComponent>(gridId, out var grid))
+        {
+            Log.Warning($"Entity {ToPrettyString(ent.Owner)} has no grid, cannot create weed blocker aura");
+            return;
+        }
+
+        var entityPos = _transform.GetGridOrMapTilePosition(ent.Owner);
+        var radius = ent.Comp.BlockRadius;
+
+        // Create a list to track spawned blockers
+        var blockerList = new List<EntityUid>();
+
+        // Spawn blocker entities in a square radius
+        for (var x = -radius; x <= radius; x++)
+        {
+            for (var y = -radius; y <= radius; y++)
+            {
+                var targetTile = entityPos + new Vector2i(x, y);
+                var coords = _mapSystem.GridTileToLocal(gridId.Value, grid, targetTile);
+
+                // Spawn an invisible weed blocker entity
+                var blocker = Spawn(null, coords);
+                EnsureComp<BlockWeedsComponent>(blocker);
+                
+                // CRITICAL: Anchor the blocker to the grid so it can be detected by weed system
+                var xform = Transform(blocker);
+                _transform.AnchorEntity(blocker, xform, gridId.Value, grid, targetTile);
+                
+                blockerList.Add(blocker);
+            }
+        }
+
+        // Store the blocker entities so we can remove them later
+        ent.Comp.BlockerEntities = blockerList;
+        Dirty(ent, ent.Comp);
+    }
+
+    private void RemoveWeedBlockers(Entity<WeedKillerAuraComponent> ent)
+    {
+        foreach (var blockerEntity in ent.Comp.BlockerEntities)
+        {
+            QueueDel(blockerEntity);
+        }
+
+        ent.Comp.BlockerEntities.Clear();
+    }
+
+    private void DestroyWeedsInRadius(Entity<WeedKillerAuraComponent> ent)
+    {
+        var gridId = _transform.GetGrid(ent.Owner);
+        if (gridId == null || !TryComp<MapGridComponent>(gridId, out var grid))
+            return;
+
+        var entityPos = _transform.GetGridOrMapTilePosition(ent.Owner);
+        var radius = ent.Comp.BlockRadius;
+
+        // Find and destroy all weeds and resin walls in the radius
+        for (var x = -radius; x <= radius; x++)
+        {
+            for (var y = -radius; y <= radius; y++)
+            {
+                var targetTile = entityPos + new Vector2i(x, y);
+                var anchored = _rmcMap.GetAnchoredEntitiesEnumerator((gridId.Value, grid), targetTile);
+                
+                while (anchored.MoveNext(out var anchoredId))
+                {
+                    // Check if this is a weed entity
+                    if (_weedsQuery.HasComp(anchoredId))
+                    {
+                        QueueDel(anchoredId);
+                    }
+                    // Check if this is a resin wall
+                    else if (_resinWallQuery.HasComp(anchoredId))
+                    {
+                        QueueDel(anchoredId);
+                    }
+                }
+            }
+        }
+    }
+
+    public override void Update(float frameTime)
+    {
+        if (_net.IsClient)
+            return;
+
+        var time = _timing.CurTime;
+
+        // Handle weed blocker expiration
+        var blockerQuery = EntityQueryEnumerator<WeedKillerAuraComponent>();
+        while (blockerQuery.MoveNext(out var blockerId, out var blocker))
+        {
+            if (!blocker.Active || blocker.ExpireAt == TimeSpan.Zero)
+                continue;
+
+            if (time >= blocker.ExpireAt)
+            {
+                blocker.Active = false;
+                Dirty(blockerId, blocker);
+
+                // Remove all blocker entities
+                RemoveWeedBlockers((blockerId, blocker));
+
+                // Notify listeners that the aura expired naturally (component remains)
+                RaiseLocalEvent(blockerId, new WeedKillerAuraExpiredEvent());
+            }
+        }
+    }
+}

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Misc/aegis_crate.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Misc/aegis_crate.yml
@@ -21,6 +21,9 @@
           map: ["enum.AegisCrateVisualLayers.Base"]
     - type: AegisCrate
       openSound: /Audio/_RMC14/Structures/secure_box_opening/secure_box_opening.ogg
+    - type: WeedKillerAura
+      blockRadius: 2
+      blockDuration: 3600 # 60 minutes
     - type: TacticalMapIcon
       icon:
         sprite: /Textures/_RMC14/Interface/map_blips.rsi


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This is the first PR of several things I am adding.

This makes it so that you can give objects 'weedkiller auras' that destroy weeds, nodes and such as they move. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Being able to make it so that certain objects have a timed weedkiller aura is good for marine objectives and such in the future, and also for PVE. 
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: weedkiller aura components
