### PR TITLE
Tool Webbing fix

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Accessory/webbing.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Accessory/webbing.yml
@@ -487,6 +487,8 @@
       - PowerCell
       - RMCNailgunCompact
       - RMCNailgunTactical
+      - RMCSynthResetKey
+      - RodMetal1
       components:
       - Welder
       - PowerCell
@@ -514,6 +516,8 @@
         - PowerCell
         - RMCNailgunCompact
         - RMCNailgunTactical
+        - RMCSynthResetKey
+        - RodMetal1
         components:
         - Welder
         - PowerCell
@@ -565,6 +569,8 @@
       - PowerCell
       - RMCNailgunCompact
       - RMCNailgunTactical
+      - RMCSynthResetKey
+      - RodMetal1
       components:
       - Welder
       - PowerCell
@@ -586,6 +592,8 @@
         - PowerCell
         - RMCNailgunCompact
         - RMCNailgunTactical
+        - RMCSynthResetKey
+        - RodMetal1
         components:
         - Welder
         - PowerCell


### PR DESCRIPTION
## About the PR
fixes tool webbing not fitting metal rods and synth reset keys

## Why / Balance
parity
<img width="670" height="710" alt="Screenshot 2025-12-26 111758" src="https://github.com/user-attachments/assets/b314cc7c-e19b-46bf-a62a-64a6ee85a3dc" />

## Technical details
yml

## Media
<img width="670" height="559" alt="Screenshot 2025-12-26 113703" src="https://github.com/user-attachments/assets/b9a86117-f2b7-4b50-81d8-70fc309c83f8" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl: CatAndHats
- fix: Tool Webbing now fits metal rods, plasteel rods, and synthetic reset keys