### PR TITLE
fix: interaction between the hypospray and syringes

### DIFF
--- a/Content.Server/_RMC14/Medical/RMCHypospraySystem.cs
+++ b/Content.Server/_RMC14/Medical/RMCHypospraySystem.cs
@@ -1,18 +1,9 @@
 using Content.Shared._RMC14.Chemistry;
-using Content.Shared._RMC14.Marines.Skills;
-using Content.Shared._RMC14.Medical.Refill;
-using Content.Shared.Administration.Logs;
-using Content.Shared.Chemistry;
 using Content.Shared.Chemistry.Components;
-using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Containers.ItemSlots;
-using Content.Shared.Database;
 using Content.Shared.FixedPoint;
-using Content.Shared.Forensics;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
-using Content.Shared.Timing;
-using Robust.Server.Audio;
 
 namespace Content.Server._RMC14.Medical;
 
@@ -89,30 +80,30 @@ public sealed class RMCHypospraySystem : RMCSharedHypospraySystem
         if (!TryComp<InjectorComponent>(injector, out var syringe))
             return;
 
-        if (!_solution.TryGetSolution(injector, syringe.SolutionName, out var soln, out var solu))
+        if (!_solution.TryGetSolution(injector, syringe.SolutionName, out var syringeSolutionComp, out var syringeSolution))
             return;
 
-        Entity<SolutionComponent>? solm;
-        Solution? soli;
+        Entity<SolutionComponent>? vialSolutionComp;
+        Solution? vialSolution;
 
         if (syringe.ToggleState == InjectorToggleMode.Inject)
         {
-            if (!_solution.TryGetInjectableSolution(vial, out solm, out soli))
+            if (!_solution.TryGetInjectableSolution(vial, out vialSolutionComp, out vialSolution))
                 return;
         }
         else
         {
-            if (!_solution.TryGetDrawableSolution(vial, out solm, out soli))
+            if (!_solution.TryGetDrawableSolution(vial, out vialSolutionComp, out vialSolution))
                 return;
         }
 
         var transferAmount = syringe.ToggleState == InjectorToggleMode.Inject ?
-            FixedPoint2.Min(syringe.TransferAmount, soli.AvailableVolume) :
-            FixedPoint2.Min(syringe.TransferAmount, solu.AvailableVolume);
+            FixedPoint2.Min(syringe.TransferAmount, vialSolution.AvailableVolume) :
+            FixedPoint2.Min(syringe.TransferAmount, syringeSolution.AvailableVolume);
 
         if (transferAmount <= 0)
         {
-            if(syringe.ToggleState == InjectorToggleMode.Inject)
+            if (syringe.ToggleState == InjectorToggleMode.Inject)
                 _popup.PopupEntity(Loc.GetString("rmc-hypospray-full", ("vial", vial)), ent, user);
             else
                 _popup.PopupEntity(Loc.GetString("rmc-hypospray-full", ("vial", injector)), ent, user);
@@ -121,24 +112,36 @@ public sealed class RMCHypospraySystem : RMCSharedHypospraySystem
 
         if (syringe.ToggleState == InjectorToggleMode.Draw)
         {
-            var removed = _solution.Draw(vial, solm.Value, transferAmount);
-            if (!_solution.TryAddSolution(soln.Value, removed))
+            var removed = _solution.Draw(vial, vialSolutionComp.Value, transferAmount);
+            if (!_solution.TryAddSolution(syringeSolutionComp.Value, removed))
                 return;
             _popup.PopupEntity(Loc.GetString("injector-component-draw-success-message",
-    ("amount", removed.Volume),
-    ("target", Identity.Entity(vial, EntityManager))), injector, user);
+                                ("amount", removed.Volume),
+                                ("target", Identity.Entity(vial, EntityManager))), injector, user);
+
+            if (syringeSolution.Volume == syringeSolution.MaxVolume)
+            {
+                syringe.ToggleState = InjectorToggleMode.Inject;
+                Dirty(injector, syringe);
+            }
         }
         else
         {
-            var adding = _solution.SplitSolution(soln.Value, transferAmount);
-            _solution.Inject(vial, solm.Value, adding);
+            var adding = _solution.SplitSolution(syringeSolutionComp.Value, transferAmount);
+            _solution.Inject(vial, vialSolutionComp.Value, adding);
             _popup.PopupEntity(Loc.GetString("injector-component-transfer-success-message",
-    ("amount", adding.Volume),
-    ("target", Identity.Entity(vial, EntityManager))), injector, user);
+                                ("amount", adding.Volume),
+                                ("target", Identity.Entity(vial, EntityManager))), injector, user);
+
+            if (syringeSolution.Volume == 0)
+            {
+                syringe.ToggleState = InjectorToggleMode.Draw;
+                Dirty(injector, syringe);
+            }
         }
 
-        Dirty(soln.Value);
-        Dirty(solm.Value);
+        Dirty(syringeSolutionComp.Value);
+        Dirty(vialSolutionComp.Value);
 
         UpdateAppearance(ent);
     }


### PR DESCRIPTION
## About the PR

title

## Why / Balance

Fixes #4358

## Technical details

- Check if the solution in the syringe is full/empty and switch the mode.
- Also renamed the variables because the code was unreadable.

## Media


https://github.com/user-attachments/assets/72659c65-a2af-48c2-8e05-7082ddb0dd5b



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- fix: Syringes now toggle correctly between drawing and injecting when used on a hypospray.
