### PR TITLE
Fix doors becoming ss14 airlocks

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Doors/Airlocks/airlocks.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Doors/Airlocks/airlocks.yml
@@ -9,11 +9,6 @@
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Doors/Airlocks/personal_door.rsi
-  - type: Construction
-    graph: CMAirlock
-    node: airlock
-    containers:
-    - board
   - type: Occluder
   - type: PaintableAirlock
     department: CMSquad

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Doors/cm_door.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Doors/cm_door.yml
@@ -171,7 +171,7 @@
   id: CMBaseDoorConstructible
   components:
   - type: Construction
-    graph: Airlock
+    graph: CMAirlock
     node: airlock
     containers:
     - board


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- Fixes some airlocks not being able to be deconstructed into rmc airlock assemblies, resulting in no metal return and other various exploits
- Double doors still need to get their own construction graphs at some point, we only have single doors.

## Technical details
<!-- Summary of code changes for easier review. -->
- Base entity was using ss14 graph, but the other airlocks were updated to use the rmc graph
- All formerly bugged airlock types tested and working
- Removed duplicated YML entry, base entity inherits construction graphs from BaseDoorConstructible

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Whisper
- fix: All airlocks should now be able to be properly deconstructed into metal.

