### PR TITLE
Give welding helmets armor

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Head/Helmets/engineering.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Head/Helmets/engineering.yml
@@ -1,10 +1,3 @@
-#- type: entity
-#  parent: ClothingHeadHatWelding
- # id: RMCHelmetWelding
-#  suffix: RMC
-#  name: welding helmet
-#  description: A head-mounted face cover designed to protect the wearer completely from space-arc eye.
-# WeldingMaskBase
 - type: entity
   parent: ClothingHeadHatWelding
   id: RMCHelmetWelding
@@ -42,6 +35,9 @@
     toggledRsi:
       sprite: _RMC14/Objects/Clothing/Head/Helmets/welding_helmet.rsi
       state: helmet-down
+  - type: CMArmor
+    melee: 10 # CLOTHING_ARMOR_LOW
+    bio: 10 # CLOTHING_ARMOR_LOW
 
 - type: Tag
   id: RMCHelmetWelding


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Hardhats and other helmets have armor currently, so thought i might as well futureproof the welding helmet

CM13 proof
<img width="538" height="266" alt="image" src="https://github.com/user-attachments/assets/ea429eec-080b-4a1e-b999-0cd233340673" />


**Changelog**
Not player facing
