### PR TITLE
fix: XO and others now keep their pointer when no longer SL

### DIFF
--- a/Content.Shared/_RMC14/Marines/Squads/SquadSystem.cs
+++ b/Content.Shared/_RMC14/Marines/Squads/SquadSystem.cs
@@ -716,8 +716,18 @@ public sealed class SquadSystem : EntitySystem
                 }
 
                 RemComp<SquadLeaderComponent>(uid);
-                RemComp<RMCTrackableComponent>(uid);
-                RemCompDeferred<RMCPointingComponent>(uid);
+
+                if (TryComp<RMCTrackableComponent>(uid, out var otherTrackable) &&
+                    !otherTrackable.Intrinsic)
+                {
+                    RemComp<RMCTrackableComponent>(uid);
+                }
+
+                if (TryComp<RMCPointingComponent>(uid, out var otherPointing) &&
+                    !otherPointing.Intrinsic)
+                {
+                    RemCompDeferred<RMCPointingComponent>(uid);
+                }
             }
         }
 
@@ -734,8 +744,17 @@ public sealed class SquadSystem : EntitySystem
             _marineOrders.StartActionUseDelay((toPromote, orders));
         }
 
-        EnsureComp<RMCTrackableComponent>(toPromote);
-        EnsureComp<RMCPointingComponent>(toPromote);
+        if (!EnsureComp(toPromote, out RMCTrackableComponent trackable))
+        {
+            trackable.Intrinsic = false;
+            Dirty(toPromote, trackable);
+        }
+
+        if (!EnsureComp(toPromote, out RMCPointingComponent pointing))
+        {
+            pointing.Intrinsic = false;
+            Dirty(toPromote, pointing);
+        }
 
         var slots = _inventory.GetSlotEnumerator(toPromote.Owner, SlotFlags.EARS);
         while (slots.MoveNext(out var slot))

--- a/Content.Shared/_RMC14/Pointing/RMCPointingComponent.cs
+++ b/Content.Shared/_RMC14/Pointing/RMCPointingComponent.cs
@@ -1,10 +1,11 @@
-﻿using Robust.Shared.GameStates;
+﻿using Content.Shared._RMC14.Marines.Squads;
+using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 
 namespace Content.Shared._RMC14.Pointing;
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-[Access(typeof(RMCPointingSystem))]
+[Access(typeof(RMCPointingSystem), typeof(SquadSystem))]
 public sealed partial class RMCPointingComponent : Component
 {
     [DataField, AutoNetworkedField]
@@ -12,4 +13,7 @@ public sealed partial class RMCPointingComponent : Component
 
     [DataField, AutoNetworkedField]
     public EntProtoId SquadArrow = "RMCPointingArrowSquad";
+
+    [DataField, AutoNetworkedField]
+    public bool Intrinsic = true;
 }

--- a/Content.Shared/_RMC14/Tracker/RMCTrackableComponent.cs
+++ b/Content.Shared/_RMC14/Tracker/RMCTrackableComponent.cs
@@ -2,5 +2,9 @@ using Robust.Shared.GameStates;
 
 namespace Content.Shared._RMC14.Tracker;
 
-[RegisterComponent, NetworkedComponent]
-public sealed partial class RMCTrackableComponent : Component;
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class RMCTrackableComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public bool Intrinsic = true;
+}


### PR DESCRIPTION
## About the PR

title

## Why / Balance

bugfix. it was getting removed and didn't consider them having it before being assigned as SL

## Technical details

mark as intrinsic and don't delete

## Media

Before:

https://github.com/user-attachments/assets/b3e03d4d-ed8c-4a0f-983f-2dd02309cf04


After:

https://github.com/user-attachments/assets/d8cfd0a3-9f47-4df6-9db3-5d9c5cee62db


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- fix: XO and others now keep their pointer when no longer SL
