### PR TITLE
Prefix RMC entities (Factions)

### DIFF
--- a/Content.Server/_RMC14/Requisitions/RequisitionsSystem.cs
+++ b/Content.Server/_RMC14/Requisitions/RequisitionsSystem.cs
@@ -47,7 +47,7 @@ public sealed partial class RequisitionsSystem : SharedRequisitionsSystem
 
     private static readonly EntProtoId AccountId = "RMCASRSAccount";
     private static readonly EntProtoId PaperRequisitionInvoice = "RMCPaperRequisitionInvoice";
-    private static readonly EntProtoId<IFFFactionComponent> MarineFaction = "FactionMarine";
+    private static readonly EntProtoId<IFFFactionComponent> MarineFaction = "RMCFactionMarine";
 
     private EntityQuery<ChasmComponent> _chasmQuery;
     private EntityQuery<ChasmFallingComponent> _chasmFallingQuery;

--- a/Content.Shared/_RMC14/Marines/Access/IdModificationConsoleComponent.cs
+++ b/Content.Shared/_RMC14/Marines/Access/IdModificationConsoleComponent.cs
@@ -25,7 +25,7 @@ public sealed partial class IdModificationConsoleComponent : Component
     public bool Authenticated;
 
     [DataField] [AutoNetworkedField]
-    public EntProtoId<IFFFactionComponent> Faction = "FactionMarine";
+    public EntProtoId<IFFFactionComponent> Faction = "RMCFactionMarine";
 
     [DataField] [AutoNetworkedField]
     public bool HasIFF;

--- a/Content.Shared/_RMC14/Marines/Access/IdModificationConsoleSystem.cs
+++ b/Content.Shared/_RMC14/Marines/Access/IdModificationConsoleSystem.cs
@@ -109,7 +109,7 @@ public sealed class IdModificationConsoleSystem : EntitySystem
             !TryComp(uid, out IdCardComponent? idCard) || !TryComp(uid, out AccessComponent? access))
             return;
 
-        _iff.SetIdFaction((uid.Value, iff), "FactionSurvivor");
+        _iff.SetIdFaction((uid.Value, iff), "RMCFactionSurvivor");
         ent.Comp.HasIFF = false;
 
         foreach (var accessToRemove in ent.Comp.AccessList)
@@ -168,7 +168,7 @@ public sealed class IdModificationConsoleSystem : EntitySystem
 
             if (iff.Factions.Count == 0)
             {
-                _iff.SetIdFaction((uid.Value, iff), "FactionSurvivor");
+                _iff.SetIdFaction((uid.Value, iff), "RMCFactionSurvivor");
             }
             else if (removed)
                 Dirty(uid.Value, iff);

--- a/Content.Shared/_RMC14/Rules/CMDistressSignalRuleComponent.cs
+++ b/Content.Shared/_RMC14/Rules/CMDistressSignalRuleComponent.cs
@@ -47,10 +47,10 @@ public sealed partial class CMDistressSignalRuleComponent : Component
     public EntProtoId LarvaEnt = "CMXenoLarva";
 
     [DataField]
-    public EntProtoId<IFFFactionComponent> MarineFaction = "FactionMarine";
+    public EntProtoId<IFFFactionComponent> MarineFaction = "RMCFactionMarine";
 
     [DataField]
-    public EntProtoId<IFFFactionComponent> SurvivorFaction = "FactionSurvivor";
+    public EntProtoId<IFFFactionComponent> SurvivorFaction = "RMCFactionSurvivor";
 
     [DataField, AutoPausedField]
     public TimeSpan? QueenDiedCheck;

--- a/Resources/Prototypes/_RMC14/Access/Groups/default_access_groups.yml
+++ b/Resources/Prototypes/_RMC14/Access/Groups/default_access_groups.yml
@@ -5,7 +5,7 @@
 - type: accessGroup
   id: RMCBaseHidden
   name: protobaseaccess UNMC Hidden
-  faction: FactionMarine
+  faction: RMCFactionMarine
   accessGroup: UNMC Hidden
   hidden: true
   tags:
@@ -14,7 +14,7 @@
 - type: accessGroup
   id: RMCBaseCommandJob
   name: protobaseaccess UNMC Command
