### PR TITLE
Fix PVIs spawning with two bags

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Provost/provost_inspector.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Provost/provost_inspector.yml
@@ -77,7 +77,6 @@
     shoes: CMBootsBlackFilled
     id: RMCIDCardProvostInspector
     belt: RMCBeltHolsterPistolHandcannonFilled
-    back: CMSatchelSecurityFilledProvostInspector
     #    pocket1: # TODO RMC14 tape recorder
     pocket2: RMCPouchGeneralLarge # TODO RMC14 3 listening devices
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
PvIs were spawning with a bag with their loadout items + bag items, and then the bag from their starting gear entry, causing duplicate items and such that we really don't want floating around.

## Why / Balance
Bug fix

## Technical details
Remove a YAML Line

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
No CL