### PR TITLE
Acid melted walls let weeds spread

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Acid/SharedXenoAcidSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Acid/SharedXenoAcidSystem.cs
@@ -4,9 +4,11 @@ using Content.Shared._RMC14.Dropship;
 using Content.Shared._RMC14.Dropship.AttachmentPoint;
 using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Xenonids.Energy;
+using Content.Shared._RMC14.Xenonids.Weeds;
 using Content.Shared.Explosion.EntitySystems;
 using Content.Shared.Weapons.Ranged.Events;
 using Content.Shared.Coordinates;
+using Content.Shared.Coordinates.Helpers;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.DoAfter;
@@ -19,6 +21,8 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Robust.Shared.Configuration;
 using Robust.Shared.Containers;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
 
 namespace Content.Shared._RMC14.Xenonids.Acid;
 
@@ -35,7 +39,9 @@ public abstract class SharedXenoAcidSystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] protected readonly IPrototypeManager PrototypeManager = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly IMapManager _map = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly SharedXenoWeedsSystem _weedsSystem = default!;
     [Dependency] private readonly XenoPlasmaSystem _xenoPlasma = default!;
     [Dependency] private readonly XenoEnergySystem _xenoEnergy = default!;
 
@@ -289,6 +295,8 @@ public abstract class SharedXenoAcidSystem : EntitySystem
                 var ev = new BeforeMeltedEvent();
                 RaiseLocalEvent(uid, ref ev);
 
+                CheckDelForWeedSpread(uid);
+
                 QueueDel(damageableCorrodingComponent.Acid);
                 RemCompDeferred<DamageableCorrodingComponent>(uid);
             }
@@ -317,8 +325,31 @@ public abstract class SharedXenoAcidSystem : EntitySystem
                 }
             }
 
+            CheckDelForWeedSpread(uid);
+
             QueueDel(uid);
             QueueDel(timedCorrodingComponent.Acid);
+        }
+    }
+
+    // Used to tell nearby weeds to check if they should spread, for example after a wall has been melted
+    public void CheckDelForWeedSpread(EntityUid uid)
+    {
+        if (_net.IsClient)
+            return;
+
+        var coordinates = _transform.GetMoverCoordinates(uid).SnapToGrid(EntityManager, _map);
+
+        if (_transform.GetGrid(coordinates) is not { } gridUid ||
+            !TryComp(gridUid, out MapGridComponent? gridComp))
+            return;
+
+        var nearbyWeeds = _weedsSystem.GetWeedsNearby(
+            new Entity<MapGridComponent>(gridUid, gridComp), coordinates, 1);
+
+        foreach (var weeds in nearbyWeeds)
+        {
+            EnsureComp<XenoWeedsSpreadingComponent>(weeds);
         }
     }
 

--- a/Content.Shared/_RMC14/Xenonids/Weeds/SharedXenoWeedsSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Weeds/SharedXenoWeedsSystem.cs
@@ -383,6 +383,7 @@ public abstract class SharedXenoWeedsSystem : EntitySystem
             _toUpdate.Add(ent);
     }
 
+    // Note: this only looks for source weeds (i.e. nodes)
     public bool HasWeedsNearby(Entity<MapGridComponent> grid, EntityCoordinates coordinates, int range = 5)
     {
         var position = _mapSystem.LocalToTile(grid, grid, coordinates);
@@ -396,6 +397,35 @@ public abstract class SharedXenoWeedsSystem : EntitySystem
         }
 
         return false;
+    }
+
+    // Note: this looks for any type of weeds, not just source weeds (i.e. not just nodes)
+    public Entity<XenoWeedsComponent>[] GetWeedsNearby(Entity<MapGridComponent> grid, EntityCoordinates coordinates, int range = 1)
+    {
+        var position = _mapSystem.LocalToTile(grid, grid, coordinates);
+
+        var nearbyWeeds = new List<Entity<XenoWeedsComponent>>();
+
+        var minTile = new Vector2i(position.X - range, position.Y - range);
+        var maxTile = new Vector2i(position.X + range, position.Y + range);
+
+        for (int x = minTile.X; x <= maxTile.X; x++)
+        {
+            for (int y = minTile.Y; y <= maxTile.Y; y++)
+            {
+                var entEnumerator = _mapSystem.GetAnchoredEntitiesEnumerator(grid, grid, new Vector2i(x, y));
+
+                while (entEnumerator.MoveNext(out var anchored))
+                {
+                    if (!_weedsQuery.TryComp(anchored, out var weeds))
+                        continue;
+
+                    nearbyWeeds.Add(new Entity<XenoWeedsComponent>(anchored.Value, weeds));
+                }
+            }
+        }
+
+        return nearbyWeeds.ToArray();
     }
 
     public bool IsOnHiveWeeds(Entity<MapGridComponent> grid, EntityCoordinates coordinates, bool sourceOnly = false)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Now when walls are melted by acid, weeds will spread over where they were
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Having to plant new source weeds on the small dry spaces left behind from walls, doors, windows, etc, melting when building resin as a xeno is tedious and likely unintended behavior. This takes away that minor annoyance
## Technical details
<!-- Summary of code changes for easier review. -->
1. `SharedXenoWeedsSystem` now has a method `GetWeedsNearby` to get an array of all weeds in a 3x3 box (or any distance really) around an entity
2. `SharedXenoAcidSystem` now calls `GetWeedsNearby` just before a melted entity is queued for deletion and ensures any found `XenoWeedsComponent` entities have a `XenoWeedsSpreadingComponent` which allows weeds to spread conforming to their typical rules
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
Here's a demonstration with both corrosion time and weed spreading sped up, these are conveniences not included in the PR
https://gyazo.com/96ca4345b531e31b72b521b5a1c63023
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed acid melted walls not letting weeds spread