### PR TITLE
Xeno location pings while watching a sister (in ovi + out of ovi)

### DIFF
--- a/Content.Client/_RMC14/TacticalMap/TacticalMapComputerBui.cs
+++ b/Content.Client/_RMC14/TacticalMap/TacticalMapComputerBui.cs
@@ -14,6 +14,8 @@ public sealed class TacticalMapComputerBui(EntityUid owner, Enum uiKey) : RMCPop
 {
     [Dependency] private readonly IPlayerManager _player = default!;
 
+    private static readonly ISawmill _logger = Logger.GetSawmill("tactical_map_settings");
+
     protected override TacticalMapWindow? Window { get; set; }
     private bool _refreshed;
     private string? _currentMapName;
@@ -114,14 +116,14 @@ public sealed class TacticalMapComputerBui(EntityUid owner, Enum uiKey) : RMCPop
         base.Dispose(disposing);
     }
 
-    public void Refresh()
+    public void Refresh(EntityUid? watchTargetUid = null, bool? liveUpdate = null)
     {
         if (Window == null)
             return;
 
         var lineLimit = EntMan.System<TacticalMapSystem>().LineLimit;
         Window.Wrapper.SetLineLimit(lineLimit);
-        UpdateBlips();
+        UpdateBlips(watchTargetUid, liveUpdate);
         UpdateLabels();
 
         if (EntMan.TryGetComponent(Owner, out TacticalMapComputerComponent? computer))
@@ -145,7 +147,7 @@ public sealed class TacticalMapComputerBui(EntityUid owner, Enum uiKey) : RMCPop
         _refreshed = true;
     }
 
-    private void UpdateBlips()
+    private void UpdateBlips(EntityUid? watchTargetUid = null, bool? liveUpdate = null)
     {
         if (Window == null)
             return;
@@ -169,11 +171,48 @@ public sealed class TacticalMapComputerBui(EntityUid owner, Enum uiKey) : RMCPop
 
         Window.Wrapper.UpdateBlips(blips, entityIds);
 
-        int? localPlayerId = _player.LocalEntity != null
-            ? (int?)EntMan.GetNetEntity(_player.LocalEntity.Value)
+        UpdateLocationPings(watchTargetUid, liveUpdate);
+    }
+
+    private void UpdateLocationPings(EntityUid? watchTargetUid = null, bool? liveUpdate = null)
+    {
+        if (Window == null)
+            return;
+
+        NetEntity? localPlayerNetEntity = _player.LocalEntity != null
+            ? EntMan.GetNetEntity(_player.LocalEntity.Value)
             : null;
+        var localPlayerId = (int?)localPlayerNetEntity ?? null;
+
         Window.Wrapper.Map.SetLocalPlayerEntityId(localPlayerId);
         Window.Wrapper.Canvas.SetLocalPlayerEntityId(localPlayerId);
+
+        // EntMan.TryGetComponent<EyeComponent>(_player.LocalEntity, out var eyeComponent);
+
+        // EntityUid.Invalid is used to denote an Unwatch event, non-null means a Watch event
+        if (watchTargetUid == null)
+            return;
+
+        int? targetId = watchTargetUid != EntityUid.Invalid
+            ? (int?)EntMan.GetNetEntity(watchTargetUid)
+            : null;
+
+        Vector2i? indices = targetId != null
+            ? GetWatchingIndices(watchTargetUid.Value)
+            : null;
+
+        Window.Wrapper.Map.SetWatchingData(targetId, liveUpdate, indices);
+        Window.Wrapper.Canvas.SetWatchingData(targetId, liveUpdate, indices);
+    }
+
+    private Vector2i? GetWatchingIndices(EntityUid ent)
+    {
+        Vector2i indices = Vector2i.Zero;
+
+        EntMan.System<TacticalMapSystem>().HasValidPosition(
+            ent, ref indices);
+
+        return indices == Vector2i.Zero ? null : indices;
     }
 
     private void UpdateLabels()

