### PR TITLE
Watch Xenonid menu searches smarter by ignoring dashes and digits in names

### DIFF
--- a/Content.Client/_RMC14/Xenonids/Watch/XenoWatchBui.cs
+++ b/Content.Client/_RMC14/Xenonids/Watch/XenoWatchBui.cs
@@ -1,4 +1,5 @@
-﻿using Content.Client._RMC14.Xenonids.UI;
+﻿using System.Text.RegularExpressions;
+using Content.Client._RMC14.Xenonids.UI;
 using Content.Shared._RMC14.Xenonids.Watch;
 using JetBrains.Annotations;
 using Robust.Client.GameObjects;
@@ -66,6 +67,33 @@ public sealed class XenoWatchBui : BoundUserInterface
         return _window;
     }
 
+    private static readonly Regex DashesAndDigitsPattern = new Regex("[-\\d]+");
+
+    /// <summary>
+    /// <c>RemoveDashesAndDigits</c> returns a copy of the input string with all hyphen <c>-</c> and digit <c>0-9</c>
+    /// characters removed. This allows for a smarter search in the Watch search menus.
+    /// <param name="name">The name of a humanoid or xenonid character</param>
+    /// <example>
+    /// <c>"KE-112-E"</c> returns <c>"KEE"</c>,
+    /// <c>"XX-42"</c> returns <c>"XX"</c>,
+    /// <c>"HEK"</c> returns <c>"HEK"</c>,
+    /// <c>"HEK-891"</c> returns <c>"HEK"</c>,
+    /// <c>"RO-123-CK"</c> returns <c>"ROCK"</c>,
+    /// <c>"Shakes-The-Friendlies"</c> returns <c>"ShakesTheFriendlies"</c>,
+    /// <c>"Zachary Randolf"</c> returns <c>"Zachary Randolf"</c>.
+    /// </example>
+    /// </summary>
+    public static string RemoveDashesAndDigits(string name)
+    {
+        return DashesAndDigitsPattern.Replace(name, "");
+    }
+
+    private bool ShowSearchResult(string search, string result)
+    {
+        return result.Contains(search, StringComparison.OrdinalIgnoreCase)
+               || RemoveDashesAndDigits(result).Contains(search, StringComparison.OrdinalIgnoreCase);
+    }
+
     private void OnSearchBarChanged(LineEditEventArgs args)
     {
         if (_window is not { Disposed: false })
@@ -79,7 +107,7 @@ public sealed class XenoWatchBui : BoundUserInterface
             if (string.IsNullOrWhiteSpace(args.Text))
                 control.Visible = true;
             else
-                control.Visible = control.NameLabel.GetMessage()?.Contains(args.Text, StringComparison.OrdinalIgnoreCase) ?? false;
+                control.Visible = ShowSearchResult(args.Text, control.NameLabel.GetMessage() ?? "");
         }
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I tweaked the Xeno Watch BUI methods to allow xenos to search for names that include postfixes without typing the numbers in the middle. If you type the numbers eg. by searching "RO-1", then the menu will continue to show "RO-123-CK" but NOT "RO-234-CK", but if you search "ROCK" then both xenos will appear, which is new.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Makes it easier for xenos to spectate others with a postfix, shouldn't be significant enough to involve balancing.
## Technical details
<!-- Summary of code changes for easier review. -->
All modifications are in the XenoWatchBui.cs file.
Firstly, added a static Regex constant for identifying dashes and digits in a string
Secondly, added two methods for using the Regex, and determining whether a search result should appear in the search window.
Lastly, reconfigured the existing OnSearchBarChanged method to use the new method which allows for a smarter search.

Note:
1. Code summary comments for the RemoveDashesAndDigits method includes examples of how it behaves eg. "RO-123-CK" -> "ROCK"
2. These methods COULD be applied to the Ghost Warp menu to allow for searching hypenated names without typing the hyphens into the search bar, but I'm not experienced enough to touch non-RMC folder files yet.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
<img width="350" height="396" alt="image" src="https://github.com/user-attachments/assets/69ecf064-bb1a-4e24-a762-51aa75334c6e" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: keegaroo65
- tweak: Changed Xeno Watch UI to ignore dashes and digits when searching, for convenience with postfixes.