### PR TITLE
add provost inspector

### DIFF
--- a/Resources/Locale/en-US/_RMC14/job/provost.ftl
+++ b/Resources/Locale/en-US/_RMC14/job/provost.ftl
@@ -25,6 +25,8 @@ rmc-job-prefix-provost-enforcer = PvE
 rmc-ghost-name-corp-provost-inspector = Provost Inspector (Friendly)
 rmc-job-name-corp-provost-inspector = Provost Inspector
 rmc-job-prefix-provost-inspector = PvI
+rmc-job-description-inspector = Mentor new MPs, and advise on and investigate matters of Marine Law and conflict resolution aboard the ship, ensuring that Military Police are acting to uphold the intentions of the Provost.
+    Inspectors are a direct line to Provost, and are the final word on Marine Law, even above the Commanding Officer.
 
 rmc-ghost-name-corp-provost-marshal = Provost Marshal (Friendly)
 rmc-job-name-corp-provost-marshal = Provost Marshal

--- a/Resources/Maps/_RMC14/Test/dev_map.yml
+++ b/Resources/Maps/_RMC14/Test/dev_map.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 264.0.2
   forkId: ""
   forkVersion: ""
-  time: 10/20/2025 02:58:23
-  entityCount: 1473
+  time: 11/22/2025 22:08:44
+  entityCount: 1474
 maps:
 - 1
 grids:
@@ -1469,7 +1469,7 @@ entities:
         path: /Audio/_RMC14/Announcements/ARES/GQfullcall.ogg
       unidentifledlifesignsSound: !type:SoundPathSpecifier
         path: /Audio/_RMC14/Announcements/ARES/unidentified_lifesigns.ogg
-      lastLocked: { }
+      lastLocked: {}
       attachmentPoints: []
       crashWarningSound: !type:SoundPathSpecifier
         params:
@@ -9470,21 +9470,21 @@ entities:
       pos: -14.5,1.5
       parent: 2
     - type: Fixtures
-      fixtures: { }
+      fixtures: {}
   - uid: 527
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 2
     - type: Fixtures
-      fixtures: { }
+      fixtures: {}
   - uid: 529
     components:
     - type: Transform
       pos: -2.5,-3.5
       parent: 2
     - type: Fixtures
-      fixtures: { }
+      fixtures: {}
   - uid: 530
     components:
     - type: Transform
@@ -9492,7 +9492,7 @@ entities:
       pos: 25.5,14.5
       parent: 2
     - type: Fixtures
-      fixtures: { }
+      fixtures: {}
   - uid: 532
     components:
     - type: Transform
@@ -9500,7 +9500,7 @@ entities:
       pos: 18.5,14.5
       parent: 2
     - type: Fixtures
-      fixtures: { }
+      fixtures: {}
   - uid: 534
     components:
     - type: Transform
@@ -9508,7 +9508,7 @@ entities:
       pos: -7.5,4.5
       parent: 2
     - type: Fixtures
-      fixtures: { }
+      fixtures: {}
   - uid: 535
     components:
     - type: Transform
@@ -9516,7 +9516,7 @@ entities:
       pos: -8.5,9.5
       parent: 2
     - type: Fixtures
-      fixtures: { }
+      fixtures: {}
   - uid: 538
     components:
     - type: Transform
@@ -9524,7 +9524,7 @@ entities:
       pos: -17.5,4.5
       parent: 2
     - type: Fixtures
-      fixtures: { }
+      fixtures: {}
   - uid: 541
     components:
     - type: Transform
@@ -9532,7 +9532,7 @@ entities:
       pos: 4.5,3.5
       parent: 2
     - type: Fixtures
-      fixtures: { }
+      fixtures: {}
   - uid: 543
     components:
     - type: Transform
@@ -9540,7 +9540,7 @@ entities:
       pos: -2.5,10.5
       parent: 2
     - type: Fixtures
-      fixtures: { }
+      fixtures: {}
   - uid: 544
     components:
     - type: Transform
@@ -9548,7 +9548,7 @@ entities:
       pos: 6.5,7.5
       parent: 2
     - type: Fixtures
-      fixtures: { }
+      fixtures: {}
   - uid: 545
     components:
     - type: Transform
@@ -9556,7 +9556,7 @@ entities:
       pos: -6.5,0.5
       parent: 2
     - type: Fixtures
-      fixtures: { }
+      fixtures: {}
   - uid: 546
     components:
     - type: Transform
@@ -9564,7 +9564,7 @@ entities:
       pos: -6.5,-10.5
       parent: 2
     - type: Fixtures
-      fixtures: { }
+      fixtures: {}
   - uid: 547
     components:
     - type: Transform
