### PR TITLE
fix missing locale for sentry and laptop ports

### DIFF
--- a/Resources/Locale/en-US/_RMC14/machine-linking/ports.ftl
+++ b/Resources/Locale/en-US/_RMC14/machine-linking/ports.ftl
@@ -1,0 +1,1 @@
+port-sentry-control = Sentry Control


### PR DESCRIPTION
## About the PR
Added missing locale for sentry and sentry laptop multitool ports

It was already defined in the yaml file but I guess the locale itself was never added

## Why / Balance
Missing locale bugfix

## Technical details
Added 1 ftl file

## Media
<img width="625" height="125" alt="obraz" src="https://github.com/user-attachments/assets/ceace86e-b1b1-44f6-a325-b1806ab0a676" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Added missing locale for sentry and sentry laptop multitool ports