### PR TITLE
Claymores can no longer be damaged while undeployed.

### DIFF
--- a/Content.Shared/_RMC14/Explosion/SharedRMCLandmineSystem.cs
+++ b/Content.Shared/_RMC14/Explosion/SharedRMCLandmineSystem.cs
@@ -144,6 +144,9 @@ public abstract partial class SharedRMCLandmineSystem : EntitySystem
     {
         if (HasComp<ProjectileComponent>(args.Source))
             args.Cancelled = true;
+
+        if (!ent.Comp.Armed)
+            args.Cancelled = true;
     }
 
     private void OnShouldInteract(Entity<RMCLandmineComponent> ent, ref CombatModeShouldHandInteractEvent args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
 Claymores no longer explode while undeployed.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug fix.
A grenade exploding near a claymore in item form would make it explode. The mine box also doesn't have any explosion resistance, so all mines in the box would explode at once.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix: Claymores no longer explode while undeployed.
