### PR TITLE
Fix debug assert triggered by high projectile damage to xenos

### DIFF
--- a/Content.Server/_RMC14/Xenonids/Emote/XenoEmoteSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Emote/XenoEmoteSystem.cs
@@ -55,7 +55,7 @@ public sealed class XenoEmoteSystem : EntitySystem
         if (!_whitelist.CheckBoth(target, comp.Blacklist, comp.Whitelist))
             return;
 
-        var chance = (5f + MathF.Floor((float)args.Damage.GetTotal() / 4f)) / 100f;
+        var chance =  Math.Clamp((5f + MathF.Floor((float)args.Damage.GetTotal() / 4f)) / 100f, 0, 1);
 
         if (_random.Prob(chance))
         {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The emote chance when being hit by a projectile is now clamped between 0 and 1.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Resolves #9069 

## Technical details
<!-- Summary of code changes for easier review. -->
_random.Prob asserts that the chance parameter is between 0 and 1. High projectile damage caused the calculated chance to be higher than 1.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
No CL