### PR TITLE
Make the targeting overlay use the laser sprites

### DIFF
--- a/Content.Client/_RMC14/Weapons/Ranged/Targeting/TargetingOverlay.cs
+++ b/Content.Client/_RMC14/Weapons/Ranged/Targeting/TargetingOverlay.cs
@@ -65,17 +65,27 @@ public sealed class TargetingOverlay : Overlay
                 var angle = diff.ToWorldAngle();
                 var length = diff.Length() / 2f;
                 var midPoint = gunWorldPos + diff / 2;
-                const float width = 0.02f;
 
-                var box = new Box2(-width, -length, width, length);
+                var box = new Box2(-targetingLaser.LaserWidth, -length, targetingLaser.LaserWidth, length);
                 var rotated = new Box2Rotated(box.Translated(midPoint), angle, midPoint);
 
-                var color = targetingLaser.CurrentLaserColor;
-                var alpha = targetingLaser.GradualAlpha && targeted.AlphaMultipliers.TryGetValue(targeter, out var mult)
-                    ? targetingLaser.LaserAlpha * mult
-                    : targetingLaser.LaserAlpha;
+                var alpha = 0f;
+                if (targetingLaser.GradualAlpha)
+                {
+                    if(targeted.AlphaMultipliers.TryGetValue(targeter, out var multiplier))
+                        alpha = targetingLaser.LaserAlpha * multiplier;
+                }
+                else
+                    alpha = targetingLaser.LaserAlpha;
 
-                worldHandle.DrawRect(rotated, color.WithAlpha(alpha));
+                var rsiState = targetingLaser.LaserType == TargetingLaserType.Normal
+                    ? targetingLaser.LaserState
+                    : targetingLaser.LaserIntenseState;
+
+                var laserTexture = _sprite.GetState(new SpriteSpecifier.Rsi(targetingLaser.RsiPath, rsiState));
+                var laserRsi = laserTexture.Frame0;
+
+                worldHandle.DrawTextureRect(laserRsi, rotated, Color.White.WithAlpha(alpha));
             }
 
             if (!xformQuery.TryGetComponent(uid, out var targetXform))

--- a/Content.Shared/_RMC14/Rangefinder/Spotting/SpotterWhitelistComponent.cs
+++ b/Content.Shared/_RMC14/Rangefinder/Spotting/SpotterWhitelistComponent.cs
@@ -1,6 +1,8 @@
+using Robust.Shared.GameStates;
+
 namespace Content.Shared._RMC14.Rangefinder.Spotting;
 
-[RegisterComponent]
+[RegisterComponent, NetworkedComponent]
 public sealed partial class SpotterWhitelistComponent : Component
 {
 

--- a/Content.Shared/_RMC14/Targeting/TargetingLaserComponent.cs
+++ b/Content.Shared/_RMC14/Targeting/TargetingLaserComponent.cs
@@ -1,4 +1,6 @@
 using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
+using Robust.Shared.Utility;
 
 namespace Content.Shared._RMC14.Targeting;
 
@@ -12,16 +14,10 @@ public sealed partial class TargetingLaserComponent : Component
     public bool ShowLaser = true;
 
     /// <summary>
-    ///     The original color of the laser.
+    ///     The laser type.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public Color LaserColor = Color.Red;
-
-    /// <summary>
-    ///     The current color of the laser
-    /// </summary>
-    [DataField, AutoNetworkedField]
-    public Color CurrentLaserColor = Color.Red;
+    public TargetingLaserType LaserType;
 
     /// <summary>
     ///     The default alpha multiplier of any lasers originating from this entity.
@@ -34,4 +30,26 @@ public sealed partial class TargetingLaserComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public bool GradualAlpha = true;
+
+    /// <summary>
+    ///     The width of the laser.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float LaserWidth = 0.3f;
+
+    [DataField]
+    public ResPath RsiPath = new("/Textures/_RMC14/Effects/beam.rsi");
+
+    [DataField]
+    public string LaserState = "laser_beam";
+
+    [DataField]
+    public string LaserIntenseState = "laser_beam_intense";
+}
+
+[Serializable, NetSerializable]
+public enum TargetingLaserType
+{
+    Normal,
+    Intense,
 }

--- a/Content.Shared/_RMC14/Weapons/Ranged/AimedShot/FocusedShooting/RMCFocusedShootingSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/AimedShot/FocusedShooting/RMCFocusedShootingSystem.cs
@@ -26,9 +26,9 @@ public sealed class RMCFocusedShootingSystem : EntitySystem
         if (TryComp(ent, out TargetingLaserComponent? targetingLaser))
         {
             if (focusCounter == 2)
-                targetingLaser.CurrentLaserColor = ent.Comp.LaserColor;
+                targetingLaser.LaserType = TargetingLaserType.Intense;
             else
-                targetingLaser.CurrentLaserColor = targetingLaser.LaserColor;
+                targetingLaser.LaserType = TargetingLaserType.Normal;
 
             Dirty(ent, targetingLaser);
         }

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Devices/binoculars.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Devices/binoculars.yml
@@ -184,9 +184,8 @@
     isCorrodible: false
   - type: Spotting
   - type: TargetingLaser
-    laserColor: orange
-    currentLaserColor: orange
-    laserAlpha: 0.2
+    laserState: laser_beam_spotter
+    laserAlpha: 1
     gradualAlpha: false
 
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- Instead of drawing a colored rectangle the targeting overlay now uses the laser sprites for aimed shots.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
No CL because I don't think people will notice.