### PR TITLE
Fix MOU53 not getting the shotgun gyroscope accuracy bonus

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/mou53_shotgun.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/mou53_shotgun.yml
@@ -11,6 +11,7 @@
   - type: Tag
     tags:
     - RMCWeaponShotgunMOU53
+    - RMCWeaponShotgun
   - type: Gun
     soundGunshot:
       path: /Audio/_RMC14/Weapons/Guns/Gunshots/gun_mou53.ogg


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Gyroscope attachment did not give its shotgun specific accuracy bonus when attached to the MOU53, this simply gives the MOU53 the bonus accuracy it should probably be getting.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
MOU53 is a shotgun and thus should receive the accuracy bonus.
Seems to be parity unless i'm stupid.

## Technical details
<!-- Summary of code changes for easier review. -->
Added `RMCWeaponShotgun` component to the MOU53

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed MOU53 not receiving the correct accuracy bonus from the gyroscopic stabilizer.