### PR TITLE
Fix: Stethoscope Grammar 

### DIFF
--- a/Resources/Locale/en-US/_RMC14/medical/rmc-stethoscope.ftl
+++ b/Resources/Locale/en-US/_RMC14/medical/rmc-stethoscope.ftl
@@ -1,12 +1,12 @@
-rmc-stethoscope-heart-healthy = You hear [color=green]normal heart beating patterns[/color], {POSS-PRONOUN($target)} heart is surely [color=green]healthy[/color].
-rmc-stethoscope-heart-littlebruised = You hear [color=yellow]small murmurs with each heart beat[/color], it is possible that {POSS-PRONOUN($target)} heart is [color=yellow]subtly damaged[/color].
+rmc-stethoscope-heart-healthy = You hear [color=green]normal heart beating patterns[/color], {POSS-ADJ($target)} heart is surely [color=green]healthy[/color].
+rmc-stethoscope-heart-littlebruised = You hear [color=yellow]small murmurs with each heart beat[/color], it is possible that {POSS-ADJ($target)} heart is [color=yellow]subtly damaged[/color].
 rmc-stethoscope-heart-bruised = You hear [color=orange]deviant heart beating patterns[/color], result of probable [color=orange]heart damage[/color].
-rmc-stethoscope-heart-broken = You hear [color=red]irregular and additional heart beating patterns[/color], probably caused by impaired blood pumping, {POSS-PRONOUN($target)} heart is certainly [color=red]failing[/color].
+rmc-stethoscope-heart-broken = You hear [color=red]irregular and additional heart beating patterns[/color], probably caused by impaired blood pumping, {POSS-ADJ($target)} heart is certainly [color=red]failing[/color].
 
-rmc-stethoscope-lungs-healthy = You also hear [color=green]normal respiration sounds[/color] as well, {POSS-PRONOUN($target)} lungs are [color=green]healthy[/color], probably.
+rmc-stethoscope-lungs-healthy = You also hear [color=green]normal respiration sounds[/color] as well, {POSS-ADJ($target)} lungs are [color=green]healthy[/color], probably.
 rmc-stethoscope-lungs-littlebruised = You also hear [color=yellow]some crackles when {SUBJECT($target)} breath[/color], {SUBJECT($target)} are possibly suffering from [color=yellow]a small damage to the lungs[/color].
 rmc-stethoscope-lungs-bruised = You also hear [color=orange]unusual respiration sounds[/color] and noticeable difficulty to breath, possibly signalling [color=orange]ruptured lungs[/color].
-rmc-stethoscope-lungs-broken = You also [color=red]barely hear any respiration sounds[/color] and a lot of difficulty to breath, {POSS-PRONOUN($target)} lungs are [color=red]heavily failing[/color].
+rmc-stethoscope-lungs-broken = You also [color=red]barely hear any respiration sounds[/color] and a lot of difficulty to breath, {POSS-ADJ($target)} lungs are [color=red]heavily failing[/color].
 
 rmc-stethoscope-unskilled = You hear a lot of sounds... it's quite hard to distinguish, really.
 rmc-stethoscope-eyes-mouth = You can't hear anything. Maybe that isn't the smartest idea.
@@ -18,7 +18,7 @@ rmc-stethoscope-verb-text = Stethoscope
 rmc-stethoscope-verb-message = Listen using the stethoscope.
 
 # Temporary until real organs are implemented. Delete when fully implemented.
-rmc-stethoscope-normal = You hear [color=green]normal heart beating patterns[/color] and [color=green]normal respiration sounds[/color] as well, {POSS-PRONOUN($target)} heart and lungs are [color=green]healthy[/color], probably.
+rmc-stethoscope-normal = You hear [color=green]normal heart beating patterns[/color] and [color=green]normal respiration sounds[/color] as well, {POSS-ADJ($target)} heart and lungs are [color=green]healthy[/color], probably.
 rmc-stethoscope-raggedy = You hear [color=yellow]small murmurs with each heart beat[/color] and [color=yellow]some crackles when {SUBJECT($target)} breath[/color].
 rmc-stethoscope-hyper = You hear [color=orange]deviant heart beating patterns[/color] and [color=orange]unusual respiration sounds[/color].
 rmc-stethoscope-irregular = You hear [color=red]irregular and additional heart beating patterns[/color] and [color=red]barely hear any respiration sounds[/color], {SUBJECT($target)} is having a lot of difficulty breathing.


### PR DESCRIPTION
## About the PR
Fixed stethoscope using incorrect grammar. e.g., "hers heart" → "her heart".

## Technical details
localization

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
- fix: Corrected stethoscope using incorrect grammar for female characters.