### PR TITLE
Medals and uniform accessories now automatically equip to uniform/outer clothing (Fixes FORECON Marksman not spawning with a gun sometimes)

### DIFF
--- a/Content.Server/_RMC14/Medal/PlaytimeMedalSystem.cs
+++ b/Content.Server/_RMC14/Medal/PlaytimeMedalSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared._RMC14.Medal;
 using Content.Shared._RMC14.UniformAccessories;
 using Content.Shared.Coordinates;
 using Content.Shared.GameTicking;
+using Content.Shared.Inventory;
 using Content.Shared.Roles;
 using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
@@ -15,6 +16,8 @@ public sealed class PlaytimeMedalSystem : EntitySystem
 {
     [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] private readonly HandsSystem _hands = default!;
+    [Dependency] private readonly SharedUniformAccessorySystem _uniformAccessory = default!;
+    [Dependency] private readonly InventorySystem _inventory = default!;
     [Dependency] private readonly PlayTimeTrackingManager _playTimeTracking = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
 
@@ -84,7 +87,11 @@ public sealed class PlaytimeMedalSystem : EntitySystem
             return;
 
         var medal = SpawnAtPosition(medalId, ev.Mob.ToCoordinates());
-        _hands.TryPickupAnyHand(ev.Mob, medal, false);
+
+        // Try to insert into a valid accessory slot. Otherwise, inserts it into the player's hands.
+        if (!_uniformAccessory.TryInsertToValidSlot(medal, ev.Mob))
+            _hands.TryPickupAnyHand(ev.Mob, medal, false);
+
         var medalComp = EnsureComp<UniformAccessoryComponent>(medal);
         medalComp.User = GetNetEntity(ev.Mob);
         Dirty(medal, medalComp);

--- a/Content.Shared/_RMC14/UniformAccessories/SharedUniformAccessorySystem.cs
+++ b/Content.Shared/_RMC14/UniformAccessories/SharedUniformAccessorySystem.cs
@@ -2,9 +2,11 @@ using Content.Shared._RMC14.Xenonids;
 using Content.Shared.Examine;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
+using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Item;
 using Content.Shared.Popups;
+using Content.Shared.Roles;
 using Content.Shared.Verbs;
 using Robust.Shared.Containers;
 using Robust.Shared.Network;
@@ -18,11 +20,14 @@ public abstract class SharedUniformAccessorySystem : EntitySystem
     [Dependency] private readonly SharedHandsSystem _hands = default!;
     [Dependency] private readonly SharedItemSystem _item = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly InventorySystem _inventory = default!;
     [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
     [Dependency] private readonly INetManager _net = default!;
 
     public override void Initialize()
     {
+        SubscribeLocalEvent<StartingGearEquippedEvent>(OnStartingGearEquipped);
+
         SubscribeLocalEvent<UniformAccessoryHolderComponent, MapInitEvent>(OnHolderMapInit);
         SubscribeLocalEvent<UniformAccessoryHolderComponent, InteractUsingEvent>(OnHolderInteractUsing);
         SubscribeLocalEvent<UniformAccessoryHolderComponent, GotEquippedEvent>(OnHolderGotEquipped);
@@ -35,6 +40,11 @@ public abstract class SharedUniformAccessorySystem : EntitySystem
             {
                 subs.Event<UniformAccessoriesBuiMsg>(OnAccessoriesBuiMsg);
             });
+    }
+
+    private void OnStartingGearEquipped(ref StartingGearEquippedEvent args)
+    {
+        TryInsertInhandAccessories(args.Entity);
     }
 
     private void OnHolderMapInit(Entity<UniformAccessoryHolderComponent> ent, ref MapInitEvent args)
@@ -55,46 +65,11 @@ public abstract class SharedUniformAccessorySystem : EntitySystem
 
     private void OnHolderInteractUsing(Entity<UniformAccessoryHolderComponent> ent, ref InteractUsingEvent args)
     {
-        if (!TryComp(args.Used, out UniformAccessoryComponent? accessory))
+        if (!HasComp<UniformAccessoryComponent>(args.Used))
             return;
 
-        var container = _container.EnsureContainer<Container>(ent, ent.Comp.ContainerId);
         args.Handled = true;
-
-        if (accessory.User is { } accessoryUser && !BelongsToUser(accessoryUser, args.User))
-        {
-            _popup.PopupClient(Loc.GetString("rmc-uniform-accessory-fail"), args.User, args.User, PopupType.SmallCaution);
-            _hands.TryDrop(args.User, ent, checkActionBlocker: false);
-            return;
-        }
-
-        if (!ent.Comp.AllowedCategories.Contains(accessory.Category))
-        {
-            _popup.PopupClient(Loc.GetString("rmc-uniform-accessory-fail-not-allowed"), args.User, args.User, PopupType.SmallCaution);
-            return;
-        }
-
-        var accessoryDictionary = new Dictionary<string, int>();
-
-        foreach (var inserted in container.ContainedEntities)
-        {
-            if (TryComp<UniformAccessoryComponent>(inserted, out var insertedComp))
-            {
-                if (accessoryDictionary.TryGetValue(insertedComp.Category, out var count))
-                    accessoryDictionary[insertedComp.Category] = count + 1;
-                else
-                    accessoryDictionary[insertedComp.Category] = 1;
-            }
-        }
-
-        if (accessoryDictionary.TryGetValue(accessory.Category, out var amount) && accessory.Limit <= amount)
-        {
-            _popup.PopupClient(Loc.GetString("rmc-uniform-accessory-fail-limit"), args.User, args.User, PopupType.SmallCaution);
-            return;
-        }
-
-        _container.Insert(args.Used, container);
-        _item.VisualsChanged(ent);
+        TryInsertUniformAccessory(args.Used, ent, args.User);
     }
 
     private void OnHolderGotEquipped(Entity<UniformAccessoryHolderComponent> ent, ref GotEquippedEvent args)
@@ -188,6 +163,78 @@ public abstract class SharedUniformAccessorySystem : EntitySystem
 
         var ownerName = Name(owner.Value);
         args.PushMarkup(Loc.GetString("rmc-uniform-accessory-owner", ("owner", ownerName)));
+    }
+
+    public void TryInsertInhandAccessories(EntityUid target)
+    {
+        foreach (var held in _hands.EnumerateHeld(target))
+        {
+            if (!HasComp<UniformAccessoryComponent>(held))
+                continue;
+
+            TryInsertToValidSlot(held, target);
+        }
+    }
+
+    public bool TryInsertToValidSlot(EntityUid accessory, EntityUid user)
+    {
+        var slots = _inventory.GetSlotEnumerator(user, SlotFlags.INNERCLOTHING | SlotFlags.OUTERCLOTHING);
+        while (slots.MoveNext(out var slot))
+        {
+            if (slot.ContainedEntity == null || !HasComp<UniformAccessoryHolderComponent>(slot.ContainedEntity))
+                continue;
+
+            if (TryInsertUniformAccessory(accessory, slot.ContainedEntity.Value, user))
+                return true;
+        }
+
+        return false;
+    }
+
+    public bool TryInsertUniformAccessory(EntityUid accessory, EntityUid holder, EntityUid user)
+    {
+        if (!TryComp(accessory, out UniformAccessoryComponent? accessoryComp))
+            return false;
+
+        if (!TryComp(holder, out UniformAccessoryHolderComponent? holderComp))
+            return false;
+
+        var container = _container.EnsureContainer<Container>(holder, holderComp.ContainerId);
+
+        if (accessoryComp.User is { } accessoryUser && !BelongsToUser(accessoryUser, user))
+        {
+            _popup.PopupClient(Loc.GetString("rmc-uniform-accessory-fail"), user, user, PopupType.SmallCaution);
+            return false;
+        }
+
+        if (!holderComp.AllowedCategories.Contains(accessoryComp.Category))
+        {
+            _popup.PopupClient(Loc.GetString("rmc-uniform-accessory-fail-not-allowed"), user, user, PopupType.SmallCaution);
+            return false;
+        }
+
+        var accessoryDictionary = new Dictionary<string, int>();
+
+        foreach (var inserted in container.ContainedEntities)
+        {
+            if (TryComp<UniformAccessoryComponent>(inserted, out var insertedComp))
+            {
+                if (accessoryDictionary.TryGetValue(insertedComp.Category, out var count))
+                    accessoryDictionary[insertedComp.Category] = count + 1;
+                else
+                    accessoryDictionary[insertedComp.Category] = 1;
+            }
+        }
+
+        if (accessoryDictionary.TryGetValue(accessoryComp.Category, out var amount) && accessoryComp.Limit <= amount)
+        {
+            _popup.PopupClient(Loc.GetString("rmc-uniform-accessory-fail-limit"), user, user, PopupType.SmallCaution);
+            return false;
+        }
+
+        _container.Insert(accessory, container);
+        _item.VisualsChanged(holder);
+        return true;
     }
 
     public bool BelongsToUser(NetEntity user, EntityUid target)

