### PR TITLE
Gives FTLs colony engineering access for APCs

### DIFF
--- a/Content.Shared/_RMC14/Power/RMCApcComponent.cs
+++ b/Content.Shared/_RMC14/Power/RMCApcComponent.cs
@@ -58,7 +58,7 @@ public sealed partial class RMCApcComponent : Component
     public ProtoId<ToolQualityPrototype> CrowbarTool = "Prying";
 
     [DataField, AutoNetworkedField]
-    public ProtoId<AccessLevelPrototype>[] Access = ["CMAccessEngineering", "CMAccessColonyEngineering" ];
+    public ProtoId<AccessLevelPrototype>[] Access = ["CMAccessEngineering", "CMAccessColonyEngineering"];
 
     [DataField, AutoNetworkedField]
     public EntProtoId<SkillDefinitionComponent> Skill = "RMCSkillEngineer";

--- a/Content.Shared/_RMC14/Power/RMCApcComponent.cs
+++ b/Content.Shared/_RMC14/Power/RMCApcComponent.cs
@@ -58,7 +58,7 @@ public sealed partial class RMCApcComponent : Component
     public ProtoId<ToolQualityPrototype> CrowbarTool = "Prying";
 
     [DataField, AutoNetworkedField]
-    public ProtoId<AccessLevelPrototype>[] Access = ["CMAccessEngineering", "CMAccessColonyEngineering"];
+    public ProtoId<AccessLevelPrototype>[] Access = ["CMAccessEngineering" ]; //TODO RMC14 resolve cover access issues for APCs
 
     [DataField, AutoNetworkedField]
     public EntProtoId<SkillDefinitionComponent> Skill = "RMCSkillEngineer";

--- a/Content.Shared/_RMC14/Power/RMCApcComponent.cs
+++ b/Content.Shared/_RMC14/Power/RMCApcComponent.cs
@@ -58,7 +58,7 @@ public sealed partial class RMCApcComponent : Component
     public ProtoId<ToolQualityPrototype> CrowbarTool = "Prying";
 
     [DataField, AutoNetworkedField]
-    public ProtoId<AccessLevelPrototype>[] Access = ["CMAccessEngineering" ]; //TODO RMC14 resolve cover access issues for APCs
+    public ProtoId<AccessLevelPrototype>[] Access = ["CMAccessEngineering", "CMAccessColonyEngineering" ];
 
     [DataField, AutoNetworkedField]
     public EntProtoId<SkillDefinitionComponent> Skill = "RMCSkillEngineer";

--- a/Resources/Prototypes/_RMC14/Access/Groups/marine_access_groups.yml
+++ b/Resources/Prototypes/_RMC14/Access/Groups/marine_access_groups.yml
@@ -16,7 +16,6 @@
   tags:
   - CMAccessMarinePrep
   - CMAccessFTLPrep
-  - CMAccessColonyEngineering
 
 - type: accessGroup
   id: WeaponSpec

--- a/Resources/Prototypes/_RMC14/Access/Groups/marine_access_groups.yml
+++ b/Resources/Prototypes/_RMC14/Access/Groups/marine_access_groups.yml
@@ -16,6 +16,7 @@
   tags:
   - CMAccessMarinePrep
   - CMAccessFTLPrep
+  - CMAccessColonyEngineering
 
 - type: accessGroup
   id: WeaponSpec

--- a/Resources/Prototypes/_RMC14/Access/Groups/marine_access_groups.yml
+++ b/Resources/Prototypes/_RMC14/Access/Groups/marine_access_groups.yml
@@ -16,6 +16,7 @@
   tags:
   - CMAccessMarinePrep
   - CMAccessFTLPrep
+  - CMAccessColonyEngineering # TODO RMC14 APC Access Wire
 
 - type: accessGroup
   id: WeaponSpec
@@ -49,7 +50,7 @@
   tags:
   - CMAccessMarinePrep
   - CMAccessCombatTechPrep
-  - CMAccessColonyEngineering
+  - CMAccessColonyEngineering #TODO RMC14 APC Access Wire
 
 # this exists because other squad members will have their own equipment vendors.
 - type: accessGroup


### PR DESCRIPTION
## About the PR
Gives FTLs colony engineering access for APCs

## Why / Balance
QoL change. APCs are already somewhat fussy when it comes to opening them and changing out cells, and the access issue complicates the process and wastes marine time. If further access changes can/should be made for other marine roles to alleviate this, or APCs could be made to be access tuned, that may also work. The intent is to smooth over what's otherwise an unintuitive mechanic a bit better.

## Technical details


## Media


## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- tweak: FTLs are now able to unlock APC covers in colonies.

