### PR TITLE
Fix: Acid Spray should still cause sizzle damage when hitting 5th stack.

### DIFF
--- a/Resources/Prototypes/_RMC14/Effects/xeno_acid.yml
+++ b/Resources/Prototypes/_RMC14/Effects/xeno_acid.yml
@@ -107,6 +107,9 @@
     - state: acid2
   - type: ApplyAcidStacks
     amount: 2
+    damage:
+      types:
+        Heat: 30
   - type: DamageOnCollide
     damage:
       types:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Gave the stacking acid spray ability the needed damage aspect of the stacking component

## Why / Balance
This is likely a dramatic praetorian buff.

Praetorian does 30 additional damage when you apply the 5th stack of acid to a target. This however does not occur if the 5th stack is applied from acid spray. 

Acid spray is notably able to penetrate marine blobs to get the 5th stack on a target who is almost able to escape. It also is able to apply as many as 4 stacks to a target if they are between tiles or moving in the direction of the attack.

## Technical details
The stacking acid ball and spit abilities had an acid stacking component that included "damage.type.Heat: 30" but the acid spray only had "amount: 2" meaning that if the last stack is given from the spray it is undefined when the 5th stack is applied. However it is only checked when the 5th stack is applied, causing it to do no additional damage at all.


## Media
I'll add this after the holidays


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Praetorian sizzle no longer does 0 damage if the 5th stack is applied by spray acid.
