### PR TITLE
Allow toggling a data or motion detector using the interact key

### DIFF
--- a/Content.Shared/_RMC14/MotionDetector/MotionDetectorSystem.cs
+++ b/Content.Shared/_RMC14/MotionDetector/MotionDetectorSystem.cs
@@ -111,8 +111,7 @@ public sealed class MotionDetectorSystem : EntitySystem
 
         if (!_hands.IsHolding(args.User, ent.Owner) &&
             HasComp<StorageComponent>(container.Owner) &&
-            !_hands.IsHolding(args.User, container.Owner) &&
-            !_inventory.InSlotWithFlags(container.Owner, SlotFlags.BACK))
+            !_container.TryGetContainingContainer(container.Owner, out _))
             return;
 
         args.Handled = true;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
You can now toggle a data or motion detector with the interact key (default E) while it's in your hand, equipped to an inventory slot, or inside a storage that you are holding or wearing.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Quality of life change.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix: Data detectors and motion detectors can now be toggled with the interact key.
