### PR TITLE
Vulpkanin accent now removed by Accentless trait

### DIFF
--- a/Resources/Prototypes/_RMC14/Traits/accents.yml
+++ b/Resources/Prototypes/_RMC14/Traits/accents.yml
@@ -57,6 +57,7 @@
     removes:
     - type: LizardAccent
     - type: MothAccent
+    - type: VulpkaninAccent
     - type: ReplacementAccent
       accent: dwarf
 


### PR DESCRIPTION
## About the PR
title

## Why / Balance
bugfixing

## Technical details
yml

## Media
I tested it but forgor to take screenshots, trust

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl: CatAndHats
- fix: Accentless trait now correctly removes Vulpkanin default accent