### PR TITLE
Fixed xenos being able to pry powered shutters and podlocks

### DIFF
--- a/Content.Shared/_RMC14/Doors/CMDoorSystem.cs
+++ b/Content.Shared/_RMC14/Doors/CMDoorSystem.cs
@@ -171,9 +171,12 @@ public sealed class CMDoorSystem : EntitySystem
                 args.Cancelled = true;
         }
 
-        if (_rmcPower.IsPowered(ent) && !HasComp<XenoComponent>(args.User))
-            args.Cancelled = true;
+        // Xenos can pry powered airlocks
+        if (HasComp<XenoComponent>(args.User) && HasComp<AirlockComponent>(ent))
+            return;
 
+        if (_rmcPower.IsPowered(ent))
+            args.Cancelled = true;
     }
 
     private void OnDoorPry(Entity<DoorComponent> ent, ref RMCDoorPryEvent args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Bug, changes logic so xenos cant pry everything powered

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed xenos being able to pry powered shutters and podlocks. They can still pry powered doors.