@@ -9572,14 +9572,14 @@ entities:
       pos: 4.5,-5.5
       parent: 2
     - type: Fixtures
-      fixtures: { }
+      fixtures: {}
   - uid: 548
     components:
     - type: Transform
       pos: 5.5,-3.5
       parent: 2
     - type: Fixtures
-      fixtures: { }
+      fixtures: {}
   - uid: 549
     components:
     - type: Transform
@@ -9587,7 +9587,7 @@ entities:
       pos: 3.5,7.5
       parent: 2
     - type: Fixtures
-      fixtures: { }
+      fixtures: {}
   - uid: 550
     components:
     - type: Transform
@@ -9595,7 +9595,7 @@ entities:
       pos: -14.5,16.5
       parent: 2
     - type: Fixtures
-      fixtures: { }
+      fixtures: {}
   - uid: 551
     components:
     - type: Transform
@@ -9603,7 +9603,7 @@ entities:
       pos: 0.5,16.5
       parent: 2
     - type: Fixtures
-      fixtures: { }
+      fixtures: {}
   - uid: 553
     components:
     - type: Transform
@@ -9611,7 +9611,7 @@ entities:
       pos: -13.5,17.5
       parent: 2
     - type: Fixtures
-      fixtures: { }
+      fixtures: {}
   - uid: 554
     components:
     - type: Transform
@@ -9619,7 +9619,7 @@ entities:
       pos: -11.5,-5.5
       parent: 2
     - type: Fixtures
-      fixtures: { }
+      fixtures: {}
   - uid: 555
     components:
     - type: Transform
@@ -9627,7 +9627,7 @@ entities:
       pos: -11.5,-0.5
       parent: 2
     - type: Fixtures
-      fixtures: { }
+      fixtures: {}
   - uid: 556
     components:
     - type: Transform
@@ -9635,7 +9635,7 @@ entities:
       pos: -15.5,-5.5
       parent: 2
     - type: Fixtures
-      fixtures: { }
+      fixtures: {}
   - uid: 557
     components:
     - type: Transform
@@ -9643,28 +9643,28 @@ entities:
       pos: -15.5,-0.5
       parent: 2
     - type: Fixtures
-      fixtures: { }
+      fixtures: {}
   - uid: 559
     components:
     - type: Transform
       pos: -14.5,6.5
       parent: 2
     - type: Fixtures
-      fixtures: { }
+      fixtures: {}
   - uid: 560
     components:
     - type: Transform
       pos: -13.5,-7.5
       parent: 2
     - type: Fixtures
-      fixtures: { }
+      fixtures: {}
   - uid: 561
     components:
     - type: Transform
       pos: -7.5,12.5
       parent: 2
     - type: Fixtures
-      fixtures: { }
+      fixtures: {}
   - uid: 562
     components:
     - type: Transform
@@ -9672,14 +9672,14 @@ entities:
       pos: 3.5,18.5
       parent: 2
     - type: Fixtures
-      fixtures: { }
+      fixtures: {}
   - uid: 564
     components:
     - type: Transform
       pos: 22.5,12.5
       parent: 2
     - type: Fixtures
-      fixtures: { }
+      fixtures: {}
   - uid: 565
     components:
     - type: Transform
@@ -9687,7 +9687,7 @@ entities:
       pos: 11.5,14.5
       parent: 2
     - type: Fixtures
-      fixtures: { }
+      fixtures: {}
 - proto: RMCLightFixtureSmall
   entities:
   - uid: 205
@@ -9707,7 +9707,7 @@ entities:
       pos: 0.5,-5.5
       parent: 2
     - type: Fixtures
-      fixtures: { }
+      fixtures: {}
   - uid: 578
     components:
     - type: Transform
@@ -9717,7 +9717,7 @@ entities:
     - type: ApcPowerReceiver
       powerLoad: 0
     - type: Fixtures
-      fixtures: { }
+      fixtures: {}
   - uid: 579
     components:
     - type: Transform
@@ -9727,7 +9727,7 @@ entities:
     - type: ApcPowerReceiver
       powerLoad: 0
     - type: Fixtures
-      fixtures: { }
+      fixtures: {}
   - uid: 580
     components:
     - type: Transform
@@ -9735,7 +9735,7 @@ entities:
       pos: -4.5,-5.5
       parent: 2
     - type: Fixtures
-      fixtures: { }
+      fixtures: {}
   - uid: 581
     components:
     - type: Transform
@@ -9743,7 +9743,7 @@ entities:
       pos: 5.5,-12.5
       parent: 2
     - type: Fixtures
-      fixtures: { }
+      fixtures: {}
 - proto: RMCMechPowerLoader
   entities:
   - uid: 1272
