### PR TITLE
Faction locked uniforms

### DIFF
--- a/Content.Shared/_RMC14/Clothing/ClothingFactionLockIgnoreComponent.cs
+++ b/Content.Shared/_RMC14/Clothing/ClothingFactionLockIgnoreComponent.cs
@@ -1,0 +1,9 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Clothing;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(RMCClothingSystem))]
+public sealed partial class ClothingFactionLockIgnoreComponent : Component
+{
+}

--- a/Content.Shared/_RMC14/Clothing/ClothingFactionLockedComponent.cs
+++ b/Content.Shared/_RMC14/Clothing/ClothingFactionLockedComponent.cs
@@ -1,0 +1,17 @@
+﻿using Content.Shared.Whitelist;
+using Content.Shared.NPC.Prototypes;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._RMC14.Clothing;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(RMCClothingSystem))]
+public sealed partial class ClothingFactionLockedComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public HashSet<ProtoId<NpcFactionPrototype>> Whitelist = new();
+
+    [DataField, AutoNetworkedField]
+    public string DenyReason = "rmc-jumpsuit-not-faction";
+}

--- a/Resources/Locale/en-US/_RMC14/armor/rmc-restricted.ftl
+++ b/Resources/Locale/en-US/_RMC14/armor/rmc-restricted.ftl
@@ -17,3 +17,5 @@ rmc-armor-not-spp-jumpsuit = You cannot wear this without wearing SPP fatigues.
 rmc-armor-not-cmb-jumpsuit = You cannot wear this without wearing a CMB uniform.
 
 rmc-armor-not-tse-jumpsuit = You cannot wear this without wearing a TSE uniform.
+
+rmc-jumpsuit-not-faction = You cannot wear this as it doesn't belong to your faction.

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/cmb.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/cmb.yml
@@ -7,6 +7,9 @@
     tags:
     - RMCUniformMarine
     - RMCUniformCMB
+  - type: ClothingFactionLocked
+    whitelist:
+    - Bureau
 
 - type: entity
   parent: RMCCMBUniformBase

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/dressblues.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/dressblues.yml
@@ -7,6 +7,9 @@
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Uniforms/DressBlues/enlisted.rsi
+  - type: ClothingFactionLocked
+    whitelist:
+    - UNMC
 
 - type: entity
   parent: RMCMarineUniformBase
@@ -16,6 +19,9 @@
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Uniforms/DressBlues/senior.rsi
+  - type: ClothingFactionLocked
+    whitelist:
+    - UNMC
 
 - type: entity
   parent: RMCMarineUniformBase
@@ -25,6 +31,9 @@
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Uniforms/DressBlues/general.rsi
+  - type: ClothingFactionLocked
+    whitelist:
+    - UNMC
 
 
 

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/liaison.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/liaison.yml
@@ -10,6 +10,10 @@
     sprite: _RMC14/Objects/Clothing/Uniforms/Liaison/liaison_regular.rsi
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/Uniforms/Liaison/liaison_regular.rsi
+  - type: ClothingFactionLocked
+    whitelist:
+    - Civilian
+    - WeYa
 
 - type: entity
   parent: CMJumpsuitLiaison

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/marines.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/marines.yml
@@ -22,6 +22,9 @@
       Snow: _RMC14/Objects/Clothing/Uniforms/Marine/standard/snow.rsi
       Classic: _RMC14/Objects/Clothing/Uniforms/Marine/standard/classic.rsi
       Urban: _RMC14/Objects/Clothing/Uniforms/Marine/standard/urban.rsi
+  - type: ClothingFactionLocked
+    whitelist:
+    - UNMC
 
 - type: entity
   parent: [JumpsuitMarine, RMCJumpsuitMarinePatchBase]
@@ -36,6 +39,9 @@
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Uniforms/Marine/formal.rsi
+  - type: ClothingFactionLocked
+    whitelist:
+    - UNMC
 
 # ComTech
 - type: entity
@@ -117,6 +123,9 @@
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Uniforms/Marine/tanker/jungle.rsi
+  - type: ClothingFactionLocked
+    whitelist:
+    - UNMC
 
 # CBRN
 
@@ -133,6 +142,9 @@
     melee: 10
     bio: 100
     explosionArmor: 10
+  - type: ClothingFactionLocked
+    whitelist:
+    - UNMC
 
 # Sun Riders
 
@@ -154,6 +166,9 @@
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Uniforms/Supply/ro.rsi
+  - type: ClothingFactionLocked
+    whitelist:
+    - UNMC
 
 # ReqTech / RT
 - type: entity
@@ -167,6 +182,9 @@
   - type: Foldable
     unfoldVerbText: rmc-pants-verb-unfold
     foldVerbText: rmc-pants-verb-fold
+  - type: ClothingFactionLocked
+    whitelist:
+    - UNMC
 
 # MessTech / Chef
 - type: entity
