### PR TITLE
Clean up of files + preventing people who view documents wiping your …

### DIFF
--- a/Content.Client/Paper/UI/PaperBoundUserInterface.cs
+++ b/Content.Client/Paper/UI/PaperBoundUserInterface.cs
@@ -44,12 +44,6 @@ public sealed class PaperBoundUserInterface : BoundUserInterface
     private void InputOnTextEntered(string text)
     {
         SendMessage(new PaperInputTextMessage(text));
-
-        if (_window != null)
-        {
-            _window.Input.TextRope = Rope.Leaf.Empty;
-            _window.Input.CursorPosition = new TextEdit.CursorPos(0, TextEdit.LineBreakBias.Top);
-        }
     }
 
     private void OnSignatureRequested(int signatureIndex)

--- a/Content.Client/Paper/UI/PaperWindow.xaml
+++ b/Content.Client/Paper/UI/PaperWindow.xaml
@@ -4,7 +4,7 @@
     SetSize="510 660"> <!-- Provide some reasonable sizes by default. Can be changed by the component -->
 
     <BoxContainer Name="ContentsRoot" Orientation="Vertical">
-        <PanelContainer StyleClasses="AngleRect" VerticalAlignment="Top" HorizontalAlignment="Right" Margin="6">
+        <PanelContainer StyleClasses="BackgroundPanel" VerticalAlignment="Top" HorizontalAlignment="Right" Margin="6">
             <TextureButton Name="CloseButton" StyleClasses="windowCloseButton"/>
         </PanelContainer>
         <PanelContainer Name="PaperBackground" StyleClasses="PaperDefaultBorder" VerticalExpand="True" HorizontalExpand="True">
@@ -13,16 +13,16 @@
                     <BoxContainer Orientation="Vertical" VerticalAlignment="Stretch">
                         <TextureButton Name="HeaderImage" HorizontalAlignment="Center" VerticalAlignment="Top" MouseFilter="Ignore"/>
                         <Control Name="TextAlignmentPadding" VerticalAlignment="Top"/>
-                        <RichTextLabel Name="BlankPaperIndicator" StyleClasses="LabelSecondaryColor" VerticalAlignment="Top" HorizontalAlignment="Center"/>
-                        <RichTextLabel Name="WrittenTextLabel" VerticalAlignment="Top"/>
+                        <RichTextLabel Name="BlankPaperIndicator" StyleClasses="LabelWeak" VerticalAlignment="Top" HorizontalAlignment="Center"/>
+                        <RichTextLabel StyleClasses="PaperWrittenText" Name="WrittenTextLabel" VerticalAlignment="Top"/>
                         <BoxContainer Name="WrittenTextContainer" Orientation="Horizontal" VerticalAlignment="Top" StyleClasses="PaperWrittenText">
                         </BoxContainer>
-                        <BoxContainer Name="InputContainer" Orientation="Vertical" VerticalExpand="True" VerticalAlignment="Stretch">
+                        <BoxContainer Name="InputContainer" StyleClasses="PaperContainer" Orientation="Vertical" VerticalExpand="True" VerticalAlignment="Stretch" Visible="False">
                             <PanelContainer StyleClasses="TransparentBorderedWindowPanel" MinHeight="100"
                                 VerticalAlignment="Stretch" VerticalExpand="True" HorizontalExpand="True">
                                 <TextEdit Name="Input" StyleClasses="PaperLineEdit" Access="Public" />
                             </PanelContainer>
-                            <Label Name="FillStatus" StyleClasses="LabelSecondaryColor"/>
+                            <Label Name="FillStatus" StyleClasses="LabelWeak"/>
                         </BoxContainer>
                         <TextureButton Name="FooterImage" HorizontalAlignment="Center" VerticalAlignment="Top" MouseFilter="Ignore"/>
                     </BoxContainer>
@@ -32,7 +32,7 @@
             </ScrollContainer>
         </PanelContainer>
         <!-- Bottom buttons for editing -->
-        <BoxContainer Name="EditButtons" Orientation="Horizontal" HorizontalAlignment="Right" Margin="6">
+        <BoxContainer Name="EditButtons" Orientation="Horizontal" HorizontalAlignment="Right" Margin="6" Visible="False">
             <Button Name="SaveButton" />
         </BoxContainer>
     </BoxContainer>

--- a/Content.Client/UserInterface/RichText/CheckTagHandler.cs
+++ b/Content.Client/UserInterface/RichText/CheckTagHandler.cs
@@ -15,7 +15,7 @@ public sealed class CheckTagHandler : IMarkupTagHandler
 {
     public string Name => "check";
     private static int _checkCounter = 0;
-    
+
     /// <summary>
     /// Font line height set by PaperWindow to ensure buttons match text height
     /// </summary>
@@ -85,9 +85,9 @@ public sealed class CheckTagHandler : IMarkupTagHandler
         var btn = new Button
         {
             Text = "☐",
-            MinSize = new Vector2(FontLineHeight + 2, FontLineHeight + 2),
-            MaxSize = new Vector2(FontLineHeight + 2, FontLineHeight + 2),
-            Margin = new Thickness(1, 0, 1, 0),
+            MinSize = new Vector2(FontLineHeight + 2, FontLineHeight + 4),
+            MaxSize = new Vector2(FontLineHeight + 2, FontLineHeight + 4),
+            Margin = new Thickness(1, 2, 1, 2),
             StyleClasses = { "ButtonSquare" },
             TextAlign = Label.AlignMode.Center
         };
@@ -114,29 +114,5 @@ public sealed class CheckTagHandler : IMarkupTagHandler
         return true;
     }
 
