### PR TITLE
Add name prefix for Ruby rank xenos

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Name/XenoRankNamesComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Name/XenoRankNamesComponent.cs
@@ -13,6 +13,6 @@ public sealed partial class XenoRankNamesComponent : Component
         {3, "rmc-xeno-elder"},
         {4, "rmc-xeno-ancient"},
         {5, "rmc-xeno-prime"},
-        {5, "rmc-xeno-ruby"},
+        {6, "rmc-xeno-prime"},
     };
 }

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-name.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-name.ftl
@@ -6,13 +6,11 @@ rmc-xeno-mature = Mature {$baseName}
 rmc-xeno-elder = Elder {$baseName}
 rmc-xeno-ancient = Ancient {$baseName}
 rmc-xeno-prime = Prime {$baseName}
-rmc-xeno-ruby = Prime {$baseName}
 
 rmc-xeno-mature-parasite = Fledgling {$baseName}
 rmc-xeno-elder-parasite = Veteran {$baseName}
 rmc-xeno-ancient-parasite = Baneful {$baseName}
 rmc-xeno-prime-parasite = Merciless {$baseName}
-rmc-xeno-ruby-parasite = Merciless {$baseName}
 
 # Only 1 because getting king multiple times will be rare
 rmc-xeno-mature-king = Ruthless {$baseName}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added name prefixes for Ruby rank xenos
This currently extends prime for regular xenos and merciless for parasites
I have been told that the names might be different, but cm13 wiki is sparse (and likely out of date)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: blueDev2
- fix: Ruby ranked xenos properly get their prefixes