### PR TITLE
add the SOCOM box to the G menu

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magazine_boxes.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magazine_boxes.yml
@@ -1049,6 +1049,7 @@
   parent: RMCBoxMagazineRifleBase
   id: RMCBoxBullets458Empty
   name: bullet bundle box (.458 SOCOM x 297) # Used to say 300 when it was, infact, not 300 rounds.
+  description: A box of bundled .458 SOCOM rounds.
   components:
   - type: Construction
     graph: RMCBoxMagazine

--- a/Resources/Prototypes/_RMC14/Recipes/Construction/magazine_box_crafting.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Construction/magazine_box_crafting.yml
@@ -159,6 +159,19 @@
   iconColor: "#695d42"
   objectType: Item
 
+# SOCOM
+- type: construction
+  parent: RMC
+  name: .458 SOCOM bullet bundle box
+  id: RMCBoxBullets458
+  graph: RMCBoxMagazine
+  startNode: start
+  targetNode: RMCBoxBullets458Empty
+  category: construction-category-cm-box-magazine
+  description: A box of bundled .458 SOCOM rounds.
+  iconColor: "#695d42"
+  objectType: Item
+
 # M1984
 - type: construction
   parent: RMC
@@ -620,6 +633,13 @@
         amount: 1
         doAfter: 0.25
 
+    # SOCOM
+    - to: RMCBoxBullets458Empty
+      steps:
+      - material: RMCSheetCardboard
+        amount: 1
+        doAfter: 0.25
+
     # M13 Auto Pistol
     - to: RMCBoxMagazinePistolM13Empty
       steps:
@@ -850,6 +870,10 @@
     entity: RMCBoxMagazineRifleM4SPRAPEmpty
   - node: RMCBoxMagazineRifleM4SPRExtEmpty
     entity: RMCBoxMagazineRifleM4SPRExtEmpty
+
+  # SOCOM
+  - node: RMCBoxBullets458Empty
+    entity: RMCBoxBullets458Empty
 
   # M13
   - node: RMCBoxMagazinePistolM13Empty


### PR DESCRIPTION
## About the PR

Title. Also gave the box a better description.

## Why / Balance

- QOL
- I failed to find it in the Z menu some rounds ago as it is under "rifle **magazine** boxes" even tho its just loose bullets. I would of expected it under either ammunition boxes or shotgun shell boxes as the game treats them like shotgun shells.

## Technical details

just yaml

## Media


https://github.com/user-attachments/assets/69683cf0-3690-49e1-85ac-9a2c4f21120d



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- tweak: The SOCOM box can now also be crafted from the construction menu.