-    /// <summary>
-    /// Replaces the nth occurrence of [check] tag with replacement symbol.
-    /// </summary>
-    private static string ReplaceNthCheckTag(string text, int index, string replacement)
-    {
-        const string checkTag = "[check]";
-        var currentIndex = 0;
-        var pos = 0;
 
-        while (pos < text.Length)
-        {
-            var foundPos = text.IndexOf(checkTag, pos);
-            if (foundPos == -1) break;
-
-            if (currentIndex == index)
-            {
-                return text.Substring(0, foundPos) + replacement + text.Substring(foundPos + checkTag.Length);
-            }
-
-            currentIndex++;
-            pos = foundPos + checkTag.Length;
-        }
-
-        return text;
-    }
 }

--- a/Content.Client/UserInterface/RichText/FormTagHandler.cs
+++ b/Content.Client/UserInterface/RichText/FormTagHandler.cs
@@ -5,7 +5,6 @@ using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface;
 using Robust.Shared.Utility;
 using Content.Client.Paper.UI;
-using Robust.Client.Graphics;
 
 namespace Content.Client.UserInterface.RichText;
 
@@ -16,15 +15,8 @@ public sealed class FormTagHandler : IMarkupTagHandler
 {
     public string Name => "form";
 
-    public bool CanHandle(MarkupNode node)
-    {
-        return node.Name == "form" || node.Value.StringValue?.StartsWith("__FORM_") == true;
-    }
-
     private static int _formCounter = 0;
-    private static readonly Dictionary<string, int> _formPositions = new();
-    private static string _lastText = "";
-    
+
     /// <summary>
     /// Font line height set by PaperWindow to ensure buttons match text height
     /// </summary>
@@ -81,25 +73,6 @@ public sealed class FormTagHandler : IMarkupTagHandler
         }
     }
 
-    /// <summary>
-    /// Caches form tag positions to avoid recalculating on every render.
-    /// </summary>
-    public static void SetFormText(string text)
-    {
-        if (_lastText != text)
-        {
-            _formPositions.Clear();
-            _lastText = text;
-            var pos = 0;
-            var index = 0;
-            while ((pos = text.IndexOf("[form]", pos)) != -1)
-            {
-                _formPositions[pos.ToString()] = index++;
-                pos += 6;
-            }
-        }
-    }
-
     public void PushDrawContext(MarkupNode node, MarkupDrawingContext context) { }
     public void PopDrawContext(MarkupNode node, MarkupDrawingContext context) { }
     public string TextBefore(MarkupNode node) => "";
@@ -113,9 +86,9 @@ public sealed class FormTagHandler : IMarkupTagHandler
         var btn = new Button
         {
             Text = "Fill",
-            MinSize = new Vector2(32, FontLineHeight + 2),
-            MaxSize = new Vector2(32, FontLineHeight + 2),
-            Margin = new Thickness(1, 0, 1, 0),
+            MinSize = new Vector2(32, FontLineHeight + 4),
+            MaxSize = new Vector2(32, FontLineHeight + 4),
+            Margin = new Thickness(1, 2, 1, 2),
             StyleClasses = { "ButtonSquare" },
             TextAlign = Label.AlignMode.Center
         };

--- a/Content.Client/UserInterface/RichText/SignatureTagHandler.cs
+++ b/Content.Client/UserInterface/RichText/SignatureTagHandler.cs
@@ -6,7 +6,6 @@ using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Utility;
 using Robust.Shared.IoC;
 using Content.Client.Paper.UI;
-using Robust.Client.Graphics;
 
 namespace Content.Client.UserInterface.RichText;
 
@@ -17,7 +16,7 @@ public sealed class SignatureTagHandler : IMarkupTagHandler
 {
     public string Name => "signature";
     private static int _signatureCounter = 0;
-    
+
     /// <summary>
     /// Font line height set by PaperWindow to ensure buttons match text height
     /// </summary>

--- a/Resources/Locale/en-US/paper/paper-component.ftl
+++ b/Resources/Locale/en-US/paper/paper-component.ftl
@@ -25,4 +25,9 @@ paper-form-dialog-ok = OK
 paper-form-dialog-cancel = Cancel
 paper-signature-unknown = Unknown
 
+# Check dialog buttons
+paper-check-dialog-blank = ☐ Blank
+paper-check-dialog-check = ✔ Check
+paper-check-dialog-cross = ✖ Cross
+
 paper-tamper-proof-modified-message = This page was written using tamper-proof ink.


### PR DESCRIPTION
…progress

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
cleaned up

made it so when other players view your editing document it no longer deletes your pogress

## Why / Balance
make paperwork less bad i guess?

## Technical details
Input clearing has been centered around populate rather than after text entry.
Edit controls now hidden by default so no more flashing edit screens in some cases.
Margin calculation has been made 1:1 with buttons so no longer any more cut off text in documents with large amount of buttons.
Simplified nth tag removers.
Removed upstream version of Id sampling leftover in code. (rmc is different)

## Media


## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Various tweaks and fixes to papercode
