### PR TITLE
Red neckerchief fix

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Loadouts/loadout_groups.yml
@@ -148,7 +148,6 @@
   - NeckerchiefTanRMC
   - NeckerchiefWhiteRMC
   
-
 - type: loadoutGroup
   id: MasksRMCPVE
   name: rmc-loadout-group-masks


### PR DESCRIPTION
## About the PR
Actually added the Red Neckerchief to loadouts selection
<img width="781" height="768" alt="image" src="https://github.com/user-attachments/assets/a6a7e925-db81-4852-8122-4e0a0d4f7ede" />


## Technical details
actually added the ItemID to the loadout selection since I forgot.


:cl:
- add: Actually added the Red Neckerchief to loadouts

