### PR TITLE
allow incinerator tanks to be emptied into reagent tanks

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Flamethrowers/m34_flamer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Flamethrowers/m34_flamer.yml
@@ -155,6 +155,9 @@
       tags:
       - RMCTankReagent
       - RMCBackpackFlamer
+    sourceWhitelist:
+      tags:
+      - RMCTankReagent
   - type: RefillableSolution
     solution: rmc_flamer_tank
   - type: DetailedExaminableSolution
@@ -166,6 +169,12 @@
   - type: Appearance
   - type: SolutionStorageFillable
     solution: rmc_flamer_tank
+  - type: RMCPressurizedSolution
+    solution: rmc_flamer_tank
+  - type: SolutionTransfer
+    canChangeTransferAmount: true
+    canSend: false
+    canReceive: false
   - type: Tag
     tags:
     - RMCTankFlamer


### PR DESCRIPTION
## About the PR

title

## Why / Balance

forgot to add it

## Technical details

a bit of yaml. similar to pressurized canisters

## Media


https://github.com/user-attachments/assets/f13f2b25-d9bc-44df-968e-22e38a63bdd3



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- tweak: Incinerator tank can now be emptied into reagent tanks.
