### PR TITLE
Mentor help UI improvements

### DIFF
--- a/Content.Client/UserInterface/Systems/Bwoink/AHelpUIController.cs
+++ b/Content.Client/UserInterface/Systems/Bwoink/AHelpUIController.cs
@@ -47,7 +47,7 @@ public sealed class AHelpUIController: UIController, IOnSystemChanged<BwoinkSyst
     public IAHelpUIHandler? UIHelper;
     private bool _discordRelayActive;
     private bool _hasUnreadAHelp;
-    private bool _hasUnreadMHelp;
+    private bool _hasUnreadMHelp; // RMC14
     private bool _bwoinkSoundEnabled;
     private string? _aHelpSound;
 
@@ -254,10 +254,11 @@ public sealed class AHelpUIController: UIController, IOnSystemChanged<BwoinkSyst
 
     public void UnreadAHelpReceived()
     {
-        _hasUnreadAHelp = true;
+        _hasUnreadAHelp = true; //RMC14
         UpdateUnreadState();
     }
 
+    //RMC14
     public void UnreadMHelpReceived()
     {
         _hasUnreadMHelp = true;
@@ -266,16 +267,18 @@ public sealed class AHelpUIController: UIController, IOnSystemChanged<BwoinkSyst
 
     public void UnreadAHelpRead()
     {
-        _hasUnreadAHelp = false;
+        _hasUnreadAHelp = false; // RMC14
         UpdateUnreadState();
     }
 
+    //RMC14
     public void UnreadMHelpRead()
     {
         _hasUnreadMHelp = false;
         UpdateUnreadState();
     }
 
+    // RMC14
     private void UpdateUnreadState()
     {
         var isAdmin = _adminManager.HasFlag(AdminFlags.Adminhelp);
@@ -311,6 +314,7 @@ public sealed class AHelpUIController: UIController, IOnSystemChanged<BwoinkSyst
                 UnreadAHelpRead();
             }
 
+            //RMC14
             if (_hasUnreadMHelp)
             {
                 UnreadMHelpReceived();
@@ -345,6 +349,7 @@ public sealed class AHelpUIController: UIController, IOnSystemChanged<BwoinkSyst
                 UnreadAHelpRead();
             }
 
+            //RMC14
             if (_hasUnreadMHelp)
             {
                 UnreadMHelpReceived();

--- a/Content.Client/UserInterface/Systems/Bwoink/AHelpUIController.cs
+++ b/Content.Client/UserInterface/Systems/Bwoink/AHelpUIController.cs
@@ -47,6 +47,7 @@ public sealed class AHelpUIController: UIController, IOnSystemChanged<BwoinkSyst
     public IAHelpUIHandler? UIHelper;
     private bool _discordRelayActive;
     private bool _hasUnreadAHelp;
+    private bool _hasUnreadMHelp;
     private bool _bwoinkSoundEnabled;
     private string? _aHelpSound;
 
@@ -253,16 +254,44 @@ public sealed class AHelpUIController: UIController, IOnSystemChanged<BwoinkSyst
 
     public void UnreadAHelpReceived()
     {
-        GameAHelpButton?.StyleClasses.Add(MenuButton.StyleClassRedTopButton);
-        LobbyAHelpButton?.StyleClasses.Add(StyleNano.StyleClassButtonColorRed);
         _hasUnreadAHelp = true;
+        UpdateUnreadState();
     }
 
-    private void UnreadAHelpRead()
+    public void UnreadMHelpReceived()
     {
-        GameAHelpButton?.StyleClasses.Remove(MenuButton.StyleClassRedTopButton);
-        LobbyAHelpButton?.StyleClasses.Remove(StyleNano.StyleClassButtonColorRed);
+        _hasUnreadMHelp = true;
+        UpdateUnreadState();
+    }
+
+    public void UnreadAHelpRead()
+    {
         _hasUnreadAHelp = false;
+        UpdateUnreadState();
+    }
+
+    public void UnreadMHelpRead()
+    {
+        _hasUnreadMHelp = false;
+        UpdateUnreadState();
+    }
+
+    private void UpdateUnreadState()
+    {
+        var isAdmin = _adminManager.HasFlag(AdminFlags.Adminhelp);
+        var isMentor = _staffHelp.IsMentor;
+        var red = isAdmin && _hasUnreadAHelp || isMentor && _hasUnreadMHelp;
+
+        if (red)
+        {
+            GameAHelpButton?.StyleClasses.Add(MenuButton.StyleClassRedTopButton);
+            LobbyAHelpButton?.StyleClasses.Add(StyleNano.StyleClassButtonColorRed);
+        }
+        else
+        {
+            GameAHelpButton?.StyleClasses.Remove(MenuButton.StyleClassRedTopButton);
+            LobbyAHelpButton?.StyleClasses.Remove(StyleNano.StyleClassButtonColorRed);
+        }
     }
 
     public void OnStateEntered(GameplayState state)
@@ -280,6 +309,15 @@ public sealed class AHelpUIController: UIController, IOnSystemChanged<BwoinkSyst
             else
             {
                 UnreadAHelpRead();
+            }
+
+            if (_hasUnreadMHelp)
+            {
+                UnreadMHelpReceived();
+            }
+            else
+            {
+                UnreadMHelpRead();
             }
         }
     }
