### PR TITLE
Fix hedgehog having slightly too much armor & not enough explosion armor

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/ravager.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/ravager.yml
@@ -285,8 +285,8 @@
       650: Critical
       750: Dead
   - type: CMArmor
-    xenoArmor: 30
-    explosionArmor: 80
+    xenoArmor: 25
+    explosionArmor: 100
   - type: XenoStrain
     name: rmc-xeno-hedgehog-name
     description: rmc-xeno-hedgehog-description


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity. Was accidentally set to zerker's level of armor. We were just missing the extra +20 explosion armor buff in general.

## Technical details
<!-- Summary of code changes for easier review. -->
yml

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed hedgehog ravager having slightly too much base armor and not enough explosion armor.
