### PR TITLE
Added another turret to north shiva lz

### DIFF
--- a/Resources/Maps/_RMC14/shiva.yml
+++ b/Resources/Maps/_RMC14/shiva.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 264.0.2
   forkId: ""
   forkVersion: ""
-  time: 01/16/2026 08:40:49
-  entityCount: 17350
+  time: 01/25/2026 22:45:41
+  entityCount: 17351
 maps:
 - 1
 grids:
@@ -127608,6 +127608,12 @@ entities:
     components:
     - type: Transform
       pos: 17.5,135.5
+      parent: 1
+  - uid: 17351
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 29.5,128.5
       parent: 1
 - proto: RMCUtilityAttachmentPoint
   entities:


### PR DESCRIPTION
## About the PR
added a turret to shiva north LZ

## Why / Balance
adds turret to prevent an easy route for xenos to walk into dropship

## Technical details
yml

## Media
circle is added turret, line is the route that xenos can currently take with little resistance
<img width="845" height="703" alt="image" src="https://github.com/user-attachments/assets/7b0e3676-3161-46c1-a953-4b6e1b14e5e1" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl: CatAndHats
- tweak: Placed an extra turret to the south-eastern side of the north shiva LZ