### PR TITLE
The Infamous ASO Debate, Part Whatever

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/auxiliary_support_officer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/auxiliary_support_officer.yml
@@ -17,9 +17,6 @@
   - !type:RoleTimeRequirement
     role: CMJobIntelOfficer
     time: 18000 # 5 hours
-  - !type:DepartmentTimeRequirement
-    department: CMRequisitions
-    time: 18000 # 5 hours
   ranks:
     RMCRankCaptain:
     - !type:RoleTimeRequirement


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
ASO doesnt require any time in Command Department and Req. Dep. as well as Aux Department in general
But they now require 5 hours in Dropship jobs

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
1. As ASO is no longer 3rd in Command and mostly 7th in case of 4 SOs they don't really need a Command timelock. The previous PR that added it justified it by stating that ASO also needs to know overwatch, to which I'd like to say that you don't really need to play SO to learn OW and this only blocks players behind potential extra 10 hours in roles that have next to 0 connection to it right now
2. Req timelock is self-explanatory
3. And replacing Aux Dep timelock with Dropship is motivated by Intel being part of Aux Dep and having the same 5 hour timelock, i.e. you can unlock ASO by only playing Intel which is weird for a head of Pilots too.

## Technical details
<!-- Summary of code changes for easier review. -->
YML-maxing

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
—

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: J C Denton
- tweak: ASO now doesn't require hours in Command or Requisitions and Aux Dep. generally, but requires 5 hours in Dropship roles.
