### PR TITLE
Fix sentry laptop not being in Comtech tool vendor

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/engineer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/engineer.yml
@@ -379,9 +379,10 @@
         amount: 2
       - id: RMCLightReplacer
         amount: 4
-    # - name: Utility
-    #   entries:
-    #   - id: Sentry Gun Network Laptop
-    #     amount: 4
+    - name: Utility
+      entries:
+      - id: RMCSentryLaptop
+        name: sentry gun network laptop
+        amount: 4
     #   - id: Sentry Gun Network Encryption KEy
     #     amount: 4


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
From CM13, it was commented out and never added for whatever reason

**Changelog**
:cl:
- add: The ComTech squad tool vendor now has 4 sentry laptops.