### PR TITLE
Update squad vending machine yaml to have more uniform conventions.

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/engineer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/engineer.yml
@@ -43,11 +43,11 @@
       - id: RMCPowerCellHigh
         points: 3
       - id: CMSheetMetal10
-        name: metal x10
+        name: Metal x10
         points: 5
         recommended: true
       - id: CMSheetPlasteel10
-        name: plasteel x10
+        name: Plasteel x10
         points: 7
         recommended: true
       - id: RMCExplosivePlastic
@@ -56,7 +56,7 @@
         points: 5
         recommended: true
       - id: CMSandbagEmpty25
-        name: sandbags x25
+        name: Sandbags x25
         points: 10
         recommended: true
       - id: RMCPowerCellSuper
@@ -93,10 +93,6 @@
         points: 6
       - id: CMMagazineRifleM4SPRExt
         points: 6
-      - id: RMCMagazinePistolM13AP
-        points: 6
-      - id: RMCMagazinePistolM13ExtAP
-        points: 8
       - id: CMMagazineSMGM63AP
         points: 6
       - id: CMMagazineSMGM63Ext
@@ -109,6 +105,10 @@
       entries:
       - id: RMCMagazinePistolM13Ext
         points: 6
+      - id: RMCMagazinePistolM13AP
+        points: 6
+      - id: RMCMagazinePistolM13ExtAP
+        points: 8
       # - id: RMCSpeedLoader44Heavy
       #   points: 6
       - id: RMCSpeedLoader44Marksman
@@ -142,10 +142,10 @@
     - name: Clothing Items
       entries:
       - id: RMCScabbardMacheteFilled
-        name: machete scabbard (Full)
+        name: Machete scabbard (Full)
         points: 6
       - id: RMCPouchMacheteFilled
-        name: machete pouch (Full)
+        name: Machete pouch (Full)
         points: 8
       - id: RMCBackpackRTO
         replaceSlot: back
@@ -236,18 +236,19 @@
       choices: { CMArmor: 1 }
       entries:
       - id: RMCArmorVestSquad
+        name: Armor vest
       - id: RMCArmorM3LightVariants
-        name: light armor
+        name: Light armor
       - id: RMCArmorM3MediumVariants
-        name: medium armor
+        name: Medium armor
         recommended: true
       - id: RMCArmorM3HeavyVariants
-        name: heavy armor
+        name: Heavy armor
     - name: Backpack
       choices: { CMBackpack: 1 }
       entries:
       - id: RMCScabbardMacheteFilled
-        name: machete scabbard (Full)
+        name: Machete scabbard (Full)
       - id: CMBackpackMarineTech
         replaceSlot: back
       - id: CMSatchelMarineTech
@@ -283,16 +284,16 @@
       - id: RMCPouchConstruction
         recommended: true
       - id: RMCPouchFirstAidInjectors
-        name: first-aid pouch (refillable injectors)
+        name: First-aid pouch (refillable injectors)
         recommended: true
       - id: RMCPouchFirstAidSplintsGauzeOintment
-        name: first-aid pouch (gauze, ointment) # TODO RMC14 splints comma
+        name: First-aid pouch (gauze, ointment) # TODO RMC14 splints comma
         recommended: true
       - id: RMCPouchFirstAidPills
-        name: first-aid pouch (pills)
+        name: First-aid pouch (pills)
         recommended: true
       - id: RMCPouchElectronicsFill
-        name: electronics pouch (Full)
+        name: Electronics pouch (Full)
       - id: RMCPouchExplosive
       - id: RMCPouchFlareFilled
         name: Flare pouch (Full)
@@ -319,7 +320,7 @@
       - id: CMWebbingHolster
       - id: RMCWebbingHolsterBlack
       - id: RMCToolWebbingSmallFilled
-        name: small tool webbing (Full)
+        name: Small tool webbing (Full)
     - name: Mask
       choices: { CMMask: 1 }
       entries:
@@ -353,7 +354,7 @@
     - name: Equipment
       entries:
       - id: CMBeltUtility
-        name: utility tool belt
+        name: Utility tool belt
         amount: 4
       - id: RMCCableCoil
         amount: 4

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/engineer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/engineer.yml
@@ -43,11 +43,11 @@
       - id: RMCPowerCellHigh
         points: 3
       - id: CMSheetMetal10
-        name: Metal x10
+        name: metal x10
         points: 5
         recommended: true
       - id: CMSheetPlasteel10
-        name: Plasteel x10
+        name: plasteel x10
         points: 7
         recommended: true
       - id: RMCExplosivePlastic
@@ -56,7 +56,7 @@
         points: 5
         recommended: true
       - id: CMSandbagEmpty25
-        name: Sandbags x25
+        name: sandbags x25
         points: 10
         recommended: true
       - id: RMCPowerCellSuper
@@ -142,10 +142,10 @@
     - name: Clothing Items
       entries:
       - id: RMCScabbardMacheteFilled
-        name: Machete scabbard (Full)
+        name: machete scabbard (Full)
         points: 6
       - id: RMCPouchMacheteFilled
-        name: Machete pouch (Full)
+        name: machete pouch (Full)
         points: 8
       - id: RMCBackpackRTO
         replaceSlot: back
@@ -236,19 +236,19 @@
       choices: { CMArmor: 1 }
       entries:
       - id: RMCArmorVestSquad
-        name: Armor vest
+        name: armor vest
       - id: RMCArmorM3LightVariants
-        name: Light armor
+        name: light armor
       - id: RMCArmorM3MediumVariants
-        name: Medium armor
+        name: medium armor
         recommended: true
       - id: RMCArmorM3HeavyVariants
-        name: Heavy armor
+        name: heavy armor
     - name: Backpack
       choices: { CMBackpack: 1 }
       entries:
       - id: RMCScabbardMacheteFilled
-        name: Machete scabbard (Full)
+        name: machete scabbard (Full)
       - id: CMBackpackMarineTech
         replaceSlot: back
       - id: CMSatchelMarineTech
@@ -284,26 +284,26 @@
       - id: RMCPouchConstruction
         recommended: true
       - id: RMCPouchFirstAidInjectors
-        name: First-aid pouch (refillable injectors)
+        name: first-aid pouch (refillable injectors)
         recommended: true
       - id: RMCPouchFirstAidSplintsGauzeOintment
-        name: First-aid pouch (gauze, ointment) # TODO RMC14 splints comma
+        name: first-aid pouch (gauze, ointment) # TODO RMC14 splints comma
         recommended: true
       - id: RMCPouchFirstAidPills
