### PR TITLE
Make forecon spotter corpse on chances use dogtags instead of an ID card

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/IdCards/cm_id_other.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/IdCards/cm_id_other.yml
@@ -337,9 +337,9 @@
     faction: FactionSurvivor
 
 - type: entity
-  parent: CMIDCardBase
+  parent: CMIDCardStandardDogtag
   id: RMCIDCardFORECONSpotter
-  name: FORECON Spotter ID card
+  name: FORECON Spotter's dogtags
   components:
   - type: IdCard
     jobTitle: rmc-job-name-forecon-spotter


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Parity
