### PR TITLE
Remove paper eating components from CMBasePaperFaxable

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Misc/Paper/paper.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Misc/Paper/paper.yml
@@ -99,18 +99,6 @@
   parent: CMBasePaper
   id: CMBasePaperFaxable
   components:
-  - type: Food
-    solution: food
-    delay: 7
-    forceFeedDelay: 7
-  - type: BadFood
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 1
-        reagents:
-        - ReagentId: Fiber
-          Quantity: 1
   - type: FaxableObject
 
 - type: entity


### PR DESCRIPTION
## About the PR
Removed paper eating components from CMBasePaperFaxable.

## Why / Balance
Closes #7601. Prevents accidental document loss from accidentally eating paper via use/hotkeys.

## Technical details
Deleted Food, BadFood, SolutionContainerManager components from:
Resources/Prototypes/_RMC14/Entities/Objects/Misc/Paper/paper.yml

## Media
N/A (prototype change, no visual changes)

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

:cl:
- fix: Paper can no longer be accidentally eaten via hotkeys/use
