### PR TITLE
Prefix RMC entities (Weapons)

### DIFF
--- a/Resources/Prototypes/_RMC14/Catalog/Fills/Cases/crate_tables.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Fills/Cases/crate_tables.yml
@@ -65,7 +65,7 @@
         - id: RMCMagazineSMGUZIExt
       - !type:AllSelector
         children:
-        - id: WeaponSMGMAC15
+        - id: RMCWeaponSMGMAC15
         - id: RMCMagazineSMGMAC15
           amount: 2
         - id: RMCMagazineSMGMAC15Ext
@@ -80,7 +80,7 @@
         amount: 2
     - !type:AllSelector # Freelancer
       children:
-      - id: WeaponRifleMAR40
+      - id: RMCWeaponRifleMAR40
       - id: RMCMagazineRifleMAR40Ext
       - id: RMCMagazineRifleMAR40
         amount: 2

--- a/Resources/Prototypes/_RMC14/Entities/Markers/Spawners/Random/guns.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Markers/Spawners/Random/guns.yml
@@ -95,16 +95,16 @@
     - RMCWeaponBoltActionRifle: RMCMagazineRifleHunting
     - RMCWeaponBoltActionRifle: RMCMagazineRifleHunting
     - RMCWeaponBoltActionRifle: RMCMagazineRifleHunting
-    - WeaponRifleM16: RMCMagazineRifleM16
-    - WeaponRifleM16: RMCMagazineRifleM16
-    - WeaponRifleM16: RMCMagazineRifleM16
-    - WeaponRifleM16: RMCMagazineRifleM16
-    - WeaponRifleM16: RMCMagazineRifleM16
-    - WeaponRifleMAR40: RMCMagazineRifleMAR40
-    - WeaponRifleMAR40: RMCMagazineRifleMAR40
+    - RMCWeaponRifleM16: RMCMagazineRifleM16
+    - RMCWeaponRifleM16: RMCMagazineRifleM16
+    - RMCWeaponRifleM16: RMCMagazineRifleM16
+    - RMCWeaponRifleM16: RMCMagazineRifleM16
+    - RMCWeaponRifleM16: RMCMagazineRifleM16
+    - RMCWeaponRifleMAR40: RMCMagazineRifleMAR40
+    - RMCWeaponRifleMAR40: RMCMagazineRifleMAR40
     - RMCWeaponRifleMAR30: RMCMagazineRifleMAR40
     - RMCWeaponRifleMAR30: RMCMagazineRifleMAR40
-    - WeaponRifleAR10: RMCMagazineRifleAR10
+    - RMCWeaponRifleAR10: RMCMagazineRifleAR10
     - RMCWeaponRifleABR40: RMCMagazineRifleABR40
     - RMCWeaponRifleSSG45NoLockStripped: RMCMagazineRifleSSG45
 
@@ -167,7 +167,7 @@
     - RMCWeaponShotgunHG3712: RMCSpawnerRandomShotgunBoxes
     - RMCWeaponShotgunHG3712: RMCSpawnerRandomShotgunBoxes
     # TODO 3 R4T rifle
-    - WeaponShotgunCustomBuilt: RMCSpawnerRandomShotgunBoxes
+    - RMCWeaponShotgunCustomBuilt: RMCSpawnerRandomShotgunBoxes
     - RMCWeaponShotgunM3717: RMCSpawnerRandomShotgunBoxes
 
 - type: entity
@@ -231,8 +231,8 @@
     - RMCWeaponSMGMP27: RMCMagazineSMGMP27
     - RMCWeaponSMGMP27: RMCMagazineSMGMP27
     - RMCWeaponSMGType19: RMCMagazineSMGType19
-    - WeaponSMGMAC15: RMCMagazineSMGMAC15
-    - WeaponSMGMAC15: RMCMagazineSMGMAC15
+    - RMCWeaponSMGMAC15: RMCMagazineSMGMAC15
+    - RMCWeaponSMGMAC15: RMCMagazineSMGMAC15
     - RMCWeaponSMGUZI: RMCMagazineSMGUZI
     - RMCWeaponSMGUZI: RMCMagazineSMGUZI
     - RMCWeaponSMGFP9000: RMCMagazineSMGFP9000
@@ -291,7 +291,7 @@
     maxMagazines: 5
     prototypes:
     - RMCWeaponMar50LMG: RMCMagazineMar50LMG
-    - WeaponShotgunCustomBuilt: RMCSpawnerRandomShotgunBoxes
+    - RMCWeaponShotgunCustomBuilt: RMCSpawnerRandomShotgunBoxes
     - RMCWeaponLauncherDisposable: RMCSpawnerRandomRocketsDisposable
     - RMCWeaponRifleM54C: CMMagazineRifleM54C
     - WeaponShotgunM890: RMCSpawnerRandomShotgunBoxes

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/gun_cases.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/gun_cases.yml
@@ -455,7 +455,7 @@
       - RMCBeltSOCOM
   - type: StorageFill
     contents:
-    - id: WeaponRifleXM88
+    - id: RMCWeaponRifleXM88
     - id: RMCAttachmentXM88Stock
     - id: RMCAttachmentXS-9
     - id: RMCBox458SOCOM
@@ -616,7 +616,7 @@
       - RMCHandful
   - type: StorageFill
     contents:
-    - id: WeaponShotgunM42A2
+    - id: RMCWeaponShotgunM42A2
     # Group 1
     - id: CMShellShotgunBuckshot # Spawn 3 handfuls of shells, each group being random
       prob: 0.25

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/misc.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/misc.yml
@@ -21,7 +21,7 @@
     # - id: CMPacketPillsOxycodone    TODO: Pain system
     - id: CMPacketPillsKelotane
     - id: CMPacketPillsBicaridine
-    - id: WeaponShotgunM890Guard
+    - id: RMCWeaponShotgunM890Guard
     - id: RMCPouchGeneralLarge
     - id: CMShellShotgunBuckshot
     - id: CMShellShotgunBuckshot

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/pve_cases.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/pve_cases.yml
@@ -86,7 +86,7 @@
       - RMCMagazineRifleM5SPRHVP
   - type: StorageFill
     contents:
-    - id: WeaponRifleM5SPR
+    - id: RMCWeaponRifleM5SPR
     - id: RMCMagazineRifleM5SPRHVP
     - id: RMCMagazineRifleM5SPRHVP
     - id: RMCMagazineRifleM5SPRHVP
@@ -144,7 +144,7 @@
       - RMCMagazineRifleM5SPRHVP
   - type: StorageFill
     contents:
-    - id: WeaponRifleM5SPR2
+    - id: RMCWeaponRifleM5SPR2
     - id: RMCMagazineRifleM5SPRHVP
     - id: RMCMagazineRifleM5SPRHVP
     - id: RMCMagazineRifleM5SPRHVP

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/specialist_loadouts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/specialist_loadouts.yml
@@ -157,7 +157,7 @@
     - id: RMCMK80
     - id: CMMagazinePistolMK80
       amount: 2
-    - id: WeaponRifleM4SPRCustom
+    - id: RMCWeaponRifleM4SPRCustom
     - id: RMCThermalTarpFolded
     - id: RMCExplosivePlastic
       amount: 2

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Magazines/riotammo.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Magazines/riotammo.yml
@@ -63,11 +63,11 @@
     - Cartridge
     - RMCCartridgeRifle10x24mmRubber
   - type: CartridgeAmmo
-    proto: BulletRifle10x24mmRubber
+    proto: RMCBulletRifle10x24mmRubber
 
 - type: entity
   parent: RMCBaseBullet
-  id: BulletRifle10x24mmRubber
+  id: RMCBulletRifle10x24mmRubber
   categories: [ HideSpawnMenu ]
   components:
   - type: Projectile
@@ -120,11 +120,11 @@
     - Cartridge
     - RMCCartridge10x20mmRubber
   - type: CartridgeAmmo