--- a/Content.Client/_RMC14/TacticalMap/TacticalMapComputerBui.cs
+++ b/Content.Client/_RMC14/TacticalMap/TacticalMapComputerBui.cs
@@ -14,8 +14,6 @@ public sealed class TacticalMapComputerBui(EntityUid owner, Enum uiKey) : RMCPop
 {
     [Dependency] private readonly IPlayerManager _player = default!;
 
-    private static readonly ISawmill _logger = Logger.GetSawmill("tactical_map_settings");
-
     protected override TacticalMapWindow? Window { get; set; }
     private bool _refreshed;
     private string? _currentMapName;

--- a/Content.Client/_RMC14/TacticalMap/TacticalMapComputerBui.cs
+++ b/Content.Client/_RMC14/TacticalMap/TacticalMapComputerBui.cs
@@ -14,8 +14,6 @@ public sealed class TacticalMapComputerBui(EntityUid owner, Enum uiKey) : RMCPop
 {
     [Dependency] private readonly IPlayerManager _player = default!;
 
-    private static readonly ISawmill _logger = Logger.GetSawmill("tactical_map_settings");
-
     protected override TacticalMapWindow? Window { get; set; }
     private bool _refreshed;
     private string? _currentMapName;
@@ -186,8 +184,6 @@ public sealed class TacticalMapComputerBui(EntityUid owner, Enum uiKey) : RMCPop
 
         Window.Wrapper.Map.SetLocalPlayerEntityId(localPlayerId);
         Window.Wrapper.Canvas.SetLocalPlayerEntityId(localPlayerId);
-
-        // EntMan.TryGetComponent<EyeComponent>(_player.LocalEntity, out var eyeComponent);
 
         // EntityUid.Invalid is used to denote an Unwatch event, non-null means a Watch event
         if (watchTargetUid == null)

--- a/Content.Client/_RMC14/TacticalMap/TacticalMapControl.xaml.cs
+++ b/Content.Client/_RMC14/TacticalMap/TacticalMapControl.xaml.cs
@@ -9,6 +9,7 @@ using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.XAML;
 using Robust.Shared.Input;
+using Robust.Shared.Map.Components;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using SixLabors.ImageSharp;
@@ -54,6 +55,8 @@ public sealed partial class TacticalMapControl : TextureRect
 
     [Dependency] private readonly IResourceCache _resourceCache = default!;
     [Dependency] private readonly IEntityManager _entityManager = default!;
+    // [UISystemDependency] private readonly TacticalMapSystem _transform = null!;
+    private static readonly ISawmill _logger = Logger.GetSawmill("tactical_map_settings");
 
     private readonly Font _font;
     private readonly Label? _tunnelInfoLabel;
@@ -67,6 +70,10 @@ public sealed partial class TacticalMapControl : TextureRect
     private int[]? _blipEntityIds;
     private int? _localPlayerEntityId;
     private Dictionary<Vector2i, string> _areaLabels = new();
+
+    private int? _watchingEntityId;
+    private bool? _watchingLiveUpdate;
+    private Vector2i? _watchingIndices;
 
     private Vector2i _min;
     private Vector2i _delta;
@@ -229,6 +236,14 @@ public sealed partial class TacticalMapControl : TextureRect
     public void SetLocalPlayerEntityId(int? entityId)
     {
         _localPlayerEntityId = entityId;
+    }
+
+    public void SetWatchingData(int? entityId, bool? liveUpdate, Vector2i? watchingIndices)
+    {
+        _logger.Debug($"Setting watching: {entityId}");
+        _watchingEntityId = entityId;
+        _watchingLiveUpdate = liveUpdate;
+        _watchingIndices = watchingIndices;
     }
 
 
@@ -571,6 +586,8 @@ public sealed partial class TacticalMapControl : TextureRect
         if (_blips == null)
             return;
 
+        var watchingPingSeperate = _watchingLiveUpdate == false && _watchingEntityId.HasValue;
+
         for (int i = 0; i < _blips.Length; i++)
         {
             TacticalMapBlip blip = _blips[i];
@@ -581,11 +598,21 @@ public sealed partial class TacticalMapControl : TextureRect
             handle.DrawTextureRect(blip.Background != null ? system.GetFrame(blip.Background, curTime) : background, rect, blip.Color);
             handle.DrawTextureRect(system.GetFrame(blip.Image, curTime), rect);
 
+            // Draw location ping for local character
             if (_localPlayerEntityId.HasValue && _blipEntityIds != null && i < _blipEntityIds.Length)
             {
                 if (_blipEntityIds[i] == _localPlayerEntityId.Value)
                 {
-                    DrawPingEffect(handle, position, scaledBlipSize, overlayScale, curTime, blip.Color);
+                    DrawPingEffect(handle, position, scaledBlipSize, overlayScale, curTime, Color.FromHex("#00FFFF"));
+                }
+            }
+
+            // Draw location ping for player you're watching
+            if (_watchingEntityId.HasValue && _blipEntityIds != null && i < _blipEntityIds.Length)
+            {
+                if (_blipEntityIds[i] == _watchingEntityId.Value && !watchingPingSeperate)
+                {
+                    DrawPingEffect(handle, position, scaledBlipSize, overlayScale, curTime, Color.Orange);
                 }
             }
 
@@ -604,6 +631,36 @@ public sealed partial class TacticalMapControl : TextureRect
             if (defibTexture != null)
                 handle.DrawTextureRect(system.GetFrame(defibTexture, curTime), rect);
         }
+
+        // If live updating is disabled, draw the location ping for who you're watching anyways
+        if (watchingPingSeperate && _watchingEntityId.HasValue && _watchingIndices.HasValue)
+        {
+            // MapGridComponent? gridComp = null;
+            // Vector2i indices = Vector2i.Zero;
+
+
+            // var netEntity = _entityManager.GetNetEntity(new EntityUid(_watchingEntityId.Value));
+
+            // var entity = new EntityUid(_watchingEntityId.Value);
+
+            _logger.Debug($"Attempting to draw w/ no ovi {_watchingEntityId.Value}");
+
+            var indices = _watchingIndices.Value;
+
+            // if (!_transform.HasValidPosition(entity,
+            //         ref gridComp,
+            //         ref indices))
+            //     return;
+
+            _logger.Debug("Drawing w/ no ovi!");
+
+            // TacticalMapBlip blip = _blips[i];
+            Vector2 position = IndicesToPosition(indices) * overlayScale + actualTopLeft;
+            float scaledBlipSize = GetScaledBlipSize(overlayScale);
+            // UIBox2 rect = UIBox2.FromDimensions(position, new Vector2(scaledBlipSize, scaledBlipSize));
+
+            DrawPingEffect(handle, position, scaledBlipSize, overlayScale, curTime, Color.Orange);
+        }
     }
 
     private void DrawPingEffect(DrawingHandleScreen handle, Vector2 center, float blipSize, float overlayScale, TimeSpan curTime, Color blipColor)
@@ -617,7 +674,7 @@ public sealed partial class TacticalMapControl : TextureRect
         float ringSize = blipSize * scale;
         Vector2 ringCenter = center + new Vector2(blipSize / 2, blipSize / 2);
 
-        Color pingColor = Color.FromHex("#00FFFF").WithAlpha(alpha);
+        Color pingColor = blipColor.WithAlpha(alpha);
 
         float thickness = PingRingThickness * overlayScale;
         int segments = 32;

--- a/Content.Client/_RMC14/TacticalMap/TacticalMapControl.xaml.cs
+++ b/Content.Client/_RMC14/TacticalMap/TacticalMapControl.xaml.cs
@@ -9,7 +9,6 @@ using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.XAML;
 using Robust.Shared.Input;
-using Robust.Shared.Map.Components;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using SixLabors.ImageSharp;
@@ -55,8 +54,6 @@ public sealed partial class TacticalMapControl : TextureRect
 
     [Dependency] private readonly IResourceCache _resourceCache = default!;
     [Dependency] private readonly IEntityManager _entityManager = default!;
-    // [UISystemDependency] private readonly TacticalMapSystem _transform = null!;
-    private static readonly ISawmill _logger = Logger.GetSawmill("tactical_map_settings");
 
     private readonly Font _font;
     private readonly Label? _tunnelInfoLabel;
@@ -240,7 +237,6 @@ public sealed partial class TacticalMapControl : TextureRect
 
     public void SetWatchingData(int? entityId, bool? liveUpdate, Vector2i? watchingIndices)
     {
-        _logger.Debug($"Setting watching: {entityId}");
         _watchingEntityId = entityId;
         _watchingLiveUpdate = liveUpdate;
         _watchingIndices = watchingIndices;
@@ -635,29 +631,10 @@ public sealed partial class TacticalMapControl : TextureRect
         // If live updating is disabled, draw the location ping for who you're watching anyways
         if (watchingPingSeperate && _watchingEntityId.HasValue && _watchingIndices.HasValue)
         {
-            // MapGridComponent? gridComp = null;
-            // Vector2i indices = Vector2i.Zero;
-
-
-            // var netEntity = _entityManager.GetNetEntity(new EntityUid(_watchingEntityId.Value));
-
-            // var entity = new EntityUid(_watchingEntityId.Value);
-
-            _logger.Debug($"Attempting to draw w/ no ovi {_watchingEntityId.Value}");
-
             var indices = _watchingIndices.Value;
 
-            // if (!_transform.HasValidPosition(entity,
-            //         ref gridComp,
-            //         ref indices))
-            //     return;
-
-            _logger.Debug("Drawing w/ no ovi!");
-
-            // TacticalMapBlip blip = _blips[i];
             Vector2 position = IndicesToPosition(indices) * overlayScale + actualTopLeft;
             float scaledBlipSize = GetScaledBlipSize(overlayScale);
-            // UIBox2 rect = UIBox2.FromDimensions(position, new Vector2(scaledBlipSize, scaledBlipSize));
 
             DrawPingEffect(handle, position, scaledBlipSize, overlayScale, curTime, Color.Orange);
         }

--- a/Content.Client/_RMC14/TacticalMap/TacticalMapSystem.cs
+++ b/Content.Client/_RMC14/TacticalMap/TacticalMapSystem.cs
@@ -1,24 +1,93 @@
 using Content.Client._RMC14.Dropship.Weapon;
+using Content.Client._RMC14.UserInterface;
 using Content.Shared._RMC14.TacticalMap;
+using Content.Shared._RMC14.Xenonids.Watch;
 using Robust.Client.Player;
+using Robust.Shared.Map.Components;
 
 namespace Content.Client._RMC14.TacticalMap;
 
 public sealed class TacticalMapSystem : SharedTacticalMapSystem
 {
     [Dependency] private readonly IPlayerManager _player = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    private readonly ISawmill _logger = Logger.GetSawmill("tactical_map_settings");
+
+
+    private EntityQuery<TransformComponent> _transformQuery;
+    private EntityQuery<TacticalMapComponent> _tacticalMapQuery;
+    private EntityQuery<MapGridComponent> _mapGridQuery;
 
     public override void Initialize()
     {
         base.Initialize();
 
+        _transformQuery = GetEntityQuery<TransformComponent>();
+        _tacticalMapQuery = GetEntityQuery<TacticalMapComponent>();
+        _mapGridQuery = GetEntityQuery<MapGridComponent>();
+
         SubscribeLocalEvent<TacticalMapUserComponent, AfterAutoHandleStateEvent>(OnUserState);
         SubscribeLocalEvent<TacticalMapComputerComponent, AfterAutoHandleStateEvent>(OnComputerState);
         SubscribeLocalEvent<TacticalMapLinesComponent, AfterAutoHandleStateEvent>(OnLinesState);
         SubscribeLocalEvent<TacticalMapLabelsComponent, AfterAutoHandleStateEvent>(OnLabelsState);
+
+        SubscribeLocalEvent<XenoWatchingComponent, XenoWatchEvent>(OnXenoWatch);
+        SubscribeLocalEvent<XenoWatchingComponent, XenoUnwatchEvent>(OnXenoUnwatch);
     }
 
-    private void RefreshUser(EntityUid ent)
+    public override bool HasValidPosition(EntityUid ent,
+        ref Vector2i indices)
+    {
+        var a = _transformQuery.TryComp(ent, out var xform);
+        if (!a || xform == null)
+        {
+            _logger.Debug("First check fails");
+            return false;
+        }
+
+        var gridId = EntityUid.Invalid;
+        a = xform.GridUid is { };
+        if (!a || !xform.GridUid.HasValue)
+        {
+            _logger.Debug("Second check fails");
+            return false;
+        }
+
+        gridId = xform.GridUid.Value;
+
+        a = _mapGridQuery.TryComp(gridId, out var gridComp);
+        if (!a)
+        {
+            _logger.Debug("Third check fails");
+            return false;
+        }
+
+        a = _tacticalMapQuery.TryComp(gridId, out var _);
+        if (!a)
+        {
+            _logger.Debug("Fourth check fails");
+            return false;
+        }
+
+        a = _transform.TryGetGridTilePosition((ent, xform), out indices, gridComp);
+
+        if (!a)
+            _logger.Debug("Fifth check fails");
+        else
+            _logger.Debug("All 5 checks PASS");
+
+        return a;
+        // return _transformQuery.TryComp(ent, out var xform) &&
+        //        xform.GridUid is { } gridId &&
+        //        _mapGridQuery.TryComp(gridId, out gridComp) &&
+        //        _tacticalMapQuery.TryComp(gridId, out var tacticalMap) &&
+        //        _transform.TryGetGridTilePosition((ent, xform), out indices, gridComp);
+    }
+
+    // watchTargetUid exists to be passed to TacticalMapControl.SetWatchingEntityId() as the EyeComponent.Target
+    //     value had race conditions preventing it from always being set in time
+    private void RefreshUser(EntityUid ent, EntityUid? watchTargetUid = null, bool? liveUpdate = null)
     {
         try
         {
@@ -28,7 +97,7 @@ public sealed class TacticalMapSystem : SharedTacticalMapSystem
             foreach (var bui in ui.ClientOpenInterfaces.Values)
             {
                 if (bui is TacticalMapUserBui userBui)
-                    userBui.Refresh();
+                    userBui.Refresh(watchTargetUid, liveUpdate);
             }
         }
         catch (Exception e)
@@ -37,7 +106,7 @@ public sealed class TacticalMapSystem : SharedTacticalMapSystem
         }
     }
 
-    private void RefreshComputer(EntityUid ent)
+    private void RefreshComputer(EntityUid ent, EntityUid? watchTargetUid = null, bool? liveUpdate = null)
     {
         try
         {
@@ -47,7 +116,7 @@ public sealed class TacticalMapSystem : SharedTacticalMapSystem
             foreach (var bui in ui.ClientOpenInterfaces.Values)
             {
                 if (bui is TacticalMapComputerBui computerBui)
-                    computerBui.Refresh();
+                    computerBui.Refresh(watchTargetUid, liveUpdate);
                 else if (bui is DropshipWeaponsBui weaponsBui)
                     weaponsBui.Refresh();
             }
@@ -85,5 +154,27 @@ public sealed class TacticalMapSystem : SharedTacticalMapSystem
 
         if (HasComp<TacticalMapComputerComponent>(ent))
             RefreshComputer(ent);
+    }
+
+    private void OnXenoWatch(Entity<XenoWatchingComponent> ent, ref XenoWatchEvent args)
+    {
+        TryComp(ent, out TacticalMapUserComponent? userComponent);
+
+        bool? liveUpdate = userComponent?.LiveUpdate ?? null;
+
+        _logger.Debug($"xeno watch seen from tacmap system ! {args.Watching}");
+        RefreshUser(ent, args.Watching, liveUpdate);
+
+        if (HasComp<TacticalMapComputerComponent>(ent))
+            RefreshComputer(ent, args.Watching, liveUpdate);
+    }
+
+    private void OnXenoUnwatch(Entity<XenoWatchingComponent> ent, ref XenoUnwatchEvent args)
+    {
+        _logger.Debug("xeno unwatch seen from tacmap system !");
+        RefreshUser(ent, EntityUid.Invalid);
+
+        if (HasComp<TacticalMapComputerComponent>(ent))
+            RefreshComputer(ent, EntityUid.Invalid);
     }
 }

--- a/Content.Client/_RMC14/TacticalMap/TacticalMapSystem.cs
+++ b/Content.Client/_RMC14/TacticalMap/TacticalMapSystem.cs
@@ -12,9 +12,6 @@ public sealed class TacticalMapSystem : SharedTacticalMapSystem
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
 
-    private readonly ISawmill _logger = Logger.GetSawmill("tactical_map_settings");
-
-
     private EntityQuery<TransformComponent> _transformQuery;
     private EntityQuery<TacticalMapComponent> _tacticalMapQuery;
     private EntityQuery<MapGridComponent> _mapGridQuery;
@@ -39,50 +36,11 @@ public sealed class TacticalMapSystem : SharedTacticalMapSystem
     public override bool HasValidPosition(EntityUid ent,
         ref Vector2i indices)
     {
-        var a = _transformQuery.TryComp(ent, out var xform);
-        if (!a || xform == null)
-        {
-            _logger.Debug("First check fails");
-            return false;
-        }
-
-        var gridId = EntityUid.Invalid;
-        a = xform.GridUid is { };
-        if (!a || !xform.GridUid.HasValue)
-        {
-            _logger.Debug("Second check fails");
-            return false;
-        }
-
-        gridId = xform.GridUid.Value;
-
-        a = _mapGridQuery.TryComp(gridId, out var gridComp);
-        if (!a)
-        {
-            _logger.Debug("Third check fails");
-            return false;
-        }
-
-        a = _tacticalMapQuery.TryComp(gridId, out var _);
-        if (!a)
-        {
-            _logger.Debug("Fourth check fails");
-            return false;
-        }
-
-        a = _transform.TryGetGridTilePosition((ent, xform), out indices, gridComp);
-
-        if (!a)
-            _logger.Debug("Fifth check fails");
-        else
-            _logger.Debug("All 5 checks PASS");
-
-        return a;
-        // return _transformQuery.TryComp(ent, out var xform) &&
-        //        xform.GridUid is { } gridId &&
-        //        _mapGridQuery.TryComp(gridId, out gridComp) &&
-        //        _tacticalMapQuery.TryComp(gridId, out var tacticalMap) &&
-        //        _transform.TryGetGridTilePosition((ent, xform), out indices, gridComp);
+        return _transformQuery.TryComp(ent, out var xform) &&
+               xform.GridUid is { } gridId &&
+               _mapGridQuery.TryComp(gridId, out var gridComp) &&
+               _tacticalMapQuery.TryComp(gridId, out var tacticalMap) &&
+               _transform.TryGetGridTilePosition((ent, xform), out indices, gridComp);
     }
 
     // watchTargetUid exists to be passed to TacticalMapControl.SetWatchingEntityId() as the EyeComponent.Target
@@ -162,7 +120,6 @@ public sealed class TacticalMapSystem : SharedTacticalMapSystem
 
         bool? liveUpdate = userComponent?.LiveUpdate ?? null;
 
-        _logger.Debug($"xeno watch seen from tacmap system ! {args.Watching}");
         RefreshUser(ent, args.Watching, liveUpdate);
 
         if (HasComp<TacticalMapComputerComponent>(ent))
@@ -171,7 +128,6 @@ public sealed class TacticalMapSystem : SharedTacticalMapSystem
 
     private void OnXenoUnwatch(Entity<XenoWatchingComponent> ent, ref XenoUnwatchEvent args)
     {
-        _logger.Debug("xeno unwatch seen from tacmap system !");
         RefreshUser(ent, EntityUid.Invalid);
 
         if (HasComp<TacticalMapComputerComponent>(ent))

--- a/Content.Client/_RMC14/TacticalMap/TacticalMapUserBui.cs
+++ b/Content.Client/_RMC14/TacticalMap/TacticalMapUserBui.cs
@@ -106,14 +106,14 @@ public sealed class TacticalMapUserBui(EntityUid owner, Enum uiKey) : RMCPopOutB
         base.Dispose(disposing);
     }
 
-    public void Refresh()
+    public void Refresh(EntityUid? watchTargetUid = null, bool? liveUpdate = null)
     {
         if (Window == null)
             return;
 
         var lineLimit = EntMan.System<TacticalMapSystem>().LineLimit;
         Window.Wrapper.SetLineLimit(lineLimit);
-        UpdateBlips();
+        UpdateBlips(watchTargetUid, liveUpdate);
         UpdateLabels();
         UpdateTimestamps();
 
@@ -151,7 +151,7 @@ public sealed class TacticalMapUserBui(EntityUid owner, Enum uiKey) : RMCPopOutB
         _refreshed = true;
     }
 
-    private void UpdateBlips()
+    private void UpdateBlips(EntityUid? watchTargetUid = null, bool? liveUpdate = null)
     {
         if (Window == null)
             return;
@@ -190,11 +190,48 @@ public sealed class TacticalMapUserBui(EntityUid owner, Enum uiKey) : RMCPopOutB
 
         Window.Wrapper.UpdateBlips(blips, entityIds);
 
-        int? localPlayerId = _player.LocalEntity != null
-            ? (int?)EntMan.GetNetEntity(_player.LocalEntity.Value)
+        UpdateLocationPings(watchTargetUid, liveUpdate);
+    }
+
+    private void UpdateLocationPings(EntityUid? watchTargetUid = null, bool? liveUpdate = null)
+    {
+        if (Window == null)
+            return;
+
+        NetEntity? localPlayerNetEntity = _player.LocalEntity != null
+            ? EntMan.GetNetEntity(_player.LocalEntity.Value)
             : null;
+        var localPlayerId = (int?)localPlayerNetEntity ?? null;
+
         Window.Wrapper.Map.SetLocalPlayerEntityId(localPlayerId);
         Window.Wrapper.Canvas.SetLocalPlayerEntityId(localPlayerId);
+
+        // EntMan.TryGetComponent<EyeComponent>(_player.LocalEntity, out var eyeComponent);
+
+        // EntityUid.Invalid is used to denote an Unwatch event, non-null means a Watch event
+        if (watchTargetUid == null)
+            return;
+
+        int? targetId = watchTargetUid != EntityUid.Invalid
+            ? (int?)EntMan.GetNetEntity(watchTargetUid)
+            : null;
+
+        Vector2i? indices = targetId != null
+            ? GetWatchingIndices(watchTargetUid.Value)
+            : null;
+
+        Window.Wrapper.Map.SetWatchingData(targetId, liveUpdate, indices);
+        Window.Wrapper.Canvas.SetWatchingData(targetId, liveUpdate, indices);
+    }
+
+    private Vector2i? GetWatchingIndices(EntityUid ent)
+    {
+        Vector2i indices = Vector2i.Zero;
+
+        EntMan.System<TacticalMapSystem>().HasValidPosition(
+            ent, ref indices);
+
+        return indices == Vector2i.Zero ? null : indices;
     }
 
     private void UpdateLabels()

--- a/Content.Server/_RMC14/Xenonids/Watch/XenoWatchSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Watch/XenoWatchSystem.cs
@@ -129,8 +129,6 @@ public sealed class XenoWatchSystem : SharedXenoWatchSystem
 
     public override void Watch(Entity<HiveMemberComponent?, ActorComponent?, EyeComponent?> watcher, Entity<HiveMemberComponent?> toWatch)
     {
-        base.Watch(watcher, toWatch);
-
         if (!HasQueenPopup(watcher))
             return;
 
@@ -147,11 +145,8 @@ public sealed class XenoWatchSystem : SharedXenoWatchSystem
         _viewSubscriber.AddViewSubscriber(toWatch, watcher.Comp2.PlayerSession);
 
         RemoveWatcher(watcher);
-        EnsureComp<XenoWatchingComponent>(watcher).Watching = toWatch;
-        EnsureComp<XenoWatchedComponent>(toWatch).Watching.Add(watcher);
 
-        var ev = new XenoWatchEvent();
-        RaiseLocalEvent(watcher, ref ev);
+        base.Watch(watcher, toWatch);
     }
 
     public override void Unwatch(Entity<EyeComponent?> watcher, ICommonSession player)

--- a/Content.Shared/_RMC14/TacticalMap/SharedTacticalMapSystem.cs
+++ b/Content.Shared/_RMC14/TacticalMap/SharedTacticalMapSystem.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Shared._RMC14.CCVar;
 using Robust.Shared.Configuration;
+using Robust.Shared.Map.Components;
 
 namespace Content.Shared._RMC14.TacticalMap;
 
@@ -101,5 +102,10 @@ public abstract class SharedTacticalMapSystem : EntitySystem
         }
 
         _ui.TryOpenUi(user.Owner, TacticalMapUserUi.Key, user);
+    }
+
+    public virtual bool HasValidPosition(EntityUid ent, ref Vector2i indices)
+    {
+        return false;
     }
 }

