### PR TITLE
Add barrel charger to req and attachment prep

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
@@ -600,6 +600,8 @@
     sections:
     - name: Barrel
       entries:
+      - id: RMCAttachmentBarrelCharger
+        amount: 2
       - id: RMCAttachmentExtendedBarrel
         amount: 7
       - id: RMCM5Bayonet

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/prep.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/prep.yml
@@ -545,6 +545,8 @@
     sections: # TODO RMC14
     - name: Barrel
       entries:
+      - id: RMCAttachmentBarrelCharger
+        amount: 1
       - id: RMCAttachmentExtendedBarrel
         amount: 3
       - id: RMCAttachmentExtendedCompensator


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
From CM13
It provides value to the game like any other attachment for certain playstyles, making single bullets hit harder. DPS stays the same.
It's horrific on shotguns, so that's not an issue (1.05x damage increase for an extra 0.25 seconds of fire delay)
Req can't buy these so they'll be decently rare

<img width="739" height="105" alt="image" src="https://github.com/user-attachments/assets/d5248ecd-430d-41ac-9525-7ef1f0d180a4" />
<img width="896" height="114" alt="image" src="https://github.com/user-attachments/assets/c4339b58-582c-401b-b22a-8e8518d9bb6b" />

CM had the attachments vendor be 0.75 and req be 1.5 so I set the attachments vendor to 1 and req to 2


**Changelog**
:cl:
- add: Added the barrel charger to the attachments vendor and requisitions. It decreases rate of fire, but allows the weapon to hit harder.
