### PR TITLE
Fiorina Passover + Hive Loot Ejection

### DIFF
--- a/Resources/Maps/_RMC14/Inserts/Fiorina/birthday_party.yml
+++ b/Resources/Maps/_RMC14/Inserts/Fiorina/birthday_party.yml
@@ -1,0 +1,307 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 264.0.2
+  forkId: ""
+  forkVersion: ""
+  time: 04/10/2026 16:05:12
+  entityCount: 40
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  0: Space
+  198: CMFloorPlating
+  1: CMFloorSteelPrisonPlate
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: grid
+    - type: Transform
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: AQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes: []
+    - type: GridAtmosphere
+      version: 2
+      data:
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: ImplicitRoof
+- proto: BrokenBottle
+  entities:
+  - uid: 31
+    components:
+    - type: Transform
+      pos: 4.5385547,1.4159306
+      parent: 1
+- proto: CMTableWoodenPoor
+  entities:
+  - uid: 20
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,3.5
+      parent: 1
+- proto: DrinkGlass
+  entities:
+  - uid: 26
+    components:
+    - type: Transform
+      pos: 3.4031372,2.56256
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      pos: 3.6531372,2.7606146
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      pos: 2.6114705,3.5319839
+      parent: 1
+- proto: FoodCakeBirthday
+  entities:
+  - uid: 24
+    components:
+    - type: Transform
+      pos: 3.0252514,3.125451
+      parent: 1
+- proto: FoodPlateSmall
+  entities:
+  - uid: 29
+    components:
+    - type: Transform
+      pos: 2.6114705,2.6146796
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      pos: 3.4343872,3.7300382
+      parent: 1
+- proto: RMCBannerSteveBirthday
+  entities:
+  - uid: 33
+    components:
+    - type: Transform
+      pos: 3.0281372,5.085146
+      parent: 1
+- proto: RMCBarricadeWood
+  entities:
+  - uid: 6
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 7
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,4.5
+      parent: 1
+- proto: RMCDrinkAlcoholGin
+  entities:
+  - uid: 32
+    components:
+    - type: Transform
+      pos: 1.3614705,1.3533874
+      parent: 1
+- proto: RMCDrinkAlcoholPurpleWine
+  entities:
+  - uid: 25
+    components:
+    - type: Transform
+      pos: 2.410668,3.3756251
+      parent: 1
+- proto: RMCLightFixtureBlueDoubleOffset
+  entities:
+  - uid: 36
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,5.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+- proto: RMCPlankWood1
+  entities:
+  - uid: 40
+    components:
+    - type: Transform
+      pos: 5.621888,2.625104
+      parent: 1
+- proto: RMCStreamerPole
+  entities:
+  - uid: 34
+    components:
+    - type: Transform
+      pos: 2.0802205,4.8870916
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 4.8510547,4.8245482
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: RMCWallPrison
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,5.5
+      parent: 1
+  - uid: 3
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 4
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 5
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,0.5
+      parent: 1
+...

