### PR TITLE
Fix CL briefing content

### DIFF
--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
@@ -934,7 +934,8 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
                     if (!_prototypes.TryIndex(paper.Id, out var entProto, logError: false))
                         continue;
 
-                    var printout = new FaxPrintout(paperComponent.Content, entProto.Name, prototypeId: paper.Id, locked: true);
+                    var content = Loc.GetString(paperComponent.Content);
+                    var printout = new FaxPrintout(content, entProto.Name, prototypeId: paper.Id, locked: true);
                     _fax.Receive(faxId, printout, component: faxComp);
                 }
             }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
It wasn't getting the locale of the content from the paper ent prototype

**Changelog**
:cl:
- fix: Fixed Corporate Liaison briefings not having any text on them.