### PR TITLE
IMP Ammo Rack Fix

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Back/backpacks.yml
@@ -268,8 +268,8 @@
     - state: ammo_pack-0
       map: ["enum.StorageFillLayers.Fill"]
   - type: ClothingSpeedModifier
-    walkModifier: 0.710
-    sprintModifier: 0.710
+    walkModifier: 0.910
+    sprintModifier: 0.850
   - type: HeldSpeedModifier
   - type: StorageFillVisualizer
     fillBaseName: ammo_pack


### PR DESCRIPTION
## About the PR
Values for IMP Ammo Rack, were off causing slower than intended slowdowns.

## Why / Balance
Makes approx same due to lack of Move_Delay

## Technical details
Yml value tweak.
Changed numbers with math! 

## Media
https://github.com/user-attachments/assets/182e135d-25a5-4ae8-b921-91c90cfbfa4c


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: IMP Ammo Racks do not slow down as much, still stacks the slowdown if you are holding multiple. Running: 29% -> 12% slowdown

