### PR TITLE
Fixed lack of hive core destroyed announcement from weedkiller

### DIFF
--- a/Content.Shared/_RMC14/WeedKiller/WeedKillerSystem.cs
+++ b/Content.Shared/_RMC14/WeedKiller/WeedKillerSystem.cs
@@ -5,7 +5,9 @@ using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Dropship;
 using Content.Shared._RMC14.Map;
 using Content.Shared._RMC14.Marines.Announce;
+using Content.Shared._RMC14.Xenonids.Construction;
 using Content.Shared.Coordinates;
+using Content.Shared.Destructible;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Configuration;
 using Robust.Shared.Map;
@@ -21,6 +23,7 @@ public sealed class WeedKillerSystem : EntitySystem
 {
     [Dependency] private readonly AreaSystem _area = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly SharedDestructibleSystem _destructible = default!;
     [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] private readonly SharedMapSystem _map = default!;
     [Dependency] private readonly SharedMarineAnnounceSystem _marineAnnounce = default!;
@@ -142,7 +145,10 @@ public sealed class WeedKillerSystem : EntitySystem
                 if (!_deletedByWeedKillerQuery.HasComp(anchoredId))
                     continue;
 
-                QueueDel(anchoredId);
+                if (TryComp(anchoredId, out HiveCoreComponent? _))
+                    _destructible.DestroyEntity(anchoredId);
+                else
+                    QueueDel(anchoredId);
             }
         }
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed lack of hive core destroyed announcement from weedkiller
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Currently if the hive core is placed in a place vulnerable to weedkiller, it disappears without a chat announcement to the hive
## Technical details
<!-- Summary of code changes for easier review. -->
Changed a `QueueDel` call to a `SharedDestructibleSystem.DestroyEntity` call for entities with `HiveCoreComponent` being destroyed from the weed killer
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
<img width="416" height="202" alt="image" src="https://github.com/user-attachments/assets/1742c058-37a5-43fa-ab03-e599a7a3d2e9" />

By the way, I wanted to fix this as well for xenos being gibbed by shuttles, but for some reason testing it crashes the server on my development environment..

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed lack of hive core destroyed announcement from weedkiller