-  faction: FactionMarine
+  faction: RMCFactionMarine
   accessGroup: UNMC Command
   tags:
   - RMCMarineDefaultAccess
@@ -22,7 +22,7 @@
 - type: accessGroup
   id: RMCBaseAuxiliaryJob
   name: protobaseaccess UNMC Auxiliary
-  faction: FactionMarine
+  faction: RMCFactionMarine
   accessGroup: UNMC Auxiliary
   tags:
   - RMCMarineDefaultAccess
@@ -30,7 +30,7 @@
 - type: accessGroup
   id: RMCBaseMiscellaneousJob
   name: protobaseaccess UNMC Miscellaneous
-  faction: FactionMarine
+  faction: RMCFactionMarine
   accessGroup: UNMC Miscellaneous
   tags:
   - RMCMarineDefaultAccess
@@ -38,7 +38,7 @@
 - type: accessGroup
   id: RMCBaseMPJob
   name: protobaseaccess UNMC Military Police
-  faction: FactionMarine
+  faction: RMCFactionMarine
   accessGroup: UNMC Military Police
   tags:
   - RMCMarineDefaultAccess
@@ -46,7 +46,7 @@
 - type: accessGroup
   id: RMCBaseEngineeringJob
   name: protobaseaccess UNMC Engineering
-  faction: FactionMarine
+  faction: RMCFactionMarine
   accessGroup: UNMC Engineering
   tags:
   - RMCMarineDefaultAccess
@@ -54,7 +54,7 @@
 - type: accessGroup
   id: RMCBaseRequisitionsJob
   name: protobaseaccess UNMC Requisitions
-  faction: FactionMarine
+  faction: RMCFactionMarine
   accessGroup: UNMC Requisitions
   tags:
   - RMCMarineDefaultAccess
@@ -62,7 +62,7 @@
 - type: accessGroup
   id: RMCBaseMedicalJob
   name: protobaseaccess UNMC Medical
-  faction: FactionMarine
+  faction: RMCFactionMarine
   accessGroup: UNMC Medical
   tags:
   - RMCMarineDefaultAccess
@@ -70,7 +70,7 @@
 - type: accessGroup
   id: RMCBaseMarinesJob
   name: protobaseaccess UNMC Marines
-  faction: FactionMarine
+  faction: RMCFactionMarine
   accessGroup: UNMC Marines
   tags:
   - RMCMarineDefaultAccess

--- a/Resources/Prototypes/_RMC14/Access/default_access.yml
+++ b/Resources/Prototypes/_RMC14/Access/default_access.yml
@@ -9,42 +9,42 @@
 - type: accessLevel
   id: RMCBaseHidden
   name: protobaseaccess UNMC Hidden
-  faction: FactionMarine
+  faction: RMCFactionMarine
   accessGroup: UNMC Hidden
   hidden: true
 
 - type: accessLevel
   id: RMCBaseCommandAccess
   name: protobaseaccess UNMC Command
-  faction: FactionMarine
+  faction: RMCFactionMarine
   accessGroup: UNMC Command
 
 - type: accessLevel
   id: RMCBaseMPAccess
   name: protobaseaccess UNMC Military Police
-  faction: FactionMarine
+  faction: RMCFactionMarine
   accessGroup: UNMC Military Police
 
 - type: accessLevel
   id: RMCBaseMedicalAccess
   name: protobaseaccess UNMC Medical
-  faction: FactionMarine
+  faction: RMCFactionMarine
   accessGroup: UNMC Medical
 
 - type: accessLevel
   id: RMCBaseEngineeringAccess
   name: protobaseaccess UNMC Engineering
-  faction: FactionMarine
+  faction: RMCFactionMarine
   accessGroup: UNMC Engineering
 
 - type: accessLevel
   id: RMCBaseMarineAccess
   name: protobaseaccess UNMC Marine
-  faction: FactionMarine
+  faction: RMCFactionMarine
   accessGroup: UNMC Marine Access
 
 - type: accessLevel
   id: RMCBaseSquadAccess
   name: protobaseaccess UNMC Squad
-  faction: FactionMarine
+  faction: RMCFactionMarine
   accessGroup: UNMC Squad

