### PR TITLE
Tacmap stays open with evolve and devolve

### DIFF
--- a/Content.Shared/_RMC14/TacticalMap/ReopenTacticalMapComponent.cs
+++ b/Content.Shared/_RMC14/TacticalMap/ReopenTacticalMapComponent.cs
@@ -1,0 +1,11 @@
+﻿using Robust.Shared.GameStates;
+using Robust.Shared.Utility;
+
+namespace Content.Shared._RMC14.TacticalMap;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(SharedTacticalMapSystem))]
+public sealed partial class ReopenTacticalMapComponent : Component
+{
+
+}

--- a/Content.Shared/_RMC14/TacticalMap/SharedTacticalMapSystem.cs
+++ b/Content.Shared/_RMC14/TacticalMap/SharedTacticalMapSystem.cs
@@ -9,7 +9,6 @@ namespace Content.Shared._RMC14.TacticalMap;
 public abstract class SharedTacticalMapSystem : EntitySystem
 {
     [Dependency] private readonly IConfigurationManager _config = default!;
-    [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
 
     public int LineLimit { get; private set; }

--- a/Content.Shared/_RMC14/TacticalMap/SharedTacticalMapSystem.cs
+++ b/Content.Shared/_RMC14/TacticalMap/SharedTacticalMapSystem.cs
@@ -129,12 +129,7 @@ public abstract class SharedTacticalMapSystem : EntitySystem
     {
         if (_ui.IsUiOpen(oldXeno.Owner, TacticalMapUserUi.Key, oldXeno))
         {
-            Log.Debug("when evolving, tacmap open: TRUE");
             EnsureComp<ReopenTacticalMapComponent>(newXeno);
-        }
-        else
-        {
-            Log.Debug("when evolving, tacmap open: FALSE");
         }
     }
 
@@ -152,14 +147,10 @@ public abstract class SharedTacticalMapSystem : EntitySystem
     // whether to reopen the Tacmap
     private void RestoreTacmapOpen(Entity<TacticalMapUserComponent> newXeno)
     {
-        Log.Debug("beginning restore process for tacmap");
-
         if (!TryComp<ReopenTacticalMapComponent>(newXeno.Owner, out _))
         {
             return;
         }
-
-        Log.Debug("trying to restore tacmap when it is open: " + _ui.IsUiOpen(newXeno.Owner, TacticalMapUserUi.Key));
 
         _ui.TryOpenUi(newXeno.Owner, TacticalMapUserUi.Key, newXeno);
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
When a xeno evolves or devolves, their Tactical Map will now stay open if it was when they started evolving or devolving
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I don't believe this affects balancing. It's a little annoying for me as a xeno when I evolve/devolve and have to reopen the tacmap. This doesn't yet automatically pop out the tacmap, but it at least saves a click there.
## Technical details
<!-- Summary of code changes for easier review. -->
1. New listeners for the before and after events of evolution and devolution in the `SharedTacticalMapSystem`
2. When evolution or devolution begins, a new `ReopenTacticalMap` component, with no values, is added to the new xeno entity
3. When the do/doafter event following evolution or devolution fires, the tactical map is reopened IF there is a `ReopenTacticalMap` component, then it is removed.

Note: I'm wary of how the server/client interactions here may behave, or whether this should be done without having to add an empty component, but it's inspired by similar things like the `XenoRecentlyDevolvedComponent` (although that one holds values like caste and timespan)
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
Demonstration: https://gyazo.com/739999db5bfbecd03c9e8ef66096889b
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: keegaroo65
- fix: Fixed the Tactical Map disappearing when you evolve or devolve (doesn't pop out automatically)