### PR TITLE
Prefix RMC entities (Gear)

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
@@ -1541,7 +1541,7 @@
 
 - type: entity
   parent: RMCBeltHolsterPistol
-  id: GoldHandcannonBeltFilled
+  id: RMCGoldHandcannonBeltFilled
   suffix: Filled, Gold Handcannon
   components:
   - type: StorageFill

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/hefa.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/hefa.yml
@@ -1,5 +1,5 @@
 ﻿- type: entity
-  parent: JumpsuitMarine
+  parent: RMCJumpsuitMarine
   id: RMCJumpsuitHEFA
   name: HEFA uniform
   description: Standard-issue HEFA uniform. They have shards of light Kevlar to help protect against stabbing weapons and bullets.

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/marines.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/marines.yml
@@ -8,7 +8,7 @@
 
 - type: entity
   parent: [RMCMarineUniformBase, RMCAlternateFoldableUniformBase]
-  id: JumpsuitMarine
+  id: RMCJumpsuitMarine
   name: UNMC uniform
   description: Standard-issue Marine uniform. They have shards of light Kevlar to help protect against stabbing weapons and bullets.
   components:
@@ -24,7 +24,7 @@
       Urban: _RMC14/Objects/Clothing/Uniforms/Marine/standard/urban.rsi
 
 - type: entity
-  parent: [JumpsuitMarine, RMCJumpsuitMarinePatchBase]
+  parent: [RMCJumpsuitMarine, RMCJumpsuitMarinePatchBase]
   id: RMCJumpsuitMarinePatch
   suffix: Patch
 
@@ -39,7 +39,7 @@
 
 # ComTech
 - type: entity
-  parent: JumpsuitMarine
+  parent: RMCJumpsuitMarine
   id: CMJumpsuitMarineEngineer
   name: UNMC ComTech uniform
   description: Standard-issue Marine combat technician fatigues. They have shards of light Kevlar to help protect against stabbing weapons and bullets.
@@ -61,7 +61,7 @@
 
 # Hospital Corpsman
 - type: entity
-  parent: JumpsuitMarine
+  parent: RMCJumpsuitMarine
   id: CMJumpsuitMarineMedic
   name: UNMC corpsman uniform
   description: Standard-issue Marine hospital corpsman fatigues. They have shards of light Kevlar to help protect against stabbing weapons and bullets.
@@ -83,7 +83,7 @@
 
 # RTO / FTL
 - type: entity
-  parent: JumpsuitMarine
+  parent: RMCJumpsuitMarine
   id: CMJumpsuitMarineRTO
   name: UNMC radio telephone operator uniform
   description: Standard-issue RTO fatigues. They have shards of light Kevlar to help protect against stabbing weapons and bullets.
@@ -105,7 +105,7 @@
 
 # Sniper
 - type: entity
-  parent: JumpsuitMarine
+  parent: RMCJumpsuitMarine
   id: CMJumpsuitMarineSniper
   name: UNMC sniper uniform
 
@@ -137,7 +137,7 @@
 # Sun Riders
 
 - type: entity
-  parent: JumpsuitMarine
+  parent: RMCJumpsuitMarine
   id: RMCJumpsuitSunRiders
   components:
   - type: UniformAccessoryHolder

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/police.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/police.yml
@@ -1,6 +1,6 @@
 # Military Police
 - type: entity
-  parent: JumpsuitMarine
+  parent: RMCJumpsuitMarine
   id: CMJumpsuitMP
   name: military police jumpsuit
   description: Standard-issue Military Police uniform. It has shards of light Kevlar to help protect against stabbing weapons and bullets.
@@ -32,7 +32,7 @@
 
 # Military Warden
 - type: entity
-  parent: JumpsuitMarine
+  parent: RMCJumpsuitMarine
   id: CMJumpsuitWarden
   name: military warden uniform
   description: Standard-issue Military Warden uniform. It has shards of light Kevlar to help protect against stabbing weapons and bullets.

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/training_dummy.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/training_dummy.yml
@@ -29,7 +29,7 @@
 - type: startingGear
   id: RMCGearTrainingDummy
   equipment:
-    jumpsuit: JumpsuitMarine
+    jumpsuit: RMCJumpsuitMarine
     shoes: CMBootsBlack
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
@@ -698,7 +698,7 @@
     sections:
     - name: Uniform
       entries:
-      - id: JumpsuitMarine
+      - id: RMCJumpsuitMarine
         amount: 20
       - id: CMJumpsuitMarineEngineer
         amount: 5

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/synthetic.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/synthetic.yml
@@ -26,7 +26,7 @@
       - id: RMCJumpsuitSynthetic
         # mandatory: true, TODO allow vendors to mark entries as mandatory
         # /obj/item/clothing/under/rank/synthetic/old
