### PR TITLE
Smart Scope blocks fire on friendlies

### DIFF
--- a/Content.Client/_RMC14/Attachable/Systems/AttachableIFFDebugOverlaySystem.cs
+++ b/Content.Client/_RMC14/Attachable/Systems/AttachableIFFDebugOverlaySystem.cs
@@ -1,0 +1,177 @@
+using System.Numerics;
+using Content.Shared._RMC14.Attachable.Events;
+using Robust.Client.Graphics;
+using Robust.Shared.Enums;
+using Robust.Shared.Map;
+using Robust.Shared.Timing;
+
+namespace Content.Client._RMC14.Attachable.Systems;
+
+public sealed class AttachableIFFDebugOverlaySystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly IOverlayManager _overlayManager = default!;
+
+    private static readonly TimeSpan SampleLifetime = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan MispredictCompareWindow = TimeSpan.FromMilliseconds(500);
+    private const float MispredictPositionTolerance = 0.25f;
+
+    private AttachableIFFDebugOverlay? _overlay;
+    private IFFDebugSample? _clientSample;
+    private IFFDebugSample? _serverSample;
+    private bool _enabled;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<AttachableIFFDebugSampleEvent>(OnClientSample);
+        SubscribeNetworkEvent<AttachableIFFDebugToggledEvent>(OnToggled);
+        SubscribeNetworkEvent<AttachableIFFServerDebugSampleEvent>(OnServerSample);
+    }
+
+    public override void Shutdown()
+    {
+        if (_overlay != null)
+        {
+            _overlayManager.RemoveOverlay(_overlay);
+            _overlay = null;
+        }
+
+        base.Shutdown();
+    }
+
+    private void OnToggled(AttachableIFFDebugToggledEvent ev)
+    {
+        _enabled = ev.Enabled;
+
+        if (_enabled)
+        {
+            if (_overlay == null)
+            {
+                _overlay = new AttachableIFFDebugOverlay(this);
+                _overlayManager.AddOverlay(_overlay);
+            }
+        }
+        else
+        {
+            if (_overlay != null)
+            {
+                _overlayManager.RemoveOverlay(_overlay);
+                _overlay = null;
+            }
+
+            _clientSample = null;
+            _serverSample = null;
+        }
+    }
+
+    private void OnClientSample(ref AttachableIFFDebugSampleEvent ev)
+    {
+        if (!_enabled || ev.IsServerSample)
+            return;
+
+        _clientSample = new IFFDebugSample(
+            ev.From,
+            ev.To,
+            ev.HasHit,
+            ev.Hit,
+            ev.BlockedByFriendly,
+            _timing.CurTime);
+    }
+
+    private void OnServerSample(AttachableIFFServerDebugSampleEvent ev)
+    {
+        if (!_enabled)
+            return;
+
+        var sample = new IFFDebugSample(
+            ev.From,
+            ev.To,
+            ev.HasHit,
+            ev.Hit,
+            ev.BlockedByFriendly,
+            _timing.CurTime);
+        _serverSample = sample;
+
+        TryLogMispredict(sample);
+    }
+
+    private void TryLogMispredict(IFFDebugSample server)
+    {
+        if (_clientSample is not { } client)
+            return;
+
+        if (server.Time - client.Time > MispredictCompareWindow)
+            return;
+
+        if (client.From.MapId != server.From.MapId ||
+            client.To.MapId != server.To.MapId)
+        {
+            return;
+        }
+
+        if ((client.From.Position - server.From.Position).Length() > MispredictPositionTolerance ||
+            (client.To.Position - server.To.Position).Length() > MispredictPositionTolerance)
+        {
+            return;
+        }
+
+        if (client.BlockedByFriendly == server.BlockedByFriendly &&
+            client.HasHit == server.HasHit)
+        {
+            return;
+        }
+
+        Log.Warning(
+            $"IFF mispredict detected: client blocked={client.BlockedByFriendly}, server blocked={server.BlockedByFriendly}, client hasHit={client.HasHit}, server hasHit={server.HasHit}");
+    }
+
+    public void Draw(in OverlayDrawArgs args)
+    {
+        if (!_enabled)
+            return;
+
+        var now = _timing.CurTime;
+        DrawSample(args.WorldHandle, args.MapId, _clientSample, now, Color.DeepSkyBlue, Color.Red);
+        DrawSample(args.WorldHandle, args.MapId, _serverSample, now, Color.Orange, Color.DarkRed);
+    }
+
+    private static void DrawSample(
+        DrawingHandleWorld handle,
+        MapId currentMap,
+        IFFDebugSample? sample,
+        TimeSpan now,
+        Color lineColor,
+        Color blockedColor)
+    {
+        if (sample is not { } value)
+            return;
+
+        if (now - value.Time > SampleLifetime || value.From.MapId != currentMap)
+            return;
+
+        var color = value.BlockedByFriendly ? blockedColor : lineColor;
+        handle.DrawLine(value.From.Position, value.To.Position, color);
+        handle.DrawCircle(value.From.Position, 0.08f, color);
+
+        if (value.HasHit)
+            handle.DrawCircle(value.Hit.Position, 0.12f, color, false);
+    }
+
+    private readonly record struct IFFDebugSample(
+        MapCoordinates From,
+        MapCoordinates To,
+        bool HasHit,
+        MapCoordinates Hit,
+        bool BlockedByFriendly,
+        TimeSpan Time);
+}
+
+public sealed class AttachableIFFDebugOverlay(AttachableIFFDebugOverlaySystem system) : Overlay
+{
+    public override OverlaySpace Space => OverlaySpace.WorldSpace;
+
+    protected override void Draw(in OverlayDrawArgs args)
+    {
+        system.Draw(args);
+    }
+}

