### PR TITLE
Fix bleeding wounds not pushing to a new line on examine

### DIFF
--- a/Content.Shared/_RMC14/Medical/Examine/RMCMedicalExamineSystem.cs
+++ b/Content.Shared/_RMC14/Medical/Examine/RMCMedicalExamineSystem.cs
@@ -44,6 +44,7 @@ public sealed class RMCMedicalExamineSystem : EntitySystem
         if (TryComp<BloodstreamComponent>(ent, out var bloodstream) && bloodstream.BleedAmount > 0)
         {
             msg.AddMarkupOrThrow(Loc.GetString(ent.Comp.BleedText, ("victim", ent.Owner)));
+            msg.PushNewline();
         }
 
         LocId? stateText = null;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Prevents stuff like "She has bleeding wounds on her body.She is unconscious" from appearing as the examine text
Now it correctly shows as for example:

She has bleeding wounds on her body.
She is unconscious.

<img width="359" height="231" alt="image" src="https://github.com/user-attachments/assets/918e1a37-bc35-4bac-9ae9-6799dd0ed08d" />


**Changelog**
:cl:
- fix: Fixed the bleeding wound text for examined marines not pushing to a new line.