-        name: First-aid pouch (pills)
+        name: first-aid pouch (pills)
         recommended: true
       - id: RMCPouchElectronicsFill
-        name: Electronics pouch (Full)
+        name: electronics pouch (Full)
       - id: RMCPouchExplosive
       - id: RMCPouchFlareFilled
-        name: Flare pouch (Full)
+        name: flare pouch (Full)
       - id: RMCPouchMagazinePistolLarge
       - id: RMCPouchMagazine
       - id: RMCPouchShotgun
       - id: RMCPouchGeneralMedium
       - id: RMCPouchPistol
       - id: RMCPouchToolsFill
-        name: Tools pouch (Full)
+        name: tools pouch (Full)
       - id: RMCPouchEngineerKit
     - name: Accessories
       choices: { CMAccessories: 1 }
@@ -320,7 +320,7 @@
       - id: CMWebbingHolster
       - id: RMCWebbingHolsterBlack
       - id: RMCToolWebbingSmallFilled
-        name: Small tool webbing (Full)
+        name: small tool webbing (Full)
     - name: Mask
       choices: { CMMask: 1 }
       entries:
@@ -354,7 +354,7 @@
     - name: Equipment
       entries:
       - id: CMBeltUtility
-        name: Utility tool belt
+        name: utility tool belt
         amount: 4
       - id: RMCCableCoil
         amount: 4

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/leader.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/leader.yml
@@ -15,11 +15,11 @@
     jobs:
     - CMSquadLeader
     sections:
-    - name: squad Leader Kit
+    - name: Squad Leader Kit
       takeAll: CMStandard
       entries:
       - id: RMCVendorBundleCrewLeader
-    - name: squad Kit (for yourself or your squad)
+    - name: Squad Kit (for yourself or your squad)
       choices: { RMCKitBase: 1 }
       entries:
       - id: RMCKitEngineering
@@ -321,7 +321,7 @@
 - type: entity
   parent: CMVendorBundleRiflemanApparel
   id: RMCVendorBundleCrewLeader
-  name: Essential SL kit
+  name: essential SL kit
   description: Contains a laser designator, a pack of signal flares, a breaching charge and a fire extinguisher.
   components:
   - type: Sprite
@@ -375,7 +375,7 @@
 - type: entity
   parent: RMCKitBase
   id: RMCKitEngineering
-  name: Engineering supply kit
+  name: engineering supply kit
   description: Contains a construction pouch with 50 metal, 30 plasteel and 15 barbed wire, and an electronics pouch with three high-capacity power cells.
   components:
   - type: Storage

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/leader.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/leader.yml
@@ -37,10 +37,10 @@
       - id: RMCBackpackRTO
         points: 5
       - id: RMCScabbardMacheteFilled
-        name: machete scabbard (Full)
+        name: Machete scabbard (Full)
         points: 4
       - id: RMCPouchMacheteFilled
-        name: machete pouch (Full)
+        name: Machete pouch (Full)
         points: 4
       - id: CMBeltUtilityCombat
         points: 15
@@ -77,11 +77,11 @@
       - id: CMHandsBlackInsulated
         points: 3
       - id: CMSheetMetal10
-        name: metal x10
+        name: Metal x10
         points: 5
         recommended: true
       - id: CMSheetPlasteel10
-        name: plasteel x10
+        name: Plasteel x10
         points: 7
         recommended: true
       - id: RMCExplosivePlastic
@@ -91,7 +91,7 @@
         points: 7
         recommended: true
       - id: CMSandbagEmpty25
-        name: sandbags x25
+        name: Sandbags x25
         points: 10
         recommended: true
       - id: RMCPackFlareCAS
@@ -158,10 +158,6 @@
         points: 6
       - id: CMMagazineRifleM4SPRExt
         points: 6
-      - id: RMCMagazinePistolM13AP
-        points: 6
-      - id: RMCMagazinePistolM13ExtAP
-        points: 8
       - id: CMMagazineSMGM63AP
         points: 6
       - id: CMMagazineSMGM63Ext
@@ -174,6 +170,10 @@
       entries:
       - id: RMCMagazinePistolM13Ext
         points: 6
+      - id: RMCMagazinePistolM13AP
+        points: 6
+      - id: RMCMagazinePistolM13ExtAP
+        points: 8
       # - id: RMCSpeedLoader44Heavy
       #  points: 6
       - id: RMCSpeedLoader44Marksman
@@ -190,10 +190,10 @@
       entries:
       - id: RMCTankFlamer
         points: 3
-        name: incinerator tank (UT-Napthal)
+        name: Incinerator tank (UT-Napthal)
       - id: RMCTankFlamerBGel
         points: 3
-        name: incinerator tank (B-Gel)
+        name: Incinerator tank (B-Gel)
     - name: Restricted Firearms
       entries:
       - id: RMCCaseFlamer
@@ -244,12 +244,12 @@
       choices: { CMArmour: 1 }
       entries:
       - id: RMCArmorB12Zipties
-        name: leader B12 pattern marine armor (zipties)
+        name: Leader B12 pattern marine armor (zipties)
         recommended: true
       - id: RMCArmorM4Zipties
-        name: leader M4 pattern marine armor (zipties)
+        name: Leader M4 pattern marine armor (zipties)
       - id: RMCArmorVestSquadLeader
-        name: leader M3-XL pattern armor vest (zipties)
+        name: Leader M3-XL pattern armor vest (zipties)
     - name: Backpack
       choices: { CMBackpack: 1 }
       entries:
@@ -281,11 +281,11 @@
       - id: RMCPouchAutoinjectorFill
         recommended: true
       - id: RMCPouchFirstAidInjectors
-        name: first-aid pouch (refillable injectors)
+        name: First-aid pouch (refillable injectors)
       - id: RMCPouchFirstAidSplintsGauzeOintment
-        name: first-aid pouch (gauze, ointment) # TODO RMC14 splints comma
+        name: First-aid pouch (gauze, ointment) # TODO RMC14 splints comma
       - id: RMCPouchFirstAidPills
-        name: first-aid pouch (pills)
+        name: First-aid pouch (pills)
         recommended: true
       - id: RMCPouchFlareFilled
         name: Flare pouch (Full)
@@ -321,7 +321,7 @@
 - type: entity
   parent: CMVendorBundleRiflemanApparel
   id: RMCVendorBundleCrewLeader
-  name: essential SL kit
+  name: Essential SL kit
   description: Contains a laser designator, a pack of signal flares, a breaching charge and a fire extinguisher.
   components:
   - type: Sprite
@@ -375,7 +375,7 @@
 - type: entity
   parent: RMCKitBase
   id: RMCKitEngineering
