### PR TITLE
Fix PMC engi armor stats

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/pmc.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/pmc.yml
@@ -238,7 +238,6 @@
   - type: Corrodible
     isCorrodible: false
 
-# TODO RMC14: Do we not have something for fire resistance?
 - type: entity
   parent: RMCArmorM4PMCNoLight
   id: RMCArmorM4PMCEngineer
@@ -248,13 +247,14 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/PMC/engineer.rsi
   - type: CMArmor
-    melee: 15
     bullet: 15 # CLOTHING_ARMOR_MEDIUMLOW
-    bio: 20 # CLOTHING_ARMOR_MEDIUM
     explosionArmor: 20 # CLOTHING_ARMOR_MEDIUM
-  - type: ClothingSpeedModifier # SLOWDOWN_ARMOR_LIGHT
-    walkModifier: 0.725
-    sprintModifier: 0.725
+    # TODO 20 internal damage protection
+  - type: TemperatureProtection
+    heatingCoefficient: 0.001
+    coolingCoefficient: 0.3
+  - type: RMCImmuneToIgnition
+    immuneToDirectHits: false
 
 - type: entity
   parent: RMCBaseJacket


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Brings them to parity, giving them fire resistance and removing some copypasted stats. Their melee and bio stats are inherited from the base PMC armor.
<img width="767" height="316" alt="image" src="https://github.com/user-attachments/assets/2aef9bfd-f08c-4ce4-afea-a8ec3d598f52" />


**Changelog**
:cl:
- fix: Fixed the engi PMC armor having the incorrect stats. It now has fire resistance and 20 melee protection as intended.