@@ -177,6 +195,9 @@
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Uniforms/Supply/chef.rsi
+  - type: ClothingFactionLocked
+    whitelist:
+    - UNMC
 
 # Engineering
 
@@ -191,6 +212,9 @@
     sprite: _RMC14/Objects/Clothing/Uniforms/Engineering/ec.rsi
   - type: CMArmor
     bio: 15
+  - type: ClothingFactionLocked
+    whitelist:
+    - UNMC
 
 # Maintenance Technician / MT
 - type: entity
@@ -203,6 +227,9 @@
     sprite: _RMC14/Objects/Clothing/Uniforms/Engineering/mt.rsi
   - type: CMArmor
     bio: 10
+  - type: ClothingFactionLocked
+    whitelist:
+    - UNMC
 
 # Ordnance Technician / OT
 - type: entity
@@ -235,6 +262,9 @@
       Snow: _RMC14/Objects/Clothing/Uniforms/Command/CO/standard/snow.rsi
       Classic: _RMC14/Objects/Clothing/Uniforms/Command/CO/standard/classic.rsi
       Urban: _RMC14/Objects/Clothing/Uniforms/Command/CO/standard/urban.rsi
+  - type: ClothingFactionLocked
+    whitelist:
+    - UNMC
 
 - type: entity
   parent: CMJumpsuitCO
@@ -310,6 +340,9 @@
   - type: Foldable
     unfoldVerbText: rmc-sleeves-verb-unfold
     foldVerbText: rmc-sleeves-verb-fold
+  - type: ClothingFactionLocked
+    whitelist:
+    - UNMC
 
 # ASO
 
@@ -324,6 +357,9 @@
   - type: Foldable
     unfoldVerbText: rmc-sleeves-verb-unfold
     foldVerbText: rmc-sleeves-verb-fold
+  - type: ClothingFactionLocked
+    whitelist:
+    - UNMC
 
 - type: entity
   parent: RMCJumpsuitASOBlack
@@ -376,6 +412,9 @@
   - type: Foldable
     unfoldVerbText: rmc-sleeves-verb-unfold
     foldVerbText: rmc-sleeves-verb-fold
+  - type: ClothingFactionLocked
+    whitelist:
+    - UNMC
 
 - type: entity
   parent: CMJumpsuitBO
@@ -420,6 +459,9 @@
     tags:
     - RMCUniformMarine
     - RMCUniformIntel
+  - type: ClothingFactionLocked
+    whitelist:
+    - UNMC
 
 - type: Tag
   id: RMCUniformIntel
@@ -436,6 +478,9 @@
   - type: Foldable
     unfoldVerbText: rmc-sleeves-verb-unfold
     foldVerbText: rmc-sleeves-verb-fold
+  - type: ClothingFactionLocked
+    whitelist:
+    - UNMC
 
 # Dropship Crew Chief
 - type: entity
@@ -446,6 +491,9 @@
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Uniforms/Auxiliary/crewchief.rsi
+  - type: ClothingFactionLocked
+    whitelist:
+    - UNMC
 
 # Civilian
 
@@ -486,6 +534,9 @@
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Uniforms/Survivor/colonist.rsi
+  - type: ClothingFactionLocked
+    whitelist:
+    - Civilian
 
 # Marine
 - type: entity
@@ -500,6 +551,9 @@
   - type: Foldable
     unfoldVerbText: rmc-sleeves-verb-unfold
     foldVerbText: rmc-sleeves-verb-fold
+  - type: ClothingFactionLocked
+    whitelist:
+    - UNMC
 
 - type: entity
   parent: CMJumpsuitSurvivorMarine
@@ -524,6 +578,9 @@
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Uniforms/Command/general.rsi
+  - type: ClothingFactionLocked
+    whitelist:
+    - UNMC
 
 # Synthetic
 - type: entity

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/other.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/other.yml
@@ -158,6 +158,9 @@
   - type: Foldable
     unfoldVerbText: rmc-sleeves-verb-unfold
     foldVerbText: rmc-sleeves-verb-fold
+  - type: ClothingFactionLocked
+    whitelist:
+    - Civilian
 
 - type: entity
   parent: RMCJumpsuitCivilian
@@ -288,7 +291,7 @@
     sprite: _RMC14/Objects/Clothing/Uniforms/Civilian/blue_jumpsuit.rsi
 
 - type: entity
-  parent: RMCMarineUniformBase
+  parent: RMCJumpsuitCivilian
   id: RMCJumpsuitRedShorts
   name: red shorts
   description: A ratty pair of red shorts. Smells of ciggarettes.
@@ -299,7 +302,7 @@
     sprite: _RMC14/Objects/Clothing/Uniforms/Survivor/varadero_shorts.rsi
 
 - type: entity
