### PR TITLE
Add screen labels to medevac and fulton systems

### DIFF
--- a/Content.Client/_RMC14/Dropship/Weapon/DropshipWeaponsBui.cs
+++ b/Content.Client/_RMC14/Dropship/Weapon/DropshipWeaponsBui.cs
@@ -403,6 +403,7 @@ public sealed class DropshipWeaponsBui : RMCPopOutBui<DropshipWeaponsWindow>
                 screen.TopRow.SetData(equip);
                 screen.BottomRow.SetData(exit);
                 screen.RightRow.SetData(one: previous, five: next);
+                screen.ScreenLabel.Text = Loc.GetString("rmc-dropship-medevac-system-screen-text");
                 break;
             }
             case Fulton:
@@ -420,6 +421,7 @@ public sealed class DropshipWeaponsBui : RMCPopOutBui<DropshipWeaponsWindow>
                 screen.TopRow.SetData(equip);
                 screen.BottomRow.SetData(exit);
                 screen.RightRow.SetData(one: previous, five: next);
+                screen.ScreenLabel.Text = Loc.GetString("rmc-dropship-fulton-system-screen-text");
                 break;
             }
             case Paradrop:

--- a/Resources/Locale/en-US/_RMC14/dropship/rmc-dropship.ftl
+++ b/Resources/Locale/en-US/_RMC14/dropship/rmc-dropship.ftl
@@ -100,3 +100,7 @@ rmc-dropship-paradrop-target-screen-target-targeting = Locked to {$dropTarget}.
 
 rmc-dropship-paradrop-lock-no-target = No target selected.
 rmc-dropship-paradrop-lock-target-not-flying = You can only enable the paradrop module while in flight.
+
+rmc-dropship-medevac-system-screen-text = RMU-4M Medevac System
+
+rmc-dropship-fulton-system-screen-text = RMU-19 Fulton Recovery System


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changes the screen labels on the medevac and fulton pages of the dropship control system UI. They now show the name of the active system page instead of the generic control system message.

## Why / Balance
QoL

## Technical details
<!-- Summary of code changes for easier review. -->
Just two lines added to rmc-dropship.ftl and a single line in each utility page case to call them.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
<img width="1448" height="714" alt="utility screen labels" src="https://github.com/user-attachments/assets/ad08386b-f6f9-4359-9f11-bdfba9308f66" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The dropship medevac and fulton screens now show the name of the active system
