### PR TITLE
Fix map insert spawning

### DIFF
--- a/Content.Server/_RMC14/MapInsert/MapInsertSystem.cs
+++ b/Content.Server/_RMC14/MapInsert/MapInsertSystem.cs
@@ -80,7 +80,8 @@ public sealed class MapInsertSystem : EntitySystem
         {
             cumulativeProbability += variation.Probability;
             if (!forceSpawn &&
-                ((variation.NightmareScenario != _distressSignal.ActiveNightmareScenario) ||
+                ((variation.NightmareScenario != _distressSignal.ActiveNightmareScenario) &&
+                 !string.IsNullOrEmpty(variation.NightmareScenario) || //only allows either inserts with the correct scenario or no scenario to spawn
                  cumulativeProbability < randomProbability))
                 continue;
             spawn = variation.Spawn;


### PR DESCRIPTION
## About the PR
Fixed it so that non-scenario inserts can spawn when a scenario is selected

## Why / Balance
Bugfixing

Currently if a scenario rolls no standard inserts will roll, this most evidently affects Solaris right now where, due to the survivor spawn together scenarios, none of the 30ish standard inserts are spawning whatsoever. This is a bug that has always been in the game, but was never noticed before now since Scenarios were quite rare up until recently.

## Technical details
added an additional check to the insert spawning code to allow for non-scenario inserts to always be able to spawn.

## Media
I tested it 30 times trust me.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl: CatAndHats
- fix: Fixed an error where map inserts wouldn't spawn when a survivor scenario would roll, Solaris is saved