### PR TITLE
Prefix RMC entities (Materials)

### DIFF
--- a/Content.Shared/_RMC14/Barricade/Components/BarbedComponent.cs
+++ b/Content.Shared/_RMC14/Barricade/Components/BarbedComponent.cs
@@ -22,7 +22,7 @@ public sealed partial class BarbedComponent : Component
     public int MaxHealthIncrease = 50;
 
     [DataField]
-    public EntProtoId Spawn = "BarbedWire1";
+    public EntProtoId Spawn = "RMCBarbedWire1";
 
     [DataField]
     public ProtoId<ToolQualityPrototype> RemoveQuality = "Cutting";

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Pouches/construction_pouch.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Pouches/construction_pouch.yml
@@ -32,7 +32,7 @@
     contents:
     - id: CMSheetPlasteel30
     - id: CMSheetMetal50
-    - id: BarbedWire15
+    - id: RMCBarbedWire15
 
 - type: entity
   parent: RMCPouchConstruction

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Materials/barbedwire.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Materials/barbedwire.yml
@@ -1,6 +1,6 @@
 - type: entity
   abstract: true
-  id: BarbedWireBase
+  id: RMCBarbedWireBase
   parent: BaseItem
   name: barbed wire
   suffix: Filled
@@ -38,8 +38,8 @@
   - type: BarbedWire
 
 - type: entity
-  parent: BarbedWireBase
-  id: BarbedWire10
+  parent: RMCBarbedWireBase
+  id: RMCBarbedWire10
   suffix: "10"
   components:
   - type: Sprite
@@ -49,8 +49,8 @@
     count: 10
 
 - type: entity
-  parent: BarbedWireBase
-  id: BarbedWire15
+  parent: RMCBarbedWireBase
+  id: RMCBarbedWire15
   suffix: "15"
   components:
   - type: Sprite
@@ -60,8 +60,8 @@
     count: 15
 
 - type: entity
-  parent: BarbedWireBase
-  id: BarbedWire1
+  parent: RMCBarbedWireBase
+  id: RMCBarbedWire1
   suffix: Single
   components:
   - type: Sprite

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Furniture/beds.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Furniture/beds.yml
@@ -136,11 +136,11 @@
     state: bunk_red
   - type: Construction
 
-# Bedroll
+# RMCBedroll
 
 - type: entity
   parent: [BaseItem, BaseFoldable]
-  id: Bedroll
+  id: RMCBedroll
   name: bedroll
   suffix: RMC
   description: A foldable bedroll, just about the only thing of comfort in the field. You're generally supposed to unroll it before sleeping, but who needs rules?
@@ -207,8 +207,8 @@
           False: {visible: true}
 
 - type: entity
-  parent: Bedroll
-  id: BedrollFolded
+  parent: RMCBedroll
+  id: RMCBedrollFolded
   suffix: folded
   components:
   - type: Foldable

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
@@ -808,7 +808,7 @@
         amount: 10
     - name: Miscellaneous
       entries:
-      - id: BedrollFolded
+      - id: RMCBedrollFolded
         amount: 30
       - id: RMCM5CameraGear
         amount: 5

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/PVE/forecon.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/PVE/forecon.yml
@@ -161,6 +161,6 @@
         amount: 15
       - id: RMCPatchUNMC
         amount: 15
-      - id: BedrollFolded
-        name: LRRP Bedroll
+      - id: RMCBedrollFolded
+        name: LRRP RMCBedroll
         amount: 15

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/prep.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/prep.yml
@@ -364,7 +364,7 @@
       - id: RMCPatchUnitedNationsSquare
         name: United Nations flag shoulder patch
         amount: 15
-      - id: BedrollFolded
+      - id: RMCBedrollFolded
         amount: 20
       - id: RMCM5CameraGear
         amount: 10

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/misc.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/misc.yml
@@ -19,7 +19,7 @@
       - id: RMCSheetCardboard10
         name: Cardboard x10
         amount: 1
-      - id: BarbedWire10
+      - id: RMCBarbedWire10
         name: Barbed Wire x10
         amount: 0
       - id: CMSheetMetal10

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Walls/shiva_walls.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Walls/shiva_walls.yml
@@ -1,7 +1,7 @@
 ﻿
 - type: entity
   parent: CMBaseWallInvincible
