### PR TITLE
Survivors Spawn Together - Trijent Dam

### DIFF
--- a/Resources/Maps/_RMC14/Inserts/Trijent/surv_spawn_bar.yml
+++ b/Resources/Maps/_RMC14/Inserts/Trijent/surv_spawn_bar.yml
@@ -1,0 +1,1590 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 264.0.2
+  forkId: ""
+  forkVersion: ""
+  time: 03/04/2026 00:49:13
+  entityCount: 251
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  0: Space
+  198: CMFloorPlating
+  1: CMFloorWood
+  4: CMPlanetTatami
+  3: CMPlanetWood
+  2: RMCPlanetSand1
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: grid
+    - type: Transform
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: xgAAAAAAAMYAAAAAAAABAAAAAAAAAQAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAAACAAAAAAAAAAAAAAAAAMYAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAADGAAAAAAAAxgAAAAAAAAAAAAAAAADGAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAQAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAEAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAABAAAAAAAAAwAAAAAAAMYAAAAAAAAAAAAAAAAAxgAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAEAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAABAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAQAAAAAAAAMAAAAAAADGAAAAAAAAAAAAAAAAAMYAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAABAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAQAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAEAAAAAAAADAAAAAAAAxgAAAAAAAAAAAAAAAADGAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAwAAAAAAAMYAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAABAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAQAAAAAAAAMAAAAAAADGAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAQAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAEAAAAAAAADAAAAAAAAxgAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAEAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAABAAAAAAAAAwAAAAAAAMYAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAMAAAAAAADGAAAAAAAAAAAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAxgAAAAAAAAAAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAAAAAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAAAAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAAAAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAAAAAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAAAAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodFloor1
+          decals:
+            9: 3.589192,2.7188365
+            10: 2.7317863,4.3241177
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodFloor2
+          decals:
+            8: 2.9225252,0.94677234
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodFloor6
+          decals:
+            7: 1.5579419,2.1872172
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodTrail2
+          decals:
+            11: 2.5547028,5.029356
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodTrail5
+          decals:
+            12: 2.7005363,5.6691175
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodXenonidSplatter1
+          decals:
+            6: 4.182942,1.7494133
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodXenonidSplatter5
+          decals:
+            5: 1.6933584,1.0301635
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCScorch2
+          decals:
+            1: 2.5058584,0.89465284
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCScorch3
+          decals:
+            4: 3.3496084,1.6555977
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCScorchSmall1
+          decals:
+            2: 1.5371084,1.3116088
+            3: 3.464192,1.8223801
+    - type: GridAtmosphere
+      version: 2
+      data:
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: ImplicitRoof
+- proto: Bedroll
+  entities:
+  - uid: 112
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 113
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 114
+    components:
+    - type: Transform
+      pos: 2.5,9.5
+      parent: 1
+  - uid: 115
+    components:
+    - type: Transform
+      pos: 3.5,10.5
+      parent: 1
+  - uid: 149
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 234
+    components:
+    - type: Transform
+      pos: 7.0755963,5.707112
+      parent: 1
+  - uid: 235
+    components:
+    - type: Transform
+      pos: 7.6693463,6.87459
+      parent: 1
+  - uid: 236
+    components:
+    - type: Transform
+      pos: 5.836012,6.1866117
+      parent: 1
+- proto: BedrollFolded
+  entities:
+  - uid: 150
+    components:
+    - type: Transform
+      pos: 0.81511927,7.4304104
+      parent: 1
+- proto: CMAirlock
+  entities:
+  - uid: 4
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,2.5
+      parent: 1
+- proto: CMAirlockMaint
+  entities:
+  - uid: 75
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,14.5
+      parent: 1
+- proto: CMApcNoPower
+  entities:
+  - uid: 68
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,12.5
+      parent: 1
+    - type: SpriteSetRenderOrder
+      offset: -0.7,-0.4
+- proto: CMAutolathe
+  entities:
+  - uid: 76
+    components:
+    - type: Transform
+      pos: 2.5,13.5
+      parent: 1
+- proto: CMBarricadeSandbag
+  entities:
+  - uid: 146
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 147
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 148
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+- proto: CMCarpetPrison
+  entities:
+  - uid: 8
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 3.5,7.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,7.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,7.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,8.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,8.5
+      parent: 1
+- proto: CMChairWoodWings
+  entities:
+  - uid: 77
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,13.5
+      parent: 1
+  - uid: 97
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 1
+  - uid: 98
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,3.5
+      parent: 1
+  - uid: 99
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 100
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 102
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,1.5
+      parent: 1
+  - uid: 103
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,3.5
+      parent: 1
+  - uid: 104
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.781896,3.3508143
+      parent: 1
+  - uid: 105
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.969396,1.4849353
+      parent: 1
+  - uid: 106
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,1.5
+      parent: 1
+  - uid: 118
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 155
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.7193947,1.4223919
+      parent: 1
+  - uid: 156
+    components:
+    - type: Transform
+      pos: 5.104811,8.844444
+      parent: 1
+  - uid: 157
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.781896,2.8608916
+      parent: 1
+  - uid: 158
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.427729,4.8416643
+      parent: 1
+  - uid: 159
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.563146,6.9055977
+      parent: 1
+  - uid: 160
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.761062,1.4745121
+      parent: 1
+- proto: CMDisposalUnit
+  entities:
+  - uid: 119
+    components:
+    - type: Transform
+      pos: 4.5,11.5
+      parent: 1
+- proto: CMDoubleDoorGenericGlass
+  entities:
+  - uid: 22
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      pos: 14.5,7.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,6.5
+      parent: 1
+- proto: CMRodMetal1
+  entities:
+  - uid: 251
+    components:
+    - type: Transform
+      pos: 5.578333,0.9974942
+      parent: 1
+- proto: CMShardGlass
+  entities:
+  - uid: 124
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 125
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.2579136,0.9568176
+      parent: 1
+  - uid: 126
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.95583,1.0923283
+      parent: 1
+- proto: CMSpawnPointSurvivor
+  entities:
+  - uid: 237
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 238
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 239
+    components:
+    - type: Transform
+      pos: 2.5,9.5
+      parent: 1
+  - uid: 240
+    components:
+    - type: Transform
+      pos: 3.5,10.5
+      parent: 1
+  - uid: 242
+    components:
+    - type: Transform
+      pos: 5.5,8.5
+      parent: 1
+  - uid: 243
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 244
+    components:
+    - type: Transform
+      pos: 6.5,6.5
+      parent: 1
+  - uid: 246
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 1
+  - uid: 247
+    components:
+    - type: Transform
+      pos: 7.5,3.5
+      parent: 1
+  - uid: 248
+    components:
+    - type: Transform
+      pos: 9.5,3.5
+      parent: 1
+  - uid: 249
+    components:
+    - type: Transform
+      pos: 10.5,11.5
+      parent: 1
+  - uid: 250
+    components:
+    - type: Transform
+      pos: 12.5,11.5
+      parent: 1
+- proto: CMTableReinforced
+  entities:
+  - uid: 71
+    components:
+    - type: Transform
+      pos: 7.5,15.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      pos: 6.5,15.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      pos: 13.5,15.5
+      parent: 1
+  - uid: 74
+    components:
+    - type: Transform
+      pos: 12.5,15.5
+      parent: 1
+- proto: CMTableWooden
+  entities:
+  - uid: 78
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,13.5
+      parent: 1
+  - uid: 93
+    components:
+    - type: Transform
+      pos: 6.5,3.5
+      parent: 1
+  - uid: 94
+    components:
+    - type: Transform
+      pos: 10.5,3.5
+      parent: 1
+  - uid: 95
+    components:
+    - type: Transform
+      pos: 10.5,7.5
+      parent: 1
+  - uid: 96
+    components:
+    - type: Transform
+      pos: 6.5,7.5
+      parent: 1
+  - uid: 163
+    components:
+    - type: Transform
+      pos: 7.5,12.5
+      parent: 1
+  - uid: 166
+    components:
+    - type: Transform
+      pos: 10.5,12.5
+      parent: 1
+  - uid: 167
+    components:
+    - type: Transform
+      pos: 11.5,12.5
+      parent: 1
+  - uid: 168
+    components:
+    - type: Transform
+      pos: 12.5,12.5
+      parent: 1
+- proto: CMVendorBooze
+  entities:
+  - uid: 69
+    components:
+    - type: Transform
+      pos: 9.5,15.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      pos: 10.5,15.5
+      parent: 1
+- proto: CMVendorCoffee
+  entities:
+  - uid: 123
+    components:
+    - type: Transform
+      pos: 0.5,11.5
+      parent: 1
+- proto: CMVendorSnack
+  entities:
+  - uid: 122
+    components:
+    - type: Transform
+      pos: 1.5,11.5
+      parent: 1
+- proto: CMVentPump
+  entities:
+  - uid: 192
+    components:
+    - type: Transform
+      pos: 11.5,2.5
+      parent: 1
+  - uid: 193
+    components:
+    - type: Transform
+      pos: 11.5,14.5
+      parent: 1
+- proto: CMWallWood
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 3
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 5
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 6
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 7
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,0.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,0.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,0.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: 13.5,1.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: 14.5,1.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      pos: 11.5,15.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,4.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      pos: 8.5,15.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,9.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      pos: 5.5,15.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      pos: 5.5,12.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      pos: 5.5,11.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      pos: 5.5,13.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      pos: 14.5,12.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: 14.5,15.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      pos: 4.5,12.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      pos: 3.5,12.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      pos: 2.5,12.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      pos: 1.5,12.5
+      parent: 1
+  - uid: 60
+    components:
+    - type: Transform
+      pos: 0.5,12.5
+      parent: 1
+- proto: DisposalBend
+  entities:
+  - uid: 174
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,7.5
+      parent: 1
+- proto: DisposalPipe
+  entities:
+  - uid: 171
+    components:
+    - type: Transform
+      pos: 4.5,10.5
+      parent: 1
+  - uid: 172
+    components:
+    - type: Transform
+      pos: 4.5,9.5
+      parent: 1
+  - uid: 173
+    components:
+    - type: Transform
+      pos: 4.5,8.5
+      parent: 1
+  - uid: 175
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,7.5
+      parent: 1
+  - uid: 176
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,7.5
+      parent: 1
+  - uid: 177
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,7.5
+      parent: 1
+  - uid: 178
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,7.5
+      parent: 1
+  - uid: 179
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,7.5
+      parent: 1
+  - uid: 180
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,7.5
+      parent: 1
+  - uid: 181
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,7.5
+      parent: 1
+  - uid: 182
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,7.5
+      parent: 1
+  - uid: 183
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,7.5
+      parent: 1
+  - uid: 184
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,7.5
+      parent: 1
+- proto: DisposalTrunk
+  entities:
+  - uid: 170
+    components:
+    - type: Transform
+      pos: 4.5,11.5
+      parent: 1
+- proto: RMCBarricadeWood
+  entities:
+  - uid: 101
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,8.5
+      parent: 1
+  - uid: 107
+    components:
+    - type: Transform
+      pos: 9.5,1.5
+      parent: 1
+  - uid: 108
+    components:
+    - type: Transform
+      pos: 6.5,1.5
+      parent: 1
+  - uid: 109
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,7.5
+      parent: 1
+  - uid: 110
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,11.5
+      parent: 1
+  - uid: 111
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,13.5
+      parent: 1
+- proto: RMCBasePropCasing11
+  entities:
+  - uid: 129
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.7975252,3.4377387
+      parent: 1
+  - uid: 130
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.182942,4.167412
+      parent: 1
+  - uid: 131
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.0996084,4.344618
+      parent: 1
+  - uid: 132
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.0787752,4.4175854
+      parent: 1
+  - uid: 133
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.7975252,3.5002818
+      parent: 1
+  - uid: 134
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.7037752,3.3647711
+      parent: 1
+  - uid: 135
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.3183584,2.7393367
+      parent: 1
+  - uid: 136
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.651692,2.1555977
+      parent: 1
+  - uid: 137
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.9121094,2.0513587
+      parent: 1
+  - uid: 138
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.922526,3.5524013
+      parent: 1
+  - uid: 139
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.8496084,4.0840206
+      parent: 1
+  - uid: 140
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.2975252,4.167412
+      parent: 1
+  - uid: 141
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.2246084,4.6573353
+      parent: 1
+  - uid: 142
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.4225252,4.8762374
+      parent: 1
+  - uid: 143
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.9850252,3.46901
+      parent: 1
+- proto: RMCBasePropCasing2
+  entities:
+  - uid: 145
+    components:
+    - type: Transform
+      pos: 4.2246084,4.573944
+      parent: 1
+- proto: RMCBasePropCasing7
+  entities:
+  - uid: 144
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.7246084,5.293194
+      parent: 1
+- proto: RMCCabinetBase
+  entities:
+  - uid: 79
+    components:
+    - type: Transform
+      pos: 0.5,15.5
+      parent: 1
+  - uid: 80
+    components:
+    - type: Transform
+      pos: 1.5,15.5
+      parent: 1
+- proto: RMCDirtBandageProp2
+  entities:
+  - uid: 152
+    components:
+    - type: Transform
+      pos: 3.1692863,5.9293675
+      parent: 1
+- proto: RMCDirtBandageProp4
+  entities:
+  - uid: 154
+    components:
+    - type: Transform
+      pos: 2.7526195,6.460987
+      parent: 1
+- proto: RMCDirtBandageProp8
+  entities:
+  - uid: 153
+    components:
+    - type: Transform
+      pos: 3.7317863,5.8355527
+      parent: 1
+- proto: RMCGasPipeStraight
+  entities:
+  - uid: 194
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,14.5
+      parent: 1
+  - uid: 195
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,14.5
+      parent: 1
+  - uid: 196
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,14.5
+      parent: 1
+  - uid: 197
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,14.5
+      parent: 1
+  - uid: 198
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,14.5
+      parent: 1
+  - uid: 199
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,14.5
+      parent: 1
+  - uid: 200
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,14.5
+      parent: 1
+  - uid: 201
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,14.5
+      parent: 1
+  - uid: 202
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,14.5
+      parent: 1
+  - uid: 203
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,14.5
+      parent: 1
+  - uid: 204
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,13.5
+      parent: 1
+  - uid: 205
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,12.5
+      parent: 1
+  - uid: 206
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,11.5
+      parent: 1
+  - uid: 207
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,10.5
+      parent: 1
+  - uid: 208
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,9.5
+      parent: 1
+  - uid: 209
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,8.5
+      parent: 1
+  - uid: 210
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,7.5
+      parent: 1
+  - uid: 211
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,7.5
+      parent: 1
+  - uid: 212
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,7.5
+      parent: 1
+  - uid: 213
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,7.5
+      parent: 1
+  - uid: 214
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,7.5
+      parent: 1
+  - uid: 215
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,7.5
+      parent: 1
+  - uid: 216
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,7.5
+      parent: 1
+  - uid: 217
+    components:
+    - type: Transform
+      pos: 7.5,6.5
+      parent: 1
+  - uid: 218
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 1
+  - uid: 219
+    components:
+    - type: Transform
+      pos: 7.5,4.5
+      parent: 1
+  - uid: 220
+    components:
+    - type: Transform
+      pos: 7.5,3.5
+      parent: 1
+  - uid: 221
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,2.5
+      parent: 1
+  - uid: 222
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,2.5
+      parent: 1
+  - uid: 223
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,2.5
+      parent: 1
+  - uid: 224
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,2.5
+      parent: 1
+  - uid: 225
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 226
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 227
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 228
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 229
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 230
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,2.5
+      parent: 1
+- proto: RMCGasPipeTJunction
+  entities:
+  - uid: 231
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,2.5
+      parent: 1
+  - uid: 232
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,7.5
+      parent: 1
+  - uid: 233
+    components:
+    - type: Transform
+      pos: 7.5,14.5
+      parent: 1
+- proto: RMCItemPoolBuckshot
+  entities:
+  - uid: 89
+    components:
+    - type: Transform
+      pos: 6.5,7.5
+      parent: 1
+  - uid: 90
+    components:
+    - type: Transform
+      pos: 10.5,7.5
+      parent: 1
+  - uid: 91
+    components:
+    - type: Transform
+      pos: 10.5,3.5
+      parent: 1
+  - uid: 92
+    components:
+    - type: Transform
+      pos: 6.5,3.5
+      parent: 1
+- proto: RMCLightFixtureOffset
+  entities:
+  - uid: 20
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,14.5
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,14.5
+      parent: 1
+  - uid: 84
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,11.5
+      parent: 1
+  - uid: 85
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,9.5
+      parent: 1
+  - uid: 86
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,4.5
+      parent: 1
+  - uid: 87
+    components:
+    - type: Transform
+      pos: 10.5,1.5
+      parent: 1
+  - uid: 88
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+- proto: RMCMarkerAreaLabel
+  entities:
+  - uid: 185
+    components:
+    - type: MetaData
+      name: Bar
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,6.5
+      parent: 1
+- proto: RMCMREWeYa
+  entities:
+  - uid: 116
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+  - uid: 117
+    components:
+    - type: Transform
+      pos: 3.5,8.5
+      parent: 1
+- proto: RMCParasiteProp
+  entities:
+  - uid: 127
+    components:
+    - type: Transform
+      pos: 4.276692,1.8741527
+      parent: 1
+  - uid: 128
+    components:
+    - type: Transform
+      pos: 2.0787752,1.3425332
+      parent: 1
+- proto: RMCPlankWood2
+  entities:
+  - uid: 164
+    components:
+    - type: Transform
+      pos: 8.289691,11.678839
+      parent: 1
+  - uid: 165
+    components:
+    - type: Transform
+      pos: 9.716775,13.086066
+      parent: 1
+  - uid: 187
+    components:
+    - type: Transform
+      pos: 8.508441,12.689958
+      parent: 1
+  - uid: 188
+    components:
+    - type: Transform
+      pos: 9.935525,11.89774
+      parent: 1
+  - uid: 189
+    components:
+    - type: Transform
+      pos: 8.654275,12.450208
+      parent: 1
+  - uid: 190
+    components:
+    - type: Transform
+      pos: 8.385177,12.562118
+      parent: 1
+  - uid: 191
+    components:
+    - type: Transform
+      pos: 10.437261,11.801172
+      parent: 1
+- proto: RMCSpawnerCorpseChef
+  entities:
+  - uid: 162
+    components:
+    - type: Transform
+      pos: 9.5,8.5
+      parent: 1
+- proto: RMCSpawnerCorpseColonist
+  entities:
+  - uid: 151
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 1
+- proto: RMCSpawnerIntelClose
+  entities:
+  - uid: 67
+    components:
+    - type: Transform
+      pos: 7.5,12.5
+      parent: 1
+  - uid: 81
+    components:
+    - type: Transform
+      pos: 0.5,15.5
+      parent: 1
+  - uid: 241
+    components:
+    - type: Transform
+      pos: 9.5,6.5
+      parent: 1
+- proto: RMCSpawnerIntelFar
+  entities:
+  - uid: 169
+    components:
+    - type: Transform
+      pos: 13.5,15.5
+      parent: 1
+- proto: RMCSpawnerIntelMedium
+  entities:
+  - uid: 245
+    components:
+    - type: Transform
+      pos: 7.5,15.5
+      parent: 1
+- proto: RMCStool
+  entities:
+  - uid: 61
+    components:
+    - type: Transform
+      pos: 7.5,11.5
+      parent: 1
+  - uid: 62
+    components:
+    - type: Transform
+      pos: 9.5,11.5
+      parent: 1
+  - uid: 63
+    components:
+    - type: Transform
+      pos: 10.5,11.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      pos: 12.5,11.5
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      pos: 6.5,10.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      pos: 11.5,10.5
+      parent: 1
+- proto: RMCVendorCigsWeYa
+  entities:
+  - uid: 120
+    components:
+    - type: Transform
+      pos: 3.5,11.5
+      parent: 1
+- proto: RMCVendorColaResearch
+  entities:
+  - uid: 121
+    components:
+    - type: Transform
+      pos: 2.5,11.5
+      parent: 1
+- proto: RMCWindowFrameWood
+  entities:
+  - uid: 28
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+- proto: RMCWindowWoodReinforced
+  entities:
+  - uid: 29
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      pos: 8.5,0.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      pos: 9.5,0.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      pos: 11.5,0.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      pos: 12.5,0.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 14.5,2.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      pos: 14.5,3.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      pos: 14.5,5.5
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      pos: 14.5,8.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      pos: 14.5,10.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      pos: 14.5,11.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      pos: 14.5,13.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      pos: 14.5,14.5
+      parent: 1
+- proto: WarpPoint
+  entities:
+  - uid: 186
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,5.5
+      parent: 1
+- proto: WeaponShotgunM357
+  entities:
+  - uid: 161
+    components:
+    - type: Transform
+      pos: 9.5,9.5
+      parent: 1
+...

