### PR TITLE
Updated XL armor vest in rfn machine to follow naming conventions

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/rifleman.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/rifleman.yml
@@ -23,6 +23,8 @@
     - name: Armor
       choices: { CMArmour: 1 }
       entries:
+      - id: RMCArmorVestRifleman
+        name: armor vest
       - id: RMCArmorM3LightVariants
         name: light armor
       - id: RMCArmorM3MediumVariants
@@ -30,7 +32,6 @@
         recommended: true
       - id: RMCArmorM3HeavyVariants
         name: heavy armor
-      - id: RMCArmorVestRifleman
     - name: Backpack
       choices: { CMBackpack: 1 }
       entries:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The extra light armor aka the armor vest was added to the rfn machine. However it didn't follow the pattern of other armors in the machine where it used a generic name (light armor vs m3-l armor). I updated to use the same naming pattern. Additionally I put it above the light armor in the list so that it is lightest to heaviest option

## Why / Balance
Matches conventions better

## Media
### Before
<img width="443" height="617" alt="Screenshot From 2025-11-15 19-03-02" src="https://github.com/user-attachments/assets/ff271ecc-96ff-44cb-b05f-a0b7a5d2ab96" />

### After

<img width="503" height="699" alt="Screenshot From 2025-11-15 18-57-00" src="https://github.com/user-attachments/assets/a1ad0f3d-3b98-49e6-a728-798fcf8dc899" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Rifleman's armor vest option now renders like the other armor options.