--- a/Content.Shared/_RMC14/TacticalMap/SharedTacticalMapSystem.cs
+++ b/Content.Shared/_RMC14/TacticalMap/SharedTacticalMapSystem.cs
@@ -1,6 +1,5 @@
 ﻿using Content.Shared._RMC14.CCVar;
 using Robust.Shared.Configuration;
-using Robust.Shared.Map.Components;
 
 namespace Content.Shared._RMC14.TacticalMap;
 

--- a/Content.Shared/_RMC14/Xenonids/Watch/SharedXenoWatchSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Watch/SharedXenoWatchSystem.cs
@@ -53,6 +53,11 @@ public abstract class SharedXenoWatchSystem : EntitySystem
 
     public virtual void Watch(Entity<HiveMemberComponent?, ActorComponent?, EyeComponent?> watcher, Entity<HiveMemberComponent?> toWatch)
     {
+        EnsureComp<XenoWatchingComponent>(watcher).Watching = toWatch;
+        EnsureComp<XenoWatchedComponent>(toWatch).Watching.Add(watcher);
+
+        var ev = new XenoWatchEvent(toWatch);
+        RaiseLocalEvent(watcher, ref ev);
     }
 
     public virtual void Unwatch(Entity<EyeComponent?> watcher, ICommonSession player)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Xeno players now see an orange ping showing the location of who they're spectating, similar to the blue ping for their own location.