-  parent: RMCMarineUniformBase
+  parent: RMCJumpsuitCivilian
   id: RMCJumpsuitChaplain
   name: chaplain's jumpsuit
   description: It's a black jumpsuit, often worn by religious folk.
@@ -354,7 +357,7 @@
     sprite: _RMC14/Objects/Clothing/Uniforms/Civilian/steward.rsi
 
 - type: entity
-  parent: RMCUniformBase
+  parent: RMCJumpsuitCivilian
   id: RMCJumpsuitWeyamart
   name: Weyamart uniform
   description: A pair of dark-grey slacks and an orange button-down shirt; a standard uniform for the Weston-Yamada branded supermarket 'Weyamart'.
@@ -365,7 +368,7 @@
     sprite: _RMC14/Objects/Clothing/Uniforms/Civilian/weyamart.rsi
 
 - type: entity
-  parent: RMCUniformBase
+  parent: RMCJumpsuitCivilian
   id: RMCJumpsuitSanitation
   name: Weston-Yamada RFF - sanitation uniform
   description: A set of Weston-Yamada RFF - Sanitation fatigues, a green pair of work slacks and a grey polo-shirt with green reflecting stripes.
@@ -376,7 +379,7 @@
     sprite: _RMC14/Objects/Clothing/Uniforms/Civilian/sanitation.rsi
 
 - type: entity
-  parent: RMCUniformBase
+  parent: RMCJumpsuitCivilian
   id: RMCJumpsuitPizzaGalaxy
   name: Pizza-Galaxy uniform
   description: A pair of red slacks and a white button-down shirt with a large 'Pizza-Galaxy' logo on the back; a standard uniform for a Pizza-Galaxy employee. Pizza-Galaxy! To infinity and beyond!
@@ -387,7 +390,7 @@
     sprite: _RMC14/Objects/Clothing/Uniforms/Civilian/pizza_galaxy.rsi
 
 - type: entity
-  parent: RMCUniformBase
+  parent: RMCJumpsuitCivilian
   id: RMCJumpsuitDailyGrind
   name: The Daily Grind uniform
   description: A pair of black slacks and a white short-sleeved button-down shirt; a standard uniform for a 'The Daily Grind' employee. Are you ready for the daily grind?
@@ -398,7 +401,7 @@
     sprite: _RMC14/Objects/Clothing/Uniforms/Civilian/daily_grind.rsi
 
 - type: entity
-  parent: RMCUniformBase
+  parent: RMCJumpsuitCivilian
   id: RMCJumpsuitTMCC
   name: tartarus-mining uniform
   description: A set of Tartarus-Mining fatigues, a yellow pair of utility work slacks and a light-grey polo-shirt with red reflecting stripes.
@@ -420,7 +423,7 @@
     sprite: _RMC14/Objects/Clothing/Uniforms/Civilian/doctor.rsi
 
 - type: entity
-  parent: RMCUniformBase
+  parent: RMCJumpsuitCivilian
   id: RMCJumpsuitEMT
   name: EMT - Paramedic uniform
   description: A set of EMT - Paramedic fatigues, this one is red.
@@ -441,7 +444,7 @@
     sprite: _RMC14/Objects/Clothing/Uniforms/Civilian/emt_green.rsi
 
 - type: entity
-  parent: RMCUniformBase
+  parent: RMCJumpsuitCivilian
   id: RMCJumpsuitLaborersOveralls
   name: laborer's overalls
   description: A set of durable overalls for getting the job done.
@@ -453,7 +456,7 @@
 
 # Kutjevo
 - type: entity
-  parent: RMCUniformBase
+  parent: RMCJumpsuitCivilian
   id: RMCJumpsuitKutjevoJumper
   name: kutjevo jumper
   description: A heavy-duty jumpsuit worn by the workers on Kutjevo.
@@ -464,7 +467,7 @@
     sprite: _RMC14/Objects/Clothing/Uniforms/Survivor/kutjevo_jumper.rsi
 
 - type: entity
-  parent: RMCUniformBase
+  parent: RMCJumpsuitCivilian
   id: RMCJumpsuitKutjevoDrysuit
   name: kutjevo drysuit
   description: A heavy-duty drysuit worn by the workers on Kutjevo.
@@ -490,6 +493,9 @@
   - type: Tag
     tags:
     - RMCUniformUNSecurity
+  - type: ClothingFactionLocked
+    whitelist:
+    - Civilian
 
 - type: entity
   parent: RMCMarineUniformBase
@@ -505,9 +511,12 @@
     tags:
     - RMCUniformMarine
     - RMCUniformUNSecurity
+  - type: ClothingFactionLocked
+    whitelist:
+    - Civilian
 
 - type: entity
