### PR TITLE
Make multiple xeno displacing abilities kill crit marines

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Cleave/XenoCleaveSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Cleave/XenoCleaveSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._RMC14.Damage;
 using Content.Shared._RMC14.Pulling;
 using Content.Shared._RMC14.Shields;
 using Content.Shared._RMC14.Slow;
@@ -18,8 +19,10 @@ public sealed class XenoCleaveSystem : EntitySystem
     [Dependency] private readonly RMCPullingSystem _rmcPulling = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedRMCMeleeWeaponSystem _rmcMelee = default!;
+    [Dependency] private readonly SharedRMCDamageableSystem _rmcDamageable = default!;
     [Dependency] private readonly RMCSlowSystem _slow = default!;
     [Dependency] private readonly RMCSizeStunSystem _sizeStun = default!;
+
     public override void Initialize()
     {
         SubscribeLocalEvent<XenoCleaveComponent, XenoCleaveActionEvent>(OnCleaveAction);
@@ -55,6 +58,7 @@ public sealed class XenoCleaveSystem : EntitySystem
             var origin = _transform.GetMapCoordinates(xeno);
 
             _sizeStun.KnockBack(args.Target, origin, flingRange, flingRange, 10, true);
+            _rmcDamageable.DoLethalDamage(args.Target, origin: xeno);
 
             if (_net.IsServer)
             {

--- a/Content.Shared/_RMC14/Xenonids/Dislocate/XenoDislocateSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Dislocate/XenoDislocateSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared._RMC14.Actions;
+using Content.Shared._RMC14.Damage;
 using Content.Shared._RMC14.Damage.ObstacleSlamming;
 using Content.Shared._RMC14.Pulling;
 using Content.Shared._RMC14.Slow;
@@ -29,6 +30,7 @@ public sealed class XenoDislocateSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly RMCSlowSystem _slow = default!;
     [Dependency] private readonly SharedRMCMeleeWeaponSystem _rmcMelee = default!;
+    [Dependency] private readonly SharedRMCDamageableSystem _rmcDamageable = default!;
     [Dependency] private readonly StandingStateSystem _standing = default!;
     [Dependency] private readonly SharedActionsSystem _actions = default!;
     [Dependency] private readonly SharedRMCActionsSystem _rmcActions = default!;
@@ -82,6 +84,7 @@ public sealed class XenoDislocateSystem : EntitySystem
                 _rmcMelee.DoLunge(xeno, targetId);
                 _obstacleSlamming.MakeImmune(targetId);
                 _sizeStun.KnockBack(targetId, origin, xeno.Comp.FlingRange, xeno.Comp.FlingRange, 10);
+                _rmcDamageable.DoLethalDamage(targetId, origin: xeno);
 
                 SpawnAttachedTo(xeno.Comp.Effect, targetId.ToCoordinates());
             }

--- a/Content.Shared/_RMC14/Xenonids/Headbutt/XenoHeadbuttSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Headbutt/XenoHeadbuttSystem.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using Content.Shared._RMC14.Actions;
+using Content.Shared._RMC14.Damage;
 using Content.Shared._RMC14.Damage.ObstacleSlamming;
 using Content.Shared._RMC14.Pulling;
 using Content.Shared._RMC14.Stun;
@@ -34,6 +35,7 @@ public sealed class XenoHeadbuttSystem : EntitySystem
     [Dependency] private readonly SharedRMCActionsSystem _rmcActions = default!;
     [Dependency] private readonly RMCObstacleSlammingSystem _rmcObstacleSlamming = default!;
     [Dependency] private readonly RMCPullingSystem _rmcPulling = default!;
+    [Dependency] private readonly SharedRMCDamageableSystem _rmcDamageable = default!;
     [Dependency] private readonly RMCSizeStunSystem _sizeStun = default!;
     [Dependency] private readonly ThrowingSystem _throwing = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
@@ -133,7 +135,9 @@ public sealed class XenoHeadbuttSystem : EntitySystem
         StopHeadbutt(xeno);
 
         var origin = _transform.GetMapCoordinates(xeno);
-        _sizeStun.KnockBack(targetId, origin, range, range, 10, true );
+        _sizeStun.KnockBack(targetId, origin, range, range, 10, true);
+
+        _rmcDamageable.DoLethalDamage(targetId, origin: xeno);
 
         if (_net.IsServer)
             SpawnAttachedTo(xeno.Comp.Effect, targetId.ToCoordinates());

--- a/Content.Shared/_RMC14/Xenonids/TailLash/XenoTailLashSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/TailLash/XenoTailLashSystem.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using Content.Shared._RMC14.Actions;
+using Content.Shared._RMC14.Damage;
 using Content.Shared._RMC14.Pulling;
 using Content.Shared._RMC14.Slow;
 using Content.Shared._RMC14.Stun;
@@ -33,6 +34,7 @@ public sealed class XenoTailLashSystem : EntitySystem
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly SharedRMCActionsSystem _rmcActions = default!;
+    [Dependency] private readonly SharedRMCDamageableSystem _rmcDamageable = default!;
     [Dependency] private readonly RMCSizeStunSystem _size = default!;
     [Dependency] private readonly RMCSlowSystem _slow = default!;
     [Dependency] private readonly SharedStunSystem _stun = default!;
@@ -136,6 +138,8 @@ public sealed class XenoTailLashSystem : EntitySystem
 
             var origin = _transform.GetMapCoordinates(xeno);
             _size.KnockBack(ent, origin, xeno.Comp.FlingDistance, xeno.Comp.FlingDistance, 10);
+
+            _rmcDamageable.DoLethalDamage(ent, origin: xeno);
         }
 
         xeno.Comp.Area = null;

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/base_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/base_armor.yml
@@ -263,7 +263,7 @@
       - RMCUniformMarine
 
 - type: entity
