### PR TITLE
Fix arrival sound not playing groundside

### DIFF
--- a/Content.Server/_RMC14/Dropship/DropshipSystem.cs
+++ b/Content.Server/_RMC14/Dropship/DropshipSystem.cs
@@ -186,12 +186,6 @@ public sealed class DropshipSystem : SharedDropshipSystem
         {
             ent.Comp.State = ftl.State;
             Dirty(ent);
-
-            if (ftl.State == FTLState.Arriving && ent.Comp.Destination is { } destination)
-            {
-                var audio = _audio.PlayPvs(ent.Comp.ArrivalSound, destination);
-                _audio.SetGridAudio(audio);
-            }
         }
 
         RefreshUI();
@@ -280,6 +274,10 @@ public sealed class DropshipSystem : SharedDropshipSystem
         if (ent.Comp.Ship != args.Relayer)
             return;
 
+        QueueDel(ent.Comp.ArrivalSoundEntity);
+        ent.Comp.ArrivalSoundEntity = null;
+        Dirty(ent);
+
         ToggleLandingLights(ent, false);
     }
 
@@ -293,6 +291,18 @@ public sealed class DropshipSystem : SharedDropshipSystem
 
         if (ftl.State is not FTLState.Arriving)
             return;
+
+        if (TryComp<DropshipComponent>(ent.Comp.Ship, out var dropship) &&
+            ftl.State == FTLState.Arriving &&
+            dropship.Destination is { } destination)
+        {
+            var audio = _audio.PlayPvs(dropship.ArrivalSound, destination);
+            if (audio != null)
+            {
+                ent.Comp.ArrivalSoundEntity = audio.Value.Entity;
+                Dirty(ent);
+            }
+        }
 
         ToggleLandingLights(ent, true);
     }

--- a/Content.Shared/_RMC14/Dropship/DropshipDestinationComponent.cs
+++ b/Content.Shared/_RMC14/Dropship/DropshipDestinationComponent.cs
@@ -14,4 +14,7 @@ public sealed partial class DropshipDestinationComponent : Component
 
     [DataField, AutoNetworkedField]
     public int LightSearchRadius = 14;
+
+    [DataField, AutoNetworkedField]
+    public EntityUid? ArrivalSoundEntity;
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The dropship arrival sound now properly plays at the destination when the dropship enters the "Arrival" state.
Also fixes an error related to why there currently is no sound being played.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fix.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix: Fixed the dropship arrival sound not playing right before a dropship lands.
