### PR TITLE
Fix vending machine hackable examine text

### DIFF
--- a/Content.Shared/_RMC14/Vendors/SharedCMAutomatedVendorSystem.cs
+++ b/Content.Shared/_RMC14/Vendors/SharedCMAutomatedVendorSystem.cs
@@ -190,7 +190,7 @@ public abstract class SharedCMAutomatedVendorSystem : EntitySystem
 
     private void OnExamined(Entity<CMAutomatedVendorComponent> ent, ref ExaminedEvent args)
     {
-        if (!_skills.HasSkill(args.Examiner, ent.Comp.HackSkill, ent.Comp.HackSkillLevel))
+        if (!_skills.HasSkill(args.Examiner, ent.Comp.HackSkill, ent.Comp.HackSkillLevel) || !ent.Comp.Hackable)
             return;
 
         using (args.PushGroup(nameof(CMAutomatedVendorComponent)))


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Vendors that aren't hackable would have the blue text saying they are hackable. This PR fixes that