--- a/Content.Client/_RMC14/Attachable/Systems/AttachableIFFDebugOverlaySystem.cs
+++ b/Content.Client/_RMC14/Attachable/Systems/AttachableIFFDebugOverlaySystem.cs
@@ -1,4 +1,3 @@
-using System.Numerics;
 using Content.Shared._RMC14.Attachable.Events;
 using Robust.Client.Graphics;
 using Robust.Shared.Enums;
@@ -13,8 +12,6 @@ public sealed class AttachableIFFDebugOverlaySystem : EntitySystem
     [Dependency] private readonly IOverlayManager _overlayManager = default!;
 
     private static readonly TimeSpan SampleLifetime = TimeSpan.FromSeconds(2);
-    private static readonly TimeSpan MispredictCompareWindow = TimeSpan.FromMilliseconds(500);
-    private const float MispredictPositionTolerance = 0.25f;
 
     private AttachableIFFDebugOverlay? _overlay;
     private IFFDebugSample? _clientSample;
@@ -91,38 +88,6 @@ public sealed class AttachableIFFDebugOverlaySystem : EntitySystem
             ev.BlockedByFriendly,
             _timing.CurTime);
         _serverSample = sample;
-
-        TryLogMispredict(sample);
-    }
-
-    private void TryLogMispredict(IFFDebugSample server)
-    {
-        if (_clientSample is not { } client)
-            return;
-
-        if (server.Time - client.Time > MispredictCompareWindow)
-            return;
-
-        if (client.From.MapId != server.From.MapId ||
-            client.To.MapId != server.To.MapId)
-        {
-            return;
-        }
-
-        if ((client.From.Position - server.From.Position).Length() > MispredictPositionTolerance ||
-            (client.To.Position - server.To.Position).Length() > MispredictPositionTolerance)
-        {
-            return;
-        }
-
-        if (client.BlockedByFriendly == server.BlockedByFriendly &&
-            client.HasHit == server.HasHit)
-        {
-            return;
-        }
-
-        Log.Warning(
-            $"IFF mispredict detected: client blocked={client.BlockedByFriendly}, server blocked={server.BlockedByFriendly}, client hasHit={client.HasHit}, server hasHit={server.HasHit}");
     }
 
     public void Draw(in OverlayDrawArgs args)

