### PR TITLE
1984 HP ammo boxes/Crates

### DIFF
--- a/Resources/Prototypes/_RMC14/Catalog/Cargo/requisitions_catalog.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Cargo/requisitions_catalog.yml
@@ -41,6 +41,8 @@
       - cost: 3000
         crate: RMCCrateBoxMagazinePistolM1984AP
       - cost: 3000
+        crate: RMCCrateBoxMagazinePistolM1984HP
+      - cost: 3000
         crate: RMCCrateBoxShellsShotgunSlugs
       - cost: 3000
         crate: RMCCrateBoxShellsShotgunBuckshot

--- a/Resources/Prototypes/_RMC14/Catalog/Fills/Crates/magazine_boxes.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Fills/Crates/magazine_boxes.yml
@@ -122,6 +122,15 @@
     contents:
     - id: RMCBoxMagazinePistolM1984AP
 
+- type: entity
+  parent: RMCCrateAmmo
+  id: RMCCrateBoxMagazinePistolM1984HP
+  name: Magazine box (M1984, 16x HP mags)
+  components:
+  - type: StorageFill
+    contents:
+    - id: RMCBoxMagazinePistolM1984HP
+
 # M77
 - type: entity
   parent: RMCCrateAmmo

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magazine_boxes.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magazine_boxes.yml
@@ -2095,13 +2095,13 @@
     - state: pistol_box_1984
       color: "#ffcb26"
     - state: pistol_box_marking
-      color: "#7c4c1b"
+      color: "#40270E"
     - state: pistol_lid
       map: [ "lid" ]
       color: "#b2976e"
     - state: pistol_lid_marking
       map: [ "lid_marking" ]
-      color: "#7c4c1b"
+      color: "#40270E"
   - type: CMItemSlots
     count: 16
     slot:
@@ -2162,6 +2162,47 @@
   components:
   - type: CMItemSlots
     startingItem: RMCMagazinePistolM1984AP
+
+# M1984 HP
+- type: entity
+  parent: RMCBoxMagazinePistolBase
+  id: RMCBoxMagazinePistolM1984HPEmpty
+  name: magazine box (HP M1984 x 16)
+  components:
+  - type: Construction
+    graph: RMCBoxMagazine
+    node: RMCBoxMagazinePistolM1984HPEmpty
+  - type: Sprite
+    layers:
+    - state: pistol_box
+      color: "#b2976e"
+    - state: pistol_ammo_full
+      map: [ "enum.CMItemSlotsLayers.Fill" ]
+      color: "#BA5D00"
+    - state: pistol_box_1984
+      color: "#ffcb26"
+    - state: pistol_box_marking
+      color: "#BA5D00"
+    - state: pistol_lid
+      map: [ "lid" ]
+      color: "#b2976e"
+    - state: pistol_lid_marking
+      map: [ "lid_marking" ]
+      color: "#BA5D00"
+  - type: CMItemSlots
+    count: 16
+    slot:
+      whitelist:
+        tags:
+        - RMCMagazinePistolM1984HP
+
+- type: entity
+  parent: RMCBoxMagazinePistolM1984HPEmpty
+  id: RMCBoxMagazinePistolM1984HP
+  suffix: Full
+  components:
+  - type: CMItemSlots
+    startingItem: RMCMagazinePistolM1984HP
 
 # MK80 REG
 - type: entity

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/m1984_pistol.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/m1984_pistol.yml
@@ -173,6 +173,10 @@
   name: M1984 hollowpoint magazine (9mm)
   description: A hollow-point 9mm pistol magazine for the M1984. These hollow-point bullets have noticeably higher stopping power on unarmored targets, and noticeably less on armored targets.
   components:
+  - type: Tag
+    tags:
+    - CMMagazinePistol
+    - RMCMagazinePistolM1984HP
   - type: BallisticAmmoProvider
     whitelist:
       tags:
@@ -211,4 +215,4 @@
         Piercing: 55 # TODO RMC14 30 shrapneltPistol9mmHP
 
 - type: Tag
-  id: RMCCartridgePistol9mmHP
+  id: RMCMagazinePistolM1984HP

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/m1984_pistol.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/m1984_pistol.yml
@@ -30,6 +30,7 @@
           tags:
           - CMMagazinePistolM1984
           - RMCMagazinePistolM1984AP
+          - RMCMagazinePistolM1984HP
           - RMCMagazinePistolM1984Rubber
         startingItem: CMMagazinePistolM1984
   - type: AttachableHolder