@@ -305,6 +343,15 @@ public sealed class AHelpUIController: UIController, IOnSystemChanged<BwoinkSyst
             else
             {
                 UnreadAHelpRead();
+            }
+
+            if (_hasUnreadMHelp)
+            {
+                UnreadMHelpReceived();
+            }
+            else
+            {
+                UnreadMHelpRead();
             }
         }
     }

--- a/Content.Client/_RMC14/Mentor/StaffHelpUIController.cs
+++ b/Content.Client/_RMC14/Mentor/StaffHelpUIController.cs
@@ -112,7 +112,8 @@ public sealed class StaffHelpUIController : UIController, IOnSystemChanged<Bwoin
             }
 
             if (IsMentor &&
-                _mentorWindow is not { IsOpen: true })
+                _mentorWindow is not { IsOpen: true } &&
+                other)
             {
                 _unread = true;
                 _aHelp.UnreadMHelpReceived();
@@ -120,9 +121,11 @@ public sealed class StaffHelpUIController : UIController, IOnSystemChanged<Bwoin
 
             _destinationNames.TryAdd(message.Destination, message.DestinationName);
             _messages.GetOrNew(message.Destination).Add(message);
-            _lastMessageTime[message.Destination] = message.Time;
 
-            if (_mentorWindow?.SelectedPlayer != message.Destination)
+            if (message.Author != null)
+                _lastMessageTime[message.Destination] = message.Time;
+
+            if (_mentorWindow?.SelectedPlayer != message.Destination && other)
                 _unreadByPlayer[message.Destination] = true;
 
             UpdatePlayerButton(message.Destination);

--- a/Content.Client/_RMC14/Mentor/StaffHelpUIController.cs
+++ b/Content.Client/_RMC14/Mentor/StaffHelpUIController.cs
@@ -47,6 +47,7 @@ public sealed class StaffHelpUIController : UIController, IOnSystemChanged<Bwoin
     private SoundSpecifier? _mHelpSound;
     private bool _unread;
     private (TimeSpan Timestamp, bool Typing) _lastTypingUpdateSent;
+    private readonly Dictionary<NetUserId, bool> _unreadByPlayer = new();
 
     public event Action? MentorStatusUpdated;
 
@@ -112,11 +113,17 @@ public sealed class StaffHelpUIController : UIController, IOnSystemChanged<Bwoin
                 _mentorWindow is not { IsOpen: true })
             {
                 _unread = true;
-                _aHelp.UnreadAHelpReceived();
+                _aHelp.UnreadMHelpReceived();
             }
 
             _destinationNames.TryAdd(message.Destination, message.DestinationName);
             _messages.GetOrNew(message.Destination).Add(message);
