### PR TITLE
Zipties are now Tiny Items

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Misc/handcuffs.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Misc/handcuffs.yml
@@ -29,6 +29,8 @@
   description: Tough single-use plastic zipties, ideal for restraining rowdy prisoners.
   suffix: RMC
   components:
+  - type: Item
+    size: Tiny
   - type: UseDelay
     delay: 4
   - type: Handcuff


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Zipties are now classified as tiny.

## Why / Balance
Parity, plus gives MPs a reason to actually take them over cuffs.

## Technical details
They are now tiny. Smol even.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Ziptie Cuffs are now tiny items.