### PR TITLE
Molotov/AGM-I Fire Fixes

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m74_airburst_grenades.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m74_airburst_grenades.yml
@@ -201,6 +201,8 @@
   - type: DirectionalTileFireOnTrigger
     range: 3
     spawn: RMCTileFire
+    intensity: 20
+    duration: 15
 
 - type: entity
   parent: RMCBaseAirBurstProjectile

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -330,6 +330,7 @@
     max: 4
   - type: TileFireOnTrigger
     spawn: RMCTileFire
+    duration: 60
   - type: Tag
     tags:
     - Grenade


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Returns the duration of improvised firebombs to 60s and makes AGM-I flames have a duration of 15 and intensity of 20.

## Why / Balance
kid named parity

## Media

https://github.com/user-attachments/assets/aea44a85-96be-4a0d-a636-8f86bc928351

<img width="307" height="169" alt="image" src="https://github.com/user-attachments/assets/b250bb47-ec38-4239-b47b-8e06ec97c6cd" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Improvised firebombs and AGM-I grenades now burn for the proper time