### PR TITLE
add: free up specialization when the spec cryos

### DIFF
--- a/Content.Shared/_RMC14/Vendors/RMCSpecCryoRefundComponent.cs
+++ b/Content.Shared/_RMC14/Vendors/RMCSpecCryoRefundComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Vendors;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class RMCSpecCryoRefundComponent : Component
+{
+    [DataField(required: true), AutoNetworkedField]
+    public EntityUid Vendor;
+
+    [DataField(required: true), AutoNetworkedField]
+    public int Entry;
+}

--- a/Content.Shared/_RMC14/Vendors/SharedCMAutomatedVendorSystem.cs
+++ b/Content.Shared/_RMC14/Vendors/SharedCMAutomatedVendorSystem.cs
@@ -43,6 +43,7 @@ using Robust.Shared.Timing;
 using Content.Shared._RMC14.Marines.Roles.Ranks;
 using Content.Shared.Storage.EntitySystems;
 using Content.Shared.Storage;
+using Content.Shared._RMC14.Cryostorage;
 
 namespace Content.Shared._RMC14.Vendors;
 
@@ -94,6 +95,8 @@ public abstract class SharedCMAutomatedVendorSystem : EntitySystem
 
         SubscribeLocalEvent<RMCRecentlyVendedComponent, GotEquippedHandEvent>(OnRecentlyGotEquipped);
         SubscribeLocalEvent<RMCRecentlyVendedComponent, GotEquippedEvent>(OnRecentlyGotEquipped);
+
+        SubscribeLocalEvent<RMCSpecCryoRefundComponent, EnteredCryostorageEvent>(OnSpecEnteredCryostorageEvent);
 
         Subs.BuiEvents<CMAutomatedVendorComponent>(CMAutomatedVendorUI.Key,
             subs =>
@@ -580,6 +583,12 @@ public abstract class SharedCMAutomatedVendorSystem : EntitySystem
 
                 thisSpecVendor.GlobalSharedVends[args.Entry] += 1;
                 Dirty(vendor, thisSpecVendor);
+
+                AddComp(actor, new RMCSpecCryoRefundComponent
+                {
+                    Vendor = vendor,
+                    Entry = args.Entry
+                }, true);
             }
         }
 
@@ -872,5 +881,19 @@ public abstract class SharedCMAutomatedVendorSystem : EntitySystem
             amount = boxAmount;
 
         return Math.Max(1, amount);
+    }
+
+    private void OnSpecEnteredCryostorageEvent(Entity<RMCSpecCryoRefundComponent> ent, ref EnteredCryostorageEvent args)
+    {
+        if (!TryComp<RMCVendorSpecialistComponent>(ent.Comp.Vendor, out var vendor))
+            return;
+
+        if (!vendor.GlobalSharedVends.TryGetValue(ent.Comp.Entry, out var current))
+            return;
+
+        if (current < 1) // How?
+            return;
+
+        vendor.GlobalSharedVends[ent.Comp.Entry] = current - 1;
     }
 }


### PR DESCRIPTION
## About the PR

title

## Why / Balance

I can't find the issue anymore, might have just been a comment on discord.

## Technical details

- Add a `RMCSpecCryoRefundComponent` to then spec when they take their kit.
- Watch for `EnteredCryostorageEvent` and free it up.
- Foxtrot and anything else with the `IgnoreSpecLimitsComponent` never gets the component.

## Media

https://github.com/user-attachments/assets/bc8e3f7a-eb4b-42d5-bd91-7c16add6c24f


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- add: Specialization kits can be chosen again after its specialist entered cryogenic storage.
