### PR TITLE
[PVE] Add FORECON Jobs to the Marine Department

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Departments/marine_department.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Departments/marine_department.yml
@@ -12,12 +12,12 @@
   - CMSmartGunOperator
   - CMHospitalCorpsman
   - CMCombatTech
-  - CMPVERifleman
+  - CMPVERifleman # PVE UNMC
   - CMPVEHospitalCorpsman
   - CMPVESquadLeader
   - CMPVESmartGunOperator
   - CMPVESectionSergeant
-  - CMRoyalMarinesTroopSargePVE
+  - CMRoyalMarinesTroopSargePVE # PVE RCM
   - CMRoyalMarinesSectionLeaderPVE
   - CMRoyalMarinesTeamLeaderPVE
   - CMRoyalMarinesAssaultEngineerPVE
@@ -26,5 +26,11 @@
   - CMRoyalMarinesScoutSniperPVE
   - CMRoyalMarinesMedicPVE
   - CMRoyalMarinesRiflemanPVE
+  - RMCFORECONPVESquadLead # PVE FORECON
+  - RMCFORECONPVEAssistantSL
+  - RMCFORECONPVERadioTelephoneOperator
+  - RMCFORECONPVECorpsman
+  - RMCFORECONPVESmartgunner
+  - RMCFORECONPVERifleman
   departmentRadio: null
   headOfDepartment: CMSquadLeader


### PR DESCRIPTION
## About the PR
Adds some jobs to the "Marine Department". Didn't test this but I doubt this breaks anything so long as the Linter passes.

## Why / Balance
They were absent so if we wanted to use these with our systems we had to upload an extra file. Adding to them department is one less thing to live upload

## Technical details
YAML

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
N/A
