### PR TITLE
Researcher ranks and factions

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Medical/researcher.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Medical/researcher.yml
@@ -20,6 +20,10 @@
     RMCRankCivilianAssociateProfessor:
     - !type:RoleTimeRequirement
       role: CMJobResearcher
+      time: 90000 # 25 hours
+    RMCRankCivilianAssistantProfessor:
+    - !type:RoleTimeRequirement
+      role: CMJobResearcher
       time: 36000 # 10 hours
     RMCRankCivilianDoctor: []
   startingGear: CMGearResearcher
@@ -63,7 +67,7 @@
   equipment:
     jumpsuit: CMJumpsuitResearch
     shoes: RMCShoesLaceup
-    id: CMIDCardResearcher
+    id: CMIDCardResearcher # TODO ID has both Marine and WeYa IFF
     # TODO RMC14 random chemical synthesis note, syringe,
 
 - type: startingGear

--- a/Resources/Prototypes/_RMC14/Roles/Ranks/Colony/civilian.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Ranks/Colony/civilian.yml
@@ -16,6 +16,11 @@
   prefix: Dr.
 
 - type: rank
+  id: RMCRankCivilianAssistantProfessor
+  name: Assistant Professor
+  prefix: Asst. Prof.
+
+- type: rank
   id: RMCRankCivilianAssociateProfessor
   name: Associate Professor
   prefix: Assoc. Prof.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Researcher parity things for the job

Gives them both the WeYa faction and Marine faction
Gives them their civilians rank:
- <10 hours, Doctor
- 10-25 hours, Assistant Professor
- 25-70 hours, Associate Professor
- 70-175 hours, Professor
- 175+ hours, Regents Professor

Gives them the right tacmap icon background, aswell

## Changelog
No player facing