@@ -10039,6 +10039,13 @@ entities:
     components:
     - type: Transform
       pos: 3.5,17.5
+      parent: 2
+- proto: RMCSpawnPointProvostInspector
+  entities:
+  - uid: 1474
+    components:
+    - type: Transform
+      pos: 0.5,3.5
       parent: 2
 - proto: RMCSurveillanceCameraAlmayer
   entities:

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Back/satchels.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Back/satchels.yml
@@ -258,6 +258,15 @@
 
 - type: entity
   parent: CMSatchelSecurity
+  suffix: Provost
+  id: CMSatchelSecurityFilledProvostInspector
+  components:
+  - type: StorageFill
+    contents:
+    - id: RMCArmorProvostFlexi
+
+- type: entity
+  parent: CMSatchelSecurity
   suffix: Provost Dep Mar
   id: CMSatchelSecurityFilledProvostDeputyMarshal
   components:

--- a/Resources/Prototypes/_RMC14/Maps/cm_dev.yml
+++ b/Resources/Prototypes/_RMC14/Maps/cm_dev.yml
@@ -45,3 +45,4 @@
           CMCargoTech: [ -1, -1 ]
           CMQuartermaster: [ -1, -1 ]
           CMSurvivor: [ -1, -1 ]
+          CMProvostInspector: [ -1, -1 ]

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Departments/military_police_department.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Departments/military_police_department.yml
@@ -5,6 +5,7 @@
   description: cm-department-MilitaryPolice-description
   color: "#DE3A3A"
   roles:
+  - CMProvostInspector
   - CMChiefMP
   - CMMilitaryWarden
   - CMMilitaryPolice

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Provost/provost_chief_inspector.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Provost/provost_chief_inspector.yml
@@ -2,13 +2,20 @@
   parent: CMJobBase
   id: CMProvostChiefInspector
   name: rmc-job-name-corp-provost-chief
-  description: rmc-ghost-role-information-provost-description
+  description: rmc-job-description-inspector
+  whitelisted: true
   playTimeTracker: CMJobProvostChiefInspector
+#  requirements:
+#  - !type:RoleTimeRequirement
+#    role: CMJobProvostInspector
+#    time: 108000 # 30 hours
   ranks:
     RMCRankProvostChiefInspector: []
   startingGear: RMCGearProvostChiefInspector
   icon: RMCJobIconProvostChiefInspector
   joinNotifyCrew: false
+  marineAuthorityLevel: 0
+  supervisors: cm-job-supervisors-marine-high-command
   accessGroups:
   - ShipMasterAccess
   special:
@@ -22,10 +29,24 @@
         RMCSkillFireman: 2
         RMCSkillMeleeWeapons: 1
         RMCSkillPolice: 2
+        RMCSkillLeadership: 2
+        RMCSkillMedical: 1
+        RMCSkillOverwatch: 1
     - type: JobPrefix
       prefix: rmc-job-prefix-provost-chief
     - type: RMCTrackable
-  hidden: true
+      hidden: true
+    - type: MarineOrders
+    - type: CommandAccent
+    - type: InnateCommandSpeech
+    - type: RMCPointing
+    - type: TacticalMapIcon
+      icon:
+        sprite: /Textures/_RMC14/Interface/map_blips.rsi
+        state: pve_chief_inspector
+      background:
+        sprite: /Textures/_RMC14/Interface/map_blips.rsi
+        state: background_mp
 
 - type: entity
   id: RMCRandomHumanoidProvostChiefInspector

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Provost/provost_inspector.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Provost/provost_inspector.yml
@@ -116,4 +116,4 @@
   id: RMCJobIconProvostInspector
   icon:
     sprite: _RMC14/Interface/cm_job_icons.rsi
-    state: hudsquad_pvi2
+    state: hudsquad_pvi

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Provost/provost_inspector.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Provost/provost_inspector.yml
@@ -52,7 +52,7 @@
     - type: TacticalMapIcon
       icon:
         sprite: /Textures/_RMC14/Interface/map_blips.rsi
-        state: pve_inspector
+        state: pve_chief_inspector
       background:
         sprite: /Textures/_RMC14/Interface/map_blips.rsi
         state: background_mp

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Provost/provost_inspector.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Provost/provost_inspector.yml
@@ -2,13 +2,29 @@
   parent: CMJobBase
   id: CMProvostInspector
   name: rmc-job-name-corp-provost-inspector
-  description: rmc-ghost-role-information-provost-description
+  description: rmc-job-description-inspector
+  whitelisted: true
   playTimeTracker: CMJobProvostInspector
