### PR TITLE
Tweaks the job rolling "Priority" system to only apply to queen and XO

### DIFF
--- a/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.Spawning.cs
+++ b/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.Spawning.cs
@@ -180,6 +180,30 @@ public sealed partial class CMDistressSignalRuleSystem
             return true;
         }
 
+        bool HasHigherPriorityJob(HumanoidCharacterProfile profile, ProtoId<JobPrototype> role, JobPriority priority)
+        {
+            if (!_prototypes.TryIndex(role, out var job))
+                return false;
+
+            foreach (var (otherId, otherPriority) in profile.JobPriorities)
+            {
+                if (otherId == role ||
+                    otherPriority <= JobPriority.Never ||
+                    !_prototypes.TryIndex(otherId, out var otherJob))
+                {
+                    continue;
+                }
+
+                if (otherJob.Weight > job.Weight ||
+                    otherJob.Weight == job.Weight && otherPriority > priority)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         NetUserId? SpawnXeno(List<NetUserId> list, EntProtoId ent, bool doBurst = false)
         {
             var playerId = _random.PickAndTake(list);
@@ -210,8 +234,13 @@ public sealed partial class CMDistressSignalRuleSystem
 
         foreach (var (id, profile) in ev.Profiles)
         {
-            if (IsAllowed(id, comp.QueenJob) && profile.JobPriorities.TryGetValue(comp.QueenJob, out var p) && p > JobPriority.Never)
+            if (IsAllowed(id, comp.QueenJob) &&
+                profile.JobPriorities.TryGetValue(comp.QueenJob, out var p) &&
+                p > JobPriority.Never &&
+                !HasHigherPriorityJob(profile, comp.QueenJob, p))
+            {
                 xenoCandidates[(int)p].Add(id);
+            }
         }
 
         NetUserId? queenSelected = null;
@@ -236,8 +265,14 @@ public sealed partial class CMDistressSignalRuleSystem
 
         foreach (var (id, profile) in ev.Profiles)
         {
-            if (id != queenSelected && IsAllowed(id, comp.XenoSelectableJob) && profile.JobPriorities.TryGetValue(comp.XenoSelectableJob, out var p) && p > JobPriority.Never)
+            if (id != queenSelected &&
+                IsAllowed(id, comp.XenoSelectableJob) &&
+                profile.JobPriorities.TryGetValue(comp.XenoSelectableJob, out var p) &&
+                p > JobPriority.Never &&
+                !HasHigherPriorityJob(profile, comp.XenoSelectableJob, p))
+            {
                 xenoCandidates[(int)p].Add(id);
+            }
         }
 
         var selectedXenos = 0;

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -13,7 +13,6 @@
     - !type:DepartmentTimeRequirement
       department: Cargo
       time: 36000 #10 hours
-  weight: 10
   startingGear: QuartermasterGear
   icon: "JobIconQuarterMaster"
   supervisors: job-supervisors-captain

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -19,7 +19,6 @@
     - !type:DepartmentTimeRequirement
       department: Command
       time: 14400 # 4 hours
-  weight: 20
   startingGear: CaptainGear
   icon: "JobIconCaptain"
   joinNotifyCrew: true

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -19,7 +19,6 @@
     - !type:DepartmentTimeRequirement
       department: Command
       time: 9000 # 2.5 hours
-  weight: 20
   startingGear: HoPGear
   icon: "JobIconHeadOfPersonnel"
   supervisors: job-supervisors-captain

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -13,7 +13,6 @@
     - !type:DepartmentTimeRequirement
       department: Engineering
       time: 36000 #10 hrs
-  weight: 10
   startingGear: ChiefEngineerGear
   icon: "JobIconChiefEngineer"
   supervisors: job-supervisors-captain

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -15,7 +15,6 @@
     - !type:DepartmentTimeRequirement
       department: Medical
       time: 36000 #10 hrs
-  weight: 10
   startingGear: CMOGear
   icon: "JobIconChiefMedicalOfficer"
   supervisors: job-supervisors-captain

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -10,7 +10,6 @@
   - !type:DepartmentTimeRequirement
     department: Science
     time: 36000 #10 hrs
-  weight: 10
   startingGear: ResearchDirectorGear
   icon: "JobIconResearchDirector"
   supervisors: job-supervisors-captain

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -16,7 +16,6 @@
     - !type:DepartmentTimeRequirement
       department: Security
       time: 36000 # 10 hrs
-  weight: 10
   startingGear: HoSGear
   icon: "JobIconHeadOfSecurity"
   supervisors: job-supervisors-captain

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -10,7 +10,6 @@
     - !type:DepartmentTimeRequirement
       department: Security
       time: 36000 #10 hrs
-  weight: 5
   startingGear: WardenGear
   icon: "JobIconWarden"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/auxiliary_support_officer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/auxiliary_support_officer.yml
@@ -29,7 +29,6 @@
       role: CMJobAuxiliarySupportOfficer
       time: 252000 # 70 hours
     RMCRankFirstLT: []
-  weight: 5
   startingGear: CMGearASO
   icon: "CMJobIconASO"
   requireAdminNotify: true

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Command/commanding_officer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Command/commanding_officer.yml
@@ -46,7 +46,6 @@
       role: CMJobCommandingOfficer
       time: 252000 # 70 hours
     RMCRankMajor: []
-  weight: 10
   startingGear: CMGearCommandingOfficer
   icon: "CMJobIconCommandingOfficer"
   requireAdminNotify: true

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Command/staff_officer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Command/staff_officer.yml
@@ -18,7 +18,6 @@
       role: CMJobStaffOfficer
       time: 252000 # 70 hours
     RMCRankSecondLT: []
-  weight: 5
   startingGear: CMGearStaffOfficer
   icon: "CMJobIconStaffOfficer"
   requireAdminNotify: true

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Engineering/chief_engineer.yml
@@ -14,7 +14,6 @@
       role: CMJobChiefEngineer
       time: 252000 # 70 hours
     RMCRankSecondLT: []
-  weight: 5
   startingGear: CMGearChiefEngineer
   icon: "CMJobIconChiefEngineer"
   requireAdminNotify: true

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -17,7 +17,6 @@
       role: CMJobCMO
       time: 252000 # 70 hours
     RMCRankSecondLT: []
-  weight: 5
   startingGear: CMGearCMO
   icon: "CMJobIconCMO"
   requireAdminNotify: true

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/MilitaryPolice/chief_military_police.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/MilitaryPolice/chief_military_police.yml
@@ -20,7 +20,6 @@
       role: CMJobChiefMP
       time: 252000 # 70 hours
     RMCRankSecondLT: []
-  weight: 5
   startingGear: CMGearChiefMP
   icon: "CMJobIconChiefMP"
   requireAdminNotify: true

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/MilitaryPolice/military_police.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/MilitaryPolice/military_police.yml
@@ -19,7 +19,6 @@
       role: CMJobMilitaryPolice
       time: 36000 # 10 hours
     RMCRankCorporal: []
-  weight: 5
   startingGear: CMGearMilitaryPolice
   icon: "CMJobIconMilitaryPolice"
   joinNotifyCrew: false

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/MilitaryPolice/military_warden.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/MilitaryPolice/military_warden.yml
@@ -18,7 +18,6 @@
       role: CMJobMilitaryWarden
       time: 36000 # 10 hours
     RMCRankSergeant: []
-  weight: 5
   startingGear: CMGearMilitaryWarden
   icon: "CMJobIconMilitaryWarden"
   joinNotifyCrew: false

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Requisitions/quartermaster.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Requisitions/quartermaster.yml
@@ -14,7 +14,6 @@
       role: CMJobQuartermaster
       time: 252000 # 70 hours
     RMCRankSecondLT: []
-  weight: 5
   startingGear: CMGearQuartermaster
   icon: "CMJobIconQuartermaster"
   requireAdminNotify: true

--- a/Resources/Prototypes/_RMC14/Roles/Xeno/Departments/xeno_department.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Xeno/Departments/xeno_department.yml
@@ -4,7 +4,6 @@
   name: department-CMXeno
   description: cm-department-Xeno-description
   color: "#8b36a6"
-  weight: 100
   customName: Xenonid
   roles:
   - CMXenoBoiler


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
When selecting jobs at roundstart, only Queen and XO jobs bypass the normal player-set job preference system. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Currently, we have a whole lot of jobs that bypass player preferences. In order of priority, those jobs are:
Queen > Xeno > CO > XO, CMO, CE, SO, CMP, MW, MP, LO, ASO > Everyone else

I imagine that the intent of this is to make sure "high impact" jobs are filled before other jobs. However, in practice, this leads to the opposite effect. If a player wants to, for example, try rolling for WS, then they NEED to have all of the jobs selected above to be set to "never", or they'll be put into them before they're even considered for WS. This leads to players simply not setting those jobs as "backups", since it sabotages their chances of getting the job they actually want. Many players currently latejoin into xeno, because having xeno on "low" is a 100% guarantee that you will always roll xeno. 

This PR will reduce the "priority" roles to just Queen > XO, as those are the only roles needed for the round to function (and they're high demand anyhow). This will also cut down on confusion, as the only way to know what roles were "priority" before was to codedive, leading to misinformation that roles like SL and survivor were also "priority", discouraging players from having them as backup jobs. 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Xeno, CO, CMO, CE, SO, CMP, MW, LO, ASO jobs no longer roll before other roles. Queen and XO retain priority. 
