### PR TITLE
[PVE] Add Sentry Computers to Cases

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Tools/sentry_laptop.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Tools/sentry_laptop.yml
@@ -52,4 +52,7 @@
   - type: RequiresSkill
     skills:
       RMCSkillEngineer: 2
+  - type: Tag
+    tags:
+    - RMCSentryLaptop
 

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/pve_cases.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/pve_cases.yml
@@ -288,15 +288,17 @@
   - type: Storage
     maxItemSize: Ginormous
     grid:
-    - 0,0,3,1
+    - 0,0,5,1
     whitelist:
       tags:
       - RMCSentry
       - RMCMagazineSentry
+      - RMCSentryLaptop
   - type: StorageFill
     contents:
     - id: RMCSentry
     - id: RMCMagazineSentry
+    - id: RMCSentryLaptop
   - type: ItemMapper
     mapLayers:
       gun:
@@ -314,6 +316,7 @@
     contents:
     - id: RMCSentryMiniSPP
     - id: RMCMagazineSentry
+    - id: RMCSentryLaptop
 
 - type: entity
   parent: RMCPVECaseSentry
@@ -326,10 +329,12 @@
       tags:
       - RMCSentryWeYa
       - RMCMagazineSentry
+      - RMCSentryLaptop
   - type: StorageFill
     contents:
     - id: RMCSentryMiniWeYa
     - id: RMCMagazineSentry
+    - id: RMCSentryLaptop
   - type: ItemMapper
     mapLayers:
       gun:

--- a/Resources/Prototypes/_RMC14/rmc_tags.yml
+++ b/Resources/Prototypes/_RMC14/rmc_tags.yml
@@ -174,3 +174,6 @@
 
 - type: Tag
   id: RMCSynthGrabbable # whitelist tag for synths being able to grab particular xenos
+
+- type: Tag
+  id: RMCSentryLaptop


### PR DESCRIPTION
## About the PR
Adds the new sentry laptop to the SPP, We-Ya, and UN sentry cases in PVE.

## Why / Balance
Parity? Apparently?
Even if not I don't see a real reason to not have this present even if nobody ends up taking it for whatever reason, the item is soulful and doesn't significantly effect balance to have one around in PVE.

## Technical details
YAML, made a new tag for the laptop entity for storage whitelist purposes

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl: PursuitinAshes
- add: [PVE] Sentry Cases will now spawn with a Sentry Laptop stored inside.
