### PR TITLE
Queen no longer has a chance to gib when killed

### DIFF
--- a/Content.Shared/_RMC14/Gibbing/RMCGibSystem.cs
+++ b/Content.Shared/_RMC14/Gibbing/RMCGibSystem.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Body.Events;
 using Content.Shared.Body.Systems;
 using Content.Shared.Damage;
+using Content.Shared.Gibbing.Components;
 using Content.Shared.Inventory;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
@@ -47,6 +48,9 @@ public sealed class RMCGibSystem : EntitySystem
 
     private void OnDeath(Entity<RMCGibOnDeathComponent> ent, ref MobStateChangedEvent args)
     {
+        if (!HasComp<GibbableComponent>(ent))
+            return;
+
         if (args.NewMobState != MobState.Dead)
             return;
 

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
@@ -273,7 +273,7 @@
     canVote: true
   - type: RemoveComponents
     components:
-    - type: RMCGibOnDeath
+    - type: Gibbable
 
 - type: entity
   parent: RMCXenoQueenBase


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The queen doesn't gib anymore when killed.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix: The queen no longer has a chance to gib when killed.