-  name: engineering supply kit
+  name: Engineering supply kit
   description: Contains a construction pouch with 50 metal, 30 plasteel and 15 barbed wire, and an electronics pouch with three high-capacity power cells.
   components:
   - type: Storage
@@ -418,7 +418,7 @@
 - type: entity
   parent: CMArmorB12
   id: RMCArmorB12Zipties
-  name: leader B12 pattern marine armor
+  name: Leader B12 pattern marine armor
   description: A lightweight suit of carbon fiber body armor built for quick movement. Designed in a lovely forest green. Use it to toggle the built-in flashlight. This one has a separate pouch for a ziptie box.
   suffix: Zipties
   components:
@@ -440,7 +440,7 @@
 - type: entity
   parent: CMArmorM4
   id: RMCArmorM4Zipties
-  name: leader M4 pattern marine armor
+  name: Leader M4 pattern marine armor
   description: A well tinkered and crafted hybrid of Smart-Gunner mesh and M3 pattern plates. Robust, yet nimble, with room for all your pouches. This one has a separate pouch for a ziptie box.
   suffix: Zipties
   components:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/leader.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/leader.yml
@@ -15,11 +15,11 @@
     jobs:
     - CMSquadLeader
     sections:
-    - name: Squad Leader Kit
+    - name: squad Leader Kit
       takeAll: CMStandard
       entries:
       - id: RMCVendorBundleCrewLeader
-    - name: Squad Kit (for yourself or your squad)
+    - name: squad Kit (for yourself or your squad)
       choices: { RMCKitBase: 1 }
       entries:
       - id: RMCKitEngineering
@@ -37,10 +37,10 @@
       - id: RMCBackpackRTO
         points: 5
       - id: RMCScabbardMacheteFilled
-        name: Machete scabbard (Full)
+        name: machete scabbard (Full)
         points: 4
       - id: RMCPouchMacheteFilled
-        name: Machete pouch (Full)
+        name: machete pouch (Full)
         points: 4
       - id: CMBeltUtilityCombat
         points: 15
@@ -77,11 +77,11 @@
       - id: CMHandsBlackInsulated
         points: 3
       - id: CMSheetMetal10
-        name: Metal x10
+        name: metal x10
         points: 5
         recommended: true
       - id: CMSheetPlasteel10
-        name: Plasteel x10
+        name: plasteel x10
         points: 7
         recommended: true
       - id: RMCExplosivePlastic
@@ -91,7 +91,7 @@
         points: 7
         recommended: true
       - id: CMSandbagEmpty25
-        name: Sandbags x25
+        name: sandbags x25
         points: 10
         recommended: true
       - id: RMCPackFlareCAS
@@ -190,10 +190,10 @@
       entries:
       - id: RMCTankFlamer
         points: 3
-        name: Incinerator tank (UT-Napthal)
+        name: incinerator tank (UT-Napthal)
       - id: RMCTankFlamerBGel
         points: 3
-        name: Incinerator tank (B-Gel)
+        name: incinerator tank (B-Gel)
     - name: Restricted Firearms
       entries:
       - id: RMCCaseFlamer
@@ -244,12 +244,12 @@
       choices: { CMArmour: 1 }
       entries:
       - id: RMCArmorB12Zipties
-        name: Leader B12 pattern marine armor (zipties)
+        name: leader B12 pattern marine armor (zipties)
         recommended: true
       - id: RMCArmorM4Zipties
-        name: Leader M4 pattern marine armor (zipties)
+        name: leader M4 pattern marine armor (zipties)
       - id: RMCArmorVestSquadLeader
-        name: Leader M3-XL pattern armor vest (zipties)
+        name: leader M3-XL pattern armor vest (zipties)
     - name: Backpack
       choices: { CMBackpack: 1 }
       entries:
@@ -281,14 +281,14 @@
       - id: RMCPouchAutoinjectorFill
         recommended: true
       - id: RMCPouchFirstAidInjectors
-        name: First-aid pouch (refillable injectors)
+        name: first-aid pouch (refillable injectors)
       - id: RMCPouchFirstAidSplintsGauzeOintment
-        name: First-aid pouch (gauze, ointment) # TODO RMC14 splints comma
+        name: first-aid pouch (gauze, ointment) # TODO RMC14 splints comma
       - id: RMCPouchFirstAidPills
-        name: First-aid pouch (pills)
+        name: first-aid pouch (pills)
         recommended: true
       - id: RMCPouchFlareFilled
-        name: Flare pouch (Full)
+        name: flare pouch (Full)
       - id: RMCPouchFuelTank
       - id: RMCPouchGeneralLarge
         recommended: true
@@ -418,7 +418,7 @@
 - type: entity
   parent: CMArmorB12
   id: RMCArmorB12Zipties
-  name: Leader B12 pattern marine armor
+  name: leader B12 pattern marine armor
   description: A lightweight suit of carbon fiber body armor built for quick movement. Designed in a lovely forest green. Use it to toggle the built-in flashlight. This one has a separate pouch for a ziptie box.
   suffix: Zipties
   components:
@@ -440,7 +440,7 @@
 - type: entity
   parent: CMArmorM4
   id: RMCArmorM4Zipties
-  name: Leader M4 pattern marine armor
+  name: leader M4 pattern marine armor
   description: A well tinkered and crafted hybrid of Smart-Gunner mesh and M3 pattern plates. Robust, yet nimble, with room for all your pouches. This one has a separate pouch for a ziptie box.
   suffix: Zipties
   components:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/medic.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/medic.yml
@@ -30,7 +30,7 @@
     #    CMMedicalSplints: 1P
 #        recommended: true
       - id: CMBloodPackFull # TODO RMC14 O-
-        name: blood bag (O-)
+        name: Blood bag (O-)
         points: 4
     - name: Firstaid Kits
       entries:
@@ -121,10 +121,6 @@
         points: 6
       - id: CMMagazineRifleM4SPRExt
         points: 6
-      - id: RMCMagazinePistolM13AP
-        points: 6
-      - id: RMCMagazinePistolM13ExtAP
-        points: 8
       - id: CMMagazineSMGM63AP
         points: 6
       - id: CMMagazineSMGM63Ext
@@ -137,6 +133,10 @@
       entries:
       - id: RMCMagazinePistolM13Ext
         points: 6
+      - id: RMCMagazinePistolM13AP
+        points: 6
+      - id: RMCMagazinePistolM13ExtAP
+        points: 8
       # - id: RMCSpeedLoader44Heavy
       #  points: 6
       - id: RMCSpeedLoader44Marksman
@@ -164,7 +164,7 @@
     - name: Clothing Items
       entries:
       - id: RMCPouchMacheteFilled
