### PR TITLE
fix: weapon targeting system stacking

### DIFF
--- a/Content.Shared/_RMC14/Dropship/ElectronicSystem/SharedDropshipElectronicSystemSystem.cs
+++ b/Content.Shared/_RMC14/Dropship/ElectronicSystem/SharedDropshipElectronicSystemSystem.cs
@@ -26,7 +26,6 @@ public abstract class SharedDropshipElectronicSystemSystem : EntitySystem
 
     private void OnDropshipWeaponShot(Entity<DropshipComponent> ent, ref DropshipWeaponShotEvent args)
     {
-        var found = false;
         foreach (var point in ent.Comp.AttachmentPoints)
         {
             if (!TryComp(point, out DropshipElectronicSystemPointComponent? electronic) ||
@@ -41,12 +40,8 @@ public abstract class SharedDropshipElectronicSystemSystem : EntitySystem
                 args.Spread = Math.Max(MinSpread, args.Spread + targeting.SpreadModifier);
                 args.BulletSpread = Math.Max(MinBulletSpread, args.BulletSpread + targeting.BulletSpreadModifier);
                 args.TravelTime = TimeSpan.FromSeconds(Math.Max(MinTravelTime, args.TravelTime.TotalSeconds + targeting.TravelingTimeModifier.TotalSeconds));
-                found = true;
-                break;
+                return;
             }
-
-            if (found)
-                break;
         }
     }
 


### PR DESCRIPTION
## About the PR

This PR makes it so that weapon targeting system no longer stack.

## Why / Balance

- fixes #9029

## Technical details

Stop looking for a attached `DropshipTargetingSystemComponent` after one has been found.

## Media

no

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- fix: Fixed dropship weapon targeting systems stacking if multiple are used at the same time.
