### PR TITLE
Fix the Kutjevo south LZ alternative layout insert lacking some turrets

### DIFF
--- a/Resources/Maps/_RMC14/Inserts/Kutjevo/lz1alternative.yml
+++ b/Resources/Maps/_RMC14/Inserts/Kutjevo/lz1alternative.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 264.0.2
   forkId: ""
   forkVersion: ""
-  time: 10/28/2025 15:55:50
-  entityCount: 1083
+  time: 01/25/2026 23:03:17
+  entityCount: 1085
 maps: []
 grids:
 - 1
@@ -4883,6 +4883,16 @@ entities:
     components:
     - type: Transform
       pos: 26.5,43.5
+      parent: 1
+  - uid: 1084
+    components:
+    - type: Transform
+      pos: 39.5,27.5
+      parent: 1
+  - uid: 1085
+    components:
+    - type: Transform
+      pos: 38.5,23.5
       parent: 1
 - proto: RMCWallKutjevoHull
   entities:


### PR DESCRIPTION
## About the PR
title

## Why / Balance
right now xenos can walk in due to this insert lacking turrets on that side.
https://discord.com/channels/1168210010233376858/1465086757723967539 talked about in this bug thread.

## Technical details
yml

## Media
added turrets circled
<img width="932" height="687" alt="image" src="https://github.com/user-attachments/assets/ceb91b4a-4e69-43fe-9045-008f724c1658" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl: CatAndHats
- fix: The Kutjevo south LZ alternative layout map insert now has turrets on the south-eastern side.