### PR TITLE
Make FORECON support tech only roll if you have doctor survivor or engineer survivor enabled

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/rmc_planets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/rmc_planets.yml
@@ -323,7 +323,7 @@
     survivorJobs:
     - RMCSurvivorCommandingOfficer: 1
     - RMCSurvivorForeconSupportTech: 1
-    - RMCSurvivorForeconBase: 7
+    - RMCSurvivorForeconBase: 6 # todo 7 when eight survs
     survivorJobInserts:
       RMCSurvivorCommandingOfficer:
       - RMCSurvivorForeconCommander: 1


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Some people don't like playing this role and would rather play another

This overrides both doctor and engineer to the ``RMCSurvivorForeconSupportTech`` role 

<img width="970" height="434" alt="image" src="https://github.com/user-attachments/assets/87c3c67f-cf31-4a90-8040-ef5c100295cc" />

Got with doctor surv on high

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: You will no longer roll FORECON Support Technician on Chance's Claim as a survivor if you do not have Doctor Survivor or Engineer Survivor enabled.
