### PR TITLE
Marine survivor chatsans

### DIFF
--- a/Resources/Prototypes/_RMC14/Accents/cm_word_replacements.yml
+++ b/Resources/Prototypes/_RMC14/Accents/cm_word_replacements.yml
@@ -27,6 +27,8 @@
     cm-chatsan-word-admins-marine: cm-chatsan-replacement-admins-marine
     cm-chatsan-word-eorg-marine: cm-chatsan-replacement-eorg-marine
     cm-chatsan-word-slopcade: cm-chatsan-replacement-slopcade
+    cm-chatsan-word-surv: cm-chatsan-word-survivor
+    cm-chatsan-word-survs: cm-chatsan-word-survivors
 
 - type: accent
   id: CMChatSanitizeXeno


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Surv -> Survivor
Survs -> Survivors

People wouldn't realistically abbreviate calling survivors of an attack 'survs'.. 
Reuses the locale for the xenonid replacements

**Changelog**
:cl:
- tweak: Added chatsan for the word 'surv' for marines.
