### PR TITLE
Change Hotsauce Bottle Opening Sounds

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Food/condiments.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Food/condiments.yml
@@ -20,8 +20,10 @@
     solution: food
   - type: Openable
     sound:
-      collection: pop
+      collection: bottleOpenSounds
     closeable: true
+    closeSound:
+      collection: bottleCloseSounds
   - type: RefillableSolution
     solution: food
   - type: Spillable


### PR DESCRIPTION
## About the PR
Changes all the hotsauce bottles opening sounds to be in line with other bottles.

## Why / Balance
This was causing issues with sound memory for admins and mentors when their chat goes off, because it used the same sound. This changes the bottle noise so both don't have to develop new sound memory entirely. Aura also told me to "pick literally anything" because they are going to be redoing the system later anyways I believe.

## Technical details
YAML, these two sound collections are used by literally every other bottle (Pretty much).

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
No CL, but maybe mention it to the admins and SEAs.