-  parent: [RMCUniformBase, RMCAlternateFoldableUniformBase]
+  parent: [RMCJumpsuitCivilian, RMCAlternateFoldableUniformBase]
   id: RMCJumpsuitCivilianJanitor
   name: janitor's jumpsuit
   description: It's the official uniform of the colony's janitor.
@@ -518,7 +527,7 @@
     sprite: _RMC14/Objects/Clothing/Uniforms/Survivor/janitor.rsi
 
 - type: entity
-  parent: RMCUniformBase
+  parent: RMCJumpsuitCivilian
   id: RMCJumpsuitCivilianEngineerWorker
   name: Weston-Yamada engineering utility uniform
   description: A set of Weston-Yamada engineering utility workers uniform, a orange pair of work slacks and a grey polo-shirt with orange reflecting stripes.
@@ -554,6 +563,10 @@
     startingAccessories:
     - RMCCLFArmband
     - RMCPatchCLF
+  - type: ClothingFactionLocked
+    whitelist:
+    - Civilian
+    - CLF
 
 # TODO RMC14 - Should be surgical webbing instead
 - type: entity
@@ -590,7 +603,7 @@
 
 # Frontier
 - type: entity
-  parent: RMCUniformBase
+  parent: RMCJumpsuitCivilian
   id: RMCJumpsuitCivilianFrontier
   name: frontier jumpsuit
   description: A cargo jumpsuit dressed down for full range of motion and state-of-the-art frontier temperature control. It's the best thing an engineer can wear in the Outer Veil.

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/other.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/other.yml
@@ -291,7 +291,7 @@
     sprite: _RMC14/Objects/Clothing/Uniforms/Civilian/blue_jumpsuit.rsi
 
 - type: entity
-  parent: RMCJumpsuitCivilian
+  parent: RMCUniformBase
   id: RMCJumpsuitRedShorts
   name: red shorts
   description: A ratty pair of red shorts. Smells of ciggarettes.
@@ -300,6 +300,9 @@
     sprite: _RMC14/Objects/Clothing/Uniforms/Survivor/varadero_shorts.rsi
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/Uniforms/Survivor/varadero_shorts.rsi
+  - type: ClothingFactionLocked
+    whitelist:
+    - Civilian
 
 - type: entity
   parent: RMCJumpsuitCivilian
@@ -357,7 +360,7 @@
     sprite: _RMC14/Objects/Clothing/Uniforms/Civilian/steward.rsi
 
 - type: entity
-  parent: RMCJumpsuitCivilian
+  parent: RMCUniformBase
   id: RMCJumpsuitWeyamart
   name: Weyamart uniform
   description: A pair of dark-grey slacks and an orange button-down shirt; a standard uniform for the Weston-Yamada branded supermarket 'Weyamart'.
@@ -366,9 +369,12 @@
     sprite: _RMC14/Objects/Clothing/Uniforms/Civilian/weyamart.rsi
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/Uniforms/Civilian/weyamart.rsi
+  - type: ClothingFactionLocked
+    whitelist:
+    - Civilian
 
 - type: entity
-  parent: RMCJumpsuitCivilian
+  parent: RMCUniformBase
   id: RMCJumpsuitSanitation
   name: Weston-Yamada RFF - sanitation uniform
   description: A set of Weston-Yamada RFF - Sanitation fatigues, a green pair of work slacks and a grey polo-shirt with green reflecting stripes.
@@ -377,9 +383,12 @@
     sprite: _RMC14/Objects/Clothing/Uniforms/Civilian/sanitation.rsi
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/Uniforms/Civilian/sanitation.rsi
+  - type: ClothingFactionLocked
+    whitelist:
+    - Civilian
 
 - type: entity
-  parent: RMCJumpsuitCivilian
+  parent: RMCUniformBase
   id: RMCJumpsuitPizzaGalaxy
   name: Pizza-Galaxy uniform
   description: A pair of red slacks and a white button-down shirt with a large 'Pizza-Galaxy' logo on the back; a standard uniform for a Pizza-Galaxy employee. Pizza-Galaxy! To infinity and beyond!
@@ -388,9 +397,12 @@
     sprite: _RMC14/Objects/Clothing/Uniforms/Civilian/pizza_galaxy.rsi
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/Uniforms/Civilian/pizza_galaxy.rsi
+  - type: ClothingFactionLocked
+    whitelist:
+    - Civilian
 
 - type: entity
-  parent: RMCJumpsuitCivilian
+  parent: RMCUniformBase
   id: RMCJumpsuitDailyGrind
   name: The Daily Grind uniform
   description: A pair of black slacks and a white short-sleeved button-down shirt; a standard uniform for a 'The Daily Grind' employee. Are you ready for the daily grind?
@@ -399,9 +411,12 @@
     sprite: _RMC14/Objects/Clothing/Uniforms/Civilian/daily_grind.rsi
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/Uniforms/Civilian/daily_grind.rsi
+  - type: ClothingFactionLocked
+    whitelist:
+    - Civilian
 
 - type: entity
