### PR TITLE
feat: implement proper tall grass collision and occlusion

### DIFF
--- a/Content.Client/Movement/Systems/FloorOcclusionSystem.cs
+++ b/Content.Client/Movement/Systems/FloorOcclusionSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._RMC14.TallGrass;
 using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Systems;
 using Robust.Client.GameObjects;
@@ -10,9 +11,13 @@ public sealed class FloorOcclusionSystem : SharedFloorOcclusionSystem
 {
     private static readonly ProtoId<ShaderPrototype> HorizontalCut = "HorizontalCut";
 
+    [Dependency] private readonly EntityLookupSystem _clientLookup = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
+    [Dependency] private readonly SharedTransformSystem _clientTransform = default!;
 
     private EntityQuery<SpriteComponent> _spriteQuery;
+    private readonly HashSet<Entity<FloorOccluderComponent>> _clientOccluders = new();
+    private readonly HashSet<EntityUid> _shaderApplied = new();
 
     public override void Initialize()
     {
@@ -20,19 +25,7 @@ public sealed class FloorOcclusionSystem : SharedFloorOcclusionSystem
 
         _spriteQuery = GetEntityQuery<SpriteComponent>();
 
-        SubscribeLocalEvent<FloorOcclusionComponent, ComponentStartup>(OnOcclusionStartup);
         SubscribeLocalEvent<FloorOcclusionComponent, ComponentShutdown>(OnOcclusionShutdown);
-        SubscribeLocalEvent<FloorOcclusionComponent, AfterAutoHandleStateEvent>(OnOcclusionAuto);
-    }
-
-    private void OnOcclusionAuto(Entity<FloorOcclusionComponent> ent, ref AfterAutoHandleStateEvent args)
-    {
-        SetShader(ent.Owner, ent.Comp.Enabled);
-    }
-
-    private void OnOcclusionStartup(Entity<FloorOcclusionComponent> ent, ref ComponentStartup args)
-    {
-        SetShader(ent.Owner, ent.Comp.Enabled);
     }
 
     private void OnOcclusionShutdown(Entity<FloorOcclusionComponent> ent, ref ComponentShutdown args)
@@ -40,9 +33,27 @@ public sealed class FloorOcclusionSystem : SharedFloorOcclusionSystem
         SetShader(ent.Owner, false);
     }
 
-    protected override void SetEnabled(Entity<FloorOcclusionComponent> entity)
+#pragma warning disable RA0028
+    public override void Update(float frameTime)
     {
-        SetShader(entity.Owner, entity.Comp.Enabled);
+        var query = EntityQueryEnumerator<FloorOcclusionComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out _, out var xform))
+        {
+            if (xform.MapUid == null)
+                continue;
+
+            if (HasComp<HiddenInGrassComponent>(uid))
+            {
+                SetShader(uid, false);
+                continue;
+            }
+
+            var coords = _clientTransform.GetMoverCoordinates(uid);
+            _clientOccluders.Clear();
+            _clientLookup.GetEntitiesInRange(coords, 0.5f, _clientOccluders);
+
+            SetShader(uid, _clientOccluders.Count > 0);
+        }
     }
 
     private void SetShader(Entity<SpriteComponent?> sprite, bool enabled)
@@ -52,16 +63,22 @@ public sealed class FloorOcclusionSystem : SharedFloorOcclusionSystem
 
         var shader = _proto.Index(HorizontalCut).Instance();
 
-        if (sprite.Comp.PostShader is not null && sprite.Comp.PostShader != shader)
-            return;
-
         if (enabled)
         {
+            // Don't overwrite another system's PostShader.
+            if (sprite.Comp.PostShader is not null && sprite.Comp.PostShader != shader)
+                return;
+
             sprite.Comp.PostShader = shader;
+            _shaderApplied.Add(sprite.Owner);
         }
         else
         {
-            sprite.Comp.PostShader = null;
+            if (!_shaderApplied.Remove(sprite.Owner))
+                return;
+
+            if (sprite.Comp.PostShader == shader)
+                sprite.Comp.PostShader = null;
         }
     }
 }

