### PR TITLE
Make colony flamer tanks flushable and reduce copypaste

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Flamethrowers/colony_flamer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Flamethrowers/colony_flamer.yml
@@ -90,7 +90,7 @@
     - RMCTankFlamerColony
 
 - type: entity
-  parent: BaseItem
+  parent: RMCBaseTankFlamer
   id: RMCTankFlamerColony
   name: LC9 flamer tank
   description: A fuel tank used to store fuel for use in the LC9 incinerator unit. Handle with care.
@@ -113,13 +113,11 @@
   - type: RMCSolutionTransferWhitelist
     popup: rmc-solution-transfer-whitelist-failed-not-reagent-tank
     targetWhitelist:
+      components:
+      - RMCFlamerBackpack
       tags:
       - RMCTankReagent
       - RMCBackpackFlamer
-  - type: RefillableSolution
-    solution: rmc_flamer_tank
-  - type: DetailedExaminableSolution
-    solution: rmc_flamer_tank
   - type: NoMixingReagents
   - type: Appearance
   - type: SolutionStorageFillable

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Flamethrowers/m34_flamer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Flamethrowers/m34_flamer.yml
@@ -127,6 +127,28 @@
 
 - type: entity
   parent: BaseItem
+  id: RMCBaseTankFlamer
+  abstract: true
+  components:
+  - type: Item
+    size: Normal
+  - type: RMCFlushableSolution
+    solution: rmc_flamer_tank
+    flushTime: 1.5
+  - type: InteractedBlacklist
+    blacklist:
+      components:
+      - Xeno
+  - type: Tag
+    tags:
+    - RMCTankFlamer
+  - type: RefillableSolution
+    solution: rmc_flamer_tank
+  - type: DetailedExaminableSolution
+    solution: rmc_flamer_tank
+
+- type: entity
+  parent: RMCBaseTankFlamer
   id: RMCTankFlamer
   name: M34 incinerator tank
   description: A fuel tank used to store fuel for use in the M34 incinerator unit. Handle with care.
@@ -157,10 +179,6 @@
       tags:
       - RMCTankReagent
       - RMCBackpackFlamer
-  - type: RefillableSolution
-    solution: rmc_flamer_tank
-  - type: DetailedExaminableSolution
-    solution: rmc_flamer_tank
   - type: NoMixingReagents
   - type: SolutionContainerVisuals
     maxFillLevels: 2
@@ -168,16 +186,6 @@
   - type: Appearance
   - type: SolutionStorageFillable
     solution: rmc_flamer_tank
-  - type: RMCFlushableSolution
-    solution: rmc_flamer_tank
-    flushTime: 1.5
-  - type: InteractedBlacklist
-    blacklist:
-      components:
-      - Xeno
-  - type: Tag
-    tags:
-    - RMCTankFlamer
 
 - type: entity
   parent: RMCTankFlamer


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Parity behaviour to my knowledge
Annoying to get a bricked flamer tank after there's only 1 unit of fuel in it

Reduces copypaste of components by adding a ``RMCBaseTankFlamer``

**Changelog**
:cl:
- tweak: You can now flush reagents from the colony flamer tank with a verb, like the M34 incinerator tank.
