### PR TITLE
Nightmare Insert: New Varadero - Varadero Pool Party (Non-Parity)

### DIFF
--- a/Resources/Maps/_RMC14/Inserts/Varadero/varadero_pool_party.yml
+++ b/Resources/Maps/_RMC14/Inserts/Varadero/varadero_pool_party.yml
@@ -1,0 +1,2638 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 264.0.2
+  forkId: ""
+  forkVersion: ""
+  time: 01/21/2026 14:56:22
+  entityCount: 441
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  0: Space
+  198: CMFloorPlating
+  3: CMFloorSteelShivaBlue0
+  4: CMFloorSteelShivaBlue1
+  7: CMFloorSteelShivaBlue2
+  5: CMFloorSteelShivaBlue3
+  9: CMFloorSteelShivaBlue4
+  10: CMFloorSteelShivaBlue5
+  12: CMFloorSteelShivaBlue6
+  11: CMFloorSteelShivaBlue7
+  2: CMFloorSteelShivaBlueFull3
+  1: CMFloorSteelShivaMultiTile
+  8: CMFloorSteelShivaMultiTile1
+  13: CMFloorSteelShivaMultiTile2
+  6: CMFloorSteelShivaPlate
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: grid
+    - type: Transform
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: xgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAADGAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAxgAAAAAAAAEAAAAAAAABAAAAAAAAAgAAAAAAAAMAAAAAAAAEAAAAAAAAAwAAAAAAAAQAAAAAAAADAAAAAAAABAAAAAAAAAMAAAAAAAAEAAAAAAAAAwAAAAAAAAQAAAAAAAACAAAAAAAAAQAAAAAAAMYAAAAAAAABAAAAAAAAAQAAAAAAAAUAAAAAAAAGAAAAAAAABgAAAAAAAAYAAAAAAAAGAAAAAAAABgAAAAAAAAYAAAAAAAAGAAAAAAAABgAAAAAAAAYAAAAAAAAGAAAAAAAABQAAAAAAAAEAAAAAAADGAAAAAAAAAQAAAAAAAAEAAAAAAAAHAAAAAAAABgAAAAAAAAYAAAAAAAAGAAAAAAAABgAAAAAAAAYAAAAAAAAGAAAAAAAABgAAAAAAAAYAAAAAAAAGAAAAAAAABgAAAAAAAAcAAAAAAAABAAAAAAAAxgAAAAAAAAEAAAAAAAABAAAAAAAABQAAAAAAAAYAAAAAAAAGAAAAAAAABgAAAAAAAAYAAAAAAAAGAAAAAAAABgAAAAAAAAYAAAAAAAAGAAAAAAAABgAAAAAAAAYAAAAAAAAFAAAAAAAAAQAAAAAAAMYAAAAAAAABAAAAAAAAAQAAAAAAAAcAAAAAAAAGAAAAAAAABgAAAAAAAAYAAAAAAAAGAAAAAAAABgAAAAAAAAYAAAAAAAAGAAAAAAAABgAAAAAAAAYAAAAAAAAGAAAAAAAABwAAAAAAAAEAAAAAAADGAAAAAAAAAQAAAAAAAAEAAAAAAAAFAAAAAAAABgAAAAAAAAYAAAAAAAAGAAAAAAAABgAAAAAAAAYAAAAAAAAGAAAAAAAABgAAAAAAAAYAAAAAAAAGAAAAAAAABgAAAAAAAAUAAAAAAAABAAAAAAAAxgAAAAAAAAEAAAAAAAABAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAAQAAAAAAAAgAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAIAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAACAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAMYAAAAAAAAJAAAAAAAAAQAAAAAAAAoAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAkAAAAAAAABAAAAAAAACgAAAAAAAAkAAAAAAAABAAAAAAAAAQAAAAAAAAoAAAAAAADGAAAAAAAABwAAAAAAAAEAAAAAAAAFAAAAAAAAxgAAAAAAAAYAAAAAAAAGAAAAAAAABgAAAAAAAAYAAAAAAADGAAAAAAAAAQAAAAAAAMYAAAAAAADGAAAAAAAAAQAAAAAAAAEAAAAAAADGAAAAAAAAxgAAAAAAAAcAAAAAAAABAAAAAAAABQAAAAAAAAYAAAAAAAAKAAAAAAAAAwAAAAAAAAMAAAAAAAAJAAAAAAAAxgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+        1,0:
+          ind: 1,0
+          tiles: xgAAAAAAAMYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAADGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAxgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAMYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAADGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAxgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAADGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAxgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAMYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAACwAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAwAAAAAAADGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAkAAAAAAAABAAAAAAAAAQAAAAAAAAoAAAAAAAADAAAAAAAACQAAAAAAAMYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAAQAAAAAAAAEAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+        0,1:
+          ind: 0,1
+          tiles: xgAAAAAAAAcAAAAAAAABAAAAAAAABQAAAAAAAAYAAAAAAAAFAAAAAAAADQAAAAAAAA0AAAAAAAAHAAAAAAAAxgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMYAAAAAAAAHAAAAAAAAAQAAAAAAAAUAAAAAAAAGAAAAAAAABQAAAAAAAA0AAAAAAAANAAAAAAAABwAAAAAAAMYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADGAAAAAAAABwAAAAAAAAEAAAAAAAAFAAAAAAAABgAAAAAAAAsAAAAAAAAEAAAAAAAABAAAAAAAAAwAAAAAAADGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxgAAAAAAAAcAAAAAAAABAAAAAAAABQAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMYAAAAAAAAHAAAAAAAAAQAAAAAAAAsAAAAAAADGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADGAAAAAAAABwAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxgAAAAAAAAcAAAAAAAABAAAAAAAACgAAAAAAAMYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMYAAAAAAADGAAAAAAAAAQAAAAAAAMYAAAAAAADGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+        0,-1:
+          ind: 0,-1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxgAAAAAAAMYAAAAAAAABAAAAAAAAxgAAAAAAAMYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMYAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAADGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADGAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAxgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxgAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAMYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMYAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAADGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADGAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAxgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxgAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAMYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMYAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAADGAAAAAAAAAAAAAAAAAA==
+          version: 7
+        -1,0:
+          ind: -1,0
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes: []
+    - type: GridAtmosphere
+      version: 2
+      data:
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: ImplicitRoof
+- proto: Basketball
+  entities:
+  - uid: 261
+    components:
+    - type: Transform
+      pos: 24.5,11.5
+      parent: 1
+- proto: BeachBall
+  entities:
+  - uid: 264
+    components:
+    - type: Transform
+      pos: 4.4998255,1.5949469
+      parent: 1
+  - uid: 265
+    components:
+    - type: Transform
+      pos: 11.6873255,7.594947
+      parent: 1
+- proto: CMAirlockGlassMedical
+  entities:
+  - uid: 105
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 25.5,12.5
+      parent: 1
+  - uid: 106
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 17.5,6.5
+      parent: 1
+  - uid: 107
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,14.5
+      parent: 1
+  - uid: 110
+    components:
+    - type: Transform
+      pos: 12.5,-7.5
+      parent: 1
+  - uid: 111
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,23.5
+      parent: 1
+  - uid: 139
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,15.5
+      parent: 1
+- proto: CMAirlockGlassSecurityLockedColony
+  entities:
+  - uid: 140
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,21.5
+      parent: 1
+- proto: CMAirlockMaintLockedColony
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 1
+  - uid: 108
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,12.5
+      parent: 1
+  - uid: 332
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,10.5
+      parent: 1
+- proto: CMApcNoPower
+  entities:
+  - uid: 280
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,15.5
+      parent: 1
+    - type: SpriteSetRenderOrder
+      offset: 0.7,-1.45
+- proto: CMBeltInflatable
+  entities:
+  - uid: 266
+    components:
+    - type: Transform
+      pos: 6.3435755,6.001197
+      parent: 1
+- proto: CMChair
+  entities:
+  - uid: 214
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,17.5
+      parent: 1
+  - uid: 215
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,16.5
+      parent: 1
+  - uid: 216
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,15.5
+      parent: 1
+  - uid: 217
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,15.5
+      parent: 1
+  - uid: 218
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,16.5
+      parent: 1
+  - uid: 219
+    components:
+    - type: Transform
+      pos: 6.5,18.5
+      parent: 1
+  - uid: 220
+    components:
+    - type: Transform
+      pos: 7.5,18.5
+      parent: 1
+  - uid: 238
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,7.5
+      parent: 1
+  - uid: 239
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 240
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,3.5
+      parent: 1
+  - uid: 257
+    components:
+    - type: Transform
+      pos: 16.5,3.5
+      parent: 1
+  - uid: 258
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 16.5,1.5
+      parent: 1
+  - uid: 385
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,1.5
+      parent: 1
+  - uid: 393
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,1.5
+      parent: 1
+  - uid: 395
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,-2.5
+      parent: 1
+  - uid: 396
+    components:
+    - type: Transform
+      pos: 13.5,-0.5
+      parent: 1
+- proto: CMChairComfy
+  entities:
+  - uid: 204
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,6.5
+      parent: 1
+- proto: CMChairFolded
+  entities:
+  - uid: 221
+    components:
+    - type: Transform
+      pos: 5.5,17.5
+      parent: 1
+- proto: CMDrinkCanCola
+  entities:
+  - uid: 399
+    components:
+    - type: Transform
+      pos: 13.6339445,-1.3082705
+      parent: 1
+- proto: CMDrinkCanIcedTea
+  entities:
+  - uid: 387
+    components:
+    - type: Transform
+      pos: 3.7433357,4.8991117
+      parent: 1
+- proto: CMDrinkCanLemonLime
+  entities:
+  - uid: 233
+    components:
+    - type: Transform
+      pos: 7.586799,17.627962
+      parent: 1
+- proto: CMDrinkWEYAWaterBottle30
+  entities:
+  - uid: 392
+    components:
+    - type: Transform
+      pos: 9.693767,1.8678617
+      parent: 1
+- proto: CMFirstAidKitFilled
+  entities:
+  - uid: 270
+    components:
+    - type: Transform
+      pos: 3.492957,1.525892
+      parent: 1
+- proto: CMHeadCapCargo
+  entities:
+  - uid: 391
+    components:
+    - type: Transform
+      pos: 8.263733,1.7099328
+      parent: 1
+- proto: CMMagazinePistolM1984
+  entities:
+  - uid: 403
+    components:
+    - type: Transform
+      pos: 1.5147734,13.819564
+      parent: 1
+- proto: CMPottedPlant21
+  entities:
+  - uid: 236
+    components:
+    - type: Transform
+      pos: 8.5,18.5
+      parent: 1
+- proto: CMPottedPlant22
+  entities:
+  - uid: 262
+    components:
+    - type: Transform
+      pos: 24.5,13.5
+      parent: 1
+- proto: CMRack
+  entities:
+  - uid: 84
+    components:
+    - type: Transform
+      pos: 14.5,1.5
+      parent: 1
+  - uid: 225
+    components:
+    - type: Transform
+      pos: 7.5,10.5
+      parent: 1
+  - uid: 231
+    components:
+    - type: Transform
+      pos: 10.5,10.5
+      parent: 1
+  - uid: 235
+    components:
+    - type: Transform
+      pos: 4.5,13.5
+      parent: 1
+  - uid: 244
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 245
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 259
+    components:
+    - type: Transform
+      pos: 24.5,11.5
+      parent: 1
+  - uid: 260
+    components:
+    - type: Transform
+      pos: 23.5,11.5
+      parent: 1
+- proto: CMSandbagFull5
+  entities:
+  - uid: 267
+    components:
+    - type: Transform
+      pos: 23.55122,11.547195
+      parent: 1
+- proto: CMSemioticAirlock
+  entities:
+  - uid: 272
+    components:
+    - type: Transform
+      pos: 4.737843,22.5
+      parent: 1
+  - uid: 273
+    components:
+    - type: Transform
+      pos: 0.70659304,16.5
+      parent: 1
+  - uid: 274
+    components:
+    - type: Transform
+      pos: 9.859963,14.5
+      parent: 1
+- proto: CMSemioticWater
+  entities:
+  - uid: 275
+    components:
+    - type: Transform
+      pos: 3.5,9.5
+      parent: 1
+  - uid: 276
+    components:
+    - type: Transform
+      pos: 15,9.5
+      parent: 1
+- proto: CMTable
+  entities:
+  - uid: 209
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,17.5
+      parent: 1
+  - uid: 211
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,16.5
+      parent: 1
+  - uid: 212
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,17.5
+      parent: 1
+  - uid: 213
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,16.5
+      parent: 1
+  - uid: 243
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 16.5,2.5
+      parent: 1
+  - uid: 386
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,1.5
+      parent: 1
+  - uid: 394
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-1.5
+      parent: 1
+- proto: CMVendorCoffee
+  entities:
+  - uid: 397
+    components:
+    - type: Transform
+      pos: 12.5,13.5
+      parent: 1
+- proto: CMVendorCola
+  entities:
+  - uid: 254
+    components:
+    - type: Transform
+      pos: 11.5,-3.5
+      parent: 1
+- proto: CMVendorSnack
+  entities:
+  - uid: 255
+    components:
+    - type: Transform
+      pos: 11.5,-4.5
+      parent: 1
+- proto: CMVentPump
+  entities:
+  - uid: 380
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,1.5
+      parent: 1
+- proto: CMWallMetal
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      pos: 4.5,22.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      pos: 14.5,-7.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      pos: 14.5,-5.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      pos: 14.5,-3.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      pos: 14.5,-1.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      pos: 14.5,0.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      pos: 15.5,0.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      pos: 17.5,0.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      pos: 17.5,2.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: 17.5,3.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      pos: 17.5,8.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      pos: 17.5,9.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      pos: 17.5,7.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      pos: 17.5,10.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      pos: 23.5,10.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      pos: 24.5,10.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      pos: 25.5,10.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      pos: 25.5,14.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      pos: 24.5,14.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      pos: 9.5,14.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      pos: 9.5,15.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      pos: 9.5,19.5
+      parent: 1
+  - uid: 74
+    components:
+    - type: Transform
+      pos: 8.5,19.5
+      parent: 1
+  - uid: 75
+    components:
+    - type: Transform
+      pos: 6.5,19.5
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      pos: 4.5,19.5
+      parent: 1
+  - uid: 79
+    components:
+    - type: Transform
+      pos: 4.5,23.5
+      parent: 1
+  - uid: 80
+    components:
+    - type: Transform
+      pos: 0.5,23.5
+      parent: 1
+  - uid: 81
+    components:
+    - type: Transform
+      pos: 0.5,22.5
+      parent: 1
+  - uid: 87
+    components:
+    - type: Transform
+      pos: 0.5,20.5
+      parent: 1
+  - uid: 90
+    components:
+    - type: Transform
+      pos: 0.5,17.5
+      parent: 1
+  - uid: 91
+    components:
+    - type: Transform
+      pos: 0.5,16.5
+      parent: 1
+  - uid: 93
+    components:
+    - type: Transform
+      pos: 0.5,13.5
+      parent: 1
+  - uid: 101
+    components:
+    - type: Transform
+      pos: -0.5,13.5
+      parent: 1
+- proto: CMWallReinforced
+  entities:
+  - uid: 4
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 5
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 6
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      pos: 10.5,0.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      pos: 10.5,-0.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: 10.5,-2.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      pos: 10.5,-3.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      pos: 10.5,-4.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      pos: 10.5,-5.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      pos: 10.5,-7.5
+      parent: 1
+  - uid: 97
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 98
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 99
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 100
+    components:
+    - type: Transform
+      pos: 0.5,9.5
+      parent: 1
+  - uid: 102
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+  - uid: 141
+    components:
+    - type: Transform
+      pos: 4.5,14.5
+      parent: 1
+  - uid: 198
+    components:
+    - type: Transform
+      pos: 10.5,9.5
+      parent: 1
+  - uid: 201
+    components:
+    - type: Transform
+      pos: 4.5,9.5
+      parent: 1
+  - uid: 202
+    components:
+    - type: Transform
+      pos: 3.5,9.5
+      parent: 1
+  - uid: 207
+    components:
+    - type: Transform
+      pos: 13.5,9.5
+      parent: 1
+  - uid: 208
+    components:
+    - type: Transform
+      pos: 14.5,9.5
+      parent: 1
+  - uid: 435
+    components:
+    - type: Transform
+      pos: 7.5,9.5
+      parent: 1
+- proto: CMWardrobeBlue
+  entities:
+  - uid: 226
+    components:
+    - type: Transform
+      pos: 8.5,10.5
+      parent: 1
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 227
+          - 228
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+  - uid: 229
+    components:
+    - type: Transform
+      pos: 9.5,10.5
+      parent: 1
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 230
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: CMWeaponPistolM1984
+  entities:
+  - uid: 152
+    components:
+    - type: Transform
+      pos: 2.0460234,14.053939
+      parent: 1
+- proto: CMWindowWhiteColony
+  entities:
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 14.5,-6.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: 14.5,-4.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      pos: 14.5,-2.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      pos: 14.5,-0.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      pos: 16.5,0.5
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      pos: 17.5,1.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      pos: 17.5,4.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      pos: 17.5,5.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      pos: 18.5,10.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      pos: 19.5,10.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      pos: 20.5,10.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      pos: 21.5,10.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      pos: 22.5,10.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: 25.5,11.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      pos: 25.5,13.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      pos: 23.5,14.5
+      parent: 1
+  - uid: 60
+    components:
+    - type: Transform
+      pos: 22.5,14.5
+      parent: 1
+  - uid: 61
+    components:
+    - type: Transform
+      pos: 19.5,14.5
+      parent: 1
+  - uid: 62
+    components:
+    - type: Transform
+      pos: 18.5,14.5
+      parent: 1
+  - uid: 63
+    components:
+    - type: Transform
+      pos: 17.5,14.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      pos: 16.5,14.5
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      pos: 15.5,14.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      pos: 12.5,14.5
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      pos: 11.5,14.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      pos: 9.5,16.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      pos: 9.5,17.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      pos: 9.5,18.5
+      parent: 1
+  - uid: 77
+    components:
+    - type: Transform
+      pos: 7.5,19.5
+      parent: 1
+  - uid: 78
+    components:
+    - type: Transform
+      pos: 5.5,19.5
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      pos: 1.5,23.5
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      pos: 3.5,23.5
+      parent: 1
+  - uid: 85
+    components:
+    - type: Transform
+      pos: 4.5,20.5
+      parent: 1
+  - uid: 86
+    components:
+    - type: Transform
+      pos: 0.5,21.5
+      parent: 1
+  - uid: 88
+    components:
+    - type: Transform
+      pos: 0.5,19.5
+      parent: 1
+  - uid: 89
+    components:
+    - type: Transform
+      pos: 0.5,18.5
+      parent: 1
+  - uid: 92
+    components:
+    - type: Transform
+      pos: 0.5,14.5
+      parent: 1
+  - uid: 103
+    components:
+    - type: Transform
+      pos: -0.5,11.5
+      parent: 1
+- proto: CMWindowWhiteColonyReinforced
+  entities:
+  - uid: 7
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      pos: 8.5,0.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      pos: 9.5,0.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      pos: 10.5,-1.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      pos: 10.5,-6.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      pos: 11.5,-7.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      pos: 13.5,-7.5
+      parent: 1
+  - uid: 94
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 95
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 96
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 1
+  - uid: 196
+    components:
+    - type: Transform
+      pos: 9.5,9.5
+      parent: 1
+  - uid: 199
+    components:
+    - type: Transform
+      pos: 12.5,9.5
+      parent: 1
+  - uid: 200
+    components:
+    - type: Transform
+      pos: 11.5,9.5
+      parent: 1
+  - uid: 205
+    components:
+    - type: Transform
+      pos: 5.5,9.5
+      parent: 1
+  - uid: 206
+    components:
+    - type: Transform
+      pos: 6.5,9.5
+      parent: 1
+  - uid: 436
+    components:
+    - type: Transform
+      pos: 8.5,9.5
+      parent: 1
+- proto: RMCBarricadeWireRailAltDrawdepth
+  entities:
+  - uid: 440
+    components:
+    - type: Transform
+      pos: 14.5,7.5
+      parent: 1
+  - uid: 441
+    components:
+    - type: Transform
+      pos: 14.5,6.5
+      parent: 1
+- proto: RMCBaseballBat
+  entities:
+  - uid: 237
+    components:
+    - type: Transform
+      pos: 4.4578285,13.561568
+      parent: 1
+- proto: RMCBeerPack
+  entities:
+  - uid: 223
+    components:
+    - type: Transform
+      pos: 7.3090568,16.857845
+      parent: 1
+  - uid: 234
+    components:
+    - type: Transform
+      pos: 6.5,16.5
+      parent: 1
+- proto: RMCBoonie
+  entities:
+  - uid: 242
+    components:
+    - type: Transform
+      pos: 3.2247648,7.6904235
+      parent: 1
+- proto: RMCBoxPizzaRandom
+  entities:
+  - uid: 222
+    components:
+    - type: Transform
+      pos: 6.6996818,17.71722
+      parent: 1
+- proto: RMCColourableRugRed
+  entities:
+  - uid: 241
+    components:
+    - type: MetaData
+      name: beach towel
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.27164,2.9247985
+      parent: 1
+- proto: RMCCrateLarge
+  entities:
+  - uid: 382
+    components:
+    - type: Transform
+      pos: 6.5,10.5
+      parent: 1
+- proto: RMCDecalSpawnerBloodSplatters
+  entities:
+  - uid: 416
+    components:
+    - type: Transform
+      pos: 1.5,14.5
+      parent: 1
+  - uid: 417
+    components:
+    - type: Transform
+      pos: 7.5,15.5
+      parent: 1
+  - uid: 418
+    components:
+    - type: Transform
+      pos: 8.5,16.5
+      parent: 1
+  - uid: 419
+    components:
+    - type: Transform
+      pos: 8.5,17.5
+      parent: 1
+  - uid: 420
+    components:
+    - type: Transform
+      pos: 6.5,18.5
+      parent: 1
+  - uid: 421
+    components:
+    - type: Transform
+      pos: 18.5,12.5
+      parent: 1
+  - uid: 422
+    components:
+    - type: Transform
+      pos: 14.5,6.5
+      parent: 1
+  - uid: 423
+    components:
+    - type: Transform
+      pos: 11.5,3.5
+      parent: 1
+  - uid: 424
+    components:
+    - type: Transform
+      pos: 6.5,3.5
+      parent: 1
+  - uid: 425
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 426
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 1
+  - uid: 427
+    components:
+    - type: Transform
+      pos: 10.5,1.5
+      parent: 1
+  - uid: 428
+    components:
+    - type: Transform
+      pos: 15.5,3.5
+      parent: 1
+  - uid: 429
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 430
+    components:
+    - type: Transform
+      pos: 8.5,15.5
+      parent: 1
+  - uid: 431
+    components:
+    - type: Transform
+      pos: 3.5,19.5
+      parent: 1
+  - uid: 432
+    components:
+    - type: Transform
+      pos: 9.5,11.5
+      parent: 1
+  - uid: 434
+    components:
+    - type: Transform
+      pos: 2.5,22.5
+      parent: 1
+  - uid: 438
+    components:
+    - type: Transform
+      pos: 13.5,-3.5
+      parent: 1
+  - uid: 439
+    components:
+    - type: Transform
+      pos: 5.5,13.5
+      parent: 1
+- proto: RMCDoubleDoorGenericGlass
+  entities:
+  - uid: 104
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,14.5
+      parent: 1
+  - uid: 112
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,14.5
+      parent: 1
+  - uid: 203
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,9.5
+      parent: 1
+  - uid: 210
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,9.5
+      parent: 1
+- proto: RMCDrinkCanSequoiaBeer
+  entities:
+  - uid: 268
+    components:
+    - type: Transform
+      pos: 3.681511,7.9073763
+      parent: 1
+- proto: RMCEntityDesertWaterShallow
+  entities:
+  - uid: 143
+    components:
+    - type: Transform
+      pos: 6.5,8.5
+      parent: 1
+  - uid: 146
+    components:
+    - type: Transform
+      pos: 4.5,8.5
+      parent: 1
+  - uid: 147
+    components:
+    - type: Transform
+      pos: 5.5,8.5
+      parent: 1
+  - uid: 148
+    components:
+    - type: Transform
+      pos: 4.5,7.5
+      parent: 1
+  - uid: 149
+    components:
+    - type: Transform
+      pos: 5.5,7.5
+      parent: 1
+  - uid: 155
+    components:
+    - type: Transform
+      pos: 9.5,8.5
+      parent: 1
+  - uid: 157
+    components:
+    - type: Transform
+      pos: 10.5,8.5
+      parent: 1
+  - uid: 159
+    components:
+    - type: Transform
+      pos: 11.5,8.5
+      parent: 1
+  - uid: 160
+    components:
+    - type: Transform
+      pos: 11.5,7.5
+      parent: 1
+  - uid: 161
+    components:
+    - type: Transform
+      pos: 12.5,8.5
+      parent: 1
+  - uid: 162
+    components:
+    - type: Transform
+      pos: 12.5,7.5
+      parent: 1
+  - uid: 163
+    components:
+    - type: Transform
+      pos: 13.5,8.5
+      parent: 1
+  - uid: 164
+    components:
+    - type: Transform
+      pos: 13.5,7.5
+      parent: 1
+  - uid: 165
+    components:
+    - type: Transform
+      pos: 13.5,4.5
+      parent: 1
+  - uid: 166
+    components:
+    - type: Transform
+      pos: 13.5,5.5
+      parent: 1
+  - uid: 167
+    components:
+    - type: Transform
+      pos: 13.5,6.5
+      parent: 1
+  - uid: 168
+    components:
+    - type: Transform
+      pos: 12.5,4.5
+      parent: 1
+  - uid: 169
+    components:
+    - type: Transform
+      pos: 12.5,5.5
+      parent: 1
+  - uid: 170
+    components:
+    - type: Transform
+      pos: 12.5,6.5
+      parent: 1
+  - uid: 171
+    components:
+    - type: Transform
+      pos: 11.5,4.5
+      parent: 1
+  - uid: 174
+    components:
+    - type: Transform
+      pos: 10.5,4.5
+      parent: 1
+  - uid: 177
+    components:
+    - type: Transform
+      pos: 9.5,4.5
+      parent: 1
+  - uid: 180
+    components:
+    - type: Transform
+      pos: 8.5,4.5
+      parent: 1
+  - uid: 183
+    components:
+    - type: Transform
+      pos: 7.5,4.5
+      parent: 1
+  - uid: 186
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 1
+  - uid: 187
+    components:
+    - type: Transform
+      pos: 6.5,5.5
+      parent: 1
+  - uid: 188
+    components:
+    - type: Transform
+      pos: 6.5,6.5
+      parent: 1
+  - uid: 189
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 1
+  - uid: 190
+    components:
+    - type: Transform
+      pos: 5.5,5.5
+      parent: 1
+  - uid: 191
+    components:
+    - type: Transform
+      pos: 5.5,6.5
+      parent: 1
+  - uid: 192
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 193
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 194
+    components:
+    - type: Transform
+      pos: 4.5,6.5
+      parent: 1
+  - uid: 412
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 1
+- proto: RMCFloorShallowWaterEntityDarkRed
+  entities:
+  - uid: 175
+    components:
+    - type: Transform
+      pos: 10.5,6.5
+      parent: 1
+  - uid: 178
+    components:
+    - type: Transform
+      pos: 9.5,6.5
+      parent: 1
+  - uid: 197
+    components:
+    - type: Transform
+      pos: 7.5,7.5
+      parent: 1
+  - uid: 414
+    components:
+    - type: Transform
+      pos: 8.5,7.5
+      parent: 1
+- proto: RMCFloorShallowWaterEntityRed
+  entities:
+  - uid: 156
+    components:
+    - type: Transform
+      pos: 8.5,8.5
+      parent: 1
+  - uid: 172
+    components:
+    - type: Transform
+      pos: 8.5,5.5
+      parent: 1
+  - uid: 173
+    components:
+    - type: Transform
+      pos: 11.5,5.5
+      parent: 1
+  - uid: 176
+    components:
+    - type: Transform
+      pos: 10.5,7.5
+      parent: 1
+  - uid: 179
+    components:
+    - type: Transform
+      pos: 9.5,7.5
+      parent: 1
+  - uid: 181
+    components:
+    - type: Transform
+      pos: 7.5,8.5
+      parent: 1
+  - uid: 184
+    components:
+    - type: Transform
+      pos: 6.5,7.5
+      parent: 1
+  - uid: 195
+    components:
+    - type: Transform
+      pos: 7.5,6.5
+      parent: 1
+  - uid: 408
+    components:
+    - type: Transform
+      pos: 11.5,6.5
+      parent: 1
+  - uid: 410
+    components:
+    - type: Transform
+      pos: 8.5,6.5
+      parent: 1
+  - uid: 411
+    components:
+    - type: Transform
+      pos: 9.5,5.5
+      parent: 1
+  - uid: 413
+    components:
+    - type: Transform
+      pos: 10.5,5.5
+      parent: 1
+- proto: RMCFoodSnackChipsPepper
+  entities:
+  - uid: 388
+    components:
+    - type: Transform
+      pos: 12.066888,3.581458
+      parent: 1
+- proto: RMCGasPipeBend
+  entities:
+  - uid: 305
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,2.5
+      parent: 1
+  - uid: 307
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,2.5
+      parent: 1
+- proto: RMCGasPipeStraight
+  entities:
+  - uid: 109
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,15.5
+      parent: 1
+  - uid: 291
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,15.5
+      parent: 1
+  - uid: 294
+    components:
+    - type: Transform
+      pos: 12.5,-7.5
+      parent: 1
+  - uid: 295
+    components:
+    - type: Transform
+      pos: 12.5,-6.5
+      parent: 1
+  - uid: 296
+    components:
+    - type: Transform
+      pos: 12.5,-5.5
+      parent: 1
+  - uid: 297
+    components:
+    - type: Transform
+      pos: 12.5,-4.5
+      parent: 1
+  - uid: 298
+    components:
+    - type: Transform
+      pos: 12.5,-3.5
+      parent: 1
+  - uid: 299
+    components:
+    - type: Transform
+      pos: 12.5,-2.5
+      parent: 1
+  - uid: 300
+    components:
+    - type: Transform
+      pos: 12.5,-1.5
+      parent: 1
+  - uid: 301
+    components:
+    - type: Transform
+      pos: 12.5,-0.5
+      parent: 1
+  - uid: 302
+    components:
+    - type: Transform
+      pos: 12.5,0.5
+      parent: 1
+  - uid: 303
+    components:
+    - type: Transform
+      pos: 12.5,1.5
+      parent: 1
+  - uid: 306
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,2.5
+      parent: 1
+  - uid: 308
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,2.5
+      parent: 1
+  - uid: 309
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,2.5
+      parent: 1
+  - uid: 310
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,2.5
+      parent: 1
+  - uid: 311
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,2.5
+      parent: 1
+  - uid: 312
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,2.5
+      parent: 1
+  - uid: 313
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 314
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 316
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 317
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 318
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 319
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 320
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 321
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 322
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,9.5
+      parent: 1
+  - uid: 324
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,10.5
+      parent: 1
+  - uid: 325
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,10.5
+      parent: 1
+  - uid: 326
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,10.5
+      parent: 1
+  - uid: 328
+    components:
+    - type: Transform
+      pos: 2.5,11.5
+      parent: 1
+  - uid: 329
+    components:
+    - type: Transform
+      pos: 2.5,12.5
+      parent: 1
+  - uid: 331
+    components:
+    - type: Transform
+      pos: 2.5,14.5
+      parent: 1
+  - uid: 334
+    components:
+    - type: Transform
+      pos: 2.5,16.5
+      parent: 1
+  - uid: 335
+    components:
+    - type: Transform
+      pos: 2.5,17.5
+      parent: 1
+  - uid: 336
+    components:
+    - type: Transform
+      pos: 2.5,18.5
+      parent: 1
+  - uid: 337
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,19.5
+      parent: 1
+  - uid: 338
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,19.5
+      parent: 1
+  - uid: 339
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,20.5
+      parent: 1
+  - uid: 340
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,21.5
+      parent: 1
+  - uid: 341
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,22.5
+      parent: 1
+  - uid: 342
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,23.5
+      parent: 1
+  - uid: 343
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,13.5
+      parent: 1
+  - uid: 344
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,13.5
+      parent: 1
+  - uid: 345
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,13.5
+      parent: 1
+  - uid: 346
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,13.5
+      parent: 1
+  - uid: 347
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,13.5
+      parent: 1
+  - uid: 348
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,13.5
+      parent: 1
+  - uid: 349
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,13.5
+      parent: 1
+  - uid: 350
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,13.5
+      parent: 1
+  - uid: 351
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,13.5
+      parent: 1
+  - uid: 352
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,13.5
+      parent: 1
+  - uid: 353
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,13.5
+      parent: 1
+  - uid: 354
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,13.5
+      parent: 1
+  - uid: 356
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,2.5
+      parent: 1
+  - uid: 357
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,2.5
+      parent: 1
+  - uid: 358
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 16.5,6.5
+      parent: 1
+  - uid: 359
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 17.5,6.5
+      parent: 1
+  - uid: 360
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,5.5
+      parent: 1
+  - uid: 361
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,4.5
+      parent: 1
+  - uid: 362
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,3.5
+      parent: 1
+  - uid: 363
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,7.5
+      parent: 1
+  - uid: 364
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,8.5
+      parent: 1
+  - uid: 365
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,9.5
+      parent: 1
+  - uid: 366
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,10.5
+      parent: 1
+  - uid: 367
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,11.5
+      parent: 1
+  - uid: 368
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,12.5
+      parent: 1
+  - uid: 370
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 16.5,13.5
+      parent: 1
+  - uid: 371
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 17.5,13.5
+      parent: 1
+  - uid: 372
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 18.5,13.5
+      parent: 1
+  - uid: 373
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 19.5,13.5
+      parent: 1
+  - uid: 374
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 20.5,13.5
+      parent: 1
+  - uid: 375
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 21.5,13.5
+      parent: 1
+  - uid: 376
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 22.5,13.5
+      parent: 1
+  - uid: 377
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 23.5,13.5
+      parent: 1
+  - uid: 378
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 24.5,13.5
+      parent: 1
+  - uid: 379
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 25.5,13.5
+      parent: 1
+- proto: RMCGasPipeTJunction
+  entities:
+  - uid: 304
+    components:
+    - type: Transform
+      pos: 12.5,2.5
+      parent: 1
+  - uid: 315
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 323
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 327
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,13.5
+      parent: 1
+  - uid: 330
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,15.5
+      parent: 1
+  - uid: 333
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,19.5
+      parent: 1
+  - uid: 355
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,6.5
+      parent: 1
+  - uid: 369
+    components:
+    - type: Transform
+      pos: 15.5,13.5
+      parent: 1
+- proto: RMCJumpsuitLiaisonCargoShorts
+  entities:
+  - uid: 230
+    components:
+    - type: Transform
+      parent: 229
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: RMCJumpsuitRedShorts
+  entities:
+  - uid: 228
+    components:
+    - type: Transform
+      parent: 226
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: RMCLightFixtureOffset
+  entities:
+  - uid: 277
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,-3.5
+      parent: 1
+  - uid: 278
+    components:
+    - type: Transform
+      pos: 14.5,1.5
+      parent: 1
+  - uid: 279
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 1
+  - uid: 281
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 16.5,7.5
+      parent: 1
+  - uid: 282
+    components:
+    - type: Transform
+      pos: 13.5,10.5
+      parent: 1
+  - uid: 283
+    components:
+    - type: Transform
+      pos: 4.5,10.5
+      parent: 1
+  - uid: 284
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,17.5
+      parent: 1
+  - uid: 285
+    components:
+    - type: Transform
+      pos: 23.5,11.5
+      parent: 1
+  - uid: 286
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,8.5
+      parent: 1
+  - uid: 287
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,8.5
+      parent: 1
+  - uid: 288
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,15.5
+      parent: 1
+  - uid: 289
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,18.5
+      parent: 1
+  - uid: 290
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,20.5
+      parent: 1
+  - uid: 292
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 293
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,2.5
+      parent: 1
+- proto: RMCPlatformKutjevoSM
+  entities:
+  - uid: 114
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,8.5
+      parent: 1
+  - uid: 119
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,7.5
+      parent: 1
+  - uid: 121
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,8.5
+      parent: 1
+  - uid: 122
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,8.5
+      parent: 1
+  - uid: 123
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,8.5
+      parent: 1
+  - uid: 124
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,8.5
+      parent: 1
+  - uid: 125
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,8.5
+      parent: 1
+  - uid: 126
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,8.5
+      parent: 1
+  - uid: 127
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,8.5
+      parent: 1
+  - uid: 128
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,7.5
+      parent: 1
+  - uid: 129
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,6.5
+      parent: 1
+  - uid: 130
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,5.5
+      parent: 1
+  - uid: 131
+    components:
+    - type: Transform
+      pos: 12.5,4.5
+      parent: 1
+  - uid: 132
+    components:
+    - type: Transform
+      pos: 11.5,4.5
+      parent: 1
+  - uid: 133
+    components:
+    - type: Transform
+      pos: 10.5,4.5
+      parent: 1
+  - uid: 134
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 135
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,6.5
+      parent: 1
+  - uid: 136
+    components:
+    - type: Transform
+      pos: 7.5,4.5
+      parent: 1
+  - uid: 137
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 1
+  - uid: 138
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 1
+  - uid: 142
+    components:
+    - type: Transform
+      pos: 14.5,7.5
+      parent: 1
+  - uid: 144
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,6.5
+      parent: 1
+  - uid: 145
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,5.5
+      parent: 1
+- proto: RMCPlatformKutjevoSMCorner
+  entities:
+  - uid: 115
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,8.5
+      parent: 1
+  - uid: 116
+    components:
+    - type: Transform
+      pos: 13.5,4.5
+      parent: 1
+  - uid: 117
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 118
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,8.5
+      parent: 1
+- proto: RMCSecureCaseDouble
+  entities:
+  - uid: 381
+    components:
+    - type: Transform
+      pos: 5.5,10.5
+      parent: 1
+  - uid: 383
+    components:
+    - type: Transform
+      pos: 17.5,13.5
+      parent: 1
+- proto: RMCSecureCaseMini
+  entities:
+  - uid: 384
+    components:
+    - type: Transform
+      pos: 18.5,13.5
+      parent: 1
+- proto: RMCSecureCaseSmall
+  entities:
+  - uid: 256
+    components:
+    - type: Transform
+      pos: 13.5,-6.5
+      parent: 1
+- proto: RMCShoesSandals
+  entities:
+  - uid: 389
+    components:
+    - type: Transform
+      pos: 7.097314,3.6786828
+      parent: 1
+- proto: RMCSpawnerCorpseBeachBum
+  entities:
+  - uid: 153
+    components:
+    - type: Transform
+      pos: 6.5,3.5
+      parent: 1
+  - uid: 158
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 1
+  - uid: 185
+    components:
+    - type: Transform
+      pos: 8.5,17.5
+      parent: 1
+  - uid: 400
+    components:
+    - type: Transform
+      pos: 10.5,6.5
+      parent: 1
+  - uid: 401
+    components:
+    - type: Transform
+      pos: 7.5,7.5
+      parent: 1
+  - uid: 409
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+- proto: RMCSpawnerCorpseUNPeacekeeper
+  entities:
+  - uid: 402
+    components:
+    - type: Transform
+      pos: 1.5,14.5
+      parent: 1
+  - uid: 404
+    components:
+    - type: Transform
+      pos: 14.5,6.5
+      parent: 1
+- proto: RMCSpawnerCorpseVaraderoCargoTechnician
+  entities:
+  - uid: 405
+    components:
+    - type: Transform
+      pos: 18.5,12.5
+      parent: 1
+  - uid: 406
+    components:
+    - type: Transform
+      pos: 6.5,18.5
+      parent: 1
+  - uid: 407
+    components:
+    - type: Transform
+      pos: 8.5,16.5
+      parent: 1
+  - uid: 415
+    components:
+    - type: Transform
+      pos: 10.5,1.5
+      parent: 1
+  - uid: 433
+    components:
+    - type: Transform
+      pos: 9.5,11.5
+      parent: 1
+- proto: RMCSpawnerCorpseVaraderoTechnician
+  entities:
+  - uid: 154
+    components:
+    - type: Transform
+      pos: 7.5,15.5
+      parent: 1
+  - uid: 182
+    components:
+    - type: Transform
+      pos: 11.5,3.5
+      parent: 1
+- proto: RMCSpawnerIntelClose
+  entities:
+  - uid: 224
+    components:
+    - type: Transform
+      pos: 7.5,16.5
+      parent: 1
+  - uid: 271
+    components:
+    - type: Transform
+      pos: 16.5,2.5
+      parent: 1
+- proto: RMCSpawnerIntelMedium
+  entities:
+  - uid: 232
+    components:
+    - type: Transform
+      pos: 10.5,10.5
+      parent: 1
+- proto: RMCSpawnerRandomToolbox
+  entities:
+  - uid: 263
+    components:
+    - type: Transform
+      pos: 7.5,10.5
+      parent: 1
+- proto: RMCStairsKutjevo
+  entities:
+  - uid: 113
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,4.5
+      parent: 1
+  - uid: 120
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,4.5
+      parent: 1
+- proto: RMCStreamerHorizonOffset
+  entities:
+  - uid: 246
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,18.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 247
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,17.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 248
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,16.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 249
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,15.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 250
+    components:
+    - type: Transform
+      pos: 8.5,13.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 253
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,14.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: RMCStreamerPoleHorizonOffset1
+  entities:
+  - uid: 252
+    components:
+    - type: Transform
+      pos: 7.5,13.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: RMCStreamerPoleHorizonOffset3
+  entities:
+  - uid: 251
+    components:
+    - type: Transform
+      pos: 6.5,13.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: RMCSunglasses
+  entities:
+  - uid: 269
+    components:
+    - type: Transform
+      pos: 14.53007,1.6030483
+      parent: 1
+- proto: RMCVendorCigsElectro
+  entities:
+  - uid: 398
+    components:
+    - type: Transform
+      pos: 11.5,13.5
+      parent: 1
+- proto: RMCWallPropBloodWall
+  entities:
+  - uid: 437
+    components:
+    - type: Transform
+      pos: 19.526672,10.791694
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: RMCWallPropBloodWallAlt
+  entities:
+  - uid: 150
+    components:
+    - type: Transform
+      pos: 18.549093,14.760444
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 151
+    components:
+    - type: Transform
+      pos: 9.233312,9.7743225
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: RMCWhistle
+  entities:
+  - uid: 390
+    components:
+    - type: Transform
+      pos: 14.222314,6.819308
+      parent: 1
+- proto: UniformShortsRed
+  entities:
+  - uid: 227
+    components:
+    - type: Transform
+      parent: 226
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+...