--- a/Content.Server/_RMC14/Attachable/AttachableIFFDebugSystem.cs
+++ b/Content.Server/_RMC14/Attachable/AttachableIFFDebugSystem.cs
@@ -1,0 +1,50 @@
+using Content.Shared._RMC14.Attachable.Events;
+using Robust.Shared.Player;
+
+namespace Content.Server._RMC14.Attachable;
+
+public sealed class AttachableIFFDebugSystem : EntitySystem
+{
+    [Dependency] private readonly ISharedPlayerManager _players = default!;
+
+    private readonly HashSet<ICommonSession> _observers = [];
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<AttachableIFFDebugSampleEvent>(OnDebugSample);
+    }
+
+    public bool ToggleObserver(ICommonSession observer)
+    {
+        if (_observers.Remove(observer))
+        {
+            RaiseNetworkEvent(new AttachableIFFDebugToggledEvent(false), observer.Channel);
+            return false;
+        }
+
+        _observers.Add(observer);
+        RaiseNetworkEvent(new AttachableIFFDebugToggledEvent(true), observer.Channel);
+        return true;
+    }
+
+    private void OnDebugSample(ref AttachableIFFDebugSampleEvent args)
+    {
+        if (!args.IsServerSample)
+            return;
+
+        if (!_players.TryGetSessionByEntity(args.User, out var session))
+            return;
+
+        if (!_observers.Contains(session))
+            return;
+
+        RaiseNetworkEvent(
+            new AttachableIFFServerDebugSampleEvent(
+                args.From,
+                args.To,
+                args.HasHit,
+                args.Hit,
+                args.BlockedByFriendly),
+            session.Channel);
+    }
+}

--- a/Content.Server/_RMC14/Attachable/ShowIFFDebugCommand.cs
+++ b/Content.Server/_RMC14/Attachable/ShowIFFDebugCommand.cs
@@ -1,0 +1,32 @@
+using Content.Server.Administration;
+using Content.Shared.Administration;
+using Robust.Shared.Console;
+
+namespace Content.Server._RMC14.Attachable;
+
+[AdminCommand(AdminFlags.Debug)]
+public sealed class ShowIFFDebugCommand : IConsoleCommand
+{
+    [Dependency] private readonly IEntitySystemManager _entitySystem = default!;
+
+    public string Command => "showiffdebug";
+    public string Description => "Toggles IFF prediction debug overlay for your client.";
+    public string Help => $"Usage: {Command}";
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        var player = shell.Player;
+        if (player == null)
+        {
+            shell.WriteLine("You must be a player to use this command.");
+            return;
+        }
+
+        var debug = _entitySystem.GetEntitySystem<AttachableIFFDebugSystem>();
+        var enabled = debug.ToggleObserver(player);
+
+        shell.WriteLine(enabled
+            ? "Enabled the IFF prediction debug overlay."
+            : "Disabled the IFF prediction debug overlay.");
+    }
+}

--- a/Content.Shared/_RMC14/Attachable/Components/AttachableIFFComponent.cs
+++ b/Content.Shared/_RMC14/Attachable/Components/AttachableIFFComponent.cs
@@ -1,8 +1,12 @@
-﻿using Content.Shared._RMC14.Attachable.Systems;
+using Content.Shared._RMC14.Attachable.Systems;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared._RMC14.Attachable.Components;
 
 [RegisterComponent, NetworkedComponent]
 [Access(typeof(AttachableIFFSystem))]
-public sealed partial class AttachableIFFComponent : Component;
+public sealed partial class AttachableIFFComponent : Component
+{
+    [DataField]
+    public bool PreventFriendlyFire;
+}

--- a/Content.Shared/_RMC14/Attachable/Components/GunAttachableIFFComponent.cs
+++ b/Content.Shared/_RMC14/Attachable/Components/GunAttachableIFFComponent.cs
@@ -1,8 +1,12 @@
-﻿using Content.Shared._RMC14.Attachable.Systems;
+using Content.Shared._RMC14.Attachable.Systems;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared._RMC14.Attachable.Components;
 
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 [Access(typeof(AttachableIFFSystem))]
-public sealed partial class GunAttachableIFFComponent : Component;
+public sealed partial class GunAttachableIFFComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public bool PreventFriendlyFire;
+}