--- a/Resources/Maps/_RMC14/Inserts/Trijent/surv_spawn_dam.yml
+++ b/Resources/Maps/_RMC14/Inserts/Trijent/surv_spawn_dam.yml
@@ -1,0 +1,678 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 264.0.2
+  forkId: ""
+  forkVersion: ""
+  time: 03/03/2026 23:23:27
+  entityCount: 93
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  0: Space
+  198: CMFloorPlating
+  2: CMFloorSteelPrison
+  3: CMFloorSteelPrisonBrightClean
+  5: CMFloorSteelPrisonDarkYellow0
+  7: CMFloorSteelPrisonDarkYellow1
+  9: CMFloorSteelPrisonDarkYellow2
+  1: CMFloorSteelPrisonDarkYellow3
+  8: CMFloorSteelPrisonDarkYellow6
+  4: CMFloorSteelPrisonDarkYellowCorners0
+  6: CMFloorSteelPrisonDarkYellowCorners1
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: grid
+    - type: Transform
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: AQAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAQAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAACAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAgAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAACAAAAAAAAAwAAAAAAAAMAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAGAAAAAAAABwAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAgAAAAAAAAMAAAAAAAADAAAAAAAAAgAAAAAAAAYAAAAAAAAHAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAIAAAAAAAAJAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodFloor3
+          decals:
+            7: 1.3149338,0.73826194
+            11: 9.198381,0.2573564
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodFloor4
+          decals:
+            3: 1.554517,2.166337
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodFloor6
+          decals:
+            10: 8.292131,0.49710643
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodFloor7
+          decals:
+            4: 0.22118378,1.9891305
+            8: 1.0545168,2.9689775
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodSplatter3
+          decals:
+            5: 3.4503503,5.1475744
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodSplatter5
+          decals:
+            2: 1.4399338,3.709075
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodTrail5
+          decals:
+            9: 1.5520501,2.7486706
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodXenonidSplatter3
+          decals:
+            6: 2.5441003,5.512411
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodXenonidSplatter6
+          decals:
+            1: 2.9503503,5.9710627
+    - type: GridAtmosphere
+      version: 2
+      data:
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: ImplicitRoof
+- proto: Bedroll
+  entities:
+  - uid: 63
+    components:
+    - type: Transform
+      pos: 7.5,2.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      pos: 9.5,1.5
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      pos: 9.5,0.5
+      parent: 1
+  - uid: 87
+    components:
+    - type: Transform
+      pos: 7.897359,1.5683129
+      parent: 1
+  - uid: 88
+    components:
+    - type: Transform
+      pos: 8.564026,2.5690079
+      parent: 1
+  - uid: 89
+    components:
+    - type: Transform
+      pos: 6.2619414,1.3494103
+      parent: 1
+- proto: BedrollFolded
+  entities:
+  - uid: 66
+    components:
+    - type: Transform
+      pos: 8.5,4.5
+      parent: 1
+- proto: CMBarricadeSandbag
+  entities:
+  - uid: 79
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+- proto: CMCrowbarRed
+  entities:
+  - uid: 9
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+- proto: CMDisposalUnit
+  entities:
+  - uid: 20
+    components:
+    - type: Transform
+      pos: 5.5,6.5
+      parent: 1
+- proto: CMFlare
+  entities:
+  - uid: 22
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+- proto: CMFlash
+  entities:
+  - uid: 8
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+- proto: CMRack
+  entities:
+  - uid: 10
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+- proto: CMRodMetal1
+  entities:
+  - uid: 69
+    components:
+    - type: Transform
+      pos: 0.87268686,1.7208232
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      pos: 0.51852036,3.2322896
+      parent: 1
+- proto: CMSpawnPointSurvivor
+  entities:
+  - uid: 56
+    components:
+    - type: Transform
+      pos: 9.5,1.5
+      parent: 1
+  - uid: 80
+    components:
+    - type: Transform
+      pos: 7.5,2.5
+      parent: 1
+  - uid: 81
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 84
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 85
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 86
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 90
+    components:
+    - type: Transform
+      pos: 6.5,1.5
+      parent: 1
+  - uid: 91
+    components:
+    - type: Transform
+      pos: 8.5,2.5
+      parent: 1
+  - uid: 92
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 1
+  - uid: 93
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 1
+- proto: CMTable
+  entities:
+  - uid: 4
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 5
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 6
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 7
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      pos: 8.5,4.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: 9.5,4.5
+      parent: 1
+- proto: CMVentPump
+  entities:
+  - uid: 52
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 1
+- proto: DecalSpawnerBloodSplatters
+  entities:
+  - uid: 57
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+- proto: RMCBarricadeWood
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 3
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,6.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,6.5
+      parent: 1
+- proto: RMCBasePropCasing1
+  entities:
+  - uid: 33
+    components:
+    - type: Transform
+      pos: 4.1935253,4.7928133
+      parent: 1
+- proto: RMCBasePropCasing11
+  entities:
+  - uid: 34
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.6785421,4.6176534
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.2514586,5.0763054
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.8868754,5.712163
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.6785421,5.9102173
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.2514586,6.066576
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.8556254,5.83725
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.0743754,5.5453806
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.4702086,5.3473268
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.0847926,5.805979
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.8035426,5.5558043
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.6993756,5.3056307
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.105626,5.0241857
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.3347926,5.055457
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.522292,6.0248804
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5431256,6.1395435
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.491042,5.524533
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5952086,5.3369026
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.293126,5.3160543
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.177052,1.0355809
+      parent: 1
+- proto: RMCBasePropCasing2
+  entities:
+  - uid: 32
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.6368754,5.232663
+      parent: 1
+- proto: RMCDirtBandageProp6
+  entities:
+  - uid: 60
+    components:
+    - type: Transform
+      pos: 2.2202086,2.191038
+      parent: 1
+- proto: RMCDirtBandageProp7
+  entities:
+  - uid: 59
+    components:
+    - type: Transform
+      pos: 1.4389586,1.8262014
+      parent: 1
+- proto: RMCGasPipeStraight
+  entities:
+  - uid: 70
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 74
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 75
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+- proto: RMCLightFixtureOffset
+  entities:
+  - uid: 12
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,2.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,3.5
+      parent: 1
+- proto: RMCMREWeYa
+  entities:
+  - uid: 61
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,2.5
+      parent: 1
+  - uid: 62
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,3.5
+      parent: 1
+- proto: RMCParasiteProp
+  entities:
+  - uid: 67
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 1
+- proto: RMCPlankWood2
+  entities:
+  - uid: 27
+    components:
+    - type: Transform
+      pos: 1.7963605,0.97527385
+      parent: 1
+- proto: RMCRadioHandheldColonyOff
+  entities:
+  - uid: 23
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+- proto: RMCRecharger
+  entities:
+  - uid: 24
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+- proto: RMCRollerBedHospitalBlood
+  entities:
+  - uid: 28
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+- proto: RMCSecureCaseDouble
+  entities:
+  - uid: 77
+    components:
+    - type: Transform
+      pos: 9.5,3.5
+      parent: 1
+- proto: RMCSecureCaseSmall
+  entities:
+  - uid: 78
+    components:
+    - type: Transform
+      pos: 8.5,3.5
+      parent: 1
+- proto: RMCSpawnerCorpseColonist
+  entities:
+  - uid: 55
+    components:
+    - type: Transform
+      pos: 9.5,0.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+- proto: RMCSpawnerRandomPowercell
+  entities:
+  - uid: 16
+    components:
+    - type: Transform
+      pos: 7.5,4.5
+      parent: 1
+- proto: RMCSpawnerRandomTools
+  entities:
+  - uid: 11
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+- proto: RMCStool
+  entities:
+  - uid: 19
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 1
+- proto: RMCTablePartTan
+  entities:
+  - uid: 68
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.84522104,0.97037065
+      parent: 1
+- proto: RMCWeaponPistolHoldout
+  entities:
+  - uid: 53
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.665235,1.2023637
+      parent: 1
+...

