### PR TITLE
Fixes Bipods staying deployed when moving

### DIFF
--- a/Content.Shared/_RMC14/Attachable/Systems/AttachableToggleableSystem.cs
+++ b/Content.Shared/_RMC14/Attachable/Systems/AttachableToggleableSystem.cs
@@ -602,11 +602,12 @@ public sealed class AttachableToggleableSystem : EntitySystem
         if (!TryComp(args.Used, out AttachableHolderComponent? holderComponent))
             return;
 
-        if (!attachable.Comp.Active && TryComp<InputMoverComponent>(args.User, out var input )) {
-            if((input.HeldMoveButtons & MoveButtons.AnyDirection) != MoveButtons.None)
-                return;
+        if (!attachable.Comp.Active &&
+            TryComp<InputMoverComponent>(args.User, out var input) &&
+            (input.HeldMoveButtons & MoveButtons.AnyDirection) != MoveButtons.None)
+        {
+            return;
         }
-
 
         FinishToggle(attachable, (used, holderComponent), args.SlotId, args.User, args.PopupText);
         args.Handled = true;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
fixes #8377

## Why / Balance
Fixes a bug

## Technical details
Literally just checks if any movement keys are held after the DoAfter finishes, as the MoveInputEvent only fires when we press new movement buttons

## Media
[Screencast_20251212_131107.webm](https://github.com/user-attachments/assets/3ba440ca-cb73-4ceb-90e7-8ba1f7a2370b)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Bipods now check if you are moving before deploying