### PR TITLE
minimum playtime for ghosted queen

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
@@ -15,6 +15,10 @@
     - RMCGuideRoleQueen
   - type: GhostRole
     name: cm-job-name-xeno-queen
+    requirements:
+    - !type:TotalJobsTimeRequirement
+      group: CMJobsXeno
+      time: 36000 # 10 hours
   - type: Sprite
     sprite: _RMC14/Mobs/Xenonids/Queen/queen.rsi
     layers:


### PR DESCRIPTION
## About the PR

title

## Why / Balance

Just had a round where TWO new players took the queen when the original one disconnected.

## Technical details

Set to 10 for now, as that's the minimum required to unlock queen round start. Personally I would even increase it to 24h, that unlocks the 3rd letter.

## Media

<img width="777" height="384" alt="image" src="https://github.com/user-attachments/assets/0b91edfb-b1d5-45c7-9925-5aa7461cd254" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- tweak: Ghosted queens now require a minimum of 10 hours as xeno to take over.