-  id: RCMWallShivaIce
+  id: RMCWallShivaIce
   name: black ice slabs
   description: Slabs on slabs of dirty black ice crusted over ancient rock formations. The permafrost fluctuates between 20in and 12in during the summer months.
   components:
@@ -22,7 +22,7 @@
 
 - type: entity
   parent: CMBaseWallInvincible
-  id: RCMWallShivaInvincibleFab
+  id: RMCWallShivaInvincibleFab
   name: reinforced prefabricated structure wall
   description: It cannot be destroyed by any means you have available. Perhaps praying to the gods may help.
   suffix: Hull
@@ -44,7 +44,7 @@
 
 - type: entity
   parent: CMWallMetal
-  id: RCMWallShivaFab
+  id: RMCWallShivaFab
   name: prefabricated structure wall
   description: This structure is made of metal support rods and robust poly-kevlon plastics. A derivative of the stuff used in UN ballistics vests, UNMC and SPP uniforms. These walls are pulled taut and have been reinforced into a more permanent structure.
   components:
@@ -63,7 +63,7 @@
 
 - type: entity
   parent: RMCBaseWallReinforced
-  id: RCMWallShivaReinforcedFab
+  id: RMCWallShivaReinforcedFab
   name: reinforced prefabricated structure wall
   description: This structure is made of metal support rods. The poly-kevlon has been replaced with sheet metal, reinforcing it.
   components:
@@ -82,7 +82,7 @@
 
 - type: entity
   parent: RMCBaseWallReinforced
-  id: RCMWallShivaReinforcedFabOrange
+  id: RMCWallShivaReinforcedFabOrange
   name: reinforced prefabricated structure wall
   description: This structure is made of metal support rods. The poly-kevlon has been replaced with sheet metal, reinforcing it.
   components:
@@ -101,7 +101,7 @@
 
 - type: entity
   parent: RMCBaseWallReinforced
-  id: RCMWallShivaReinforcedFabBlue
+  id: RMCWallShivaReinforcedFabBlue
   name: reinforced prefabricated structure wall
   description: This structure is made of metal support rods. The poly-kevlon has been replaced with sheet metal, reinforcing it.
   components:
@@ -120,7 +120,7 @@
 
 - type: entity
   parent: RMCBaseWallReinforced
-  id: RCMWallShivaReinforcedFabPink
+  id: RMCWallShivaReinforcedFabPink
   name: reinforced prefabricated structure wall
   description: This structure is made of metal support rods. The poly-kevlon has been replaced with sheet metal, reinforcing it.
   components:
@@ -139,7 +139,7 @@
 
 - type: entity
   parent: RMCBaseWallReinforced
-  id: RCMWallShivaReinforcedFabWhite
+  id: RMCWallShivaReinforcedFabWhite
   name: reinforced prefabricated structure wall
   description: This structure is made of metal support rods. The poly-kevlon has been replaced with sheet metal, reinforcing it.
   components:
@@ -158,7 +158,7 @@
 
 - type: entity
   parent: RMCBaseWallReinforced
-  id: RCMWallShivaReinforcedFabRed
+  id: RMCWallShivaReinforcedFabRed
   name: reinforced prefabricated structure wall
   description: This structure is made of metal support rods. The poly-kevlon has been replaced with sheet metal, reinforcing it.
   components:

--- a/Resources/Prototypes/_RMC14/Recipes/Construction/Graphs/Materials/barbed_wire.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Construction/Graphs/Materials/barbed_wire.yml
@@ -14,4 +14,4 @@
               amount: 1
 
     - node: nodeBarbedWire
-      entity: BarbedWire1
+      entity: RMCBarbedWire1

--- a/Resources/Prototypes/_RMC14/Recipes/Construction/Graphs/Structures/barricade_metal.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Construction/Graphs/Structures/barricade_metal.yml
@@ -54,7 +54,7 @@
           !type:IsBarbed
         action:
           !type:SpawnPrototype
-          prototype: BarbedWire1
+          prototype: RMCBarbedWire1
           amount: 1
       - !type:DeleteEntity
       conditions:

--- a/Resources/Prototypes/_RMC14/Recipes/Construction/Graphs/Structures/barricade_metal_door.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Construction/Graphs/Structures/barricade_metal_door.yml
@@ -28,7 +28,7 @@
           !type:IsBarbed
         action:
           !type:SpawnPrototype
-          prototype: BarbedWire1
+          prototype: RMCBarbedWire1
       - !type:DeleteEntity
       conditions:
       - !type:EntityAnchored

