### PR TITLE
Prevent dead marines layering under dead xenos and items

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
@@ -377,7 +377,7 @@
   - type: XenoToggleChargingParalyze
   - type: RMCMobStateDrawDepth
     drawDepths:
-      Dead: DeadMobs
+      Dead: BelowMobs
   - type: IVDripTarget
   - type: FixedIdentity
     name: rmc-host


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changes the layer to BelowMobs

I don't think a dead marine should be hidden by a gun

**Changelog**
:cl:
- fix: Fixed dead marines layering under dead xenos and items.