### PR TITLE
fix: patch infinite power exploit with dynamic charging state

### DIFF
--- a/Content.Server/Power/EntitySystems/ChargerSystem.cs
+++ b/Content.Server/Power/EntitySystems/ChargerSystem.cs
@@ -28,6 +28,7 @@ internal sealed class ChargerSystem : EntitySystem
     {
         SubscribeLocalEvent<ChargerComponent, ComponentStartup>(OnStartup);
         SubscribeLocalEvent<ChargerComponent, PowerChangedEvent>(OnPowerChanged);
+        SubscribeLocalEvent<ChargerComponent, AnchorStateChangedEvent>(OnAnchorChanged);
         SubscribeLocalEvent<ChargerComponent, EntInsertedIntoContainerMessage>(OnInserted);
         SubscribeLocalEvent<ChargerComponent, EntRemovedFromContainerMessage>(OnRemoved);
         SubscribeLocalEvent<ChargerComponent, ContainerIsInsertingAttemptEvent>(OnInsertAttempt);
@@ -98,6 +99,11 @@ internal sealed class ChargerSystem : EntitySystem
     }
 
     private void OnPowerChanged(EntityUid uid, ChargerComponent component, ref PowerChangedEvent args)
+    {
+        UpdateStatus(uid, component);
+    }
+
+    private void OnAnchorChanged(EntityUid uid, ChargerComponent component, ref AnchorStateChangedEvent args)
     {
         UpdateStatus(uid, component);
     }

--- a/Content.Server/_RMC14/Power/RMCPowerSystem.cs
+++ b/Content.Server/_RMC14/Power/RMCPowerSystem.cs
@@ -52,6 +52,8 @@ public sealed class RMCPowerSystem : SharedRMCPowerSystem
 
         SubscribeLocalEvent<RMCPowerReceiverComponent, PowerChangedEvent>(OnReceiverPowerChanged);
         SubscribeLocalEvent<RMCPowerUsageDisplayComponent, ExaminedEvent>(OnUsageDisplayEvent);
+        SubscribeLocalEvent<ActiveChargerComponent, ComponentStartup>(OnActiveChargerStartup);
+        SubscribeLocalEvent<ActiveChargerComponent, ComponentShutdown>(OnActiveChargerShutdown);
 
         Subs.CVar(_config, RMCCVars.RMCPowerUpdateEverySeconds, v => _updateEvery = TimeSpan.FromSeconds(v), true);
         Subs.CVar(_config, RMCCVars.RMCPowerLoadMultiplier, v => _powerLoadMultiplier = v, true);
@@ -70,8 +72,30 @@ public sealed class RMCPowerSystem : SharedRMCPowerSystem
 
     private void OnReceiverPowerChanged(Entity<RMCPowerReceiverComponent> ent, ref PowerChangedEvent args)
     {
-        ent.Comp.Mode = args.Powered ? RMCPowerMode.Active : RMCPowerMode.Off;
+        if (args.Powered && HasComp<ChargerComponent>(ent))
+            ent.Comp.Mode = RMCPowerMode.Idle;
+        else
+            ent.Comp.Mode = args.Powered ? RMCPowerMode.Active : RMCPowerMode.Off;
+
         ToUpdate.Add(ent);
+    }
+
+    private void OnActiveChargerStartup(EntityUid uid, ActiveChargerComponent comp, ComponentStartup args)
+    {
+        if (!TryComp<RMCPowerReceiverComponent>(uid, out var receiver))
+            return;
+
+        receiver.Mode = RMCPowerMode.Active;
+        ToUpdate.Add(uid);
+    }
+
+    private void OnActiveChargerShutdown(EntityUid uid, ActiveChargerComponent comp, ComponentShutdown args)
+    {
+        if (!TryComp<RMCPowerReceiverComponent>(uid, out var receiver))
+            return;
+
+        receiver.Mode = RMCPowerMode.Idle;
+        ToUpdate.Add(uid);
     }
 
     protected override void OnReceiverMapInit(Entity<RMCPowerReceiverComponent> ent, ref MapInitEvent args)

--- a/Content.Shared/_RMC14/Power/SharedRMCPowerSystem.cs
+++ b/Content.Shared/_RMC14/Power/SharedRMCPowerSystem.cs
@@ -319,13 +319,18 @@ public abstract class SharedRMCPowerSystem : EntitySystem
 
     private void OnReceiverRemove<T>(Entity<RMCPowerReceiverComponent> ent, ref T args)
     {
-        if (!TryGetPowerArea(ent, out var area) ||
-            TerminatingOrDeleted(area))
+        if (ent.Comp.Area is not { } areaId ||
+            TerminatingOrDeleted(areaId) ||
+            !_areaPowerQuery.TryComp(areaId, out var areaPower))
         {
             return;
         }
 
+        var area = new Entity<RMCAreaPowerComponent>(areaId, areaPower);
         GetAreaReceivers(area, ent.Comp.Channel).Remove(ent);
+        area.Comp.Load[(int) ent.Comp.Channel] -= ent.Comp.LastLoad;
+        ent.Comp.Area = null;
+        Dirty(areaId, areaPower);
     }
 
     private void OnFusionReactorMapInit(Entity<RMCFusionReactorComponent> ent, ref MapInitEvent args)

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Power/recharger.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Power/recharger.yml
@@ -32,9 +32,13 @@
       machine_parts: !type:Container
   - type: ApcPowerReceiver
     needsPower: false # TODO RMC14
-    powerLoad: 0 #15 kW
+    powerLoad: 0
+  - type: RMCPowerReceiver
+    idleLoad: 0
+    activeLoad: 1500
+    channel: Equipment
   - type: Charger
-    chargeRate: 1000
+    chargeRate: 10
     chargeLevelSteps: 6
   - type: ItemSlots
     slots:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

- APCs with power cells now deliver a balanced amount of power when charging another cell.
- As a side effect, chargers now draw from the correct APC when moved to a new location and check if a battery is inside when re-wrenched.

Addresses #9070

## Why / Balance
Currently players can generate unlimited power using two power cells. This obviously isn't intended behavior. This change should only affect charging stations and power cells. A charging station will now draw 1500W but remain at 0W when not in use. This change should make it so that batteries now draw 50% more power than they charge with, preventing the exploit.

When a charger is moved to a new location and wrenched down, it will also update its charging status depending on whether a battery is already present in the charger or not.

## Technical details
Added RMCPowerReceiverComponent to RMCRecharger so it registers as a load on the RMC APC system. The charger draws 1500W while actively charging and 0W when idle by listening to ActiveChargerComponent lifecycle events that ChargerSystem already manages.

OnReceiverRemove subtracts LastLoad in SharedRMCPowerSystem from the area's load on removal and nulls any cached Area reference. 

This also adds an AnchorStateChangedEvent subscription to ChargerSystem so charger status is re-evaluated on anchor changes, fixing re-anchored chargers not resuming when moved.

## Media
N/A

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed rechargers not drawing power from APCs, allowing infinite battery swapping.
- fix: Fixed power load leaking when powered devices are removed from an area.
- fix: Fixed chargers not resuming charging after being re-anchored.
- tweak: Reduced recharger charge rate from 1000 to 10 for power balance.
