### PR TITLE
SPP SOF Sorokyne Insert [FINAL]

### DIFF
--- a/Resources/Maps/_RMC14/Inserts/Sorokyne/spp_sof.yml
+++ b/Resources/Maps/_RMC14/Inserts/Sorokyne/spp_sof.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 264.0.2
   forkId: ""
   forkVersion: ""
-  time: 02/14/2026 01:25:28
-  entityCount: 180
+  time: 03/03/2026 01:53:10
+  entityCount: 195
 maps: []
 grids:
 - 1
@@ -188,6 +188,26 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 5.383629,8.5312195
       parent: 1
+  - uid: 181
+    components:
+    - type: Transform
+      pos: 7.831556,10.198413
+      parent: 1
+  - uid: 182
+    components:
+    - type: Transform
+      pos: 7.331556,10.189147
+      parent: 1
+  - uid: 183
+    components:
+    - type: Transform
+      pos: 5.238963,10.175248
+      parent: 1
+  - uid: 184
+    components:
+    - type: Transform
+      pos: 5.7435927,10.165982
+      parent: 1
 - proto: CMSheetGlass10
   entities:
   - uid: 26
@@ -199,6 +219,66 @@ entities:
     components:
     - type: Transform
       pos: 9.5,15.5
+      parent: 1
+- proto: CMSpawnPointSPPSOFMedic
+  entities:
+  - uid: 192
+    components:
+    - type: Transform
+      pos: 5.5,8.5
+      parent: 1
+- proto: CMSpawnPointSPPSOFRifleman
+  entities:
+  - uid: 188
+    components:
+    - type: Transform
+      pos: 3.5,10.5
+      parent: 1
+  - uid: 189
+    components:
+    - type: Transform
+      pos: 9.5,10.5
+      parent: 1
+  - uid: 190
+    components:
+    - type: Transform
+      pos: 12.5,6.5
+      parent: 1
+  - uid: 191
+    components:
+    - type: Transform
+      pos: 1.5,8.5
+      parent: 1
+  - uid: 193
+    components:
+    - type: Transform
+      pos: 5.5,6.5
+      parent: 1
+  - uid: 194
+    components:
+    - type: Transform
+      pos: 7.5,6.5
+      parent: 1
+- proto: CMSpawnPointSPPSOFSapper
+  entities:
+  - uid: 195
+    components:
+    - type: Transform
+      pos: 7.5,7.5
+      parent: 1
+- proto: CMSpawnPointSPPSOFSL
+  entities:
+  - uid: 186
+    components:
+    - type: Transform
+      pos: 6.5,11.5
+      parent: 1
+- proto: CMSpawnPointSPPSOFSpec
+  entities:
+  - uid: 187
+    components:
+    - type: Transform
+      pos: 7.5,9.5
       parent: 1
 - proto: CMSPPSOFCockpit
   entities:
@@ -766,6 +846,13 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 13.5,0.5
+      parent: 1
+- proto: RMCHeadCapSPPSOF
+  entities:
+  - uid: 185
+    components:
+    - type: Transform
+      pos: 5.5,9.5
       parent: 1
 - proto: RMCLightFixtureBlueOffset
   entities:

--- a/Resources/Maps/_RMC14/Inserts/Sorokyne/spp_sof_alt.yml
+++ b/Resources/Maps/_RMC14/Inserts/Sorokyne/spp_sof_alt.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 264.0.2
   forkId: ""
   forkVersion: ""
-  time: 02/14/2026 01:23:01
-  entityCount: 191
+  time: 03/03/2026 01:57:18
+  entityCount: 201
 maps: []
 grids:
 - 1
@@ -104,6 +104,38 @@ entities:
     - type: Transform
       pos: 7.5,16.5
       parent: 1
+- proto: CMGrenadeHighExplosive
+  entities:
+  - uid: 196
+    components:
+    - type: Transform
+      pos: 4.5,12.5
+      parent: 1
+  - uid: 197
+    components:
+    - type: Transform
+      pos: 4.5,12.5
+      parent: 1
+  - uid: 198
+    components:
+    - type: Transform
+      pos: 4.5,12.5
+      parent: 1
+  - uid: 199
+    components:
+    - type: Transform
+      pos: 4.5,12.5
+      parent: 1
+  - uid: 200
+    components:
+    - type: Transform
+      pos: 4.5,12.5
+      parent: 1
+  - uid: 201
+    components:
+    - type: Transform
+      pos: 4.5,12.5
+      parent: 1
 - proto: CMRodMetal1
   entities:
   - uid: 65
@@ -200,6 +232,30 @@ entities:
     - type: Transform
       pos: 6.492432,20.453466
       parent: 1
+- proto: RMCArmorHelmetSPPSOF
+  entities:
+  - uid: 193
+    components:
+    - type: Transform
+      pos: 5,16
+      parent: 1
+- proto: RMCArmorSPPSOF
+  entities:
+  - uid: 192
+    components:
+    - type: Transform
+      pos: 5.5,15.5
+      parent: 1
+  - uid: 194
+    components:
+    - type: Transform
+      pos: 4.5,13.5
+      parent: 1
+  - uid: 195
+    components:
+    - type: Transform
+      pos: 4.5,13.5
+      parent: 1
 - proto: RMCBeltHolsterPistolSPPT73
   entities:
   - uid: 111
@@ -214,24 +270,22 @@ entities:
     - type: Transform
       pos: 5.492432,19.26514
       parent: 1
-- proto: RMCBoxMagazineRifleAK4047
-  entities:
-  - uid: 100
-    components:
-    - type: Transform
-      pos: 4.364705,11.565371
-      parent: 1
-  - uid: 101
-    components:
-    - type: Transform
-      pos: 4.3542886,11.836391
-      parent: 1
 - proto: RMCBoxMagazineRifleAK4047Empty
   entities:
   - uid: 99
     components:
     - type: Transform
       pos: 6.677205,11.294349