--- a/Resources/Maps/_RMC14/Inserts/Fiorina/nogear.yml
+++ b/Resources/Maps/_RMC14/Inserts/Fiorina/nogear.yml
@@ -1,0 +1,529 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 264.0.2
+  forkId: ""
+  forkVersion: ""
+  time: 04/10/2026 15:51:37
+  entityCount: 82
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  0: Space
+  198: CMFloorPlating
+  1: CMFloorSteelPrison
+  2: CMFloorSteelPrisonBrightClean
+  3: CMFloorSteelPrisonPlate
+  4: CMFloorSteelPrisonRedFull
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: grid
+    - type: Transform
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: AQAAAAAAAAEAAAAAAAABAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAwAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAgAAAAAAAAMAAAAAAAACAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADGAAAAAAAABAAAAAAAAAMAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAABAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAQAAAAAAAADAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAgAAAAAAAAQAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAEAAAAAAAAAwAAAAAAAAQAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAEAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAgAAAAAAAAMAAAAAAAAEAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAACAAAAAAAAAwAAAAAAAAIAAAAAAAACAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes: []
+    - type: GridAtmosphere
+      version: 2
+      data:
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: ImplicitRoof
+- proto: CMAirlockMaint
+  entities:
+  - uid: 33
+    components:
+    - type: Transform
+      pos: 6.5,1.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: 6.5,5.5
+      parent: 1
+- proto: CMApcNoPower
+  entities:
+  - uid: 79
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,7.5
+      parent: 1
+    - type: SpriteSetRenderOrder
+      offset: 0.7,-1.45
+- proto: CMPottedPlant26
+  entities:
+  - uid: 78
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+- proto: CMShoesLaceupCommander
+  entities:
+  - uid: 51
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
+- proto: CMWebbingHolster
+  entities:
+  - uid: 74
+    components:
+    - type: Transform
+      pos: 7.458819,0.44634295
+      parent: 1
+- proto: CMWindowReinforcedDirectional
+  entities:
+  - uid: 26
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,0.5
+      parent: 1
+  - uid: 77
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,0.5
+      parent: 1
+- proto: RMCDecalSpawnerBloodSplatters
+  entities:
+  - uid: 62
+    components:
+    - type: Transform
+      pos: 7.5,6.5
+      parent: 1
+  - uid: 63
+    components:
+    - type: Transform
+      pos: 6.5,7.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      pos: 4.5,6.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      pos: 3.5,7.5
+      parent: 1
+- proto: RMCJumpsuitOrange
+  entities:
+  - uid: 53
+    components:
+    - type: Transform
+      pos: 7.5,4.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      pos: 6.5,2.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+- proto: RMCKitchenKnifeChef
+  entities:
+  - uid: 68
+    components:
+    - type: Transform
+      pos: 2.194991,3.9487755
+      parent: 1
+- proto: RMCLightFixtureBlueDoubleOffset
+  entities:
+  - uid: 81
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,1.5
+      parent: 1
+- proto: RMCLockerGun
+  entities:
+  - uid: 39
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      pos: 7.5,4.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      pos: 7.5,3.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      pos: 7.5,2.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+- proto: RMCLockerPoliceSoro
+  entities:
+  - uid: 72
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      pos: 8.5,0.5
+      parent: 1
+- proto: RMCPacketGrenadeFlashBang
+  entities:
+  - uid: 75
+    components:
+    - type: Transform
+      pos: 8.510903,0.540159
+      parent: 1
+- proto: RMCRackParts
+  entities:
+  - uid: 69
+    components:
+    - type: Transform
+      pos: 2.4970746,1.6138201
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      pos: 3.4554079,1.6242445
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      pos: 4.4658246,1.6138201
+      parent: 1
+- proto: RMCRC6RiotShield
+  entities:
+  - uid: 37
+    components:
+    - type: Transform
+      pos: 7.4975758,6.5443287
+      parent: 1
+- proto: RMCShoesBlack
+  entities:
+  - uid: 52
+    components:
+    - type: Transform
+      pos: 7.5,3.5
+      parent: 1
+  - uid: 60
+    components:
+    - type: Transform
+      pos: 3.413741,6.169068
+      parent: 1
+- proto: RMCShoesGaloshes
+  entities:
+  - uid: 59
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+- proto: RMCSpawnerCorpseUNRiotOfficer
+  entities:
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 4.5,7.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: 6.5,6.5
+      parent: 1
+- proto: RMCSpawnerIntelClose
+  entities:
+  - uid: 38
+    components:
+    - type: Transform
+      pos: 7.5,7.5
+      parent: 1
+- proto: RMCSpawnerRandomGunPistolLow
+  entities:
+  - uid: 49
+    components:
+    - type: Transform
+      pos: 7.5,2.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 61
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+- proto: RMCTablePrison
+  entities:
+  - uid: 80
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,6.5
+      parent: 1
+- proto: RMCWallPrisonHull
+  entities:
+  - uid: 19
+    components:
+    - type: Transform
+      pos: 8.5,2.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      pos: 8.5,3.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      pos: 8.5,5.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      pos: 8.5,6.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      pos: 8.5,7.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      pos: 5.5,5.5
+      parent: 1
+- proto: RMCWallPrisonReinforced
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 3
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 4
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 5
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 6
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 7
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      pos: 8.5,4.5
+      parent: 1
+- proto: RMCWaterCooler
+  entities:
+  - uid: 67
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+- proto: RMCWindowPrisonReinforced
+  entities:
+  - uid: 30
+    components:
+    - type: Transform
+      pos: 5.5,6.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      pos: 5.5,7.5
+      parent: 1
+...

--- a/Resources/Prototypes/_RMC14/Entities/Markers/Inserts/fiorina.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Markers/Inserts/fiorina.yml
@@ -1,4 +1,6 @@
 # Fiorina
+# TODO RMC14 missing sprinkles: Basketball (20%) Research Pristine (25%) Pool Party (20%) Pizza Time (30%) Repair Panels LZ (30%) Scav Ship Holder (10%) Engineer Office (30%) Warden Office Decorated (15%) Gamer Time (20%)
+
 - type: entity
   abstract: true
   parent: RMCMapInsertBase
@@ -9,6 +11,8 @@
     clearEntities: true
     clearDecals: true
     replaceAreas: false
+
+# Sprinkles
 
 - type: entity
   parent: RMCMapInsertFiorinaBase