--- a/Resources/Prototypes/_RMC14/Entities/Markers/Inserts/varadero.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Markers/Inserts/varadero.yml
@@ -20,3 +20,17 @@
     - spawn: "/Maps/_RMC14/Inserts/Varadero/clf_raid.yml"
       probability: 1
       nightmareScenario: clfraid_varadero
+
+- type: entity
+  parent: RMCMapInsertVaraderoBase
+  id: RMCMapInsertVaraderoPoolParty
+  name: Varadero Pool Party
+  suffix: Insert Varadero
+  components:
+  - type: MapInsert
+    clearEntities: true
+    clearDecals: true
+    replaceAreas: false
+    variations:
+    - spawn: "/Maps/_RMC14/Inserts/Varadero/varadero_pool_party.yml"
+      probability: 0.15

--- a/Resources/Prototypes/_RMC14/Entities/Markers/Spawners/Corpses/civilians.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Markers/Spawners/Corpses/civilians.yml
@@ -139,6 +139,38 @@
 
 - type: entity
   parent: RMCSpawnerCorpse
+  id: RMCSpawnerCorpseBeachBum
+  name: Corpse Spawner - Beach Bum
+  components:
+  - type: CorpseSpawner
+    spawn: RMCCorpseColonistBeachBum
+
+- type: entity
+  parent: RMCSpawnerCorpse
+  id: RMCSpawnerCorpseVaraderoTechnician
+  name: Corpse Spawner - New Varadero Technician
+  components:
+  - type: CorpseSpawner
+    spawn: RMCCorpseVaraderoTechnician
+
+- type: entity
+  parent: RMCSpawnerCorpse
+  id: RMCSpawnerCorpseVaraderoCargoTechnician
+  name: Corpse Spawner - New Varadero Cargo Technician
+  components:
+  - type: CorpseSpawner
+    spawn: RMCCorpseCargoTechnician
+
+- type: entity
+  parent: RMCSpawnerCorpse
+  id: RMCSpawnerCorpseUNPeacekeeper
+  name: Corpse Spawner - UN Peacekeeper
+  components:
+  - type: CorpseSpawner
+    spawn: RMCCorpseUNPeacekeeper
+
+- type: entity
+  parent: RMCSpawnerCorpse
   id: RMCSpawnerCorpseCLF
   name: Corpse Spawner - CLF Soldier
   components:

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Corpses/civilians.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Corpses/civilians.yml
@@ -261,6 +261,33 @@
     - RMCM5Bayonet
     - RMCRadioHandheldColonyOff
 
