### PR TITLE
add fultons to squad corpsman's point buy

### DIFF
--- a/Resources/Prototypes/_RMC14/Catalog/Fills/Boxes/medical.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Fills/Boxes/medical.yml
@@ -49,13 +49,13 @@
   - type: StorageFill
     contents:
       - id: CMPillCanister
-        amount: 7
+        amount: 8
   - type: Sprite
     state: pillbox
   - type: Storage
     maxItemSize: Small
     grid:
-    - 0,0,13,1
+    - 0,0,15,1
     areaInsert: true
     areaInsertRadius: 1
     whitelist:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/medic.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/medic.yml
@@ -173,8 +173,6 @@
         points: 3
     - name: Utilities
       entries:
-      - id: RMCFulton20
-        points: 5
       - id: CMFireExtinguisherPortable
         points: 3
       - id: RMCMotionDetector

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/medic.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/medic.yml
@@ -173,6 +173,8 @@
         points: 3
     - name: Utilities
       entries:
+      - id: RMCFulton20
+        points: 5
       - id: CMFireExtinguisherPortable
         points: 3
       - id: RMCMotionDetector


### PR DESCRIPTION

## About the PR
Does what is says on the tin, adds fulton packs as a 5 point buy to the corpsman's vendor.

## Why / Balance
I found it odd and more than a little annoying that every other squad role has fultons as a point buy except for corpsman.

## Technical details
N/A

## Media
<img width="613" height="518" alt="Screenshot 2026-01-02 122517" src="https://github.com/user-attachments/assets/18c5d4c5-2967-4648-87dc-11e2a98f53a3" />



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Added fultons as a point buy for corpsmen.