### PR TITLE
add: replacement squad radio headsets

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/marine_headsets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/marine_headsets.yml
@@ -1,6 +1,8 @@
 - type: entity
   parent: RMCHeadsetShip
   id: RMCHeadsetMarine
+  name: marine squad radio headset
+  description: A standard military radio headset.
   components:
   - type: GrantSquadLeaderTracker
     defaultMode: SquadLeader

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
@@ -764,6 +764,8 @@
       entries:
       - id: RMCHeadsetShip
         amount: 5
+      - id: RMCHeadsetMarine
+        amount: 5
       - id: CMEncryptionKeyAlpha
         amount: 5
       - id: CMEncryptionKeyBravo

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/prep.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/prep.yml
@@ -171,7 +171,7 @@
         amount: 15
       - id: RMCHandsGreyMarine
         amount: 15
-      - id: RMCHeadsetShip
+      - id: RMCHeadsetMarine
         amount: 15
       - id: ArmorHelmetM10
         amount: 15


### PR DESCRIPTION
## About the PR

Replaces the headset inside the prep area vendor with the squad variant and added the squad variant headset to the req vendor.

## Why / Balance

In case someone looses it or gets assigned to a squad and wants to track the SL.

## Technical details

minor yaml

## Media


https://github.com/user-attachments/assets/c57e41d1-21dd-4fd7-8c9f-a9251038be80

<img width="522" height="291" alt="image" src="https://github.com/user-attachments/assets/3548f58f-242d-4df8-986e-9335d5941536" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- add: Requisitions now also stocks replacement squad headsets with built in tracking.
