### PR TITLE
Make the MarineRadioPhones less chat spam.

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Devices/Electronics/radio.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Devices/Electronics/radio.yml
@@ -23,6 +23,7 @@
   - type: Tag
     tags:
     - Radio
+  - type: ChatRepeatIgnoreSender # RMC14
   - type: InteractedBlacklist
     blacklist:
       components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
added the ChatRepeatIgnoreSender from HandheldRadioColony to the marine radiophones.

## Why / Balance
Less chat spam is great, especially for ghosts

## Technical details
<img width="335" height="23" alt="image" src="https://github.com/user-attachments/assets/2784a26d-015a-48e0-a301-e2050f8ab751" />

## Media
<img width="381" height="28" alt="image" src="https://github.com/user-attachments/assets/f4a04824-47df-4e0b-b6dc-a2b055e83ff7" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:

- tweak: Marine Radiophones now stack the same messages in chatbox.