--- a/Content.Client/_RMC14/Sprite/RMCSpriteSystem.cs
+++ b/Content.Client/_RMC14/Sprite/RMCSpriteSystem.cs
@@ -2,6 +2,7 @@
 using Content.Shared._RMC14.CrashLand;
 using Content.Shared._RMC14.Mobs;
 using Content.Shared._RMC14.Sprite;
+using Content.Shared._RMC14.TallGrass;
 using Content.Shared._RMC14.Xenonids.Hide;
 using Content.Shared.Ghost;
 using Content.Shared.ParaDrop;
@@ -112,6 +113,9 @@ public sealed class RMCSpriteSystem : SharedRMCSpriteSystem
                 return;
 
             if (TryComp(player, out XenoHideComponent? hide) && hide.Hiding)
+                return;
+
+            if (HasComp<HiddenInGrassComponent>(player))
                 return;
 
             if (TryComp(player, out SpriteComponent? playerSprite) &&

--- a/Content.Shared/Movement/Systems/SharedFloorOcclusionSystem.cs
+++ b/Content.Shared/Movement/Systems/SharedFloorOcclusionSystem.cs
@@ -1,6 +1,5 @@
 using Content.Shared._RMC14.Water;
 using Content.Shared.Movement.Components;
-using Robust.Shared.Physics.Events;
 
 namespace Content.Shared.Movement.Systems;
 
@@ -9,45 +8,76 @@ namespace Content.Shared.Movement.Systems;
 /// </summary>
 public abstract class SharedFloorOcclusionSystem : EntitySystem
 {
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
     [Dependency] private readonly RMCWaterSystem _rmcWater = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    private readonly HashSet<Entity<FloorOccluderComponent>> _nearbyOccluders = new();
+    private readonly HashSet<EntityUid> _validOccluders = new();
 
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeLocalEvent<FloorOccluderComponent, StartCollideEvent>(OnStartCollide);
-        SubscribeLocalEvent<FloorOccluderComponent, EndCollideEvent>(OnEndCollide);
+        SubscribeLocalEvent<FloorOcclusionComponent, MapInitEvent>(OnOcclusionMapInit);
     }
 
-    private void OnStartCollide(Entity<FloorOccluderComponent> entity, ref StartCollideEvent args)
+    private void OnOcclusionMapInit(Entity<FloorOcclusionComponent> ent, ref MapInitEvent args)
     {
-        var other = args.OtherEntity;
+        SyncOcclusion(ent, ent.Comp);
+    }
 
-        if (!TryComp<FloorOcclusionComponent>(other, out var occlusion) ||
-            occlusion.Colliding.Contains(entity.Owner))
+    public override void Update(float frameTime)
+    {
+        var query = EntityQueryEnumerator<FloorOcclusionComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out var occlusion, out var xform))
         {
-            return;
+            if (xform.MapUid == null)
+                continue;
+
+            SyncOcclusion(uid, occlusion);
+        }
+    }
+
+    private void SyncOcclusion(EntityUid uid, FloorOcclusionComponent occlusion)
+    {
+        var coords = _transform.GetMoverCoordinates(uid);
+        _nearbyOccluders.Clear();
+        _lookup.GetEntitiesInRange(coords, 0.5f, _nearbyOccluders);
+
+        _validOccluders.Clear();
+        foreach (var occluder in _nearbyOccluders)
+        {
+            if (_rmcWater.CanCollide(occluder.Owner, uid))
+                _validOccluders.Add(occluder.Owner);
         }
 
-        if (!_rmcWater.CanCollide(entity.Owner, other))
-            return;
+        var changed = false;
 
-        occlusion.Colliding.Add(entity.Owner);
-        Dirty(other, occlusion);
-        SetEnabled((other, occlusion));
-    }
+        // Remove stale or out-of-range entries
+        for (var i = occlusion.Colliding.Count - 1; i >= 0; i--)
+        {
+            if (!_validOccluders.Contains(occlusion.Colliding[i]))
+            {
+                occlusion.Colliding.RemoveAt(i);
+                changed = true;
+            }
+        }
 
