### PR TITLE
Fix shooting the ML66D sometimes not being predicted correctly

### DIFF
--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -207,9 +207,10 @@ public abstract partial class SharedGunSystem : EntitySystem
         }
 
         //RMC14
-        if (_rmcSharedWeaponController.TryGetControlledWeapon(entity, out var weapon, out gunComp))
+        if (_rmcSharedWeaponController.TryGetControlledWeapon(entity, out var weapon, out gun))
         {
             gunEntity = weapon.Value;
+            gunComp = gun;
             return true;
         }
         //

--- a/Content.Shared/_RMC14/Emplacements/SharedWeaponMountSystem.cs
+++ b/Content.Shared/_RMC14/Emplacements/SharedWeaponMountSystem.cs
@@ -279,6 +279,8 @@ public abstract class SharedWeaponMountSystem : EntitySystem
             return;
 
         weapon.MountedTo = GetNetEntity(ent);
+        Dirty(args.Used.Value, weapon);
+
         ent.Comp.MountedEntity = args.Used;
         _collisionWake.SetEnabled(ent, false);
         _item.SetSize(ent, ent.Comp.MountedWeaponSize);
@@ -315,9 +317,10 @@ public abstract class SharedWeaponMountSystem : EntitySystem
             return;
 
         _container.EmptyContainer(container);
-        if (TryComp(ent.Comp.MountedEntity, out MountableWeaponComponent? attachedWeapon))
+        if (TryComp(ent.Comp.MountedEntity, out MountableWeaponComponent? mountableWeapon))
         {
-            attachedWeapon.MountedTo = GetNetEntity(ent);
+            mountableWeapon.MountedTo = null;
+            Dirty(ent.Comp.MountedEntity.Value, mountableWeapon);
         }
 
         if (TryComp(ent.Comp.MountedEntity, out MetaDataComponent? mountedMeta) && mountedMeta.EntityPrototype != null)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed the ML66D sometimes not being predicted correctly because of a value on the `MountableWeaponComponent` not updating on the client.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Resolves #9142 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
No CL
