### PR TITLE
Headset default channel fixes

### DIFF
--- a/Content.Shared/Radio/Components/EncryptionKeyHolderComponent.cs
+++ b/Content.Shared/Radio/Components/EncryptionKeyHolderComponent.cs
@@ -60,6 +60,7 @@ public sealed partial class EncryptionKeyHolderComponent : Component
     ///     This is the channel that will be used when using the default/department prefix (<see cref="SharedChatSystem.DefaultChannelKey"/>).
     /// </summary>
     [ViewVariables]
+    [DataField] // RMC14 datafield attribute
     [AutoNetworkedField]
     public string? DefaultChannel;
 

--- a/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
+++ b/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.Shared._RMC14.Radio; // RMC14
 using Content.Shared.Chat;
 using Content.Shared.DoAfter;
 using Content.Shared.Examine;
@@ -66,7 +67,9 @@ public sealed partial class EncryptionKeySystem : EntitySystem
             return;
 
         component.Channels.Clear();
-        component.DefaultChannel = null;
+
+        if (!HasComp<RMCStaticDefaultChannelComponent>(uid))
+            component.DefaultChannel = null; // RMC14
 
         //RMC14
         component.ReadOnlyChannels.Clear();
@@ -77,7 +80,9 @@ public sealed partial class EncryptionKeySystem : EntitySystem
             {
                 component.Channels.UnionWith(key.Channels);
                 component.ReadOnlyChannels.UnionWith(key.ReadOnlyChannels);
-                component.DefaultChannel ??= key.DefaultChannel;
+
+                if (!HasComp<RMCStaticDefaultChannelComponent>(uid))
+                    component.DefaultChannel ??= key.DefaultChannel;
             }
         }
         //RMC14

--- a/Content.Shared/_RMC14/Radio/RMCStaticDefaultChannelComponent.cs
+++ b/Content.Shared/_RMC14/Radio/RMCStaticDefaultChannelComponent.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Radio;
+
+/// <summary>
+///     Add this component to headsets that should not have their default channel updated with encryption keys.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class RMCStaticDefaultChannelComponent : Component;

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/distress_headsets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/distress_headsets.yml
@@ -243,6 +243,7 @@
   - type: RMCHeadset
     channels:
     - MarineSOF
+  - type: RMCStaticDefaultChannel
   - type: EncryptionKeyHolder
     defaultChannel: MarineSOF
   - type: GrantSquadLeaderTracker
@@ -268,8 +269,6 @@
 - type: entity
   parent: RMCHeadsetForecon
   id: RMCHeadsetMARSOC
-  name: UNMC SOF headset
-  description: Issued exclusively to Marine Raiders and members of the UNMC's Force Reconnaissance.
   suffix: ERT
   components:
   - type: ContainerFill

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/distress_headsets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/distress_headsets.yml
@@ -243,6 +243,8 @@
   - type: RMCHeadset
     channels:
     - MarineSOF
+  - type: EncryptionKeyHolder
+    defaultChannel: MarineSOF
   - type: GrantSquadLeaderTracker
     defaultMode: SquadLeader
     trackerModes:

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/marine_headsets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/marine_headsets.yml
@@ -21,6 +21,8 @@
   components:
   - type: Sprite
     state: alpha_headset
+  - type: EncryptionKeyHolder
+    defaultChannel: MarineAlpha
   - type: ContainerFill
     containers:
       key_slots:
@@ -96,6 +98,8 @@
   components:
   - type: Sprite
     state: bravo_headset
+  - type: EncryptionKeyHolder
+    defaultChannel: MarineBravo
   - type: ContainerFill
     containers:
       key_slots:
@@ -171,6 +175,8 @@
   components:
   - type: Sprite
     state: charlie_headset
+  - type: EncryptionKeyHolder
+    defaultChannel: MarineCharlie
   - type: ContainerFill
     containers:
       key_slots:
@@ -246,6 +252,8 @@
   components:
   - type: Sprite
     state: delta_headset
+  - type: EncryptionKeyHolder
+    defaultChannel: MarineDelta
   - type: ContainerFill
     containers:
       key_slots:
@@ -321,6 +329,8 @@
   components:
   - type: Sprite
     state: echo_headset
+  - type: EncryptionKeyHolder
+    defaultChannel: MarineEcho
   - type: ContainerFill
     containers:
       key_slots:
@@ -396,6 +406,8 @@
   components:
   - type: Sprite
     state: cryo_headset
+  - type: EncryptionKeyHolder
+    defaultChannel: MarineFoxtrot
   - type: ContainerFill
     containers:
       key_slots:

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/marine_headsets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/marine_headsets.yml
@@ -11,6 +11,7 @@
     - PrimaryLandingZone
   - type: GrantTacMapAlert
   - type: HeadsetAutoSquad
+  - type: RMCStaticDefaultChannel
 
 # Alpha
 - type: entity

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/ship_headsets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/ship_headsets.yml
@@ -379,6 +379,8 @@
     - MarineFoxtrot
   - type: RMCHeadset
     radioTextIncrease: 3
+  - type: EncryptionKeyHolder
+    defaultChannel: MarineIntel
   - type: GrantSquadLeaderTracker
     defaultMode: AuxiliarySupportOfficer
     trackerModes:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Gives various squad headsets their default channel
Since the channels are applied innately from the squad, we need to give the headset itself the default channel

**Changelog**
:cl:
- fix: Fixed squad headsets not having the correct default channel, they should now default to your squad.