-    private void OnEndCollide(Entity<FloorOccluderComponent> entity, ref EndCollideEvent args)
-    {
-        var other = args.OtherEntity;
+        // Add nearby occluders not already tracked
+        foreach (var valid in _validOccluders)
+        {
+            if (!occlusion.Colliding.Contains(valid))
+            {
+                occlusion.Colliding.Add(valid);
+                changed = true;
+            }
+        }
 
-        if (!TryComp<FloorOcclusionComponent>(other, out var occlusion))
-            return;
-
-        if (!occlusion.Colliding.Remove(entity.Owner))
-            return;
-
-        Dirty(other, occlusion);
-        SetEnabled((other, occlusion));
+        if (changed)
+        {
+            Dirty(uid, occlusion);
+            SetEnabled((uid, occlusion));
+        }
     }
 
     protected virtual void SetEnabled(Entity<FloorOcclusionComponent> entity)

--- a/Content.Shared/_RMC14/TallGrass/HiddenInGrassComponent.cs
+++ b/Content.Shared/_RMC14/TallGrass/HiddenInGrassComponent.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.TallGrass;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(TallGrassSystem))]
+public sealed partial class HiddenInGrassComponent : Component
+{
+}

--- a/Content.Shared/_RMC14/TallGrass/TallGrassComponent.cs
+++ b/Content.Shared/_RMC14/TallGrass/TallGrassComponent.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.TallGrass;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(TallGrassSystem))]
+public sealed partial class TallGrassComponent : Component
+{
+}

--- a/Content.Shared/_RMC14/TallGrass/TallGrassSystem.cs
+++ b/Content.Shared/_RMC14/TallGrass/TallGrassSystem.cs
@@ -1,0 +1,78 @@
+using Content.Shared._RMC14.Sprite;
+using Content.Shared._RMC14.Stun;
+using Content.Shared._RMC14.Xenonids;
+
+namespace Content.Shared._RMC14.TallGrass;
+
+public sealed class TallGrassSystem : EntitySystem
+{
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private readonly SharedRMCSpriteSystem _rmcSprite = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    private readonly HashSet<Entity<TallGrassComponent>> _nearbyGrass = new();
+
+    private static readonly HashSet<RMCSizes> HideableSizes = new()
+    {
+        RMCSizes.Small,
+        RMCSizes.VerySmallXeno,
+        RMCSizes.SmallXeno,
+    };
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<HiddenInGrassComponent, GetDrawDepthEvent>(OnHiddenGetDrawDepth);
+        SubscribeLocalEvent<HiddenInGrassComponent, ComponentStartup>(OnHiddenStartup);
+    }
+
+    private void OnHiddenGetDrawDepth(Entity<HiddenInGrassComponent> ent, ref GetDrawDepthEvent args)
+    {
+        args.DrawDepth = Content.Shared.DrawDepth.DrawDepth.SmallMobs;
+    }
+
+    private void OnHiddenStartup(Entity<HiddenInGrassComponent> ent, ref ComponentStartup args)
+    {
+        _rmcSprite.UpdateDrawDepth(ent);
+    }
+
+    private bool IsInGrass(EntityUid uid)
+    {
+        var coords = _transform.GetMoverCoordinates(uid);
+        _nearbyGrass.Clear();
+        _lookup.GetEntitiesInRange(coords, 0.5f, _nearbyGrass);
+        return _nearbyGrass.Count > 0;
+    }
+
+    private bool CanHideInGrass(EntityUid uid)
+    {
+        return TryComp(uid, out RMCSizeComponent? size) && HideableSizes.Contains(size.Size);
+    }
+
+    public override void Update(float frameTime)
+    {
+        var query = EntityQueryEnumerator<XenoComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out _, out var xform))
+        {
+            if (xform.MapUid == null)
+                continue;
+
+            if (!CanHideInGrass(uid))
+                continue;
+
+            var inGrass = IsInGrass(uid);
+
+            if (inGrass && !HasComp<HiddenInGrassComponent>(uid))
+            {
+                EnsureComp<HiddenInGrassComponent>(uid);
+                _rmcSprite.UpdateDrawDepth(uid);
+            }
+            else if (!inGrass && HasComp<HiddenInGrassComponent>(uid))
+            {
+                RemComp<HiddenInGrassComponent>(uid);
+                _rmcSprite.UpdateDrawDepth(uid);
+            }
+        }
+    }
+}

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
@@ -326,6 +326,8 @@
       sprite: /Textures/_RMC14/Interface/map_blips.rsi
       state: background_xeno
   - type: XenoMapTracked
