### PR TITLE
Label pill bottles, add missing no-skill pill bottles

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Medical/pill_canisters.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Medical/pill_canisters.yml
@@ -97,7 +97,7 @@
   parent: RMCPillCanisterNoSkill
   id: RMCPillCanisterBicaridineNoSkill
   name: bicaridine pill bottle
-  description: It's an airtight container for storing medication. It's labeled "Bicardine (15u, 2 pill OD) Used to treat brute damage."
+  description: It's an airtight container for storing medication. It's labeled "Bicaridine (15u, 2 pill OD) Used to treat brute damage."
   suffix: Bicaridine, 16, No Skill
   components:
   - type: Item
@@ -163,7 +163,7 @@
   parent: RMCPillCanisterNoSkill
   id: RMCPillCanisterDexalinNoSkill
   name: dexalin pill bottle
-  description: It's an airtight container for storing medication. It's labeled "Dexaline (15u, 2 pill OD) Used to treat oxygen deprivation."
+  description: It's an airtight container for storing medication. It's labeled "Dexalin (15u, 2 pill OD) Used to treat oxygen deprivation."
   suffix: Dexalin, 16, No Skill
   components:
   - type: Item
@@ -196,7 +196,7 @@
   parent: RMCPillCanisterNoSkill
   id: RMCPillCanisterDyloveneNoSkill
   name: dylovene pill bottle
-  description: It's an airtight container for storing medication. It's labeled "Dlyovene (15u, 2 pill OD) An anti-toxin medication. It neutralizes many common toxins, as well as treating toxin damage."
+  description: It's an airtight container for storing medication. It's labeled "Dylovene (15u, 2 pill OD) An anti-toxin medication. It neutralizes many common toxins, as well as treating toxin damage."
   suffix: Dylovene, 16, No Skill
   components:
   - type: Item
@@ -427,7 +427,7 @@
   parent: RMCPillCanisterNoSkill
   id: RMCPillCanisterDexalinPlusNoSkill
   name: dexalin plus pill bottle
-  description: It's an airtight container for storing medication. It's labeled "Dexaline Plus (10u, 15u OD) Used to instantly treat oxygen deprivation."
+  description: It's an airtight container for storing medication. It's labeled "Dexalin Plus (10u, 15u OD) Used to instantly treat oxygen deprivation."
   suffix: DexalinPlus, 16, No Skill
   components:
   - type: Item


### PR DESCRIPTION
For all pill bottles they now:
1. Feature an inspect description that tells you what the pills are
2. Have a no-skill variant for whomever needs such things

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added description messages for pill bottles that are in the pattern of:
```
It's an airtight container for storing medication. Its labeled "Bicardine (15u, 2 pill OD) Used to treat brute damage."
```

Additionally some pills did not have no-skill variants. These were added for completeness.

## Why / Balance
If we were manufacturing these pills in house it would be against SOP or at least a faus pas to not have labels like this. Further it would make the lives of young medics a little bit easier.

## Technical details
A `description` tag was added to the no-skill variant of each pill canister. It combines the existing description of the canister with the pill's description available to medics, and dosage information based on guidebook. Any pill canister without a no-skill variant was given the no-skill variant. Care was given to maintain stability with pill canister `id`'s such that if a pill canister did not have a no-skill variant and was given one, it's skill variant keeps the same `id` as before.


## Media
<img width="411" height="160" alt="Screenshot From 2025-12-22 16-35-14" src="https://github.com/user-attachments/assets/6b655961-bc7c-46bb-9921-efde6437276e" />
<img width="427" height="165" alt="Screenshot From 2025-12-22 16-37-26" src="https://github.com/user-attachments/assets/66af90e4-133e-427c-add8-d7b27a53a88e" />
<img width="425" height="163" alt="Screenshot From 2025-12-22 16-37-18" src="https://github.com/user-attachments/assets/d3a128a4-4427-4d37-bf25-6b850e7e1b0a" />
<img width="1051" height="44" alt="Screenshot From 2025-12-22 16-35-36" src="https://github.com/user-attachments/assets/21f546ac-9a72-4a49-96ce-e116048dfca7" />
<img width="774" height="891" alt="Screenshot From 2025-12-22 16-45-48" src="https://github.com/user-attachments/assets/3313ee03-fc66-4969-943f-ffd5b6dfc06d" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added labels, dosage, and overdose information for all stock pills. Even for the MB, KD, and FN for admins and mappers!
- admin: Added no-skill variants for all pill bottles missing it!