### PR TITLE
Ignore slows on walk speed until sprinting is slower than walking

### DIFF
--- a/Content.Shared/Movement/Systems/SharedMoverController.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.cs
@@ -266,10 +266,11 @@ public abstract partial class SharedMoverController : VirtualController
             var sprintSpeed = moveSpeedComponent?.CurrentSprintSpeed ?? MovementSpeedModifierComponent.DefaultBaseSprintSpeed;
 
             // RMC14
-            // Ignore slows while walking if sprint speed is higher than walking speed
-            if (MovementSpeedModifierComponent.DefaultBaseWalkSpeed < sprintSpeed)
-                walkSpeed = MovementSpeedModifierComponent.DefaultBaseWalkSpeed;
-            // If you are slowed so much that sprinting is slower than walking, make walking speed the same as sprint speed.
+            var baseWalkSpeed = moveSpeedComponent?.BaseWalkSpeed ?? MovementSpeedModifierComponent.DefaultBaseWalkSpeed;
+            // Keep the walk speed unchanged if the modified sprint speed is higher than the base walk speed.
+            if (baseWalkSpeed < sprintSpeed)
+                walkSpeed = baseWalkSpeed;
+            // If the sprint speed drops below the walk speed, lower the walk speed to match the sprint speed.
             else
                 walkSpeed = sprintSpeed;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- Walking now ignores slows until sprint speed drops below base walk speed.
- Walking is now as fast as sprinting while sprint speed is lower than the base walk speed.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This change allows people wearing armor to walk(not sprint) at the same speed as people wearing no armor.

Example:
Base sprint speed of a human: 5
Base walk speed of a human: 2.7

**Before this PR:**

Slowed by 25%:

- Sprint speed = 3.75
- Walk speed = 2.025

Slowed by 50%:

- Sprint speed = 2.5
- Walk speed = 1.35

**After this PR:**

Slowed by 25%:

- Sprint speed = 3.75
- Walk speed = 2.7

Slowed by 50%:

- Sprint speed = 2.5
- Walk speed = 2.5

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- tweak: Walking ignores slows until sprint speed drops below the base walk speed.
- tweak: Walking is no longer slower than sprinting while sprint speed is lower than the base walk speed.
