### PR TITLE
King tacmap icon fix

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/king.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/king.yml
@@ -135,10 +135,10 @@
     name: rmc-job-name-xeno-king
   - type: TacticalMapIcon
     icon:
-      sprite: _RMC14/Interface/map_blips.rsi
+      sprite: /Textures/_RMC14/Interface/map_blips.rsi
       state: xenoking
     background:
-      sprite: _RMC14/Interface/map_blips.rsi
+      sprite: /Textures/_RMC14/Interface/map_blips.rsi
       state: xeno_ruler
   - type: StunOnExplosionReceived
     weak: false


### PR DESCRIPTION
## About the PR
fixed icon, was broken before and wouldn't show due to incorrect filepath

## Why / Balance
fix

## Technical details
yml

## Media
<img width="356" height="360" alt="image" src="https://github.com/user-attachments/assets/b44dcfb1-9ddb-4c13-a847-505be30e5fb2" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl: CatAndHats
- fix: the King's tactical map icon is no longer broken