### PR TITLE
Make the lobby timer 500 seconds (#7787)

### DIFF
--- a/Resources/ConfigPresets/Build/development.toml
+++ b/Resources/ConfigPresets/Build/development.toml
@@ -1,6 +1,7 @@
 ﻿[game]
 # Straight in-game baby
-lobbyenabled = false
+lobbyenabled = true
+lobbyduration = 500
 # Dev map for faster loading & convenience
 map = "RMCDev"
 role_timers = false

--- a/Resources/ConfigPresets/RMC14/rmc.toml
+++ b/Resources/ConfigPresets/RMC14/rmc.toml
@@ -37,7 +37,7 @@ soft_max_players = 350
 panic_bunker.enabled = false
 round_end_pvs_overrides = false
 round_restart_time = 180
-lobbyduration = 180
+lobbyduration = 500
 
 [gateway]
 generator_enabled = false


### PR DESCRIPTION
## About the PR
Increases the lobby timer from 150 seconds (2:30) to 500 seconds (8 minutes 20 seconds) for parity with the original game and to allow players to take a moment between rounds to get a snack or use the bathroom.

## Why / Balance
 150 seconds (2:30) is too short between rounds — players barely have time to grab a drink or use the bathroom. 500 seconds gives everyone a proper break without making the wait too long.

Closes #7787

## Technical Details
- Changed `GameLobbyDuration` in `Content.Shared/CCVar/CCVars.Game.cs` from 150 to 500
- Enabled lobby and set duration in `Resources/ConfigPresets/Build/development.toml`
- Set `lobbyenabled = true` and `lobbyduration = 500` in dev config

## Media
<img width="2560" height="1392" alt="lobby" src="https://github.com/user-attachments/assets/750d94b5-6400-410d-af65-61d2861c4b86" />


## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.io/en/getting-started/pr-guideline).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

## Changelog
:cl:
- tweak: Increased lobby timer to 500 seconds for RMC 