### PR TITLE
fix: no more errors when trying to burn things without physics

### DIFF
--- a/Content.Shared/_RMC14/Atmos/SharedRMCFlammableSystem.cs
+++ b/Content.Shared/_RMC14/Atmos/SharedRMCFlammableSystem.cs
@@ -34,6 +34,7 @@ using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
+using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Player;
@@ -983,14 +984,14 @@ public abstract class SharedRMCFlammableSystem : EntitySystem
             }
         }
 
-        var steppingQuery = EntityQueryEnumerator<SteppingOnFireComponent>();
-        while (steppingQuery.MoveNext(out var uid, out var stepping))
+        var steppingQuery = EntityQueryEnumerator<SteppingOnFireComponent, PhysicsComponent>();
+        while (steppingQuery.MoveNext(out var uid, out var stepping, out var body))
         {
             stepping.ArmorMultiplier = 1;
             Dirty(uid, stepping);
 
             var isStepping = false;
-            foreach (var contact in _physics.GetContactingEntities(uid, approximate: true))
+            foreach (var contact in _physics.GetContactingEntities(uid, body, approximate: true))
             {
                 if (!_igniteOnCollideQuery.TryComp(contact, out var ignite))
                     continue;


### PR DESCRIPTION
## About the PR

title

## Why / Balance

fixes

## Technical details

Things like spawpoints do not have a PhysicsComponent. If a flame where to touch em it would log an error.

## Media



<details>
<summary>Example log from before the fix:</summary>


```
[ERRO] system.physics: Can't resolve "Robust.Shared.Physics.Components.PhysicsComponent" on entity chief engineer spawn point (428/n428, CMSpawnPointChiefEngineer)!
   at System.Environment.get_StackTrace()
   at Robust.Shared.Physics.Systems.SharedPhysicsSystem.GetContactingEntities(Entity`1 ent, HashSet`1 contacting, Boolean approximate) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Queries.cs:line 210
   at Robust.Shared.Physics.Systems.SharedPhysicsSystem.GetContactingEntities(EntityUid uid, PhysicsComponent body, Boolean approximate) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Queries.cs:line 228
   at Content.Shared._RMC14.Atmos.SharedRMCFlammableSystem.Update(Single frameTime) in /home/ignaz/git/RMC-14/Content.Shared/_RMC14/Atmos/SharedRMCFlammableSystem.cs:line 993
   at Robust.Shared.GameObjects.EntitySystemManager.TickUpdate(Single frameTime, Boolean noPredictions) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Shared/GameObjects/EntitySystemManager.cs:line 318
   at Robust.Shared.GameObjects.EntityManager.TickUpdate(Single frameTime, Boolean noPredictions, Histogram histogram) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 276
   at Robust.Server.GameObjects.ServerEntityManager.TickUpdate(Single frameTime, Boolean noPredictions, Histogram histogram) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/GameObjects/ServerEntityManager.cs:line 170
   at Robust.Server.BaseServer.Update(FrameEventArgs frameEventArgs) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/BaseServer.cs:line 732
   at Robust.Server.BaseServer.<SetupMainLoop>b__67_1(Object sender, FrameEventArgs args) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/BaseServer.cs:line 545
   at Robust.Shared.Timing.GameLoop.Run() in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Shared/Timing/GameLoop.cs:line 235
   at Robust.Server.BaseServer.MainLoop() in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/BaseServer.cs:line 572
   at Robust.Server.Program.ParsedMain(CommandLineArgs args, Boolean contentStart, ServerOptions options) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/Program.cs:line 74
   at Robust.Server.Program.Start(String[] args, ServerOptions options, Boolean contentStart) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/Program.cs:line 42
   at Robust.Server.ContentStart.Start(String[] args) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/ContentStart.cs:line 10
   at Content.Server.Program.Main(String[] args) in /home/ignaz/git/RMC-14/Content.Server/Program.cs:line 9
[ERRO] system.physics: Can't resolve "Robust.Shared.Physics.Components.PhysicsComponent" on entity dropship pilot spawn point (447/n447, CMSpawnPointPilotDropship)!
   at System.Environment.get_StackTrace()
   at Robust.Shared.Physics.Systems.SharedPhysicsSystem.GetContactingEntities(Entity`1 ent, HashSet`1 contacting, Boolean approximate) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Queries.cs:line 210
   at Robust.Shared.Physics.Systems.SharedPhysicsSystem.GetContactingEntities(EntityUid uid, PhysicsComponent body, Boolean approximate) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Queries.cs:line 228
   at Content.Shared._RMC14.Atmos.SharedRMCFlammableSystem.Update(Single frameTime) in /home/ignaz/git/RMC-14/Content.Shared/_RMC14/Atmos/SharedRMCFlammableSystem.cs:line 993
   at Robust.Shared.GameObjects.EntitySystemManager.TickUpdate(Single frameTime, Boolean noPredictions) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Shared/GameObjects/EntitySystemManager.cs:line 318
   at Robust.Shared.GameObjects.EntityManager.TickUpdate(Single frameTime, Boolean noPredictions, Histogram histogram) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 276
   at Robust.Server.GameObjects.ServerEntityManager.TickUpdate(Single frameTime, Boolean noPredictions, Histogram histogram) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/GameObjects/ServerEntityManager.cs:line 170
   at Robust.Server.BaseServer.Update(FrameEventArgs frameEventArgs) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/BaseServer.cs:line 732
   at Robust.Server.BaseServer.<SetupMainLoop>b__67_1(Object sender, FrameEventArgs args) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/BaseServer.cs:line 545
   at Robust.Shared.Timing.GameLoop.Run() in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Shared/Timing/GameLoop.cs:line 235
   at Robust.Server.BaseServer.MainLoop() in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/BaseServer.cs:line 572
   at Robust.Server.Program.ParsedMain(CommandLineArgs args, Boolean contentStart, ServerOptions options) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/Program.cs:line 74
   at Robust.Server.Program.Start(String[] args, ServerOptions options, Boolean contentStart) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/Program.cs:line 42
   at Robust.Server.ContentStart.Start(String[] args) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/ContentStart.cs:line 10
   at Content.Server.Program.Main(String[] args) in /home/ignaz/git/RMC-14/Content.Server/Program.cs:line 9
[ERRO] system.physics: Can't resolve "Robust.Shared.Physics.Components.PhysicsComponent" on entity auxiliary support officer spawn point (426/n426, CMSpawnPointASO)!
   at System.Environment.get_StackTrace()
   at Robust.Shared.Physics.Systems.SharedPhysicsSystem.GetContactingEntities(Entity`1 ent, HashSet`1 contacting, Boolean approximate) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Queries.cs:line 210
   at Robust.Shared.Physics.Systems.SharedPhysicsSystem.GetContactingEntities(EntityUid uid, PhysicsComponent body, Boolean approximate) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Queries.cs:line 228
   at Content.Shared._RMC14.Atmos.SharedRMCFlammableSystem.Update(Single frameTime) in /home/ignaz/git/RMC-14/Content.Shared/_RMC14/Atmos/SharedRMCFlammableSystem.cs:line 993
   at Robust.Shared.GameObjects.EntitySystemManager.TickUpdate(Single frameTime, Boolean noPredictions) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Shared/GameObjects/EntitySystemManager.cs:line 318
   at Robust.Shared.GameObjects.EntityManager.TickUpdate(Single frameTime, Boolean noPredictions, Histogram histogram) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 276
   at Robust.Server.GameObjects.ServerEntityManager.TickUpdate(Single frameTime, Boolean noPredictions, Histogram histogram) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/GameObjects/ServerEntityManager.cs:line 170
   at Robust.Server.BaseServer.Update(FrameEventArgs frameEventArgs) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/BaseServer.cs:line 732
   at Robust.Server.BaseServer.<SetupMainLoop>b__67_1(Object sender, FrameEventArgs args) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/BaseServer.cs:line 545
   at Robust.Shared.Timing.GameLoop.Run() in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Shared/Timing/GameLoop.cs:line 235
   at Robust.Server.BaseServer.MainLoop() in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/BaseServer.cs:line 572
   at Robust.Server.Program.ParsedMain(CommandLineArgs args, Boolean contentStart, ServerOptions options) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/Program.cs:line 74
   at Robust.Server.Program.Start(String[] args, ServerOptions options, Boolean contentStart) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/Program.cs:line 42
   at Robust.Server.ContentStart.Start(String[] args) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/ContentStart.cs:line 10
   at Content.Server.Program.Main(String[] args) in /home/ignaz/git/RMC-14/Content.Server/Program.cs:line 9
[ERRO] system.physics: Can't resolve "Robust.Shared.Physics.Components.PhysicsComponent" on entity fireteam leader spawn point (437/n437, CMSpawnPointFireteamLeader)!
   at System.Environment.get_StackTrace()
   at Robust.Shared.Physics.Systems.SharedPhysicsSystem.GetContactingEntities(Entity`1 ent, HashSet`1 contacting, Boolean approximate) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Queries.cs:line 210
   at Robust.Shared.Physics.Systems.SharedPhysicsSystem.GetContactingEntities(EntityUid uid, PhysicsComponent body, Boolean approximate) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Queries.cs:line 228
   at Content.Shared._RMC14.Atmos.SharedRMCFlammableSystem.Update(Single frameTime) in /home/ignaz/git/RMC-14/Content.Shared/_RMC14/Atmos/SharedRMCFlammableSystem.cs:line 993
   at Robust.Shared.GameObjects.EntitySystemManager.TickUpdate(Single frameTime, Boolean noPredictions) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Shared/GameObjects/EntitySystemManager.cs:line 318
   at Robust.Shared.GameObjects.EntityManager.TickUpdate(Single frameTime, Boolean noPredictions, Histogram histogram) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 276
   at Robust.Server.GameObjects.ServerEntityManager.TickUpdate(Single frameTime, Boolean noPredictions, Histogram histogram) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/GameObjects/ServerEntityManager.cs:line 170
   at Robust.Server.BaseServer.Update(FrameEventArgs frameEventArgs) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/BaseServer.cs:line 732
   at Robust.Server.BaseServer.<SetupMainLoop>b__67_1(Object sender, FrameEventArgs args) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/BaseServer.cs:line 545
   at Robust.Shared.Timing.GameLoop.Run() in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Shared/Timing/GameLoop.cs:line 235
   at Robust.Server.BaseServer.MainLoop() in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/BaseServer.cs:line 572
   at Robust.Server.Program.ParsedMain(CommandLineArgs args, Boolean contentStart, ServerOptions options) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/Program.cs:line 74
   at Robust.Server.Program.Start(String[] args, ServerOptions options, Boolean contentStart) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/Program.cs:line 42
   at Robust.Server.ContentStart.Start(String[] args) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/ContentStart.cs:line 10
   at Content.Server.Program.Main(String[] args) in /home/ignaz/git/RMC-14/Content.Server/Program.cs:line 9
[ERRO] system.physics: Can't resolve "Robust.Shared.Physics.Components.PhysicsComponent" on entity chief engineer spawn point (428/n428, CMSpawnPointChiefEngineer)!
   at System.Environment.get_StackTrace()
   at Robust.Shared.Physics.Systems.SharedPhysicsSystem.GetContactingEntities(Entity`1 ent, HashSet`1 contacting, Boolean approximate) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Queries.cs:line 210
   at Robust.Shared.Physics.Systems.SharedPhysicsSystem.GetContactingEntities(EntityUid uid, PhysicsComponent body, Boolean approximate) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Queries.cs:line 228
   at Content.Shared._RMC14.Atmos.SharedRMCFlammableSystem.Update(Single frameTime) in /home/ignaz/git/RMC-14/Content.Shared/_RMC14/Atmos/SharedRMCFlammableSystem.cs:line 993
   at Robust.Shared.GameObjects.EntitySystemManager.TickUpdate(Single frameTime, Boolean noPredictions) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Shared/GameObjects/EntitySystemManager.cs:line 318
   at Robust.Shared.GameObjects.EntityManager.TickUpdate(Single frameTime, Boolean noPredictions, Histogram histogram) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 276
   at Robust.Server.GameObjects.ServerEntityManager.TickUpdate(Single frameTime, Boolean noPredictions, Histogram histogram) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/GameObjects/ServerEntityManager.cs:line 170
   at Robust.Server.BaseServer.Update(FrameEventArgs frameEventArgs) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/BaseServer.cs:line 732
   at Robust.Server.BaseServer.<SetupMainLoop>b__67_1(Object sender, FrameEventArgs args) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/BaseServer.cs:line 545
   at Robust.Shared.Timing.GameLoop.Run() in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Shared/Timing/GameLoop.cs:line 235
   at Robust.Server.BaseServer.MainLoop() in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/BaseServer.cs:line 572
   at Robust.Server.Program.ParsedMain(CommandLineArgs args, Boolean contentStart, ServerOptions options) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/Program.cs:line 74
   at Robust.Server.Program.Start(String[] args, ServerOptions options, Boolean contentStart) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/Program.cs:line 42
   at Robust.Server.ContentStart.Start(String[] args) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/ContentStart.cs:line 10
   at Content.Server.Program.Main(String[] args) in /home/ignaz/git/RMC-14/Content.Server/Program.cs:line 9
[ERRO] system.physics: Can't resolve "Robust.Shared.Physics.Components.PhysicsComponent" on entity dropship pilot spawn point (447/n447, CMSpawnPointPilotDropship)!
   at System.Environment.get_StackTrace()
   at Robust.Shared.Physics.Systems.SharedPhysicsSystem.GetContactingEntities(Entity`1 ent, HashSet`1 contacting, Boolean approximate) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Queries.cs:line 210
   at Robust.Shared.Physics.Systems.SharedPhysicsSystem.GetContactingEntities(EntityUid uid, PhysicsComponent body, Boolean approximate) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Queries.cs:line 228
   at Content.Shared._RMC14.Atmos.SharedRMCFlammableSystem.Update(Single frameTime) in /home/ignaz/git/RMC-14/Content.Shared/_RMC14/Atmos/SharedRMCFlammableSystem.cs:line 993
   at Robust.Shared.GameObjects.EntitySystemManager.TickUpdate(Single frameTime, Boolean noPredictions) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Shared/GameObjects/EntitySystemManager.cs:line 318
   at Robust.Shared.GameObjects.EntityManager.TickUpdate(Single frameTime, Boolean noPredictions, Histogram histogram) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 276
   at Robust.Server.GameObjects.ServerEntityManager.TickUpdate(Single frameTime, Boolean noPredictions, Histogram histogram) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/GameObjects/ServerEntityManager.cs:line 170
   at Robust.Server.BaseServer.Update(FrameEventArgs frameEventArgs) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/BaseServer.cs:line 732
   at Robust.Server.BaseServer.<SetupMainLoop>b__67_1(Object sender, FrameEventArgs args) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/BaseServer.cs:line 545
   at Robust.Shared.Timing.GameLoop.Run() in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Shared/Timing/GameLoop.cs:line 235
   at Robust.Server.BaseServer.MainLoop() in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/BaseServer.cs:line 572
   at Robust.Server.Program.ParsedMain(CommandLineArgs args, Boolean contentStart, ServerOptions options) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/Program.cs:line 74
   at Robust.Server.Program.Start(String[] args, ServerOptions options, Boolean contentStart) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/Program.cs:line 42
   at Robust.Server.ContentStart.Start(String[] args) in /home/ignaz/git/RMC-14/RobustToolbox/Robust.Server/ContentStart.cs:line 10
   at Content.Server.Program.Main(String[] args) in /home/ignaz/git/RMC-14/Content.Server/Program.cs:line 9
```


</details>


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

No