--- a/Content.Shared/_RMC14/UniformAccessories/SharedUniformAccessorySystem.cs
+++ b/Content.Shared/_RMC14/UniformAccessories/SharedUniformAccessorySystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared.Examine;
+using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
 using Content.Shared.Inventory;
@@ -26,7 +27,7 @@ public abstract class SharedUniformAccessorySystem : EntitySystem
 
     public override void Initialize()
     {
-        SubscribeLocalEvent<StartingGearEquippedEvent>(OnStartingGearEquipped);
+        SubscribeLocalEvent<HandsComponent, StartingGearEquippedEvent>(OnStartingGearEquipped);
 
         SubscribeLocalEvent<UniformAccessoryHolderComponent, MapInitEvent>(OnHolderMapInit);
         SubscribeLocalEvent<UniformAccessoryHolderComponent, InteractUsingEvent>(OnHolderInteractUsing);
@@ -42,9 +43,9 @@ public abstract class SharedUniformAccessorySystem : EntitySystem
             });
     }
 
-    private void OnStartingGearEquipped(ref StartingGearEquippedEvent args)
+    private void OnStartingGearEquipped(Entity<HandsComponent> ent, ref StartingGearEquippedEvent args)
     {
-        TryInsertInhandAccessories(args.Entity);
+        TryInsertInhandAccessories(ent.Owner);
     }
 
     private void OnHolderMapInit(Entity<UniformAccessoryHolderComponent> ent, ref MapInitEvent args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Title, they'll autoequip
CM13 parity aswell for the loadout items

Ensures survivors that spawn with shit inhand do not lose it due to your loadout or medal, and is general QOL aswell

## Technical details
Adds the ``TryInsertUniformAccessory`` method, a generic method for inserting uniform accessories to holders without being inside of the interact using event

Entities with hands component will be checked for any accessories inhand and will have them equipped
Medals get auto equipped if you have a uniform/outer clothing with accessory holder

## Media
medal + weya patch on forecon marksman

https://github.com/user-attachments/assets/8c19b4c7-0f53-4a19-a458-cfaaba264906



**Changelog**
:cl:
- fix: Medals and uniform accessories from loadouts now automatically equip when you spawn in to your jumpsuit or jacket. Notably, this fixes roles that spawn with weapons in their hands not spawning if you are full of uniform accessory loadouts/medals.
