### PR TITLE
Add M2C to xeno chatsan

### DIFF
--- a/Resources/Locale/en-US/_RMC14/cm-chatsan.ftl
+++ b/Resources/Locale/en-US/_RMC14/cm-chatsan.ftl
@@ -795,6 +795,9 @@ cm-chatsan-word-xover = xover
 cm-chatsan-word-xenoover = xenover
 cm-chatsan-word-replacement-xover = over
 
+cm-chatsan-word-m2c = m2c
+cm-chatsan-word-replacement-m2c = heavy spitter
+
 cm-chatsan-word-m13 = m13
 cm-chatsan-word-replacement-m13 = fast spitter
 

--- a/Resources/Locale/en-US/_RMC14/cm-chatsan.ftl
+++ b/Resources/Locale/en-US/_RMC14/cm-chatsan.ftl
@@ -796,7 +796,7 @@ cm-chatsan-word-xenoover = xenover
 cm-chatsan-word-replacement-xover = over
 
 cm-chatsan-word-m2c = m2c
-cm-chatsan-word-replacement-m2c = heavy spitter
+cm-chatsan-word-replacement-m2c = heavy mounted spitter
 
 cm-chatsan-word-m13 = m13
 cm-chatsan-word-replacement-m13 = fast spitter

--- a/Resources/Prototypes/_RMC14/Accents/cm_word_replacements.yml
+++ b/Resources/Prototypes/_RMC14/Accents/cm_word_replacements.yml
@@ -29,7 +29,7 @@
     cm-chatsan-word-eorg-marine: cm-chatsan-replacement-eorg-marine
     cm-chatsan-word-xx121-marine: cm-chatsan-replacement-xx121-marine
     cm-chatsan-word-xx-121-marine: cm-chatsan-replacement-xx-121-marine
-    
+
     cm-chatsan-word-slopcade: cm-chatsan-replacement-slopcade
     cm-chatsan-word-surv: cm-chatsan-word-survivor
     cm-chatsan-word-survs: cm-chatsan-word-survivors
@@ -297,6 +297,7 @@
     cm-chatsan-word-batonged: cm-chatsan-word-replacement-batonged
     cm-chatsan-word-xover: cm-chatsan-word-replacement-xover
     cm-chatsan-word-xenover: cm-chatsan-word-replacement-xover
+    cm-chatsan-word-m2c: cm-chatsan-word-replacement-m2c
     cm-chatsan-word-m13: cm-chatsan-word-replacement-m13
     cm-chatsan-word-m63: cm-chatsan-word-replacement-m63
     cm-chatsan-word-p90: cm-chatsan-word-replacement-p90


### PR DESCRIPTION
## About the PR
Adds "M2C" to xeno chatsan, replaces it with "heavy spitter"

## Why / Balance
I've seen most xeno players call it this already, so it should help standardize things for newer/non-marine players for xenos who don't.

Also it's LRP to call it by the real name as a xeno so, mechanical enforcement

## Technical details
yaml + locale

## Media

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Added chatsan for the word "M2C" for xenonids.
