### PR TITLE
Updated CT Gear Vendor Recommendations and Order

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/engineer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/engineer.yml
@@ -277,7 +277,6 @@
       - id: RMCM82FHolster
       - id: RMCM276ShotgunShellLoadingRig
       - id: RMCBeltGrenade
-
     - name: Pouches
       choices: { RMCPouch: 2 }
       entries:


### PR DESCRIPTION
## About the PR
Updates for CT Gear Vendor:
- Moved construction belt and toolbelt to top of the belts section
- Flagged small tool webbing as recommended instead of brown webbing vest and moved it to the top of the accessory section

## Why / Balance
- Suggested on discord - Encourages newer CTs to use the CT exclusive webbing and belt as many don't even realize they were an option until they've picked another option.
- Also moved the filled toolbelt up next to the construction rig as it's also a solid option for some CT loadouts, but have not flagged it as recommended so new players still lean towards the construction rig + tool webbing combo.

## Technical details
- YAML changes only

## Media
Belts:
<img width="634" height="621" alt="image" src="https://github.com/user-attachments/assets/2f11b16c-a9ca-479e-87a9-0978d1223cb0" />
Accessories:
<img width="632" height="701" alt="image" src="https://github.com/user-attachments/assets/f3dc39c3-48a6-4512-b361-8b52a9d3a758" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: Updated recommendations and ordering in CT gear vendor