--- a/Resources/Maps/_RMC14/Inserts/Trijent/surv_spawn_hospital.yml
+++ b/Resources/Maps/_RMC14/Inserts/Trijent/surv_spawn_hospital.yml
@@ -1,0 +1,955 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 264.0.2
+  forkId: ""
+  forkVersion: ""
+  time: 03/03/2026 23:58:39
+  entityCount: 125
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  0: Space
+  198: CMFloorPlating
+  13: CMFloorSteelPrisonBrightClean
+  2: CMFloorSteelPrisonWhiteFull
+  4: CMFloorSteelPrisonWhiteGreen0
+  9: CMFloorSteelPrisonWhiteGreen1
+  3: CMFloorSteelPrisonWhiteGreen2
+  12: CMFloorSteelPrisonWhiteGreen3
+  7: CMFloorSteelPrisonWhiteGreen4
+  8: CMFloorSteelPrisonWhiteGreen5
+  5: CMFloorSteelPrisonWhiteGreen6
+  6: CMFloorSteelPrisonWhiteGreen7
+  18: CMFloorSteelPrisonWhiteGreenCorner0
+  11: CMFloorSteelPrisonWhiteGreenCorner1
+  10: CMFloorSteelPrisonWhiteGreenCorner2
+  1: CMFloorSteelPrisonWhiteGreenCorner3
+  16: RMCFloorPlatingDamage1
+  15: RMCFloorPlatingDamage2
+  14: RMCFloorPlatingDamage3
+  17: RMCFloorPlatingScorched
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: grid
+    - type: Transform
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: xgAAAAAAAAEAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMYAAAAAAAACAAAAAAAABQAAAAAAAAYAAAAAAAACAAAAAAAAAwAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADGAAAAAAAAAgAAAAAAAAcAAAAAAAAIAAAAAAAAAgAAAAAAAAMAAAAAAAAJAAAAAAAACQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxgAAAAAAAAoAAAAAAAACAAAAAAAAAgAAAAAAAAsAAAAAAAAFAAAAAAAACQAAAAAAAAkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMYAAAAAAAAMAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADGAAAAAAAADAAAAAAAAAIAAAAAAAACAAAAAAAAAwAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxgAAAAAAAAwAAAAAAAACAAAAAAAAAgAAAAAAAAMAAAAAAAANAAAAAAAADQAAAAAAAA4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMYAAAAAAAAMAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAADQAAAAAAAA8AAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARAAAAAAAAAQAAAAAAAAIAAAAAAAACAAAAAAAAEgAAAAAAAAcAAAAAAAAEAAAAAAAADwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxgAAAAAAAAIAAAAAAAAFAAAAAAAABgAAAAAAAAIAAAAAAAADAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMYAAAAAAAACAAAAAAAABwAAAAAAAAgAAAAAAAACAAAAAAAAAwAAAAAAAAkAAAAAAAAJAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADGAAAAAAAACQAAAAAAAAoAAAAAAAACAAAAAAAAAgAAAAAAAAMAAAAAAAAJAAAAAAAACQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodFloor1
+          decals:
+            16: 6.784111,10.127704
+            18: 0.9299438,8.699193
+            19: 1.4611938,10.074732
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodFloor3
+          decals:
+            15: 6.9924445,9.116585
+            20: 0.9924438,9.199123
+            21: 1.6278605,9.063613
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodFloor4
+          decals:
+            17: 7.044528,10.367454
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodSplatter1
+          decals:
+            9: 4.67872,2.9079263
+            14: 2.20997,4.0337086
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodSplatter3
+          decals:
+            6: 1.6519942,5.9450912
+            11: 1.61622,3.4082742
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodTrail3
+          decals:
+            10: 3.0641365,3.1164045
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodTrail6
+          decals:
+            12: 2.1370533,3.1268282
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodTrail7
+          decals:
+            13: 2.1891365,4.06498
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodXenonidFloor4
+          decals:
+            26: 1.9611938,1.4118519
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodXenonidFloor7
+          decals:
+            25: 4.5861945,1.0678627
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodXenonidSplatter3
+          decals:
+            22: 3.679944,0.098439455
+            23: 1.700777,0.3277657
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodXenonidSplatter4
+          decals:
+            8: 1.2457443,4.735918
+            24: 1.7424438,1.2033737
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodXenonidSplatter5
+          decals:
+            7: 0.881161,4.8505807
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodXenonidSplatter6
+          decals:
+            27: 2.5028605,1.4848194
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCScorch1
+          decals:
+            33: 7.190361,5.489575
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCScorch2
+          decals:
+            28: 6.6486945,5.2289777
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCScorch4
+          decals:
+            29: 6.607028,6.6362047
+            30: 7.159111,7.991313
+            32: 6.2111945,7.9704647
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCScorchSmall1
+          decals:
+            31: 6.0236945,7.574356
+        - node:
+            color: '#FFFFFFFF'
+            id: TriageBottom
+          decals:
+            1: 1.0131335,0.017828465
+            2: 2.0085042,0.02072525
+            3: 3.0085044,0.024451852
+            4: 4.0085044,0.024451852
+        - node:
+            color: '#FFFFFFFF'
+            id: TriageBottomLeft
+          decals:
+            5: 5.0085044,0.024451852
+    - type: GridAtmosphere
+      version: 2
+      data:
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: ImplicitRoof
+- proto: Bedroll
+  entities:
+  - uid: 73
+    components:
+    - type: Transform
+      pos: 7.3349705,5.325925
+      parent: 1
+  - uid: 74
+    components:
+    - type: Transform
+      pos: 6.574554,6.2640767
+      parent: 1
+- proto: CMBarricadeSandbag
+  entities:
+  - uid: 60
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,11.5
+      parent: 1
+- proto: CMChair
+  entities:
+  - uid: 55
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,4.5
+      parent: 1
+- proto: CMChairFolded
+  entities:
+  - uid: 49
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+- proto: CMChairOfficeDark
+  entities:
+  - uid: 45
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.160445,5.6801457
+      parent: 1
+- proto: CMCircularSaw
+  entities:
+  - uid: 19
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+- proto: CMDoubleDoorMedicalGlass
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      pos: 0.5,10.5
+      parent: 1
+  - uid: 4
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,9.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+- proto: CMHandsWhite
+  entities:
+  - uid: 20
+    components:
+    - type: Transform
+      pos: 6.5,9.5
+      parent: 1
+- proto: CMHealthAnalyzer
+  entities:
+  - uid: 22
+    components:
+    - type: Transform
+      pos: 4.5,8.5
+      parent: 1
+- proto: CMRodMetal1
+  entities:
+  - uid: 17
+    components:
+    - type: Transform
+      pos: 1.2040777,5.381852
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.827112,6.9796324
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.6187787,8.449404
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      pos: 7.431279,6.7607303
+      parent: 1
+- proto: CMShardGlass
+  entities:
+  - uid: 14
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.7353277,5.4443955
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.4228277,6.0177107
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.26657772,5.6424503
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      pos: 7.368779,6.5626764
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.004196,7.709306
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.0562787,7.3548927
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.1083627,8.574491
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.6708627,7.135991
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.6780236,8.52128
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.1780236,8.719335
+      parent: 1
+- proto: CMSpawnPointSurvivor
+  entities:
+  - uid: 108
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 1
+  - uid: 109
+    components:
+    - type: Transform
+      pos: 6.5,6.5
+      parent: 1
+  - uid: 110
+    components:
+    - type: Transform
+      pos: 6.5,7.5
+      parent: 1
+  - uid: 111
+    components:
+    - type: Transform
+      pos: 5.5,9.5
+      parent: 1
+  - uid: 112
+    components:
+    - type: Transform
+      pos: 4.5,10.5
+      parent: 1
+  - uid: 113
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 114
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+  - uid: 115
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 116
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 117
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 118
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 119
+    components:
+    - type: Transform
+      pos: 6.5,3.5
+      parent: 1
+- proto: CMTableReinforced
+  entities:
+  - uid: 24
+    components:
+    - type: Transform
+      pos: 5.5,7.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      pos: 5.5,6.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      pos: 5.5,5.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,4.5
+      parent: 1
+- proto: CMVentPump
+  entities:
+  - uid: 77
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,10.5
+      parent: 1
+- proto: CMWallReinforced
+  entities:
+  - uid: 6
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 1
+  - uid: 7
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+- proto: CMWindowReinforcedDirectional
+  entities:
+  - uid: 28
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,7.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,7.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,6.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,5.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,4.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      pos: 7.5,4.5
+      parent: 1
+- proto: CMWindowWhiteColonyReinforced
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      pos: 0.5,11.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+- proto: RMCBarricadeWood
+  entities:
+  - uid: 5
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,11.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,9.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,10.5
+      parent: 1
+  - uid: 61
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,11.5
+      parent: 1
+  - uid: 62
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,10.5
+      parent: 1
+  - uid: 75
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,8.5
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,9.5
+      parent: 1
+  - uid: 79
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 80
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,2.5
+      parent: 1
+- proto: RMCBasePropCasing10
+  entities:
+  - uid: 83
+    components:
+    - type: Transform
+      pos: 2.4611938,10.814482
+      parent: 1
+- proto: RMCBasePropCasing11
+  entities:
+  - uid: 59
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.0016365,5.7011857
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.20997,5.9617834
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.9391365,6.274501
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.27247,6.7018814
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.0328865,6.8582397
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.2933033,5.920088
+      parent: 1
+  - uid: 84
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.0341105,10.178623
+      parent: 1
+  - uid: 85
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.4611938,10.043113
+      parent: 1
+  - uid: 86
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.2841105,8.406559
+      parent: 1
+  - uid: 87
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.6278605,9.115385
+      parent: 1
+  - uid: 88
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.4924438,9.970145
+      parent: 1
+  - uid: 89
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.700777,10.387102
+      parent: 1
+  - uid: 90
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.0236945,2.558134
+      parent: 1
+  - uid: 91
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.138277,8.917331
+      parent: 1
+  - uid: 92
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.3674438,8.6567335
+      parent: 1
+  - uid: 93
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.0028605,8.979874
+      parent: 1
+  - uid: 94
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5653605,10.772786
+      parent: 1
+  - uid: 95
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.6486938,10.83533
+      parent: 1
+  - uid: 96
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.2528605,2.818732
+      parent: 1
+  - uid: 100
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.8778605,3.5171337
+      parent: 1
+  - uid: 101
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.6799438,2.9229712
+      parent: 1
+  - uid: 102
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5341105,2.6102538
+      parent: 1
+  - uid: 103
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.367444,2.1203303
+      parent: 1
+  - uid: 104
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.419527,1.9014282
+      parent: 1
+  - uid: 105
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.4924445,2.3288078
+      parent: 1
+  - uid: 106
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.1799438,3.673492
+      parent: 1
+  - uid: 107
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.4299438,4.017481
+      parent: 1
+- proto: RMCBasePropCasing7
+  entities:
+  - uid: 82
+    components:
+    - type: Transform
+      pos: 2.2528605,9.594885
+      parent: 1
+- proto: RMCGasPipeStraight
+  entities:
+  - uid: 120
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,10.5
+      parent: 1
+- proto: RMCInflatableDoor
+  entities:
+  - uid: 125
+    components:
+    - type: Transform
+      pos: 7.5,2.5
+      parent: 1
+- proto: RMCInflatableDoorFolded1
+  entities:
+  - uid: 78
+    components:
+    - type: Transform
+      pos: 6.888278,1.4853735
+      parent: 1
+- proto: RMCLightFixtureEmptyOffset
+  entities:
+  - uid: 44
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,7.5
+      parent: 1
+- proto: RMCLightFixtureOffset
+  entities:
+  - uid: 54
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,11.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,4.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 1
+- proto: RMCMREWeYa
+  entities:
+  - uid: 121
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.575778,4.9384093
+      parent: 1
+  - uid: 123
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.544528,5.6680827
+      parent: 1
+- proto: RMCParasiteProp
+  entities:
+  - uid: 18
+    components:
+    - type: Transform
+      pos: 1.6415777,5.7466893
+      parent: 1
+  - uid: 97
+    components:
+    - type: Transform
+      pos: 2.732027,1.9431236
+      parent: 1
+  - uid: 98
+    components:
+    - type: Transform
+      pos: 4.336194,1.0466678
+      parent: 1
+  - uid: 99
+    components:
+    - type: Transform
+      pos: 2.3049438,0.8590374
+      parent: 1
+- proto: RMCPlankWood2
+  entities:
+  - uid: 63
+    components:
+    - type: Transform
+      pos: 7.040133,10.350067
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      pos: 6.8109665,9.161741
+      parent: 1
+  - uid: 81
+    components:
+    - type: Transform
+      pos: 2.0228608,4.6485143
+      parent: 1
+- proto: RMCRecharger
+  entities:
+  - uid: 47
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,4.5
+      parent: 1
+- proto: RMCRollerBedHospital
+  entities:
+  - uid: 48
+    components:
+    - type: Transform
+      pos: 1.7333617,9.438857
+      parent: 1
+- proto: RMCRollerBedHospitalBlood
+  entities:
+  - uid: 53
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+- proto: RMCRollerBedHospitalSheet
+  entities:
+  - uid: 50
+    components:
+    - type: Transform
+      pos: 1.6708617,10.178955
+      parent: 1
+- proto: RMCSecureCaseDouble
+  entities:
+  - uid: 122
+    components:
+    - type: Transform
+      pos: 7.5,3.5
+      parent: 1
+- proto: RMCSecureCaseSmall
+  entities:
+  - uid: 124
+    components:
+    - type: Transform
+      pos: 4.5,7.5
+      parent: 1
+- proto: RMCSpawnerCorpseDoctor
+  entities:
+  - uid: 21
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+- proto: RMCSpawnerIntelScience
+  entities:
+  - uid: 23
+    components:
+    - type: Transform
+      pos: 5.5,6.5
+      parent: 1
+- proto: RMCWindowFrameBunker
+  entities:
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+...

