### PR TITLE
Shiva's Panic Room insert missing tacmap label fix

### DIFF
--- a/Resources/Maps/_RMC14/Inserts/Shiva/panic_room_hold.yml
+++ b/Resources/Maps/_RMC14/Inserts/Shiva/panic_room_hold.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 264.0.2
   forkId: ""
   forkVersion: ""
-  time: 02/16/2026 02:09:59
-  entityCount: 483
+  time: 03/10/2026 21:49:28
+  entityCount: 485
 maps: []
 grids:
 - 2
@@ -2321,6 +2321,22 @@ entities:
     components:
     - type: Transform
       pos: 14.5,3.5
+      parent: 2
+- proto: RMCMarkerAreaLabel
+  entities:
+  - uid: 484
+    components:
+    - type: MetaData
+      name: Crisis Center
+    - type: Transform
+      pos: 12.5,14.5
+      parent: 2
+  - uid: 485
+    components:
+    - type: MetaData
+      name: Panic Room
+    - type: Transform
+      pos: 10.5,4.5
       parent: 2
 - proto: RMCPhotocopier
   entities:


### PR DESCRIPTION
## About the PR
Fixes this insert missing its tactical map labels

## Why / Balance
fixes

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl: CatAndHats
- fix: Fixed shiva's snowball panic room insert not having its tactical map labels