### PR TITLE
Fixes invalid weapon prototype in Solaris Crashlanding PMC scenario + Selection fix

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/rmc_planets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/rmc_planets.yml
@@ -54,7 +54,6 @@
     announcement: "Weston-Yamada has lost contact with one of its Biological Storage Facilities, Solaris Ridge, on the planet of LV-1413. The UNS Almayer has been requested to look into the blackout by Weston-Yamada."
     specialFaxes:
       Liaison: RMCPaperWeYaLiaisonBriefingSolaris
-    selectRandomSurvivorInsert: false
     nightmareScenarios:
     - scenarioName: clfmining
       scenarioProbability: 0.1

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Solaris/Crashlanding_Offices/base.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Solaris/Crashlanding_Offices/base.yml
@@ -50,7 +50,7 @@
     randomWeapon:
     - [ RMCWeaponRifleM54CWhiteNoLock, CMMagazineRifleM54C, CMMagazineRifleM54C]
     - [ RMCWeaponRifleSSG45NoLockStripped, RMCMagazineRifleSSG45, RMCMagazineRifleSSG45 ]
-    - [ CMBaseWeaponSMG, CMMagazineSMGM63, CMMagazineSMGM63 ]
+    - [ WeaponSMGM63, CMMagazineSMGM63, CMMagazineSMGM63 ]
     - [ RMCWeaponSMGFP9000PMC, RMCMagazineSMGFP9000, RMCMagazineSMGFP9000 ]
     - [ WeaponShotgunM890, CMShellShotgunBuckshot, CMShellShotgunBuckshot, CMShellShotgunBuckshot ]
     tryEquipRandomWeapon: true


### PR DESCRIPTION
## About the PR
PMC's on solaris offices crashlanding scenario should now correctly spawn with an M63

Also sets the SelectRandomSurvivorInsert bool on Solaris to true by default because otherwise according to others it would make some surv variants impossible to roll

## Why / Balance
Bugfix

## Technical details
Changes a weapon proto in pmc survivor weapons spawner to not reference an invalid prototype

## Media

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl: not player facing