-      - id: JumpsuitMarine
+      - id: RMCJumpsuitMarine
       - id: CMJumpsuitMarineMedic
     - name: Webbing
       choices: { CMAccessories: 1 }

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/prep.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/prep.yml
@@ -163,7 +163,7 @@
         amount: 15
       - id: CMBootsGrey
         amount: 15
-      - id: JumpsuitMarine
+      - id: RMCJumpsuitMarine
         amount: 15
       - id: CMHandsBrown
         amount: 15

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/fireteam_leader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/fireteam_leader.yml
@@ -62,7 +62,7 @@
 - type: startingGear
   id: CMGearFireteamLeaderEquipped
   equipment:
-    jumpsuit: JumpsuitMarine
+    jumpsuit: RMCJumpsuitMarine
     shoes: CMBootsBlackFilled
     head: CMArmorHelmetM12
     outerClothing: CMArmorM4

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/recruit.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/recruit.yml
@@ -36,7 +36,7 @@
 - type: startingGear
   id: RMCGearRecruit
   equipment:
-    jumpsuit: JumpsuitMarine
+    jumpsuit: RMCJumpsuitMarine
     shoes: CMBootsBlack
     gloves: CMHandsBlackMarine
     id: CMDogtagRifleman

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/rifleman.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/rifleman.yml
@@ -53,7 +53,7 @@
 - type: startingGear
   id: CMGearRiflemanEquipped
   equipment:
-    jumpsuit: JumpsuitMarine
+    jumpsuit: RMCJumpsuitMarine
     shoes: CMBootsBlackFilled
     head: ArmorHelmetM10
     outerClothing: RMCArmorM3MediumVariants

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/smart_gun_operator.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/smart_gun_operator.yml
@@ -61,7 +61,7 @@
 - type: startingGear
   id: CMGearSmartGunOperatorEquipped
   equipment:
-    jumpsuit: JumpsuitMarine
+    jumpsuit: RMCJumpsuitMarine
     shoes: CMBootsBlackFilled
     head: ArmorHelmetM10
     outerClothing: CMArmorSmartGunCombatHarness

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/squad_leader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/squad_leader.yml
@@ -86,7 +86,7 @@
 - type: startingGear
   id: CMGearSquadLeaderEquipped
   equipment:
-    jumpsuit: JumpsuitMarine
+    jumpsuit: RMCJumpsuitMarine
     shoes: CMBootsBlackFilled
     head: CMArmorHelmetM11
     outerClothing: CMArmorB12

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/weapons_specialist.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/weapons_specialist.yml
@@ -67,7 +67,7 @@
 - type: startingGear
   id: CMGearWeaponsSpecialistEquipped
   equipment:
-    jumpsuit: JumpsuitMarine
+    jumpsuit: RMCJumpsuitMarine
     shoes: CMBootsBlackFilled
     head: ArmorHelmetM10
     gloves: CMHandsBlackMarine

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/FORECON/assisstantsquadlead.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/FORECON/assisstantsquadlead.yml
@@ -57,7 +57,7 @@
   equipment:
     id: CMDogtagRifleman
     ears: RMCHeadsetMarine
-    jumpsuit: JumpsuitMarine
+    jumpsuit: RMCJumpsuitMarine
     shoes: CMBootsBlackFilled
 
 - type: playTimeTracker

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/FORECON/corpsman.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/FORECON/corpsman.yml
@@ -58,7 +58,7 @@
   equipment:
     id: CMDogtagRifleman
     ears: RMCHeadsetMarine
-    jumpsuit: JumpsuitMarine
+    jumpsuit: RMCJumpsuitMarine
     shoes: CMBootsBlackFilled
 
 - type: playTimeTracker

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/FORECON/rifleman.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/FORECON/rifleman.yml
@@ -54,7 +54,7 @@
   equipment:
     id: CMDogtagRifleman
     ears: RMCHeadsetMarine
-    jumpsuit: JumpsuitMarine
+    jumpsuit: RMCJumpsuitMarine
     shoes: CMBootsBlackFilled
 
 - type: playTimeTracker

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/FORECON/rto.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/FORECON/rto.yml
@@ -64,7 +64,7 @@
   equipment:
     id: CMDogtagRifleman
     ears: RMCHeadsetMarine