--- a/Resources/Maps/_RMC14/Inserts/Trijent/surv_spawn_tunneldorm.yml
+++ b/Resources/Maps/_RMC14/Inserts/Trijent/surv_spawn_tunneldorm.yml
@@ -1,0 +1,1172 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 264.0.2
+  forkId: ""
+  forkVersion: ""
+  time: 03/04/2026 03:12:13
+  entityCount: 179
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  0: Space
+  198: CMFloorPlating
+  14: CMFloorSteelPrisonKitchen
+  4: RMCFloorCement1
+  3: RMCFloorCement10
+  6: RMCFloorCement12
+  13: RMCFloorCement14
+  7: RMCFloorCement15
+  2: RMCFloorCement3
+  9: RMCFloorHybrisaWood
+  8: RMCFloorKutjevoFakeWood0
+  12: RMCFloorPlatingDamage1
+  11: RMCFloorPlatingDamage2
+  10: RMCFloorPlatingScorched
+  1: RMCPlanetRedDesertRockTransitionNorth
+  5: RMCPlanetRedDesertRockTransitionSouth
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: grid
+    - type: Transform
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: AQAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAQAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAACAAAAAAAAAwAAAAAAAAMAAAAAAAAEAAAAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAYAAAAAAAAGAAAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxgAAAAAAAMYAAAAAAAAIAAAAAAAACAAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAkAAAAAAAAJAAAAAAAACAAAAAAAAAgAAAAAAAAJAAAAAAAACQAAAAAAAAkAAAAAAAAJAAAAAAAACQAAAAAAAAoAAAAAAADGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJAAAAAAAACQAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAoAAAAAAAALAAAAAAAACgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACQAAAAAAAAkAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAMYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAkAAAAAAAAJAAAAAAAACAAAAAAAAAgAAAAAAAAJAAAAAAAACQAAAAAAAAkAAAAAAAAIAAAAAAAACQAAAAAAAAkAAAAAAADGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAAAIAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAACAAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMYAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAADGAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAxgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADGAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAxgAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAMYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+        -1,0:
+          ind: -1,0
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADGAAAAAAAADQAAAAAAAAYAAAAAAAAGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMYAAAAAAAAOAAAAAAAADgAAAAAAAA4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADGAAAAAAAADgAAAAAAAA4AAAAAAAAOAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxgAAAAAAAA4AAAAAAAAOAAAAAAAADgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMYAAAAAAAAOAAAAAAAADgAAAAAAAA4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#FFFFFFFF'
+            id: Dirt
+          decals:
+            1: 0,3
+            4: -1,4
+            5: -2,6
+            10: 6,4
+            11: 7,4
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtHeavyMonotile
+          decals:
+            13: 7,5
+            14: 4,6
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtLight
+          decals:
+            2: -1,6
+            6: -3,6
+            7: -3,4
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtMedium
+          decals:
+            3: -3,5
+    - type: GridAtmosphere
+      version: 2
+      data:
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: ImplicitRoof
+- proto: Bedroll
+  entities:
+  - uid: 83
+    components:
+    - type: Transform
+      pos: 1.7737045,6.556953
+      parent: 1
+  - uid: 132
+    components:
+    - type: Transform
+      pos: 2.1330795,5.822578
+      parent: 1
+  - uid: 136
+    components:
+    - type: Transform
+      pos: 4.93049,6.697578
+      parent: 1
+- proto: CMAirlock
+  entities:
+  - uid: 52
+    components:
+    - type: Transform
+      pos: 3.5,8.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      pos: 7.5,8.5
+      parent: 1
+- proto: CMBarricadeSandbag
+  entities:
+  - uid: 62
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,5.5
+      parent: 1
+  - uid: 78
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 137
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 1
+- proto: CMBedsheetBrown
+  entities:
+  - uid: 111
+    components:
+    - type: Transform
+      pos: 4.5,10.5
+      parent: 1
+  - uid: 112
+    components:
+    - type: Transform
+      pos: 8.5,9.5
+      parent: 1
+- proto: CMChair
+  entities:
+  - uid: 71
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 100
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,10.5
+      parent: 1
+  - uid: 101
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,9.5
+      parent: 1
+- proto: CMChairFolded
+  entities:
+  - uid: 73
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 114
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,5.5
+      parent: 1
+- proto: CMGauze10
+  entities:
+  - uid: 141
+    components:
+    - type: Transform
+      pos: 5.5190077,7.579103
+      parent: 1
+- proto: CMGirder
+  entities:
+  - uid: 50
+    components:
+    - type: Transform
+      pos: 10.5,4.5
+      parent: 1
+- proto: CMMicrowave
+  entities:
+  - uid: 75
+    components:
+    - type: Transform
+      pos: -2.3597536,7.8031845
+      parent: 1
+- proto: CMOintment10
+  entities:
+  - uid: 80
+    components:
+    - type: Transform
+      pos: 0.7053695,7.857435
+      parent: 1
+- proto: CMPlushieFarwa
+  entities:
+  - uid: 109
+    components:
+    - type: Transform
+      pos: 4.5492306,10.65431
+      parent: 1
+- proto: CMPosterSafetyClean
+  entities:
+  - uid: 121
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+- proto: CMPottedPlant26
+  entities:
+  - uid: 113
+    components:
+    - type: Transform
+      pos: 2.3773556,9.232435
+      parent: 1
+- proto: CMRollerBed
+  entities:
+  - uid: 81
+    components:
+    - type: Transform
+      pos: 1.4189072,7.857435
+      parent: 1
+- proto: CMShardGlass
+  entities:
+  - uid: 56
+    components:
+    - type: Transform
+      pos: -0.67652273,3.7406845
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      pos: 9.682852,6.6938095
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      pos: 10.448477,5.8656845
+      parent: 1
+  - uid: 63
+    components:
+    - type: Transform
+      pos: 6.340477,3.4906845
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      pos: 7.231102,3.7406845
+      parent: 1
+- proto: CMSpawnPointSurvivor
+  entities:
+  - uid: 168
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 169
+    components:
+    - type: Transform
+      pos: 3.5,9.5
+      parent: 1
+  - uid: 170
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 171
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 172
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 173
+    components:
+    - type: Transform
+      pos: 6.5,5.5
+      parent: 1
+  - uid: 174
+    components:
+    - type: Transform
+      pos: 6.5,6.5
+      parent: 1
+  - uid: 175
+    components:
+    - type: Transform
+      pos: 8.5,6.5
+      parent: 1
+  - uid: 176
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 177
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+  - uid: 178
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 179
+    components:
+    - type: Transform
+      pos: 5.5,6.5
+      parent: 1
+- proto: CMTable
+  entities:
+  - uid: 69
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+- proto: CMTableWooden
+  entities:
+  - uid: 60
+    components:
+    - type: Transform
+      pos: 7.5,4.5
+      parent: 1
+  - uid: 61
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      pos: 5.5,7.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      pos: 4.5,7.5
+      parent: 1
+  - uid: 98
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 99
+    components:
+    - type: Transform
+      pos: 8.5,10.5
+      parent: 1
+  - uid: 153
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 1
+- proto: CMVentPump
+  entities:
+  - uid: 157
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 1
+- proto: CMWallMetal
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
+  - uid: 3
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 1
+  - uid: 4
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 5
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 6
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 7
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      pos: 1.5,8.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      pos: 1.5,10.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      pos: 1.5,11.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      pos: 2.5,11.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: 3.5,11.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      pos: 4.5,11.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      pos: 5.5,11.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      pos: 6.5,11.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      pos: 8.5,11.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      pos: 9.5,11.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      pos: 9.5,10.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      pos: 9.5,9.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      pos: 9.5,8.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      pos: 10.5,8.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      pos: 5.5,10.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      pos: 5.5,9.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      pos: 5.5,8.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      pos: 4.5,8.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: 6.5,8.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 8.5,8.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: 10.5,7.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      pos: 10.5,3.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      pos: 9.5,3.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      pos: 8.5,3.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 104
+    components:
+    - type: Transform
+      pos: 7.5,11.5
+      parent: 1
+- proto: CMWindowWhiteColonyReinforced
+  entities:
+  - uid: 42
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+- proto: RMCAshtray
+  entities:
+  - uid: 110
+    components:
+    - type: Transform
+      pos: 8.377356,10.388685
+      parent: 1
+- proto: RMCBarricadeWood
+  entities:
+  - uid: 44
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 77
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,6.5
+      parent: 1
+  - uid: 79
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+- proto: RMCBasePropCasing11
+  entities:
+  - uid: 105
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.7127695,9.52931
+      parent: 1
+- proto: RMCBasePropCasing4
+  entities:
+  - uid: 133
+    components:
+    - type: Transform
+      pos: 0.7737045,4.572578
+      parent: 1
+- proto: RMCBedDingy
+  entities:
+  - uid: 96
+    components:
+    - type: Transform
+      pos: 8.5,9.5
+      parent: 1
+  - uid: 97
+    components:
+    - type: Transform
+      pos: 4.5,10.5
+      parent: 1
+- proto: RMCBoxDonut
+  entities:
+  - uid: 76
+    components:
+    - type: Transform
+      pos: -1.5160036,7.8344345
+      parent: 1
+- proto: RMCBoxShotgunBuckshot
+  entities:
+  - uid: 91
+    components:
+    - type: Transform
+      pos: 4.6272445,7.576185
+      parent: 1
+- proto: RMCBoxShotgunSlugs
+  entities:
+  - uid: 138
+    components:
+    - type: Transform
+      pos: 5.150674,7.8442564
+      parent: 1
+- proto: RMCCabinetBase
+  entities:
+  - uid: 94
+    components:
+    - type: Transform
+      pos: 4.5,9.5
+      parent: 1
+  - uid: 95
+    components:
+    - type: Transform
+      pos: 6.5,10.5
+      parent: 1
+- proto: RMCCalendarColonist
+  entities:
+  - uid: 87
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+- proto: RMCCatClock
+  entities:
+  - uid: 123
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: RMCDecalSpawnerBloodSplatters
+  entities:
+  - uid: 86
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+  - uid: 116
+    components:
+    - type: Transform
+      pos: 9.5,7.5
+      parent: 1
+  - uid: 117
+    components:
+    - type: Transform
+      pos: 8.5,7.5
+      parent: 1
+  - uid: 128
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 148
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+- proto: RMCDecalSpawnerXenoSplatters
+  entities:
+  - uid: 118
+    components:
+    - type: Transform
+      pos: 9.5,4.5
+      parent: 1
+  - uid: 119
+    components:
+    - type: Transform
+      pos: 10.5,6.5
+      parent: 1
+  - uid: 124
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 125
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 127
+    components:
+    - type: Transform
+      pos: 6.5,3.5
+      parent: 1
+  - uid: 129
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 130
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 134
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 152
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 166
+    components:
+    - type: Transform
+      pos: 8.5,5.5
+      parent: 1
+  - uid: 167
+    components:
+    - type: Transform
+      pos: 10.5,5.5
+      parent: 1
+- proto: RMCDeskFanTan
+  entities:
+  - uid: 108
+    components:
+    - type: Transform
+      pos: 8.642981,10.919935
+      parent: 1
+- proto: RMCDirtBandageProp6
+  entities:
+  - uid: 150
+    components:
+    - type: Transform
+      pos: -0.8531923,5.797853
+      parent: 1
+- proto: RMCDirtBandageProp7
+  entities:
+  - uid: 149
+    components:
+    - type: Transform
+      pos: 0.7405577,7.266603
+      parent: 1
+- proto: RMCDoubleDoorGenericGlass
+  entities:
+  - uid: 49
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,3.5
+      parent: 1
+- proto: RMCGasPipeStraight
+  entities:
+  - uid: 158
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 159
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 160
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 161
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 162
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 163
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+- proto: RMCGunRackM357WallFilled
+  entities:
+  - uid: 92
+    components:
+    - type: Transform
+      pos: 5.5,8.5
+      parent: 1
+- proto: RMCItemPoolBuckshot
+  entities:
+  - uid: 139
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 140
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 1
+- proto: RMCLightFixtureOffset
+  entities:
+  - uid: 142
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 143
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 144
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,7.5
+      parent: 1
+  - uid: 145
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,7.5
+      parent: 1
+  - uid: 146
+    components:
+    - type: Transform
+      pos: 2.5,9.5
+      parent: 1
+  - uid: 147
+    components:
+    - type: Transform
+      pos: 6.5,9.5
+      parent: 1
+- proto: RMCMagazinePistolHoldout
+  entities:
+  - uid: 84
+    components:
+    - type: Transform
+      pos: 7.332159,4.750978
+      parent: 1
+  - uid: 85
+    components:
+    - type: Transform
+      pos: 7.5862045,4.681953
+      parent: 1
+- proto: RMCMREWeYa
+  entities:
+  - uid: 154
+    components:
+    - type: Transform
+      pos: 2.464366,7.813478
+      parent: 1
+  - uid: 155
+    components:
+    - type: Transform
+      pos: -1.613759,5.125978
+      parent: 1
+  - uid: 156
+    components:
+    - type: Transform
+      pos: 6.636241,7.266603
+      parent: 1
+- proto: RMCNanoMed
+  entities:
+  - uid: 93
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+- proto: RMCOverheadPipeCorner
+  entities:
+  - uid: 164
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,9.5
+      parent: 1
+  - uid: 165
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,9.5
+      parent: 1
+- proto: RMCParasiteProp
+  entities:
+  - uid: 151
+    components:
+    - type: Transform
+      pos: 1.5686827,2.563478
+      parent: 1
+- proto: RMCPlankWood1
+  entities:
+  - uid: 88
+    components:
+    - type: Transform
+      pos: 0.48661947,4.09181
+      parent: 1
+  - uid: 89
+    components:
+    - type: Transform
+      pos: 9.944263,5.400703
+      parent: 1
+  - uid: 90
+    components:
+    - type: Transform
+      pos: 8.627245,4.419935
+      parent: 1
+  - uid: 126
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 131
+    components:
+    - type: Transform
+      pos: 3.6018295,4.3591256
+      parent: 1
+- proto: RMCPosterWEYA4
+  entities:
+  - uid: 120
+    components:
+    - type: Transform
+      pos: 6.5,11.5
+      parent: 1
+- proto: RMCPropCommunicationsConsoleAlt
+  entities:
+  - uid: 102
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,10.5
+      parent: 1
+- proto: RMCSecureCaseDouble
+  entities:
+  - uid: 135
+    components:
+    - type: Transform
+      pos: 6.4142575,7.775703
+      parent: 1
+- proto: RMCSpawnerCorpseColonist
+  entities:
+  - uid: 103
+    components:
+    - type: Transform
+      pos: 7.5,10.5
+      parent: 1
+- proto: RMCSpawnerCorpseEngineer
+  entities:
+  - uid: 115
+    components:
+    - type: Transform
+      pos: 9.5,7.5
+      parent: 1
+- proto: RMCSpawnerIntelClose
+  entities:
+  - uid: 106
+    components:
+    - type: Transform
+      pos: 6.5,10.5
+      parent: 1
+  - uid: 107
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+- proto: RMCWallPropBloodWall
+  entities:
+  - uid: 22
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.2908945,11.40431
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: RMCWallRockTrijent
+  entities:
+  - uid: 48
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 1
+- proto: RMCWaterCoolerStacks
+  entities:
+  - uid: 74
+    components:
+    - type: Transform
+      pos: -0.7660036,8.0219345
+      parent: 1
+- proto: RMCWeaponPistolHoldout
+  entities:
+  - uid: 82
+    components:
+    - type: Transform
+      pos: 7.277523,9.81056
+      parent: 1
+    - type: ContainerContainer
+      containers:
+        gun_magazine: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+        gun_chamber: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+        rmc-aslot-barrel: !type:ContainerSlot
+          showEnts: False
+          occludes: False
+          ent: null
+        rmc-aslot-rail: !type:ContainerSlot
+          showEnts: False
+          occludes: False
+          ent: null
+        rmc-aslot-underbarrel: !type:ContainerSlot
+          showEnts: False
+          occludes: False
+          ent: null
+    - type: UseDelay
+      delays:
+        RMCWieldDelay:
+          endTime: 1240.9206243
+          startTime: 1514.2984857
+          length: 0.4
+    - type: RMCWeaponAccuracy
+      modifiedAccuracyMultiplier: 0.85
+- proto: RMCWindowFrameColony
+  entities:
+  - uid: 51
+    components:
+    - type: Transform
+      pos: 10.5,6.5
+      parent: 1
+- proto: RMCWindowFrameColonyReinforced
+  entities:
+  - uid: 40
+    components:
+    - type: Transform
+      pos: 6.5,3.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      pos: 7.5,3.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+- proto: RMCWoodClock
+  entities:
+  - uid: 122
+    components:
+    - type: Transform
+      pos: 3.5,11.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: TableReinforced
+  entities:
+  - uid: 67
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+...