-    proto: Bullet10x20mmRubber
+    proto: RMCBullet10x20mmRubber
 
 - type: entity
   parent: RMCBaseBullet
-  id: Bullet10x20mmRubber
+  id: RMCBullet10x20mmRubber
   categories: [ HideSpawnMenu ]
   components:
   - type: Projectile

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/BoltAction/hunting_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/BoltAction/hunting_rifle.yml
@@ -132,7 +132,7 @@
     proto: RMCBulletRifleHunting
 
 - type: entity
-  parent: BulletRifle10x24mm
+  parent: RMCBulletRifle10x24mm
   id: RMCBulletRifleHunting
   categories: [ HideSpawnMenu ]
   components:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/mk80_pistol.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/mk80_pistol.yml
@@ -123,11 +123,11 @@
     - Cartridge
     - RMCCartridgePistol9mmSquashHead
   - type: CartridgeAmmo
-    proto: RCMBulletPistol9mmSquashHead
+    proto: RMCBulletPistol9mmSquashHead
 
 - type: entity # todo rmc14 this is missing a lot of effects, shrapnel, debilitate etc
   parent: CMBulletBase
-  id: RCMBulletPistol9mmSquashHead
+  id: RMCBulletPistol9mmSquashHead
   name: bullet (9mm Squash-Head)
   categories: [ HideSpawnMenu ]
   components:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/L24_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/L24_rifle.yml
@@ -344,7 +344,7 @@
     - Cartridge
     - RMCCartridgeRifleL24
   - type: CartridgeAmmo
-    proto: BulletRifle888x51mm
+    proto: RMCBulletRifle888x51mm
 
 - type: entity
   parent: CMBaseCartridgeRifle
@@ -357,7 +357,7 @@
     - Cartridge
     - RMCCartridgeRifleL24AP
   - type: CartridgeAmmo
-    proto: BulletRifle888x51mmAP
+    proto: RMCBulletRifle888x51mmAP
 
 - type: entity
   parent: CMBaseCartridgeRifle
@@ -370,7 +370,7 @@
     - Cartridge
     - RMCCartridgeRifleL24HEAP
   - type: CartridgeAmmo
-    proto: BulletRifle888x51mmHEAP
+    proto: RMCBulletRifle888x51mmHEAP
 
 - type: entity
   parent: CMBaseCartridgeRifle
@@ -383,11 +383,11 @@
     - Cartridge
     - RMCCartridgeRifleL24Incendiary
   - type: CartridgeAmmo
-    proto: BulletRifle888x51mmIncendiary
+    proto: RMCBulletRifle888x51mmIncendiary
 
 - type: entity
-  parent: BulletRifle10x24mm
-  id: BulletRifle888x51mmAP
+  parent: RMCBulletRifle10x24mm
+  id: RMCBulletRifle888x51mmAP
   categories: [ HideSpawnMenu ]
   components:
   - type: Projectile
@@ -398,8 +398,8 @@
     amount: 50
 
 - type: entity
-  parent: BulletRifle10x24mm
-  id: BulletRifle888x51mm
+  parent: RMCBulletRifle10x24mm
+  id: RMCBulletRifle888x51mm
   categories: [ HideSpawnMenu ]
   components:
   - type: Projectile
@@ -410,8 +410,8 @@
     amount: 10
 
 - type: entity
-  parent: BulletRifle10x24mm
-  id: BulletRifle888x51mmHEAP
+  parent: RMCBulletRifle10x24mm
+  id: RMCBulletRifle888x51mmHEAP
   categories: [ HideSpawnMenu ]
   components:
   - type: Projectile
@@ -422,8 +422,8 @@
     amount: 50
 
 - type: entity
-  parent: BulletRifle10x24mm
-  id: BulletRifle888x51mmIncendiary
+  parent: RMCBulletRifle10x24mm
+  id: RMCBulletRifle888x51mmIncendiary
   categories: [ HideSpawnMenu ]
   components:
   - type: Projectile

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/L83A3.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/L83A3.yml
@@ -335,7 +335,7 @@
     - Cartridge
     - RMCCartridgeRifleL83AHEAP
   - type: CartridgeAmmo
-    proto: BulletRifle556x45mmHEAP
+    proto: RMCBulletRifle556x45mmHEAP
 
 - type: entity
   parent: CMBaseCartridgeRifle
@@ -348,11 +348,11 @@
     - Cartridge
     - RMCCartridgeRifleL83AIncendiary
   - type: CartridgeAmmo
-    proto: BulletRifle556x45mmIncendiary
+    proto: RMCBulletRifle556x45mmIncendiary
 
 - type: entity
-  parent: BulletRifle10x24mm
-  id: BulletRifle556x45mmHEAP
+  parent: RMCBulletRifle10x24mm
+  id: RMCBulletRifle556x45mmHEAP
   components:
   - type: Projectile
     damage:
@@ -362,8 +362,8 @@
     amount: 50
 
 - type: entity
-  parent: BulletRifle10x24mm
-  id: BulletRifle556x45mmIncendiary
+  parent: RMCBulletRifle10x24mm
+  id: RMCBulletRifle556x45mmIncendiary
   components:
   - type: Projectile
     damage:
@@ -396,7 +396,7 @@
 
 - type: entity
   parent: [ CMBaseWeaponRifle, RMCBaseWeaponMagazineVisuals ]
-  id: WeaponRifleL83A3F
+  id: RMCWeaponRifleL83A3F
   name: L83A3F rifle
   description: A variant of the L83A3 with a heavily modified firing mechanism, which grants it a burst-fire option.
   suffix: Filled
@@ -532,7 +532,7 @@
       rmc-aslot-underbarrel: 0.3, -0.30
 
 - type: entity
-  parent: WeaponRifleL83A3F
+  parent: RMCWeaponRifleL83A3F
   id: RMCWeaponRifleL83A3FStripped
   suffix: Stripped
   components:
@@ -597,7 +597,7 @@
 # Marksman L83A3 Variant will call it L83A3M (M for Marksman)
 - type: entity
   parent: [ CMBaseWeaponRifle, RMCBaseWeaponMagazineVisuals ]
-  id: WeaponRifleL83A3M
+  id: RMCWeaponRifleL83A3M
   name: L83A3M rifle
   description: The L83A3M Battle Rifle is a modification sold to the Three Suns Empire. This particular version of the weapon has been given a custom stock and variable zoom scope. Reliable and deadly.
   suffix: Filled

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/ar10_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/ar10_rifle.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: [ CMBaseWeaponRifle, RMCBaseWeaponMagazineVisuals ]
   name: AR10 assault rifle
-  id: WeaponRifleAR10
+  id: RMCWeaponRifleAR10
   description: An earlier version of the more widespread M16 rifle. Considered to be the father of the 20th century rifle. How one of these ended up here is a mystery of its own. It is chambered in 7.62x51mm.
   suffix: Filled
   components:
@@ -146,11 +146,11 @@
     - Cartridge
     - RMCCartridgeRifleAR10
   - type: CartridgeAmmo
-    proto: BulletRifleAR10
+    proto: RMCBulletRifleAR10
 
 - type: entity
   parent: RMCBaseBullet
-  id: BulletRifleAR10
+  id: RMCBulletRifleAR10
   categories: [ HideSpawnMenu ]
   components:
   - type: Projectile

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/l83a2_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/l83a2_rifle.yml
@@ -229,7 +229,7 @@
     - Cartridge
     - RMCCartridgeRifleL83A
   - type: CartridgeAmmo
-    proto: BulletRifle556x45mm
+    proto: RMCBulletRifle556x45mm
 
 - type: entity
   parent: RMCMagazineRifleL83A2
@@ -355,11 +355,11 @@
     - Cartridge
     - RMCCartridgeRifleL83AAP
   - type: CartridgeAmmo
-    proto: BulletRifle556x45mmAP
+    proto: RMCBulletRifle556x45mmAP
 
 - type: entity
