### PR TITLE
[Fix] Pill packets fit in more medical storage things

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
@@ -389,6 +389,7 @@
       - Dropper
       - GlassBeaker
       - Bottle
+      - PillPacket
       - PillCanister
       - Syringe
       - CMSurgicalLine

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/lifesaver_bag.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/lifesaver_bag.yml
@@ -17,6 +17,7 @@
       - DiscreteHealthAnalyzer
       - BodyBag
       - Bottle
+      - PillPacket
       - PillCanister
       - Syringe
       - CMAutoInjector
@@ -36,6 +37,7 @@
     items:
       tags:
       - PillCanister
+      - PillPacket
   - type: ItemCamouflage
     camouflageVariations:
       Jungle: _RMC14/Objects/Clothing/Belt/medicbag/jungle-classic.rsi

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Pouches/medical.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Pouches/medical.yml
@@ -24,6 +24,7 @@
       - CMSurgicalLine
       - CMSynthGraft
       - Hypospray
+      - PillPacket
       components:
       - Hypospray
 

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Pouches/medical_kit_pouch.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Pouches/medical_kit_pouch.yml
@@ -1,4 +1,4 @@
-﻿# MedKit Pouch
+# MedKit Pouch
 - type: entity
   parent: [RMCPouchOpenClosed, RMCPouchStorage]
   id: RMCPouchMedkit
@@ -14,6 +14,7 @@
         - DiscreteHealthAnalyzer
         - Dropper
         - Pill
+        - PillPacket
         - Bottle
         - Syringe
         - PillCanister
@@ -47,6 +48,7 @@
       - DiscreteHealthAnalyzer
       - Dropper
       - Pill
+      - PillPacket
       - Bottle
       - Syringe
       - PillCanister

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Pouches/medical_pouch.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Pouches/medical_pouch.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   parent: [RMCPouchOpenClosed, RMCPouchStorage]
   id: RMCPouchMedical
   name: medical pouch

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Medical/firstaidkits.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Medical/firstaidkits.yml
@@ -20,6 +20,7 @@
       - DiscreteHealthAnalyzer
       - Dropper
       - Pill
+      - PillPacket
       - Bottle
       - Syringe
       - PillCanister
@@ -59,6 +60,7 @@
   - type: IgnoreContentsSize
     items:
       tags:
+      - PillPacket
       - PillCanister
       - CMSurgicalCase
       - RMCSyringeCase


### PR DESCRIPTION
## About the PR
Added pill packets to the white lists of several medical storage related items.

## Why / Balance
Its weird they dont fit in. Closes #9027 

## Technical details
Minor yml changes

## Media

https://github.com/user-attachments/assets/bdaa30cb-23c4-41aa-9dee-e97d8d473d1e



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**>
:cl:
- fix: Pill packets now fit in various medical storages