-  parent: RMCJumpsuitCivilian
+  parent: RMCUniformBase
   id: RMCJumpsuitTMCC
   name: tartarus-mining uniform
   description: A set of Tartarus-Mining fatigues, a yellow pair of utility work slacks and a light-grey polo-shirt with red reflecting stripes.
@@ -410,6 +425,9 @@
     sprite: _RMC14/Objects/Clothing/Uniforms/Civilian/tartarus_mining.rsi
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/Uniforms/Civilian/tartarus_mining.rsi
+  - type: ClothingFactionLocked
+    whitelist:
+    - Civilian
 
 - type: entity
   parent: RMCJumpsuitCivilian
@@ -423,7 +441,7 @@
     sprite: _RMC14/Objects/Clothing/Uniforms/Civilian/doctor.rsi
 
 - type: entity
-  parent: RMCJumpsuitCivilian
+  parent: RMCUniformBase
   id: RMCJumpsuitEMT
   name: EMT - Paramedic uniform
   description: A set of EMT - Paramedic fatigues, this one is red.
@@ -432,6 +450,9 @@
     sprite: _RMC14/Objects/Clothing/Uniforms/Civilian/emt.rsi
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/Uniforms/Civilian/emt.rsi
+  - type: ClothingFactionLocked
+    whitelist:
+    - Civilian
 
 - type: entity
   parent: RMCJumpsuitEMT
@@ -444,7 +465,7 @@
     sprite: _RMC14/Objects/Clothing/Uniforms/Civilian/emt_green.rsi
 
 - type: entity
-  parent: RMCJumpsuitCivilian
+  parent: RMCUniformBase
   id: RMCJumpsuitLaborersOveralls
   name: laborer's overalls
   description: A set of durable overalls for getting the job done.
@@ -453,10 +474,13 @@
     sprite: _RMC14/Objects/Clothing/Uniforms/Survivor/laborers_overalls.rsi
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/Uniforms/Survivor/laborers_overalls.rsi
+  - type: ClothingFactionLocked
+    whitelist:
+    - Civilian
 
 # Kutjevo
 - type: entity
-  parent: RMCJumpsuitCivilian
+  parent: RMCUniformBase
   id: RMCJumpsuitKutjevoJumper
   name: kutjevo jumper
   description: A heavy-duty jumpsuit worn by the workers on Kutjevo.
@@ -465,9 +489,12 @@
     sprite: _RMC14/Objects/Clothing/Uniforms/Survivor/kutjevo_jumper.rsi
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/Uniforms/Survivor/kutjevo_jumper.rsi
+  - type: ClothingFactionLocked
+    whitelist:
+    - Civilian
 
 - type: entity
-  parent: RMCJumpsuitCivilian
+  parent: RMCUniformBase
   id: RMCJumpsuitKutjevoDrysuit
   name: kutjevo drysuit
   description: A heavy-duty drysuit worn by the workers on Kutjevo.
@@ -476,6 +503,9 @@
     sprite: _RMC14/Objects/Clothing/Uniforms/Survivor/kutjevo_drysuit.rsi
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/Uniforms/Survivor/kutjevo_drysuit.rsi
+  - type: ClothingFactionLocked
+    whitelist:
+    - Civilian
 
 # Security
 - type: entity
@@ -516,7 +546,7 @@
     - Civilian
 
 - type: entity
-  parent: [RMCJumpsuitCivilian, RMCAlternateFoldableUniformBase]
+  parent: [RMCUniformBase, RMCAlternateFoldableUniformBase]
   id: RMCJumpsuitCivilianJanitor
   name: janitor's jumpsuit
   description: It's the official uniform of the colony's janitor.
@@ -525,9 +555,12 @@
     sprite: _RMC14/Objects/Clothing/Uniforms/Survivor/janitor.rsi
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/Uniforms/Survivor/janitor.rsi
+  - type: ClothingFactionLocked
+    whitelist:
+    - Civilian
 
 - type: entity
-  parent: RMCJumpsuitCivilian
+  parent: RMCUniformBase
   id: RMCJumpsuitCivilianEngineerWorker
   name: Weston-Yamada engineering utility uniform
   description: A set of Weston-Yamada engineering utility workers uniform, a orange pair of work slacks and a grey polo-shirt with orange reflecting stripes.
@@ -536,6 +569,9 @@
     sprite: _RMC14/Objects/Clothing/Uniforms/Survivor/engineer_worker.rsi
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/Uniforms/Survivor/engineer_worker.rsi
+  - type: ClothingFactionLocked
+    whitelist:
+    - Civilian
 
 - type: entity
   parent: RMCJumpsuitCivilianEngineerWorker
@@ -603,7 +639,7 @@
 
 # Frontier
 - type: entity
