### PR TITLE
Makes Flares actually spent on burning out.

### DIFF
--- a/Content.Server/Light/EntitySystems/ExpendableLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/ExpendableLightSystem.cs
@@ -2,6 +2,7 @@ using Content.Server.Light.Components;
 using Content.Server.Stack;
 using Content.Shared._RMC14.Dropship.Weapon;
 using Content.Shared._RMC14.Xenonids;
+using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Clothing.Components;
 using Content.Shared.Clothing.EntitySystems;
 using Content.Shared.IgnitionSource;
@@ -201,6 +202,10 @@ namespace Content.Server.Light.EntitySystems
 
                 case ExpendableLightState.Dead:
                     _appearance.SetData(ent, ExpendableLightVisuals.Behavior, string.Empty, appearance);
+                    // RMC14
+                    if (TryComp<CartridgeAmmoComponent>(ent, out var cartridge))
+                        cartridge.Spent = true;
+
                     var ignite = new IgnitionEvent(false);
                     RaiseLocalEvent(ent, ref ignite);
                     break;

--- a/Content.Server/Light/EntitySystems/ExpendableLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/ExpendableLightSystem.cs
@@ -205,6 +205,7 @@ namespace Content.Server.Light.EntitySystems
                     // RMC14
                     if (TryComp<CartridgeAmmoComponent>(ent, out var cartridge))
                         cartridge.Spent = true;
+                        Dirty(ent,cartridge);
 
                     var ignite = new IgnitionEvent(false);
                     RaiseLocalEvent(ent, ref ignite);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->


<details>
  <summary>  Before</summary> 

https://github.com/user-attachments/assets/d28b106c-236b-4b76-a7ce-449ee3512978


</details>
<details>
  <summary>  After</summary> 
 

https://github.com/user-attachments/assets/3b790760-03cc-447e-bfe7-d9dd00119fe5


</details>



## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

fixes #8318 

## Technical details
<!-- Summary of code changes for easier review. -->


So essentially, the AmmoCartridgeComponent has a "Spent" variable, which was never being set to True. Just needed to update "Spent" when the flare also calls its expendable lighting component to update the flare to being dead.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Flares now correctly let you know when they're spent on examination.
