### PR TITLE
Make hybrisa caves lockdown doors always powered

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Doors/Shutters/poddoor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Doors/Shutters/poddoor.yml
@@ -183,6 +183,7 @@
 - type: entity
   parent: RMCPodDoorIndestructible
   id: RMCPodDoorHybrisaIndestructibleUltra
+  description: A heavily reinforced metal-alloy door, designed to be virtually indestructible—nothing can penetrate its defenses.
   suffix: Indestructible
   components:
   - type: Sprite


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Prevents people prying them open
Also gives it the CM13 description

**Changelog**
:cl:
- fix: Fixed Hybrisa Caves Lockdown podlocks being pryable
