### PR TITLE
Fix rocket launcher melee damage

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m5_atl_rocket_launcher.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m5_atl_rocket_launcher.yml
@@ -54,6 +54,10 @@
   - type: WieldDelay
     baseDelay: 1.2
     preventFiring: true
+  - type: MeleeWeapon
+    damage:
+      types:
+        Blunt: 15
   - type: IgnorePredictionHide
   - type: GunIgnorePrediction
   - type: AssistedReloadWeapon


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
From CM13
They have a force of 15 in CM13, the base rocket launcher

:cl:
- fix: Fixed rocket launchers having incorrect melee damage. They now deal 15 damage, from 5.