### PR TITLE
Mortar effects update

### DIFF
--- a/Content.Shared/_RMC14/Mortar/MortarComponent.cs
+++ b/Content.Shared/_RMC14/Mortar/MortarComponent.cs
@@ -75,7 +75,7 @@ public sealed partial class MortarComponent : Component
     public SoundSpecifier? DeploySound = new SoundPathSpecifier("/Audio/_RMC14/Weapons/gun_mortar_unpack.ogg");
 
     [DataField, AutoNetworkedField]
-    public SoundSpecifier? ReloadSound = new SoundPathSpecifier("/Audio/_RMC14/Weapons/gun_mortar_reload.ogg");
+    public SoundSpecifier? ReloadSound = new SoundPathSpecifier("/Audio/_RMC14/Weapons/gun_mortar_reload.ogg", AudioParams.Default.WithVariation(0.4f));
 
     [DataField, AutoNetworkedField]
     public SoundSpecifier? FireSound = new SoundPathSpecifier("/Audio/_RMC14/Weapons/gun_mortar_fire.ogg", AudioParams.Default.AddVolume(4));


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
CM13 parity

Adds a little camera shake when the mortar fires
Gives variation to the reloading sound
Makes the reloading sound play for the user. This makes it a PlayPvs instead of a PlayPredicted. It didn't matter either way since it returns serverside earlier in the code.

**Changelog**
:cl:
- tweak: Firing a mortar will shake the camera of marines near the mortar