### PR TITLE
Fix: Attachment action icons resetting after dropping and picking up items

### DIFF
--- a/Content.Shared/_RMC14/Attachable/Systems/AttachableToggleableSystem.cs
+++ b/Content.Shared/_RMC14/Attachable/Systems/AttachableToggleableSystem.cs
@@ -761,6 +761,8 @@ public sealed class AttachableToggleableSystem : EntitySystem
 
         _actionsSystem.GrantContainedAction(user, ent.Owner, actionId);
 
+        _actionsSystem.SetToggled(actionId, ent.Comp.Active);
+
         if (exists)
             return;
 


### PR DESCRIPTION
## About the PR
Fixes: #9286 

## Technical details
Added a call to set the action's toggled state to match the attachment's active state.

## Media
[flamer.webm](https://github.com/user-attachments/assets/73d196e3-d97f-4251-a075-2513e81c14e3)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed UBE action icon appearing inactive after dropping and picking up the flamer despite remaining active.