### PR TITLE
Fix: Tacmap Drawing and Zooming

### DIFF
--- a/Content.Client/_RMC14/TacticalMap/TacticalMapControl.xaml.cs
+++ b/Content.Client/_RMC14/TacticalMap/TacticalMapControl.xaml.cs
@@ -895,7 +895,7 @@ public sealed partial class TacticalMapControl : TextureRect
             }
             else if (_dragging && Drawing && !LabelEditMode)
             {
-                if (_dragStart != null)
+                if (_dragStart != null && StraightLineMode)
                 {
                     Vector2i currentPos = LogicalToPixel(args.RelativePosition).Floored();
                     Vector2i diff = currentPos - _dragStart.Value;
@@ -985,6 +985,9 @@ public sealed partial class TacticalMapControl : TextureRect
         if (Texture == null)
             return;
 
+        Vector2 mousePixelPos = LogicalToPixel(args.RelativePosition);
+        (Vector2 oldActualSize, Vector2 oldActualTopLeft, float oldOverlayScale) = GetDrawParameters();
+
         float oldZoom = _zoomFactor;
 
         if (args.Delta.Y > 0)
@@ -996,16 +999,12 @@ public sealed partial class TacticalMapControl : TextureRect
 
         if (Math.Abs(_zoomFactor - oldZoom) > 0.001f)
         {
-            Vector2 mousePixelPos = LogicalToPixel(args.RelativePosition);
-            Vector2 availableSize = new(PixelWidth, PixelHeight);
-            (Vector2 actualSize, Vector2 actualTopLeft, float overlayScale) = GetDrawParameters();
-
-            Vector2 relativeToTexture = (mousePixelPos - actualTopLeft) / overlayScale;
+            Vector2 relativeToTexture = (mousePixelPos - oldActualTopLeft) / oldOverlayScale;
 
             ApplyViewSettings();
 
-            (actualSize, actualTopLeft, overlayScale) = GetDrawParameters();
-            Vector2 newMousePos = relativeToTexture * overlayScale + actualTopLeft;
+            (Vector2 newActualSize, Vector2 newActualTopLeft, float newOverlayScale) = GetDrawParameters();
+            Vector2 newMousePos = relativeToTexture * newOverlayScale + newActualTopLeft;
             Vector2 mouseDelta = mousePixelPos - newMousePos;
 
             _panOffset += mouseDelta;


### PR DESCRIPTION
## About the PR
Fixed the tacmap creating a new line back to the start when letting go of mouse button in freehand mode. Resolves: #8611  
Fixed tacmap seemingly wanting to zoom to the center of the map rather than on the cursor. Resolves: #8613 

## Technical details
Added a StraightLineMode guard so a final line is only added on mouse release when StraightLineMode is active.

Changed so it captures the mouse position and current draw parameters before changing zoom. After applying the zoom change and clamping, recomputes layout and adjusts_panOffset so the same texture point stays under the cursor.

## Media
[before.webm](https://github.com/user-attachments/assets/d6b465b0-c171-4d89-928d-b82cb0afabce)

[after.webm](https://github.com/user-attachments/assets/36651a37-96af-4a15-92f2-0ae668c729c2)


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Tacmap zooms on cursor rather than the center of the map.
- fix: Tacmap freehand lines no longer creates a line back to where it began.