+  requirements:
+  - !type:DepartmentTimeRequirement
+    department: CMSquad
+    time: 126000 # 35 hours, any roles
+  - !type:DepartmentTimeRequirement
+    department: CMMilitaryPolice
+    time: 108000 # 30 hours
+  - !type:RoleTimeRequirement
+    role: CMJobMilitaryWarden
+    time: 108000 # 30 hours
+  - !type:RoleTimeRequirement
+    role: CMJobChiefMP
+    time: 108000 # 30 hours
   ranks:
     RMCRankProvostInspector: []
   startingGear: RMCGearProvostInspector
   icon: RMCJobIconProvostInspector
-  joinNotifyCrew: false
+  joinNotifyCrew: true
+  marineAuthorityLevel: 0
+  supervisors: cm-job-supervisors-marine-high-command
   accessGroups:
   - ShipMasterAccess
   special:
@@ -22,10 +38,24 @@
         RMCSkillFireman: 2
         RMCSkillMeleeWeapons: 1
         RMCSkillPolice: 2
+        RMCSkillLeadership: 2
+        RMCSkillMedical: 1
+        RMCSkillOverwatch: 1
     - type: JobPrefix
       prefix: rmc-job-prefix-provost-inspector
+    - type: MarineOrders
+    - type: CommandAccent
+    - type: InnateCommandSpeech
+    - type: RMCPointing
     - type: RMCTrackable
-  hidden: true
+    - type: SeeNewPlayers
+    - type: TacticalMapIcon
+      icon:
+        sprite: /Textures/_RMC14/Interface/map_blips.rsi
+        state: pve_inspector
+      background:
+        sprite: /Textures/_RMC14/Interface/map_blips.rsi
+        state: background_mp
 
 - type: entity
   id: RMCRandomHumanoidProvostInspector
@@ -52,6 +82,16 @@
       settings: short
   - type: GhostRoleApplySpecial
 
+- type: entity
+  parent: CMSpawnPointJobBase
+  id: RMCSpawnPointProvostInspector
+  name: Provost Inspector spawn point
+  components:
+  - type: SpawnPoint
+    job_id: CMProvostInspector
+  - type: Sprite
+    state: x # todo rmc14 need a spawn location sprite
+
 - type: startingGear
   id: RMCGearProvostInspector
   equipment:
@@ -63,7 +103,7 @@
     gloves: CMHandsBlackMarine # TODO RMC14 black gloves
     shoes: CMBootsBlackFilled
     id: RMCIDCardProvostInspector
-    belt: CMBeltSecurityMPFilled
+    belt: RMCM1984BeltFilled
     back: CMSatchelSecurityFilledProvost
     #    pocket1: # TODO RMC14 tape recorder
     pocket2: RMCPouchGeneralLarge # TODO RMC14 3 listening devices

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Provost/provost_inspector.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Provost/provost_inspector.yml
@@ -104,7 +104,7 @@
     shoes: CMBootsBlackFilled
     id: RMCIDCardProvostInspector
     belt: RMCM1984BeltFilled
-    back: CMSatchelSecurityFilledProvost
+    back: CMSatchelSecurityFilledProvostInspector
     #    pocket1: # TODO RMC14 tape recorder
     pocket2: RMCPouchGeneralLarge # TODO RMC14 3 listening devices
 

--- a/Resources/Prototypes/_RMC14/Roles/Ranks/UNMC/provost.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Ranks/UNMC/provost.yml
@@ -26,25 +26,26 @@
   prefix: PvDM.
   paygrade: O6
 
-# Fax responder
-- type: rank
-  id: RMCRankProvostCommunicationsOfficer
-  name: Communications Officer
-  prefix: ComOff.
-
 # Any player with high law understanding
 - type: rank
   id: RMCRankProvostChiefInspector
   name: Chief Inspector
   prefix: PvCI.
-  paygrade: CI
+  paygrade: O5
 
 # Any player with medium-low law understanding
 - type: rank
   id: RMCRankProvostInspector
   name: Provost Inspector
   prefix: PvI.
-  paygrade: I
+  paygrade: O4
+
+# Fax responder
+- type: rank
+  id: RMCRankProvostCommunicationsOfficer
+  name: Communications Officer
+  prefix: ComOff.
+  paygrade: O2
 
 # Any player with low law understanding, with guidance
 - type: rank


### PR DESCRIPTION
Adds the Provost Inspector, a whitelisted shipside SEA style role for the military police to ensure the intents of Provost are followed. (Not to be confused with provost advisor.)

- Needs spawn point mapped and 1 slot added to the selectable roles for the map.

<img width="368" height="385" alt="image" src="https://github.com/user-attachments/assets/b92b9f28-1bed-4a53-aadc-efd9f32722fb" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Whisper
- add: Added the Provost Inspector, an SEA style role for the military police to ensure the intents of Provost are followed.
