### PR TITLE
Reduce fire damage taken by barricades

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Walls/Barricades/barricade_base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Walls/Barricades/barricade_base.yml
@@ -83,7 +83,7 @@
     maximumFireStacks: 0.5
     damage:
       types:
-        Heat: 1.9
+        Heat: 2
   - type: ExaminableDamage
     messages: RMCBarricadeMessages
   # - type: RMCGenericExamine TODO


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The damage over time from fire to barricades has been reduced by 47%.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity.
Before this PR it takes around 8 seconds to burn down a regular metal barricade using UT-Napthal, after this PR it takes around 16 seconds, which is the same amount of time it takes in CM.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix: Fixed fire dealing too much damage to barricades, now dealing 47% less damage over time to them.