### PR TITLE
boots no longer fit inside of helmets

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Head/Helmets/basic_helmets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Head/Helmets/basic_helmets.yml
@@ -66,7 +66,6 @@
       - RMCFlask
       - CMScalpel
       - Figurine
-      - Matchbox
       - HelmetAccessory
       - CassettePlayer
       - CassetteTape


### PR DESCRIPTION
## About the PR

title

## Why / Balance

Fixes #8199

## Technical details

All our matchboxes are already `tiny`, so having the `Matchbox` component in the whitelist just causes boots to be allowed.

## Media


https://github.com/user-attachments/assets/b7475e77-1d2a-4383-91e3-8bcf82253d0e



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- fix: You can no longer store boots inside of helmets.
