### PR TITLE
Allow examining while overwatching

### DIFF
--- a/Content.Shared/_RMC14/Medical/HUD/Systems/HolocardSystem.cs
+++ b/Content.Shared/_RMC14/Medical/HUD/Systems/HolocardSystem.cs
@@ -1,5 +1,4 @@
 using Content.Shared._RMC14.Marines.Skills;
-using Content.Shared._RMC14.Overwatch;
 using Content.Shared._RMC14.Medical.HUD.Components;
 using Content.Shared._RMC14.Medical.HUD.Events;
 using Content.Shared._RMC14.Medical.Scanner;


### PR DESCRIPTION
## About the PR
Allows examining while viewing Overwatch cameras or watching xenos.

## Why / Balance
Parity. Originally brought up by PR #5079 which wanted to display pronouns on the Overwatch console, but multiple comments (including one from Smug) said it'd be better just to make examining work through cameras and find pronouns that way. 
So, this fixes the pronouns problem and gets us closer to parity.

I also prevented holocard changing while viewing cameras for the sake of parity. If nobody objects, I would like holocard changing to be re-enabled though.
## Technical details
The overwatched entity is treated as the examiner. So whether you can inspect things is determined by its proximity and visibility to the entity you're watching. Same goes for xenos.

For preventing holocard changing, it's just a component check.

## Media
Notice how I cannot examine obscured objects, like the cake while watching the WS's camera.

https://github.com/user-attachments/assets/c930faef-49a7-431a-b0d2-763b149438b0


https://github.com/user-attachments/assets/e0bef652-f674-4371-909c-0a02777883d1


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: Examining now works while watching xenos or viewing Overwatch cameras.
