### PR TITLE
Fix MOU53 not spawning with flechettes

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/mou53_shotgun.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/mou53_shotgun.yml
@@ -38,7 +38,7 @@
       - RMCShellShotgunIncendiary
       - RMCShellShotgunBeanbag
       - RMCShellShotgunFlechette
-    proto: CMShellShotgunSlugs
+    proto: CMShellShotgunFlechette
     capacity: 3 #It's a lovely triple barrel
     soundInsert:
       path: /Audio/_RMC14/Weapons/Guns/Reload/gun_mou_reload.ogg


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Supposed to spawn with these, from CM13

**Changelog**
:cl:
- fix: Fix MOU53 not coming pre-equipped with flechette shells.