### PR TITLE
Hive core rebuild cooldown now applies after 15 minute mark

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Hive/HiveComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hive/HiveComponent.cs
@@ -65,7 +65,7 @@ public sealed partial class HiveComponent : Component
     public TimeSpan NewCoreCooldown = TimeSpan.FromMinutes(5);
 
     [DataField, AutoNetworkedField]
-    public TimeSpan PreSetupCutoff = TimeSpan.FromMinutes(20);
+    public TimeSpan PreSetupCutoff = TimeSpan.FromMinutes(15);
 
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
     public TimeSpan? NewCoreAt;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Hive core can currently be destroyed and rebuilt without cooldown any time before the 20 minute mark. This PR changes it to only apply before the 15 minute mark.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Hive core cooldown-free rebuild time reduced from 20 minutes after round start to 15 minutes.
