### PR TITLE
Oppressor and Boiler targetting improvements and abduct fix

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Abduct/XenoAbductComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Abduct/XenoAbductComponent.cs
@@ -32,6 +32,9 @@ public sealed partial class XenoAbductComponent : Component
     public TimeSpan Cooldown = TimeSpan.FromSeconds(15);
 
     [DataField, AutoNetworkedField]
+    public int Range = 6;
+
+    [DataField, AutoNetworkedField]
     public TimeSpan SlowTime = TimeSpan.FromSeconds(2.5);
 
     [DataField, AutoNetworkedField]

--- a/Content.Shared/_RMC14/Xenonids/Bombard/XenoBombardSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Bombard/XenoBombardSystem.cs
@@ -49,7 +49,7 @@ public sealed class XenoBombardSystem : EntitySystem
 
         var direction = target.Position - source.Position;
         if (direction.Length() > ent.Comp.Range)
-            target = target.Offset(direction.Normalized() * ent.Comp.Range);
+            target = source.Offset(direction.Normalized() * ent.Comp.Range);
 
         _audio.PlayPredicted(ent.Comp.PrepareSound, ent, ent);
 

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
@@ -800,7 +800,7 @@
       state: bombard
     useDelay: 1
   - type: TargetAction
-    range: 10
+    range: 15 # the actual range is in XenoBombardComponent
     checkCanAccess: false
   - type: WorldTargetAction
     event: !type:XenoBombardActionEvent
@@ -1204,7 +1204,7 @@
       state: abduct
     useDelay: 15
   - type: TargetAction
-    range: 6
+    range: 15 # the actual range is in XenoAbductComponent
     deselectOnMiss: false
     checkCanAccess: false
   - type: EntityTargetAction


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Oppressor abduct and boiler bombard can now be targeted further than their range, activating the ability at the maximum range, in the process I think the occasional abduct jank is fixed. Also a potential boiler bug is fixed.

## Why / Balance
This is how acid spray, flamethrowers, and the other oppressor abilities work. Also I think this fixes #8249

## Technical details
changed the action range of abduct and bombard to 15, which should allow for activation anywhere onscreen. Copied the acid spray code over to abduct to limit the range. Bombard already had a range limiter, but it uses target to offset resulting in doubling the range instead! So I switched that to use the boiler's position.

The Oppressor's original code was using the wrong position, resulting in strange behavior when the range was increased looking exactly like issue #8249. With the acid spray code it seems likely that bug is fixed.

## Media
(https://youtu.be/5E48NOuK2YQ)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: ExponentialWizard
- add: Oppressor abduct and Boiler bombard can now be targetted further than their range, automatically capping at the max range.
- fix: Fixed some abduct and bombard issues.
