### PR TITLE
getusername toolshed command

### DIFF
--- a/Content.Server/_RMC14/Admin/GetUsernameCommand.cs
+++ b/Content.Server/_RMC14/Admin/GetUsernameCommand.cs
@@ -1,0 +1,28 @@
+using System.Linq;
+using Content.Server.Administration;
+using Content.Shared.Administration;
+using Robust.Server.Player;
+using Robust.Shared.Toolshed;
+
+namespace Content.Server._RMC14.Admin;
+
+[ToolshedCommand, AdminCommand(AdminFlags.Admin)]
+public sealed class GetUsernameCommand : ToolshedCommand
+{
+    [Dependency] private readonly IPlayerManager _players = default!;
+
+    [CommandImplementation]
+    public string? GetUsername([PipedArgument] EntityUid entity)
+    {
+        if (!_players.TryGetSessionByEntity(entity, out var session))
+            return null;
+
+        return session.Data.UserName;
+    }
+
+    [CommandImplementation]
+    public IEnumerable<string?> GetUsername([PipedArgument] IEnumerable<EntityUid> entities)
+    {
+        return entities.Select(entity => GetUsername(entity));
+    }
+}

--- a/Resources/Locale/en-US/_RMC14/commands/rmc-toolshed-commands.ftl
+++ b/Resources/Locale/en-US/_RMC14/commands/rmc-toolshed-commands.ftl
@@ -91,3 +91,5 @@ command-description-movespeed = Changes the max movement speed for given entitie
 
 command-description-stairwell = Sets the teleportation offset for the given Teleporter entities.
 command-description-stairwellprojector = Sets the projection id for the given TeleporterView entities.
+
+command-description-getusername = Gets the username attached to an entity.


### PR DESCRIPTION
## About the PR

Implements the requested "getusername" command.

## Why / Balance

Fixes #8369.

## Technical details

You have to use "$SELF" and not "$ID", so for example: `entities with Marine with Actor getusername do "kick $SELF"` to kick every marine. See https://github.com/space-wizards/RobustToolbox/blob/master/Robust.Shared/Toolshed/Commands/Entities/DoCommand.cs for a deeper explanation.

## Media


https://github.com/user-attachments/assets/1980b753-cf7c-4532-bc1f-44bacb9d4705



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- admin: Added the "getusername" toolshed command.
