### PR TITLE
add some vials to the med plus vendor

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/medical.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/medical.yml
@@ -132,6 +132,8 @@
         amount: 2
       - id: CMHyposprayFilledTricord
         amount: 2
+      - id: RMCVial
+        amount: 2
       - id: CMHealthAnalyzer
         amount: 5
       - id: CMBeltMedical


### PR DESCRIPTION
## About the PR

title

## Why / Balance

Some people raid the hypos for their vials, leaving them unusable for others.

## Technical details

Two lines of yaml. Same amount as hypos.

## Media

<img width="629" height="725" alt="image" src="https://github.com/user-attachments/assets/9234ba0f-e069-4942-bb9d-1f85e4eb36a3" />


Example of a raid:

<img width="304" height="271" alt="Screenshot From 2025-12-29 20-31-59" src="https://github.com/user-attachments/assets/a2d8808e-58c3-473e-9577-6b39fb2bb650" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: We-Ya-Med Plus now contains additional spare vials.