-  parent: RMCJumpsuitCivilian
+  parent: RMCUniformBase
   id: RMCJumpsuitCivilianFrontier
   name: frontier jumpsuit
   description: A cargo jumpsuit dressed down for full range of motion and state-of-the-art frontier temperature control. It's the best thing an engineer can wear in the Outer Veil.
@@ -612,3 +648,6 @@
     sprite: _RMC14/Objects/Clothing/Uniforms/Survivor/frontier.rsi
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/Uniforms/Survivor/frontier.rsi
+  - type: ClothingFactionLocked
+    whitelist:
+    - Civilian

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/police.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/police.yml
@@ -20,6 +20,9 @@
     tags:
     - RMCUniformMarine
     - RMCUniformMP
+  - type: ClothingFactionLocked
+    whitelist:
+    - UNMC
 
 - type: entity
   parent: RMCMarineUniformBase
@@ -29,6 +32,11 @@
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Uniforms/MP/standard/corporate.rsi
+  - type: ClothingFactionLocked
+    whitelist:
+    - UNMC
+    - WeYa
+    - Civilian
 
 # Military Warden
 - type: entity
@@ -52,6 +60,9 @@
     tags:
     - RMCUniformMarine
     - RMCUniformWarden
+  - type: ClothingFactionLocked
+    whitelist:
+    - UNMC
 
 - type: entity
   parent: RMCMarineUniformBase
@@ -61,6 +72,9 @@
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Uniforms/MP/Warden/blue.rsi
+  - type: ClothingFactionLocked
+    whitelist:
+    - UNMC
 
 - type: entity
   parent: RMCMarineUniformBase
@@ -70,6 +84,9 @@
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Uniforms/MP/Warden/red.rsi
+  - type: ClothingFactionLocked
+    whitelist:
+    - UNMC
 
 - type: entity
   parent: RMCMarineUniformBase
@@ -79,6 +96,9 @@
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Uniforms/MP/Warden/corporate.rsi
+  - type: ClothingFactionLocked
+    whitelist:
+    - UNMC
 
 - type: entity
   parent: RMCMarineUniformBase
@@ -88,6 +108,9 @@
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Uniforms/MP/Warden/navy.rsi
+  - type: ClothingFactionLocked
+    whitelist:
+    - UNMC
 
 - type: entity
   parent: RMCMarineUniformBase
@@ -97,6 +120,9 @@
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Uniforms/MP/Warden/tan.rsi
+  - type: ClothingFactionLocked
+    whitelist:
+    - UNMC
 
 # Warrant Officer / CMP
 - type: entity
@@ -118,6 +144,9 @@
     tags:
     - RMCUniformMarine
     - RMCUniformCMP
+  - type: ClothingFactionLocked
+    whitelist:
+    - UNMC
 
 # Prisoner
 - type: entity

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/provost.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/provost.yml
@@ -19,6 +19,9 @@
     - RMCUniformMP
     - RMCUniformWarden
     - RMCUniformCMP
+  - type: ClothingFactionLocked
+    whitelist:
+    - UNMC
 
 - type: entity
   parent: CMJumpsuitProvost
@@ -47,7 +50,6 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Uniforms/Provost/marshal.rsi
 
-
 - type: entity
   parent: RMCMarineUniformBase
   id: CMJumpsuitProvostAgent
@@ -62,3 +64,6 @@
     - RMCUniformMP
     - RMCUniformWarden
     - RMCUniformCMP
+  - type: ClothingFactionLocked
+    whitelist:
+    - UNMC

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/spp.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/spp.yml
@@ -15,6 +15,9 @@
   - type: Tag
     tags:
     - RMCUniformSPP
+  - type: ClothingFactionLocked
+    whitelist:
+    - SPP
 
 - type: entity
   parent: CMJumpsuitSPP

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/tse.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/tse.yml
@@ -11,6 +11,9 @@
   - type: Tag
     tags:
     - RMCUniformTSE
+  - type: ClothingFactionLocked
+    whitelist:
+    - TSE
 
 # Royal
 - type: entity

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/veteran.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/veteran.yml
@@ -133,6 +133,7 @@
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Uniforms/PMC/hybrisa.rsi
+
 - type: entity
   parent: RMCJumpsuitVeteranPMCCorporateLead
   id: RMCJumpsuitVeteranPMCHybrisaLead

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/veteran.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/veteran.yml
@@ -6,6 +6,9 @@
   - type: Tag
     tags:
     - RMCUniformPMC
+  - type: ClothingFactionLocked
+    whitelist:
+    - WeYa
 
 - type: entity
   parent: [RMCVeteranUniformBase, RMCAlternateFoldableUniformBase]
@@ -130,7 +133,6 @@
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Uniforms/PMC/hybrisa.rsi
-
 - type: entity
   parent: RMCJumpsuitVeteranPMCCorporateLead
   id: RMCJumpsuitVeteranPMCHybrisaLead
