### PR TITLE
More non loop noises markers

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Markers/rmc_sound_markers.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Markers/rmc_sound_markers.yml
@@ -132,6 +132,33 @@
     sound:
       path: /Audio/_RMC14/Structures/metalhit.ogg
 
+- type: entity
+  parent: RMCMarkerSoundSingleBase
+  id: RMCMarkerSoundXenoVentCrawl
+  suffix: Vent Crawl
+  components:
+  - type: RMCEmitSoundOnSpawn
+    sound:
+      collection: XenoVentCrawl
+
+- type: entity
+  parent: RMCMarkerSoundSingleBase
+  id: RMCMarkerSoundXenoVentPass
+  suffix: Vent Pass
+  components:
+  - type: RMCEmitSoundOnSpawn
+    sound:
+      collection: XenoVentPass
+
+- type: entity
+  parent: RMCMarkerSoundSingleBase
+  id: RMCMarkerSoundXenoDoorPry
+  suffix: Xeno Door Pry
+  components:
+  - type: RMCEmitSoundOnSpawn
+    sound:
+      collection: RMCXenoPry
+
 # Ambient Markers
 
 - type: entity


### PR DESCRIPTION
## About the PR
Adds non-loop noise markers for vent crawling, vent passing, and xeno door prying.

## Why / Balance
Useful for PvE, lets us indicate that xenos are doing something without them having to actually be there.

## Technical details
YAML

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl: PursuitInAshes
- add: [PvE] Three new sound markers have been added for GM use. (Vent Crawl/Pass, Xeno Door Prying)
