### PR TITLE
Fix aimed shot visual drawing below entities

### DIFF
--- a/Content.Client/_RMC14/Weapons/Ranged/Targeting/TargetingOverlay.cs
+++ b/Content.Client/_RMC14/Weapons/Ranged/Targeting/TargetingOverlay.cs
@@ -13,7 +13,7 @@ namespace Content.Client._RMC14.Weapons.Ranged.Targeting;
 
 public sealed class TargetingOverlay : Overlay
 {
-    public override OverlaySpace Space => OverlaySpace.WorldSpaceBelowFOV;
+    public override OverlaySpace Space => OverlaySpace.WorldSpace;
 
     private readonly IEntityManager _entManager;
     private readonly SpriteSystem _sprite;

--- a/Content.Shared/_RMC14/Weapons/Ranged/AimedShot/SharedRMCAimedShotSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/AimedShot/SharedRMCAimedShotSystem.cs
@@ -216,7 +216,7 @@ public abstract class SharedRMCAimedShotSystem : EntitySystem
             }
         }
         // Update ammo visualiser because client doesn't know about the shot.
-        var ev = new UpdateClientAmmoEvent();
+        var ev = new UpdateClientAmmoEvent(-1);
         RaiseLocalEvent(ent, ref ev);
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

- Xeno vision no longer draws the aimed shot visual below it's target, it does mean that anyone can see the marker through walls, but the laser already goes through walls anyways so I don't think it's an issue.
- The ammo indicator now updates correctly after doing an aimed shot.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes.
Resolves #9346 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix: Fixed xenonids not seeing the aimed shot visual.