### PR TITLE
Neurotoxin gas no longer affects entities while paradropping

### DIFF
--- a/Content.Shared/ParaDrop/SharedParaDropSystem.cs
+++ b/Content.Shared/ParaDrop/SharedParaDropSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared._RMC14.Dropship;
 using Content.Shared._RMC14.Dropship.Weapon;
 using Content.Shared._RMC14.Pulling;
 using Content.Shared._RMC14.Rules;
+using Content.Shared._RMC14.Xenonids.Neurotoxin;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Damage;
 using Content.Shared.Interaction.Events;
@@ -61,6 +62,7 @@ public abstract partial class SharedParaDropSystem : EntitySystem
         SubscribeLocalEvent<ParaDroppingComponent, ThrowPushbackAttemptEvent>(OnThrowPushbackAttempt);
         SubscribeLocalEvent<ParaDroppingComponent, BeforeDamageChangedEvent>(OnBeforeDamageChanged);
         SubscribeLocalEvent<ParaDroppingComponent, UpdateCanMoveEvent>(OnUpdateCanMove);
+        SubscribeLocalEvent<ParaDroppingComponent, NeurotoxinInjectAttemptEvent>(OnNeurotoxinInjectAttempt);
 
         SubscribeLocalEvent<SkyFallingComponent, ComponentShutdown>(OnComponentShutdown);
     }
@@ -192,6 +194,11 @@ public abstract partial class SharedParaDropSystem : EntitySystem
     private void OnUpdateCanMove(Entity<ParaDroppingComponent> ent, ref UpdateCanMoveEvent args)
     {
         args.Cancel();
+    }
+
+    private void OnNeurotoxinInjectAttempt(Entity<ParaDroppingComponent> ent, ref NeurotoxinInjectAttemptEvent args)
+    {
+        args.Cancelled = true;
     }
 
     /// <summary>

--- a/Content.Shared/_RMC14/Xenonids/Neurotoxin/NeurotoxinInjectAttemptEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Neurotoxin/NeurotoxinInjectAttemptEvent.cs
@@ -1,0 +1,4 @@
+namespace Content.Shared._RMC14.Xenonids.Neurotoxin;
+
+[ByRefEvent]
+public record struct NeurotoxinInjectAttemptEvent(bool Cancelled = false);

--- a/Content.Shared/_RMC14/Xenonids/Neurotoxin/SharedNeurotoxinSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Neurotoxin/SharedNeurotoxinSystem.cs
@@ -142,6 +142,12 @@ public abstract class SharedNeurotoxinSystem : EntitySystem
                     continue;
                 }
 
+                var ev = new NeurotoxinInjectAttemptEvent();
+                RaiseLocalEvent(marine, ref ev);
+
+                if (ev.Cancelled)
+                    continue;
+
                 if (!EnsureComp<NeurotoxinComponent>(marine, out var builtNeurotoxin))
                 {
                     builtNeurotoxin.LastMessage = time;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Neurotoxin gas no longer affects entities while they are paradropping.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Resolves #7743

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix: Neurotoxin gas no longer affects entities that are paradropping.
