### PR TITLE
Acider runner can fill traps

### DIFF
--- a/Content.Server/_RMC14/Xenonids/Construction/ResinHole/XenoResinHoleSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Construction/ResinHole/XenoResinHoleSystem.cs
@@ -200,12 +200,12 @@ public sealed class XenoResinHoleSystem : SharedXenoResinHoleSystem
         {
             if (HasComp<XenoAciderGenerationComponent>(args.User))
             {
-                if (!_xenoEnergy.HasEnergyPopup(args.User, ourAcid.EnergyCost, false))
+                if (!_xenoEnergy.HasEnergyPopup(args.User, ourAcid.Cost, false))
                     return;
             }
             else 
             {
-                if (!_xenoPlasma.HasPlasmaPopup(args.User, ourAcid.PlasmaCost, false))
+                if (!_xenoPlasma.HasPlasmaPopup(args.User, ourAcid.Cost, false))
                     return;
             }
 
@@ -283,8 +283,8 @@ public sealed class XenoResinHoleSystem : SharedXenoResinHoleSystem
                 return;
 
             if (HasComp<XenoAciderGenerationComponent>(args.User))
-                _xenoEnergy.TryRemoveEnergy(args.User, acid.EnergyCost);
-            if (!_xenoPlasma.TryRemovePlasmaPopup(args.User, acid.PlasmaCost) && !HasComp<XenoAciderGenerationComponent>(args.User))
+                _xenoEnergy.TryRemoveEnergy(args.User, acid.Cost);
+            if (!_xenoPlasma.TryRemovePlasmaPopup(args.User, acid.Cost) && !HasComp<XenoAciderGenerationComponent>(args.User))
                 return;
 
             SetTrapType(resinHole, acid.Spray);

--- a/Content.Shared/_RMC14/Xenonids/Acid/AcidTrapComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Acid/AcidTrapComponent.cs
@@ -13,10 +13,7 @@ public sealed partial class AcidTrapComponent : Component
     public int TrapLevel = 2;
 
     [DataField, AutoNetworkedField]
-    public int PlasmaCost = 100;
-
-    [DataField, AutoNetworkedField]
-    public int EnergyCost = 75;
+    public int Cost = 100;
 
     [DataField, AutoNetworkedField]
     public EntProtoId Spray = "XenoAcidSprayTrap";

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/runner.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/runner.yml
@@ -252,6 +252,7 @@
   - type: XenoAciderGeneration
   - type: AcidTrap
     trapLevel: 3
+    cost: 75
     spray: XenoAcidSprayTrapStrong
   - type: SlowOnPull
     slowdowns:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Made it so acider runners can now fill resin traps with strong acid, costing 75 from their reserve.

## Why / Balance
Parity, acider runners should be able to fill traps with tier 3 acid by spending some of their acid reserve.
I checked the numbers, a cost of 75 is parity.
 - Fixes #8256

## Technical details
If the xeno has a XenoAciderGenerationComponent, then it uses energy instead of plasma to fill the trap.

## Media

https://github.com/user-attachments/assets/72b8ea4f-6b0b-4e84-adf5-c51f23801de2

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Acider runners can now fill resin traps with acid.
- fix: Fixed a popup with non-xenoids clicking on resin traps.