### PR TITLE
Attacking a phone as a xeno stops the sound it makes

### DIFF
--- a/Content.Shared/_RMC14/Telephone/SharedRMCTelephoneSystem.cs
+++ b/Content.Shared/_RMC14/Telephone/SharedRMCTelephoneSystem.cs
@@ -1,11 +1,13 @@
 using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.Marines.Squads;
+using Content.Shared._RMC14.Xenonids;
 using Content.Shared.Actions;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Audio;
 using Content.Shared.Database;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
+using Content.Shared.Interaction.Events;
 using Content.Shared.Inventory;
 using Content.Shared.Popups;
 using Content.Shared.UserInterface;
@@ -42,6 +44,7 @@ public abstract class SharedRMCTelephoneSystem : EntitySystem
         SubscribeLocalEvent<RotaryPhoneComponent, BeforeActivatableUIOpenEvent>(OnRotaryPhoneBeforeOpen);
         SubscribeLocalEvent<RotaryPhoneComponent, ComponentShutdown>(OnRotaryPhoneTerminating);
         SubscribeLocalEvent<RotaryPhoneComponent, EntityTerminatingEvent>(OnRotaryPhoneTerminating);
+        SubscribeLocalEvent<RotaryPhoneComponent, GettingAttackedAttemptEvent>(OnRotaryPhoneGettingAttacked);
 
         SubscribeLocalEvent<RotaryPhoneDialingComponent, InteractUsingEvent>(OnRotaryPhoneDialingInteractUsing);
 
@@ -91,6 +94,17 @@ public abstract class SharedRMCTelephoneSystem : EntitySystem
             phone.RotaryPhone = null;
             Dirty(ent.Comp.Phone.Value, phone);
         }
+    }
+
+    private void OnRotaryPhoneGettingAttacked(Entity<RotaryPhoneComponent> ent, ref GettingAttackedAttemptEvent args)
+    {
+        if (!HasComp<XenoComponent>(args.Attacker))
+            return;
+
+        StopSound(ent);
+
+        _audio.PlayPredicted(RemoteHangupSound, ent, args.Attacker);
+        _popup.PopupClient(Loc.GetString("rmc-dropship-launch-alarm-xeno-shutdown", ("console", ent)), args.Attacker, args.Attacker);
     }
 
     private void OnRotaryPhoneDialingInteractUsing(Entity<RotaryPhoneDialingComponent> ent, ref InteractUsingEvent args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
A xeno attacking a phone stops any sound currently being played by it.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Allows xenonids to fly the dropship without a permanent beeping sound if they killed someone that was using the phone.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- tweak: Attacking a phone as a xenonid will stop any sound it's currently playing.
