### PR TITLE
Fix SSG magazine ammo type label

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/ssg45.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/ssg45.yml
@@ -169,7 +169,7 @@
 - type: entity
   parent: CMMagazineRifleBase
   id: RMCMagazineRifleSSG45
-  name: "SSG45 magazine (7x62mm)"
+  name: "SSG45 magazine (10x24mm)"
   components:
   - type: Tag
     tags:
@@ -196,7 +196,7 @@
 - type: entity
   parent: RMCMagazineRifleSSG45
   id: RMCMagazineRifleSSG45Extended
-  name: "SSG45 extended magazine (7x62mm)"
+  name: "SSG45 extended magazine (10x24mm)"
   components:
   - type: Tag
     tags:
@@ -224,7 +224,7 @@
 - type: entity
   parent: RMCMagazineRifleSSG45
   id: RMCMagazineRifleSSG45AP
-  name: "SSG45 AP magazine (7x62mm)"
+  name: "SSG45 AP magazine (10x24mm)"
   components:
   - type: Tag
     tags:
@@ -250,7 +250,7 @@
 - type: entity
   parent: RMCMagazineRifleSSG45
   id: RMCMagazineRifleSSG45HEAP
-  name: "SSG45 HEAP magazine (7x62mm)"
+  name: "SSG45 HEAP magazine (10x24mm)"
   components:
   - type: Tag
     tags:
@@ -284,7 +284,7 @@
 - type: entity
   parent: RMCMagazineRifleSSG45
   id: RMCMagazineRifleSSG45Incend
-  name: "SSG45 Incendiary magazine (7x62mm)"
+  name: "SSG45 Incendiary magazine (10x24mm)"
   components:
   - type: Tag
     tags:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Had the wrong ammo type labelled

:cl:
- fix: SSG-45 magazines are now correctly labelled as 10x24mm