### PR TITLE
Fixed soak heal occurring multiple times

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Soak/XenoSoakSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Soak/XenoSoakSystem.cs
@@ -52,7 +52,7 @@ public sealed class XenoSoakSystem : EntitySystem
 
     private void OnXenoSoakingDamageChanged(Entity<XenoSoakingDamageComponent> xeno, ref DamageChangedEvent args)
     {
-        if (!args.DamageIncreased || args.DamageDelta == null || args.DamageDelta.GetTotal() < 0)
+        if (!args.DamageIncreased || args.DamageDelta == null || args.DamageDelta.GetTotal() < 0 || xeno.Comp.LifeStage > ComponentLifeStage.Running)
             return;
 
         xeno.Comp.DamageAccumulated += args.DamageDelta.GetTotal().Float();

--- a/Content.Shared/_RMC14/Xenonids/Soak/XenoSoakSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Soak/XenoSoakSystem.cs
@@ -52,7 +52,7 @@ public sealed class XenoSoakSystem : EntitySystem
 
     private void OnXenoSoakingDamageChanged(Entity<XenoSoakingDamageComponent> xeno, ref DamageChangedEvent args)
     {
-        if (!args.DamageIncreased || args.DamageDelta == null || args.DamageDelta.GetTotal() < 0 || xeno.Comp.LifeStage > ComponentLifeStage.Running)
+        if (!args.DamageIncreased || args.DamageDelta == null || args.DamageDelta.GetTotal() < 0 || !xeno.Comp.Running)
             return;
 
         xeno.Comp.DamageAccumulated += args.DamageDelta.GetTotal().Float();


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Steelcrest's Soak ability could potentially heal multiple times if damaged multiple times in the same frame. This PR fixes it to only trigger once at most.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfix.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed Steelcrest's Soak ability occasionally healing for more than intended.