+  - type: RMCMobStateDrawDepth
+  - type: FloorOcclusion
   - type: Evasion
   - type: RMCWeaponAccuracy # This is so projectiles fired by xenos get a correctly-generated seed for RNG.
   - type: StunOnExplosionReceived

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Flora/tallgrass.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Flora/tallgrass.yml
@@ -5,14 +5,38 @@
   name: tallgrass
   suffix: Centre
   components:
-  # make this slashable by only machete
+  - type: Tag
+    tags: []
+  - type: TallGrass
+  - type: FloorOccluder
   - type: Sprite
     sprite: _RMC14/Structures/Flora/tallgrass.rsi
     state: tallgrass
     drawdepth: Walls
   - type: Physics
-    canCollide: false
+    canCollide: true
   - type: Fixtures
+    fixtures:
+      fix1:
+        hard: false
+        density: 7
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.5,-0.5,0.5,0.5"
+        layer:
+        - LowImpassable
+  - type: SpeedModifierContacts
+    walkSpeedModifier: 0.65
+    sprintSpeedModifier: 0.65
+    ignoreWhitelist:
+      components:
+      - Xeno
+  - type: Flammable
+    fireSpread: false
+    maximumFireStacks: 0.5
+    damage:
+      types:
+        Heat: 1
   - type: Damageable
     damageContainer: Inorganic
   - type: MeleeSound


### PR DESCRIPTION
## About the PR
In its current form, tall grass serves essentially no purpose other than to be removed because it's a hindrance to both teams. This PR makes the grass actually act like grass.

## Why / Balance
The new grass includes following features / balance changes:
- Tall grass no longer blocks placement of resin buildings
- Tall grass now provides full occlusion for small xenos & partial occlusion for larger xenos (mainly for immersion).
- Tall grass slows human movement to 0.65
- Tall grass is now flammable, no longer blocks flames, and no longer blocks xeno ground spits

## Technical details
- TallGrassComponent added to tall grass entity prototypes to identify them for spatial queries.
- HiddenInGrassComponent dynamically added/removed from small xenos when they enter/leave grass. Drives a GetDrawDepthEvent handler that lowers draw depth to SmallMobs, rendering the xeno behind the grass sprite (at Walls depth).
- TallGrassSystem polls every tick, iterating all XenoComponent entities. Filters by RMCSizes (only Small, VerySmallXeno, SmallXeno can hide). Uses EntityLookupSystem.GetEntitiesInRange<TallGrassComponent> to detect proximity to grass and adds/removes HiddenInGrassComponent accordingly, calling UpdateDrawDepth on change.
- Added MapInitEvent handler for initial sync on spawn, and an Update() loop that runs SyncOcclusion for every FloorOcclusionComponent entity each tick.
- SyncOcclusion performs a spatial query, then filters results through RMCWaterSystem.CanCollide, and checks the result against the existing Colliding list. Only calls Dirty()/SetEnabled() when the list actually changes.
- tallgrass.yml: Enabled physics, added TallGrass, FloorOccluder, SpeedModifierContacts (0.65 speed), and Flammable components.
- base_xeno.yml: Added RMCMobStateDrawDepth and FloorOcclusion components to CMXenoBase, giving all xeno castes floor occlusion support.

## Media

![flamethrower](https://github.com/user-attachments/assets/bb918245-edc3-40bc-9f83-76fbfaa02076)

![spitter](https://github.com/user-attachments/assets/2c4ff680-9916-4234-93cf-8975242c429e)

![building](https://github.com/user-attachments/assets/01f81e03-ce93-44d0-b9d5-a060e026e277)

<img width="600" height="449" alt="Content Client_IlgvCjlHPb" src="https://github.com/user-attachments/assets/f01cd37e-34b7-492b-b95b-8fefba4d1572" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: Tall grass no longer prevents placement of resin secretions.
- tweak: Tall grass is now flammable.
- tweak: Tall grass now occludes sprites based on size, fully hiding small xenos and partially obscuring larger entities.
- tweak: Tall grass no longer blocks acid spit.
- tweak: Tall grass will now slow marine movement to 0.65.