### PR TITLE
Medevac fixes

### DIFF
--- a/Content.Shared/_RMC14/Dropship/Utility/Components/MedevacComponent.cs
+++ b/Content.Shared/_RMC14/Dropship/Utility/Components/MedevacComponent.cs
@@ -10,8 +10,12 @@ public sealed partial class MedevacComponent : Component
     public const string AnimationState = "medevac_system_active";
     public const string AnimationDelay = "medevac_system_delay";
 
-    public bool IsActivated = false;
+    [DataField, AutoNetworkedField]
+    public bool IsActivated;
 
     [DataField, AutoNetworkedField]
     public TimeSpan DelayLength = TimeSpan.FromSeconds(3);
+
+    [DataField, AutoNetworkedField]
+    public EntityUid? Target;
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

- The use cooldown on the medevac system now only applies after a successful medevac, it still has a short 3 second cooldown during the animation. Previously it would apply the cooldown the moment a medevac attempt was made with the system. If for example someone used 3 different systems to try and grab the same target, 1 would grab it and all 3 would be on cooldown. Or if someone moved off the stretcher after the medevac was started, no second attempt could be made with the same system until the cooldown had finished.
- The medevac system now always tries grabbing the person on the stretcher that is targeted during the start(the moment someone interacts with the medevac system) of the medevac. Previously it would try to grab the person on the stretcher that was targeted at the end of the medevac's 3 second delay. It would also fail the medevac attempt if the pilot swapped to a flare during the 3 second delay.
- Fixed a visual bug where the medevac stretcher would keep playing the "being lifted" animation after a failed medevac using that stretcher. If someone stepped off a stretcher during a medevac it would keep looping the animation if someone was laying on it, even if it was not targeted by any dropship, until a successful medevac happened with that stretcher.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix: The medevac system cooldown now starts after you successfully grab a target, instead of when you activate it.
- fix: Fixed the medevac system sometimes grabbing a different target than the one originally selected.
- fix: Fixed the medevac stretcher sometimes playing its lift animation when no medevac was in progress.