### PR TITLE
M12 blast grenade fixes 

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -255,8 +255,8 @@
   - type: Sprite
     sprite: _RMC14/Objects/Weapons/Grenades/m12blast.rsi
   - type: Explosive
-    maxIntensity: 30 # max 150 brute, 150 burn
-    intensitySlope: 3
+    maxIntensity: 35 # max 175 brute, 175 burn
+    intensitySlope: 5
     totalIntensity: 280
   - type: Tag
     tags:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removed the M12 blasst grenades shrapnel, buffed the max intensity to 30 (should mirror CM13, in CM the HEDP has 100 explosive power and the M12 has 200)
Also fixes it unable to fit inside of the M85A1, and removed some copypaste from grenades.

<img width="650" height="191" alt="image" src="https://github.com/user-attachments/assets/6291c089-5c5a-472b-944a-929a6dc56c47" />


**Changelog**
:cl:
- fix: Fixed the M12 Blast Grenade not fitting inside of the M85A1 launcher, fixed it being weaker than intended, and fixed it having shrapnel.