### PR TITLE
Change the headset in CMD Cabinet

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Storage/wall_lockers.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Storage/wall_lockers.yml
@@ -46,4 +46,4 @@
   table: !type:AllSelector
     children:
     - id: RMCTabletCO
-    - id: RMCHeadsetMarineCommand
+    - id: CMHeadsetSeniorCommand


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Break off from my previous PR as I think this simple change has merit. Change out the Command Headset in the Command Tablet Cabinet with a Senior Command Headset. Whoever access the cabinet is the Commander, which is usually CO/XO, but in cases where nether are there then whoever becomes Commander doesn't have a direct line of communication to the MPs. The Commander has a couple of duties under SOP/Mlaw that having a direct way to speak to the MPs would help.

## Media
<!-- Media -->
<img width="450" height="351" alt="image" src="https://github.com/user-attachments/assets/b7c261e6-313b-43cc-8609-9db2cffdae55" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Replace the headset in the Command Tablet Cabinet
