### PR TITLE
Fix fire sometimes passing through walls and doors

### DIFF
--- a/Content.Shared/_RMC14/Line/LineSystem.cs
+++ b/Content.Shared/_RMC14/Line/LineSystem.cs
@@ -1,15 +1,18 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Numerics;
 using Content.Shared._RMC14.Barricade;
 using Content.Shared._RMC14.Entrenching;
-using Content.Shared._RMC14.Map;
 using Content.Shared.Beam.Components;
 using Content.Shared.Coordinates.Helpers;
 using Content.Shared.Doors.Components;
+using Content.Shared.Physics;
 using Content.Shared.Tag;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Network;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Systems;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
@@ -19,6 +22,7 @@ public sealed class LineSystem : EntitySystem
 {
     [Dependency] private readonly IMapManager _mapManager = default!;
     [Dependency] private readonly SharedMapSystem _mapSystem = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly TagSystem _tag = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
@@ -142,6 +146,26 @@ public sealed class LineSystem : EntitySystem
         if (grid == null)
             return false;
 
+        // Check if the next tile is blocked by more than one wall/structure to prevent the line from passing through diagonally.
+        var direction = coords.Position - previousCoords.Position;
+        var ray = new CollisionRay(previousCoords.Position, direction.Normalized(), (int)CollisionGroup.FullTileMask);
+        var intersect = _physics.IntersectRayWithPredicate(Transform(previousCoords.EntityId).MapID, ray, direction.Length(), e => !Transform(e).Anchored, false);
+        var results = intersect.Select(r => r.HitEntity).ToHashSet();
+        var blockCount = 0;
+        foreach (var entity in results)
+        {
+            if (!_tag.HasAnyTag(entity, StructureTag, WallTag))
+                continue;
+
+            blockCount++;
+
+            if (blockCount < 2)
+                continue;
+
+            blocker = entity;
+            return true;
+        }
+
         var indices = _mapSystem.TileIndicesFor(grid.Value, grid, coords);
         var anchored = _mapSystem.GetAnchoredEntitiesEnumerator(grid.Value, grid, indices);
         while (anchored.MoveNext(out var uid))
@@ -165,7 +189,7 @@ public sealed class LineSystem : EntitySystem
             }
             else if (_doorQuery.TryComp(uid, out var door))
             {
-                if (door.State != DoorState.Closed)
+                if (door.State != DoorState.Closed && door.State != DoorState.Denying && door.State != DoorState.Welded)
                     continue;
 
                 blocker = uid.Value;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

- Fire can no longer continue through walls when shot diagonally. It will still light the diagonal tile past the two walls on fire, but this is parity.
- Fire no longer goes through doors when you shoot while bumping into a door you aren't able to open.
- Fire no longer goes through welded doors.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Resolves #8951 

## Technical details
<!-- Summary of code changes for easier review. -->
The `LineSystem` now uses a CollisionRay to block a line if there are 2 or more walls/structures between the current tile and the next tile in the line.

Doors only blocked fire while in a "Closed" state, now they also block while in a "Denying" or "Welded" state.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix: Fire will no longer clip through walls when shot at diagonal angles.
- fix: Doors now always block fire while closed.