--- a/Resources/Prototypes/_RMC14/Recipes/Construction/Graphs/Structures/barricade_plasteel_door.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Construction/Graphs/Structures/barricade_plasteel_door.yml
@@ -28,7 +28,7 @@
           !type:IsBarbed
         action:
           !type:SpawnPrototype
-          prototype: BarbedWire1
+          prototype: RMCBarbedWire1
       - !type:DeleteEntity
       conditions:
       - !type:EntityAnchored

--- a/Resources/Prototypes/_RMC14/Recipes/Materials/metal.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Materials/metal.yml
@@ -7,7 +7,7 @@
 - type: rmcConstruction
   id: RMCBarbedWireBuild
   name: barbed wire
-  prototype: BarbedWire1
+  prototype: RMCBarbedWire1
   doAfterTime: 1
   doAfterTimeMin: 1
   skill: RMCSkillConstruction

--- a/Resources/Prototypes/_RMC14/Stacks/comtech_stacks.yml
+++ b/Resources/Prototypes/_RMC14/Stacks/comtech_stacks.yml
@@ -2,5 +2,5 @@
   id: BarbedWire
   name: barbed wire
   icon: { sprite: _RMC14/Objects/barbed_wire.rsi, state: barbed_wire }
-  spawn: BarbedWire1
+  spawn: RMCBarbedWire1
   maxCount: 20

--- a/Resources/ServerInfo/Guidebook/_RMC14/Guides/RMCGuideRoleCombatTechnician.xml
+++ b/Resources/ServerInfo/Guidebook/_RMC14/Guides/RMCGuideRoleCombatTechnician.xml
@@ -134,7 +134,7 @@
   Once a Barricade is built, it isn't finished until you lace it with barbed wire, which you can craft for 1 metal per barricade. A Barbed barricade will harm anything that strikes it, as well as completely prevent anything from vaulting over it. [bold]Every Barricade should have some barbed wire[/bold].
 
   <Box>
-    <GuideEntityEmbed Entity="BarbedWire1"/>
+    <GuideEntityEmbed Entity="RMCBarbedWire1"/>
   </Box>
 
   Non-foldable Barricades have three upgrades which require 2 metal:

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -1479,3 +1479,20 @@ CMPosterZSPA2: RMCPosterTSEPA2
 CMPosterZSPA3: RMCPosterTSEPA3
 RMCSpawnerERTShuttleZSPA: RMCSpawnerERTShuttleTSEPA
 RMCSpawnerShuttleZSPA: RMCSpawnerShuttleTSEPA
+ 
+# 2026-02-14 - Prefix RMC entities (Materials)
+BarbedWire1: RMCBarbedWire1
+BarbedWire10: RMCBarbedWire10
+BarbedWire15: RMCBarbedWire15
+BarbedWireBase: null
+Bedroll: RMCBedroll
+BedrollFolded: RMCBedrollFolded
+RCMWallShivaFab: RMCWallShivaFab
+RCMWallShivaIce: RMCWallShivaIce
+RCMWallShivaInvincibleFab: RMCWallShivaInvincibleFab
+RCMWallShivaReinforcedFab: RMCWallShivaReinforcedFab
+RCMWallShivaReinforcedFabBlue: RMCWallShivaReinforcedFabBlue
+RCMWallShivaReinforcedFabOrange: RMCWallShivaReinforcedFabOrange
+RCMWallShivaReinforcedFabPink: RMCWallShivaReinforcedFabPink
+RCMWallShivaReinforcedFabRed: RMCWallShivaReinforcedFabRed
+RCMWallShivaReinforcedFabWhite: RMCWallShivaReinforcedFabWhite


### PR DESCRIPTION
Partially addresses #8892

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Standardizes materials/construction-related entity IDs under `_RMC14` with `RMC` prefixes and updates references.

## Why / Balance

Enforce consistent prefixes for materials entities:

- Keep `CM` prefixes and `RMC` prefixes.
- Add `RMC` to entities without either prefix.

## Technical details

- Renamed material/construction entities (barbed wire, bedrolls, Shiva wall variants) to `RMC...` IDs.
- Updated references across construction graphs/recipes, vending entries, and shared barricade code.
- Added migration mappings for renamed materials entities.

## Media

Not required (naming consistency changes only).

## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:

- code: Standardized RMC materials/construction entity IDs and updated references.
