### PR TITLE
Makes the Correspondent microphone functional as a microphone

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Devices/correspondent.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Devices/correspondent.yml
@@ -15,7 +15,7 @@
     broadcastChannel: Handheld
   - type: Speech
     speechVerb: Robotic
-  - type: ChatRepeatIgnoreSender # RMC14
+  - type: ChatRepeatIgnoreSender
   - type: InteractedBlacklist
     blacklist:
       components:


### PR DESCRIPTION
## About the PR
Made the Correspondent microphone function as a microphone.

## Why / Balance
An audio component to a correspondent's broadcast is a natural part of its kit, rather than just as a prop!

## Technical details


## Media


## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:

- tweak: The Correspondent's microphone now functions as an actual microphone for handheld radios!

