### PR TITLE
Fixes Nutritious Property not restoring enough nutrition.

### DIFF
--- a/Content.Shared/_RMC14/Chemistry/Effects/Neutral/Nutritious.cs
+++ b/Content.Shared/_RMC14/Chemistry/Effects/Neutral/Nutritious.cs
@@ -11,9 +11,7 @@ public sealed partial class Nutritious : RMCChemicalEffect
 {
     protected override string ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
     {
-        var updatedFactor = NutrimentFactor > 0
-            ? NutrimentFactor
-            : Potency;
+        var updatedFactor = NutrimentFactor + ActualPotency;
         return $"Restores [color=green]{updatedFactor * ActualPotency}[/color] nutrients to the body and satiates hunger";
     }
 
@@ -27,9 +25,7 @@ public sealed partial class Nutritious : RMCChemicalEffect
         if (mobStateSystem.IsDead(target))
             return;
 
-        var updatedFactor = NutrimentFactor > 0
-            ? NutrimentFactor
-            : Potency;
+        var updatedFactor = NutrimentFactor + ActualPotency;
         hungerSystem.ModifyHunger(target, updatedFactor * ActualPotency);
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity fix
I misinterpreted what "holder.nutriment_factor += level" did.
## Technical details
<!-- Summary of code changes for easier review. -->
(nutriment factor) + level = updated factor
updated factor * level = nutrition/life_tick
nutrition/life_tick * 0.5 = nutrition/s

**Nutriment:**
(15 * 0.1) + 2 = 3.5
3.5 * 2 = 7
7 * 0.5 = 3.5 nutrition/s

**RMCSugar:**
(0) + 1 = 1
1 * 1 = 1
1 * 0.5 = 0.5 nutrition/s

If you test this on a cm13 local, Nutriment will be restoring 6.45 nutrition per life_tick.
The 0.5 drain is coming from nutriment's hemogenic property while 0.05 is coming from passive hunger drain.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed Nutritious Property restoring less nutrition than intended.