### PR TITLE
Fix buckling and climbing being blocked by barbed barricades not actually in the way

### DIFF
--- a/Content.Shared/Climbing/Events/AttemptClimbEvent.cs
+++ b/Content.Shared/Climbing/Events/AttemptClimbEvent.cs
@@ -4,4 +4,5 @@ namespace Content.Shared.Climbing.Events;
 public record struct AttemptClimbEvent(EntityUid User, EntityUid Climber, EntityUid Climbable)
 {
     public bool Cancelled;
+    public bool PopupHandled;
 }

--- a/Content.Shared/_RMC14/Barricade/SharedBarbedSystem.cs
+++ b/Content.Shared/_RMC14/Barricade/SharedBarbedSystem.cs
@@ -192,6 +192,7 @@ public abstract class SharedBarbedSystem : EntitySystem
         if (barbed.Comp.IsBarbed)
         {
             args.Cancelled = true;
+            args.PopupHandled = true;
             _popupSystem.PopupClient(Loc.GetString("barbed-wire-cant-climb"), barbed.Owner, args.User);
         }
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

- Barbed barricades now only block buckle and climbing attempts when in between the user and the target.
- You're now able to mount an ML66D that's deployed on the same tile as a barbed barricade. 
- You no longer get two different popups at the same time when climbing or buckling fails because of something being in the way. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Resolves #8117 
Resolves #9255 

## Technical details
<!-- Summary of code changes for easier review. -->
The check now uses a CollisionRay instead of an EdgeShape.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix: Barbed barricades now only block climbing over or buckling to objects when in between the user and the object.