### PR TITLE
Port door access wire

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Doors/Windoors/windoor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Doors/Windoors/windoor.yml
@@ -85,7 +85,7 @@
   - type: WiresPanel
   - type: Wires
     boardName: wires-board-name-windoor
-    layoutId: Airlock
+    layoutId: RMCAirlock
   - type: UserInterface
     interfaces:
       enum.AiUi.Key:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Doors/cm_door.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Doors/cm_door.yml
@@ -118,7 +118,7 @@
   - type: WiresPanelSecurity
   - type: Wires
     boardName: wires-board-name-airlock
-    layoutId: Airlock
+    layoutId: RMCAirlock
   - type: DoorSignalControl
   - type: DeviceNetwork
     deviceNetId: Wireless

--- a/Resources/Prototypes/_RMC14/Wires/layouts.yml
+++ b/Resources/Prototypes/_RMC14/Wires/layouts.yml
@@ -1,0 +1,11 @@
+- type: wireLayout
+  id: RMCAirlock
+  wires:
+  - !type:PowerWireAction
+  - !type:PowerWireAction
+    pulseTimeout: 15
+  - !type:DoorBoltWireAction
+  - !type:DoorBoltLightWireAction
+  - !type:DoorTimingWireAction
+  - !type:DoorSafetyWireAction
+  - !type:AccessWireAction


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds the access wire from CM13
New RMC wire layout prototype

**Changelog**
:cl:
- add: Added the access wire for airlocks.