### PR TITLE
CMP highlights autofill

### DIFF
--- a/Resources/Locale/en-US/_RMC14/chat/highlights.ftl
+++ b/Resources/Locale/en-US/_RMC14/chat/highlights.ftl
@@ -27,7 +27,7 @@ highlights-nurse = Nurse, Medical, MedBay, "Med", Infected, Surgery, "Chem", "Ch
 highlights-researcher = Researcher, Research, Science, "Sci", "Chem", "Chems"
 
 # Military Police
-highlights-chief-MP = Chief MP, "CMP", "MP", "MPs", "MW", "Alert", Brig, "Perma", Loose, Colonist, Survivor, "SOP", Arrest, Detain, Appeal, "Command"
+highlights-chief-mp = Chief MP, "CMP", "MP", "MPs", "MW", "Alert", Brig, "Perma", Loose, Colonist, Survivor, "SOP", Arrest, Detain, Appeal, "Command"
 highlights-military-warden = Military Warden, Warden, "CMP", "MP", "MPs", "MW", "Alert", Brig, "Perma", Loose, Colonist, Survivor, "SOP", Arrest, Detain, Appeal
 highlights-military-police = Military Police, "CMP", "MP", "MPs", "MW", "Alert", Brig, "Perma", Loose, Colonist, Survivor, "SOP", Arrest, Detain, Appeal
 


### PR DESCRIPTION
## About the PR
Fixed the chat highlights for CMP, they now autofill correctly.

## Why / Balance
fixes https://github.com/RMC-14/RMC-14/issues/7809
## Technical details

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: CMP chat highlights now autofill