@@ -79,6 +80,7 @@
           tags:
           - CMMagazinePistolM1984
           - RMCMagazinePistolM1984AP
+          - RMCMagazinePistolM1984HP
 
 #9mm
 - type: entity

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/requisitions.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/requisitions.yml
@@ -15,7 +15,7 @@
       - RMCCrateBoxMagazineM54CE2
       - RMCCrateBoxMagazinePistolM1984
       - RMCCrateBoxMagazinePistolM1984AP
-#      - RMCCrateBoxMagazinePistolM1984HP
+      - RMCCrateBoxMagazinePistolM1984HP
       - RMCCrateBoxMagazineRifleM54C
       - RMCCrateBoxMagazineRifleM54CAP
       - RMCCrateBoxMagazineRifleM4SPRAP

--- a/Resources/Prototypes/_RMC14/Recipes/Construction/magazine_box_crafting.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Construction/magazine_box_crafting.yml
@@ -197,6 +197,18 @@
   iconColor: "#b2976e"
   objectType: Item
 
+- type: construction
+  parent: RMC
+  name: Magazine Box (M1984 HP)
+  id: RMCBoxMagazinePistolM1984HP
+  graph: RMCBoxMagazine
+  startNode: start
+  targetNode: RMCBoxMagazinePistolM1984HPEmpty
+  category: construction-category-cm-box-magazine
+  description: A magazine box that can contain hollow point M1984 mags.
+  iconColor: "#b2976e"
+  objectType: Item
+
 # 88 mod 4 / 88m4
 - type: construction
   parent: RMC
@@ -709,6 +721,12 @@
         amount: 1
         doAfter: 0.25
 
+    - to: RMCBoxMagazinePistolM1984HPEmpty
+      steps:
+      - material: RMCSheetCardboard
+        amount: 1
+        doAfter: 0.25
+
     # M77AP
     - to: RMCBoxMagazinePistolM77APEmpty
       steps:
@@ -902,6 +920,8 @@
     entity: RMCBoxMagazinePistolM1984Empty
   - node: RMCBoxMagazinePistolM1984APEmpty
     entity: RMCBoxMagazinePistolM1984APEmpty
+  - node: RMCBoxMagazinePistolM1984HPEmpty
+    entity: RMCBoxMagazinePistolM1984HPEmpty
 
   # M77AP
   - node: RMCBoxMagazinePistolM77APEmpty

--- a/Resources/Prototypes/_RMC14/Recipes/Materials/cardboard.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Materials/cardboard.yml
@@ -252,6 +252,7 @@
   listed:
   - RMCBoxMagazinePistolM1984EmptyBuild
   - RMCBoxMagazinePistolM1984APEmptyBuild
+  - RMCBoxMagazinePistolM1984HPEmptyBuild
   - RMCDividerConstruction
   - RMCBoxMagazinePistolMK80EmptyBuild
   - RMCDividerConstruction
@@ -280,6 +281,12 @@
   id: RMCBoxMagazinePistolM1984APEmptyBuild
   name: M1984 magazine box (AP)
   prototype: RMCBoxMagazinePistolM1984APEmpty
+
+- type: rmcConstruction
+  parent: RMCCardboardBuildBase
+  id: RMCBoxMagazinePistolM1984HPEmptyBuild
+  name: M1984 magazine box (HP)
+  prototype: RMCBoxMagazinePistolM1984HPEmpty
 
 - type: rmcConstruction
   parent: RMCCardboardBuildBase

--- a/Resources/Prototypes/_RMC14/rmc_tags.yml
+++ b/Resources/Prototypes/_RMC14/rmc_tags.yml
@@ -11,6 +11,9 @@
   id: CMCartridgePistol9mmAP
 
 - type: Tag
+  id: RMCCartridgePistol9mmHP
+
+- type: Tag
   id: RMCCartridgeRevolver44
 
 - type: Tag


### PR DESCRIPTION
## About the PR
- Adds the 1984 HP ammo box made from cardboard,
- Adds the crate for them in req
- Adds them to the random crates from ARES 
- Tweaks the colour strip on the Basic 1984 ammo, to make it darker and more distinct from the HP box.

## Why / Balance
parity, Closes #7849 

## Technical details
YML changes

## Media

https://github.com/user-attachments/assets/231a1f03-7d1f-4c96-b70f-7f3e783b5451



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: 1984HP Boxes and crates
