### PR TITLE
Prevent anchored entities from using ladders

### DIFF
--- a/Content.Shared/_RMC14/Ladder/SharedLadderSystem.cs
+++ b/Content.Shared/_RMC14/Ladder/SharedLadderSystem.cs
@@ -183,6 +183,9 @@ public abstract class SharedLadderSystem : EntitySystem
         {
             args.Cancel();
         }
+
+        if (Transform(user).Anchored)
+            args.Cancel();
     }
 
     private void OnLadderDoAfter(Entity<LadderComponent> ent, ref LadderDoAfterEvent args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Anchored entities can't use ladders anymore. I think the only one affected by this is a base caste fortified Defender, Steelcrests can still use ladders while fortified.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity.
Fix bugs related to fortified defenders using a ladder.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix: Fixed the base Defender caste being able to use ladders while fortified.