### PR TITLE
New Varadero fix to stop people paradropping out of bounds

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Areas/areas_varadero.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Areas/areas_varadero.yml
@@ -263,16 +263,13 @@
     minimapColor: '#0603C4EE'
 
 - type: entity
-  parent: RMCAreaVaraderoExterior
+  parent: RMCAreaVaraderoInteriorOob
   id: RMCAreaVaraderoExteriorFarocean
   name: New Varadero - Far Ocean
   components:
   - type: Sprite
     state: varadero3
   - type: Area
-    avoidBioscan: false
-    noTunnel: true
-    unweedable: false
     minimapColor: '#0603C4EE'
 
 - type: entity


### PR DESCRIPTION
## About the PR
stopped paradropping in far ocean area by making it parent off the Out Of Bounds area.

## Why / Balance
fix. so admins don't need to fish marines out of the ocean

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: CatAndHats
- fix: Fixed marines being able to paradrop into the out of bounds water area of New Varadero