### PR TITLE
Change burrowed scaling for total hive numbers

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
@@ -415,8 +415,7 @@ public sealed class XenoEvolutionSystem : EntitySystem
             _xenoHive.TryGetTierLimit((oldHive, oldHive.Comp), newXenoComp.Tier, out var limit))
         {
             var existing = 0;
-            var total = Math.Sqrt(oldHive.Comp.BurrowedLarva * oldHive.Comp.BurrowedLarvaSlotFactor);
-            total = Math.Min(total, oldHive.Comp.BurrowedLarva);
+            var total = oldHive.Comp.BurrowedLarva * oldHive.Comp.BurrowedLarvaSlotFactor;
 
             var current = EntityQueryEnumerator<XenoComponent, HiveMemberComponent>();
             var slotCount = oldHive.Comp.FreeSlots.ToDictionary();

--- a/Content.Shared/_RMC14/Xenonids/Hive/HiveComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hive/HiveComponent.cs
@@ -83,7 +83,7 @@ public sealed partial class HiveComponent : Component
     public int BurrowedLarva;
 
     [DataField, AutoNetworkedField]
-    public int BurrowedLarvaSlotFactor = 4;
+    public float BurrowedLarvaSlotFactor = 0.66f;
 
     [DataField, AutoNetworkedField]
     public bool LateJoinGainLarva;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changes burrowed larvas to be counted as .66x xenos, instead of sqrt(4x). This changes how many tier 2s and tier 3s the hive can support from burrowed larva.

## Why / Balance
Xenos suffer from having a lot of burrowed. Each burrowed is a potential player not building, evolving, and is not counted as a whole xeno for the sake of how many tier 2 and 3s the hive can support. The current formula for how many xenos a burrowed is worth is logarithmic, so the more burrowed they have, the less each one is worth. CM13 doesn't reach very high burrowed counts as they don't have many players so this equation is not a problem for them.
At low numbers its nearly 1:1, 1 burrowed is 1 xeno, 5 burrowed is 4 xenos, 10 burrowed is 6 xenos. 
It starts to fall apart when the hive is down a lot of players! 20 burrowed is worth 9 xenos, 30 burrowed is 11 xenos, 40 burrowed is 13 xenos, which if filled by players would count as 6 more tier 3 slots.

You could make it so each burrowed is worth 1 xeno so I tried to look for the origin of why that's not the case. This formula was introducted 7 years ago in https://github.com/cmss13-devs/cmss13/commit/6244df5af1201f61b20dfab0470d83a528d9d8be without any reasoning listed, so I imagine its so all slots aren't taken so late joiners xenos can still have a shot at higher tiers. Though this has no reason to be logarithmic like it is now so I believe a flat number like .66 makes it less silly.

this is how the 2 equations compare: https://www.desmos.com/calculator/s3dmv2khvp

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: shibechef
- tweak: Burrowed larva now count as 2/3s of a xeno for tier 2 and tier 3 slots, instead of a logarithmic amount.

