### PR TITLE
Add hyposprays as a pointbuy for corpsmen

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/medic.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/medic.yml
@@ -95,7 +95,7 @@
       - id: CMStasisBagFolded
         points: 6
       - id: CMHyposprayFilledTricord
-        points: 10
+        points: 8
     - name: Explosives
       entries:
       - id: CMPacketGrenadeHighExplosiveFilled

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/medic.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/medic.yml
@@ -94,6 +94,8 @@
         points: 4
       - id: CMStasisBagFolded
         points: 6
+      - id: CMHyposprayFilledTricord
+        points: 10
     - name: Explosives
       entries:
       - id: CMPacketGrenadeHighExplosiveFilled


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added hyposprays as a point buy option for corpsmen for 8 points under Medical Utilities.  Comes filled with tricordizine, similiar to the regular medvendors.

## Why / Balance
Hyposprays are an important aspect of almost every corpsman loadout in some fashion, to the point of being near prohibitive if a corpsman can't get their hands on one.  Latejoining corpsmen, or those going through the req line, could sometimes find themselves without any hyposprays because the quick access ones in medical were empty, and couldn't spare any more time on an already long prep time to get one in a more time consuming but reliable way.  Even then, these more reliable ways need medical to be staffed, and one, the field doctor vendor, requires a CMO to access in the first place, and sometimes neither of these things are the case.  Adding hyposprays as a point buy removes a key restraint to loadouts, allowing for much more freedom to loadout selection, making corpsmen more open to those that want to experiment.  

Of course, with hyposprays being one of the better options for chem delivery, it should be expensive, but not prohibitively so.  Originally I planned on making it 10 points, but went with 8 points after discussions with medical players.  8, 16, even 24 points is a not insignificant number, but still allows for other utilities and gear to be bought.  

## Technical details
<!-- Summary of code changes for easier review. -->
N/A
## Media
<img width="560" height="251" alt="image" src="https://github.com/user-attachments/assets/84206026-03b9-4005-bfbc-2271192c430b" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added hyposprays as a point buy for corpsmen.