### PR TITLE
req can now vend pistol and bullet boxes from prep

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/prep.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/prep.yml
@@ -83,7 +83,7 @@
       - id: CMPackFlare
         amount: 10
         recommended: true
-    - name: Boxes
+    - name: Magazine Boxes
       hasBoxes: true
       jobs:
       - CMQuartermaster
@@ -104,6 +104,38 @@
         box: CMMagazineSMGM63
       - id: RMCBoxMagazineRifleM54C
         box: CMMagazineRifleM54C
+      - id: RMCBoxMagazinePistolM77AP
+        box: CMMagazinePistolM77AP
+      - id: RMCBoxMagazineRevolverM44
+        box: RMCSpeedLoaderM44
+      - id: RMCBoxMagazinePistolM1984
+        box: CMMagazinePistolM1984
+      - id: RMCBoxMagazinePistolM13
+        box: RMCMagazinePistolM13
+    - name: Ammunition Boxes
+      hasBoxes: true
+      jobs:
+      - CMQuartermaster
+      - CMCargoTech
+      entries:
+      - id: RMCBoxBulletsRifle
+        name: rifle ammunition box (10x24mm) (M4SPR)
+        box: CMMagazineRifleM4SPR
+        boxSlots: 24 # 600 / 25
+      - id: RMCBoxBulletsSMG
+        name: SMG HV ammunition box (10x20mm) (M63)
+        box: CMMagazineSMGM63
+        boxSlots: 13 # 600 / 48, yes we loose half a mag to the void
+      - id: RMCBoxBulletsRifle
+        name: rifle ammunition box (10x24mm) (M54C)
+        box: CMMagazineRifleM54C
+        boxSlots: 15 # 600 / 40
+    - name: Other Boxes
+      hasBoxes: true
+      jobs:
+      - CMQuartermaster
+      - CMCargoTech
+      entries:
       - id: RMCBoxPackFlare
         box: CMPackFlare
 


### PR DESCRIPTION
## About the PR

title

## Why / Balance

requested by saani, more QOL

## Technical details

Same as the last QOL PR with sections only visible to the LO and any RT that has been given access,

## Media

<img width="742" height="873" alt="Screenshot From 2026-01-07 21-25-10" src="https://github.com/user-attachments/assets/46a9944e-332f-4752-b74d-bdfa3a936555" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: The logistics officer can now also vend filled pistol and bullet boxes from the vendors in the squad preparation areas.