--- a/Content.Shared/_RMC14/Attachable/Events/AttachableGrantIFFEvent.cs
+++ b/Content.Shared/_RMC14/Attachable/Events/AttachableGrantIFFEvent.cs
@@ -1,4 +1,4 @@
-﻿namespace Content.Shared._RMC14.Attachable.Events;
+namespace Content.Shared._RMC14.Attachable.Events;
 
 [ByRefEvent]
-public record struct AttachableGrantIFFEvent(bool Grants);
+public record struct AttachableGrantIFFEvent(bool Grants = false, bool PreventFriendlyFire = false);

--- a/Content.Shared/_RMC14/Attachable/Events/AttachableIFFDebugEvents.cs
+++ b/Content.Shared/_RMC14/Attachable/Events/AttachableIFFDebugEvents.cs
@@ -1,0 +1,35 @@
+using Robust.Shared.Map;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Attachable.Events;
+
+[ByRefEvent]
+public readonly record struct AttachableIFFDebugSampleEvent(
+    EntityUid User,
+    MapCoordinates From,
+    MapCoordinates To,
+    bool HasHit,
+    MapCoordinates Hit,
+    bool BlockedByFriendly,
+    bool IsServerSample);
+
+[Serializable, NetSerializable]
+public sealed class AttachableIFFDebugToggledEvent(bool enabled) : EntityEventArgs
+{
+    public readonly bool Enabled = enabled;
+}
+
+[Serializable, NetSerializable]
+public sealed class AttachableIFFServerDebugSampleEvent(
+    MapCoordinates from,
+    MapCoordinates to,
+    bool hasHit,
+    MapCoordinates hit,
+    bool blockedByFriendly) : EntityEventArgs
+{
+    public readonly MapCoordinates From = from;
+    public readonly MapCoordinates To = to;
+    public readonly bool HasHit = hasHit;
+    public readonly MapCoordinates Hit = hit;
+    public readonly bool BlockedByFriendly = blockedByFriendly;
+}

--- a/Content.Shared/_RMC14/Attachable/Systems/AttachableIFFSystem.cs
+++ b/Content.Shared/_RMC14/Attachable/Systems/AttachableIFFSystem.cs
@@ -1,8 +1,24 @@
-﻿using Content.Shared._RMC14.Attachable.Components;
+using System.Collections.Generic;
+using System.Numerics;
+using Content.Shared._RMC14.Attachable.Components;
 using Content.Shared._RMC14.Attachable.Events;
+using Content.Shared._RMC14.Random;
+using Content.Shared._RMC14.Weapons.Ranged;
 using Content.Shared._RMC14.Weapons.Ranged.IFF;
+using Content.Shared.Projectiles;
 using Content.Shared.Examine;
+using Content.Shared.Inventory;
+using Content.Shared.Physics;
+using Content.Shared.Weapons.Ranged.Components;
+using Content.Shared.Weapons.Ranged;
 using Content.Shared.Weapons.Ranged.Events;
+using Content.Shared.Weapons.Ranged.Systems;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+using Robust.Shared.Network;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Systems;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
 namespace Content.Shared._RMC14.Attachable.Systems;
