### PR TITLE
Accentless trait to cost 0

### DIFF
--- a/Resources/Prototypes/_RMC14/Traits/accents.yml
+++ b/Resources/Prototypes/_RMC14/Traits/accents.yml
@@ -51,7 +51,7 @@
   name: trait-accentless-name
   description: trait-accentless-desc
   category: SpeechTraits
-  cost: 2
+  cost: 0
   components:
   - type: Accentless
     removes:


### PR DESCRIPTION
## About the PR
Making the accentless trait, that removes species-specific accents, cost 0

## Why / Balance
Players should be able to be scottish lizards or pirate vulps while simultaneously removing their in-built species accents, right now they cannot since the accentless trait takes all their accent points.

## Technical details
yml

## Media
video shows accentless trait working with other accents. Even as a dwarf removing the innate scottish accent and then adding it back, accent works and doesn't cause any errors.
https://github.com/user-attachments/assets/6835ba1f-59d0-4a20-af4e-5dba30451648


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl: CatAndHats
- tweak: The Accentless trait now costs 0