### PR TITLE
Intel Tech Tree Localization Support

### DIFF
--- a/Content.Client/_RMC14/Intel/TechControlConsoleBui.cs
+++ b/Content.Client/_RMC14/Intel/TechControlConsoleBui.cs
@@ -87,7 +87,7 @@ public sealed class TechControlConsoleBui : BoundUserInterface
                 {
                     OpenOptionWindow(option, tier, optionIndex, console.Tree.Points, console.Tree.Tier);
                 };
-                optionButton.ToolTip = option.Name;
+                optionButton.ToolTip = Loc.GetString(option.Name);
                 optionButton.TooltipDelay = 0.1f;
 
                 optionContainer.AddChild(new Control { HorizontalExpand = true });
@@ -110,10 +110,10 @@ public sealed class TechControlConsoleBui : BoundUserInterface
         _optionWindow = new TechControlConsoleOptionWindow();
         _optionWindow.OpenCentered();
         _optionWindow.OnClose += () => _optionWindow = null;
-        _optionWindow.Title = option.Name;
+        _optionWindow.Title = Loc.GetString(option.Name);
         _optionWindow.CurrentPointsLabel.Text = Loc.GetString("rmc-ui-tech-points-value", ("value", points.Double().ToString("F1")));
-        _optionWindow.NameLabel.Text = option.Name;
-        _optionWindow.DescriptionLabel.Text = option.Description;
+        _optionWindow.NameLabel.Text = Loc.GetString(option.Name);
+        _optionWindow.DescriptionLabel.Text = Loc.GetString(option.Description);
         _optionWindow.CostLabel.Text = $"{option.CurrentCost}";
 
         _optionWindow.Statistics.DisposeAllChildren();

--- a/Content.Shared/_RMC14/Intel/Tech/TechAnnounceEvent.cs
+++ b/Content.Shared/_RMC14/Intel/Tech/TechAnnounceEvent.cs
@@ -5,4 +5,4 @@ namespace Content.Shared._RMC14.Intel.Tech;
 
 [DataRecord]
 [Serializable, NetSerializable]
-public sealed record TechAnnounceEvent(string Author, string Message, SoundSpecifier? Sound);
+public sealed record TechAnnounceEvent(LocId Author, LocId Message, SoundSpecifier? Sound);

