### PR TITLE
Fixed M13/Flaregun Holster being unable to be put on the back

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
@@ -1839,6 +1839,9 @@
     whitelist:
       tags:
       - RMCFlareGun
+  - type: Tag
+    tags:
+    - RMCM82FHolster
 
 - type: entity
   parent: RMCM82FHolster

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/base_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/base_armor.yml
@@ -62,6 +62,7 @@
       - RMCXM51Holster
       - RMCDetector
       - RMCMatebaHolster
+      - RMCBeltHolsterM13
 
 - type: entity
   abstract: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added M13 holsters id to the base armor whitelist, and added the id tag for the flaregun which was missing.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
 Adds parity feature of these two holsters and lets them be place on the back when having armor
## Technical details
<!-- Summary of code changes for easier review. -->
 Added M13 to basearmor Whitelist and Added type tag on flaregun to match its id
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed M276 pattern M13 holster rig not being able to be equipped on the suit storage slot.
- fix: Fixed M276 pattern M82F flare gun holster rig not being able to be equipped on the suit storage slot.
