### PR TITLE
Pizza box storage fix

### DIFF
--- a/Resources/Prototypes/_RMC14/Catalog/Fills/Clothing/satchels.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Fills/Clothing/satchels.yml
@@ -12,10 +12,6 @@
     - id: RMCBoxPizzaMeat
     - id: CMDrinkCanDrGibb
     # ThirteenLoko
-  - type: IgnoreContentsSize
-    items:
-      tags:
-      - BoxCardboard
 
 - type: entity
   parent: CMSatchel

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Food/pizza.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Food/pizza.yml
@@ -367,7 +367,7 @@
     stateDoorClosed: pizzabox1
   - type: Appearance
   - type: Storage
-    maxItemSize: Normal
+    maxItemSize: Small
     grid:
     - 0,0,1,1
     whitelist:


### PR DESCRIPTION
## About the PR
Fixed the pizza boxes not fitting in normal bags

## Why / Balance
Parity. fixes https://github.com/RMC-14/RMC-14/issues/8211
<img width="1452" height="533" alt="image" src="https://github.com/user-attachments/assets/36fc78a8-1e03-4c83-8aa9-d21561bedc26" />

## Technical details

## Media
<img width="792" height="681" alt="image" src="https://github.com/user-attachments/assets/95944dd5-3555-4be7-9fe9-b07b4e305a33" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Pizza boxes now fit into storages like any other normal-sized item.