### PR TITLE
fix: lifeboat and liaison pod console access

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/rmc_communications_console.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/rmc_communications_console.yml
@@ -296,6 +296,7 @@
   components:
   - type: EvacuationComputer
     earlyCrashChance: 0
+  - type: ActivatableUIRequiresAccess
   - type: AccessReader
     access: [ [ "RMCAccessWeYa" ] ]
 
@@ -316,6 +317,7 @@
       enum.LifeboatComputerUi.Key:
         type: LifeboatComputerBui
   - type: LifeboatComputer
+  - type: ActivatableUIRequiresAccess
   - type: AccessReader
     access: [ [ "CMAccessDropship" ], [ "RMCAccessSeniorCommand" ] ]
   - type: ActivatableUIBlacklist


### PR DESCRIPTION
## About the PR

The consoles did not check for access.

## Why / Balance

fixes #9333

## Technical details

they where missing the `ActivatableUIRequiresAccessComponent`

## Media


https://github.com/user-attachments/assets/03b2c882-f124-48b3-963e-d0a5b9a3662b



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- fix: The consoles inside of lifeboats and the liaisons pod now check for access.