@@ -147,3 +149,6 @@
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Uniforms/PMC/director.rsi
+  - type: ClothingFactionLocked
+    whitelist:
+    - WeYa

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/CLF/commander.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/CLF/commander.yml
@@ -49,6 +49,7 @@
     - type: ScoutWhitelist
     - type: SniperWhitelist
     - type: PyroWhitelist
+    - type: ClothingFactionLockIgnore
   hidden: true
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/CLF/doctor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/CLF/doctor.yml
@@ -42,6 +42,7 @@
     - type: ScoutWhitelist
     - type: SniperWhitelist
     - type: PyroWhitelist
+    - type: ClothingFactionLockIgnore
   hidden: true
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/CLF/heavy_gunner.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/CLF/heavy_gunner.yml
@@ -40,6 +40,7 @@
     - type: ScoutWhitelist
     - type: SniperWhitelist
     - type: PyroWhitelist
+    - type: ClothingFactionLockIgnore
   hidden: true
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/CLF/standard.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/CLF/standard.yml
@@ -40,6 +40,7 @@
     - type: ScoutWhitelist
     - type: SniperWhitelist
     - type: PyroWhitelist
+    - type: ClothingFactionLockIgnore
   hidden: true
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/FORECON/assisstantsquadlead.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/FORECON/assisstantsquadlead.yml
@@ -51,6 +51,7 @@
     - type: ScoutWhitelist
     - type: SniperWhitelist
     - type: PyroWhitelist
+    - type: ClothingFactionLockIgnore
   hidden: true
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/FORECON/corpsman.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/FORECON/corpsman.yml
@@ -52,6 +52,7 @@
     - type: ScoutWhitelist
     - type: SniperWhitelist
     - type: PyroWhitelist
+    - type: ClothingFactionLockIgnore
   hidden: true
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/FORECON/rifleman.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/FORECON/rifleman.yml
@@ -46,6 +46,7 @@
     - type: ScoutWhitelist
     - type: SniperWhitelist
     - type: PyroWhitelist
+    - type: ClothingFactionLockIgnore
   hidden: true
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/FORECON/rto.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/FORECON/rto.yml
@@ -47,6 +47,7 @@
     - type: ScoutWhitelist
     - type: SniperWhitelist
     - type: PyroWhitelist
+    - type: ClothingFactionLockIgnore
   hidden: true
 
 

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/FORECON/smartgunner.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/FORECON/smartgunner.yml
@@ -46,6 +46,7 @@
     - type: ScoutWhitelist
     - type: SniperWhitelist
     - type: PyroWhitelist
+    - type: ClothingFactionLockIgnore
   hidden: true
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/FORECON/squadlead.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/FORECON/squadlead.yml
@@ -54,6 +54,7 @@
     - type: ScoutWhitelist
     - type: SniperWhitelist
     - type: PyroWhitelist
+    - type: ClothingFactionLockIgnore
   hidden: true
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/PMC/corpsman.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/PMC/corpsman.yml
@@ -56,6 +56,7 @@
       background:
         sprite: /Textures/_RMC14/Interface/map_blips.rsi
         state: background_pmc
+    - type: ClothingFactionLockIgnore
   hidden: true
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/PMC/force_lead.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/PMC/force_lead.yml
@@ -57,6 +57,7 @@
       background:
         sprite: /Textures/_RMC14/Interface/map_blips.rsi
         state: background_pmc
+    - type: ClothingFactionLockIgnore
   hidden: true
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/PMC/operator.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/PMC/operator.yml
@@ -45,6 +45,7 @@
       background:
         sprite: /Textures/_RMC14/Interface/map_blips.rsi
         state: background_pmc
+    - type: ClothingFactionLockIgnore
   hidden: true
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/PMC/overwatch.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/PMC/overwatch.yml
@@ -57,6 +57,7 @@
       background:
         sprite: /Textures/_RMC14/Interface/map_blips.rsi
         state: background_pmc
+    - type: ClothingFactionLockIgnore
   hidden: true
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/PMC/support_gunner.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/PMC/support_gunner.yml
@@ -47,6 +47,7 @@
       background:
         sprite: /Textures/_RMC14/Interface/map_blips.rsi
         state: background_pmc
+    - type: ClothingFactionLockIgnore
   hidden: true
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/PMC/team_lead.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/PMC/team_lead.yml
@@ -52,6 +52,7 @@
       background:
         sprite: /Textures/_RMC14/Interface/map_blips.rsi
         state: background_pmc
+    - type: ClothingFactionLockIgnore
   hidden: true
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/SPPoverwatch.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/SPPoverwatch.yml
@@ -51,6 +51,7 @@
     - type: ScoutWhitelist
     - type: SniperWhitelist
     - type: PyroWhitelist