+
+            if (_mentorWindow?.SelectedPlayer != message.Destination)
+                _unreadByPlayer[message.Destination] = true;
+
+            UpdatePlayerButton(message.Destination);
+
             if (_mentorWindow is { IsOpen: true })
             {
                 MentorAddPlayerButton(message.Destination);
@@ -245,7 +252,11 @@ public sealed class StaffHelpUIController : UIController, IOnSystemChanged<Bwoin
 
         SetAHelpButtonPressed(true);
         _staffHelpWindow = new StaffHelpWindow();
-        _staffHelpWindow.OnClose += () => _staffHelpWindow = null;
+        _staffHelpWindow.OnClose += () =>
+        {
+            _staffHelpWindow = null;
+            SetAHelpButtonPressed(false);
+        };
         _staffHelpWindow.OpenCentered();
         UIManager.ClickSound();
 
@@ -270,6 +281,7 @@ public sealed class StaffHelpUIController : UIController, IOnSystemChanged<Bwoin
     {
         SetAHelpButtonPressed(false);
         _unread = false;
+        _aHelp.UnreadMHelpRead();
         if (IsMentor)
         {
             if (OpenWindow(ref _mentorWindow,
@@ -364,6 +376,7 @@ public sealed class StaffHelpUIController : UIController, IOnSystemChanged<Bwoin
         if (_mentorWindow.PlayerDict.TryGetValue(player, out var button))
         {
             button.SetPositionFirst();
+            UpdatePlayerButton(player);
             return;
         }
 
@@ -382,6 +395,8 @@ public sealed class StaffHelpUIController : UIController, IOnSystemChanged<Bwoin
                 return;
 
             _mentorWindow.SelectedPlayer = player;
+            _unreadByPlayer.Remove(player);
+            UpdatePlayerButton(player);
             _mentorWindow.Messages.Clear();
             _mentorWindow.Chat.Editable = true;
             UpdateClaimIndicator(player);
@@ -399,6 +414,7 @@ public sealed class StaffHelpUIController : UIController, IOnSystemChanged<Bwoin
         _mentorWindow.Players.AddChild(playerButton);
         playerButton.SetPositionFirst();
         _mentorWindow.PlayerDict[player] = playerButton;
+        UpdatePlayerButton(player);
     }
 
     private bool OpenWindow<T>(
@@ -451,9 +467,9 @@ public sealed class StaffHelpUIController : UIController, IOnSystemChanged<Bwoin
         else if (message.Author.Value != message.Destination)
         {
             if (message.IsAdmin)
-                author = $"[bold][color=red]{author}[/color][/bold]";
+                author = $"[bold][color=red](Admin) {author}[/color][/bold]";
             else if (message.IsMentor)
-                author = $"[bold][color=orange]{author}[/color][/bold]";
+                author = $"[bold][color=orange](Mentor) {author}[/color][/bold]";
 
             text = $"{message.Time:HH:mm} {author}: {FormattedMessage.EscapeText(message.Text)}";
         }
@@ -470,8 +486,8 @@ public sealed class StaffHelpUIController : UIController, IOnSystemChanged<Bwoin
         if (_aHelp.GameAHelpButton != null)
             _aHelp.GameAHelpButton.Pressed = pressed;
 
-        if (_aHelp.GameAHelpButton != null)
-            _aHelp.GameAHelpButton.Pressed = pressed;
+        if (_aHelp.LobbyAHelpButton != null)
+            _aHelp.LobbyAHelpButton.Pressed = pressed;
     }
 
     private void UpdateTypingIndicator()
@@ -527,5 +543,24 @@ public sealed class StaffHelpUIController : UIController, IOnSystemChanged<Bwoin
         }
 
         _mentorWindow.ClaimIndicator.Text = $"Claimed by {string.Join(", ", claims)}";
+    }
+
+    private void UpdatePlayerButton(NetUserId player)
+    {
+        if (_mentorWindow is null)
+            return;
+
+        if (!_mentorWindow.PlayerDict.TryGetValue(player, out var button))
+            return;
+
+        var unread = _unreadByPlayer.TryGetValue(player, out var isUnread) && isUnread;
+
+        if (unread)
+        {
+            button.AddStyleClass(StyleNano.StyleClassButtonColorRed);
+            button.SetPositionFirst();
+        }
+        else
+            button.RemoveStyleClass(StyleNano.StyleClassButtonColorRed);
     }
 }

--- a/Content.Client/_RMC14/Mentor/StaffHelpUIController.cs
+++ b/Content.Client/_RMC14/Mentor/StaffHelpUIController.cs
@@ -295,7 +295,11 @@ public sealed class StaffHelpUIController : UIController, IOnSystemChanged<Bwoin
                     window => window.Chat,
                     window => window.SelectedPlayer))
             {
-                foreach (var destination in _messages.Keys)
+                var ordered = _messages.Keys
+                    .OrderByDescending(player => _lastMessageTime.GetValueOrDefault(player))
+                    .ToList();
+
+                foreach (var destination in ordered)
                 {
                     MentorAddPlayerButton(destination);
                 }

--- a/Content.Client/_RMC14/Mentor/StaffHelpUIController.cs
+++ b/Content.Client/_RMC14/Mentor/StaffHelpUIController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Threading;
 using Content.Client.Administration.Systems;
 using Content.Client.Stylesheets;
@@ -38,6 +39,8 @@ public sealed class StaffHelpUIController : UIController, IOnSystemChanged<Bwoin
     private readonly Dictionary<NetUserId, string> _destinationNames = new();
     private readonly Dictionary<NetUserId, (List<string> People, CancellationTokenSource Cancel)> _peopleTyping = new();
     private readonly Dictionary<NetUserId, List<string>> _claims = new();
+    private readonly Dictionary<NetUserId, bool> _unreadByPlayer = new();
+    private readonly Dictionary<NetUserId, DateTime> _lastMessageTime = new();
 
     public bool IsMentor { get; private set; }
     private bool _canReMentor;
@@ -47,7 +50,6 @@ public sealed class StaffHelpUIController : UIController, IOnSystemChanged<Bwoin
     private SoundSpecifier? _mHelpSound;
     private bool _unread;
     private (TimeSpan Timestamp, bool Typing) _lastTypingUpdateSent;
-    private readonly Dictionary<NetUserId, bool> _unreadByPlayer = new();
 
     public event Action? MentorStatusUpdated;
 
@@ -118,6 +120,7 @@ public sealed class StaffHelpUIController : UIController, IOnSystemChanged<Bwoin
 
             _destinationNames.TryAdd(message.Destination, message.DestinationName);
             _messages.GetOrNew(message.Destination).Add(message);
+            _lastMessageTime[message.Destination] = message.Time;
 
             if (_mentorWindow?.SelectedPlayer != message.Destination)
                 _unreadByPlayer[message.Destination] = true;
@@ -144,6 +147,8 @@ public sealed class StaffHelpUIController : UIController, IOnSystemChanged<Bwoin
                 _mentorHelpWindow.Messages.ScrollToBottom();
             }
         }
