### PR TITLE
using spawn as job no longer leaves a ghost behind

### DIFF
--- a/Content.Server/_RMC14/Admin/RMCAdminSystem.cs
+++ b/Content.Server/_RMC14/Admin/RMCAdminSystem.cs
@@ -15,7 +15,9 @@ using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.TacticalMap;
 using Content.Shared.Database;
 using Content.Shared.GameTicking;
+using Content.Shared.Ghost;
 using Content.Shared.Humanoid.Prototypes;
+using Content.Shared.Mind.Components;
 using Content.Shared.Preferences;
 using Content.Shared.Roles;
 using Robust.Shared.Configuration;
@@ -156,6 +158,12 @@ public sealed class RMCAdminSystem : SharedRMCAdminSystem
                 profile
             );
             RaiseLocalEvent(mobUid.Value, spawnEv, true);
+        }
+
+        if (HasComp<GhostComponent>(target))
+        {
+            RemComp<MindContainerComponent>(target);
+            QueueDel(target);
         }
 
         _adminLog.Add(LogType.RMCSpawnJob, $"{ToPrettyString(user)} spawned {ToPrettyString(mobUid)} as job {jobName}");


### PR DESCRIPTION
## About the PR

title

## Why / Balance

fixes #7148

## Technical details

We create a new mind for the new entity and the old mind gets left behind inside the ghost. We can simply remove the container and have the mind-system handle the cleanup.

## Media

https://github.com/user-attachments/assets/d1703479-ce00-4531-a0f8-1581b55ee3c3

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- admin: Using "Spawn here as job" no longer leaves a ghost behind.