+      parent: 1
+  - uid: 100
+    components:
+    - type: Transform
+      pos: 4.496439,11.8118105
+      parent: 1
+  - uid: 101
+    components:
+    - type: Transform
+      pos: 4.5,11.5
       parent: 1
 - proto: RMCCrateAmmo
   entities:
@@ -499,7 +553,7 @@ entities:
   - uid: 113
     components:
     - type: Transform
-      pos: 4.989705,11.37774
+      pos: 5.044001,11.587695
       parent: 1
   - uid: 114
     components:

--- a/Resources/Prototypes/_RMC14/Entities/Markers/Inserts/sorokyne.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Markers/Inserts/sorokyne.yml
@@ -18,9 +18,8 @@
   - type: MapInsert
     variations:
     - spawn: "/Maps/_RMC14/Inserts/Sorokyne/spp_sof.yml"
-      probability: 0.4 # "weight": 4, "type": "def", "values": { "lvevent": "sof_insert" } } // TODO: Hook 40% chance up to scenario once spawners are mapped
-#     probability: 1
-#     nightmareScenario: spp_sof
+      probability: 1
+      nightmareScenario: spp_sof
 
 - type: entity
   parent: RMCMapInsertSorokyneBase
@@ -30,9 +29,8 @@
   - type: MapInsert
     variations:
     - spawn: "/Maps/_RMC14/Inserts/Sorokyne/spp_sof_alt.yml"
-      probability: 0.4 # "weight": 4, "type": "def", "values": { "lvevent": "sof_insert" } } // TODO: Hook chance up to scenario once spawners are mapped
-#     probability: 1
-#     nightmareScenario: spp_sof
+      probability: 1
+      nightmareScenario: spp_sof
 
 # Standalones
 - type: entity

--- a/Resources/Prototypes/_RMC14/Entities/rmc_planets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/rmc_planets.yml
@@ -458,6 +458,9 @@
     camouflage: Jungle
     minPlayers: 130
     announcement: "An automated distress signal has been recieved from a mining colony on border world LV-976, \"Sorokyne Outpost\". A response team from the UNS Almayer will be dispatched shortly to investigate."
+    nightmareScenarios:
+    - scenarioName: spp_sof
+      scenarioProbability: 0.4
     survivorJobVariants:
       CMSurvivor:
       - CMJobSurvivorSoroCivilian: -1
@@ -493,26 +496,26 @@
 #        - : -1
 #        CMSurvivorScientist:
 #        - : -1
-#    survivorJobScenarios: # TODO: Check if these job slots are actually parity
-#      spp_sof:
-#      - CMSurvivorEngineer: 1
-#      - CMSurvivorDoctor: 1
-#      - CMSurvivorSecurity: 2
-#      - CMSurvivor: -1
-#    survivorJobVariantScenarios:
-#      spp_sof:
-#        CMSurvivorSecurity:
-#        - RMCSurvivorSPPSOFSpec: 1
-#        - RMCSurvivorSPPSOFSL: 1
-#        CMSurvivorDoctor:
-#        - RMCSurvivorSPPSOFMedic: 1
-#        CMSurvivorEngineer:
-#        - RMCSurvivorSPPSOFSapper: 1
-#        CMSurvivor:
-#        - RMCSurvivorSPPSOFSoldier: -1
-#    survivorJobOverrideScenarios: # Scientist rolls for SOF medic
-#      spp_sof :
-#        CMSurvivorScientist: CMSurvivorDoctor
+    survivorJobScenarios: # TODO: Check if these job slots are actually parity
+      spp_sof:
+      - CMSurvivorEngineer: 1
+      - CMSurvivorDoctor: 1
+      - CMSurvivorSecurity: 2
+      - CMSurvivor: -1
+    survivorJobVariantScenarios:
+      spp_sof:
+        CMSurvivorSecurity:
+        - RMCSurvivorSPPSOFSpec: 1
+        - RMCSurvivorSPPSOFSL: 1
+        CMSurvivorDoctor:
+        - RMCSurvivorSPPSOFMedic: 1
+        CMSurvivorEngineer:
+        - RMCSurvivorSPPSOFSapper: 1
+        CMSurvivor:
+        - RMCSurvivorSPPSOFSoldier: -1
+    survivorJobOverrideScenarios: # Scientist rolls for SOF medic
+      spp_sof :
+        CMSurvivorScientist: CMSurvivorDoctor
 
 # PVE Maps Below
 - type: entity


### PR DESCRIPTION
## About the PR
Adds missing spawners to sorokyne dropship insert, links them both to a nightmare scenario and adds the SPP SOF nightmare scenario into the game.

Also adds:
- Missing SPP SOF armor and HEDP grenades to SOF supply ship
- Missing SPP SOF beret to SOF dropship
- FIxed filled ammo boxes spawning instead of empty ones

Has a 40% chance of occuring overall

## Why / Balance
Paridy

Tested, works. All roles spawn like usual

## Technical details
YAML and mapping

## Media
<img width="725" height="712" alt="obraz" src="https://github.com/user-attachments/assets/ac5b9ac7-1a38-4307-b796-981f5d8ebec4" />
<img width="1203" height="1044" alt="obraz" src="https://github.com/user-attachments/assets/32e393c6-4e34-436b-b287-aadd89d4aa6f" />
<img width="1067" height="1127" alt="obraz" src="https://github.com/user-attachments/assets/5fa3483a-537e-4f88-916e-b5ff92dc0f2e" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Added a possible scenario for 121/RECON, an SPP SOF team investigating the Sorokyne Outpost distress signal. Has a 40% chance of occuring.