### PR TITLE
Add Camo Beret to Loadouts

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Loadouts/Items/headwear.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Loadouts/Items/headwear.yml
@@ -18,6 +18,12 @@
     head: CMHeadBeretTan
 
 - type: loadout
+  id: CamoBeretRMC
+  cost: 2
+  equipment:
+    head: RMCHeadBeret
+
+- type: loadout
   id: BoonieRMC
   cost: 2
   equipment:

--- a/Resources/Prototypes/_RMC14/Roles/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Loadouts/loadout_groups.yml
@@ -155,7 +155,7 @@
   - NeckerchiefGrayRMC
   - NeckerchiefTanRMC
   - NeckerchiefWhiteRMC
-  
+
 - type: loadoutGroup
   id: MasksRMCPVE
   name: rmc-loadout-group-masks
@@ -187,6 +187,7 @@
   - SquadBeretRMC
   - GreenBeretRMC
   - TanBeretRMC
+  - CamoBeretRMC
   - BoonieRMC
   - BoonieTanRMC
   - CapRMC
@@ -679,6 +680,7 @@
   - SquadBeretRMC
   - GreenBeretRMC
   - TanBeretRMC
+  - CamoBeretRMC
   - BoonieRMC
   - BoonieTanRMC
   - CapRMC


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds the standard RMC beret to loadouts for 2 points.

## Why / Balance
Berets are fun, respecting planet camo is always nice.

## Media
<img width="784" height="771" alt="image" src="https://github.com/user-attachments/assets/aedbd2c4-30c0-4e8d-969e-e38aaa2b8627" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Marines can now take a camo beret in their loadout.