--- a/Resources/Prototypes/_RMC14/Entities/Objects/IdCards/cm_base_id.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/IdCards/cm_base_id.yml
@@ -24,7 +24,7 @@
     canMicrowave: false
   - type: ItemIFF
     factions:
-    - FactionMarine
+    - RMCFactionMarine
   - type: TakeableTags
   - type: Appearance
   - type: Foldable
@@ -176,7 +176,7 @@
     - DoorBumpOpener
   - type: ItemIFF
     factions:
-    - FactionMarine
+    - RMCFactionMarine
   - type: Corrodible
     isCorrodible: false
 
@@ -224,3 +224,46 @@
     slots:
     - idcard
     sprite: _RMC14/Objects/CMIDs/lanyard.rsi
+
+- type: entity
+  id: RMCFactionMarine
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: IFFFaction
+  - type: FactionFrequencies
+    channels:
+    - MarineCommand
+    - MarineMedical
+    - MarineEngineer
+    - MarineMilitaryPolice
+#    - TODO RMC14 sentry
+    - MarineAlpha
+    - MarineBravo
+    - MarineCharlie
+    - MarineDelta
+    - MarineEcho
+    - MarineFoxtrot
+    - MarineRequisition
+    - MarineJTAC
+    - MarineIntel
+    - MarineSOF
+    - WEYA
+
+- type: entity
+  id: RMCFactionSurvivor
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: IFFFaction
+  - type: FactionFrequencies
+    channels:
+    - Colony
+
+- type: entity
+  id: RMCFactionTSE
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: IFFFaction
+  - type: FactionFrequencies
+    channels:
+    - Colony
+    - TSE

--- a/Resources/Prototypes/_RMC14/Entities/Objects/IdCards/cm_id_other.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/IdCards/cm_id_other.yml
@@ -23,7 +23,7 @@
     job: CMSurvivor
   - type: ItemIFF
     factions:
-    - FactionSurvivor
+    - RMCFactionSurvivor
 
 - type: entity
   parent: CMIDCardSilver
@@ -34,7 +34,7 @@
     job: CMSurvivorDoctor
   - type: ItemIFF
     factions:
-    - FactionSurvivor
+    - RMCFactionSurvivor
 
 - type: entity
   parent: CMIDCardLanyard
@@ -45,7 +45,7 @@
     job: CMSurvivorEngineer
   - type: ItemIFF
     factions:
-    - FactionSurvivor
+    - RMCFactionSurvivor
 
 - type: entity
   parent: CMIDCardSilver
@@ -56,7 +56,7 @@
     job: CMSurvivorScientist
   - type: ItemIFF
     factions:
-    - FactionSurvivor
+    - RMCFactionSurvivor
 
 - type: entity
   parent: CMIDCardLanyard
@@ -72,7 +72,7 @@
     job: CMSurvivorSecurity
   - type: ItemIFF
     factions:
-    - FactionSurvivor
+    - RMCFactionSurvivor
 
 - type: entity
   parent: CMIDCardSilver
@@ -85,8 +85,8 @@
     state: corporate_liaison
   - type: ItemIFF
     factions:
-    - FactionWeYa
-    - FactionMarine
+    - RMCFactionWeYa
+    - RMCFactionMarine
   - type: PresetIdCard
     job: CMLiaison
 
@@ -101,7 +101,7 @@
     state: pmc
   - type: ItemIFF
     factions:
-    - FactionWeYa
+    - RMCFactionWeYa
 
 - type: entity
   parent: CMIDCardLiaison
@@ -114,7 +114,7 @@
     state: pmc
   - type: ItemIFF
     factions:
-    - FactionWeYa
+    - RMCFactionWeYa
   - type: PresetIdCard
     job: CMLiaison
 
@@ -125,8 +125,8 @@
   components:
   - type: ItemIFF
     factions:
-    - FactionWeYa
-    - FactionSurvivor
+    - RMCFactionWeYa
+    - RMCFactionSurvivor
   - type: PresetIdCard
     job: CMSurvivorCorporate
 
@@ -194,7 +194,7 @@
     job: CMBureauMarshal
   - type: ItemIFF
     factions:
-    - FactionMarine
+    - RMCFactionMarine
 
 - type: entity
   parent: CMIDCardSilver
