### PR TITLE
tweak: rename the M34 crate

### DIFF
--- a/Resources/Prototypes/_RMC14/Catalog/Fills/Crates/weapons.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Fills/Crates/weapons.yml
@@ -65,7 +65,7 @@
 - type: entity
   parent: RMCCrateWeapons
   id: RMCCrateM34
-  name: M34 Flamethrower Crate (M34 x2, Broiler-T Fuelback x2)
+  name: M34 Flamethrower Crate (M34 x2, G4-1 fueltank x2)
   components:
   - type: StorageFill
     contents:


### PR DESCRIPTION
## About the PR

title

## Why / Balance

The name is wrong here AND in CM13. It contains the G4-1 instead of the broiler-t in both.

Also while I am here:

- fixes #1129
- fixes #924

## Technical details

just a name change

## Media

no

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

no
