### PR TITLE
Fix AMR error

### DIFF
--- a/Content.Shared/_RMC14/Projectiles/Penetration/RMCPenetratingProjectileComponent.cs
+++ b/Content.Shared/_RMC14/Projectiles/Penetration/RMCPenetratingProjectileComponent.cs
@@ -19,10 +19,10 @@ public sealed partial class RMCPenetratingProjectileComponent : Component
     public EntityCoordinates? ShotFrom;
 
     /// <summary>
-    ///     The multiplier for range and damage loss if a membrane is hit.
+    ///     A list of net ID's already hit by this projectile.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public List<EntityUid> HitTargets = new();
+    public List<int> HitTargetIds = new();
 
     /// <summary>
     ///     The amount of range lost per hit entity.

--- a/Content.Shared/_RMC14/Projectiles/Penetration/RMCPenetratingProjectileSystem.cs
+++ b/Content.Shared/_RMC14/Projectiles/Penetration/RMCPenetratingProjectileSystem.cs
@@ -36,7 +36,7 @@ public sealed class RMCPenetratingProjectileSystem : EntitySystem
     /// </summary>
     private void OnPreventCollide(Entity<RMCPenetratingProjectileComponent> ent, ref PreventCollideEvent args)
     {
-        if(!ent.Comp.HitTargets.Contains(args.OtherEntity))
+        if(!ent.Comp.HitTargetIds.Contains(GetNetEntity(args.OtherEntity).Id))
             return;
 
         args.Cancelled = true;
@@ -47,13 +47,14 @@ public sealed class RMCPenetratingProjectileSystem : EntitySystem
     /// </summary>
     private void OnProjectileHit(Entity<RMCPenetratingProjectileComponent> ent, ref ProjectileHitEvent args)
     {
-        if (ent.Comp.HitTargets.Contains(args.Target))
+        var netId = GetNetEntity(args.Target).Id;
+        if (ent.Comp.HitTargetIds.Contains(netId))
         {
             args.Handled = true;
             return;
         }
 
-        ent.Comp.HitTargets.Add(args.Target);
+        ent.Comp.HitTargetIds.Add(netId);
         Dirty(ent);
     }
 
@@ -117,7 +118,7 @@ public sealed class RMCPenetratingProjectileSystem : EntitySystem
             (_transform.GetMoverCoordinates(ent).Position - ent.Comp.ShotFrom.Value.Position).Length();
         var range = ent.Comp.Range - distanceTravelled;
 
-        ent.Comp.HitTargets.Add(args.Target);
+        ent.Comp.HitTargetIds.Add(GetNetEntity(args.Target).Id);
         Dirty(ent);
 
         if (range < 0)

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Doors/cm_door.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Doors/cm_door.yml
@@ -144,7 +144,8 @@
           "/Audio/Weapons/smash.ogg"
   - type: AirlockReceiverXenoClaws
   - type: Damageable
-    damageContainer: Inorganic
+    damageContainer: StructuralMarine
+    damageModifierSet: StructuralMarine
   - type: Destructible
     thresholds:
     - trigger:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

- Fixed an error that would be thrown when a penetrating projectile destroyed an entity.
- Airlocks now take structural damage.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fix.

## Technical details
<!-- Summary of code changes for easier review. -->
The `PenetratingProjectileComponent` would attempt to network a deleted entity in it's list of already hit targets.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix: Structure damage modifiers now apply to airlocks.
