### PR TITLE
Shivas commando helmet fixes and M5X whiteout helmet fixes

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Head/pmc.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Head/pmc.yml
@@ -101,14 +101,35 @@
       - state: equipped-HELMET
 
 - type: entity
-  parent: ArmorHelmetM10
-  id: ArmorHelmetPMCCommandoSurvivor
+  parent: RMCArmorHelmetPMCTactical
+  id: RMCArmorHelmetPMCCommando
+  name: We-Ya commando helmet
+  description: A standard enclosed helmet utilized by Weston-Yamada Commandos.
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Clothing/Head/PMC/commando.rsi
+  - type: Clothing
+    sprite: _RMC14/Objects/Clothing/Head/PMC/commando.rsi
+  - type: CMArmor
+    bullet: 40
+    explosionArmor: 40
+    melee: 30
+    bio: 30
+    # armor_internaldamage = 40
+  - type: RMCEarProtection
+  - type: ParasiteResistance
+    maxCount: 6
+  - type: PointLight
+    color: "#e7e2e3"
+
+- type: entity
+  parent: RMCArmorHelmetPMCCommando
+  id: RMCArmorHelmetPMCCommandoDamaged
   name: damaged We-Ya Commando helmet
   description: A standard enclosed helmet utilized by Weston-Yamada Commandos. Has been through a lot of wear and tear.
+  suffix: Damaged
   components:
-  - type: ItemCamouflage
-    camouflageVariations: { }
-  - type: Sprite # TODO: Sprites
+  - type: Sprite
     sprite: _RMC14/Objects/Clothing/Head/PMC/commando.rsi
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/Head/PMC/commando.rsi
@@ -116,16 +137,16 @@
     melee: 20
     bio: 20
     # armor_internaldamage = 20
-  - type: Corrodible
-    isCorrodible: false
+  - type: ParasiteResistance
+    maxCount: 0
 
 - type: entity
   parent: RMCArmorHelmetPMCTactical
-  id: ArmorHelmetPMCCommando
+  id: RMCArmorHelmetPMCDeathsquad
   name: PMC M5X helmet
   description: A fully enclosed, armored helmet made to complete the M5X exoskeleton armor.
   components:
-  - type: Sprite
+  - type: Sprite # TODO: Sprites
     sprite: _RMC14/Objects/Clothing/Head/PMC/commando.rsi
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/Head/PMC/commando.rsi
@@ -146,12 +167,12 @@
     color: "#e41c1f"
 
 - type: entity
-  parent: ArmorHelmetPMCCommando
-  id: RMCArmorHelmetPMCCommandoAlt
+  parent: RMCArmorHelmetPMCDeathsquad
+  id: RMCArmorHelmetPMCDeathsquadAlt
   suffix: Alt
   description: A fully enclosed, armored helmet made to complete the M5X exoskeleton armor. This one has had a skull scratched into the visor.
   components:
-  - type: Sprite
+  - type: Sprite # TODO: Sprites
     sprite: _RMC14/Objects/Clothing/Head/PMC/commando_alt.rsi
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/Head/PMC/commando_alt.rsi

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/WeYa/whiteout.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/WeYa/whiteout.yml
@@ -113,7 +113,7 @@
     jumpsuit: RMCJumpsuitVeteranPMCCommando
     outerClothing: CMArmorM4PMCCommando
     gloves: RMCHandsVeteranPMCCommando
-    head: ArmorHelmetPMCCommando
+    head: RMCArmorHelmetPMCDeathsquad
     shoes: RMCBootsPMCCommandoFilled
     mask: RMCMaskCoifPMC
     ears: RMCHeadsetDistressPMC

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/WeYa/whiteout_gunner.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/WeYa/whiteout_gunner.yml
@@ -28,7 +28,7 @@
     jumpsuit: RMCJumpsuitVeteranPMCCommando
     outerClothing: CMArmorM4PMCSmartGunHarnessCommando
     gloves: RMCHandsVeteranPMCCommando
-    head: ArmorHelmetPMCCommando
+    head: RMCArmorHelmetPMCDeathsquad
     shoes: RMCBootsPMCCommandoFilled
     mask: RMCMaskCoifPMC
     ears: RMCHeadsetDistressPMC

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Shivas/Panic_Room/shivas_panic_room_weya_commando.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Shivas/Panic_Room/shivas_panic_room_weya_commando.yml
@@ -45,7 +45,7 @@
   equipment:
     jumpsuit: RMCJumpsuitVeteranPMCCommandoSurvivor
     shoes: RMCBootsPMCCommandoFilled
-    head: ArmorHelmetPMCCommandoSurvivor
+    head: RMCArmorHelmetPMCCommandoDamaged
     ears: RMCHeadsetHvHWeYaPMCCommando
     belt: RMCBeltPMCFilledCommando
     id: CMIDCardCommando


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds the weya commando helmet and damaged one with the correct stats from CM13
This is seperate from the M5X, which mirrors the M5X apesuit in CM13
M5X is used by whiteout

Marked the M5X sprites as todo. Crow said to use the current commando sprites as the WeYa commando sprites until he resprites the whiteout/deathsquad gear.

Also fixed the damaged commando helmet being uncorrdible. It's acidifable in CM13

## Technical details
Renames ``ArmorHelmetPMCCommandoSurvivor`` to ``RMCArmorHelmetPMCCommandoDamaged``
Renames ``ArmorHelmetPMCCommando`` to ``RMCArmorHelmetPMCDeathsquad``
Renames ``RMCArmorHelmetPMCCommandoAlt`` to ``RMCArmorHelmetPMCDeathsquadAlt``

**Changelog**
Update not out yet