-        name: machete pouch (Full)
+        name: Machete pouch (Full)
         points: 8
       - id: RMCBackpackRTO
         replaceSlot: back
@@ -227,20 +227,21 @@
       entries:
       - id: CMVendorBundleSquadMedicalApparel
       - id: RMCHandsLatexMarine
-        name: combat sterile gloves
+        name: Combat sterile gloves
       - id: CMMRE
       #- id: CMMap # TODO: Make a map
     - name: Armor
       choices: { CMArmor: 1 }
       entries:
       - id: RMCArmorVestSquad
+        name: Armor vest
       - id: RMCArmorM3LightVariants
-        name: light armor
+        name: Light armor
       - id: RMCArmorM3MediumVariants
-        name: medium armor
+        name: Medium armor
         recommended: true
       - id: RMCArmorM3HeavyVariants
-        name: heavy armor
+        name: Heavy armor
     - name: Helmet
       choices: { CMHelmet: 1 }
       entries:
@@ -284,14 +285,14 @@
       - id: RMCPouchReagentCanister
         name: Pressurized Reagent Canister Pouch\n(EMPTY)
       - id: RMCPouchVialFill
-        name: vial pouch (Full)
+        name: Vial pouch (Full)
       - id: RMCPouchMedical
       - id: RMCPouchFirstAidInjectors
-        name: first-aid pouch (refillable injectors)
+        name: First-aid pouch (refillable injectors)
       - id: RMCPouchFirstAidSplintsGauzeOintment
-        name: first-aid pouch (gauze, ointment) # TODO RMC14 splints comma
+        name: First-aid pouch (gauze, ointment) # TODO RMC14 splints comma
       - id: RMCPouchFirstAidPills
-        name: first-aid pouch (pills)
+        name: First-aid pouch (pills)
       - id: RMCPouchFlareFilled
         name: Flare pouch (Full)
       - id: RMCPouchGeneralLarge
@@ -348,7 +349,7 @@
       takeAll: CMStandard
       entries:
       - id: RMCHandsLatexMarine
-        name: combat sterile gloves
+        name: Combat sterile gloves
       - id: CMMaskSterile
     - name: Helmet
       choices: { CMHelmet: 1 }
@@ -393,14 +394,14 @@
       - id: RMCPouchReagentCanister
         name: Pressurized Reagent Canister Pouch\n(EMPTY)
       - id: RMCPouchVialFill
-        name: vial pouch (Full)
+        name: Vial pouch (Full)
       - id: RMCPouchMedical
       - id: RMCPouchFirstAidInjectors
-        name: first-aid pouch (refillable injectors)
+        name: First-aid pouch (refillable injectors)
       - id: RMCPouchFirstAidSplintsGauzeOintment
-        name: first-aid pouch (gauze, ointment) # TODO RMC14 splints comma
+        name: First-aid pouch (gauze, ointment) # TODO RMC14 splints comma
       - id: RMCPouchFirstAidPills
-        name: first-aid pouch (pills)
+        name: First-aid pouch (pills)
 
 - type: entity
   parent: RMCColMarTechMedicalEquipmentPVE
@@ -415,7 +416,7 @@
       takeAll: CMStandard
       entries:
       - id: RMCHandsLatexMarine
-        name: combat sterile gloves
+        name: Combat sterile gloves
       - id: CMMaskSterile
       - id: RMCSatchelPMCMedic
         recommended: true
@@ -450,14 +451,14 @@
       - id: RMCPouchReagentCanister
         name: Pressurized Reagent Canister Pouch\n(EMPTY)
       - id: RMCPouchVialFill
-        name: vial pouch (Full)
+        name: Vial pouch (Full)
       - id: RMCPouchMedical
       - id: RMCPouchFirstAidInjectors
-        name: first-aid pouch (refillable injectors)
+        name: First-aid pouch (refillable injectors)
       - id: RMCPouchFirstAidSplintsGauzeOintment
-        name: first-aid pouch (gauze, ointment) # TODO RMC14 splints comma
+        name: First-aid pouch (gauze, ointment) # TODO RMC14 splints comma
       - id: RMCPouchFirstAidPills
-        name: first-aid pouch (pills)
+        name: First-aid pouch (pills)
 
 - type: entity
   parent: RMCColMarTechMedicalEquipmentPVE

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/medic.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/medic.yml
@@ -30,7 +30,7 @@
     #    CMMedicalSplints: 1P
 #        recommended: true
       - id: CMBloodPackFull # TODO RMC14 O-
-        name: Blood bag (O-)
+        name: blood bag (O-)
         points: 4
     - name: Firstaid Kits
       entries:
@@ -164,7 +164,7 @@
     - name: Clothing Items
       entries:
       - id: RMCPouchMacheteFilled
-        name: Machete pouch (Full)
+        name: machete pouch (Full)
         points: 8
       - id: RMCBackpackRTO
         replaceSlot: back
@@ -227,21 +227,21 @@
       entries:
       - id: CMVendorBundleSquadMedicalApparel
       - id: RMCHandsLatexMarine
-        name: Combat sterile gloves
+        name: combat sterile gloves
       - id: CMMRE
       #- id: CMMap # TODO: Make a map
     - name: Armor
       choices: { CMArmor: 1 }
       entries:
       - id: RMCArmorVestSquad
-        name: Armor vest
+        name: armor vest
       - id: RMCArmorM3LightVariants
-        name: Light armor
+        name: light armor
       - id: RMCArmorM3MediumVariants
-        name: Medium armor
+        name: medium armor
         recommended: true
       - id: RMCArmorM3HeavyVariants
-        name: Heavy armor
+        name: heavy armor
     - name: Helmet
       choices: { CMHelmet: 1 }
       entries:
@@ -285,16 +285,16 @@
       - id: RMCPouchReagentCanister
         name: Pressurized Reagent Canister Pouch\n(EMPTY)
       - id: RMCPouchVialFill
-        name: Vial pouch (Full)
+        name: vial pouch (Full)
       - id: RMCPouchMedical
       - id: RMCPouchFirstAidInjectors
-        name: First-aid pouch (refillable injectors)
+        name: first-aid pouch (refillable injectors)
       - id: RMCPouchFirstAidSplintsGauzeOintment
-        name: First-aid pouch (gauze, ointment) # TODO RMC14 splints comma
+        name: first-aid pouch (gauze, ointment) # TODO RMC14 splints comma
       - id: RMCPouchFirstAidPills
-        name: First-aid pouch (pills)
+        name: first-aid pouch (pills)
       - id: RMCPouchFlareFilled