-    jumpsuit: JumpsuitMarine
+    jumpsuit: RMCJumpsuitMarine
     shoes: CMBootsBlackFilled
 
 - type: playTimeTracker

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/FORECON/smartgunner.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/FORECON/smartgunner.yml
@@ -54,7 +54,7 @@
   equipment:
     id: CMDogtagRifleman
     ears: RMCHeadsetMarine
-    jumpsuit: JumpsuitMarine
+    jumpsuit: RMCJumpsuitMarine
     shoes: CMBootsBlackFilled
 
 - type: playTimeTracker

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/FORECON/squadlead.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/FORECON/squadlead.yml
@@ -57,7 +57,7 @@
   equipment:
     id: CMDogtagRifleman
     ears: RMCHeadsetMarine
-    jumpsuit: JumpsuitMarine
+    jumpsuit: RMCJumpsuitMarine
     shoes: CMBootsBlackFilled
 
 - type: playTimeTracker

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/WeYa/corporate_executives.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/WeYa/corporate_executives.yml
@@ -516,7 +516,7 @@
     jumpsuit: RMCJumpsuitVeteranPMCDirector
     shoes: RMCShoesLaceup
     back: CMSatchel
-    belt: GoldHandcannonBeltFilled
+    belt: RMCGoldHandcannonBeltFilled
     outerClothing: RMCArmorPMCDirector
     id: CMIDCardPMCExecutive
     ears: RMCHeadsetDistressPMCDirector

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Base_Survs/military_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Base_Survs/military_survivor.yml
@@ -24,7 +24,7 @@
 - type: startingGear
   id: RMCGearMilitarySurvivor
   equipment:
-    jumpsuit: JumpsuitMarine
+    jumpsuit: RMCJumpsuitMarine
     shoes: CMBootsBlackFilled
     back: CMSatchelMarine
 

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Base_Survs/unmc_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Base_Survs/unmc_survivor.yml
@@ -35,7 +35,7 @@
   id: RMCGearSurvivorUNMC
   equipment:
     id: CMDogtagRifleman
-    jumpsuit: JumpsuitMarine
+    jumpsuit: RMCJumpsuitMarine
     outerClothing: RMCArmorM3LightVariants
     shoes: CMBootsBlackFilled
     back: CMSatchelFillSurvivor # remake to be marine satchel

--- a/Resources/Prototypes/_RMC14/Roles/Loadouts/Items/RoleSpecific/synthetic.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Loadouts/Items/RoleSpecific/synthetic.yml
@@ -60,7 +60,7 @@
 - type: loadout
   id: MarineUniformRMC
   equipment:
-    jumpsuit: JumpsuitMarine
+    jumpsuit: RMCJumpsuitMarine
 
 - type: loadout
   id: CorpsmanUniformRMC
@@ -276,7 +276,7 @@
     - CMHeadCapOfficer
 
 - type: loadout
-  id: ArmorHelmetM10RMC
+  id: RMCArmorHelmetM10RMC
   storage:
     back:
     - ArmorHelmetM10

--- a/Resources/Prototypes/_RMC14/Roles/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Loadouts/loadout_groups.yml
@@ -686,7 +686,7 @@
   - CapMPRMC
   - CapQuartermasterRMC
   - HeadCapCargoRMC
-  - ArmorHelmetM10RMC
+  - RMCArmorHelmetM10RMC
   - HardHatRMC
   - HardHatOrangeRMC
   - HardHatWhiteRMC

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -1479,3 +1479,8 @@ CMPosterZSPA2: RMCPosterTSEPA2
 CMPosterZSPA3: RMCPosterTSEPA3
 RMCSpawnerERTShuttleZSPA: RMCSpawnerERTShuttleTSEPA
 RMCSpawnerShuttleZSPA: RMCSpawnerShuttleTSEPA
+ 
+# 2026-02-13 - Prefix RMC entities (Gear)
+ArmorHelmetM10RMC: RMCArmorHelmetM10CMB
+GoldHandcannonBeltFilled: RMCGoldHandcannonBeltFilled
+JumpsuitMarine: RMCJumpsuitMarine


### PR DESCRIPTION
Partially addresses #8892

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Standardizes gear/loadout-related entity IDs under `_RMC14` to use the `RMC` prefix and updates references.

## Why / Balance

Enforce consistent prefixes for gear entities:

- Keep `CM` prefixes and `RMC` prefixes.
- Add `RMC` to entities without either prefix.

## Technical details

- Renamed selected gear entities (uniform/belt/loadout-adjacent IDs) to `RMC...` forms.
- Updated references across marine/PVE job loadouts and vendor definitions.
- Added migration mappings for renamed gear entities.

## Media

Not required (naming consistency changes only).

## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:

- code: Standardized RMC gear/loadout entity IDs and updated references.