+    - type: ClothingFactionLockIgnore
   hidden: true
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/corpsman.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/corpsman.yml
@@ -49,6 +49,7 @@
     - type: ScoutWhitelist
     - type: SniperWhitelist
     - type: PyroWhitelist
+    - type: ClothingFactionLockIgnore
   hidden: true
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/heavy_gunner.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/heavy_gunner.yml
@@ -39,6 +39,7 @@
     - type: ScoutWhitelist
     - type: SniperWhitelist
     - type: PyroWhitelist
+    - type: ClothingFactionLockIgnore
   hidden: true
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/rifleman.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/rifleman.yml
@@ -38,6 +38,7 @@
     - type: ScoutWhitelist
     - type: SniperWhitelist
     - type: PyroWhitelist
+    - type: ClothingFactionLockIgnore
   hidden: true
 
 

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/section_lead.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/section_lead.yml
@@ -46,6 +46,7 @@
     - type: ScoutWhitelist
     - type: SniperWhitelist
     - type: PyroWhitelist
+    - type: ClothingFactionLockIgnore
   hidden: true
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/squad_lead.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/squad_lead.yml
@@ -45,6 +45,7 @@
     - type: ScoutWhitelist
     - type: SniperWhitelist
     - type: PyroWhitelist
+    - type: ClothingFactionLockIgnore
   hidden: true
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/UNMC/corpsman.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/UNMC/corpsman.yml
@@ -47,6 +47,7 @@
       icon:
         sprite: /Textures/_RMC14/Interface/map_blips.rsi
         state: medic
+    - type: ClothingFactionLockIgnore
   hidden: true
 
 - type: playTimeTracker

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/UNMC/platoon_commander.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/UNMC/platoon_commander.yml
@@ -57,6 +57,7 @@
         sprite: /Textures/_RMC14/Interface/map_blips.rsi
         state: background_command
     - type: RMCTrackable
+    - type: ClothingFactionLockIgnore
   hidden: true
 
 - type: playTimeTracker

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/UNMC/rifleman.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/UNMC/rifleman.yml
@@ -29,6 +29,7 @@
       icon:
         sprite: /Textures/_RMC14/Interface/map_blips.rsi
         state: private
+    - type: ClothingFactionLockIgnore
   hidden: true
 
 - type: playTimeTracker

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/UNMC/section_sergeant.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/UNMC/section_sergeant.yml
@@ -50,6 +50,7 @@
         sprite: /Textures/_RMC14/Interface/map_blips.rsi
         state: leader
     - type: RMCTrackable
+    - type: ClothingFactionLockIgnore
   hidden: true
 
 - type: playTimeTracker

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/UNMC/smart_gun_operator.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/UNMC/smart_gun_operator.yml
@@ -40,6 +40,7 @@
         state: smartgunner
     - type: JobPrefix
       prefix: cm-job-prefix-gun-operator
+    - type: ClothingFactionLockIgnore
   hidden: true
 
 - type: playTimeTracker

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/UNMC/squad_leader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/UNMC/squad_leader.yml
@@ -45,6 +45,7 @@
         sprite: /Textures/_RMC14/Interface/map_blips.rsi
         state: tl
     - type: RMCTrackable
+    - type: ClothingFactionLockIgnore
   hidden: true
 
 - type: playTimeTracker

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Base_Survs/civilian_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Base_Survs/civilian_survivor.yml
@@ -41,6 +41,7 @@
       - Civilian
     - type: IntelRescueSurvivorObjective
     - type: RMCAllowSuitStorage
+    - type: ClothingFactionLockIgnore
   greeting: rmc-job-greeting-survivor
   hasIcon: false
   useLoadoutOfJob: CMSurvivor # for inheritance


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds faction locking to uniforms. Jobs such as rifleman can no longer wear PMC fatigues and so on. PVE Jobs and Survivors have a new component to ignore faction locking on uniforms.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
RP issue of roles taking gear not intended for their faction and wearing it for stats / drip, leading to stuff like IOs wearing PMC gear or rifleman wearing UN peacekeeper gear.

## Technical details
<!-- Summary of code changes for easier review. -->
ClothingFactionLockIgnoreComponent and ClothingFactionLockedComponent. OnFactionLockedBeingEquippedAttempt function in RMCClothingSystem checks for ClothingFactionLockedComponent on a piece of clothing and if the equip target doesnt have any of the whitelisted factions or ClothingFactionLockIgnoreComponent it prevents them from wearing it.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
https://github.com/user-attachments/assets/3b103bef-8cc9-4174-8f0e-5a1137471b3a

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [ ] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: noctyrnal
- add: Added faction locking to uniforms. You can no longer wear uniforms not intended for your faction - Survivors and PVE roles can ignore faction locking and wear any uniforms like usual.
