### PR TITLE
fix: spec cryoing should work now

### DIFF
--- a/Content.Shared/_RMC14/Vendors/SharedCMAutomatedVendorSystem.cs
+++ b/Content.Shared/_RMC14/Vendors/SharedCMAutomatedVendorSystem.cs
@@ -521,13 +521,11 @@ public abstract class SharedCMAutomatedVendorSystem : EntitySystem
 
         if (section.SharedSpecLimit is { } globalLimit && !HasComp<IgnoreSpecLimitsComponent>(actor))
         {
-            if (HasComp<RMCVendorSpecialistComponent>(vendor))
+            if (TryComp<RMCVendorSpecialistComponent>(vendor, out var thisSpecVendor))
             {
-                var thisSpecVendor = Comp<RMCVendorSpecialistComponent>(vendor);
-
                 // If the vendor's own value is at or above the capacity, immediately return.
                 if (thisSpecVendor.GlobalSharedVends.TryGetValue(args.Entry, out var vendCount) &&
-                    vendCount >= section.SharedSpecLimit)
+                    vendCount >= globalLimit)
                 {
                     // FIXME
                     ResetChoices();
@@ -537,50 +535,31 @@ public abstract class SharedCMAutomatedVendorSystem : EntitySystem
 
                 // Get every RMCVendorSpec
                 var specVendors = EntityQueryEnumerator<RMCVendorSpecialistComponent>();
-                // Used to verify newer vendors
-                var maxAmongVendors = 0;
+                var allVendorsTotal = 0;
 
-                if (thisSpecVendor.GlobalSharedVends.TryGetValue(args.Entry, out vendCount))
-                    // So it doesn't matter what order the vendors are checked in
-                    maxAmongVendors = vendCount;
-
-                // Goes through each RMCVendorSpec and gets the largest value for this kit type.
-                while (specVendors.MoveNext(out var vendorId, out _))
+                // Goes through each RMCVendorSpec and gets the value for this kit type.
+                while (specVendors.MoveNext(out _, out var specVendorComponent))
                 {
-                    var specVendorComponent = EnsureComp<RMCVendorSpecialistComponent>(vendorId);
                     foreach (var linkedEntry in args.LinkedEntries)
                     {
                         specVendorComponent.GlobalSharedVends.TryGetValue(linkedEntry, out var linkedCount);
-                        maxAmongVendors += linkedCount;
+                        allVendorsTotal += linkedCount;
                     }
-
                     if (specVendorComponent.GlobalSharedVends.TryGetValue(args.Entry, out vendCount))
                     {
-                        if (vendCount > maxAmongVendors)
-                        {
-                            maxAmongVendors = specVendorComponent.GlobalSharedVends[args.Entry];
-                        }
-                        else
-                        {
-                            specVendorComponent.GlobalSharedVends[args.Entry] = maxAmongVendors;
-                        }
+                        allVendorsTotal += vendCount;
                     }
-                    else // Does not exist on the currently checked vendor
-                        specVendorComponent.GlobalSharedVends.Add(args.Entry, maxAmongVendors);
-
-                    Dirty(vendorId, specVendorComponent);
                 }
 
-                thisSpecVendor.GlobalSharedVends[args.Entry] = maxAmongVendors;
-
-                if (thisSpecVendor.GlobalSharedVends[args.Entry] >= section.SharedSpecLimit)
+                if (allVendorsTotal >= globalLimit)
                 {
                     ResetChoices();
                     _popup.PopupEntity(Loc.GetString("cm-vending-machine-specialist-max"), vendor.Owner, actor);
                     return;
                 }
 
-                thisSpecVendor.GlobalSharedVends[args.Entry] += 1;
+                var old = thisSpecVendor.GlobalSharedVends.GetValueOrDefault(args.Entry, 0);
+                thisSpecVendor.GlobalSharedVends[args.Entry] = old + 1;
                 Dirty(vendor, thisSpecVendor);
 
                 AddComp(actor, new RMCSpecCryoRefundComponent


### PR DESCRIPTION
## About the PR

This PR fixes the spec count not going down after a spec entered cryo.

## Why / Balance

Bugfix. Reported on discord.

## Technical details

The vendors saved the total across all vendors before.

## Media

Before:

https://github.com/user-attachments/assets/bbab3b1a-9a3f-476c-a590-2197c97500ee

After:

https://github.com/user-attachments/assets/e999b8d3-b2ca-4772-8370-bf658fe25376

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: The specialization of weapons specialists now gets freed up correctly upon entering cryosleep.
