### PR TITLE
Fix ziptie boxes no longer fitting in armor

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/armored_vest.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/armored_vest.yml
@@ -83,6 +83,7 @@
       - PillCanister
       - CMSurgicalCase
       - RMCSyringeCase
+      - RMCBoxZipties
   - type: RMCNameItemOnVend
     item: Armor
   - type: ExplosionResistance

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/base_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/base_armor.yml
@@ -219,6 +219,7 @@
       - PillCanister
       - CMSurgicalCase
       - RMCSyringeCase
+      - RMCBoxZipties
   - type: RMCArmorSpeedTier
     speedTier: medium
   - type: RMCNameItemOnVend


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Title

## Why / Balance
It is a bug.

## Technical details
The item size of ziptie boxes is now ignored by armor.

## Media
No

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl: BramvanZijp
- fix: Ziptie boxes will now fit in armor and armor vests again.