@@ -11,13 +27,22 @@ public sealed class AttachableIFFSystem : EntitySystem
 {
     [Dependency] private readonly AttachableHolderSystem _holder = default!;
     [Dependency] private readonly GunIFFSystem _gunIFF = default!;
+    [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
+
+    private const float FallbackProjectileLifetime = 10f;
+    private const float FallbackProjectileRadius = 0.1f;
+
+    private readonly HashSet<EntProtoId<IFFFactionComponent>> _factionBuffer = new();
 
     public override void Initialize()
     {
         SubscribeLocalEvent<AttachableIFFComponent, AttachableAlteredEvent>(OnAttachableIFFAltered);
         SubscribeLocalEvent<AttachableIFFComponent, AttachableRelayedEvent<AttachableGrantIFFEvent>>(OnAttachableIFFGrant);
 
+        SubscribeLocalEvent<GunAttachableIFFComponent, AttemptShootEvent>(OnGunAttachableIFFAttemptShoot);
         SubscribeLocalEvent<GunAttachableIFFComponent, AmmoShotEvent>(OnGunAttachableIFFAmmoShot);
         SubscribeLocalEvent<GunAttachableIFFComponent, ExaminedEvent>(OnGunAttachableIFFExamined);
     }
@@ -38,6 +63,162 @@ public sealed class AttachableIFFSystem : EntitySystem
     private void OnAttachableIFFGrant(Entity<AttachableIFFComponent> ent, ref AttachableRelayedEvent<AttachableGrantIFFEvent> args)
     {
         args.Args.Grants = true;
+
+        if (ent.Comp.PreventFriendlyFire)
+            args.Args.PreventFriendlyFire = true;
+    }
+
+    private void OnGunAttachableIFFAttemptShoot(Entity<GunAttachableIFFComponent> ent, ref AttemptShootEvent args)
+    {
+        if (args.Cancelled ||
+            !ent.Comp.PreventFriendlyFire ||
+            args.ToCoordinates is not { } toCoordinates ||
+            !TryComp<GunComponent>(ent, out var gun))
+        {
+            return;
+        }
+
+        if (!_gunIFF.TryGetFactions((args.User, CompOrNull<UserIFFComponent>(args.User)), _factionBuffer, SlotFlags.IDCARD))
+            return;
+
+        try
+        {
+            var from = _transform.ToMapCoordinates(args.FromCoordinates);
+            var to = _transform.ToMapCoordinates(toCoordinates);
+            if (from.MapId != to.MapId)
+                return;
+
+            var initialDirection = to.Position - from.Position;
+            if (initialDirection == Vector2.Zero)
+                return;
+
+            var shotDirection = GetPredictedShotDirection((ent.Owner, gun), initialDirection);
+            if (shotDirection == Vector2.Zero)
+                return;
+
+            var maxDistance = GetIffCheckDistance((ent.Owner, gun));
+            if (maxDistance <= 0)
+                return;
+
+            var shotEnd = from.Position + shotDirection * maxDistance;
+            var shotRadius = GetIffCheckRadius((ent.Owner, gun));
+            var perpendicular = new Vector2(-shotDirection.Y, shotDirection.X);
+            var shooter = args.User;
+            var weapon = ent.Owner;
+
+            var blockedByFriendly = false;
+            var hasHit = false;
+            var hitPosition = shotEnd;
+            blockedByFriendly = ProcessRay(0f);
+            if (!blockedByFriendly && shotRadius > 0f)
+            {
+                blockedByFriendly = ProcessRay(shotRadius) || ProcessRay(-shotRadius);
+            }
+
+            if (blockedByFriendly)
+            {
+                args.Cancelled = true;
+                args.Message = Loc.GetString("rmc-iff-friendly-in-line");
+            }
+
+            RaiseDebugSample(args.User, from, shotEnd, hasHit, hitPosition, blockedByFriendly);
+
+            bool ProcessRay(float offset)
+            {
+                var ray = new CollisionRay(
+                    from.Position + perpendicular * offset,
+                    shotDirection,
+                    (int) CollisionGroup.BulletImpassable);
+                var hits = _physics.IntersectRayWithPredicate(
+                    from.MapId,
+                    ray,
+                    (user: shooter, gun: weapon),
+                    static (uid, state) => uid == state.user || uid == state.gun,
+                    maxDistance,
+                    returnOnFirstHit: false);
+
+                foreach (var hit in hits)
+                {
+                    hasHit = true;
+                    hitPosition = hit.HitPos;
+
+                    if (IsFriendlyEntity(hit.HitEntity))
+                    {
+                        return true;
+                    }
+
+                    break;
+                }
+
+                return false;
+            }
+        }
+        finally
+        {
+            _factionBuffer.Clear();
+        }
+    }
+
+    private Vector2 GetPredictedShotDirection(Entity<GunComponent> gun, Vector2 initialDirection)
+    {
+        var baseAngle = initialDirection.ToAngle();
+
+        var timeSinceLastFire = (_timing.CurTime - gun.Comp.LastFire).TotalSeconds;
+        var newTheta = MathHelper.Clamp(
+            gun.Comp.CurrentAngle.Theta + gun.Comp.AngleIncreaseModified.Theta - gun.Comp.AngleDecayModified.Theta * timeSinceLastFire,
+            gun.Comp.MinAngleModified.Theta,
+            gun.Comp.MaxAngleModified.Theta);
+
+        long tick = _timing.CurTick.Value;
+        tick = tick << 32;
+        tick |= (uint) GetNetEntity(gun.Owner).Id;
+        var random = new Xoroshiro64S(tick).NextFloat(-0.5f, 0.5f);
+
+        var shotAngle = new Angle(baseAngle.Theta + newTheta * random);
+        return shotAngle.ToVec();
+    }
+
+    private bool IsFriendlyEntity(EntityUid target)
+    {
+        foreach (var faction in _factionBuffer)
+        {
+            if (_gunIFF.IsInFaction(target, faction))
+                return true;
+        }
+
+        return false;
+    }
+
+    private float GetIffCheckDistance(Entity<GunComponent> gun)
+    {
+        return gun.Comp.ProjectileSpeedModified * FallbackProjectileLifetime;
+    }
+
+    private float GetIffCheckRadius(Entity<GunComponent> _)
+    {
+        return FallbackProjectileRadius;
+    }
+
+    private void RaiseDebugSample(
+        EntityUid user,
+        MapCoordinates from,
+        Vector2 shotEnd,
+        bool hasHit,
+        Vector2 hitPosition,
+        bool blockedByFriendly)
+    {
+        if (_net.IsClient && !_timing.IsFirstTimePredicted)
+            return;
+
+        var ev = new AttachableIFFDebugSampleEvent(
+            user,
+            from,
+            new MapCoordinates(shotEnd, from.MapId),
+            hasHit,
+            new MapCoordinates(hitPosition, from.MapId),
+            blockedByFriendly,
+            _net.IsServer);
+        RaiseLocalEvent(ref ev);
     }
 
     private void OnGunAttachableIFFAmmoShot(Entity<GunAttachableIFFComponent> ent, ref AmmoShotEvent args)
@@ -49,7 +230,9 @@ public sealed class AttachableIFFSystem : EntitySystem
     {
         using (args.PushGroup(nameof(GunAttachableIFFComponent)))
         {
-            args.PushMarkup(Loc.GetString("rmc-examine-text-iff"));
+            args.PushMarkup(Loc.GetString(ent.Comp.PreventFriendlyFire
+                ? "rmc-examine-text-iff-prevent-friendly-fire"
+                : "rmc-examine-text-iff"));
         }
     }
 
@@ -65,8 +248,17 @@ public sealed class AttachableIFFSystem : EntitySystem
             return;
 
         if (ev.Grants)
-            EnsureComp<GunAttachableIFFComponent>(gun);
+        {
+            var gunIff = EnsureComp<GunAttachableIFFComponent>(gun);
+            if (gunIff.PreventFriendlyFire != ev.PreventFriendlyFire)
+            {
+                gunIff.PreventFriendlyFire = ev.PreventFriendlyFire;
+                Dirty(gun, gunIff);
+            }
+        }
         else
+        {
             RemCompDeferred<GunAttachableIFFComponent>(gun);
+        }
     }
 }

