### PR TITLE
Fixes CPR bug that opens the strip menu.

### DIFF
--- a/Content.Shared/_RMC14/Medical/CPR/CPRSystem.cs
+++ b/Content.Shared/_RMC14/Medical/CPR/CPRSystem.cs
@@ -42,7 +42,6 @@ public sealed class CPRSystem : EntitySystem
     {
         base.Initialize();
 
-        // TODO RMC14 use skills
         // TODO RMC14 something more generic than "marine"
         SubscribeLocalEvent<MarineComponent, InteractHandEvent>(OnMarineInteractHand,
             before: [typeof(InteractionPopupSystem), typeof(StunShakeableSystem)]);
@@ -108,9 +107,8 @@ public sealed class CPRSystem : EntitySystem
 
     private void OnReceivingCPRAttempt(Entity<ReceivingCPRComponent> ent, ref ReceiveCPRAttemptEvent args)
     {
-        bool isStale = _timing.CurTime - ent.Comp.StartTime > TimeSpan.FromSeconds(8) || ent.Comp.Performer != null && !Exists(ent.Comp.Performer.Value);
-        // If stale, remove the component and allow the new CPR attempt
-        if (isStale)
+        var isStale = _timing.CurTime - ent.Comp.StartTime > TimeSpan.FromSeconds(7);
+        if (isStale) // If stale, remove the component and allow the new CPR attempt
         {
             RemCompDeferred<ReceivingCPRComponent>(ent);
             return;
@@ -196,7 +194,6 @@ public sealed class CPRSystem : EntitySystem
             return false;
 
         var cprComp = EnsureComp<ReceivingCPRComponent>(target);
-        cprComp.Performer = performer;
         cprComp.StartTime = _timing.CurTime;
         Dirty(target, cprComp);
 

--- a/Content.Shared/_RMC14/Medical/CPR/ReceivingCPRComponent.cs
+++ b/Content.Shared/_RMC14/Medical/CPR/ReceivingCPRComponent.cs
@@ -11,8 +11,5 @@ public sealed partial class ReceivingCPRComponent : Component
     public int CPRPerformingTime = 4;
 
     [DataField, AutoNetworkedField]
-    public EntityUid? Performer;
-
-    [DataField, AutoNetworkedField]
     public TimeSpan StartTime;
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes a CPR bug.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Sometimes, when you try to CPR someone, it will instead open the strip menu with a red pop-up saying that CPR is already being performed on that person.
This results in someone savable becoming permadead instead.
## Technical details
<!-- Summary of code changes for easier review. -->
This bug is caused by lines 68-69 failing to remove the component. Probably caused by de-sync issues, somehow losing MarineComponent, or getting deleted in the middle of the do-after.

Added a check to remove any stale ReceivingCPRComponent after 7 seconds have passed.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed not being able to perform CPR after a previous attempt fails, causing the strip menu to open instead.
