### PR TITLE
SPP SOF fixes

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/spp.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/spp.yml
@@ -198,6 +198,7 @@
     - id: RMCTacticalPrybar
     - id: RMCMagazineRifleAK4047
     - id: RMCMagazineRifleAK4047
+    - id: RMCRadioHandheldColony
 
 - type: entity
   parent: RMCArmorSPP

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Dropships/spp_sof_doors.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Dropships/spp_sof_doors.yml
@@ -2,6 +2,7 @@
   parent: RMCDropshipCockpitBase
   id: CMSPPSOFCockpit
   suffix: Voron
+  name: voron crew hatch
   components:
   - type: RemoveComponents
     components:
@@ -26,3 +27,5 @@
     - state: panel_open
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
       color: "#b09e90"
+  - type: AccessReader
+    access: [["CMAccessColonyPublic"]]

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/SPP_SOF/spp_sof_medic.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/SPP_SOF/spp_sof_medic.yml
@@ -10,6 +10,7 @@
   special:
   - !type:AddComponentSpecial
     components:
+    - type: RMCSurvivor
     - type: NpcFactionMember
       factions:
       - SPP

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/SPP_SOF/spp_sof_sapper.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/SPP_SOF/spp_sof_sapper.yml
@@ -10,6 +10,7 @@
   special:
   - !type:AddComponentSpecial
     components:
+    - type: RMCSurvivor
     - type: NpcFactionMember
       factions:
       - SPP

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/SPP_SOF/spp_sof_sl.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/SPP_SOF/spp_sof_sl.yml
@@ -10,6 +10,7 @@
   special:
   - !type:AddComponentSpecial
     components:
+    - type: RMCSurvivor
     - type: NpcFactionMember
       factions:
       - SPP

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/SPP_SOF/spp_sof_sl.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/SPP_SOF/spp_sof_sl.yml
@@ -53,6 +53,7 @@
     - RMCTacticalPrybar
     - RMCMagazineRifleAK4047
     - RMCMagazineRifleAK4047
+    - RMCRadioHandheldColony
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/SPP_SOF/spp_sof_soldier.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/SPP_SOF/spp_sof_soldier.yml
@@ -7,6 +7,7 @@
   special:
   - !type:AddComponentSpecial
     components:
+    - type: RMCSurvivor
     - type: NpcFactionMember
       factions:
       - SPP

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/SPP_SOF/spp_sof_spec.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/SPP_SOF/spp_sof_spec.yml
@@ -10,6 +10,7 @@
   special:
   - !type:AddComponentSpecial
     components:
+    - type: RMCSurvivor
     - type: NpcFactionMember
       factions:
       - SPP

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/SPP_SOF/spp_sof_spec.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/SPP_SOF/spp_sof_spec.yml
@@ -42,6 +42,7 @@
     - RMCTacticalPrybar
     - RMCMagazineRifleAK4047
     - RMCMagazineRifleAK4047
+    - RMCRadioHandheldColony
 
 - type: entity
   parent: CMSpawnPointJobBase


### PR DESCRIPTION
## About the PR
SPP SOF can now open the doors to their dropship and can no longer hear marine announcements

Also they start with handhelds because they didn't before

## Why / Balance
Parity

## Technical details
YAML

## Media

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed SPP SOF not being able to open their own dropship doors
- fix: Fixed SPP SOF not spawning with shortwave radios
- fix: Fixed SPP SOF hearing marine announcements