-        name: Flare pouch (Full)
+        name: flare pouch (Full)
       - id: RMCPouchGeneralLarge
      #- id: CMSlingPouch
       - id: RMCPouchMagazinePistolLarge
@@ -349,7 +349,7 @@
       takeAll: CMStandard
       entries:
       - id: RMCHandsLatexMarine
-        name: Combat sterile gloves
+        name: combat sterile gloves
       - id: CMMaskSterile
     - name: Helmet
       choices: { CMHelmet: 1 }
@@ -394,14 +394,14 @@
       - id: RMCPouchReagentCanister
         name: Pressurized Reagent Canister Pouch\n(EMPTY)
       - id: RMCPouchVialFill
-        name: Vial pouch (Full)
+        name: vial pouch (Full)
       - id: RMCPouchMedical
       - id: RMCPouchFirstAidInjectors
-        name: First-aid pouch (refillable injectors)
+        name: first-aid pouch (refillable injectors)
       - id: RMCPouchFirstAidSplintsGauzeOintment
-        name: First-aid pouch (gauze, ointment) # TODO RMC14 splints comma
+        name: first-aid pouch (gauze, ointment) # TODO RMC14 splints comma
       - id: RMCPouchFirstAidPills
-        name: First-aid pouch (pills)
+        name: first-aid pouch (pills)
 
 - type: entity
   parent: RMCColMarTechMedicalEquipmentPVE
@@ -416,7 +416,7 @@
       takeAll: CMStandard
       entries:
       - id: RMCHandsLatexMarine
-        name: Combat sterile gloves
+        name: combat sterile gloves
       - id: CMMaskSterile
       - id: RMCSatchelPMCMedic
         recommended: true
@@ -451,14 +451,14 @@
       - id: RMCPouchReagentCanister
         name: Pressurized Reagent Canister Pouch\n(EMPTY)
       - id: RMCPouchVialFill
-        name: Vial pouch (Full)
+        name: vial pouch (Full)
       - id: RMCPouchMedical
       - id: RMCPouchFirstAidInjectors
-        name: First-aid pouch (refillable injectors)
+        name: first-aid pouch (refillable injectors)
       - id: RMCPouchFirstAidSplintsGauzeOintment
-        name: First-aid pouch (gauze, ointment) # TODO RMC14 splints comma
+        name: first-aid pouch (gauze, ointment) # TODO RMC14 splints comma
       - id: RMCPouchFirstAidPills
-        name: First-aid pouch (pills)
+        name: first-aid pouch (pills)
 
 - type: entity
   parent: RMCColMarTechMedicalEquipmentPVE

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/prep.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/prep.yml
@@ -241,16 +241,16 @@
     - name: Pouches
       entries:
       - id: RMCPouchBayonetFill
-        name: Bayonet Sheath (Full)
+        name: bayonet sheath (Full)
         amount: 15
       - id: RMCPouchFirstAidSplintsGauzeOintment
-        name: First-Aid Pouch (Splints, Gauze, Ointment)
+        name: first-aid pouch (splints, gauze, ointment)
         amount: 15
       - id: RMCPouchFirstAidPills
-        name: First-Aid Pouch (Pill Packets)
+        name: first-aid pouch (pill packets)
         amount: 15
       - id: RMCPouchFlareFilled
-        name: Flare Pouch (Full)
+        name: flare pouch (Full)
         amount: 15
       - id: RMCPouchDocumentSmall
         amount: 15
@@ -271,7 +271,7 @@
       - id: RMCPouchExplosive
         amount: 1
       - id: RMCPouchFirstResponder
-        name: First Responder Pouch (Empty)
+        name: first responder pouch (empty)
         amount: 2
       - id: RMCPouchMagazinePistolLarge
         amount: 2
@@ -311,7 +311,7 @@
         name: M10 helmet rain cover
         amount: 10
       - id: RMCHelmetGarbGunOil
-        name: Firearm lubricant
+        name: firearm lubricant
         amount: 15
       - id: RMCHelmetGarbUNMCFlair
         amount: 15
@@ -339,7 +339,7 @@
     - name: Optics
       entries:
       - id: RMCVisorMedicalAdvanced
-        name: Advanced medical optic (CORPSMAN ONLY)
+        name: advanced medical optic (CORPSMAN ONLY)
         amount: 4
       - id: RMCVisorSquad
         amount: 15
@@ -480,7 +480,7 @@
       - id: CMRollerBedSpawnFolded
         amount: 1
       - id: RMCScabbardMacheteFilled
-        name: Machete scabbard (Full)
+        name: machete scabbard (Full)
         amount: 5
       - id: RMCBinoculars
         amount: 1

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/prep.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/prep.yml
@@ -311,7 +311,7 @@
         name: M10 helmet rain cover
         amount: 10
       - id: RMCHelmetGarbGunOil
-        name: firearm lubricant
+        name: Firearm lubricant
         amount: 15
       - id: RMCHelmetGarbUNMCFlair
         amount: 15
@@ -339,7 +339,7 @@
     - name: Optics
       entries:
       - id: RMCVisorMedicalAdvanced
-        name: advanced medical optic (CORPSMAN ONLY)
+        name: Advanced medical optic (CORPSMAN ONLY)
         amount: 4
       - id: RMCVisorSquad
         amount: 15
@@ -480,7 +480,7 @@
       - id: CMRollerBedSpawnFolded
         amount: 1
       - id: RMCScabbardMacheteFilled
-        name: machete scabbard (Full)
+        name: Machete scabbard (Full)
         amount: 5
       - id: RMCBinoculars
         amount: 1

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/rifleman.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/rifleman.yml
@@ -24,23 +24,23 @@
       choices: { CMArmour: 1 }
       entries:
       - id: RMCArmorVestSquad
-        name: armor vest
+        name: Armor vest
       - id: RMCArmorM3LightVariants
-        name: light armor
+        name: Light armor
       - id: RMCArmorM3MediumVariants
-        name: medium armor
+        name: Medium armor
         recommended: true
       - id: RMCArmorM3HeavyVariants
-        name: heavy armor
+        name: Heavy armor
     - name: Backpack
       choices: { CMBackpack: 1 }
       entries:
       - id: CMBackpackMarine
         replaceSlot: back
-        name: backpack
+        name: Backpack
       - id: CMSatchelMarine
         replaceSlot: back
-        name: satchel
+        name: Satchel
         recommended: true
       - id: RMCScabbardShotgun
     - name: Belt
@@ -63,15 +63,15 @@
       choices: { RMCPouch: 2 }
       entries:
       - id: RMCPouchBayonetFill