--- a/Resources/Prototypes/_RMC14/Entities/Markers/Inserts/trijent.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Markers/Inserts/trijent.yml
@@ -107,3 +107,44 @@
       probability: 0.2
     clearDecals: false
     replaceAreas: false
+
+# Regular Surv Spawns
+
+- type: entity
+  parent: RMCMapInsertTrijentBase
+  id: RMCMapInsertTrijentSurvSpawnHospital
+  name: Hospital Surv Spawn
+  suffix: Insert Trijent
+  components:
+  - type: MapInsert
+    variations:
+    - spawn: "/Maps/_RMC14/Inserts/Trijent/surv_spawn_hospital.yml"
+      probability: 1
+      nightmareScenario: trijent_surv_spawn_hospital
+    replaceAreas: false
+
+- type: entity
+  parent: RMCMapInsertTrijentBase
+  id: RMCMapInsertTrijentSurvSpawnDam
+  name: Dam Surv Spawn
+  suffix: Insert Trijent
+  components:
+  - type: MapInsert
+    variations:
+    - spawn: "/Maps/_RMC14/Inserts/Trijent/surv_spawn_dam.yml"
+      probability: 1
+      nightmareScenario: trijent_surv_spawn_dam
+    replaceAreas: false
+
+- type: entity
+  parent: RMCMapInsertTrijentBase
+  id: RMCMapInsertTrijentSurvSpawnBar
+  name: Bar Surv Spawn
+  suffix: Insert Trijent
+  components:
+  - type: MapInsert
+    variations:
+    - spawn: "/Maps/_RMC14/Inserts/Trijent/surv_spawn_bar.yml"
+      probability: 1
+      nightmareScenario: trijent_surv_spawn_bar
+    replaceAreas: false