+
+        SortPlayerButtons();
 
         if (other)
         {
@@ -375,7 +380,6 @@ public sealed class StaffHelpUIController : UIController, IOnSystemChanged<Bwoin
 
         if (_mentorWindow.PlayerDict.TryGetValue(player, out var button))
         {
-            button.SetPositionFirst();
             UpdatePlayerButton(player);
             return;
         }
@@ -412,7 +416,6 @@ public sealed class StaffHelpUIController : UIController, IOnSystemChanged<Bwoin
         };
 
         _mentorWindow.Players.AddChild(playerButton);
-        playerButton.SetPositionFirst();
         _mentorWindow.PlayerDict[player] = playerButton;
         UpdatePlayerButton(player);
     }
@@ -558,9 +561,26 @@ public sealed class StaffHelpUIController : UIController, IOnSystemChanged<Bwoin
         if (unread)
         {
             button.AddStyleClass(StyleNano.StyleClassButtonColorRed);
-            button.SetPositionFirst();
         }
         else
             button.RemoveStyleClass(StyleNano.StyleClassButtonColorRed);
+    }
+
+    private void SortPlayerButtons()
+    {
+        if (_mentorWindow == null)
+            return;
+
+        var ordered = _messages.Keys
+            .OrderByDescending(player => _lastMessageTime.GetValueOrDefault(player))
+            .ToList();
+
+        _mentorWindow.Players.RemoveAllChildren();
+
+        foreach (var player in ordered)
+        {
+            if (_mentorWindow.PlayerDict.TryGetValue(player, out var button))
+                _mentorWindow.Players.AddChild(button);
+        }
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- The Ahelp button no longer turns red if you are a de-mentored admin and a mentor help message is sent.
- The Ahelp button no longer turns red if you are a mentor and an Ahelp is sent.
- The Ahelp button no longer turns red because of the disconnect/reconnect message in a mentor help chat.
- The Ahelp button no longer stays green if you close the window by pressing escape.
- If a mentor help chat has an unread message the button for that chat is now red.
- Usernames in mentor help chats now have a prefix showing if the user is an admin or a mentor.
- The mentor help chat list is now sorted by most recent message sent/received.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Mentor help improvements.

## Technical details
<!-- Summary of code changes for easier review. -->
Resolves #8436 
Implements features 2, 3?, 6 and 8 from #7566

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
<img width="1110" height="611" alt="image" src="https://github.com/user-attachments/assets/a1f58b70-4343-4713-89fa-ed7c8bc0c65b" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- admin: Slightly improved the mentor help UI.
