### PR TITLE
Xeno construction QOL

### DIFF
--- a/Content.Client/_RMC14/Xenonids/Construction/XenoConstructionGhostSystem.cs
+++ b/Content.Client/_RMC14/Xenonids/Construction/XenoConstructionGhostSystem.cs
@@ -422,7 +422,7 @@ public sealed class XenoConstructionGhostSystem : EntitySystem
             if (buildRange > 0 && !_transform.InRange(origin, target, buildRange))
                 return false;
 
-            if (_transform.InRange(origin, target, 0.75f))
+            if (_transform.InRange(origin, target, _xenoConstruction.GetStructureMinRange(buildChoice).Float()))
                 return false;
 
             if (isRemoteConstruction && !CanDoRemoteConstruction(xeno, target))
@@ -473,7 +473,7 @@ public sealed class XenoConstructionGhostSystem : EntitySystem
 
     private bool CanOrderConstruction(Entity<XenoConstructionComponent> xeno, EntityCoordinates target, EntProtoId? choice)
     {
-        if (!CanSecreteOnTile(xeno, xeno.Comp.BuildChoice, target, false, false))
+        if (!CanSecreteOnTile(xeno, choice, target, false, false))
             return false;
 
         if (_transform.GetGrid(target) is not { } gridId ||

--- a/Content.Shared/_RMC14/Xenonids/Construction/XenoConstructionMinRangeComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/XenoConstructionMinRangeComponent.cs
@@ -1,0 +1,11 @@
+using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.Construction;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class XenoConstructionMinRangeComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 MinRange = 0.25;
+}

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_doors.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_doors.yml
@@ -85,6 +85,7 @@
       types:
         Slash: 600
   - type: XenoConstructionRequiresSupport
+  - type: XenoConstructionMinRange
   - type: ExplosionResistance
     damageCoefficient: 7.5 # Doors take 15x explosive damage, resin doors reduce that by 50%
   - type: XenoConstruct

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_walls.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_walls.yml
@@ -21,6 +21,7 @@
       - !type:DoActsBehavior
         acts: ["Destruction"]
   - type: XenoNestSurface
+  - type: XenoConstructionMinRange
   - type: XenoConstructionPlasmaCost
     plasma: 120
     scalingCost: true
@@ -94,6 +95,7 @@
         - GlassLayer
         density: 1000
   - type: XenoNestSurface
+  - type: XenoConstructionMinRange
   - type: XenoConstructionPlasmaCost
     plasma: 95
     scalingCost: true


### PR DESCRIPTION
## About the PR
Sticky and speed resin, along with all of the hive structures now can be build directly under yourself
Minimal range for walls and doors have been made _much_ more lenient (it is still big enough to not let you push yourself into a wall)
And also hivelords can now upgrade resin through a corner.

Almost forgot to mention i also made it so the doafter for building does no cancel if you try to build before it ends,
this means you can spam click to build as soon as the previous structure finishes.

## Why / Balance
So in 13 you can straight up build resin right on top of yourself, and you don't collide with it until you move off the wall, but just getting pushed off to the side should be good enough.

## Technical details
While on it caught a tiny bug, `CanOrderConstructionPopup` was passing current selected resin (wall, door etc) structure selected into a `CanSecreteOnTile` check instead of the actual hive structure you are trying to place.

## Media

https://github.com/user-attachments/assets/8b31f436-cd11-4e30-9e46-8c8a6d204b59



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: As a xeno you can now build sticky/speed resin and hive structures on the same tile you are standing on.
- tweak: Minimal range to build walls and doors have been made much more lenient.
- tweak: Hivelords can now upgrade resin on the diagonal corners.
- tweak: Secrete resin ability no longer cancels current resin structure doafter when trying to build a new one too early
