### PR TITLE
boxes in the weapons rack only visible to requisitions

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/prep.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/prep.yml
@@ -83,6 +83,29 @@
       - id: CMPackFlare
         amount: 10
         recommended: true
+    - name: Boxes
+      hasBoxes: true
+      jobs:
+      - CMQuartermaster
+      - CMCargoTech
+      entries:
+      - id: RMCBoxShellsFlechette
+        box: RMCBoxShotgunFlechette
+        boxAmount: 4
+      - id: RMCBoxShellsBuckshot
+        box: RMCBoxShotgunBuckshot
+        boxAmount: 4
+      - id: RMCBoxShellsSlugs
+        box: RMCBoxShotgunSlugs
+        boxAmount: 4
+      - id: RMCBoxMagazineRifleM4SPR
+        box: CMMagazineRifleM4SPR
+      - id: RMCBoxMagazineSMGM63
+        box: CMMagazineSMGM63
+      - id: RMCBoxMagazineRifleM54C
+        box: CMMagazineRifleM54C
+      - id: RMCBoxPackFlare
+        box: CMPackFlare
 
 - type: entity
   parent: ColMarTechBase


### PR DESCRIPTION
## About the PR

This PR adds the existing magazine, shell and flare boxes to the weapons rack found in the squad prep areas. They are only visible to the logistics officer (and requisitions technician if they "somehow" acquire access).

## Why / Balance

QOL

## Technical details

Just another section that has the boxes and is limited to the above mentioned jobs.

## Media

<img width="740" height="352" alt="Screenshot From 2025-11-13 22-46-54" src="https://github.com/user-attachments/assets/86de41de-373a-4ed6-a5b0-a28926b3ee14" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- add: The logistics officer can now vend filled boxes from weapons racks.
