### PR TITLE
the smart refill tank can be used like a beaker

### DIFF
--- a/Content.Shared/_RMC14/Medical/Refill/CMRefillableSolutionSystem.cs
+++ b/Content.Shared/_RMC14/Medical/Refill/CMRefillableSolutionSystem.cs
@@ -21,6 +21,7 @@ using Content.Shared.DoAfter;
 using Content.Shared.Nutrition.Components;
 using Content.Shared.Chemistry.Reagent;
 using Robust.Shared.Audio.Systems;
+using Content.Shared.Tag;
 
 namespace Content.Shared._RMC14.Medical.Refill;
 
@@ -33,6 +34,7 @@ public sealed class CMRefillableSolutionSystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedSolutionContainerSystem _solution = default!;
     [Dependency] private readonly SolutionTransferSystem _solutionTransfer = default!;
+    [Dependency] private readonly TagSystem _tag = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
     [Dependency] private readonly RMCPlanetSystem _rmcPlanet = default!;
@@ -425,7 +427,8 @@ public sealed class CMRefillableSolutionSystem : EntitySystem
         if (args.Handled)
             return;
 
-        if (!TryComp<CMRefillableSolutionComponent>(args.Used, out var refillableSolutionComponent) ||
+        if (!_tag.HasTag(args.Used, ent.Comp.OnlyFillThis) ||
+            !TryComp<CMRefillableSolutionComponent>(args.Used, out var refillableSolutionComponent) ||
             !_solution.TryGetSolution(args.Used, refillableSolutionComponent.Solution, out var penSolutionComp) ||
             !_solution.TryGetSolution(ent.Owner, ent.Comp.Solution, out var tankSolutionComp))
             return;

--- a/Content.Shared/_RMC14/Medical/Refill/RMCSmartRefillTankComponent.cs
+++ b/Content.Shared/_RMC14/Medical/Refill/RMCSmartRefillTankComponent.cs
@@ -1,4 +1,6 @@
+using Content.Shared.Tag;
 using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared._RMC14.Medical.Refill;
 
@@ -8,4 +10,7 @@ public sealed partial class RMCSmartRefillTankComponent : Component
 {
     [DataField(required: true), AutoNetworkedField]
     public string Solution = string.Empty;
+
+    [DataField, AutoNetworkedField]
+    public ProtoId<TagPrototype> OnlyFillThis = "CMAutoInjector";
 }

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Medical/beaker.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Medical/beaker.yml
@@ -278,7 +278,7 @@
 
 # Minitank /obj/item/reagent_container/glass/minitank
 - type: entity
-  parent: RMCSealedChemicalContainer
+  parent: RMCBeakerBaseMetallic
   id: CMMiniTank
   name: MS-11 Smart Refill Tank
   description: A robust little tank capable of refilling autoinjectors that previously required a nanomed system to refill. Using the wonders of microchips, it automatically sorts the correct chemicals into most single reagent autoinjectors. It is unable to partially fill them however. A valve exists on the top to transfer reagents to another container or to flush it entirely.
@@ -308,9 +308,20 @@
     - ChemDispensable
   - type: RMCSmartRefillTank
     solution: beaker
-  - type: RMCFlushableSolution
-    solution: beaker
-    flushTime: 3
+  - type: SolutionTransfer
+    transferAmount: 180
+    maxTransferAmount: 180
+    canChangeTransferAmount: true
+    transferAmounts:
+    - 5
+    - 10
+    - 15
+    - 30
+    - 45
+    - 60
+    - 90
+    - 120
+    - 180
   - type: PhysicalComposition
     materialComposition:
       CMSteel: 500


### PR DESCRIPTION
## About the PR

title

## Why / Balance

parity it seems

## Technical details

I thought it was sealed like the p-can. turns out I was wrong.

## Media

https://github.com/user-attachments/assets/b1abc1d4-f91e-45bc-9a0a-2f0ee691f88c



https://github.com/user-attachments/assets/78460430-3cdc-410a-b483-f86963d9cd39



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- tweak: The smart refill tank can now be filled and emptied like a beaker.