@@ -21,6 +25,30 @@
     - spawn: "/Maps/_RMC14/Inserts/Fiorina/podholder.yml"
       probability: 0.1
       offset: 1,1
+
+- type: entity
+  parent: RMCMapInsertFiorinaBase
+  id: RMCMapInsertFiorinaBirthdayParty
+  name: Birthday Party
+  suffix: Insert Fiorina
+  components:
+  - type: MapInsert
+    variations:
+    - spawn: "/Maps/_RMC14/Inserts/Fiorina/birthday_party.yml"
+      probability: 0.15
+
+- type: entity
+  parent: RMCMapInsertFiorinaBase
+  id: RMCMapInsertFiorinaNoGear
+  name: Armory No Gear
+  suffix: Insert Fiorina
+  components:
+  - type: MapInsert
+    variations:
+    - spawn: "/Maps/_RMC14/Inserts/Fiorina/nogear.yml"
+      probability: 0.15
+
+# Standalone
 
 - type: entity
   parent: RMCMapInsertFiorinaBase


### PR DESCRIPTION
## About the PR
A mapping parity passover for Fiorina Science Annex.

Also added some comments about what inserts are left to map, there are a lot but since they are mostly meme inserts I did not map all of them.

## Why / Balance
Parity

## Technical details
Map and yaml for 2 inserts and mapping changes on fiorina

## Media (non exhaustive there is a lot of small changes)
### Hive loot ejection
special weapon spawner, m890, flamer and smg spawner moved from elevators
<img width="385" height="295" alt="fio1" src="https://github.com/user-attachments/assets/9e3f6302-8f16-4dbc-831c-e052a6d6b823" />
<img width="474" height="424" alt="fio3" src="https://github.com/user-attachments/assets/e1038f65-d5af-4131-92b5-874a531ab60b" />
<img width="698" height="514" alt="fio2" src="https://github.com/user-attachments/assets/78eb603e-6b52-4398-8e36-cbf15494f948" />
Moved metal and sentry spawner
<img width="966" height="624" alt="fiorina123123" src="https://github.com/user-attachments/assets/9000e50d-710c-4f4a-aaee-a6eda18e3508" />
Moved incendiary slugs out of scavship hive
<img width="966" height="726" alt="fiorinaa" src="https://github.com/user-attachments/assets/5ccd1532-b0bd-440f-8d3e-358c019df3ff" />



### Passover changes
Fixed iwalls being accessible
<img width="437" height="427" alt="fiorinuhh" src="https://github.com/user-attachments/assets/5ed2a862-ae22-4914-a9ed-8f460581d40d" />
Blue powerloader, doorgunner module in engi ring
<img width="1410" height="760" alt="powerloader" src="https://github.com/user-attachments/assets/57328f08-72fa-4dc2-9864-f410e1007a07" />
Replaced all instances of We-Ya Goon corpses with UN Officer corpses (They are identical loadout wise to UN RCO's so I didn't bother adding a separate spawner for what is essentially a rename)
<img width="1173" height="947" alt="corpses" src="https://github.com/user-attachments/assets/fb9f5d15-5bc3-4b8c-b542-e5841b36291c" />
Birthday party insert (15%)
<img width="809" height="752" alt="bday" src="https://github.com/user-attachments/assets/b982c87c-f952-43e7-bc10-04cbf025d514" />
Armory no gear insert (20%)
<img width="1236" height="1069" alt="nogear" src="https://github.com/user-attachments/assets/2d3e8b8a-89d7-4664-8ea1-b3f2dc54530a" />
ML66D mounted barricade in garden
<img width="479" height="451" alt="lmg" src="https://github.com/user-attachments/assets/5b720794-f5c3-4ec5-8808-ab9a2f12466b" />
ML66D in survivor camp
<img width="818" height="756" alt="ml66d" src="https://github.com/user-attachments/assets/32141d5d-0f4b-4cbd-8101-400cf0d7f0c8" />
Some more parity decor in hospital
<img width="1519" height="707" alt="decor1" src="https://github.com/user-attachments/assets/7106db5f-5287-46a1-aea9-2730010e7bf8" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Ported Armory No Gear insert (20%) and Birthday Party insert (15%) on Fiorina
- add: Ported the ML66D in the Survivor Camp on Fiorina
- tweak: Replaced all instances of We-Ya goon corpses in Fiorina with riot control officer corpses
- tweak: A bunch of tweaks to loot on Fiorina
- tweak: Flamethrower on Fiorina has been moved to western Transit Hub, M890 has been moved to chapel, and the special weapons as well as turret spawner was moved to NE Hospital.
- fix: Fixed the Riot In Progress insert not overriding non-insert armory loot.