### PR TITLE
Adjust Blood Pack and IV Drip rates

### DIFF
--- a/Content.Shared/_RMC14/Medical/IV/BloodPackComponent.cs
+++ b/Content.Shared/_RMC14/Medical/IV/BloodPackComponent.cs
@@ -28,10 +28,10 @@ public sealed partial class BloodPackComponent : Component
     public string FillBaseName = "bloodpack";
 
     [DataField, AutoNetworkedField]
-    public FixedPoint2 TransferAmount = FixedPoint2.New(5);
+    public FixedPoint2 TransferAmount = FixedPoint2.New(3);
 
     [DataField, AutoNetworkedField]
-    public TimeSpan TransferDelay = TimeSpan.FromSeconds(3);
+    public TimeSpan TransferDelay = TimeSpan.FromSeconds(2);
 
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
     public TimeSpan TransferAt;

--- a/Content.Shared/_RMC14/Medical/IV/IVDripComponent.cs
+++ b/Content.Shared/_RMC14/Medical/IV/IVDripComponent.cs
@@ -19,7 +19,7 @@ public sealed partial class IVDripComponent : Component
     public string Slot = "pack";
 
     [DataField, AutoNetworkedField]
-    public FixedPoint2 TransferAmount = FixedPoint2.New(5);
+    public FixedPoint2 TransferAmount = FixedPoint2.New(4.5);
 
     [DataField, AutoNetworkedField]
     public TimeSpan TransferDelay = TimeSpan.FromSeconds(3);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity-ish?

## Technical details
<!-- Summary of code changes for easier review. -->
In CM, the rates are:
Blood packs: 3cl every 2 seconds (SSobj)
IV Drips: 4cl every 3.5 seconds (SSmachinery)

The code says a container with blood in IV drips is sped up?
The code implies it used to do very small amounts of any reagents over time, but someone changed it to only inject blood.

Whoever made the blood pack PR might have simply forgotten to update the IV drips? Dunno.

I’m going to use 1.5/s as a baseline for both. We can always adjust it later.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Blood Packs now transfer blood every 2 seconds instead of 3. Very slightly (10%) reduced the blood transfer amount from Packs and IV Drips.