-  parent: BulletRifle10x24mm
-  id: BulletRifle556x45mmAP
+  parent: RMCBulletRifle10x24mm
+  id: RMCBulletRifle556x45mmAP
   categories: [ HideSpawnMenu ]
   components:
   - type: Projectile

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m16_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m16_rifle.yml
@@ -1,6 +1,6 @@
 - type: entity
   parent: [ CMBaseWeaponRifle, RMCBaseWeaponMagazineVisuals ]
-  id: WeaponRifleM16 # TODO: Make the M16 grenadier rifle when impact nades exist
+  id: RMCWeaponRifleM16 # TODO: Make the M16 grenadier rifle when impact nades exist
   name: M16 rifle
   description: An old, reliable design first adopted by the U.N. military in the 1960s. Something like this belongs in a museum of war history. It is chambered in 5.56x45mm.
   suffix: Filled
@@ -164,11 +164,11 @@
     - Cartridge
     - RMCCartridgeRifleM16
   - type: CartridgeAmmo
-    proto: BulletRifle556x45mm
+    proto: RMCBulletRifle556x45mm
 
 - type: entity
-  parent: BulletRifle10x24mm
-  id: BulletRifle556x45mm
+  parent: RMCBulletRifle10x24mm
+  id: RMCBulletRifle556x45mm
   categories: [ HideSpawnMenu ]
   components:
   - type: Projectile

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m4spr_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m4spr_rifle.yml
@@ -113,7 +113,7 @@
 - type: entity
   parent: WeaponRifleM4SPR
   name: M5SPR battle rifle
-  id: WeaponRifleM5SPR
+  id: RMCWeaponRifleM5SPR
   description: The M5SPR battle rifle is a modified version of the M4SPR, able to chamber High Velocity Piercing rounds, and equipped a two-burst configuration.
   components:
   - type: Sprite
@@ -187,8 +187,8 @@
     - RMCWeaponRifleM5SPR
 
 - type: entity
-  parent: WeaponRifleM5SPR
-  id: WeaponRifleM5SPR2
+  parent: RMCWeaponRifleM5SPR
+  id: RMCWeaponRifleM5SPR2
   name: M5SPR/2 battle rifle
   description: The M5SPR/2 battle rifle is a modified version of the M5SPR, designed for PMC Operatives to take out targets at longer ranges.
   components:
@@ -237,7 +237,7 @@
 
 - type: entity
   parent: WeaponRifleM4SPR
-  id: WeaponRifleM4SPRFilled
+  id: RMCWeaponRifleM4SPRFilled
   suffix: Filled
   components:
   - type: ItemSlots
@@ -464,11 +464,11 @@
     - Cartridge
     - RMCCartridgeRifleM5SPRHVP
   - type: CartridgeAmmo
-    proto: BulletRifleM5SPRHVP
+    proto: RMCBulletRifleM5SPRHVP
 
 - type: entity
   parent: RMCBaseBullet
-  id: BulletRifleM5SPRHVP
+  id: RMCBulletRifleM5SPRHVP
   categories: [ HideSpawnMenu ]
   components:
   - type: Projectile
@@ -504,11 +504,11 @@
     - Cartridge
     - RMCCartridgeRifleM5SPRHVHIP
   - type: CartridgeAmmo
-    proto: BulletRifleM5SPRHVHIP
+    proto: RMCBulletRifleM5SPRHVHIP
 
 - type: entity
-  parent: BulletRifleM5SPRHVP
-  id: BulletRifleM5SPRHVHIP
+  parent: RMCBulletRifleM5SPRHVP
+  id: RMCBulletRifleM5SPRHVHIP
   components:
   - type: RMCStunOnHit
     stuns:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m4spr_scout_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m4spr_scout_rifle.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: WeaponRifleM4SPR
   name: M4SPR custom battle rifle
-  id: WeaponRifleM4SPRCustom
+  id: RMCWeaponRifleM4SPRCustom
   description: An improvement over the already great M4SPR. Able to take A19 rounds, as well as having better control and accuracy at the cost of being harder to use. Can take traditional M4SPR mags, at lower damage.
   components:
   - type: GuideHelp
@@ -208,7 +208,7 @@
     - Cartridge
     - RMCCartridgeRifleM4SPRA19
   - type: CartridgeAmmo
-    proto: BulletRifleM4SPRA19
+    proto: RMCBulletRifleM4SPRA19
 
 - type: entity
   parent: RMCCartridgeRifleM4SPRA19
@@ -221,7 +221,7 @@
     - Cartridge
     - RMCCartridgeRifleM4SPRA19Impact
   - type: CartridgeAmmo
-    proto: BulletRifleM4SPRA19Impact
+    proto: RMCBulletRifleM4SPRA19Impact
 
 - type: entity
   parent: RMCCartridgeRifleM4SPRA19
@@ -234,11 +234,11 @@
     - Cartridge
     - RMCCartridgeRifleM4SPRA19Incendiary
   - type: CartridgeAmmo
-    proto: BulletRifleM4SPRA19Incendiary
+    proto: RMCBulletRifleM4SPRA19Incendiary
 
 - type: entity
   parent: RMCBaseBullet
-  id: BulletRifleM4SPRA19
+  id: RMCBulletRifleM4SPRA19
   categories: [ HideSpawnMenu ]
   components:
   - type: Projectile
@@ -263,7 +263,7 @@
 
 - type: entity
   parent: RMCBaseBullet
-  id: BulletRifleM4SPRA19Impact
+  id: RMCBulletRifleM4SPRA19Impact
   categories: [ HideSpawnMenu ]
   components:
   - type: Projectile
@@ -297,7 +297,7 @@
 
 - type: entity
   parent: RMCBaseBullet
-  id: BulletRifleM4SPRA19Incendiary
+  id: RMCBulletRifleM4SPRA19Incendiary
   categories: [ HideSpawnMenu ]
   components:
   - type: Projectile

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m54c_heavy_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m54c_heavy_rifle.yml
@@ -184,11 +184,11 @@
     - Cartridge
     - CMCartridgeRifle10x24mmHT
   - type: CartridgeAmmo
-    proto: BulletRifle10x24mmHT
+    proto: RMCBulletRifle10x24mmHT
 
 - type: entity
-  parent: BulletRifle10x24mm
-  id: BulletRifle10x24mmHT
+  parent: RMCBulletRifle10x24mm
+  id: RMCBulletRifle10x24mmHT
   categories: [ HideSpawnMenu ]
   components:
   - type: Projectile

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m54c_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m54c_rifle.yml
@@ -497,7 +497,7 @@
     - Cartridge
     - CMCartridgeRifle10x24mm
   - type: CartridgeAmmo
-    proto: BulletRifle10x24mm
+    proto: RMCBulletRifle10x24mm
 
 - type: entity
   parent: CMCartridgeRifle10x24mm
@@ -510,7 +510,7 @@
     - Cartridge
     - CMCartridgeRifle10x24mmAP
   - type: CartridgeAmmo
-    proto: BulletRifle10x24mmAP
+    proto: RMCBulletRifle10x24mmAP
 
 - type: entity
   parent: CMCartridgeRifle10x24mm
@@ -553,7 +553,7 @@
 
 - type: entity
   parent: RMCBaseBullet
-  id: BulletRifle10x24mm
+  id: RMCBulletRifle10x24mm
   categories: [ HideSpawnMenu ]
   components:
   - type: Projectile
@@ -576,8 +576,8 @@
       falloff: 10
 
 - type: entity
-  parent: BulletRifle10x24mm
-  id: BulletRifle10x24mmAP
+  parent: RMCBulletRifle10x24mm
+  id: RMCBulletRifle10x24mmAP
   categories: [ HideSpawnMenu ]
   components:
   - type: Projectile
@@ -588,7 +588,7 @@
     amount: 40
 
 - type: entity