--- a/Resources/Prototypes/_RMC14/Entities/Markers/Inserts/trijent.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Markers/Inserts/trijent.yml
@@ -148,3 +148,16 @@
       probability: 1
       nightmareScenario: trijent_surv_spawn_bar
     replaceAreas: false
+
+- type: entity
+  parent: RMCMapInsertTrijentBase
+  id: RMCMapInsertTrijentSurvSpawnTunnelDorm
+  name: Tunnel Dorm Surv Spawn
+  suffix: Insert Trijent
+  components:
+  - type: MapInsert
+    variations:
+    - spawn: "/Maps/_RMC14/Inserts/Trijent/surv_spawn_tunneldorm.yml"
+      probability: 1
+      nightmareScenario: trijent_surv_spawn_tunneldorm
+    replaceAreas: false

--- a/Resources/Prototypes/_RMC14/Entities/rmc_planets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/rmc_planets.yml
@@ -256,11 +256,13 @@
     announcement: "We've lost contact with Weston-Yamada's extra-solar colony, \"Trijent Dam\", on the planet \"Raijin.\" The UNS Almayer has been dispatched to assist."
     nightmareScenarios:
     - scenarioName: trijent_surv_spawn_bar # Reduce this once CLF/SPP survivors are in
-      scenarioProbability: 0.33
+      scenarioProbability: 0.25
     - scenarioName: trijent_surv_spawn_hospital
