### PR TITLE
tweak: foxtrot scaling

### DIFF
--- a/Content.Server/_RMC14/Intel/Tech/TechSystem.cs
+++ b/Content.Server/_RMC14/Intel/Tech/TechSystem.cs
@@ -2,9 +2,12 @@ using Content.Server.GameTicking.Events;
 using Content.Server.Ghost.Roles.Components;
 using Content.Server.Humanoid.Components;
 using Content.Server.Spawners.Components;
+using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Intel.Tech;
 using Content.Shared.Humanoid.Prototypes;
 using Robust.Server.GameObjects;
+using Robust.Shared.Configuration;
+using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
@@ -12,9 +15,11 @@ namespace Content.Server._RMC14.Intel.Tech;
 
 public sealed class ServerTechSystem : EntitySystem
 {
-    [Dependency] private readonly IRobustRandom _random = default!;
-    [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly IComponentFactory _componentFactory = default!;
+    [Dependency] private readonly IConfigurationManager _config = default!;
+    [Dependency] private readonly ISharedPlayerManager _playerManager = default!;
+    [Dependency] private readonly IPrototypeManager _proto = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly TransformSystem _transform = default!;
 
     private static readonly EntProtoId CombatTechProto = "RMCRandomHumanoidFoxtrotCombatTech";
@@ -26,6 +31,7 @@ public sealed class ServerTechSystem : EntitySystem
     private static readonly EntProtoId WeaponsSpecialistProto = "RMCRandomHumanoidFoxtrotWeaponsSpecialist";
 
     private bool _cryoMarinesPurchased = false;
+    private int _cryoMarinesScale;
 
     public override void Initialize()
     {
@@ -33,6 +39,8 @@ public sealed class ServerTechSystem : EntitySystem
         SubscribeLocalEvent<TechCryoMarinesEvent>(OnTechCryoMarines);
         SubscribeLocalEvent<TechCryoSpecEvent>(OnTechCryoSpec);
         SubscribeLocalEvent<RoundStartingEvent>(OnRoundStart);
+
+        Subs.CVar(_config, RMCCVars.RMCCryoMarinesScale, v => _cryoMarinesScale = v, true);
     }
 
     private void OnRoundStart(RoundStartingEvent ev)
@@ -42,11 +50,14 @@ public sealed class ServerTechSystem : EntitySystem
 
     private void OnTechCryoMarines(TechCryoMarinesEvent ev)
     {
+        var players = (float)_playerManager.PlayerCount;
+        var scale = players / _cryoMarinesScale;
+
         // TODO RMC14 this should spawn you as your character but with random name
         SpawnCryo(_cryoMarinesPurchased ? FireteamLeaderProto : SquadLeaderProto, 1);
-        SpawnCryo(CombatTechProto, 1);
-        SpawnCryo(HospitalCorpsmanProto, 1);
-        SpawnCryo(RiflemanProto, 2);
+        SpawnCryo(CombatTechProto, Scale(scale, 1));
+        SpawnCryo(HospitalCorpsmanProto, Scale(scale, 1));
+        SpawnCryo(RiflemanProto, Scale(scale, 2));
 
         _cryoMarinesPurchased = true;
     }
@@ -56,7 +67,7 @@ public sealed class ServerTechSystem : EntitySystem
         SpawnCryo(WeaponsSpecialistProto, 1);
     }
 
-    private void SpawnCryo(EntProtoId spawnerId, uint amount)
+    private void SpawnCryo(EntProtoId spawnerId, int amount)
     {
         if (!_proto.TryIndex(spawnerId, out var spawner) ||
             !spawner.TryGetComponent<RandomHumanoidSpawnerComponent>(out var human, _componentFactory) ||
@@ -82,5 +93,10 @@ public sealed class ServerTechSystem : EntitySystem
             var choice = _random.Pick(valid);
             Spawn(spawnerId, _transform.GetMapCoordinates(choice));
         }
+    }
+
+    private static int Scale(float scale, int amount)
+    {
+        return (int)MathF.Floor((scale + 1) * amount);
     }
 }

--- a/Content.Shared/_RMC14/CCVar/RMCCVars.cs
+++ b/Content.Shared/_RMC14/CCVar/RMCCVars.cs
@@ -145,6 +145,9 @@ public sealed partial class RMCCVars : CVars
     public static readonly CVarDef<int> RMCBioscanVariance =
         CVarDef.Create("rmc.bioscan_variance", 2, CVar.REPLICATED | CVar.SERVER);
 
+    public static readonly CVarDef<int> RMCCryoMarinesScale =
+        CVarDef.Create("rmc.cryo_marines_scale", 301, CVar.REPLICATED | CVar.SERVER);
+
     public static readonly CVarDef<int> RMCDropshipFabricatorStartingPoints =
         CVarDef.Create("rmc.dropship_fabricator_starting_points", 10000, CVar.REPLICATED | CVar.SERVER);
 


### PR DESCRIPTION
## About the PR

This PR adds scaling to the number of ghosts spawned when purchasing "Wake Up Additional Troops" from the tech console.

## Why / Balance

The current numbers are based on CM13 which has (as far as I know) a player limit of 150. This PR adjusts the number of slots  above that limit.

With the currently configured scale of `301`:

- Base: One leader, medic, ct and two rifleman.
- 151+: One additional rifleman.
- 301+: One additional medic, ct and rifleman.
- 452+: One additional rifleman.
- 602+: One additional medic, ct and rifleman.
- ...

Alternatively we could only scale the number of rifleman, but that is for the hosts to decide.

## Technical details

Additional cvar `rmc.cryo_marines_scale` to configure the scaling with the default value of `301`.

## Media

https://github.com/user-attachments/assets/07528f9c-67e3-4709-8d2f-6a7d6349700f


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- tweak: The amount of cryomarines woken up now scales with the amount of players.