-  parent: BulletRifle10x24mm
+  parent: RMCBulletRifle10x24mm
   id: RMCBulletRifle10x24mmWP
   categories: [ HideSpawnMenu ]
   components:
@@ -604,7 +604,7 @@
     lifetime: 0.2
 
 - type: entity
-  parent: BulletRifle10x24mm
+  parent: RMCBulletRifle10x24mm
   id: RMCBulletRifle10x24mmIncendiary
   categories: [ HideSpawnMenu ]
   components:
@@ -617,7 +617,7 @@
   - type: IgniteOnProjectileHit
 
 - type: entity
-  parent: BulletRifle10x24mm
+  parent: RMCBulletRifle10x24mm
   id: RMCBulletRifle10x24mmHEAP
   categories: [ HideSpawnMenu ]
   components:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/mar30_carbine.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/mar30_carbine.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: WeaponRifleMAR40
+  parent: RMCWeaponRifleMAR40
   id: RMCWeaponRifleMAR30
   name: MAR-30 battle carbine
   description: A cheap, reliable carbine chambered in 7.62x39mm. Commonly found in the hands of criminals or mercenaries.

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/mar40_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/mar40_rifle.yml
@@ -1,6 +1,6 @@
 - type: entity
   parent: [ CMBaseWeaponRifle, RMCBaseWeaponMagazineVisuals ]
-  id: WeaponRifleMAR40
+  id: RMCWeaponRifleMAR40
   name: MAR-40 battle rifle
   description: A cheap, reliable assault rifle chambered in 7.62x39mm. Commonly found in the hands of criminals or mercenaries, or in the hands of the SPP or CLF.
   suffix: Filled
@@ -208,11 +208,11 @@
     - Cartridge
     - RMCCartridgeRifleMAR40
   - type: CartridgeAmmo
-    proto: BulletRifleMAR40
+    proto: RMCBulletRifleMAR40
 
 - type: entity
-  parent: BulletRifle10x24mm
-  id: BulletRifleMAR40
+  parent: RMCBulletRifle10x24mm
+  id: RMCBulletRifleMAR40
   categories: [ HideSpawnMenu ]
   components:
   - type: Projectile

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/xm88_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/xm88_rifle.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: RMCBaseWeaponRifleNoMagazineProvider
   name: XM88 Heavy Rifle
-  id: WeaponRifleXM88
+  id: RMCWeaponRifleXM88
   description: An experimental man-portable anti-materiel rifle chambered in .458 SOCOM. It must be manually chambered for every shot.
   components:
   - type: Sprite
@@ -107,7 +107,7 @@
     content: rmc-lore-examinable-xm-88-heavy-rifle # Mention Favela Wars lore analogue here
 
 - type: entity
-  parent: BulletRifle10x24mm
+  parent: RMCBulletRifle10x24mm
   id: RMCBullet458SOCOM
   categories: [ HideSpawnMenu ]
   components:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/fp9000.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/fp9000.yml
@@ -230,7 +230,7 @@
     proto: RMCBullet57x28mmFP9000
 
 - type: entity
-  parent: Bullet10x20mm
+  parent: RMCBullet10x20mm
   id: RMCBullet57x28mmFP9000
   categories: [ HideSpawnMenu ]
   components:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/m63_smg.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/m63_smg.yml
@@ -311,7 +311,7 @@
     - Cartridge
     - CMCartridge10x20mm
   - type: CartridgeAmmo
-    proto: Bullet10x20mm
+    proto: RMCBullet10x20mm
 
 - type: entity
   parent: CMCartridge10x20mm
@@ -323,7 +323,7 @@
     - Cartridge
     - CMCartridge10x20mmAP
   - type: CartridgeAmmo
-    proto: Bullet10x20mmAP
+    proto: RMCBullet10x20mmAP
 
 - type: entity
   parent: CMCartridge10x20mm
@@ -363,7 +363,7 @@
 
 - type: entity
   parent: RMCBaseBullet
-  id: Bullet10x20mm
+  id: RMCBullet10x20mm
   categories: [ HideSpawnMenu ]
   components:
   - type: Projectile
@@ -386,8 +386,8 @@
       falloff: 10
 
 - type: entity
-  parent: Bullet10x20mm
-  id: Bullet10x20mmAP
+  parent: RMCBullet10x20mm
+  id: RMCBullet10x20mmAP
   categories: [ HideSpawnMenu ]
   components:
   - type: Projectile
@@ -398,7 +398,7 @@
     amount: 30
 
 - type: entity
-  parent: Bullet10x20mm
+  parent: RMCBullet10x20mm
   id: RMCBullet10x20mmHEAP
   categories: [ HideSpawnMenu ]
   components:
@@ -410,7 +410,7 @@
     amount: 30
 
 - type: entity
-  parent: Bullet10x20mm
+  parent: RMCBullet10x20mm
   id: RMCBullet10x20mmWP
   categories: [ HideSpawnMenu ]
   components:
@@ -426,7 +426,7 @@
     lifetime: 0.2
 
 - type: entity
-  parent: Bullet10x20mm
+  parent: RMCBullet10x20mm
   id: RMCBullet10x20mmIncendiary
   categories: [ HideSpawnMenu ]
   components:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/mac15.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/mac15.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: CMBaseWeaponSMG
   name: MAC-15 submachinegun
-  id: WeaponSMGMAC15 # TODO RMC14 10% chance to have an underbarrel grenade launcher
+  id: RMCWeaponSMGMAC15 # TODO RMC14 10% chance to have an underbarrel grenade launcher
   description: A cheap, reliable design and manufacture make this ubiquitous submachinegun useful despite the age.
   suffix: Filled
   components:
@@ -146,7 +146,7 @@
     - Cartridge
     - RMCCartridge9mmSMGMAC15
   - type: CartridgeAmmo
-    proto: Bullet10x20mm
+    proto: RMCBullet10x20mm
 
 - type: Tag
   id: RMCMagazineSMGMAC15

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/mp27.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/mp27.yml
@@ -170,7 +170,7 @@
     proto: RMCBullet46x30mm
 
 - type: entity
-  parent: Bullet10x20mm
+  parent: RMCBullet10x20mm
   id: RMCBullet46x30mm
   categories: [ HideSpawnMenu ]
   components:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/mp5_smg.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/mp5_smg.yml
@@ -144,7 +144,7 @@
     proto: CMBullet9mmSMG
 
 - type: entity
-  parent: Bullet10x20mm
+  parent: RMCBullet10x20mm
   id: CMBullet9mmSMG #Yes it does use a seperate type of 9mm thats mechanically identical to 10x20mm for some reason
   categories: [ HideSpawnMenu ]
 

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/p90.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/p90.yml
@@ -136,7 +136,7 @@
     proto: RMCBullet57x28mm
 
 - type: entity
-  parent: Bullet10x20mm
+  parent: RMCBullet10x20mm
   id: RMCBullet57x28mm
   categories: [ HideSpawnMenu ]
   components:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/type19.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/type19.yml
@@ -171,7 +171,7 @@
     proto: RMCBullet762x25mm
 
 - type: entity
-  parent: Bullet10x20mm
+  parent: RMCBullet10x20mm
   id: RMCBullet762x25mm
   categories: [ HideSpawnMenu ]
   components:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/uzi.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/uzi.yml
@@ -143,11 +143,11 @@
     - Cartridge
     - RMCCartridge9x21mmSMGUZI
   - type: CartridgeAmmo
-    proto: Bullet9x21mmUZI
+    proto: RMCBullet9x21mmUZI
 
 - type: entity
-  parent: Bullet10x20mm
-  id: Bullet9x21mmUZI
+  parent: RMCBullet10x20mm
+  id: RMCBullet9x21mmUZI
   categories: [ HideSpawnMenu ]
   components:
   - type: Projectile

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/custombuilt.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/custombuilt.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: [ RMCBaseWeaponShotgun, RMCBaseAttachableHolder ]
   name: custom built shotgun
