### PR TITLE
Fix tantrum being ignoring it's own max range sometimes

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Tantrum/XenoTantrumComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Tantrum/XenoTantrumComponent.cs
@@ -35,4 +35,7 @@ public sealed partial class XenoTantrumComponent : Component
 
     [DataField, AutoNetworkedField]
     public Color EnrageColor = Color.FromHex("#A31010");
+
+    [DataField, AutoNetworkedField]
+    public float Range = 8;
 }

--- a/Content.Shared/_RMC14/Xenonids/Tantrum/XenoTantrumSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Tantrum/XenoTantrumSystem.cs
@@ -28,6 +28,8 @@ public sealed class XenoTantrumSystem : EntitySystem
     [Dependency] private readonly MovementSpeedModifierSystem _speed = default!;
     [Dependency] private readonly CMArmorSystem _armor = default!;
     [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
     public override void Initialize()
     {
         SubscribeLocalEvent<XenoTantrumComponent, XenoTantrumActionEvent>(OnXenoTantrumAction);
@@ -76,6 +78,9 @@ public sealed class XenoTantrumSystem : EntitySystem
     private void OnXenoTantrumAction(Entity<XenoTantrumComponent> xeno, ref XenoTantrumActionEvent args)
     {
         if (args.Handled)
+            return;
+
+        if (!_transform.InRange(xeno.Owner, args.Target, xeno.Comp.Range))
             return;
 
         if (HasComp<TantrumingComponent>(xeno))


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug!

## Technical details
<!-- Summary of code changes for easier review. -->
Add a range check in the action code. Without it you can use it in xeno OW from far away, for some reason.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed Valk Tantrum being usuable past it's max range sometimes
