### PR TITLE
"nukemap" command

### DIFF
--- a/Content.Server/_RMC14/Admin/RMCNukeMap.cs
+++ b/Content.Server/_RMC14/Admin/RMCNukeMap.cs
@@ -1,0 +1,37 @@
+using System.Globalization;
+using Content.Server._RMC14.Nuke;
+using Content.Server.Administration;
+using Content.Shared.Administration;
+using Robust.Shared.Console;
+using Robust.Shared.Map;
+
+namespace Content.Server._RMC14.Admin;
+
+[AdminCommand(AdminFlags.Fun)]
+public sealed class RMCNukeMap : LocalizedEntityCommands
+{
+    [Dependency] private readonly SharedMapSystem _mapSystem = default!;
+    [Dependency] private readonly RMCNukeSystem _nuke = default!;
+
+    public override string Command => "nukemap";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length != 1)
+        {
+            shell.WriteError("Wrong number of args.");
+            return;
+        }
+
+        var arg = args[0];
+        var mapId = new MapId(int.Parse(arg, CultureInfo.InvariantCulture));
+
+        if (!_mapSystem.MapExists(mapId))
+        {
+            shell.WriteError("Map does not exist!");
+            return;
+        }
+
+        _nuke.NukeMap(mapId);
+    }
+}

--- a/Content.Server/_RMC14/Nuke/RMCNukeSystem.cs
+++ b/Content.Server/_RMC14/Nuke/RMCNukeSystem.cs
@@ -1,0 +1,95 @@
+using Content.Server._RMC14.Power;
+using Content.Shared._RMC14.Gibbing;
+using Content.Shared._RMC14.Power;
+using Content.Shared._RMC14.Repairable;
+using Content.Shared._RMC14.Sensor;
+using Content.Shared._RMC14.Vents;
+using Content.Shared._RMC14.Xenonids.Construction.Tunnel;
+using Content.Shared.Damage;
+using Robust.Shared.Map;
+
+namespace Content.Server._RMC14.Nuke;
+
+public sealed class RMCNukeSystem : EntitySystem
+{
+    [Dependency] private readonly DamageableSystem _damageable = default!;
+    [Dependency] private readonly IEntityManager _entity = default!;
+    [Dependency] private readonly RMCGibSystem _rmcGib = default!;
+    [Dependency] private readonly SensorTowerSystem _sensorTower = default!;
+    [Dependency] private readonly RMCPowerSystem _power = default!;
+
+    private readonly DamageSpecifier _damage = new() { DamageDict = { { "Blunt", 1e10 } } };
+    private EntityQuery<RMCRepairableComponent> _repairable;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        _repairable = GetEntityQuery<RMCRepairableComponent>();
+    }
+
+    private void KillEverythingOnMap(MapId mapId)
+    {
+        var toDelete = new HashSet<EntityUid>();
+
+        var living = EntityQueryEnumerator<DamageableComponent, TransformComponent>();
+        var tunnels = EntityQueryEnumerator<XenoTunnelComponent, TransformComponent>();
+        var vents = EntityQueryEnumerator<VentCrawlableComponent, TransformComponent>();
+        while (living.MoveNext(out var uid, out var _, out var transform))
+        {
+            if (transform.MapID != mapId)
+                continue;
+
+            toDelete.Add(uid);
+        }
+        while (tunnels.MoveNext(out var uid, out var _, out var transform))
+        {
+            if (transform.MapID != mapId)
+                continue;
+
+            toDelete.Add(uid);
+        }
+        while (vents.MoveNext(out var uid, out var _, out var transform))
+        {
+            if (transform.MapID != mapId)
+                continue;
+
+            toDelete.Add(uid);
+        }
+
+        foreach (var uid in toDelete)
+        {
+            if (_repairable.HasComp(uid))
+            {
+                _damageable.TryChangeDamage(uid, _damage, true);
+            }
+            else
+            {
+                _rmcGib.ScatterInventoryItems(uid);
+                _entity.TryQueueDeleteEntity(uid);
+            }
+        }
+
+        var sensors = EntityQueryEnumerator<SensorTowerComponent, TransformComponent>();
+        var generators = EntityQueryEnumerator<RMCFusionReactorComponent, TransformComponent>();
+        while (sensors.MoveNext(out var uid, out var sensor, out var transform))
+        {
+            if (transform.MapID != mapId)
+                continue;
+
+            _sensorTower.FullyDestroy(new(uid, sensor));
+        }
+        while (generators.MoveNext(out var uid, out var generator, out var transform))
+        {
+            if (transform.MapID != mapId)
+                continue;
+
+            _power.FullyDestroy(new(uid, generator));
+        }
+    }
+
+    public void NukeMap(MapId mapId)
+    {
+        for (var i = 0; i < 3; i++)
+            KillEverythingOnMap(mapId);
+    }
+}

--- a/Content.Shared/_RMC14/Power/SharedRMCPowerSystem.cs
+++ b/Content.Shared/_RMC14/Power/SharedRMCPowerSystem.cs
@@ -565,6 +565,13 @@ public abstract class SharedRMCPowerSystem : EntitySystem
         ReactorUpdated(ent);
     }
 
+    public void FullyDestroy(Entity<RMCFusionReactorComponent> ent)
+    {
+        ent.Comp.State = RMCFusionReactorState.Weld;
+        Dirty(ent);
+        UpdateAppearance(ent);
+    }
+
     private void OnFusionReactorExamined(Entity<RMCFusionReactorComponent> ent, ref ExaminedEvent args)
     {
         if (HasComp<XenoComponent>(args.Examiner))

--- a/Content.Shared/_RMC14/Sensor/SensorTowerSystem.cs
+++ b/Content.Shared/_RMC14/Sensor/SensorTowerSystem.cs
@@ -201,7 +201,11 @@ public sealed class SensorTowerSystem : EntitySystem
             return;
 
         args.Handled = true;
+        FullyDestroy(ent);
+    }
 
+    public void FullyDestroy(Entity<SensorTowerComponent> ent)
+    {
         ent.Comp.State = SensorTowerState.Weld;
         Dirty(ent);
         UpdateAppearance(ent);

--- a/Resources/Locale/en-US/_RMC14/commands/rmc-entity-commands.ftl
+++ b/Resources/Locale/en-US/_RMC14/commands/rmc-entity-commands.ftl
@@ -1,2 +1,5 @@
 cmd-fixpower-desc = Force the RMCPowerSystem to recalculate all power related entities.
 cmd-fixpower-help = Usage: fixpower
+
+cmd-nukemap-desc = Kills and destroys everything on a map!
+cmd-nukemap-help = nukemap <mapID>


### PR DESCRIPTION
## About the PR

I actually started to implement the nuke endgame before I saw aura working on it. This is the first "feature" I had. Its a method and admin command to "nuke" / "glass" a map, as in kill and destroy everything. Now I know that people had said that it would probably lag the server to death, but I say, why not test it! Or at least give admins the option to use it for events.

## Why / Balance

feature that might be used for the nuke

## Technical details

- Goes over every damageable entity (plus vents and tunnels) and destroys them.
- Goes over anything that can be "repaired" (generators, sensors) and sets them to destroyed.
  - Coms are damageable, so no need.
- Does the above 3 times to make sure.

## Media


https://github.com/user-attachments/assets/a6432b17-fd72-42e1-9c5b-9971b8e72146


(Yes it did take ~7 seconds to blow up Hybrisa with nothing on it.)

## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- admin: New "nukemap" command to glass a map.
