### PR TITLE
remove duplicate mateba kit, make ltcol/col berets 0pts

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Command/commanding_officer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Command/commanding_officer.yml
@@ -1,4 +1,5 @@
-﻿- type: job
+﻿
+- type: job
   parent: CMJobBase
   id: CMCommandingOfficer
   name: cm-job-name-commanding-officer
@@ -91,8 +92,6 @@
     ears: CMHeadsetSeniorCommand
     pocket1: RMCPouchCommand
     pocket2: RMCPouchGeneralLarge
-  inhand:
-    - RMCMatebaCustomizationCase
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_RMC14/Roles/Loadouts/Items/RoleSpecific/commanding_officer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Loadouts/Items/RoleSpecific/commanding_officer.yml
@@ -1,7 +1,7 @@
 # Commanding Officer
 - type: loadout
   id: ColBeretRMC
-  cost: 3 # same price as headwear
+  cost: 0 # Shouldn't cost anything as it is a rank reward.
   effects:
   - !type:JobRequirementLoadoutEffect
     requirement:
@@ -14,7 +14,7 @@
 
 - type: loadout
   id: LtColBeretRMC
-  cost: 3
+  cost: 0 # Shouldn't cost anything as it is a rank reward.
   effects:
   - !type:JobRequirementLoadoutEffect
     requirement:


### PR DESCRIPTION
title

Removes the mateba customization kit from the CO spawn as it's a duplicate item with the loadout changes.

Makes LtCol/Col beret costs 0pts in loadout. This, in my opinion, should not cost points to wear as it is a rank reward and I would treat it the same as just the regular CO berets that they normally spawn with. It is not a 'special item' - it is a beret that bears insignia of rank and it would be strange for a high ranking officer to be without.

:cl:
- fix: Commanding Officers no longer spawn with a Mateba Customization Kit
- tweak: Lieutenant Colonel and Colonel berets no longer take points from the loadout menu.