-        name: bayonet sheath (Full)
+        name: Bayonet sheath (Full)
       - id: RMCPouchFirstAidInjectors
-        name: first-aid pouch (refillable injectors)
+        name: First-aid pouch (refillable injectors)
         recommended: true
       - id: RMCPouchFirstAidSplintsGauzeOintment
-        name: first-aid pouch (gauze, ointment) # TODO RMC14 splints comma
+        name: First-aid pouch (gauze, ointment) # TODO RMC14 splints comma
         recommended: true
       - id: RMCPouchFirstAidPills
-        name: first-aid pouch (pills)
+        name: First-aid pouch (pills)
         recommended: true
       - id: RMCPouchFlareFilled
         name: Flare pouch (Full)
@@ -93,7 +93,7 @@
       - id: CMEntrenchingTool
         points: 5
       - id: CMSandbagEmpty25
-        name: sandbags x25
+        name: Sandbags x25
         points: 20
 #      - id: ES-11 Mobile Fuel Canister
 #        points: 5
@@ -133,10 +133,6 @@
         points: 10
       - id: CMMagazineRifleM4SPRExt
         points: 10
-      - id: RMCMagazinePistolM13AP
-        points: 6
-      - id: RMCMagazinePistolM13ExtAP
-        points: 8
       - id: CMMagazineSMGM63AP
         points: 10
       - id: CMMagazineSMGM63Ext
@@ -149,6 +145,10 @@
       entries:
       - id: RMCMagazinePistolM13Ext
         points: 6
+      - id: RMCMagazinePistolM13AP
+        points: 6
+      - id: RMCMagazinePistolM13ExtAP
+        points: 8
       #- id: M44 Heavy Speedloader
       #  points: 10
       - id: RMCSpeedLoader44Marksman
@@ -190,10 +190,10 @@
       - id: RMCWebbingHolsterBlack
         points: 15
       - id: RMCScabbardMacheteFilled
-        name: machete scabbard (Full)
+        name: Machete scabbard (Full)
         points: 15
       - id: RMCPouchMacheteFilled
-        name: machete pouch (Full)
+        name: Machete pouch (Full)
         points: 15
       - id: RMCBackpackRTO
         replaceSlot: back

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/rifleman.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/rifleman.yml
@@ -24,23 +24,23 @@
       choices: { CMArmour: 1 }
       entries:
       - id: RMCArmorVestSquad
-        name: Armor vest
+        name: armor vest
       - id: RMCArmorM3LightVariants
-        name: Light armor
+        name: light armor
       - id: RMCArmorM3MediumVariants
-        name: Medium armor
+        name: medium armor
         recommended: true
       - id: RMCArmorM3HeavyVariants
-        name: Heavy armor
+        name: heavy armor
     - name: Backpack
       choices: { CMBackpack: 1 }
       entries:
       - id: CMBackpackMarine
         replaceSlot: back
-        name: Backpack
+        name: backpack
       - id: CMSatchelMarine
         replaceSlot: back
-        name: Satchel
+        name: satchel
         recommended: true
       - id: RMCScabbardShotgun
     - name: Belt
@@ -63,18 +63,18 @@
       choices: { RMCPouch: 2 }
       entries:
       - id: RMCPouchBayonetFill
-        name: Bayonet sheath (Full)
+        name: bayonet sheath (Full)
       - id: RMCPouchFirstAidInjectors
-        name: First-aid pouch (refillable injectors)
+        name: first-aid pouch (refillable injectors)
         recommended: true
       - id: RMCPouchFirstAidSplintsGauzeOintment
-        name: First-aid pouch (gauze, ointment) # TODO RMC14 splints comma
+        name: first-aid pouch (gauze, ointment) # TODO RMC14 splints comma
         recommended: true
       - id: RMCPouchFirstAidPills
-        name: First-aid pouch (pills)
+        name: first-aid pouch (pills)
         recommended: true
       - id: RMCPouchFlareFilled
-        name: Flare pouch (Full)
+        name: flare pouch (Full)
         recommended: true
       - id: RMCPouchDocumentSmall
       - id: RMCPouchMagazine
@@ -93,7 +93,7 @@
       - id: CMEntrenchingTool
         points: 5
       - id: CMSandbagEmpty25
-        name: Sandbags x25
+        name: sandbags x25
         points: 20
 #      - id: ES-11 Mobile Fuel Canister
 #        points: 5
@@ -190,10 +190,10 @@
       - id: RMCWebbingHolsterBlack
         points: 15
       - id: RMCScabbardMacheteFilled
-        name: Machete scabbard (Full)
+        name: machete scabbard (Full)
         points: 15
       - id: RMCPouchMacheteFilled
-        name: Machete pouch (Full)
+        name: machete pouch (Full)
         points: 15
       - id: RMCBackpackRTO
         replaceSlot: back

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/smart_gun_operator.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/smart_gun_operator.yml
@@ -155,16 +155,16 @@
       choices: { RMCPouch: 2 }
       entries:
       - id: RMCPouchFlareFilled
-        name: Flare pouch (Full)
+        name: flare pouch (Full)
       - id: RMCPouchElectronics
       - id: RMCPouchFirstAidInjectors
-        name: First-aid pouch (refillable injectors)
+        name: first-aid pouch (refillable injectors)
         recommended: true
       - id: RMCPouchFirstAidSplintsGauzeOintment
-        name: First-aid pouch (gauze, ointment) # TODO RMC14 splints comma
+        name: first-aid pouch (gauze, ointment) # TODO RMC14 splints comma
         recommended: true
       - id: RMCPouchFirstAidPills
-        name: First-aid pouch (pills)
+        name: first-aid pouch (pills)
         recommended: true
       - id: RMCPouchMagazinePistolLarge
         recommended: true
@@ -173,7 +173,7 @@
       - id: RMCPouchGeneralMedium
       - id: RMCPouchPistol
       - id: RMCPouchMacheteFilled
-        name: Machete pouch (Full)
+        name: machete pouch (Full)
     #- id: CMSlingPouch
     - name: Accessories
       choices: { CMAccessories: 1 }

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/smart_gun_operator.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/smart_gun_operator.yml
@@ -50,6 +50,10 @@
       entries:
       - id: RMCMagazinePistolM13Ext
         points: 6
+      - id: RMCMagazinePistolM13AP
+        points: 6
+      - id: RMCMagazinePistolM13ExtAP
+        points: 8
       # - id: RMCSpeedLoader44Heavy
       #  points: 10
       - id: RMCSpeedLoader44Marksman
@@ -154,13 +158,13 @@
         name: Flare pouch (Full)
       - id: RMCPouchElectronics
       - id: RMCPouchFirstAidInjectors
