### PR TITLE
Fix fultons

### DIFF
--- a/Content.Server/Medical/DefibrillatorSystem.cs
+++ b/Content.Server/Medical/DefibrillatorSystem.cs
@@ -249,11 +249,6 @@ public sealed class DefibrillatorSystem : EntitySystem
             _chatManager.TrySendInGameICMessage(uid, Loc.GetString(unrevivable.ReasonMessage),
                 InGameICChatType.Speak, true);
         }
-        else if (HasComp<RMCHasSuicidedComponent>(target)) // RMC-Suicide-Fix
-        {
-            _chatManager.TrySendInGameICMessage(uid, Loc.GetString("defibrillator-unrevivable"),
-                InGameICChatType.Speak, true);
-        }
         else
         {
             if (_mobState.IsDead(target, mob))

--- a/Content.Shared/_RMC14/Dropship/Utility/Systems/RMCFultonSystem.cs
+++ b/Content.Shared/_RMC14/Dropship/Utility/Systems/RMCFultonSystem.cs
@@ -73,7 +73,7 @@ public sealed class RMCFultonSystem : EntitySystem
         }
 
         if (HasComp<PerishableComponent>(target) && !_rotting.IsRotten(target) ||
-            HasComp<RMCRevivableComponent>(target) && !_unrevivable.IsUnrevivable(target) || !HasComp<RMCHasSuicidedComponent>(target))
+            HasComp<RMCRevivableComponent>(target) && !_unrevivable.IsUnrevivable(target))
         {
             _popup.PopupClient(Loc.GetString("rmc-fulton-not-unrevivable", ("fulton", used), ("target", target)), target, user);
             return;

--- a/Content.Shared/_RMC14/Medical/Unrevivable/RMCRevivableComponent.cs
+++ b/Content.Shared/_RMC14/Medical/Unrevivable/RMCRevivableComponent.cs
@@ -8,6 +8,9 @@ namespace Content.Shared._RMC14.Medical.Unrevivable;
 public sealed partial class RMCRevivableComponent : Component
 {
     [DataField, AutoNetworkedField]
+    public bool KillLarva = true;
+
+    [DataField, AutoNetworkedField]
     public TimeSpan UnrevivableDelay = TimeSpan.FromMinutes(5);
 
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]

--- a/Content.Shared/_RMC14/Medical/Unrevivable/RMCUnrevivableSystem.cs
+++ b/Content.Shared/_RMC14/Medical/Unrevivable/RMCUnrevivableSystem.cs
@@ -42,7 +42,7 @@ public sealed class RMCUnrevivableSystem : EntitySystem
         return HasComp<UnrevivableComponent>(uid);
     }
 
-    public void MakeUnrevivable(Entity<RMCRevivableComponent?> ent)
+    public void MakeUnrevivable(Entity<RMCRevivableComponent?> ent, bool killLarva = true)
     {
         if (!Resolve(ent.Owner, ref ent.Comp, false))
             return;
@@ -51,7 +51,17 @@ public sealed class RMCUnrevivableSystem : EntitySystem
         unrevivable.Analyzable = false;
         unrevivable.Cloneable = false;
         unrevivable.ReasonMessage = ent.Comp.UnrevivableReasonMessage;
+
+        ent.Comp.KillLarva = killLarva;
         Dirty(ent);
+    }
+
+    public bool DoesKillLarvaOnUnrevivable(Entity<RMCRevivableComponent?> ent)
+    {
+        if (!Resolve(ent.Owner, ref ent.Comp, false))
+            return false;
+
+        return ent.Comp.KillLarva;
     }
 
     public int GetUnrevivableStage(Entity<RMCRevivableComponent?> ent, int maxStages)

--- a/Content.Shared/_RMC14/Suicide/RMCSuicideSystem.cs
+++ b/Content.Shared/_RMC14/Suicide/RMCSuicideSystem.cs
@@ -158,6 +158,7 @@ public sealed class RMCSuicideSystem : EntitySystem
         _damageable.TryChangeDamage(user, ent.Comp.Damage, true);
         _mobState.ChangeMobState(user, MobState.Dead);
         _audio.PlayPredicted(gun.SoundGunshot, held, ent);
+        _unrevivable.MakeUnrevivable(user, false);
         EnsureComp<RMCHasSuicidedComponent>(user);
     }
 

--- a/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
@@ -714,7 +714,11 @@ public abstract partial class SharedXenoParasiteSystem : EntitySystem
             }
             else
             {
-                if (_mobState.IsDead(uid) && (HasComp<InfectStopOnDeathComponent>(uid) || _rotting.IsRotten(uid) || _unrevivable.IsUnrevivable(uid)))
+                if (_mobState.IsDead(uid)
+                    && (HasComp<InfectStopOnDeathComponent>(uid)
+                    || _rotting.IsRotten(uid)
+                    || _unrevivable.IsUnrevivable(uid)
+                    && _unrevivable.DoesKillLarvaOnUnrevivable(uid)))
                 {
                     if (infected.SpawnedLarva != null)
                         TryBurst((uid, infected));


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Happens because of the suicide changes.
Removes the suicide check and adds a new ``KillLarva`` parameter in make unrevivable, and a new datafield in the unrevivable component

**Changelog**
:cl:
- fix: Fixed fultons not working.