### PR TITLE
Queen tracker fix

### DIFF
--- a/Content.Shared/_RMC14/Tracker/Xeno/HiveTrackerSystem.cs
+++ b/Content.Shared/_RMC14/Tracker/Xeno/HiveTrackerSystem.cs
@@ -272,6 +272,7 @@ public sealed class HiveTrackerSystem : EntitySystem
             if (TryComp(uid, out HiveMemberComponent? member) && trackerMode?.Component != null)
             {
                 var trackableQuery = EntityQueryEnumerator<RMCTrackableComponent, HiveMemberComponent>();
+                var trackingComponent = _factory.GetComponent(trackerMode.Component).GetType();
                 while (trackableQuery.MoveNext(out var trackableUid, out _, out var targetMember))
                 {
                     if (member.Hive != targetMember.Hive)
@@ -280,7 +281,6 @@ public sealed class HiveTrackerSystem : EntitySystem
                     // Only automatically track the first found target if looking for a queen
                     if (trackerMode.Component == QueenTrackerComponent)
                     {
-                        var trackingComponent = _factory.GetComponent(trackerMode.Component).GetType();
                         if (EntityManager.TryGetComponent(trackableUid, trackingComponent, out _))
                         {
                             SetTarget((uid, tracker), trackableUid);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Fixed the tracker not automatically tracking the queen.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Resolves #7228


## Technical details
<!-- Summary of code changes for easier review. -->
The loop to find a new target did not account for anything else than the queen being trackable, so it would exit on the first target found, which would often be a round start tunnel, then not set a target because the found entity did  not have the component the queen tracker mode was looking for.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix: The hive tracker now tracks the queen by default.