### PR TITLE
Fix medical examine issues

### DIFF
--- a/Content.Shared/_RMC14/Medical/Examine/RMCMedicalExamineSystem.cs
+++ b/Content.Shared/_RMC14/Medical/Examine/RMCMedicalExamineSystem.cs
@@ -25,7 +25,10 @@ public sealed class RMCMedicalExamineSystem : EntitySystem
         using (args.PushGroup(nameof(RMCMedicalExamineSystem), -1))
         {
             if (ent.Comp.Simple && _mobState.IsDead(ent.Owner))
+            {
                 args.PushMarkup(Loc.GetString(ent.Comp.DeadText, ("victim", ent.Owner)));
+                return;
+            }
 
             if (HasComp<RMCBlockMedicalExamineComponent>(args.Examiner))
                 return;
@@ -51,10 +54,7 @@ public sealed class RMCMedicalExamineSystem : EntitySystem
             stateText = ent.Comp.CritText;
 
         if (stateText != null)
-        {
-            msg.PushNewline();
             msg.AddMarkupOrThrow(Loc.GetString(stateText, ("victim", ent.Owner)));
-        }
 
         return msg;
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- Fixed marine status examine making a new line (leftover from when the examine was seperated with a button)
- Fixed xeno dead examine text appearing twice

:cl:
- fix: Fixed the dead examine text for xenos appearing twice.
