### PR TITLE
Changed the xeno rank 6 name from prime to apex

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Name/XenoRankNamesComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Name/XenoRankNamesComponent.cs
@@ -13,6 +13,6 @@ public sealed partial class XenoRankNamesComponent : Component
         {3, "rmc-xeno-elder"},
         {4, "rmc-xeno-ancient"},
         {5, "rmc-xeno-prime"},
-        {6, "rmc-xeno-prime"},
+        {6, "rmc-xeno-apex"},
     };
 }

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-name.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-name.ftl
@@ -6,6 +6,7 @@ rmc-xeno-mature = Mature {$baseName}
 rmc-xeno-elder = Elder {$baseName}
 rmc-xeno-ancient = Ancient {$baseName}
 rmc-xeno-prime = Prime {$baseName}
+rmc-xeno-apex = Apex {$baseName}
 
 rmc-xeno-mature-parasite = Fledgling {$baseName}
 rmc-xeno-elder-parasite = Veteran {$baseName}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Changed the rank 6 name for xenos from `Prime` to `Apex`

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Xenos got a new icon for rank 6 but no new name yet. As the server is getting older and as people accumulate more play time it's fun for everyone to see new rank names.

Thoughts I had on this:
* Xenos had a new icon, but no name distinction yet
* The previous ranks all indicate age in some way. But I could not find a good name that goes beyond prime in that way.
* I think Apex fits well in the theme of xenos
* I assume there will eventually be even more ranks for xenos? Apex sounds like it should be at the top but maybe names past it could follow a different convention. Perhaps mythical, legendary and similiar themed, because a xeno mind that old is beyond normal age.

## Technical details
<!-- Summary of code changes for easier review. -->
Added new translation to an FTL file and mapped it in the component.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
![apexqueen](https://github.com/user-attachments/assets/24a5f003-b2e5-4269-91fc-2b5f2ff9dbc5)
![apexwarrior](https://github.com/user-attachments/assets/a2656e7f-0b5b-40de-bb57-dd9346a66665)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Scyarah
- add: Added the "Apex" name prefix as a new playtime reward for xenos
