### PR TITLE
SO gaining requisitions time requirement

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Command/staff_officer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Command/staff_officer.yml
@@ -11,6 +11,9 @@
   - !type:TotalDepartmentsTimeRequirement
     group: CMDepartmentsHuman
     time: 54000 # 15 hours
+  - !type:DepartmentTimeRequirement
+    department: CMRequisitions
+    time: 3600 # 1 hour
   ranks:
     RMCRankFirstLT:
     - !type:RoleTimeRequirement


### PR DESCRIPTION
## About the PR
Gave one hour of requisitions department time required to play Staff Officer.

This is a new PR, I previously had an older PR with other time requirement changes that I no longer agree with, but this one is a change I still believe would be good for said role.

## Why / Balance

As an SO this is the shipside department you will most often be in contact with and it will be a good idea for anyone wishing to play a Staff Officer to have played a round (or two) of requisitions; knowing how the squad supply side of the operation works is useful for an SO who will often be sending in requests, asking for their supply crate to be readied, and then also being the one sending down the crate itself. 

Having some time in requisitions would be good for an SO so they know how long the department will take to ready an order, the possibility of certain requests the squad may make, knowing what things they can ask to be packed to help their squad, and ultimately so they have the knowledge to have a productive and fun time with the role.

## Technical details
basic yml

## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl: CatAndHats
- tweak: Changed the time requirement of SO to now also include one hour of Requisitions department.