### PR TITLE
Burrowing sound fix

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Burrow/SharedXenoBurrowSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Burrow/SharedXenoBurrowSystem.cs
@@ -137,6 +137,8 @@ public abstract class SharedXenoBurrowSystem : EntitySystem
         if (args.burrowed)
         {
             _transform.AnchorEntity(burrower);
+            if (_net.IsServer)
+                _audio.PlayPvs(burrower.Comp.BurrowDownSound, burrower);
         }
         else
         {
@@ -225,10 +227,7 @@ public abstract class SharedXenoBurrowSystem : EntitySystem
                 burrower.Comp.Tunneling = true;
                 Dirty(burrower);
             }
-
             Dirty(burrower);
-            if (_net.IsServer)
-                _audio.PlayPvs(burrower.Comp.BurrowDownSound, burrower);
         }
         else
         {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes burrow down audio, it will now only be played when initially entering the burrowed state, once the do-after completes.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity + Prevents other players knowing if you have stopped burrowing to a location.

## Technical details
<!-- Summary of code changes for easier review. -->
Moved the code for playing the audio file "/Audio/_RMC14/Xeno/burrowing_b.ogg" so it will be triggered by BurrowedEvent instead of XenoBurrowActionEvent.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

https://github.com/user-attachments/assets/d59d9cbc-f105-4cc3-9e15-1e54c5a2285b


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X ] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed burrow-down sound being played when selecting a tile to burrow to, or cancelling a burrow. It will now only be played upon entering the burrowed state.
