### PR TITLE
Change CE deployment clause to require no ASO, change CE overseer to current commander

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Engineering/chief_engineer.yml
@@ -20,7 +20,7 @@
   requireAdminNotify: true
   joinNotifyCrew: false
   marineAuthorityLevel: 9
-  supervisors: cm-job-supervisors-aso
+  supervisors: rmc-job-supervisors-commander
   accessGroups:
   - CMCE
   roleWeight: 0.25

--- a/Resources/ServerInfo/Guidebook/_RMC14/SOP/RMCMarineSOPDepartment.xml
+++ b/Resources/ServerInfo/Guidebook/_RMC14/SOP/RMCMarineSOPDepartment.xml
@@ -37,9 +37,8 @@
 
   ## Engineering
 
-  - The [bold]Chief Engineer[/bold] is in charge of modifications made to the warship as well as performing repairs, and maintenance.
-  - The [bold]Chief Engineer[/bold] is still required to follow the warship modifications section of SOP.
-  - The [bold]Auxiliary Support Officer[/bold] holds authority over the [bold]Chief Engineer[/bold].
+  - The [bold]Chief Engineer[/bold] is in charge of modifications made to the ship as well as performing repairs, and maintenance.
+  - The [bold]Chief Engineer[/bold] is still required to follow the ship modifications section of SOP.
   - The ordnance technicians are part of the engineering department.
   - During code [bold][color=black]Delta[/color][/bold], the engineering department is to follow orders from command. All engineering personnel are to join the marines in either holding the warship, or assisting with evacuation of civilians, depending on the orders of command.
 

--- a/Resources/ServerInfo/Guidebook/_RMC14/SOP/RMCMarineSOPNONModDeployment.xml
+++ b/Resources/ServerInfo/Guidebook/_RMC14/SOP/RMCMarineSOPNONModDeployment.xml
@@ -41,7 +41,7 @@
 
   [bold]Engineering[/bold]
 
-  - The [bold]Chief Engineer[/bold] may deploy to the [bold]FOB[/bold] if there is an [bold]Auxiliary Support Officer[/bold] on board, but still requires permission from them or the [color=#008000][bold]Commander[/bold][/color].
+  - The [bold]Chief Engineer[/bold] may deploy to the [bold]FOB[/bold] with permission from the [color=#008000][bold]Commander[/bold][/color], only if there is other personnel on board capable of performing mission critical engineering and maintenance tasks, such as shipside deconstruction and loading of the Orbital Cannon.
   - Both the [bold]Chief Engineer[/bold] and maintenance techs may only deploy with the purpose of building the [bold]FOB[/bold], and telecommunications, but must leave if these areas are no longer considered secure.
 
   [bold]Medical[/bold]


### PR DESCRIPTION
## About the PR
From a discussion, it was pointed out that the ASO technically had authority over the CE, which is largely unknown amongst the community, and causes some issues in chain of command. Its weird that one Head of department should be be in charge of another head of department.

Saani further asked me to help him throw together this PR to suggest the change, from this feature thread :  [Discord Link](https://discord.com/channels/1168210010233376858/1466246035369099376)

## Why / Balance
Prevent future authority abuse. Clearer chain of command. Allow the CE to deploy, if there is no ASO.

## Technical details
Minor YML Changes

## Media
Removed reference to the ASO having authority over the CE
<img width="1362" height="463" alt="image" src="https://github.com/user-attachments/assets/7fa3b0ff-7e2a-4c75-8181-e16f13cd1a11" />

Adjusted the wording in the deployment section to require only the Commanders approval, and only not required onboard.
<img width="1366" height="583" alt="image" src="https://github.com/user-attachments/assets/8ba7a1c0-2e29-4a09-891c-36cef9bd7638" />

Changed the supervisor in the Job YML so the join message is updated appropriately
<img width="1127" height="408" alt="image" src="https://github.com/user-attachments/assets/36a6e86e-038c-4130-9842-babf1728ab98" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: ASO no longer has authority over the CE.
