### PR TITLE
Caps movespeed buff from orders based on armor

### DIFF
--- a/Content.Shared/_RMC14/Marines/Orders/SharedMarineOrdersSystem.cs
+++ b/Content.Shared/_RMC14/Marines/Orders/SharedMarineOrdersSystem.cs
@@ -94,9 +94,7 @@ public abstract class SharedMarineOrdersSystem : EntitySystem
             if (_moveOrderArmorQuery.HasComp(slot.ContainedEntity))
             {
                 if (_moveOrderArmorSpeedQuery.TryGetComponent(slot.ContainedEntity, out var speedModifierComponent))
-                {
                     armorSprintModifier = speedModifierComponent.SprintModifier;
-                }
                 hasArmor = true;
                 break;
             }

--- a/Content.Shared/_RMC14/Marines/Orders/SharedMarineOrdersSystem.cs
+++ b/Content.Shared/_RMC14/Marines/Orders/SharedMarineOrdersSystem.cs
@@ -104,7 +104,7 @@ public abstract class SharedMarineOrdersSystem : EntitySystem
             return;
 
         var speed = (comp.MoveSpeedModifier * comp.Received[0].Multiplier).Float();
-        speed = (speed + armorSprintModifier > 1) ? (1 - armorSprintModifier.Value + 1) : 1 + speed;
+        speed = (speed + armorSprintModifier > 1) ? (2 - armorSprintModifier.Value) : 1 + speed;
         args.ModifySpeed(speed, speed);
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
You can no longer move faster with armor then if you were armorless, simply because you were ordered to.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Genuinely unsure if this is parity or not, but it seemed to be the intention with only getting the buff if you have armor. 

Fixes: https://github.com/RMC-14/RMC-14/issues/7688

## Technical details
<!-- Summary of code changes for easier review. -->
Grabs the armor speed modifier value if there is some, does some math to see if it would be faster then armorless speed if buff was fully applied, and if so, calculates the amount of buff needed to make them the same as their armorless speed, giving them that instead.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: You can no longer go faster then 100% speed via orders and minimum armor slowdown.
