### PR TITLE
Prefix RMC entities (Xeno)

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Bombard/XenoBombardComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Bombard/XenoBombardComponent.cs
@@ -19,13 +19,13 @@ public sealed partial class XenoBombardComponent : Component
     public TimeSpan Delay = TimeSpan.FromSeconds(4.5);
 
     [DataField, AutoNetworkedField]
-    public EntProtoId Projectile = "XenoBombardAcidProjectile";
+    public EntProtoId Projectile = "RMCXenoBombardAcidProjectile";
 
     [DataField, AutoNetworkedField]
     public EntProtoId[] Projectiles = new[]
     {
-        new EntProtoId("XenoBombardAcidProjectile"),
-        new EntProtoId("XenoBombardNeurotoxinProjectile"),
+        new EntProtoId("RMCXenoBombardAcidProjectile"),
+        new EntProtoId("RMCXenoBombardNeurotoxinProjectile"),
     };
 
     [DataField, AutoNetworkedField]

--- a/Content.Shared/_RMC14/Xenonids/Construction/ResinHole/XenoResinHoleComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/ResinHole/XenoResinHoleComponent.cs
@@ -10,11 +10,11 @@ public sealed partial class XenoResinHoleComponent : Component
 {
     public const string ParasitePrototype = "CMXenoParasite";
 
-    public const string BoilerAcid = "XenoBombardAcidProjectile";
+    public const string BoilerAcid = "RMCXenoBombardAcidProjectile";
 
     public const string AcidGasPrototype = "RMCSmokeAcid";
 
-    public const string BoilerNeuro = "XenoBombardNeurotoxinProjectile";
+    public const string BoilerNeuro = "RMCXenoBombardNeurotoxinProjectile";
 
     public const string NeuroGasPrototype = "RMCSmokeNeurotoxin";
 

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Other/boilgun.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Other/boilgun.yml
@@ -21,13 +21,13 @@
     soundGunshot:
       path: /Audio/_RMC14/Xeno/blobattack.ogg
   - type: ProjectileBatteryAmmoProvider
-    proto: XenoBombardAcidProjectile
+    proto: RMCXenoBombardAcidProjectile
     fireCost: 1
   - type: BatteryWeaponFireModes
     fireModes:
-    - proto: XenoBombardAcidProjectile
+    - proto: RMCXenoBombardAcidProjectile
       fireCost: 1
-    - proto: XenoBombardNeurotoxinProjectile
+    - proto: RMCXenoBombardNeurotoxinProjectile
       fireCost: 1
   - type: Battery
     maxCharge: 10

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_projectiles.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_projectiles.yml
@@ -210,7 +210,7 @@
 
 - type: entity
   parent: XenoBaseProjectile
-  id: XenoBombardAcidProjectile
+  id: RMCXenoBombardAcidProjectile
   name: glob of acid gas
   categories: [ HideSpawnMenu ]
   components:
@@ -266,7 +266,7 @@
 
 - type: entity
   parent: XenoBaseProjectile
-  id: XenoBombardNeurotoxinProjectile
+  id: RMCXenoBombardNeurotoxinProjectile
   name: glob of neurotoxin gas
   categories: [ HideSpawnMenu ]
   components:
@@ -470,4 +470,3 @@
         - BulletImpassable
         - XenoProjectileImpassable
         - BarricadeImpassable
-

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Base/base_structure.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Base/base_structure.yml
@@ -103,7 +103,7 @@
         - WallLayer
         density: 1000
   - type: XenoWeedable
-    spawn: XenoWeedsWall
+    spawn: RMCXenoWeedsWall
   - type: XenoConstructionSupport
   - type: RMCDropshipBlocked
   - type: MinimapColor

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_weeds.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_weeds.yml
@@ -355,7 +355,7 @@
 
 
 - type: entity
-  id: XenoWeedsWall
+  id: RMCXenoWeedsWall
   name: weeds
   placement:
     mode: SnapgridCenter

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -1479,3 +1479,8 @@ CMPosterZSPA2: RMCPosterTSEPA2
 CMPosterZSPA3: RMCPosterTSEPA3
 RMCSpawnerERTShuttleZSPA: RMCSpawnerERTShuttleTSEPA
 RMCSpawnerShuttleZSPA: RMCSpawnerShuttleTSEPA
+
+# 2026-02-17 - Prefix RMC entities (Xeno)
+XenoBombardAcidProjectile: RMCXenoBombardAcidProjectile
+XenoBombardNeurotoxinProjectile: RMCXenoBombardNeurotoxinProjectile
+XenoWeedsWall: RMCXenoWeedsWall


### PR DESCRIPTION
Partially addresses #8892

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Standardizes xeno-related entity IDs under `_RMC14` to use `RMC` prefixes and updates references.

## Why / Balance

Enforce consistent prefixes for xeno entities:

- Keep `CM` prefixes and `RMC` prefixes.
- Add `RMC` to entities without either prefix.

## Technical details

- Renamed xeno projectile/structure IDs to `RMC...` forms.
- Updated references across xeno prototypes, map entries, and shared xeno component code.
- Added migration mappings for renamed xeno entities.

## Media

Not required (naming consistency changes only).

## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:

- code: Standardized RMC xeno entity IDs and updated references.
