### PR TITLE
Fix barricade upgrades taking too much fire damage over time

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Walls/Barricades/barricade_metal.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Walls/Barricades/barricade_metal.yml
@@ -105,7 +105,7 @@
     - type: Flammable
       damage:
         types:
-          Heat: 2.8125
+          Heat: 1.5
 
 - type: entity
   parent: CMBarricadeMetal
@@ -154,7 +154,7 @@
     - type: Flammable
       damage:
         types:
-          Heat: 1.875
+          Heat: 1
 
 # Turnstile (not sure how to make a one-way door so for now it is a glorified fence)
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I forgot to lower the damage the barricade upgrades receive when I lowered the base barricade's received damage in #9082. This means that currently bio barricades take more fire damage than regular ones, and composite ones barely improve fire resistance.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

1. Regular barricades keep their current fire damage value of 2.
2. Bio barricades now have a damage value of 1.5(reduced by ~47%)
3. Composite barricades now have a damage value of 1(reduced by ~47%)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix: Fixed barricade upgrades taking too much fire damage over time
