### PR TITLE
Remove scream from hot bar (#7665)

### DIFF
--- a/Content.Server/Speech/EntitySystems/VocalSystem.cs
+++ b/Content.Server/Speech/EntitySystems/VocalSystem.cs
@@ -31,13 +31,6 @@ public sealed class VocalSystem : EntitySystem
         SubscribeLocalEvent<VocalComponent, ScreamActionEvent>(OnScreamAction);
     }
 
-    private void OnMapInit(EntityUid uid, VocalComponent component, MapInitEvent args)
-    {
-        // try to add scream action when vocal comp added
-        _actions.AddAction(uid, ref component.ScreamActionEntity, component.ScreamAction);
-        LoadSounds(uid, component);
-    }
-
     private void OnShutdown(EntityUid uid, VocalComponent component, ComponentShutdown args)
     {
         // remove scream action when component removed
@@ -46,6 +39,7 @@ public sealed class VocalSystem : EntitySystem
             _actions.RemoveAction(uid, component.ScreamActionEntity);
         }
     }
+
 
     private void OnSexChanged(EntityUid uid, VocalComponent component, SexChangedEvent args)
     {
@@ -71,6 +65,11 @@ public sealed class VocalSystem : EntitySystem
         args.Handled = _chat.TryPlayEmoteSound(uid, _proto.Index(sounds), args.Emote);
     }
 
+    private void OnMapInit(EntityUid uid, VocalComponent component, MapInitEvent args)
+    {
+        
+        LoadSounds(uid, component);
+    }
     private void OnScreamAction(EntityUid uid, VocalComponent component, ScreamActionEvent args)
     {
         if (args.Handled)


### PR DESCRIPTION
## About the PR
removes the scream button from the hotbar. Scream is now only accessible through the emote wheel.


## Why / Balance
"It's ungodly LRP with the way it's used, that being as a reaction to anything, even slight happening on cooldown. We have scream in the emote wheel, and that's where you should have to go for scream as well. It will encourage using other emotes besides scream and it may cause marines to RP more. Emotes are bindable."
Closes #7665
## Technical details

- Removed the automatic addition of scream action in `VocalSystem.OnMapInit`
- Players can still bind scream to any key via client settings
- Scream remains fully functional through the emote wheel
- More complex solutions (like multi-purpose emote button) can be considered separately if desired
## Media


https://github.com/user-attachments/assets/f139676d-38fc-4855-b3b7-9fad2f0c54f6



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- remove: Removed scream button from hotbar. Scream is now only available through the emote wheel.
