### PR TITLE
tweak: show if something protects agains direct ignition

### DIFF
--- a/Content.Shared/_RMC14/Atmos/SharedRMCFlammableSystem.cs
+++ b/Content.Shared/_RMC14/Atmos/SharedRMCFlammableSystem.cs
@@ -714,7 +714,7 @@ public abstract class SharedRMCFlammableSystem : EntitySystem
     {
         using (args.PushGroup(nameof(RMCImmuneToIgnitionComponent)))
         {
-            args.PushMarkup(Loc.GetString("rmc-immune-to-ignition-examine", ("ent", ent)));
+            args.PushMarkup(Loc.GetString("rmc-immune-to-ignition-examine", ("ent", ent), ("direct", ent.Comp.ImmuneToDirectHits)));
         }
     }
 

--- a/Resources/Locale/en-US/_RMC14/flammable.ftl
+++ b/Resources/Locale/en-US/_RMC14/flammable.ftl
@@ -1,3 +1,6 @@
-﻿rmc-immune-to-ignition-examine = [color=cyan]{CAPITALIZE(SUBJECT($ent))} can't be ignited![/color]
+﻿rmc-immune-to-ignition-examine = [color=cyan]{CAPITALIZE(SUBJECT($ent))} can't be {$direct ->
+    [true]{""}
+    *[false]{"indirectly "}
+    }ignited![/color]
 rmc-immune-to-fire-tile-damage-examine = [color=cyan]{CAPITALIZE(SUBJECT($ent))} takes no damage from tile fires![/color]
 rmc-fire-armor-debuff-modifier-examine = [color=cyan]{CAPITALIZE(SUBJECT($ent))} has {POSS-ADJ($ent)} armor reduced {$percentage}% less when standing on green fire![/color]


### PR DESCRIPTION
## About the PR

title

## Why / Balance

Adjust the examine text to show if something has protection against direct or only indirect ignition. Pyro spec got confused how they got ignited (someone flamed them directly).

## Technical details

Variable in the ftl.

## Media

<img width="444" height="245" alt="Screenshot From 2025-12-10 22-05-58" src="https://github.com/user-attachments/assets/6737c794-fb58-48df-94f8-5da3c0857465" />
<img width="528" height="511" alt="Screenshot From 2025-12-10 22-05-48" src="https://github.com/user-attachments/assets/40c22d3f-eee4-4271-8b92-f488d6fa0e40" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- tweak: The fire-immunity examination text now differentiates between direct and indirect ignition.
