### PR TITLE
Mess techs are now mutiny eligible

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/mess_tech.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/mess_tech.yml
@@ -44,6 +44,7 @@
       icon:
         sprite: /Textures/_RMC14/Interface/map_blips.rsi
         state: mst
+    - type: MutinyEligible
 
 - type: startingGear
   id: CMGearMessTech


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Oversight

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed Mess Techs not being mutiny eligible