@@ -206,7 +206,7 @@
     job: CMBureauDeputy
   - type: ItemIFF
     factions:
-    - FactionMarine
+    - RMCFactionMarine
 
 - type: entity
   parent: CMIDCardSilver
@@ -216,11 +216,21 @@
   components:
   - type: ItemIFF
     factions:
-    - FactionWeYa
+    - RMCFactionWeYa
   - type: Access
     groups:
     - Colony
     - RMCWeYa
+
+- type: entity
+  id: RMCFactionWeYa
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: IFFFaction
+  - type: FactionFrequencies
+    channels:
+    - Colony
+    - WEYA
 
 - type: entity
   parent: CMIDCardLanyard
@@ -324,7 +334,7 @@
     job: RMCJobSyntheticColony
   - type: ItemIFF
     factions:
-    - FactionSurvivor
+    - RMCFactionSurvivor
 
 - type: entity
   id: RMCIDCardAegis

--- a/Resources/Prototypes/_RMC14/Entities/Objects/IdCards/rmc_id_cmb.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/IdCards/rmc_id_cmb.yml
@@ -50,8 +50,8 @@
     sprite: _RMC14/Objects/CMIDs/cmb_deputy.rsi
   - type: ItemIFF
     factions:
-    - FactionMarine
-    - FactionSurvivor
+    - RMCFactionMarine
+    - RMCFactionSurvivor
   - type: PresetIdCard
     job: CMSurvivorCMBDeputy
 
@@ -70,5 +70,5 @@
     sprite: _RMC14/Objects/CMIDs/cmb_marshal.rsi
   - type: ItemIFF
     factions:
-    - FactionMarine
-    - FactionSurvivor
+    - RMCFactionMarine
+    - RMCFactionSurvivor

--- a/Resources/Prototypes/_RMC14/Entities/Objects/IdCards/rmc_id_tse.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/IdCards/rmc_id_tse.yml
@@ -13,7 +13,7 @@
     sprite: _RMC14/Objects/CMIDs/tsepa_silver.rsi
   - type: ItemIFF
     factions:
-    - FactionTSE
+    - RMCFactionTSE
 
 - type: entity
   parent: CMIDCardBase
@@ -30,7 +30,7 @@
     sprite: _RMC14/Objects/CMIDs/tsepa_silver_gold.rsi
   - type: ItemIFF
     factions:
-    - FactionTSE
+    - RMCFactionTSE
 
 - type: entity
   parent: CMIDCardBase
@@ -47,7 +47,7 @@
     sprite: _RMC14/Objects/CMIDs/tsepa_gold.rsi
   - type: ItemIFF
     factions:
-    - FactionTSE
+    - RMCFactionTSE
 
 # Survivors
 - type: entity
@@ -59,5 +59,5 @@
   components:
   - type: ItemIFF
     factions:
-    - FactionTSE
-    - FactionSurvivor
+    - RMCFactionTSE
+    - RMCFactionSurvivor

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -1479,3 +1479,9 @@ CMPosterZSPA2: RMCPosterTSEPA2
 CMPosterZSPA3: RMCPosterTSEPA3
 RMCSpawnerERTShuttleZSPA: RMCSpawnerERTShuttleTSEPA
 RMCSpawnerShuttleZSPA: RMCSpawnerShuttleTSEPA
+ 
+# 2026-02-12 - Prefix RMC entities (Factions)
+FactionMarine: RMCFactionMarine
+FactionSurvivor: RMCFactionSurvivor
+FactionTSE: RMCFactionTSE
+FactionWeYa: RMCFactionWeYa


### PR DESCRIPTION
Partially addresses #8892

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Standardizes faction-related entity IDs and references under `_RMC14`, using `RMC`-prefixed faction identifiers where applicable.

## Why / Balance

Enforce consistent faction naming:

- Keep `CM` prefixes and `RMC` prefixes.
- Add `RMC` to faction entities without either prefix.

## Technical details

- Renamed faction entity IDs and synchronized ID-card/access/requisition references.
- Updated shared/server systems that reference those faction IDs.
- Added migration mappings for renamed faction entities.

## Media

Not required (naming consistency changes only).

## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:

- code: Standardized RMC faction entity IDs and updated access/system references.
