### PR TITLE
prioritize figure in bag over hand

### DIFF
--- a/Content.Server/_RMC14/Figurines/FigurineSystem.cs
+++ b/Content.Server/_RMC14/Figurines/FigurineSystem.cs
@@ -68,8 +68,6 @@ public sealed class FigurineSystem : EntitySystem
             return;
 
         var figurine = Spawn(figurineId, MapCoordinates.Nullspace);
-        if (_hands.TryPickupAnyHand(ev.Mob, figurine, false))
-            return;
 
         var backs = _inventory.GetSlotEnumerator(ev.Mob, SlotFlags.BACK);
         while (backs.MoveNext(out var slot))
@@ -80,6 +78,9 @@ public sealed class FigurineSystem : EntitySystem
             if (_storage.Insert(slot.ContainedEntity.Value, figurine, out _, storageComp: storage))
                 return;
         }
+
+        if (_hands.TryPickupAnyHand(ev.Mob, figurine, false))
+            return;
     }
 
     private void ReloadAllFigurines()

--- a/Resources/Prototypes/_RMC14/Entities/Objects/patron_figurines.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/patron_figurines.yml
@@ -26,6 +26,17 @@
 
 - type: entity
   parent: RMCBaseFigurinePatron
+  id: RMCFigurineDeveloper
+  name: developer figurine
+  components:
+  - type: Sprite
+    sprite: Mobs/Pets/corgi.rsi
+    state: real_mouse
+  - type: PatronFigurine
+    id: 00000000-0000-0000-0000-000000000000 # Change to your UID for testing.
+
+- type: entity
+  parent: RMCBaseFigurinePatron
   id: RMCFigurinePatronFoxBridgeton
   name: Fox Bridgeton figurine
   description: This is like that book by George Orwell, Nineteen Eighty Fo'


### PR DESCRIPTION
## About the PR

This PR makes it so that it first attempts to insert the patreon figurine into the backpack and then into the hands.

## Why / Balance

Certain rolls spawn with equipment in their hands. They currently loose that equipment because the hands are already full.

## Technical details

Also merge #9419 to remove the medal from the hand.

## Media

The leader is supposed to spawn with a shotgun and a box of slugs.

Before:

https://github.com/user-attachments/assets/f469b0bd-6742-468c-897e-558b43b9752b

After:

https://github.com/user-attachments/assets/deab2061-9ea2-434f-9b30-3b0d136da2f2

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- tweak: You can now find your patreon figurine inside your backpack when you wake up.
