### PR TITLE
Switched hour requirement from Hospital Corpsman to Nurse for Colonist

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Base_Survs/civilian_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Base_Survs/civilian_survivor.yml
@@ -13,7 +13,7 @@
     time: 18000 # 5 hours
   - !type:RoleTimeRequirement
     role: CMJobNurse
-    time: 3600 # 1 hour
+    time: 18000 # 5 hours
   ranks:
     RMCRankCivilian: []
   startingGear: RMCGearSurvivor


### PR DESCRIPTION
Reduce excessive colonist medical requirements.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I reduced the time requirement for colonists by having players play an hour of Nurse before becoming a colonist. Hospital Corpsman is less applicable because colonists are not going to use bags, fultons, or squad tactics to evacuate troopers by dropship.

## Why / Balance
Both the Hospital Corpsman and Nurse are medical roles that teach medical mechanics.

## Technical details
The time requirement was switched between the roles.

## Media
There is nothing to show, sadly.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Changed the five required hours as a Hospital Corpsman to play a Civilian Colonist to Nurse hours.