--- a/Content.Shared/_RMC14/Intel/Tech/TechOption.cs
+++ b/Content.Shared/_RMC14/Intel/Tech/TechOption.cs
@@ -6,8 +6,8 @@ namespace Content.Shared._RMC14.Intel.Tech;
 [DataRecord]
 [Serializable, NetSerializable]
 public readonly record struct TechOption(
-    string Name,
-    string Description,
+    LocId Name,
+    LocId Description,
     int Cost,
     int Increase,
     bool Repurchasable,

--- a/Content.Shared/_RMC14/Intel/Tech/TechSystem.cs
+++ b/Content.Shared/_RMC14/Intel/Tech/TechSystem.cs
@@ -43,7 +43,11 @@ public sealed class TechSystem : EntitySystem
 
     private void OnTechAnnounce(TechAnnounceEvent ev)
     {
-        var msg = Loc.GetString("rmc-announcement-message-raw", ("author", ev.Author), ("message", ev.Message));
+        var translatedAuthor = Loc.GetString(ev.Author);
+        var translatedMessage = Loc.GetString(ev.Message);
+        var msg = Loc.GetString("rmc-announcement-message-raw", 
+            ("author", translatedAuthor), 
+            ("message", translatedMessage));
         _marineAnnounce.AnnounceToMarines(msg, ev.Sound);
     }
 

--- a/Resources/Locale/en-US/_RMC14/rmc-intel-tech-tree.ftl
+++ b/Resources/Locale/en-US/_RMC14/rmc-intel-tech-tree.ftl
@@ -1,0 +1,75 @@
+﻿# Common Announcers
+rmc-intel-announcer-almayer-assets = ALMAYER SPECIAL ASSETS AUTHORIZED
+rmc-intel-announcer-almayer-defcon = ALMAYER DEFCON LEVEL INCREASED
+
+### Tier Unlocks
+rmc-intel-tech-tier-unlock-desc = Transitions the tree to another tier.
+
+# Tier 1
+rmc-intel-tech-unlock-tier-1-name = Unlock Tier 1
+
+# Tier 2
+rmc-intel-tech-unlock-tier-2-name = Unlock Tier 2
+rmc-intel-tech-unlock-tier-2-announce =
+    THREAT ASSESSMENT LEVEL INCREASED TO LEVEL 2.
+    LEVEL 2 assets have been authorised to handle the situation.
+
+# Tier 3
+rmc-intel-tech-unlock-tier-3-name = Unlock Tier 3
+rmc-intel-tech-unlock-tier-3-announce =
+    THREAT ASSESSMENT LEVEL INCREASED TO LEVEL 3.
+    LEVEL 3 assets have been authorised to handle the situation.
+
+# Tier 4
+rmc-intel-tech-unlock-tier-4-name = Unlock Tier 4
+rmc-intel-tech-unlock-tier-4-announce =
+    THREAT ASSESSMENT LEVEL INCREASED TO LEVEL 4.
+    LEVEL 4 assets have been authorised to handle the situation.
+
+### Budget & Logistics
+
+# Requisitions
+rmc-intel-tech-budget-req-name = Requisition Budget Increase
+rmc-intel-tech-budget-req-desc = Distributes resources to requisitions for spending.
+rmc-intel-tech-budget-req-announce = Additional supply budget has been authorised for this operation.
+
+# Dropship
+rmc-intel-tech-budget-ds-name = Dropship Budget Increase
+rmc-intel-tech-budget-ds-desc = Distributes resources to the dropship fabricator.
+rmc-intel-tech-budget-ds-announce = Additional dropship part fabricator points have been authorised for this operation.
+
+### Orbital Bombardment (OB)
+
+# HE
+rmc-intel-tech-ob-he-name = Additional OB projectiles - HE
+rmc-intel-tech-ob-he-desc = Highly explosive bombardment ammo, to be loaded into the orbital cannon.
+rmc-intel-tech-ob-he-announce = Additional Orbital Bombardment warheads (HE) have been delivered to Requisitions' ASRS.
+
+# Incendiary
+rmc-intel-tech-ob-incend-name = Additional OB projectiles - Incendiary
+rmc-intel-tech-ob-incend-desc = Highly flammable bombardment ammo, to be loaded into the orbital cannon.
+rmc-intel-tech-ob-incend-announce = Additional Orbital Bombardment warheads (Incendiary) have been delivered to Requisitions' ASRS.
+
+# Cluster
+rmc-intel-tech-ob-cluster-name = Additional OB projectiles - Cluster
+rmc-intel-tech-ob-cluster-desc = Highly explosive bombardment ammo that fragments, to be loaded into the orbital cannon.
+rmc-intel-tech-ob-cluster-announce = Additional Orbital Bombardment warheads (Cluster) have been delivered to Requisitions' ASRS.
+
+### Reinforcements
+
+# Troops
+rmc-intel-tech-wake-marines-name = Wake Up Additional Troops
+rmc-intel-tech-wake-marines-desc = Wakes up additional troops to fight against any threats.
+rmc-intel-tech-wake-marines-announce = Additional troops are being taken out of cryo.
+
+# Specialist
+rmc-intel-tech-wake-spec-name = Wake Up Additional Specialist
+rmc-intel-tech-wake-spec-desc = Wakes up an additional specialist to fight against any threats.
+rmc-intel-tech-wake-spec-announce = An additional specialist is being taken out of cryo.
+
+### Special Equipment
+
+# Nuclear Device
+rmc-intel-tech-nuke-name = Nuclear Device
+rmc-intel-tech-nuke-desc = Purchase a nuclear device. Only purchasable 116 minutes into the operation. It's the only way to be sure.
+rmc-intel-tech-nuke-announce = The deployment of Nuclear Ordnance have been authorized and will be delivered to the Requisitions Department, via ASRS.

--- a/Resources/Prototypes/_RMC14/Entities/Objects/rmc_intel.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/rmc_intel.yml
@@ -168,8 +168,8 @@
     tree:
       options:
       -
-        - name: Unlock Tier 1
-          description: Transitions the tree to another tier.
+        - name: rmc-intel-tech-unlock-tier-1-name
+          description: rmc-intel-tech-tier-unlock-desc
           cost: 0
           events:
           - !type:TechUnlockTierEvent
@@ -178,8 +178,8 @@
             sprite: _RMC14/Interface/tech_tree.rsi
             state: upgrade
       -
-        - name: Requisition Budget Increase
-          description: Distributes resources to requisitions for spending.
+        - name: rmc-intel-tech-budget-req-name
+          description: rmc-intel-tech-budget-req-desc
           cost: 7
           increase: 1
           repurchasable: true
@@ -187,13 +187,13 @@
           - !type:TechRequisitionsBudgetEvent
             amount: 5000
           - !type:TechAnnounceEvent
-            author: ALMAYER SPECIAL ASSETS AUTHORIZED
-            message: Additional supply budget has been authorised for this operation.
+            author: rmc-intel-announcer-almayer-assets
+            message: rmc-intel-tech-budget-req-announce
           icon:
             sprite: _RMC14/Interface/tech_tree.rsi
             state: budget_req
-        - name: Dropship Budget Increase
-          description: Distributes resources to the dropship fabricator.
+        - name: rmc-intel-tech-budget-ds-name
+          description: rmc-intel-tech-budget-ds-desc
           cost: 6
           increase: 1
           repurchasable: true
@@ -201,29 +201,27 @@
           - !type:TechDropshipBudgetEvent
             amount: 2000
           - !type:TechAnnounceEvent
-            author: ALMAYER SPECIAL ASSETS AUTHORIZED
-            message: Additional dropship part fabricator points have been authorised for this operation.
+            author: rmc-intel-announcer-almayer-assets
+            message: rmc-intel-tech-budget-ds-announce
           icon:
             sprite: _RMC14/Interface/tech_tree.rsi
             state: budget_ds
-        - name: Unlock Tier 2
-          description: Transitions the tree to another tier.
+        - name: rmc-intel-tech-unlock-tier-2-name
+          description: rmc-intel-tech-tier-unlock-desc
           cost: 5
           events:
           - !type:TechUnlockTierEvent
             tier: 2
           - !type:TechAnnounceEvent
-            author: ALMAYER DEFCON LEVEL INCREASED
-            message: "THREAT ASSESSMENT LEVEL INCREASED TO LEVEL 2.
-
-              LEVEL 2 assets have been authorised to handle the situation."
+            author: rmc-intel-announcer-almayer-defcon
+            message: rmc-intel-tech-unlock-tier-2-announce
             sound: /Audio/_RMC14/AI/commandreport.ogg
           icon:
             sprite: _RMC14/Interface/tech_tree.rsi
             state: upgrade
       -
-        - name: Additional OB projectiles - HE
-          description: Highly explosive bombardment ammo, to be loaded into the orbital cannon.
+        - name: rmc-intel-tech-ob-he-name
+          description: rmc-intel-tech-ob-he-desc
           cost: 5
           increase: 2
           repurchasable: true
@@ -231,13 +229,13 @@
           - !type:TechLogisticsDeliveryEvent
             object: RMCOrbitalCannonWarheadExplosive
           - !type:TechAnnounceEvent
-            author: ALMAYER SPECIAL ASSETS AUTHORIZED
-            message: Additional Orbital Bombardment warheads (HE) have been delivered to Requisitions' ASRS.
+            author: rmc-intel-announcer-almayer-assets
+            message: rmc-intel-tech-ob-he-announce
           icon:
             sprite: _RMC14/Interface/tech_tree.rsi
             state: ob_he
-        - name: Additional OB projectiles - Incendiary
-          description: Highly flammable bombardment ammo, to be loaded into the orbital cannon.
+        - name: rmc-intel-tech-ob-incend-name
+          description: rmc-intel-tech-ob-incend-desc
           cost: 5
           increase: 2
           repurchasable: true
@@ -245,13 +243,13 @@
           - !type:TechLogisticsDeliveryEvent
             object: RMCOrbitalCannonWarheadIncendiary
           - !type:TechAnnounceEvent
-            author: ALMAYER SPECIAL ASSETS AUTHORIZED
-            message: Additional Orbital Bombardment warheads (Incendiary) have been delivered to Requisitions' ASRS.
+            author: rmc-intel-announcer-almayer-assets
+            message: rmc-intel-tech-ob-incend-announce
           icon:
             sprite: _RMC14/Interface/tech_tree.rsi
             state: ob_incend
-        - name: Additional OB projectiles - Cluster
-          description: Highly explosive bombardment ammo that fragments, to be loaded into the orbital cannon.
+        - name: rmc-intel-tech-ob-cluster-name
+          description: rmc-intel-tech-ob-cluster-desc
           cost: 5
           increase: 2
           repurchasable: true
@@ -259,77 +257,73 @@
           - !type:TechLogisticsDeliveryEvent
             object: RMCOrbitalCannonWarheadCluster
           - !type:TechAnnounceEvent
-            author: ALMAYER SPECIAL ASSETS AUTHORIZED
-            message: Additional Orbital Bombardment warheads (Cluster) have been delivered to Requisitions' ASRS.
+            author: rmc-intel-announcer-almayer-assets
+            message: rmc-intel-tech-ob-cluster-announce
           icon:
             sprite: _RMC14/Interface/tech_tree.rsi
             state: ob_cluster
-        - name: Unlock Tier 3
-          description: Transitions the tree to another tier.
+        - name: rmc-intel-tech-unlock-tier-3-name
+          description: rmc-intel-tech-tier-unlock-desc
           cost: 5
           events:
           - !type:TechUnlockTierEvent
             tier: 3
           - !type:TechAnnounceEvent
-            author: ALMAYER DEFCON LEVEL INCREASED
-            message: "THREAT ASSESSMENT LEVEL INCREASED TO LEVEL 3.
-
-              LEVEL 3 assets have been authorised to handle the situation."
+            author: rmc-intel-announcer-almayer-defcon
+            message: rmc-intel-tech-unlock-tier-3-announce
             sound: /Audio/_RMC14/AI/commandreport.ogg
           icon:
             sprite: _RMC14/Interface/tech_tree.rsi
             state: upgrade
       -
-        - name: Wake Up Additional Troops
-          description: Wakes up additional troops to fight against any threats.
+        - name: rmc-intel-tech-wake-marines-name
+          description: rmc-intel-tech-wake-marines-desc
           cost: 6
           increase: 6
           repurchasable: true
           events:
           - !type:TechCryoMarinesEvent
           - !type:TechAnnounceEvent
-            author: ALMAYER SPECIAL ASSETS AUTHORIZED
-            message: Additional troops are being taken out of cryo.
+            author: rmc-intel-announcer-almayer-assets
+            message: rmc-intel-tech-wake-marines-announce
           icon:
             sprite: _RMC14/Interface/tech_tree.rsi
             state: cryotroops
-        - name: Wake Up Additional Specialist
-          description: Wakes up an additional specialist to fight against any threats.
+        - name: rmc-intel-tech-wake-spec-name
+          description: rmc-intel-tech-wake-spec-desc
           cost: 8
           events:
           - !type:TechCryoSpecEvent
           - !type:TechAnnounceEvent
-            author: ALMAYER SPECIAL ASSETS AUTHORIZED
-            message: An additional specialist is being taken out of cryo.
+            author: rmc-intel-announcer-almayer-assets
+            message: rmc-intel-tech-wake-spec-announce
           icon:
             sprite: _RMC14/Interface/tech_tree.rsi
             state: overshield
-        - name: Unlock Tier 4
-          description: Transitions the tree to another tier.
+        - name: rmc-intel-tech-unlock-tier-4-name
+          description: rmc-intel-tech-tier-unlock-desc
           cost: 5
           events:
           - !type:TechUnlockTierEvent
             tier: 4
           - !type:TechAnnounceEvent
-            author: ALMAYER DEFCON LEVEL INCREASED
-            message: "THREAT ASSESSMENT LEVEL INCREASED TO LEVEL 4.
-
-              LEVEL 4 assets have been authorised to handle the situation."
+            author: rmc-intel-announcer-almayer-defcon
+            message: rmc-intel-tech-unlock-tier-4-announce
             sound: /Audio/_RMC14/AI/commandreport.ogg
           icon:
             sprite: _RMC14/Interface/tech_tree.rsi
             state: upgrade
       -
-        - name: Nuclear Device
-          description: 	Purchase a nuclear device. Only purchasable 116 minutes into the operation. It's the only way to be sure.
+        - name: rmc-intel-tech-nuke-name
+          description: rmc-intel-tech-nuke-desc
           cost: 5
           timeLock: 115m
           events:
           - !type:TechLogisticsDeliveryEvent
             object: RMCNuke
           - !type:TechAnnounceEvent
-            author: ALMAYER SPECIAL ASSETS AUTHORIZED
-            message: The deployment of Nuclear Ordnance have been authorized and will be delivered to the Requisitions Department, via ASRS.
+            author: rmc-intel-announcer-almayer-assets
+            message: rmc-intel-tech-nuke-announce
           icon:
             sprite: _RMC14/Interface/tech_tree.rsi
             state: nuke


### PR DESCRIPTION
## About the PR
Migrates the Intel Tech Tree system to Fluent localization. Hardcoded strings in TechOption and TechAnnounceEvent replaced with LocId.

## Why / Balance
Improves maintainability and enables multi-language support (RU, CN, etc.) without modifying C# or YAML files.

## Technical details
- Changed field types from `string` to `LocId` in `TechOption` and `TechAnnounceEvent`.
- Updated `TechSystem` to use `Loc.GetString` for radio announcements.

## Media
<img width="1077" height="835" alt="Content Client_lo8FzF0soZ" src="https://github.com/user-attachments/assets/8d6c658e-461a-4af1-83b7-89cef6e96716" />

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- code: Migrated Intel Tech Tree strings (names, descriptions, and announcements) to localization files.