### PR TITLE
Make the lobby timer 500 seconds (#7787)

### DIFF
--- a/Content.Shared/CCVar/CCVars.Game.cs
+++ b/Content.Shared/CCVar/CCVars.Game.cs
@@ -21,7 +21,7 @@ public sealed partial class CCVars
     ///     Controls the duration of the lobby timer in seconds. Defaults to 2 minutes and 30 seconds.
     /// </summary>
     public static readonly CVarDef<int>
-        GameLobbyDuration = CVarDef.Create("game.lobbyduration", 150, CVar.ARCHIVE);
+        GameLobbyDuration = CVarDef.Create("game.lobbyduration", 500, CVar.ARCHIVE);
 
     /// <summary>
     ///     Controls if players can latejoin at all.


### PR DESCRIPTION
## About the PR
Increases the lobby timer from 150 seconds (2:30) to 500 seconds (8 minutes 20 seconds) for parity with the original game and to allow players to take a moment between rounds to get a snack or use the bathroom.

## Why / Balance
This change brings the lobby timer in line with the original RMC behavior. The current 150 seconds (2:30) feels rushed between rounds, especially for players who want to take a short break. 500 seconds (8 minutes 20 seconds) provides a comfortable window without being excessively long.

Closes #7787

## Technical Details
Changed `GameLobbyDuration` value in `Content.Shared/CCVar/CCVars.cs` from 150 to 500 seconds.

## Media
N/A - Simple configuration change, no visual changes needed.

## Changelog
:cl:
- tweak: Increased lobby timer to 500 seconds for RMC parity.