### PR TITLE
Fix #8759

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/WeYa/pmc_synthetic.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/WeYa/pmc_synthetic.yml
@@ -55,13 +55,17 @@
         types:
           Blunt: 35
     - type: Synth
+    - type: AssignSquad
+      whitelist:
+        tags:
+        - RMCSquadPMC
   hidden: true
 
 - type: startingGear
   id: RMCGearPMCSynthetic
   equipment:
     head: ArmorHelmetPMCOfficer # Why the shit is the PMC beret a HELMET???
-    ears: RMCHeadsetDistressWeYa
+    ears: RMCHeadsetDistressPMC
     # eyes: RMCGogglesMeson // TODO RMC14 mesons
     back: RMCPMCSyntheticSmartpack
     belt: RMCBeltMedicBagPMCFilled

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/squads.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/squads.yml
@@ -188,6 +188,12 @@
     leaderIcon:
       sprite: _RMC14/Interface/cm_job_icons.rsi
       state: pmc_ld
+  - type: Tag
+    tags:
+    - RMCSquadPMC
+
+- type: Tag
+  id: RMCSquadPMC
 
 - type: entity
   parent: SquadBase


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added PMC support synths to the PMC squad
Swapped generic WeYa distress headset for a PMC distress headset so they get a tracker

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Resolves #8759 

## Technical details
<!-- Summary of code changes for easier review. -->
yml

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed WeYa PMC synthetics not being automatically assigned to the PMC squad and missing a tracker for PMC squad leaders
