### PR TITLE
Sorokyne SOF insert missing tacmap label fix

### DIFF
--- a/Resources/Maps/_RMC14/Inserts/Sorokyne/spp_sof.yml
+++ b/Resources/Maps/_RMC14/Inserts/Sorokyne/spp_sof.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 264.0.2
   forkId: ""
   forkVersion: ""
-  time: 03/03/2026 01:53:10
-  entityCount: 195
+  time: 03/10/2026 23:51:39
+  entityCount: 196
 maps: []
 grids:
 - 1
@@ -912,6 +912,15 @@ entities:
     components:
     - type: Transform
       pos: 5.5,5.5
+      parent: 1
+- proto: RMCMarkerAreaLabel
+  entities:
+  - uid: 196
+    components:
+    - type: MetaData
+      name: Aerodrom
+    - type: Transform
+      pos: 7.5,11.5
       parent: 1
 - proto: RMCPatchSPPAlt
   entities:


### PR DESCRIPTION
## About the PR
fixed missing tacmap label for aerodrom on the insert

## Why / Balance
bugfixing

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: CatAndHats
- fix: Fixed the missing aerodrom tacmap label on the Sorokyne Strata SPP SOF map insert