### PR TITLE
lz turrets have rotating warning lights

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Sentries/lz_sentries.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Sentries/lz_sentries.yml
@@ -66,6 +66,13 @@
   name: UN-577 spaceborne gauss turret
   description: A fully-automated defence turret with mid-range targeting capabilities. Armed with a modified M32-S Autocannon and an internal belt feed.
   components:
+  - type: PointLight
+    radius: 40
+    energy: 10.0
+    color: "#880808"
+    mask: /Textures/Effects/LightMasks/double_cone.png
+  - type: RotatingLight
+    speed: 90
   - type: Gun
     fireRate: 15
     selectedMode: FullAuto


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- Adds a rotating red pointlight to landing zone turrets, that extends just almost a screen further than their range.
- This was tested on hybrisa. It could be tested on live as these are YML changes.
- Xenonids can teach new players to avoid landing zones at the start of the game. (this can be moved onto a tutorial later)
- Experienced Xenonids can avoid landing zones.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

https://github.com/user-attachments/assets/3862e316-dc37-41b1-81dc-2fc4f3faf990


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Whisper
- add: LZ sentries have a rotating warning light.
