### PR TITLE
Underbarrel FlashLight Grip Parity

### DIFF
--- a/Content.Server/Light/EntitySystems/HandheldLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/HandheldLightSystem.cs
@@ -2,6 +2,7 @@ using Content.Server.Actions;
 using Content.Server.Popups;
 using Content.Server.Power.EntitySystems;
 using Content.Server.PowerCell;
+using Content.Shared._RMC14.Attachable.Components;
 using Content.Shared.Actions;
 using Content.Shared.Examine;
 using Content.Shared.Interaction;
@@ -69,6 +70,11 @@ namespace Content.Server.Light.EntitySystems
 
         private void OnGetActions(EntityUid uid, HandheldLightComponent component, GetItemActionsEvent args)
         {
+            // Don't add action if this item is an attachment that requires being attached to a holder
+            if (TryComp(uid, out AttachableToggleableComponent? attachable) &&
+                attachable.AttachedOnly && !attachable.Attached)
+                return;
+
             args.AddAction(ref component.ToggleActionEntity, component.ToggleAction);
         }
 
@@ -76,6 +82,14 @@ namespace Content.Server.Light.EntitySystems
         {
             if (args.Handled)
                 return;
+
+            // Prevent toggling if item is an attachment that requires being attached to a holder
+            if (TryComp(ent.Owner, out AttachableToggleableComponent? attachable) &&
+                attachable.AttachedOnly && !attachable.Attached)
+            {
+                args.Handled = true;
+                return;
+            }
 
             if (ent.Comp.Activated)
                 TurnOff(ent);
@@ -126,6 +140,14 @@ namespace Content.Server.Light.EntitySystems
         {
             if (args.Handled || !args.Complex || !ent.Comp.ToggleOnInteract)
                 return;
+
+            // Prevent toggling if item is an attachment that requires being attached to a holder
+            if (TryComp(ent.Owner, out AttachableToggleableComponent? attachable) &&
+                attachable.AttachedOnly && !attachable.Attached)
+            {
+                args.Handled = true;
+                return;
+            }
 
             if (ToggleStatus(args.User, ent))
                 args.Handled = true;

--- a/Content.Shared/Item/ItemToggle/ItemToggleSystem.cs
+++ b/Content.Shared/Item/ItemToggle/ItemToggleSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._RMC14.Attachable.Components;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Item.ItemToggle.Components;
@@ -64,6 +65,11 @@ public sealed class ItemToggleSystem : EntitySystem
         if (args.Handled || !ent.Comp.OnUse)
             return;
 
+        // Prevent toggling if item is an attachment that requires being attached to a holder
+        if (TryComp(ent.Owner, out AttachableToggleableComponent? attachable) &&
+            attachable.AttachedOnly && !attachable.Attached)
+            return;
+
         args.Handled = true;
 
         Toggle((ent, ent.Comp), args.User, predicted: ent.Comp.Predictable);
@@ -107,6 +113,14 @@ public sealed class ItemToggleSystem : EntitySystem
     {
         if (args.Handled || !ent.Comp.OnActivate)
             return;
+
+        // Prevent toggling if item is an attachment that requires being attached to a holder
+        if (TryComp(ent.Owner, out AttachableToggleableComponent? attachable) &&
+            attachable.AttachedOnly && !attachable.Attached)
+        {
+            args.Handled = true;
+            return;
+        }
 
         args.Handled = true;
         Toggle((ent.Owner, ent.Comp), args.User, predicted: ent.Comp.Predictable);

--- a/Content.Shared/_RMC14/Attachable/Systems/AttachableToggleableSystem.cs
+++ b/Content.Shared/_RMC14/Attachable/Systems/AttachableToggleableSystem.cs
@@ -140,6 +140,11 @@ public sealed class AttachableToggleableSystem : EntitySystem
         if (args.User == null)
             return;
 
+        // Check if attachment has AttachedOnly restriction
+        if (TryComp(attachable.Owner, out AttachableToggleableComponent? toggleableComponent) &&
+            toggleableComponent.AttachedOnly && !toggleableComponent.Attached)
+            return;
+
         switch (args.Alteration)
         {
             case AttachableAlteredType.Activated:
@@ -731,6 +736,10 @@ public sealed class AttachableToggleableSystem : EntitySystem
 
     private void Toggle(Entity<AttachableToggleableComponent> attachable, EntityUid? user, bool interrupted = false)
     {
+        // Prevent toggling if attachment is restricted to being attached only
+        if (attachable.Comp.AttachedOnly && !attachable.Comp.Attached)
+            return;
+
         if (!_attachableHolderSystem.TryGetHolder(attachable.Owner, out var holderUid) ||
             !TryComp(holderUid, out AttachableHolderComponent? holderComponent) ||
             !_attachableHolderSystem.TryGetSlotId(holderUid.Value, attachable.Owner, out var slotId))
@@ -758,6 +767,10 @@ public sealed class AttachableToggleableSystem : EntitySystem
 
     private void GrantAttachableActions(Entity<AttachableToggleableComponent> ent, EntityUid user, bool doSecondTry = true)
     {
+        // Don't grant action if AttachedOnly is true and not currently attached
+        if (ent.Comp.AttachedOnly && !ent.Comp.Attached)
+            return;
+
         // This is to prevent ActionContainerSystem from shitting itself if the attachment has actions other than its attachment toggle.
         if (!TryComp(ent.Owner, out ActionsContainerComponent? actionsContainerComponent) || actionsContainerComponent.Container == null)
         {
@@ -828,6 +841,8 @@ public sealed class AttachableToggleableSystem : EntitySystem
         }
 
         _actionsSystem.RemoveProvidedAction(user, ent, action);
+        ent.Comp.Action = null;
+        Dirty(ent);
     }
 
     private void RemoveRelayedActions(Entity<AttachableToggleableComponent> attachable, EntityUid user)


### PR DESCRIPTION
## About the PR
Light no longer toggle-able unless its attached to a weapon. 
Hopefully fixes 
"_error system.action_container: action activate underbarrel flashlightgrip cmactiontoggleattachable  is not contained in the expected container under barrel flashlight grip rmcattachmentflashlightgrip_"




All previous interactions as is, still stays as a lit light source if weapon is attached to corpse or dropped.
Upon being unattached to weapon light source will turn off automatically.

## Why / Balance
Parity and _hopefully_ less random under barrel flashlight grips spammed around ground side.

## Media
https://github.com/user-attachments/assets/c2ce081a-6446-4b0d-9876-9dce383d06cc

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed the underbarrel flashlight grip being toggleable without being attached to an appropriate weapon.