-  parent: [ RMCBaseMarineArmorNoAccessory , RMCBaseUniformAccessoryItemOuterClothing ]
+  parent: RMCBaseMarineArmorNoAccessory
   id: RMCBaseMarineArmor
   abstract: true
 
@@ -349,7 +349,7 @@
     autoRechargeRate: 2 #recharge of 2 makes total drain 1w / s so max charge is 1:1 with time. Time to fully charge should be 5 minutes. Having recharge gives light an extended flicker period which gives you some warning to return to light area.
 
 - type: entity
-  parent: [ RMCBaseMarineArmorLightNoAccessory, RMCBaseUniformAccessoryItemOuterClothing ]
+  parent: RMCBaseMarineArmorLightNoAccessory
   id: RMCBaseMarineArmorLight
   abstract: true
 

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/base_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/base_armor.yml
@@ -263,7 +263,7 @@
       - RMCUniformMarine
 
 - type: entity
-  parent: RMCBaseMarineArmorNoAccessory
+  parent: [ RMCBaseMarineArmorNoAccessory , RMCBaseUniformAccessoryItemOuterClothing ]
   id: RMCBaseMarineArmor
   abstract: true
 
@@ -349,7 +349,7 @@
     autoRechargeRate: 2 #recharge of 2 makes total drain 1w / s so max charge is 1:1 with time. Time to fully charge should be 5 minutes. Having recharge gives light an extended flicker period which gives you some warning to return to light area.
 
 - type: entity
-  parent: RMCBaseMarineArmorLightNoAccessory
+  parent: [ RMCBaseMarineArmorLightNoAccessory, RMCBaseUniformAccessoryItemOuterClothing ]
   id: RMCBaseMarineArmorLight
   abstract: true
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
fixes #8638

https://github.com/user-attachments/assets/ed9d33a7-e346-4584-8225-e6e00e22cd08



Made:
Defender headbutt
Warrior fling
Oppressor dislocate (the throw version)
Oppressor tail lash
Vanguard fling cleave

Kill crit marines

Added a generic method for dealing lethal damage to critical mobs




**Changelog**
:cl:
- fix: Fixed defender headbutt, warrior fling, oppressor dislocate, oppressor tail lash, and vanguard fling cleave not killing crit marines.