-        name: first-aid pouch (refillable injectors)
+        name: First-aid pouch (refillable injectors)
         recommended: true
       - id: RMCPouchFirstAidSplintsGauzeOintment
-        name: first-aid pouch (gauze, ointment) # TODO RMC14 splints comma
+        name: First-aid pouch (gauze, ointment) # TODO RMC14 splints comma
         recommended: true
       - id: RMCPouchFirstAidPills
-        name: first-aid pouch (pills)
+        name: First-aid pouch (pills)
         recommended: true
       - id: RMCPouchMagazinePistolLarge
         recommended: true
@@ -169,7 +173,7 @@
       - id: RMCPouchGeneralMedium
       - id: RMCPouchPistol
       - id: RMCPouchMacheteFilled
-        name: machete pouch (Full)
+        name: Machete pouch (Full)
     #- id: CMSlingPouch
     - name: Accessories
       choices: { CMAccessories: 1 }

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/specialist.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/specialist.yml
@@ -151,7 +151,7 @@
 - type: entity
   parent: [BaseItem, RMCVendorWeaponsSpecialistGearBase]
   id: RMCKitWeaponsSpecialist
-  name: specialist kit
+  name: Specialist kit
   description: A paper box. Open it and get a specialist kit.
   components:
   - type: Sprite
@@ -216,13 +216,13 @@
       choices: { RMCPouch: 2 }
       entries:
       - id: RMCPouchFirstAidInjectors
-        name: first-aid pouch (refillable injectors)
+        name: First-aid pouch (refillable injectors)
         recommended: true
       - id: RMCPouchFirstAidSplintsGauzeOintment
-        name: first-aid pouch (gauze, ointment) # TODO RMC14 splints comma
+        name: First-aid pouch (gauze, ointment) # TODO RMC14 splints comma
         recommended: true
       - id: RMCPouchFirstAidPills
-        name: first-aid pouch (pills)
+        name: First-aid pouch (pills)
         recommended: true
       - id: RMCPouchFlareFilled
         name: Flare pouch (Full)
@@ -264,6 +264,10 @@
       entries:
       - id: RMCMagazinePistolM13Ext
         points: 6
+      - id: RMCMagazinePistolM13AP
+        points: 6
+      - id: RMCMagazinePistolM13ExtAP
+        points: 8
       # - id: RMCSpeedLoader44Heavy
       #  points: 10
       - id: RMCSpeedLoader44Marksman
@@ -279,10 +283,10 @@
     - name: Clothing Items
       entries:
       - id: RMCScabbardMacheteFilled
-        name: machete scabbard (Full)
+        name: Machete scabbard (Full)
         points: 6
       - id: RMCPouchMacheteFilled
-        name: machete pouch (Full)
+        name: Machete pouch (Full)
         points: 15
       - id: RMCBackpackRTO
         points: 15
@@ -295,7 +299,7 @@
       - id: CMBeltUtilityCombat
         points: 15
       - id: RMCPouchAutoinjectorFill
-        name: autoinjector pouch (Full)
+        name: Autoinjector pouch (Full)
         points: 15
     - name: Utilities
       entries:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/specialist.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/specialist.yml
@@ -151,7 +151,7 @@
 - type: entity
   parent: [BaseItem, RMCVendorWeaponsSpecialistGearBase]
   id: RMCKitWeaponsSpecialist
-  name: Specialist kit
+  name: specialist kit
   description: A paper box. Open it and get a specialist kit.
   components:
   - type: Sprite
@@ -216,16 +216,16 @@
       choices: { RMCPouch: 2 }
       entries:
       - id: RMCPouchFirstAidInjectors
-        name: First-aid pouch (refillable injectors)
+        name: first-aid pouch (refillable injectors)
         recommended: true
       - id: RMCPouchFirstAidSplintsGauzeOintment
-        name: First-aid pouch (gauze, ointment) # TODO RMC14 splints comma
+        name: first-aid pouch (gauze, ointment) # TODO RMC14 splints comma
         recommended: true
       - id: RMCPouchFirstAidPills
-        name: First-aid pouch (pills)
+        name: first-aid pouch (pills)
         recommended: true
       - id: RMCPouchFlareFilled
-        name: Flare pouch (Full)
+        name: flare pouch (Full)
       - id: RMCPouchMagazine
         recommended: true
       - id: RMCPouchShotgun
@@ -283,10 +283,10 @@
     - name: Clothing Items
       entries:
       - id: RMCScabbardMacheteFilled
-        name: Machete scabbard (Full)
+        name: machete scabbard (Full)
         points: 6
       - id: RMCPouchMacheteFilled
-        name: Machete pouch (Full)
+        name: machete pouch (Full)
         points: 15
       - id: RMCBackpackRTO
         points: 15
@@ -299,7 +299,7 @@
       - id: CMBeltUtilityCombat
         points: 15
       - id: RMCPouchAutoinjectorFill
-        name: Autoinjector pouch (Full)
+        name: autoinjector pouch (Full)
         points: 15
     - name: Utilities
       entries:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/team_leader.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/team_leader.yml
@@ -90,17 +90,17 @@
       - id: RMCBackpackRTO
         points: 5
       - id: RMCScabbardMacheteFilled
-        name: Machete scabbard (Full)
+        name: machete scabbard (Full)
         points: 5
       - id: RMCPouchMacheteFilled
-        name: Machete pouch (Full)
+        name: machete pouch (Full)
         points: 15
       - id: RMCWeldingGoggles
         points: 3
       - id: CMBeltUtilityCombat
         points: 15
       - id: RMCPouchAutoinjectorFill
-        name: Autoinjector pouch (Full)
+        name: autoinjector pouch (Full)
         points: 15
       - id: CMHandsInsulated
         points: 3
@@ -217,16 +217,16 @@
       choices: { RMCPouch: 2 }
       entries:
       - id: RMCPouchFirstAidInjectors
-        name: First-aid pouch (refillable injectors)
+        name: first-aid pouch (refillable injectors)
         recommended: true
       - id: RMCPouchFirstAidSplintsGauzeOintment
-        name: First-aid pouch (gauze, ointment) # TODO RMC14 splints comma
+        name: first-aid pouch (gauze, ointment) # TODO RMC14 splints comma
         recommended: true
       - id: RMCPouchFirstAidPills
-        name: First-aid pouch (pills)
+        name: first-aid pouch (pills)
       - id: RMCPouchFirstResponder
       - id: RMCPouchFlareFilled
