### PR TITLE
Add MSgt rank to CMilitaryWarden

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/MilitaryPolice/military_warden.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/MilitaryPolice/military_warden.yml
@@ -9,6 +9,10 @@
     department: CMMilitaryPolice
     time: 36000 # 10 hours
   ranks:
+    RMCRankMasterSergeant:
+    - !type:RoleTimeRequirement
+      role: CMJobMilitaryWarden
+      time: 630000 # 175 hours
     RMCRankGunnerySergeant:
     - !type:RoleTimeRequirement
       role: CMJobMilitaryWarden


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds Master Sergeant rank at 175 hours (Platinum) for Military Warden.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Since the change for the QM role to the LO role the MSgt. rank has not been used by any roles other than SEA. This would make experienced wardens be above in rank to Squad Leaders. It would also offer a reward for the people which achieve such a number of hours.

@QuietlyWhisper should weigh in if this is something that would be ok for MWs to receive.

## Technical details
<!-- Summary of code changes for easier review. -->
yaml

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Military Warden can now rank up Master Sergeant
