### PR TITLE
Corporate Dome CL rank fix

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/LV624/corporate_dome_cl.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/LV624/corporate_dome_cl.yml
@@ -5,6 +5,8 @@
   description: cm-job-description-survivor
   spawnMenuRoleName: Paranoid Corporate Liaison (LV624 Special Survivor)
   startingGear: RMCGearSurvivorLV624CorporateLiaison
+  ranks:
+    RMCRankWeYaExecutiveSpecialist: []
   special:
   - !type:AddComponentSpecial
     components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Makes corporate dome CL insert WYC5 instead of general WYC2->WYC5 progression of normal CL survivor

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity

## Technical details
<!-- Summary of code changes for easier review. -->
2 YML lines

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
—

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: J C Denton
- fix: Fixed Paranoid Corporate Liaison survivor on LV-624 having incorrect rank.
