### PR TITLE
(PVE)RCM TCO Time Requirment

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/RCM/troop_commander.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/RCM/troop_commander.yml
@@ -4,6 +4,10 @@
   name: rmc-job-name-rcm-pve-troop-commander
   description: rmc-ghost-role-information-rcm-description
   playTimeTracker: RMCJobRoyalTroopCommanderPVE
+  requirements:
+    - !type:RoleTimeRequirement
+      role: CMJobExecutiveOfficer
+      time: 10800 # 3 hours
   ranks:
     RMCRankTSESecondLieutenant: [ ]
   startingGear: RMCGearRoyalTroopCommanderPVE


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The RCM Troop Commander has no XO time requirement unlike ever other version of this role, for such a important role it should require that person knows how to do it.

## Technical details
<!-- Summary of code changes for easier review. -->
Added the 3h time requirement for XO like all the other PlatCo roles

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: [PVE] RCM TCO now has proper time requirment.
