### PR TITLE
Fix stop drop roll animation not playing when resisting xeno spit

### DIFF
--- a/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
@@ -277,6 +277,7 @@ namespace Content.Server.Atmos.EntitySystems
             if (args.Handled)
                 return;
 
+            _rmcFlammable.DoStopDropRollAnimation(ent.Owner);
             Resist(ent, ent);
             _xenoSpit.Resist(ent.Owner);
             args.Handled = true;
@@ -433,7 +434,6 @@ namespace Content.Server.Atmos.EntitySystems
             flammable.Resisting = true;
             Dirty(uid, flammable);
 
-            RaiseNetworkEvent(new RMCStopDropRollVisualsNetworkEvent(GetNetEntity(uid)), Filter.Pvs(uid)); // RMC14
             _popup.PopupEntity(Loc.GetString("flammable-component-resist-message"), uid, uid);
             _stunSystem.TryParalyze(uid, flammable.ResistDuration, true, force: true);
 

--- a/Content.Server/_RMC14/Atmos/RMCFlammableSystem.cs
+++ b/Content.Server/_RMC14/Atmos/RMCFlammableSystem.cs
@@ -1,12 +1,15 @@
 using Content.Server.Atmos.EntitySystems;
 using Content.Shared._RMC14.Atmos;
+using Content.Shared.ActionBlocker;
 using Content.Shared.Atmos.Components;
+using Robust.Shared.Player;
 
 namespace Content.Server._RMC14.Atmos;
 
 public sealed class RMCFlammableSystem : SharedRMCFlammableSystem
 {
     [Dependency] private readonly FlammableSystem _flammable = default!;
+    [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
 
     public override void Initialize()
     {
@@ -76,5 +79,13 @@ public sealed class RMCFlammableSystem : SharedRMCFlammableSystem
         Dirty(flammable);
 
         _flammable.AdjustFireStacks(flammable, stacks, flammable);
+    }
+
+    public override void DoStopDropRollAnimation(EntityUid uid)
+    {
+        if (!_actionBlocker.CanInteract(uid, null))
+            return;
+
+        RaiseNetworkEvent(new RMCStopDropRollVisualsNetworkEvent(GetNetEntity(uid)), Filter.Pvs(uid)); // RMC14
     }
 }

--- a/Content.Shared/_RMC14/Atmos/SharedRMCFlammableSystem.cs
+++ b/Content.Shared/_RMC14/Atmos/SharedRMCFlammableSystem.cs
@@ -399,6 +399,10 @@ public abstract class SharedRMCFlammableSystem : EntitySystem
     {
     }
 
+    public virtual void DoStopDropRollAnimation(EntityUid uid)
+    {
+    }
+
     private void SpawnFireChain(EntProtoId spawn, EntityUid chain, EntityCoordinates coordinates, int? intensity, int? duration)
     {
         var spawned = Spawn(spawn, coordinates);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Simple fix

Moves it out of the flammable resist method and plays it right before xeno spit and flame resist
with an interaction check to prevent spamming


https://github.com/user-attachments/assets/b5f6d96c-2459-4680-a138-b4a3cd8fef75


https://github.com/user-attachments/assets/35e0fb6f-bcde-4191-b66c-2da769ba55a3



**Changelog**
Small change
