### PR TITLE
Fix motion detectors and data detectors turning off when smart-equipped

### DIFF
--- a/Content.Shared/_RMC14/Intel/Detector/IntelDetectorSystem.cs
+++ b/Content.Shared/_RMC14/Intel/Detector/IntelDetectorSystem.cs
@@ -134,7 +134,7 @@ public sealed class IntelDetectorSystem : EntitySystem
         }
     }
 
-    private void Toggle(Entity<IntelDetectorComponent> ent)
+    public void Toggle(Entity<IntelDetectorComponent> ent)
     {
         ref var enabled = ref ent.Comp.Enabled;
         enabled = !enabled;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
## About the PR
Makes sure motion detectors and data detectors stay on after using a keybind to equip them.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #8986 

## Technical details
The issue is with smart-equipping calling TryDrop(), since MDs and data detectors turn off when dropped. But I didn't modify that logic just in case it would break something, instead turning the detectors back on after smart equipping turns them off. This does mean the number on the MD sprite is set back to 0, but it should be fine.

## Media
The video shows detectors only being turned on after smart-equipping if they were previously on.

https://github.com/user-attachments/assets/0456270b-e0c5-4d70-91bd-fd0c7653b679

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed motion detectors and data detectors turning off when equipped using a keybind
