### PR TITLE
[FIX] Fixed Rollerbeds not appearing in hand.

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Furniture/rollerbeds.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Furniture/rollerbeds.yml
@@ -50,6 +50,11 @@
       visible: false
   - type: Item
     size: Small
+    inhandVisuals:
+      left:
+      - state: inhand-left
+      right:
+      - state: inhand-right
   - type: GenericVisualizer
     visuals:
       enum.StrapVisuals.State:


### PR DESCRIPTION

## About the PR
Fixed Rollerbeds not appearing in hand.

## Why / Balance
Because i was looking at something else and relised how to fix it...

## Technical details
Set inhand components

## Media

https://github.com/user-attachments/assets/ee69d4bb-6950-46bd-a489-96cd4e26ea32



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed Rollerbeds not appearing in hand.