-      scenarioProbability: 0.33
+      scenarioProbability: 0.25
     - scenarioName: trijent_surv_spawn_dam
-      scenarioProbability: 0.34
+      scenarioProbability: 0.25
+    - scenarioName: trijent_surv_spawn_tunneldorm
+      scenarioProbability: 0.25
     survivorJobVariants:
       CMSurvivor:
       - CMSurvivor: -1

--- a/Resources/Prototypes/_RMC14/Entities/rmc_planets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/rmc_planets.yml
@@ -254,6 +254,13 @@
     camouflage: Desert
     minPlayers: 130
     announcement: "We've lost contact with Weston-Yamada's extra-solar colony, \"Trijent Dam\", on the planet \"Raijin.\" The UNS Almayer has been dispatched to assist."
+    nightmareScenarios:
+    - scenarioName: trijent_surv_spawn_bar # Reduce this once CLF/SPP survivors are in
+      scenarioProbability: 0.33
+    - scenarioName: trijent_surv_spawn_hospital
+      scenarioProbability: 0.33
+    - scenarioName: trijent_surv_spawn_dam
+      scenarioProbability: 0.34
     survivorJobVariants:
       CMSurvivor:
       - CMSurvivor: -1


### PR DESCRIPTION
## About the PR
Added three (One more WIP by SharkSnake) inserts where survivors spawn all together, with equally distributed spawn chance.

Removes all standard surv spawns so only insert survs can spawn

## Why / Balance
Tested, works. Continuing progress on surv rework

## Technical details
Yaml + mapping

## Media
<img width="1369" height="1168" alt="loot1" src="https://github.com/user-attachments/assets/528a0494-e411-4375-9af5-d4d8fd6bea99" />
<img width="1498" height="1196" alt="bar" src="https://github.com/user-attachments/assets/f0016ffa-e161-4d12-b5b5-7ed54f8d0636" />

<img width="1188" height="1235" alt="hospital" src="https://github.com/user-attachments/assets/f6a99259-5073-452b-be9b-9e8345702ad5" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: Survivor now spawn together instead of separately on Trijent Dam. Their holdout locations include the Dam, Bar and Hospital.