### PR TITLE
Swap flash and stun baton paralyze times

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Melee/flash.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Melee/flash.yml
@@ -6,7 +6,7 @@
   components:
   - type: Flash
     slowTo: 0.25
-    meleeStunDuration: 20
+    meleeStunDuration: 12
     range: 3
   - type: Sprite
     sprite: _RMC14/Objects/Weapons/Melee/flash.rsi

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Melee/stun_baton.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Melee/stun_baton.yml
@@ -40,6 +40,7 @@
     skills:
       RMCSkillPolice: 1
   - type: StunOnHit
+    duration: 20
     whitelist:
       components:
       - Marine


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Stun baton is almost useless
- Flash stuns for longer
- Disabler can be used as melee

Swapping the times will give some more purpose to the stun baton

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: Swapped the flash's direct hit paralyze time and stun baton's paralyze time. The flash now stuns for 12 seconds and the baton for 20 seconds.