### PR TITLE
Fix trucker survivor access

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Multi_Map/trucker_survivour.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Multi_Map/trucker_survivour.yml
@@ -5,6 +5,8 @@
   description: cm-job-description-survivor
   startingGear: RMCGearSurvivorTrucker
   playTimeTracker: CMJobSurvivorEngineer
+  accessGroups:
+  - ColonistEngi
   special:
   - !type:AddComponentSpecial
     components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<img width="761" height="263" alt="image" src="https://github.com/user-attachments/assets/61638d7b-6548-43d3-b10c-869eea79a36e" />

They have engi access in CM, in RMC they have civilian access

**Changelog**
:cl:
- fix: Fixed Survivor Cargo Techs, Heavy Vehicle Operators, and truckers having civilian access instead of engineering access.