### PR TITLE
Fix parasites leaping from underneath a resin door

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
@@ -351,9 +351,9 @@ public abstract partial class SharedXenoParasiteSystem : EntitySystem
 
         if (nearestResinDoor is not null)
         {
-            PreventCollideComponent collisionPreventComp = new();
+            var collisionPreventComp = EnsureComp<PreventCollideComponent>(ent);
             collisionPreventComp.Uid = nearestResinDoor.Value;
-            AddComp(ent, collisionPreventComp);
+            Dirty(ent, collisionPreventComp);
         }
 
         if (TryComp(ent, out FixturesComponent? fixtures))
@@ -365,7 +365,7 @@ public abstract partial class SharedXenoParasiteSystem : EntitySystem
 
     private void OnParasiteLeapStopped(Entity<XenoParasiteComponent> ent, ref XenoLeapStoppedEvent args)
     {
-        RemCompDeferred<PreventCollideComponent>(ent);
+        RemComp<PreventCollideComponent>(ent);
 
         if (TryComp(ent, out FixturesComponent? fixtures))
         {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

- Fixed a bug where parasites were sometimes unable to leap while underneath a resin door
- Fixed a bug where parasites were sometimes able to leap through closed doors even when not underneath it.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug fix.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix: Fixed parasites sometimes being unable to leap while under a resin door.
- fix: Fixed parasites sometimes being able to leap through closed doors.