### PR TITLE
tweak: flamers can now be filled from welderpacks

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Back/backpacks.yml
@@ -239,6 +239,7 @@
     popup: rmc-solution-transfer-whitelist-failed-not-welding-tank
     sourceWhitelist:
       components:
+      - RMCFlamerTank
       - Welder
     targetWhitelist:
       tags:

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Back/satchels.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Back/satchels.yml
@@ -532,6 +532,7 @@
     popup: rmc-solution-transfer-whitelist-failed-not-welding-tank
     sourceWhitelist:
       components:
+      - RMCFlamerTank
       - Welder
     targetWhitelist:
       tags:


### PR DESCRIPTION
## About the PR

title

## Why / Balance

fixes #5703

## Technical details

just whitelist

## Media


https://github.com/user-attachments/assets/8d5cf80e-cac0-4a65-98e7-201a5051f9b8



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- tweak: Incinerators can now be filled from welderpacks.
