### PR TITLE
Fix Xeno pheromones on leader selected

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/HiveLeader/HiveLeaderSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/HiveLeader/HiveLeaderSystem.cs
@@ -148,6 +148,7 @@ public sealed class HiveLeaderSystem : EntitySystem
         Dirty(watching, leaderComp);
 
         ent.Comp.Leaders.Add(watching);
+        SyncPheromones(ent);
         Dirty(ent);
 
         msg = $"You've selected {Name(watching)} as a Hive Leader.";


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Existing bug: when the xeno queen selects a new leader, there's a bug where the pheromones don't instantly relay. The queen has to disable and re-enable pheromones for them to relay.

This PR fixes this bug with one missing line. Now when a leader is given, the pheromones instantly relay onto the new leader.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfix
## Technical details
<!-- Summary of code changes for easier review. -->
One new call to SyncPheromones
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
https://gyazo.com/ec7488d01fced23c3a0543341e815e25

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed pheromones not relaying instantly to newly selected Xeno leaders