### PR TITLE
Allow xenos to see the appearance of their own characters that they bursted out of roundstart

### DIFF
--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
@@ -41,6 +41,7 @@ using Content.Shared._RMC14.CameraShake;
 using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Dropship;
 using Content.Shared._RMC14.Fax;
+using Content.Shared._RMC14.Humanoid;
 using Content.Shared._RMC14.Intel;
 using Content.Shared._RMC14.Item;
 using Content.Shared._RMC14.Light;
@@ -610,6 +611,9 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
                     _parasite.SetHive((corpseMob, victimInfected), comp.Hive);
                     _parasite.SpawnLarva((corpseMob, victimInfected), out var newXeno);
                     _parasite.SetBurstDelay((corpseMob, victimInfected), comp.XenoSurvivorCorpseBurstDelay);
+
+                    // Allow xenos to see their character that they bursted out of
+                    RemCompDeferred<HiddenAppearanceComponent>(corpseMob);
 
                     _xeno.MakeXeno(newXeno);
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This is so the larva can see their own characters
They'll still appear as 'tall host' and such its just the appearance that isnt hidden

## Why/Balance
No balancing effect, you will just be able to see the appearance of roundstart xeno corpse bursts
I believe it's cooler to see your own character when you spawn in as larva and this might prevent possible rulebreaks with xeno corpses, since a player might think that it's a randomly generated corpse when they spawn in, rather then their character profile

**Changelog**
:cl:
- tweak: As a xenonid, you can now see the appearance of your own character that you bursted out of roundstart.