### PR TITLE
fix: the broiler no longer 'deletes' guns

### DIFF
--- a/Content.Shared/_RMC14/Armor/Magnetic/RMCMagneticSystem.cs
+++ b/Content.Shared/_RMC14/Armor/Magnetic/RMCMagneticSystem.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Shared._RMC14.Inventory;
+using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Hands;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Inventory;
@@ -13,6 +14,7 @@ public sealed class RMCMagneticSystem : EntitySystem
     [Dependency] private readonly SharedContainerSystem _container = default!;
     [Dependency] private readonly InventorySystem _inventory = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly ItemSlotsSystem _slots = default!;
     [Dependency] private readonly ThrownItemSystem _thrownItem = default!;
 
     public override void Initialize()
@@ -63,18 +65,22 @@ public sealed class RMCMagneticSystem : EntitySystem
         while (everySlotEnumerator.MoveNext(out var slot))
         {
             if (slot.ContainedEntity is not { } slotItem ||
-                !HasComp<RMCMagneticItemReceiverComponent>(slotItem))
+                !HasComp<RMCMagneticItemReceiverComponent>(slotItem) ||
+                !TryComp<ItemSlotsComponent>(slotItem, out var itemSlotsComp))
                 continue;
 
             foreach (var slotContainer in _container.GetAllContainers(slotItem))
             {
-                if (_container.CanInsert(args.Args.Item, slotContainer))
-                {
-                    args.Args.Magnetizer = ent;
-                    args.Args.ReceivingItem = slotItem;
-                    args.Args.ReceivingContainer = slotContainer.ID;
-                    return;
-                }
+                if (!_slots.TryGetSlot(slotItem, slotContainer.ID, out var itemSlot, itemSlotsComp))
+                    continue;
+
+                if (!_slots.CanInsert(ent, args.Args.Item, args.Args.User, itemSlot, false))
+                    continue;
+
+                args.Args.Magnetizer = ent;
+                args.Args.ReceivingItem = slotItem;
+                args.Args.ReceivingContainer = slotContainer.ID;
+                return;
             }
         }
 


### PR DESCRIPTION
## About the PR

title

## Why / Balance

bugfix, issue reported on discord

## Technical details

- Items where being send into the "actions" container.
- Items where not being checked against the ItemSlots whitelist.

## Media


https://github.com/user-attachments/assets/5d563743-2c14-49be-9297-d9e84a7b05e1



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- fix: The broiler backpack should no longer delete dropped guns.
