### PR TITLE
Change boxes of pill bottles capacity from 7 bottles to 8

### DIFF
--- a/Resources/Prototypes/_RMC14/Catalog/Fills/Boxes/medical.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Fills/Boxes/medical.yml
@@ -49,13 +49,13 @@
   - type: StorageFill
     contents:
       - id: CMPillCanister
-        amount: 7
+        amount: 8
   - type: Sprite
     state: pillbox
   - type: Storage
     maxItemSize: Small
     grid:
-    - 0,0,13,1
+    - 0,0,15,1
     areaInsert: true
     areaInsertRadius: 1
     whitelist:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Boxes of pill bottles hold 8 bottles apiece instead of 7.

## Why / Balance
A small QoL for doctors, as now the boxes match the capacity of the chemmaster instead of being one short.  Basically the 9 to 10 ammo capacity for the pump shotgun, evens out the numbers and makes things smoother.  One box of bottles makes one batch, simple as that.
## Technical details
N/A

## Media
<img width="674" height="76" alt="Screenshot 2026-01-02 153930" src="https://github.com/user-attachments/assets/339ac754-3a8d-47f1-8ba4-528c8913f058" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Changed the capacity of boxes of pill bottles from 7 to 8