--- a/Resources/Locale/en-US/_RMC14/weapons/guns.ftl
+++ b/Resources/Locale/en-US/_RMC14/weapons/guns.ftl
@@ -42,6 +42,8 @@ rmc-examine-text-scatter-max = Current maximum scatter is [color={$colour}]{TOST
 rmc-examine-text-scatter-min = Current minimum scatter is [color={$colour}]{TOSTRING($scatter, "F1")}[/color] degrees.
 rmc-examine-text-shots-to-max-scatter = It takes [color={$colour}]{$shots}[/color] shots to reach maximum scatter.
 rmc-examine-text-iff = [color=cyan]This gun will ignore and shoot past friendlies![/color]
+rmc-examine-text-iff-prevent-friendly-fire = [color=cyan]This gun will not fire if friendlies are in the line of fire.[/color]
+rmc-iff-friendly-in-line = IFF lockout: friendly in line of fire.
 rmc-examine-text-id-lock-no-user = [color=chartreuse]It's unregistered. Pick it up to register yourself as its owner.[/color]
 rmc-examine-text-id-lock = [color=chartreuse]It is registered to [/color][color={$color}]{$name}[/color][color=chartreuse].[/color]
 rmc-examine-text-id-lock-unlocked = [color=chartreuse]It is registered to [/color][color={$color}]{$name}[/color][color=chartreuse], but has its fire restrictions unlocked.[/color]

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/rail_attachments.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/rail_attachments.yml
@@ -463,7 +463,6 @@
     preventFriendlyFire: true
   - type: AttachableWeaponRangedMods
     modifiers:
-    - damageAddMult: -0.2
     - conditions:
         wieldedOnly: true
         inactiveOnly: true

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/rail_attachments.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/rail_attachments.yml
@@ -458,8 +458,9 @@
       sprite: _RMC14/Objects/Weapons/Guns/Attachments/rail.rsi
       state: huntingscope
     actionName: Look through B8 Smart-Scope
-    actionDesc: Lets you see further and shoot through your fellow marines without harming them.
+    actionDesc: Lets you see further and prevents firing when friendlies are in your line of fire.
   - type: AttachableIFF
+    preventFriendlyFire: true
   - type: AttachableWeaponRangedMods
     modifiers:
     - damageAddMult: -0.2

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m54c_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m54c_rifle.yml
@@ -76,6 +76,7 @@
           - RMCAttachmentS6ReflexSight
           - RMCAttachmentS84xTelescopicScope
           - RMCAttachmentS42xTelescopicMiniscope
+          - RMCAttachmentB8SmartScope
       rmc-aslot-stock:
         startingAttachable: RMCAttachmentM54CStockCollapsible
         whitelist:
@@ -151,6 +152,7 @@
           - RMCAttachmentS6ReflexSight
           - RMCAttachmentS84xTelescopicScope
           - RMCAttachmentS42xTelescopicMiniscope
+          - RMCAttachmentB8SmartScope
       rmc-aslot-stock:
         whitelist:
           tags:
@@ -208,6 +210,7 @@
           - RMCAttachmentS6ReflexSight
           - RMCAttachmentS84xTelescopicScope
           - RMCAttachmentS42xTelescopicMiniscope
+          - RMCAttachmentB8SmartScope
       rmc-aslot-stock:
         startingAttachable: RMCAttachmentM54CStockCollapsible
         whitelist:
@@ -284,6 +287,7 @@
           - RMCAttachmentS6ReflexSight
           - RMCAttachmentS84xTelescopicScope
           - RMCAttachmentS42xTelescopicMiniscope
+          - RMCAttachmentB8SmartScope
       rmc-aslot-stock:
         startingAttachable: RMCAttachmentM54CStockCollapsibleWhite
         whitelist:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Smart Scope blocks fire on friendlies, instead of allowing you to just shoot over them.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
parity - idk if its wanted on the smart scope, but can probably be used in the future if you want a weapon to work like this as a balancing thing or for pve sgo
## Technical details
<!-- Summary of code changes for easier review. -->
Bassically draws a ray in the direction of fire using a deterministic random spread to prevent mispredicts, if friendlies are found within this ray it cancels the fire.

Added debug overlay to show bullet travel. The bullet still ignores friendlies, because I wouldn't know how to make this work with pvs, just prevents you firing when in pvs range. It didn't seem to have issues with mispredicting in my testing, but I'm also no expert with this stuff.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Vixting
- fix: The smart scope now blocks firing on friendlies instead of allowing you to just shoot over them.
- add: Smart scope can be attached to MK2.
- tweak: Removed damage decrease modifier from smart scope.