<img width="246" height="186" alt="image" src="https://github.com/user-attachments/assets/7a8bb168-99d4-441c-949e-c9573b5a6e1f" />

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This new feature is comparable to tacmap labels or the personal location ping. Any experienced player can identify the location of a player while spectating them, but newer players who are unfamiliar with maps may struggle. This "levels" the playing field of skill necessary for new xeno players to coordinate.

When the queen is in ovi, which allows all xenos to view a live tacmap, the orange ping will follow the watched xeno's icon on the map. When the queen is *not* in ovi, the orange ping will appear on it's own separate from the watched xenos icon (even appearing if it hasn't been updated to the tacmap yet), which means there is no additional benefit (such as players being able to update their map one xeno at a time by moving each icon using this feature, as the pings are disconnected) except for seeing one specific xeno's location at a time.
## Technical details
<!-- Summary of code changes for easier review. -->
1. `TacticalMapControl.xaml.cs` has the bulk of changes, with new variables being updated by the `TacticalMapUserBui` and `TacticalMapComputerBui`s, originating from `XenoWatchEvent` and `XenoUnwatchEvent`s in the Client `TacticalMapSystem`.
2. Client `TacticalMapSystem` can now search for locations of `Entity`s to show on the map, as previously this was all done server-side. Since it's only used to show one at a time, which will appear using the `EyeComponent` system, this should be alright. This MAY need more robust multiplayer testing (if it attempts to find the location of something that hasn't been loaded client-side, I am unaware of the implications, but as it uses `EntityUid`s and it is frequently refreshed, I expect it to be okay.
3. `XenoWatchEvent`s were not passing the watched `Entity` as a parameter, as expected. Now they do.
4. Moved the `XenoWatchingComponent` code from the Client `XenoWatchSystem` to the `SharedXenoWatchSystem`
5. Note: there are three TacMap BUIs: User, Computer, and Weapons. I believe only User is necessary for this PR, but the Computer one has been updated as well (allowing for this feature to be applied to Overwatch consoles in the future), but the Weapons BUI has been left unmodified for now, I'm not sure if it would be beneficial there as I have not piloted the gunship or dropship.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
1. Queen in ovi, her perspective: https://gyazo.com/bb29a5695e771284a93b3c748e853ed4
2. Queen in ovi, others' perspective: https://gyazo.com/e962535a60f121f2cf29c65038e4e734
3. Queen not in ovi, her perspective: https://gyazo.com/087614469fa7404bfda5593483ab8031
6. Queen not in ovi, others' perspective: https://gyazo.com/62d9e0253c0c1bad86c9af3ba5c3b5e0
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added an orange location ping for xenos to see where whoever they're watching is on the Tactical Map
- code: XenoWatchEvent now includes the Watched parameter as expected, instead of being empty