-  id: WeaponShotgunCustomBuilt
+  id: RMCWeaponShotgunCustomBuilt
   description: A cobbled-together pile of scrap and alien wood. Point end towards things you want to die. Has a burst fire feature, as if it needed it.
   components:
   - type: Sprite

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/m42a1_shotgun.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/m42a1_shotgun.yml
@@ -1,7 +1,7 @@
 - type: entity
-  parent: WeaponShotgunM42A2
+  parent: RMCWeaponShotgunM42A2
   name: M42A1 pump shotgun
-  id: WeaponShotgunM42A1
+  id: RMCWeaponShotgunM42A1
   description: An AEGIS Armaments classic design, the M42A1 combines close-range firepower with long term reliability. Needs to be pumped.
   components:
   - type: Sprite

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/m42a2_shotgun.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/m42a2_shotgun.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: [ RMCBaseWeaponShotgun, RMCBaseAttachableHolder ]
   name: M42A2 pump shotgun
-  id: WeaponShotgunM42A2
+  id: RMCWeaponShotgunM42A2
   description: An AEGIS modern take on an all-time classic, combining close range firepower with long-term reliability. Requires a pump.
   components:
   - type: Sprite
@@ -85,7 +85,7 @@
     - RMCWeaponShotgun
 
 - type: entity
-  parent: WeaponShotgunM42A2
+  parent: RMCWeaponShotgunM42A2
   id: RMCWeaponShotgunM42A2Filled
   suffix: Filled
   components:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/m890_guardshotgun.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/m890_guardshotgun.yml
@@ -1,6 +1,6 @@
 - type: entity
   parent: WeaponShotgunM890
-  id: WeaponShotgunM890Guard
+  id: RMCWeaponShotgunM890Guard
   description: The Weston-Yamada M890 Shotgun, a semi-automatic shotgun with a quick fire rate. Equipped with a red handle to signify its use with Military Police Honor Guards.
   suffix: Honor Guard
   components:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Projectiles/xeno_spike.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Projectiles/xeno_spike.yml
@@ -1,5 +1,5 @@
 - type: entity
-  id: XenoSpikeProjectile
+  id: RMCXenoSpikeProjectile
   name: spike shard
   description: A sharp spike shard.
   components:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Sentries/almayer_sentries.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Sentries/almayer_sentries.yml
@@ -48,7 +48,7 @@
         5.5
   - type: UserIFF
     factions:
-    - FactionMarine
+    - RMCFactionMarine
 
 - type: entity
   parent: BaseStructure

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Sentries/sentries.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Sentries/sentries.yml
@@ -98,7 +98,7 @@
     - UNMC
   - type: UserIFF
     factions:
-    - FactionMarine
+    - RMCFactionMarine
   - type: XenoCrusherChargable
     setDamage:
       types:
@@ -199,7 +199,7 @@
     - WeYa
   - type: UserIFF
     factions:
-    - FactionWeYa
+    - RMCFactionWeYa
   - type: Tag
     tags:
     - RMCSentryWeYa
@@ -492,7 +492,7 @@
     magazineTag: RMCMagazineSentryFire
 
 - type: entity
-  parent: RMCSentry
+  parent: RMCBaseSentry
   id: RMCSentryFire
   name: UN 55-FA assault sentry flamer
   description: The Flamethrower Sentry Gun automatically tracks and fires upon any target that is wearing an ID not hooked up to the Almayer's systems. Just like the UA 571-C Sentry gun, this sentry has IFF but the fire that lingers doesn't.
@@ -520,7 +520,7 @@
     - UNMC
   - type: UserIFF
     factions:
-    - FactionMarine
+    - RMCFactionMarine
   - type: Sentry
     upgrades: ["RMCSentryMiniFire", "RMCSentrySniperFire"]
     startingMagazine: RMCMagazineSentryFireBlue
@@ -606,4 +606,4 @@
   - type: UserIFF
     factions:
     - FactionCLF
-    - FactionSurvivor
+    - RMCFactionSurvivor

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Sentries/tesla.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Sentries/tesla.yml
@@ -133,7 +133,7 @@
     - UNMC
   - type: UserIFF
     factions:
-    - FactionMarine
+    - RMCFactionMarine
 
 - type: entity
   parent: RMCTesla
@@ -189,7 +189,7 @@
     - UNMC
   - type: UserIFF
     factions:
-    - FactionMarine
+    - RMCFactionMarine
   - type: Sentry
     deployDelay: 0.75
     undeployDelay: 0.75
@@ -233,7 +233,7 @@
     - UNMC
   - type: UserIFF
     factions:
-    - FactionMarine
+    - RMCFactionMarine
   - type: Sentry
     upgrades: null
   - type: RMCTeslaCoil

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/GunRacks/shotguns.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/GunRacks/shotguns.yml
@@ -50,9 +50,9 @@
   - type: ContainerFill
     containers:
       item_1:
-      - WeaponShotgunM42A2
+      - RMCWeaponShotgunM42A2
       item_2:
-      - WeaponShotgunM42A2
+      - RMCWeaponShotgunM42A2
 
 - type: entity
   parent: RMCGunRackM42A2Empty

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/intel.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/intel.yml
@@ -246,7 +246,7 @@
         amount: 4
       - id: WeaponSMGM63
         amount: 4
-      - id: WeaponShotgunM42A2
+      - id: RMCWeaponShotgunM42A2
         amount: 4
       - id: RMCWeaponRifleM54C
         amount: 4

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/pilot.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/pilot.yml
@@ -222,7 +222,7 @@
         amount: 4
       - id: WeaponSMGM63
         amount: 4
-      - id: WeaponShotgunM42A2
+      - id: RMCWeaponShotgunM42A2
         amount: 4
       - id: RMCWeaponRifleM54C
         amount: 4

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
@@ -34,7 +34,7 @@
     sections:
     - name: Primary firearms
       entries:
-      - id: WeaponShotgunM42A2
+      - id: RMCWeaponShotgunM42A2
         amount: 30
       - id: WeaponSMGM63
         amount: 60

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/prep.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/prep.yml
@@ -19,7 +19,7 @@
       entries:
       - id: WeaponRifleM4SPR
         amount: 10
-      - id: WeaponShotgunM42A2
+      - id: RMCWeaponShotgunM42A2
         amount: 15
       - id: WeaponSMGM63
         amount: 30

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Storage/securecrates.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Storage/securecrates.yml
@@ -103,19 +103,19 @@
     - CMWeaponPistolM1984: CMMagazinePistolM1984
     - RMCWeaponPistolHandcannon: RMCMagazinePistolHandcannon
     - RMCWeaponRevolver38Magnum: RMCSpeedLoader38
-    - WeaponShotgunCustomBuilt: CMShellShotgunBuckshot
+    - RMCWeaponShotgunCustomBuilt: CMShellShotgunBuckshot
     - RMCWeaponShotgunHG3712: CMShellShotgunBuckshot
     - RMCWeaponSMGMP27: RMCMagazineSMGMP27
     - RMCWeaponSMGType64: RMCMagazineSMGType64
-    - WeaponSMGMAC15: RMCMagazineSMGMAC15
+    - RMCWeaponSMGMAC15: RMCMagazineSMGMAC15
     - RMCWeaponSMGUZI: RMCMagazineSMGUZI
     - RMCWeaponRifleMAR30: RMCMagazineRifleMAR40
     - RMCWeaponRifleL42A: RMCMagazineRifleL42A
     - RMCWeaponSMGType19: RMCMagazineSMGType19
     - RMCWeaponRifleABR40: RMCMagazineRifleABR40
     - WeaponSMGMP5: CMMagazineSMGMP5
-    - WeaponRifleM16: RMCMagazineRifleM16
-    - WeaponRifleAR10: RMCMagazineRifleAR10
+    - RMCWeaponRifleM16: RMCMagazineRifleM16
+    - RMCWeaponRifleAR10: RMCMagazineRifleAR10
     - RMCWeaponRifleType71: RMCMagazineRifleType71
     - RMCWeaponSMGFP9000: RMCMagazineSMGFP9000
 
