### PR TITLE
Give the M85 breech loading characteristics and cycling delay.

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m85a1_grenade_launcher.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m85a1_grenade_launcher.yml
@@ -5,16 +5,30 @@
   description: A heavy, low-angle, break-action 40mm grenade launcher. Archaic in core design, inferior to more modern semi automatic M92, M95 grenade launchers and M94 impact launcher, but doesn't require a magnetic armature or an advanced expertice to operate, not to mention near flawless reliability, extremely low cost and low weight due to mostly being made out of polymer materials.
   components:
   - type: Sprite
-    sprite: _RMC14/Objects/Weapons/Guns/GrenadeLaunchers/m85a1/m85a1_inhands.rsi
+    sprite: _RMC14/Objects/Weapons/Guns/GrenadeLaunchers/m85a1/m85a1_icon.rsi
     layers:
-    - sprite: _RMC14/Objects/Weapons/Guns/GrenadeLaunchers/m85a1/m85a1_icon.rsi
-      state: base
-      map: [ "enum.RMCMagazineVisuals.SlideOpen" ]
+    - state: base
+      map: [ "enum.BreechVisuals.Open" ]
+  - type: Appearance
+  - type: GenericVisualizer
+    visuals:
+      enum.BreechVisuals.Open:
+        enum.BreechVisuals.Open:
+          True: { state: bolt-open }
+          False: { state: base }
   - type: Clothing
     sprite: _RMC14/Objects/Weapons/Guns/GrenadeLaunchers/m85a1/m85a1_inhands.rsi
     slots:
     - Back
     - suitStorage
+  - type: ShootUseDelay
+  - type: UseDelay
+  - type: BreechLoaded
+    openSound:
+      path: /Audio/_RMC14/Weapons/Guns/Breech/pkd_open_chamber.ogg
+    closeSound:
+      path: /Audio/_RMC14/Weapons/Guns/Breech/pkd_close_chamber.ogg
+    toggleDelay: 1.1
   - type: Gun
     soundGunshot:
       path: /Audio/_RMC14/Weapons/Guns/Gunshots/m79_shoot.ogg

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m85a1_grenade_launcher.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m85a1_grenade_launcher.yml
@@ -5,9 +5,10 @@
   description: A heavy, low-angle, break-action 40mm grenade launcher. Archaic in core design, inferior to more modern semi automatic M92, M95 grenade launchers and M94 impact launcher, but doesn't require a magnetic armature or an advanced expertice to operate, not to mention near flawless reliability, extremely low cost and low weight due to mostly being made out of polymer materials.
   components:
   - type: Sprite
-    sprite: _RMC14/Objects/Weapons/Guns/GrenadeLaunchers/m85a1/m85a1_icon.rsi
+    sprite: _RMC14/Objects/Weapons/Guns/GrenadeLaunchers/m85a1/m85a1_inhands.rsi
     layers:
-    - state: base
+    - sprite: _RMC14/Objects/Weapons/Guns/GrenadeLaunchers/m85a1/m85a1_icon.rsi
+      state: base
       map: [ "enum.BreechVisuals.Open" ]
   - type: Appearance
   - type: GenericVisualizer


### PR DESCRIPTION
## About the PR
Replaced M85 loading characteristics with breech loading characteristics and MOU delay.

## Why / Balance
From an accuracy standpoint, the M85 is literally a breech-loaded weapon; as such, it makes sense for it to behave in accordance with one.

From a gameplay perspective, the M85 has had the capability to spam grenades, which in the right hands has been able to deliver on the same level of performance, if not better, than a grenadier specialist. In fact, some grenadiers eschew the use of their primary weapon in favor of the M85 and its ability to quick reload. This brings the M85 more in-line with other restricted weapons, as well as making the grenadier weapon the better-performing weapon for quick target saturation.

As a caveat, this PR is not a commentary on the adequacy of the performance of the grenadier specialist, or their primary weapon, but just as a means to circumvent the potentially overtuned performance of a non-specialist weapon.

## Technical details


## Media



https://github.com/user-attachments/assets/e8f35983-fa23-4ba9-b525-6624efb8e422




## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.


:cl:

- tweak: Converted the M85A1 to a breech-loaded weapon, with a breech delay.