+- type: randomHumanoidSettings
+  parent: RMCCorpse
+  id: RMCCorpseUNPeacekeeper
+  components:
+  - type: Loadout
+    prototypes: [ RMCGearCorpseUNPeacekeeper ]
+  - type: Rank
+    rank: RMCRankCivilianOfficer
+
+- type: startingGear
+  id: RMCGearCorpseUNPeacekeeper
+  equipment:
+    head: ArmorHelmetPMCRiotShield
+    jumpsuit: RMCJumpsuitUNSecurity
+    outerClothing: RMCArmorPMCRiot
+    back: CMSatchelSecurity
+    shoes: RMCShoesJackboots
+    eyes: CMGlassesSecurity
+    gloves: CMHandsBlackMarine
+    id: CMIDCardColonistSecurity
+    ears: CMHeadsetColony
+    belt: CMBeltSecurityMPFilled
+  storage:
+    back:
+    - RMCM5Bayonet
+    - RMCRadioHandheldColonyOff
+
 # Corporate Liaison
 - type: randomHumanoidSettings
   parent: RMCCorpseWeYa
@@ -385,6 +412,65 @@
   id: RMCCorpseColonistKutjevoBurst
   components:
   - type: VictimBurst
+
+- type: randomHumanoidSettings
+  parent: RMCCorpse
+  id: RMCCorpseColonistBeachBum
+  components:
+  - type: Loadout
+    prototypes: [ RMCGearCorpseColonistBeachBum ]
+
+- type: startingGear
+  id: RMCGearCorpseColonistBeachBum
+  equipment:
+    jumpsuit: RMCJumpsuitRedShorts
+    back: CMSatchel
+    head: RMCBoonie
+    mask: RMCCigarette
+    shoes: RMCShoesSandals
+    gloves: CMHandsBrown
+    id: CMIDCardColonist
+    ears: CMHeadsetColony
+
+- type: randomHumanoidSettings
+  parent: RMCCorpse
+  id: RMCCorpseVaraderoTechnician
+  components:
+  - type: Loadout
+    prototypes: [ RMCGearCorpseVaraderoTechnician ]
+
+- type: startingGear
+  id: RMCGearCorpseVaraderoTechnician
+  equipment:
+    head: RMCHardhatBlue
+    jumpsuit: RMCJumpsuitCivilian
+    outerClothing: RMCHazardVestBlue
+    back: CMSatchelEngineer
+    shoes: CMBootsBlackFilled
+    eyes: RMCWeldingGoggles
+    gloves: CMHandsInsulated
+    id: CMIDCardColonistEngineer
+    ears: CMHeadsetColony
+    belt: CMBeltUtilityFilled
+
+- type: randomHumanoidSettings
+  parent: RMCCorpse
+  id: RMCCorpseCargoTechnician
+  components:
+  - type: Loadout
+    prototypes: [ RMCGearCorpseCargoTechnician ]
+
+- type: startingGear
+  id: RMCGearCorpseCargoTechnician
+  equipment:
+    jumpsuit: RMCJumpsuitCivilianBrown
+    back: CMSatchelMarineTechSurvivorFill
+    head: RMCHeadBeanieTan
+    shoes: RMCShoesJackboots
+    gloves: CMHandsBrown
+    id: CMIDCardColonistEngineer
+    ears: CMHeadsetColony
+    pocket2: RMCPouchToolsFill
 
 # Guidebook Colonist
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added the Pool Party Nightmare Insert, as well as some corpses for New Varadero

**THIS IS A NON-PARITY INSERT**

## Why / Balance
Varadero has a lack of inserts, so adding one which takes a prexisting concept (Varadero having a pool) and adding a thematic insert based on it would be cool, especially since it adds some more soul to the map. Corpses are needed for this insert

As for balance, no major additions apart from two UN Peacekeeper bodies with UN Riot Armour and an M1984 pistol with a magazine. Could affect roundflow due to changes to the walls and layout.

## Technical details
YML

## Media
<img width="804" height="876" alt="image" src="https://github.com/user-attachments/assets/2cb5d76a-451e-4187-bb94-14b4847010d2" />
<img width="780" height="935" alt="image" src="https://github.com/user-attachments/assets/8594b8e2-c414-4d3f-874b-ced2a21bd4a8" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Added a Varadero Pool Party insert with a 15% chance of spawning
- add: Added New Varadero corpse spawners for Beach Bums, Engi and Cargo Techs, and UN Peacekeepers