@@ -171,7 +171,7 @@
     - RMCWeaponPistolKT42: RMCMagazinePistolKT42
     - CMWeaponPistolM1984: CMMagazinePistolM1984
     - RMCWeaponRifleMAR30: RMCMagazineRifleMAR40
-    - WeaponRifleMAR40: RMCMagazineRifleMAR40
+    - RMCWeaponRifleMAR40: RMCMagazineRifleMAR40
     - RMCType88SniperRifle: RMCMagazineSniperType88
     - RMCWeaponSMGType19: RMCMagazineSMGType19
 
@@ -194,7 +194,7 @@
     prototypes:
     - CMWeaponPistolM1984: CMMagazinePistolM1984
     - RMCWeaponRifleM54C: CMMagazineRifleM54C
-    - WeaponShotgunM42A2: CMShellShotgunSlugs
+    - RMCWeaponShotgunM42A2: CMShellShotgunSlugs
     - WeaponSMGM63: CMMagazineSMGM63
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/CLF/clf_leader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/CLF/clf_leader.yml
@@ -81,7 +81,7 @@
     outerClothing: RMCCoatMilitia
     gloves: CMHandsBlackMarine
     shoes: RMCShoesCombat
-    suitstorage: WeaponRifleMAR40
+    suitstorage: RMCWeaponRifleMAR40
     id: RMCIDCardCLFCellLeader # TODO RMC14
     belt: RMCMAR40BeltFilled
     back: RMCSatchelLightpack

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/CLF/clf_medic.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/CLF/clf_medic.yml
@@ -76,7 +76,7 @@
     pocket1: RMCFlashlight
     pocket2: RMCPouchMagazineLarge
   inhand:
-  - WeaponSMGMAC15  # TODO RMC14 - Make randomized
+  - RMCWeaponSMGMAC15  # TODO RMC14 - Make randomized
   storage:
     back:
     - RMCGrenadeIED

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/CLF/clf_soldier.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/CLF/clf_soldier.yml
@@ -78,7 +78,7 @@
     pocket1: RMCFlashlight
     pocket2: RMCPouchFirstAidERTFill
   inhand:
-  - WeaponRifleMAR40
+  - RMCWeaponRifleMAR40
   storage:
     outerClothing:
     - RMCMagazineRifleMAR40

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Freelancers/medic.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Freelancers/medic.yml
@@ -100,7 +100,7 @@
     eyes: RMCGlassesMedicalHUDGlasses
     back: RMCSatchelLightpackFreelancerMedic
     belt: CMBeltMedicBagFilled
-    suitstorage: WeaponRifleMAR40
+    suitstorage: RMCWeaponRifleMAR40
     pocket1: RMCPouchMedicalERT
     pocket2: RMCPouchMagazineLargeMAR40
     gloves: RMCHandsVeteranPMC

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Freelancers/standard.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Freelancers/standard.yml
@@ -97,7 +97,7 @@
   equipment:
     back: RMCSatchelLightpackFreelancerStandard
     belt: RMCMAR40BeltFilled
-    suitstorage: WeaponRifleMAR40
+    suitstorage: RMCWeaponRifleMAR40
     gloves: RMCHandsVeteranPMC
     jumpsuit: RMCJumpsuitFreelancer
     outerClothing: CMArmorFreelancer

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Base_Survs/civilian_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Base_Survs/civilian_survivor.yml
@@ -142,7 +142,7 @@
     - [ CMBeltMarineHunting, RMCWeaponBoltActionRifle ]
     - [ RMCBeltMarineUZI, RMCWeaponSMGUZI ]
     - [ CMBeltMarineBuckshot, RMCWeaponShotgunHG3712 ]
-    - [ CMBeltMarineAR10, WeaponRifleAR10 ]
+    - [ CMBeltMarineAR10, RMCWeaponRifleAR10 ]
     primaryWeaponChance: 0.6
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Base_Survs/security_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Base_Survs/security_survivor.yml
@@ -73,7 +73,7 @@
     - [ RMCBeltMarineMAR, RMCWeaponRifleMAR30 ]
     - [ CMBeltMarineMP5, WeaponSMGMP5 ]
     - [ CMBeltMarineBuckshot, RMCWeaponShotgunHG3712 ]
-    - [ CMBeltMarineM16, WeaponRifleM16 ]
+    - [ CMBeltMarineM16, RMCWeaponRifleM16 ]
     primaryWeaponChance: 1
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/base_forecon.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/base_forecon.yml
@@ -62,7 +62,7 @@
   components:
   - type: SurvivorPreset
     primaryWeapons:
-    - [ CMMagazineRifleM4SPR, CMMagazineRifleM4SPR, WeaponRifleM4SPRFilled ]
+    - [ CMMagazineRifleM4SPR, CMMagazineRifleM4SPR, RMCWeaponRifleM4SPRFilled ]
     primaryWeaponChance: 1
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/marksman.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/marksman.yml
@@ -67,4 +67,4 @@
   components:
   - type: SurvivorPreset
     primaryWeapons:
-    - [ WeaponRifleM4SPRCustom, RMCMagazineRifleM4SPRA19, RMCMagazineRifleM4SPRA19 ]
+    - [ RMCWeaponRifleM4SPRCustom, RMCMagazineRifleM4SPRA19, RMCMagazineRifleM4SPRA19 ]

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/squad_leader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/squad_leader.yml
@@ -70,4 +70,4 @@
   components:
   - type: SurvivorPreset
     primaryWeapons:
-    - [ WeaponShotgunM42A2, RMCBoxShotgunSlugs ]
+    - [ RMCWeaponShotgunM42A2, RMCBoxShotgunSlugs ]

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Hybrisa_Prospera/emt_paramedic.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Hybrisa_Prospera/emt_paramedic.yml
@@ -76,4 +76,4 @@
     - [ RMCJumpsuitEMTGreen, RMCHazardVestEMTGreen, RMCBeltMedicalDefibAnalyzerFilled, CMHandsLatex ]
     - [ RMCJumpsuitEMTGreen, RMCHazardVestEMTGreen, RMCBeltMedicalDefibAnalyzerFilled, CMHandsLatex ]
     - [ RMCJumpsuitEMTGreen, RMCHazardVestEMTGreen, RMCBeltMedicalDefibAnalyzerFilled, CMHandsLatex ]
-    - [ RMCCoatParamedic, RMCJumpsuitEMT, RMCArmorHelmetParamedic, RMCBeltMedicalDefibAnalyzerFilled, RMCHandsCombat, WeaponRifleMAR40, RMCPouchMagazineFilledMAR40Ext ]
+    - [ RMCCoatParamedic, RMCJumpsuitEMT, RMCArmorHelmetParamedic, RMCBeltMedicalDefibAnalyzerFilled, RMCHandsCombat, RMCWeaponRifleMAR40, RMCPouchMagazineFilledMAR40Ext ]

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Hybrisa_Prospera/tmcc_miner.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Hybrisa_Prospera/tmcc_miner.yml
@@ -55,6 +55,6 @@
     - [ RMCHardhatRedTMCC, RMCJumpsuitTMCC, CMBackpackEngineer, RMCHazardVestTMCC, RMCShoesJackboots, RMCPouchToolsFill, RMCHandsCombat ]
     - [ RMCHardhatRedTMCC, RMCJumpsuitTMCC, CMBackpackEngineer, RMCHazardVestTMCC, RMCShoesJackboots, RMCPouchToolsFill, RMCHandsCombat ]
     - [ RMCHardhatRedTMCC, RMCJumpsuitTMCC, CMBackpackEngineer, RMCHazardVestTMCC, RMCShoesJackboots, RMCPouchToolsFill, RMCHandsCombat ]
