### PR TITLE
Fix species-specific gas camo sprites

### DIFF
--- a/Content.Client/_RMC14/Item/ItemCamouflageVisualizerSystem.cs
+++ b/Content.Client/_RMC14/Item/ItemCamouflageVisualizerSystem.cs
@@ -89,8 +89,9 @@ public sealed class ItemCamouflageVisualizerSystem : VisualizerSystem<ItemCamouf
 
                             var rsi = _resource.GetResource<RSIResource>(SpriteSpecifierSerializer.TextureRoot / layer.RsiPath).RSI;
 
-                            var newState = $"equipped-{args.Slot.ToUpper()}-color";
-                            var speciesState = $"{state}-{speciesId}";
+                            var baseEquippedState = $"equipped-{args.Slot.ToUpper()}";
+                            var newState = $"{baseEquippedState}-color";
+                            var speciesState = $"{baseEquippedState}-{speciesId}-color";
 
                             // species specific
                             if (speciesId != null && rsi.TryGetState(speciesState, out _))


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixes snouts on the gas mask being smushed

<img width="135" height="173" alt="image" src="https://github.com/user-attachments/assets/36067dde-f753-437f-88a8-d5dcf6d8af8c" />
<img width="145" height="199" alt="image" src="https://github.com/user-attachments/assets/11f1042d-750b-4433-bc56-089fbf4cbaf1" />
<img width="200" height="179" alt="image" src="https://github.com/user-attachments/assets/4a6b0332-8627-436e-8133-a58709e2b3db" />

## Technical Details
``ItemCamouflageVisualizerSystem.OnGetClothingVisuals`` now gets the ``InventoryComponent`` for getting the correct species-specific sprite with item camo color


**Changelog**
:cl:
- tweak: Fixed the gas mask not using the species-specific sprites for the species that have them.
