### PR TITLE
spotter pamphlet fix

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Misc/pamphlets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Misc/pamphlets.yml
@@ -91,6 +91,7 @@
     - type: SpotterWhitelist
     addSkills:
       RMCSkillJtac: 1
+    bypassLimit: true
     giveJobTitle: rmc-job-name-spotter
     givePrefix: rmc-job-prefix-spotter
     isAppendPrefix: false


### PR DESCRIPTION
## About the PR
let spotter pamphlet bypass the pamphlet limit, currently anyone that has already used a skill pamphlet cannot become a spotter which isn't correct

## Why / Balance
parity
<img width="427" height="144" alt="image" src="https://github.com/user-attachments/assets/1d709b61-477d-43f6-94ec-5530304b9a2f" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl: CatAndHats
- fix: You can now use the spotter instructional pamphlet even if you have already used a skill pamphlet