-    - [ CMBackpackEngineer, RMCJumpsuitTMCC, RMCArmorTMCC, RMCArmorHelmetTMCCMiner, RMCShoesJackboots, RMCPouchToolsFill, RMCHandsCombat, WeaponRifleMAR40, RMCPouchMagazineFilledMAR40Ext ]
-    - [ CMBackpackEngineer, RMCJumpsuitTMCC, RMCArmorTMCC, RMCArmorHelmetTMCCMiner, RMCShoesJackboots, RMCPouchToolsFill, RMCHandsCombat, WeaponRifleMAR40, RMCPouchMagazineFilledMAR40Ext ]
+    - [ CMBackpackEngineer, RMCJumpsuitTMCC, RMCArmorTMCC, RMCArmorHelmetTMCCMiner, RMCShoesJackboots, RMCPouchToolsFill, RMCHandsCombat, RMCWeaponRifleMAR40, RMCPouchMagazineFilledMAR40Ext ]
+    - [ CMBackpackEngineer, RMCJumpsuitTMCC, RMCArmorTMCC, RMCArmorHelmetTMCCMiner, RMCShoesJackboots, RMCPouchToolsFill, RMCHandsCombat, RMCWeaponRifleMAR40, RMCPouchMagazineFilledMAR40Ext ]
     - [ RMCSatchelLightpack, RMCPouchToolsFill, RMCJumpsuitTMCC, RMCArmorTMCCAlt, RMCArmorHelmetTMCCMiner, RMCBootsRoyalFilled, RMCHandsVeteranRoyalMarine, RMCWeaponSMGP90, RMCPouchMagazineFilledP90 ]

--- a/Resources/ServerInfo/Guidebook/_RMC14/Guides/RMCGuideRoleSpec.xml
+++ b/Resources/ServerInfo/Guidebook/_RMC14/Guides/RMCGuideRoleSpec.xml
@@ -42,6 +42,6 @@
 
   - [bold][textlink="Scout Specialist" link="RMCGuideRoleScoutSpec"][/textlink][/bold] - "Silent Hunter & Intel"
   - Armed with the hard-hitting M4SPR custom battle rifle and an M68 Thermal Cloak, the Scout excels in reconnaissance, target designation with their Scout Designator, and surgical engagements.
-  <Box> <GuideEntityEmbed Entity="WeaponRifleM4SPRCustom" Context=""/> <GuideEntityEmbed Entity="RMCBackpackScout" Context=""/> <GuideEntityEmbed Entity="RMCLaserDesignatorScout" Context=""/> </Box>
+  <Box> <GuideEntityEmbed Entity="RMCWeaponRifleM4SPRCustom" Context=""/> <GuideEntityEmbed Entity="RMCBackpackScout" Context=""/> <GuideEntityEmbed Entity="RMCLaserDesignatorScout" Context=""/> </Box>
 
 </Document>

--- a/Resources/ServerInfo/Guidebook/_RMC14/Guides/RMCGuideRoleSpecScout.xml
+++ b/Resources/ServerInfo/Guidebook/_RMC14/Guides/RMCGuideRoleSpecScout.xml
@@ -9,7 +9,7 @@
 
   ## Standard Issue Kit
   The Scout deploys equipped with the following important equipment:
-  <Box> <GuideEntityEmbed Entity="WeaponRifleM4SPRCustom"/> <GuideEntityEmbed Entity="RMCBackpackScout"/> <GuideEntityEmbed Entity="RMCLaserDesignatorScout"/></Box>
+  <Box> <GuideEntityEmbed Entity="RMCWeaponRifleM4SPRCustom"/> <GuideEntityEmbed Entity="RMCBackpackScout"/> <GuideEntityEmbed Entity="RMCLaserDesignatorScout"/></Box>
 
   ## Core Capabilities & Equipment
 
@@ -28,7 +28,7 @@
   - You [bold]can laze targets[/bold] for Close Air Support (CAS) or Orbital Bombardment (OB).
 
   ### M4SPR Custom Battle Rifle: The Surgical Tool
-  <GuideEntityEmbed Entity="WeaponRifleM4SPRCustom" HorizontalAlignment="Left"/>
+  <GuideEntityEmbed Entity="RMCWeaponRifleM4SPRCustom" HorizontalAlignment="Left"/>
   While not necessarily the highest raw damage dealer, the M4SPR Custom Battle Rifle is prized for its accuracy, versatility, and crippling effects. Its unique ammo and attachment compatibility allow for tailored performance.
 
   <Box>[bold]Ammunition Types[/bold]:</Box>

--- a/Resources/ServerInfo/Guidebook/_RMC14/Guides/RMCSurvivor.xml
+++ b/Resources/ServerInfo/Guidebook/_RMC14/Guides/RMCSurvivor.xml
@@ -114,7 +114,7 @@
 
   [bold]Shotguns will likely be your main weapon as you are traversing the map due to their ability to stun and destroy out of place xenonids.[/bold]
 
-  <GuideEntityEmbed Entity="WeaponShotgunM42A2"/>
+  <GuideEntityEmbed Entity="RMCWeaponShotgunM42A2"/>
 
   The M42A2 pump shotgun is the most reliable weapon for a survivor. With a mounted bayonet, the pump shotgun is capable of brawling, breaking weeds, and beating back most foes. This weapon should be used one handed and loaded with buckshot. When using the pump shotgun, be extremely careful to not shoot your allies. A poorly placed buckshot can instantly kill anybody not wearing armor and deliver a lengthy stun to anybody who survives the hit. Fortunately, buckshot can also briefingly stun xenonids and slow them for an extended time after you land a stike. Weave around enemies and pick off weaker targets and provide openings for your allies.
 
@@ -122,7 +122,7 @@
 
   The HG 37-12 pump shotgun is a less reliable more specialized version of the M42A2 pump shotgun. The HG 37 is currently crippled by not having it's dual tube feature, allowing the user to swap on the go. The HG 37 should be wielded and loaded with the user's choice of ammo. If using slugs, the HG 37 is highly accurate. If you use buckshot, use the HG 37 similarly to the pump shotgun, but be sure to wield the weapon before firing it to prevent your target from dodging.
 
-  <GuideEntityEmbed Entity="WeaponShotgunCustomBuilt"/>
+  <GuideEntityEmbed Entity="RMCWeaponShotgunCustomBuilt"/>
 
   This is arguably the most deadly weapon obtainable without admin intervention. The custom built shotgun, often called the "custom" in character, is a shotgun with a 6 shell capacity. It sports a burst fire mode, capable of quickly firing two buckshot consecutively. This can kill almost any T1 instantly or greviously wound any T2 horribly. Be extremely careful when using this weapon around allies.
 
@@ -133,19 +133,19 @@
 
   [bold]Rifles are highly effective options, however many of the survivor exclusive rifles are not very useful unless used in a specific manner.[/bold]
 
-  <GuideEntityEmbed Entity="WeaponRifleAR10"/>
+  <GuideEntityEmbed Entity="RMCWeaponRifleAR10"/>
 
   The AR10 Assault Rifle is a weapon known for being laughably terrible by the survivor community, however it does have a few merits. In spite of it's low DPS, each bullet does a large amount of damage, making it very ammo efficient and good at keeping xenonids off of your barricades for an extended period. In addition, any AR10 on the map is [bold]guranteed[/bold] to start with attachments to strip and put onto a less terrible gun. Make use of what you have, even if it is an AR10.
 
-  <GuideEntityEmbed Entity="WeaponRifleM16"/>
+  <GuideEntityEmbed Entity="RMCWeaponRifleM16"/>
 
   The M16 is a direct upgrade to the AR10. It sports a higher fire rate, accuracy, and a similar damage per bullet to the AR10, making it a reliable weapon. The M16 has very far falloff as well and responds well to attachments. This is one of the most reliable guns that you can come across as a survivor and typically when it is present, ammo for it is plentiful. Use the M16 as a brawling gun in the backline of your group or to shoot xenonids attacking your cades with the intention to put serious hurt out.
 
