### PR TITLE
fix: give whisperer and designer a heart and soul (intel)

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/hivelord.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/hivelord.yml
@@ -94,6 +94,10 @@
     prefix: hivelord
   - type: FixedIdentity
     name: cm-job-name-xeno-hivelord
+  - type: IntelRecoverCorpseObjectiveOnDeath
+    value: 0.2
+  - type: RMCSurgeryXenoHeart
+    item: RMCOrganXenoHeartT2
 
 - type: entity
   parent: CMXenoHivelordBase
@@ -147,10 +151,6 @@
     strains:
     - CMXenoHivelordResinWhisperer
     - CMXenoHivelordDesigner
-  - type: IntelRecoverCorpseObjectiveOnDeath
-    value: 0.2
-  - type: RMCSurgeryXenoHeart
-    item: RMCOrganXenoHeartT2
   - type: RMCActionOrder
     id: CMXenoHivelord
 


### PR DESCRIPTION
## About the PR

title

## Why / Balance

The hivelord strains currently do not give intel and cannot be operated on.

Bug was reported on discord.

## Technical details

moved intel and heart into the base

## Media

no

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- fix: Hivelord strains now give intel and have a heart.
