### PR TITLE
tweak: give LO RMCAccessSeniorCommand access

### DIFF
--- a/Resources/Prototypes/_RMC14/Access/Groups/requisition_access_groups.yml
+++ b/Resources/Prototypes/_RMC14/Access/Groups/requisition_access_groups.yml
@@ -12,6 +12,7 @@
   - CMAccessDelta
   - CMAccessMarinePrep
   - RMCAccessDatabase
+  - RMCAccessSeniorCommand
 
 - type: accessGroup
   id: CMCargoTech


### PR DESCRIPTION
## About the PR

title

## Why / Balance

- fixes #9477
- looks like it was forgotten when we changed QM to LO

## Technical details

one more access

## Media

<img width="1210" height="437" alt="Screenshot From 2026-03-13 16-09-43" src="https://github.com/user-attachments/assets/4899a515-2354-4cbf-81ae-bb9d22ab6ec0" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- tweak: The logistics officer can now use the consoles in the command bubble, the command tablet and launch the lifeboats.