-  <GuideEntityEmbed Entity="RMCWeaponRifleM54C"/> <GuideEntityEmbed Entity="RMCWeaponRifleM54CMK1"/> <GuideEntityEmbed Entity="WeaponRifleM4SPRCustom"/>
+  <GuideEntityEmbed Entity="RMCWeaponRifleM54C"/> <GuideEntityEmbed Entity="RMCWeaponRifleM54CMK1"/> <GuideEntityEmbed Entity="RMCWeaponRifleM4SPRCustom"/>
 
   Highly standardized marine weapons. Ammo for these weapons is best conserved for bigger fights and the holding phase, however they are incredibly useful for brawling if used properly. The M4SPR allows full movement speed while wielded, the MK2 has high DPS, and the MK1 is like the MK2 but slighly better overall. Use these as you would as a marine but more conservatively. You cannot call requisitions for a supply drop... usually.
 
-  <GuideEntityEmbed Entity="WeaponRifleMAR40"/>
+  <GuideEntityEmbed Entity="RMCWeaponRifleMAR40"/>
 
   A highly unreliable weapon, contrary to the in game description. The MAR40 is laughably inaccurate and cannot be used outside of extremely close range, similar to that of a shotgun. If you are to use this weapon, use it because it has a surplus of ammo and can consistently put lead down range. In addition, a bipod and reflex sight allow this weapon to shoot fairly straight and take advantage of its powerful bullets. Use this weapon as a last resort, similar to the AR10, or whenever you are in a brawl and need to hurt something that cannot be stunned by a shotgun.
 

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -446,7 +446,7 @@ CMMagazinePistolVP78: CMMagazinePistolMK80
 #CMMagazineRifleM4RAAP: CMMagazineRifleM4DMRAP
 #CMMagazineRifleM4RAExt: CMMagazineRifleM4DMRExt
 #WeaponRifleM4RA: WeaponRifleM4DMR
-WeaponShotgunM37A2: WeaponShotgunM42A2
+WeaponShotgunM37A2: RMCWeaponShotgunM42A2
 CMCrateBoxMagazineSMGM39: RMCCrateBoxMagazineSMGM63
 CMCrateBoxMagazineSMGM39AP: RMCCrateBoxMagazineSMGM63AP
 CMCrateBoxMagazineSMGM39Ext: RMCCrateBoxMagazineSMGM63Ext
@@ -1064,7 +1064,7 @@ WaterTankFull: RMCTankReagentWater
 #WeaponRifleM54CE2Camo: WeaponRifleM54CE2
 WeaponRifleM4SPRCamo: WeaponRifleM4SPR
 WeaponSMGM63Camo: WeaponSMGM63
-WeaponShotgunM42A2Camo: WeaponShotgunM42A2
+WeaponShotgunM42A2Camo: RMCWeaponShotgunM42A2
 WeaponM96SSniperRifleCamo: CMM96SSniperRifle
 WeaponLauncherM83Camo: WeaponLauncherM83
 RMCBinocularsCamo: RMCBinoculars
@@ -1096,7 +1096,7 @@ RMCCrateBoxMagazineM44RevolverMarksman: RMCCrateBoxMagazineRevolverM44Marksman
 RMCCrateM54C: RMCCrateM54CMK1
 
 # 2025-02-10
-BulletRifle5.56x45mm: BulletRifle556x45mm
+BulletRifle5.56x45mm: RMCBulletRifle556x45mm
 CMBulletPistol.22mm: CMBulletPistol22mm
 CMCartridgePistol.22mm: CMCartridgePistol22mm
 
@@ -1479,3 +1479,46 @@ CMPosterZSPA2: RMCPosterTSEPA2
 CMPosterZSPA3: RMCPosterTSEPA3
 RMCSpawnerERTShuttleZSPA: RMCSpawnerERTShuttleTSEPA
 RMCSpawnerShuttleZSPA: RMCSpawnerShuttleTSEPA
+ 
+# 2026-02-16 - Prefix RMC entities (Weapons)
+Bullet10x20mm: RMCBullet10x20mm
+Bullet10x20mmAP: RMCBullet10x20mmAP
+Bullet10x20mmRubber: RMCBullet10x20mmRubber
+Bullet9x21mmUZI: RMCBullet9x21mmUZI
+BulletRifle10x24mm: RMCBulletRifle10x24mm
+BulletRifle10x24mmAP: RMCBulletRifle10x24mmAP
+BulletRifle10x24mmHT: RMCBulletRifle10x24mmHT
+BulletRifle10x24mmRubber: RMCBulletRifle10x24mmRubber
+BulletRifle556x45mm: RMCBulletRifle556x45mm
+BulletRifle556x45mmAP: RMCBulletRifle556x45mmAP
+BulletRifle556x45mmHEAP: RMCBulletRifle556x45mmHEAP
+BulletRifle556x45mmIncendiary: RMCBulletRifle556x45mmIncendiary
+BulletRifle888x51mm: RMCBulletRifle888x51mm
+BulletRifle888x51mmAP: RMCBulletRifle888x51mmAP
+BulletRifle888x51mmHEAP: RMCBulletRifle888x51mmHEAP
+BulletRifle888x51mmIncendiary: RMCBulletRifle888x51mmIncendiary
+BulletRifleAR10: RMCBulletRifleAR10
+BulletRifleM4SPRA19: RMCBulletRifleM4SPRA19
+BulletRifleM4SPRA19Impact: RMCBulletRifleM4SPRA19Impact
+BulletRifleM4SPRA19Incendiary: RMCBulletRifleM4SPRA19Incendiary
+BulletRifleM5SPRHVHIP: RMCBulletRifleM5SPRHVHIP
+BulletRifleM5SPRHVP: RMCBulletRifleM5SPRHVP
+BulletRifleMAR40: RMCBulletRifleMAR40
+RCMBulletPistol9mmSquashHead: RMCBulletPistol9mmSquashHead
+RMCSentryConstruct: RMCSentry
+WeaponRifleAR10: RMCWeaponRifleAR10
+WeaponRifleL83A3F: RMCWeaponRifleL83A3F
+WeaponRifleL83A3M: RMCWeaponRifleL83A3M
+WeaponRifleM16: RMCWeaponRifleM16
+WeaponRifleM4SPRCustom: RMCWeaponRifleM4SPRCustom
+WeaponRifleM4SPRFilled: RMCWeaponRifleM4SPRFilled
+WeaponRifleM5SPR: RMCWeaponRifleM5SPR
+WeaponRifleM5SPR2: RMCWeaponRifleM5SPR2
+WeaponRifleMAR40: RMCWeaponRifleMAR40
+WeaponRifleXM88: RMCWeaponRifleXM88
+WeaponSMGMAC15: RMCWeaponSMGMAC15
+WeaponShotgunCustomBuilt: RMCWeaponShotgunCustomBuilt
+WeaponShotgunM42A1: RMCWeaponShotgunM42A1
+WeaponShotgunM42A2: RMCWeaponShotgunM42A2
+WeaponShotgunM890Guard: RMCWeaponShotgunM890Guard
+XenoSpikeProjectile: RMCXenoSpikeProjectile


### PR DESCRIPTION
Partially addresses #8892

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Standardizes weapon/projectile-related entity IDs under `_RMC14` to use `RMC` prefixes and updates references.

## Why / Balance

Enforce consistent prefixes for weapons entities:

- Keep `CM` prefixes and `RMC` prefixes.
- Add `RMC` to entities without either prefix.

## Technical details

- Renamed weapon/projectile IDs (rifles, shotguns, SMGs, bullets, sentry entries) to `RMC...` forms.
- Updated references across weapon prototypes, vendor inventories, role loadouts, crate/case fills, and guidebook docs.
- Added migration mappings for renamed weapons entities.

## Media

Not required (naming consistency changes only).

## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:

- code: Standardized RMC weapons/projectile entity IDs and updated references.