-        name: Flare pouch (Full)
+        name: flare pouch (Full)
       - id: RMCPouchFuelTank
       - id: RMCPouchGeneralLarge
       #- id: CMSlingPouch
@@ -236,7 +236,7 @@
       - id: RMCPouchPistol
       - id: RMCPouchToolsFill
         recommended: true
-        name: Tools pouch (Full)
+        name: tools pouch (Full)
     - name: Accessories
       choices: { CMAccessories: 1 }
       entries:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/team_leader.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/team_leader.yml
@@ -261,7 +261,7 @@
 - type: entity
   parent: CMVendorBundleRiflemanApparel
   id: RMCVendorBundleCrewFireteamLeader
-  name: Essential fireteam leader utilities
+  name: essential fireteam leader utilities
   description: Contains a laser designator, and two packs of signal flares.
   components:
   - type: Sprite

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/team_leader.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/team_leader.yml
@@ -45,10 +45,6 @@
         points: 10
       - id: CMMagazineRifleM4SPRExt
         points: 10
-      - id: RMCMagazinePistolM13AP
-        points: 6
-      - id: RMCMagazinePistolM13ExtAP
-        points: 8
       - id: CMMagazineSMGM63AP
         points: 10
       - id: CMMagazineSMGM63Ext
@@ -61,6 +57,10 @@
       entries:
       - id: RMCMagazinePistolM13Ext
         points: 6
+      - id: RMCMagazinePistolM13AP
+        points: 6
+      - id: RMCMagazinePistolM13ExtAP
+        points: 8
       # - id: RMCSpeedLoader44Heavy
       #  points: 10
       - id: RMCSpeedLoader44Marksman
@@ -90,17 +90,17 @@
       - id: RMCBackpackRTO
         points: 5
       - id: RMCScabbardMacheteFilled
-        name: machete scabbard (Full)
+        name: Machete scabbard (Full)
         points: 5
       - id: RMCPouchMacheteFilled
-        name: machete pouch (Full)
+        name: Machete pouch (Full)
         points: 15
       - id: RMCWeldingGoggles
         points: 3
       - id: CMBeltUtilityCombat
         points: 15
       - id: RMCPouchAutoinjectorFill
-        name: autoinjector pouch (Full)
+        name: Autoinjector pouch (Full)
         points: 15
       - id: CMHandsInsulated
         points: 3
@@ -217,13 +217,13 @@
       choices: { RMCPouch: 2 }
       entries:
       - id: RMCPouchFirstAidInjectors
-        name: first-aid pouch (refillable injectors)
+        name: First-aid pouch (refillable injectors)
         recommended: true
       - id: RMCPouchFirstAidSplintsGauzeOintment
-        name: first-aid pouch (gauze, ointment) # TODO RMC14 splints comma
+        name: First-aid pouch (gauze, ointment) # TODO RMC14 splints comma
         recommended: true
       - id: RMCPouchFirstAidPills
-        name: first-aid pouch (pills)
+        name: First-aid pouch (pills)
       - id: RMCPouchFirstResponder
       - id: RMCPouchFlareFilled
         name: Flare pouch (Full)
@@ -261,7 +261,7 @@
 - type: entity
   parent: CMVendorBundleRiflemanApparel
   id: RMCVendorBundleCrewFireteamLeader
-  name: essential fireteam leader utilities
+  name: Essential fireteam leader utilities
   description: Contains a laser designator, and two packs of signal flares.
   components:
   - type: Sprite


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Some labels in vending machines started with a capital letter, others did not. Now all should start with lowercase.

Some machines had the newly added M13 AP and M13 APEXT mags in the primary ammunition category with the existing M13 Ext mags in the secondary ammunition category. Updated to move all sources where it is in primary to secondary.

Likely because this was put in the primary ammunition category, it was not added to machines that do not have a primary ammunition category (SGO and WS). I added the new m13 mags to their secondary ammunition category at the same price as everywhere else.

## Why / Balance
This is ultimately a 'stylistic' pr. It aims to unify conventions around m13 being a secondary weapon and labels starting with a lowercase letter. This will have balance impact as it allows WS and SGO to more easily acquire AP and APExt M13 mags. But I'm betting that was more oversight than intentional.

## Technical details
every `name:` label in the yaml was updated to have a lowercase letter at the start of the following string.
every instance of the m3-xl armor vest being in a vending machine where armor is called "light armor", "medium armor", and "heavy armor" has been given a `name:` label with "armor vest" as the title.
Every machine that had m13 AP and APExt mags in the primary section had it moved to secondary
Every machine that had a secondary section without the AP mags but had the existing m13 ext mags was given the AP mags.

## Media
<img width="550" height="253" alt="image" src="https://github.com/user-attachments/assets/f45b08f8-630b-411c-ac5d-0d4ef4098214" />
<img width="511" height="544" alt="image" src="https://github.com/user-attachments/assets/38d400ec-aa7d-4668-a07d-fb1df9a6dfc6" />

<img width="522" height="729" alt="Screenshot From 2025-12-16 18-08-36" src="https://github.com/user-attachments/assets/7cb1d9ee-4894-4f37-a495-075634fb220a" />
<img width="512" height="655" alt="Screenshot From 2025-12-16 18-10-10" src="https://github.com/user-attachments/assets/1ee66751-ce74-4607-830c-bb322032623c" />
<img width="512" height="655" alt="Screenshot From 2025-12-16 18-10-58" src="https://github.com/user-attachments/assets/039879ac-426d-4bac-b9da-5d6d5668c895" />
<img width="548" height="430" alt="Screenshot From 2025-12-16 18-12-00" src="https://github.com/user-attachments/assets/d3ff1c10-b735-4005-b8b1-fa7aff48f8c7" />
<img width="547" height="501" alt="Screenshot From 2025-12-16 18-12-44" src="https://github.com/user-attachments/assets/610feb18-f40d-4b8b-80d2-2df15a66f143" />
<img width="587" height="626" alt="Screenshot From 2025-12-16 18-13-36" src="https://github.com/user-attachments/assets/3025828c-ff81-4786-9daf-355c24e87163" />
<img width="535" height="702" alt="Screenshot From 2025-12-16 18-14-17" src="https://github.com/user-attachments/assets/0c4206ad-b2ef-4cb2-a8b8-5eef3f19f938" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: WS and SGO vending machines now have AP and APExt M13 mags for sale!
- tweak: Any machine that sold AP M13 mags as primary ammo now sells it as secondary ammo. (You can still use the M13 as your primary if you would like)
- tweak: Item names in squad machines should now start with lowercase letters.
- tweak: Machines that call armor "light", "medium", and "heavy" now call the M3-XL armor an "armor vest"