### PR TITLE
Command text for RCM-P Commander

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Hybrisa_Prospera/Paramarines/Para_Commander.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Hybrisa_Prospera/Paramarines/Para_Commander.yml
@@ -23,6 +23,7 @@
         - type: MotionDetectorTracked
         - type: MarineOrders
         - type: RMCPointing
+        - type: InnateCommandSpeech
         - type: CommandAccent
         - type: RMCTrackable
         - type: TacticalMapIcon
@@ -72,4 +73,3 @@
   icon:
     sprite: _RMC14/Interface/cm_job_icons.rsi
     state: para_commander_alt
-    


### PR DESCRIPTION
## About the PR
Title
big text for RCM-P commander

## Why / Balance
Didn't check if this was parity because why shouldn't an O5 have command speech?

## Technical details
1 line of yaml

## Media
<img width="360" height="215" alt="obraz" src="https://github.com/user-attachments/assets/fa9a8d46-ecc8-4eea-a4f6-ca6d1d4aec20" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: RCM Paramarines Commander now has big text
