### PR TITLE
Fixed FORECON never spawning with a secondary weapon

### DIFF
--- a/Content.Shared/_RMC14/Survivor/SurvivorPresetComponent.cs
+++ b/Content.Shared/_RMC14/Survivor/SurvivorPresetComponent.cs
@@ -29,6 +29,9 @@ public sealed partial class SurvivorPresetComponent : Component
     public bool TryEquipRandomOtherGear = true;
 
     [DataField, AutoNetworkedField]
+    public bool TryEquipRandomWeapon = false;
+
+    [DataField, AutoNetworkedField]
     public Dictionary<EntProtoId, (int, int)> RareItems = new();
 
     [DataField, AutoNetworkedField]

--- a/Content.Shared/_RMC14/Survivor/SurvivorSystem.cs
+++ b/Content.Shared/_RMC14/Survivor/SurvivorSystem.cs
@@ -71,7 +71,7 @@ public sealed class SurvivorSystem : EntitySystem
             var gear = _random.Pick(comp.RandomWeapon);
             foreach (var item in gear)
             {
-                Equip(mob, item, tryEquip: false);
+                Equip(mob, item, tryEquip: comp.TryEquipRandomWeapon);
             }
         }
 

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/base_forecon.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/base_forecon.yml
@@ -57,6 +57,7 @@
     - [ RMCM1984BeltFilled ]
     - [ RMCHolsterSMGPouchFilledExtended ]
     - [ RMCMotionDetector ]
+    tryEquipRandomWeapon: true
 
 - type: entity
   parent: RMCSurvivorPresetForeconNoPrimary


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
TryEquipRandomWeapon enabled for forecon

Since it would ignore equipping and their sidearms are belts

:cl:
- fix: Fixed FORECON never spawning with a secondary weapon.
