### PR TITLE
fixed secure we-ya crate having wrong accesses

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Storage/crates.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Storage/crates.yml
@@ -705,7 +705,7 @@
   - type: Icon
     sprite: _RMC14/Structures/Storage/Crates/secure_we_ya.rsi
   - type: AccessReader
-    access: [["CMAccessRequisitions"], ["RMCAccessWeYa"]]
+    access: [["RMCAccessWeYa"]]
 
 - type: entity
   parent: RMCCrateSecure


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
req cant open - weya can

## Why / Balance
even if it isn't parity why can req open up and look through what i send the CL as an admin

## Technical details


## Media


## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: secure we-ya crate having wrong access
