### PR TITLE
Restored logic after refactor CMDistressSignalRuleSystem

### DIFF
--- a/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.Helpers.cs
+++ b/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.Helpers.cs
@@ -13,6 +13,7 @@ using Content.Shared.Coordinates;
 using Content.Shared.Fax.Components;
 using Content.Shared.Roles;
 using Robust.Shared.Map;
+using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
@@ -22,6 +23,21 @@ namespace Content.Server._RMC14.Rules.DistressSignal;
 public sealed partial class CMDistressSignalRuleSystem
 {
     private const int FaxPowerLoadValue = 5;
+
+    /// <summary>
+    /// Checks whether a player is allowed to play the specified job, considering bans and playtime requirements.
+    /// </summary>
+    private bool IsJobAllowed(NetUserId id, ProtoId<JobPrototype> role)
+    {
+        if (!_player.TryGetSessionById(id, out var player))
+            return false;
+
+        var jobBans = _bans.GetJobBans(player.UserId);
+        if (jobBans != null && jobBans.Contains(role))
+            return false;
+
+        return _playTime.IsAllowed(player, role);
+    }
 
     // TODO RMC14: Move these to a prototype
     private string GetRandomOperationName()
@@ -45,6 +61,7 @@ public sealed partial class CMDistressSignalRuleSystem
         return name.Trim();
     }
 
+    // TODO RMC14 this would be literally anywhere else if the code for loading maps wasn't dogshit and broken upstream
     private void SpawnAdminAreas(CMDistressSignalRuleComponent comp)
     {
         bool SpawnMap(ResPath path, [NotNullWhen(true)] out EntityUid? mapEntityUid)
@@ -92,6 +109,10 @@ public sealed partial class CMDistressSignalRuleSystem
             _camo.CurrentMapCamouflage = SelectedPlanetMap.Value.Comp.Camouflage;
     }
 
+    /// <summary>
+    /// Sets the hive of all loaded xeno friendly entities (e.g., weeds).
+    /// Only makes sense for distress signal with 1 hive, with multiple hives you would need to determine which weeds belong to which hive
+    /// </summary>
     private void SetFriendlyHives(EntityUid hive)
     {
         var query = EntityQueryEnumerator<XenoFriendlyComponent>();
@@ -122,6 +143,7 @@ public sealed partial class CMDistressSignalRuleSystem
         
         foreach (var tunnel in tunnels)
         {
+            // Replace all pre-mapped tunnels with a new tunnel with name and associated with the hive
             if (_xenoTunnel.TryPlaceTunnel(hive, null, tunnel.ToCoordinates(), out var newTunnel))
                 RemCompDeferred<DeletedByWeedKillerComponent>(newTunnel.Value);
 

--- a/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.Hijack.cs
+++ b/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.Hijack.cs
@@ -48,6 +48,7 @@ public sealed partial class CMDistressSignalRuleSystem
                 _destruction.DestroyEntity(id);
         }
 
+        //TODO RMC14 only do main hive
         var xenos = EntityQueryEnumerator<XenoComponent, MobStateComponent, InfectableComponent, TransformComponent>();
         var xenoAmount = 0;
         var larva = 0;
@@ -67,6 +68,7 @@ public sealed partial class CMDistressSignalRuleSystem
                 if (comp.CountedInSlots)
                     larva++;
 
+                //Ghost player and send message
                 if (TryComp(xeno, out ActorComponent? actor))
                 {
                     var session = actor.PlayerSession;
@@ -91,6 +93,7 @@ public sealed partial class CMDistressSignalRuleSystem
                 xenoAmount++;
         }
 
+        //Queen Maturing - TODO only main hive
         var queens = EntityQueryEnumerator<XenoMaturingComponent, MobStateComponent>();
         while (queens.MoveNext(out var queen, out var maturing, out _))
         {
@@ -100,7 +103,9 @@ public sealed partial class CMDistressSignalRuleSystem
             _maturing.Mature((queen, maturing));
         }
 
+        //Surge
         var shipQuery = EntityQueryEnumerator<MarineComponent, MobStateComponent, InfectableComponent, TransformComponent>();
+
         float totalHostWeights = 0;
         while (shipQuery.MoveNext(out var marine, out _, out _, out _, out var transformComp))
         {
@@ -160,7 +165,7 @@ public sealed partial class CMDistressSignalRuleSystem
 
         var didCameraShake = false;
         var warshipQuery = EntityQueryEnumerator<AlmayerComponent, TransformComponent>();
-        while (warshipQuery.MoveNext(out var uid, out _, out var xform))
+        while (warshipQuery.MoveNext(out var uid, out _, out var xform)) // Stun everyone on the Almayer
         {
             if (!didCameraShake)
             {
@@ -174,8 +179,12 @@ public sealed partial class CMDistressSignalRuleSystem
         }
     }
 
+    /// <summary>
+    /// Stuns all non-xeno on the Almayer.
+    /// </summary>
     private void StunAllEntitiesOnAlmayer(TransformComponent xform)
     {
+        // Get enumeration exceptions from people dropping things if we just paralyze as we go
         var toKnock = new ValueList<EntityUid>();
         GetAllEntitiesOnAlmayer(xform, ref toKnock);
 
@@ -188,8 +197,12 @@ public sealed partial class CMDistressSignalRuleSystem
         }
     }
 
+    /// <summary>
+    /// Gets all non-xeno on the Almayer.
+    /// </summary>
     private void GetAllEntitiesOnAlmayer(TransformComponent xform, ref ValueList<EntityUid> reference)
     {
+        // Not recursive because probably not necessary? If we need it to be that's why this method is separate.
         var childEnumerator = xform.ChildEnumerator;
         while (childEnumerator.MoveNext(out var child))
         {

--- a/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.Hijack.cs
+++ b/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.Hijack.cs
@@ -170,14 +170,14 @@ public sealed partial class CMDistressSignalRuleSystem
                 didCameraShake = true;
             }
 
-            StunAllMarinesOnAlmayer(xform);
+            StunAllEntitiesOnAlmayer(xform);
         }
     }
 
-    private void StunAllMarinesOnAlmayer(TransformComponent xform)
+    private void StunAllEntitiesOnAlmayer(TransformComponent xform)
     {
         var toKnock = new ValueList<EntityUid>();
-        GetMarinesOnAlmayer(xform, ref toKnock);
+        GetAllEntitiesOnAlmayer(xform, ref toKnock);
 
         foreach (var child in toKnock)
         {
@@ -188,7 +188,7 @@ public sealed partial class CMDistressSignalRuleSystem
         }
     }
 
-    private void GetMarinesOnAlmayer(TransformComponent xform, ref ValueList<EntityUid> reference)
+    private void GetAllEntitiesOnAlmayer(TransformComponent xform, ref ValueList<EntityUid> reference)
     {
         var childEnumerator = xform.ChildEnumerator;
         while (childEnumerator.MoveNext(out var child))

--- a/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.Planet.cs
+++ b/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.Planet.cs
@@ -57,6 +57,7 @@ public sealed partial class CMDistressSignalRuleSystem
             _mapInsert.ProcessMapInsert((uid, mapInsert));
         }
 
+        // TODO RMC14 this should be delayed by 3 minutes + 13 second warning for immersion
         if (_landingZoneMiasmaEnabled &&
             rule.Comp.LandingZoneGas is { } gas &&
             TryComp(rule.Comp.XenoMap, out AreaGridComponent? areaGrid))

--- a/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.RoundEnd.cs
+++ b/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.RoundEnd.cs
@@ -215,8 +215,6 @@ public sealed partial class CMDistressSignalRuleSystem
         }
 
         distress.QueenDiedCheck ??= Timing.CurTime + distress.QueenDiedDelay;
-        if (distress.QueenDiedCheck == null)
-            return;
 
         if (Timing.CurTime >= distress.QueenDiedCheck)
         {
@@ -269,7 +267,7 @@ public sealed partial class CMDistressSignalRuleSystem
                 DistressSignalRuleResult.MajorMarineVictory => -1,
                 DistressSignalRuleResult.MinorMarineVictory => -1,
                 DistressSignalRuleResult.MajorXenoVictory => 1,
-                DistressSignalRuleResult.MinorXenoVictory => 0,
+                DistressSignalRuleResult.MinorXenoVictory => 0, // hijack but all xenos die or timeout happens
                 DistressSignalRuleResult.AllDied => 0,
                 null => 0,
                 _ => throw new ArgumentOutOfRangeException(),
@@ -299,6 +297,7 @@ public sealed partial class CMDistressSignalRuleSystem
         if (!rule.AutoEnd)
             return;
 
+        // TODO RMC14: Refactor round end timing
         if (rule.StartTime == null || Timing.CurTime - rule.StartTime < rule.RoundEndCheckDelay)
             return;
 
@@ -339,7 +338,11 @@ public sealed partial class CMDistressSignalRuleSystem
 
     private void OnMobStateChanged<T>(Entity<T> ent, ref MobStateChangedEvent args) where T : IComponent?
     {
-        if (args.NewMobState != MobState.Dead) return;
+        if (args.NewMobState != MobState.Dead)
+        {
+            return;
+        }
+
         RemCompDeferred<GhostRoleComponent>(ent);
         CheckRoundShouldEnd();
     }
@@ -391,15 +394,19 @@ public sealed partial class CMDistressSignalRuleSystem
             var xenoCandidates = 0;
             foreach (var player in ev.Players)
             {
-                if (!_prefsManager.TryGetCachedPreferences(player.UserId, out var preferences)) continue;
-                if (preferences.GetProfile(preferences.SelectedCharacterIndex) is not HumanoidCharacterProfile profile)
-                    continue;
-
-                if (profile.JobPriorities.TryGetValue(distress.XenoSelectableJob, out var xenoPriority) &&
-                    xenoPriority > JobPriority.Never || profile.JobPriorities.TryGetValue(distress.QueenJob, out var queenPriority) &&
-                    queenPriority > JobPriority.Never)
+                if (_prefsManager.TryGetCachedPreferences(player.UserId, out var preferences))
                 {
-                    xenoCandidates++;
+                    var profile = (HumanoidCharacterProfile) preferences.GetProfile(preferences.SelectedCharacterIndex);
+                    if (profile.JobPriorities.TryGetValue(distress.XenoSelectableJob, out var xenoPriority) &&
+                        xenoPriority > JobPriority.Never)
+                    {
+                        xenoCandidates++;
+                    }
+                    else if (profile.JobPriorities.TryGetValue(distress.QueenJob, out var queenPriority) &&
+                        queenPriority > JobPriority.Never)
+                    {
+                        xenoCandidates++;
+                    }
                 }
             }
 

--- a/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.RoundEnd.cs
+++ b/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.RoundEnd.cs
@@ -251,6 +251,10 @@ public sealed partial class CMDistressSignalRuleSystem
         InvalidateActiveRule();
         StartPlanetVote();
         ResetSelectedPlanet();
+        _spawnedDropships = false;
+        OperationName = null;
+        _usingCustomOperationName = false;
+        ActiveNightmareScenario = null;
         _config.SetCVar(CCVars.GameDisallowLateJoins, false);
 
         if (!_autoBalance)

--- a/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.Spawning.cs
+++ b/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.Spawning.cs
@@ -303,7 +303,8 @@ public sealed partial class CMDistressSignalRuleSystem
             if (_mapSystem.TryGetMap(destTransform.MapID, out var destinationMapId) && comp.XenoMap == destinationMapId)
                 continue;
 
-            if (destination.Spawn == null) continue;
+            if (destination.Spawn == null)
+                continue;
 
             var gridOffset = new Vector2(shipIndex * 100, shipIndex * 100);
             shipIndex++;

--- a/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.Spawning.cs
+++ b/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.Spawning.cs
@@ -1,11 +1,11 @@
-﻿using System.Linq;
-using System.Numerics;
+﻿using System.Numerics;
 using Content.Server.GameTicking;
 using Content.Server.Station.Components;
 using Content.Server.Station.Systems;
 using Content.Shared._RMC14.Bioscan;
 using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Dropship;
+using Content.Shared._RMC14.Fax;
 using Content.Shared._RMC14.Humanoid;
 using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.Marines.Squads;
@@ -15,11 +15,11 @@ using Content.Shared._RMC14.Weapons.Ranged.IFF;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared._RMC14.Xenonids.Parasite;
 using Content.Shared.Coordinates;
+using Content.Shared.Database;
 using Content.Shared.Fax.Components;
 using Content.Shared.GameTicking;
 using Content.Shared.Nutrition.Components;
 using Content.Shared.Preferences;
-using Content.Shared.Roles;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
@@ -51,16 +51,19 @@ public sealed partial class CMDistressSignalRuleSystem
         SelectAndSpawnXenos(comp, ev);
 
         if (_spawnedDropships) return;
+
         _spawnedDropships = true;
         InitializeDropships(comp);
     }
 
     private void InitializeXenoMap(Entity<CMDistressSignalRuleComponent> rule, CMDistressSignalRuleComponent comp)
     {
+        // TODO: come up with random name like operation name, in a function that can be reused for hive v hive
         comp.Hive = _hive.CreateHive("xenonid hive", comp.HiveId);
         if (comp.SpawnPlanet && !SpawnXenoMap((rule.Owner, comp)))
         {
             Log.Error("Failed to load xeno map");
+            // TODO: how should the gamemode handle failure? restart immediately or create an alert for admins
             return;
         }
 
@@ -103,6 +106,7 @@ public sealed partial class CMDistressSignalRuleSystem
     private void ApplyJobSlotScaling(CMDistressSignalRuleComponent comp, RulePlayerSpawningEvent ev)
     {
         var totalXenos = (int) Math.Round(Math.Max(1, ev.PlayerPool.Count / _marinesPerXeno));
+        // TODO RMC14 dont count survivors
         var totalSurvivors = (int) Math.Clamp((int)Math.Round(ev.PlayerPool.Count / _marinesPerSurvivor), _minimumSurvivors, _maximumSurvivors);
         var marines = ev.PlayerPool.Count - totalXenos - totalSurvivors;
 
@@ -137,6 +141,8 @@ public sealed partial class CMDistressSignalRuleSystem
                         available[i] = slots;
                     }
                 }
+
+                Log.Info($"Setting {job} to {slots} slots.");
                 _stationJobs.TrySetJobSlot(stationId, job, slots, stationJobs: stationJobs);
             }
         }
@@ -146,6 +152,8 @@ public sealed partial class CMDistressSignalRuleSystem
     /// Selects xeno players based on job priorities and spawns them as queen or larva.
     /// Handles burrowed larva calculation if there aren't enough xeno players.
     /// </summary>
+    /// <param name="comp">The distress signal rule component.</param>
+    /// <param name="ev">The rule player spawning event.</param>
     private void SelectAndSpawnXenos(CMDistressSignalRuleComponent comp, RulePlayerSpawningEvent ev)
     {
         if (!comp.SpawnXenos)
@@ -163,21 +171,6 @@ public sealed partial class CMDistressSignalRuleSystem
         while (leaderSpawnQuery.MoveNext(out var spawnUid, out _))
         {
             xenoLeaderSpawnPoints.Add(spawnUid);
-        }
-
-        bool IsAllowed(NetUserId id, ProtoId<JobPrototype> role)
-        {
-            if (!_player.TryGetSessionById(id, out var player))
-                return false;
-
-            var jobBans = _bans.GetJobBans(player.UserId);
-            if (jobBans != null && jobBans.Contains(role))
-                return false;
-
-            if (!_playTime.IsAllowed(player, role))
-                return false;
-
-            return true;
         }
 
         NetUserId? SpawnXeno(List<NetUserId> list, EntProtoId ent, bool doBurst = false)
@@ -210,7 +203,7 @@ public sealed partial class CMDistressSignalRuleSystem
 
         foreach (var (id, profile) in ev.Profiles)
         {
-            if (IsAllowed(id, comp.QueenJob) && profile.JobPriorities.TryGetValue(comp.QueenJob, out var p) && p > JobPriority.Never)
+            if (IsJobAllowed(id, comp.QueenJob) && profile.JobPriorities.TryGetValue(comp.QueenJob, out var p) && p > JobPriority.Never)
                 xenoCandidates[(int)p].Add(id);
         }
 
@@ -236,7 +229,7 @@ public sealed partial class CMDistressSignalRuleSystem
 
         foreach (var (id, profile) in ev.Profiles)
         {
-            if (id != queenSelected && IsAllowed(id, comp.XenoSelectableJob) && profile.JobPriorities.TryGetValue(comp.XenoSelectableJob, out var p) && p > JobPriority.Never)
+            if (id != queenSelected && IsJobAllowed(id, comp.XenoSelectableJob) && profile.JobPriorities.TryGetValue(comp.XenoSelectableJob, out var p) && p > JobPriority.Never)
                 xenoCandidates[(int)p].Add(id);
         }
 
@@ -279,6 +272,8 @@ public sealed partial class CMDistressSignalRuleSystem
 
             RemCompDeferred<HiddenAppearanceComponent>(corpseMob);
             _xeno.MakeXeno(newXeno);
+
+            _adminLog.Add(LogType.RMCXenoSpawn, $"Player {player} with mob {ToPrettyString(newXeno):xeno} spawned as a xeno from their corpse {ToPrettyString(corpseMob):corpse}");
             return newXeno;
         }
 
@@ -294,6 +289,7 @@ public sealed partial class CMDistressSignalRuleSystem
     /// </summary>
     private void InitializeDropships(CMDistressSignalRuleComponent comp)
     {
+        // don't open shitcode inside
         _mapSystem.CreateMap(out var dropshipMap);
         var dropshipPoints = EntityQueryEnumerator<DropshipDestinationComponent, TransformComponent>();
         var shipIndex = 0;
@@ -317,14 +313,17 @@ public sealed partial class CMDistressSignalRuleSystem
             {
                 if (xform.GridUid != shipGrids.Value) continue;
 
-                _dropship.FlyTo(
+                if (!_dropship.FlyTo(
                     (computerId, computer),
                     destinationId,
                     user: null,
                     startupTime: 1f,
                     hyperspaceTime: 1f,
-                    offset: true
-                );
+                    offset: true))
+                {
+                    continue;
+                }
+
                 break;
             }
         }
@@ -340,46 +339,87 @@ public sealed partial class CMDistressSignalRuleSystem
         {
             _fax.Refresh(faxId, faxComp);
         }
+
+        if (SelectedPlanetMap == null)
+            return;
+
+        var specialFaxesList = SelectedPlanetMap.Value.Comp.SpecialFaxes;
+        if (specialFaxesList == null)
+            return;
+
+        var specialFaxes = EntityQueryEnumerator<FaxMachineComponent, SpecialFaxComponent>();
+        while (specialFaxes.MoveNext(out var faxId, out var faxComp, out var special))
+        {
+            foreach (var (targetFaxId, paper) in specialFaxesList)
+            {
+                if (special.FaxId != targetFaxId)
+                    continue;
+
+                if (!paper.TryGet(out var paperComponent, _prototypes, _compFactory))
+                    continue;
+
+                if (!_prototypes.TryIndex(paper.Id, out var entProto, logError: false))
+                    continue;
+
+                var content = Loc.GetString(paperComponent.Content);
+                var printout = new FaxPrintout(content, entProto.Name, prototypeId: paper.Id, locked: true);
+                _fax.Receive(faxId, printout, component: faxComp);
+            }
+        }
     }
 
     private void OnPlayerSpawning(PlayerSpawningEvent ev)
     {
-        if (ev.Job is not { } jobId || !_prototypes.TryIndex(jobId, out var job) || !job.IsCM)
+        if (ev.Job is not { } jobId ||
+            !_prototypes.TryIndex(jobId, out var job) ||
+            !job.IsCM)
+        {
             return;
+        }
 
         var comp = TryGetActiveRule();
         if (comp == null)
             return;
 
-        var squadPref = ev.HumanoidCharacterProfile?.SquadPreference;
-        if (GetSpawner(comp, job, squadPref) is not { } spawnerInfo)
+        var squadPreference = ev.HumanoidCharacterProfile?.SquadPreference;
+        if (GetSpawner(comp, job, squadPreference) is not { } spawnerInfo)
             return;
 
         var (spawner, squad) = spawnerInfo;
-        if (_hyperSleepChamberQuery.TryComp(spawner, out var hyperSleep) && _containers.TryGetContainer(spawner, hyperSleep.ContainerId, out var container))
+        if (_hyperSleepChamberQuery.TryComp(spawner, out var hyperSleep) &&
+            _containers.TryGetContainer(spawner, hyperSleep.ContainerId, out var container))
         {
             ev.SpawnResult = _stationSpawning.SpawnPlayerMob(spawner.ToCoordinates(), ev.Job, ev.HumanoidCharacterProfile, ev.Station);
             _containers.Insert(ev.SpawnResult.Value, container);
         }
         else
         {
-            ev.SpawnResult = _stationSpawning.SpawnPlayerMob(_transform.GetMoverCoordinates(spawner), ev.Job, ev.HumanoidCharacterProfile, ev.Station);
+            var coordinates = _transform.GetMoverCoordinates(spawner);
+            ev.SpawnResult = _stationSpawning.SpawnPlayerMob(coordinates, ev.Job, ev.HumanoidCharacterProfile, ev.Station);
         }
 
-        if (squad != null) _squad.AssignSquad(ev.SpawnResult.Value, squad.Value, jobId);
+        if (squad != null)
+        {
+            _squad.AssignSquad(ev.SpawnResult.Value, squad.Value, jobId);
 
-        if (TryComp(spawner, out TransformComponent? xform) && xform.GridUid != null)
-            EnsureComp<AlmayerComponent>(xform.GridUid.Value);
+            // TODO RMC14 add this to the map file
+            if (TryComp(spawner, out TransformComponent? xform) &&
+                xform.GridUid != null)
+            {
+                EnsureComp<AlmayerComponent>(xform.GridUid.Value);
+            }
 
-        if (comp.SetHunger && TryComp(ev.SpawnResult, out HungerComponent? hunger))
-            _hunger.SetHunger(ev.SpawnResult.Value, 50.0f, hunger);
+            if (comp.SetHunger && TryComp(ev.SpawnResult, out HungerComponent? hunger))
+                _hunger.SetHunger(ev.SpawnResult.Value, 50.0f, hunger);
+        }
     }
 
     private void SpawnSquads(Entity<CMDistressSignalRuleComponent> rule)
     {
-        foreach (var id in rule.Comp.SquadIds.Where(id => !rule.Comp.Squads.ContainsKey(id)))
+        foreach (var id in rule.Comp.SquadIds)
         {
-            rule.Comp.Squads[id] = Spawn(id);
+            if (!rule.Comp.Squads.ContainsKey(id))
+                rule.Comp.Squads[id] = Spawn(id);
         }
 
         foreach (var id in rule.Comp.ExtraSquadIds)

--- a/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.Spawning.cs
+++ b/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.Spawning.cs
@@ -45,10 +45,15 @@ public sealed partial class CMDistressSignalRuleSystem
 
         OperationName ??= GetRandomOperationName();
 
-        InitializeXenoMap(rule.Value, comp);
+        if (!InitializeXenoMap(rule.Value, comp))
+            return;
+
         SetupSurvivorJobs(comp);
         ApplyJobSlotScaling(comp, ev);
+
+        var initialPlayerCount = ev.PlayerPool.Count;
         SelectAndSpawnXenos(comp, ev);
+        SpawnSurvivors(comp, ev, initialPlayerCount);
 
         if (_spawnedDropships) return;
 
@@ -56,7 +61,7 @@ public sealed partial class CMDistressSignalRuleSystem
         InitializeDropships(comp);
     }
 
-    private void InitializeXenoMap(Entity<CMDistressSignalRuleComponent> rule, CMDistressSignalRuleComponent comp)
+    private bool InitializeXenoMap(Entity<CMDistressSignalRuleComponent> rule, CMDistressSignalRuleComponent comp)
     {
         // TODO: come up with random name like operation name, in a function that can be reused for hive v hive
         comp.Hive = _hive.CreateHive("xenonid hive", comp.HiveId);
@@ -64,7 +69,7 @@ public sealed partial class CMDistressSignalRuleSystem
         {
             Log.Error("Failed to load xeno map");
             // TODO: how should the gamemode handle failure? restart immediately or create an alert for admins
-            return;
+            return false;
         }
 
         _intel.RunSpawners();
@@ -82,24 +87,35 @@ public sealed partial class CMDistressSignalRuleSystem
             var bioscan = Spawn(null, MapCoordinates.Nullspace);
             EnsureComp<BioscanComponent>(bioscan);
         }
+
+        return true;
     }
 
     private void SetupSurvivorJobs(CMDistressSignalRuleComponent comp)
     {
-        if (SelectedPlanetMap?.Comp.SurvivorJobs == null)
+        if (SelectedPlanetMap == null)
             return;
 
-        comp.SurvivorJobs = _serialization.CreateCopy(SelectedPlanetMap.Value.Comp.SurvivorJobs, notNullableOverride: true);
         comp.SurvivorJobVariants = _serialization.CreateCopy(SelectedPlanetMap.Value.Comp.SurvivorJobVariants);
         comp.SurvivorJobOverrides = _serialization.CreateCopy(SelectedPlanetMap.Value.Comp.SurvivorJobOverrides);
 
+        if (SelectedPlanetMap.Value.Comp.SurvivorJobs != null)
+            comp.SurvivorJobs = _serialization.CreateCopy(SelectedPlanetMap.Value.Comp.SurvivorJobs, notNullableOverride: true);
+
         if (ActiveNightmareScenario != null)
         {
-            if (SelectedPlanetMap.Value.Comp.SurvivorJobScenarios?.TryGetValue(ActiveNightmareScenario, out var scenarioJobs) == true)
+            var activeScenarioSurvivors = _serialization.CreateCopy(SelectedPlanetMap.Value.Comp.SurvivorJobScenarios);
+            var activeScenarioSurvivorOverrides = _serialization.CreateCopy(SelectedPlanetMap.Value.Comp.SurvivorJobOverrideScenarios);
+            var activeScenarioSurvivorVariants = _serialization.CreateCopy(SelectedPlanetMap.Value.Comp.SurvivorJobVariantScenarios);
+
+            if (activeScenarioSurvivors != null && activeScenarioSurvivors.TryGetValue(ActiveNightmareScenario, out var scenarioJobs))
                 comp.SurvivorJobs = scenarioJobs;
 
-            SelectedPlanetMap.Value.Comp.SurvivorJobOverrideScenarios?.TryGetValue(ActiveNightmareScenario, out comp.SurvivorJobOverrides);
-            SelectedPlanetMap.Value.Comp.SurvivorJobVariantScenarios?.TryGetValue(ActiveNightmareScenario, out comp.SurvivorJobVariantScenarios);
+            if (activeScenarioSurvivorOverrides != null)
+                activeScenarioSurvivorOverrides.TryGetValue(ActiveNightmareScenario, out comp.SurvivorJobOverrides);
+
+            if (activeScenarioSurvivorVariants != null)
+                activeScenarioSurvivorVariants.TryGetValue(ActiveNightmareScenario, out comp.SurvivorJobVariantScenarios);
         }
     }
 

--- a/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.Survivors.cs
+++ b/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.Survivors.cs
@@ -1,0 +1,417 @@
+﻿using System.Linq;
+using Content.Server.GameTicking;
+using Content.Server.Spawners.Components;
+using Content.Shared._RMC14.Rules;
+using Content.Shared._RMC14.TacticalMap;
+using Content.Shared.Coordinates;
+using Content.Shared.GameTicking;
+using Content.Shared.Preferences;
+using Content.Shared.Roles;
+using Robust.Shared.Network;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+using Robust.Shared.Utility;
+
+namespace Content.Server._RMC14.Rules.DistressSignal;
+
+public sealed partial class CMDistressSignalRuleSystem
+{
+    /// <summary>
+    /// Main survivor spawning handler. Delegates to helper methods for job collection,
+    /// candidate assignment, and individual survivor spawning.
+    /// </summary>
+    private void SpawnSurvivors(CMDistressSignalRuleComponent comp, RulePlayerSpawningEvent ev)
+    {
+        if (!comp.SpawnSurvivors || comp.SurvivorJobs.Count == 0)
+            return;
+
+        if (ActiveNightmareScenario == null)
+            comp.SurvivorJobs = comp.SurvivorJobs.OrderBy(_ => _random.Next()).ToList();
+
+        var possibleJobs = CollectPossibleSurvivorJobs(comp);
+        var (spawners, spawnersLeft) = FindSurvivorSpawners(possibleJobs);
+        var candidates = CollectSurvivorCandidates(comp, ev);
+
+        SpawnSurvivorsFromCandidates(comp, ev, candidates, spawners, spawnersLeft);
+    }
+
+    private List<ProtoId<JobPrototype>> CollectPossibleSurvivorJobs(CMDistressSignalRuleComponent comp)
+    {
+        var jobs = new List<ProtoId<JobPrototype>>();
+        jobs.AddRange(comp.SurvivorJobs.Select(x => x.Job));
+        if (comp.SurvivorJobOverrides != null)
+            jobs.AddRange(comp.SurvivorJobOverrides.Values);
+        if (comp.SurvivorJobVariants != null)
+            jobs.AddRange(comp.SurvivorJobVariants.Values.SelectMany(x => x).Select(x => x.Variant));
+        if (comp.SurvivorJobVariantScenarios != null)
+            jobs.AddRange(comp.SurvivorJobVariantScenarios.Values.SelectMany(x => x).Select(x => x.Special));
+        return jobs;
+    }
+
+    private (Dictionary<ProtoId<JobPrototype>, List<EntityUid>> Spawners,
+             Dictionary<ProtoId<JobPrototype>, List<EntityUid>> SpawnersLeft)
+        FindSurvivorSpawners(List<ProtoId<JobPrototype>> possibleJobs)
+    {
+        var spawners = new Dictionary<ProtoId<JobPrototype>, List<EntityUid>>();
+        var spawnerQuery = EntityQueryEnumerator<SpawnPointComponent>();
+        while (spawnerQuery.MoveNext(out var spawnId, out var spawnComp))
+        {
+            if (spawnComp.Job is { } job && possibleJobs.Contains(job))
+                spawners.GetOrNew(job).Add(spawnId);
+        }
+
+        var spawnersLeft = spawners.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToList());
+        return (spawners, spawnersLeft);
+    }
+
+    private Dictionary<ProtoId<JobPrototype>, List<NetUserId>[]> CollectSurvivorCandidates(
+        CMDistressSignalRuleComponent comp,
+        RulePlayerSpawningEvent ev)
+    {
+        var priorities = Enum.GetValues<JobPriority>().Length;
+        var candidates = new Dictionary<ProtoId<JobPrototype>, List<NetUserId>[]>();
+
+        foreach (var job in comp.SurvivorJobs)
+        {
+            var jobList = new List<NetUserId>[priorities];
+            for (var i = 0; i < jobList.Length; i++)
+            {
+                jobList[i] = [];
+            }
+            candidates[job.Job] = jobList;
+        }
+
+        foreach (var player in ev.PlayerPool)
+        {
+            foreach (var (job, players) in candidates)
+            {
+                TryAddSurvivorCandidate(player.UserId, job, players, comp, ev);
+            }
+        }
+
+        return candidates;
+    }
+
+    private void TryAddSurvivorCandidate(
+        NetUserId id,
+        ProtoId<JobPrototype> job,
+        List<NetUserId>[] players,
+        CMDistressSignalRuleComponent comp,
+        RulePlayerSpawningEvent ev)
+    {
+        if (!IsJobAllowed(id, comp.CivilianSurvivorJob) || !IsJobAllowed(id, job))
+            return;
+
+        if (!ev.Profiles.TryGetValue(id, out var profile))
+            return;
+
+        if (comp.SurvivorJobOverrides != null)
+        {
+            foreach (var (originalJob, overrideJob) in comp.SurvivorJobOverrides)
+            {
+                if (profile.JobPriorities.TryGetValue(originalJob, out var overridePrio) &&
+                    overridePrio > JobPriority.Never && overrideJob == job)
+                {
+                    players[(int)overridePrio].Add(id);
+                    return;
+                }
+            }
+        }
+
+        if (profile.JobPriorities.TryGetValue(job, out var prio) && prio > JobPriority.Never)
+        {
+            players[(int)prio].Add(id);
+        }
+    }
+
+    private void SpawnSurvivorsFromCandidates(
+        CMDistressSignalRuleComponent comp,
+        RulePlayerSpawningEvent ev,
+        Dictionary<ProtoId<JobPrototype>, List<NetUserId>[]> candidates,
+        Dictionary<ProtoId<JobPrototype>, List<EntityUid>> spawners,
+        Dictionary<ProtoId<JobPrototype>, List<EntityUid>> spawnersLeft)
+    {
+        var priorities = Enum.GetValues<JobPriority>().Length;
+        var totalSurvivors = (int)Math.Clamp((int)Math.Round(ev.PlayerPool.Count / _marinesPerSurvivor), _minimumSurvivors, _maximumSurvivors);
+        var selected = 0;
+
+        for (var i = priorities - 1; i >= 0; i--)
+        {
+            foreach (var (job, players) in candidates)
+            {
+                var ignoreLimit = comp.IgnoreMaximumSurvivorJobs.Contains(job);
+                var playerNames = players[i].Select(p => ev.Profiles.TryGetValue(p, out var prof) ? prof.Name : p.ToString());
+                Log.Info($"Rolling survivor job {job} with priority {i} and players {string.Join(", ", playerNames)}");
+                while (players[i].Count > 0 && (ignoreLimit || selected < totalSurvivors))
+                {
+                    if (TrySpawnSingleSurvivor(job, players[i], comp, ev, spawnersLeft, spawners, out var playerId))
+                    {
+                        var name = ev.Profiles.TryGetValue(playerId, out var prof) ? prof.Name : playerId.ToString();
+                        Log.Info($"Spawned survivor job {job} with name/id {name}, ignore limit: {ignoreLimit}");
+                        RemoveCandidateFromAllLists(candidates, playerId);
+                        if (!ignoreLimit)
+                            selected++;
+                    }
+                    else
+                    {
+                        Log.Info($"Stopped rolling survivor job {job}");
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    private void RemoveCandidateFromAllLists(
+        Dictionary<ProtoId<JobPrototype>, List<NetUserId>[]> candidates,
+        NetUserId playerId)
+    {
+        foreach (var (_, priorityLists) in candidates)
+        {
+            foreach (var list in priorityLists)
+            {
+                list.Remove(playerId);
+            }
+        }
+    }
+
+    private bool TrySpawnSingleSurvivor(
+        ProtoId<JobPrototype> job,
+        List<NetUserId> list,
+        CMDistressSignalRuleComponent comp,
+        RulePlayerSpawningEvent ev,
+        Dictionary<ProtoId<JobPrototype>, List<EntityUid>> spawnersLeft,
+        Dictionary<ProtoId<JobPrototype>, List<EntityUid>> spawners,
+        out NetUserId spawnedId)
+    {
+        var playerId = _random.Pick(list);
+        if (!_player.TryGetSessionById(playerId, out var player))
+        {
+            spawnedId = default;
+            return false;
+        }
+
+        var spawnAsJob = DetermineSurvivorJob(job, playerId, comp, out var stop);
+        if (stop)
+        {
+            spawnedId = default;
+            return false;
+        }
+
+        var spawner = FindSurvivorSpawner(spawnAsJob, comp, spawnersLeft, spawners, out stop);
+        if (stop)
+        {
+            spawnedId = default;
+            return false;
+        }
+
+        list.Remove(playerId);
+        ev.PlayerPool.Remove(player);
+        GameTicker.PlayerJoinGame(player);
+
+        var profile = GameTicker.GetPlayerProfile(player);
+        var survivorMob = _stationSpawning.SpawnPlayerMob(spawner.ToCoordinates(), spawnAsJob, profile, null);
+
+        if (!_mind.TryGetMind(playerId, out var mind))
+            mind = _mind.CreateMind(playerId);
+
+        RemCompDeferred<TacticalMapUserComponent>(survivorMob);
+        _mind.TransferTo(mind.Value, survivorMob);
+        _roles.MindAddJobRole(mind.Value, jobPrototype: spawnAsJob);
+        _playTime.PlayerRolesChanged(player);
+
+        RaiseLocalEvent(survivorMob, new PlayerSpawnCompleteEvent(survivorMob, player, spawnAsJob, false, true, 0, default, profile), true);
+
+        spawnedId = playerId;
+        return true;
+    }
+
+    private ProtoId<JobPrototype> DetermineSurvivorJob(
+        ProtoId<JobPrototype> job,
+        NetUserId playerId,
+        CMDistressSignalRuleComponent comp,
+        out bool stop)
+    {
+        stop = false;
+        var spawnAsJob = job;
+        var selectRandomVariant = SelectedPlanetMap?.Comp.SelectRandomSurvivorVariant ?? false;
+
+        if (TryGetScenarioJob(job, playerId, comp, ref spawnAsJob, ref stop))
+            return spawnAsJob;
+
+        if (TryGetVariantJob(job, playerId, comp, ref spawnAsJob, ref stop, selectRandomVariant))
+            return spawnAsJob;
+
+        if (!DecrementSurvivorJobSlot(job, comp, selectRandomVariant, ref spawnAsJob))
+        {
+            stop = true;
+        }
+
+        return spawnAsJob;
+    }
+
+    private bool TryGetScenarioJob(
+        ProtoId<JobPrototype> job,
+        NetUserId playerId,
+        CMDistressSignalRuleComponent comp,
+        ref ProtoId<JobPrototype> spawnAsJob,
+        ref bool stop)
+    {
+        if (comp.SurvivorJobVariantScenarios == null ||
+            !comp.SurvivorJobVariantScenarios.TryGetValue(job, out var scenarioJobsList))
+        {
+            return false;
+        }
+
+        for (var i = 0; i < scenarioJobsList.Count; i++)
+        {
+            var (scenarioJob, amount) = scenarioJobsList[i];
+            if (!IsJobAllowed(playerId, scenarioJob))
+                continue;
+
+            if (amount == -1)
+            {
+                spawnAsJob = scenarioJob;
+                return true;
+            }
+
+            if (amount <= 0)
+                continue;
+
+            scenarioJobsList[i] = (scenarioJob, amount - 1);
+            spawnAsJob = scenarioJob;
+            return true;
+        }
+
+        stop = true;
+        return true;
+    }
+
+    private bool TryGetVariantJob(
+        ProtoId<JobPrototype> job,
+        NetUserId playerId,
+        CMDistressSignalRuleComponent comp,
+        ref ProtoId<JobPrototype> spawnAsJob,
+        ref bool stop,
+        bool selectRandomVariant)
+    {
+        if (comp.SurvivorJobVariants == null ||
+            !comp.SurvivorJobVariants.TryGetValue(job, out var variants))
+        {
+            return false;
+        }
+
+        if (selectRandomVariant)
+        {
+            var allowedIndices = new List<int>();
+            for (var j = 0; j < variants.Count; j++)
+            {
+                var (vJob, vAmount) = variants[j];
+                if (vAmount != -1 && vAmount <= 0)
+                    continue;
+
+                if (IsJobAllowed(playerId, vJob))
+                    allowedIndices.Add(j);
+            }
+
+            if (allowedIndices.Count > 0)
+            {
+                var chosenIdx = _random.Pick(allowedIndices);
+                spawnAsJob = variants[chosenIdx].Variant;
+                if (variants[chosenIdx].Amount != -1)
+                    variants[chosenIdx] = (variants[chosenIdx].Variant, variants[chosenIdx].Amount - 1);
+                return true;
+            }
+            stop = true;
+            return true;
+        }
+
+        for (var i = 0; i < variants.Count; i++)
+        {
+            var (variantJob, amount) = variants[i];
+            if (!IsJobAllowed(playerId, variantJob))
+                continue;
+
+            if (amount == -1)
+            {
+                spawnAsJob = variantJob;
+                return true;
+            }
+
+            if (amount <= 0)
+                continue;
+
+            variants[i] = (variantJob, amount - 1);
+            spawnAsJob = variantJob;
+            return true;
+        }
+
+        stop = true;
+        return true;
+    }
+
+    private bool DecrementSurvivorJobSlot(
+        ProtoId<JobPrototype> job,
+        CMDistressSignalRuleComponent comp,
+        bool selectRandomVariant,
+        ref ProtoId<JobPrototype> spawnAsJob)
+    {
+        for (var i = 0; i < comp.SurvivorJobs.Count; i++)
+        {
+            var (survJob, amount) = comp.SurvivorJobs[i];
+            if (survJob != job)
+                continue;
+
+            if (selectRandomVariant &&
+                comp.SurvivorJobVariants != null &&
+                comp.SurvivorJobVariants.TryGetValue(job, out var randomInsertList) &&
+                randomInsertList.Count > 0)
+            {
+                spawnAsJob = _random.Pick(randomInsertList).Variant;
+            }
+
+            if (amount == -1)
+                return true;
+
+            if (amount <= 0)
+                return false;
+
+            comp.SurvivorJobs[i] = (survJob, amount - 1);
+        }
+        return true;
+    }
+
+    private EntityUid FindSurvivorSpawner(
+        ProtoId<JobPrototype> spawnAsJob,
+        CMDistressSignalRuleComponent comp,
+        Dictionary<ProtoId<JobPrototype>, List<EntityUid>> spawnersLeft,
+        Dictionary<ProtoId<JobPrototype>, List<EntityUid>> spawners,
+        out bool stop)
+    {
+        stop = false;
+
+        if (!spawnersLeft.TryGetValue(spawnAsJob, out var jobSpawners) &&
+            !spawnersLeft.TryGetValue(comp.CivilianSurvivorJob, out jobSpawners))
+        {
+            stop = true;
+            return default;
+        }
+
+        if (jobSpawners.Count == 0)
+        {
+            if (spawners.TryGetValue(comp.CivilianSurvivorJob, out var fallbackSpawners))
+            {
+                jobSpawners.Clear();
+                jobSpawners.AddRange(fallbackSpawners);
+            }
+
+            if (jobSpawners.Count == 0)
+            {
+                stop = true;
+                return default;
+            }
+        }
+
+        return _random.PickAndTake(jobSpawners);
+    }
+}

--- a/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.Survivors.cs
+++ b/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.Survivors.cs
@@ -20,19 +20,32 @@ public sealed partial class CMDistressSignalRuleSystem
     /// Main survivor spawning handler. Delegates to helper methods for job collection,
     /// candidate assignment, and individual survivor spawning.
     /// </summary>
-    private void SpawnSurvivors(CMDistressSignalRuleComponent comp, RulePlayerSpawningEvent ev)
+    /// <param name="comp">The distress signal rule component.</param>
+    /// <param name="ev">The rule player spawning event.</param>
+    /// <param name="initialPlayerCount">Player count before any players were removed from the pool (for correct totalSurvivors calculation).</param>
+    private void SpawnSurvivors(CMDistressSignalRuleComponent comp, RulePlayerSpawningEvent ev, int initialPlayerCount)
     {
         if (!comp.SpawnSurvivors || comp.SurvivorJobs.Count == 0)
             return;
 
         if (ActiveNightmareScenario == null)
-            comp.SurvivorJobs = comp.SurvivorJobs.OrderBy(_ => _random.Next()).ToList();
+        {
+            var compCopy = comp;
+            IEnumerable<(ProtoId<JobPrototype> Job, int Amount)> jobs = comp.SurvivorJobs
+                .Where(entry => entry.Job != compCopy.CivilianSurvivorJob)
+                .OrderBy(_ => _random.Next());
+
+            if (comp.SurvivorJobs.TryFirstOrNull(entry => entry.Job == compCopy.CivilianSurvivorJob, out var civJob))
+                jobs = jobs.Append(civJob.Value);
+
+            comp.SurvivorJobs = jobs.ToList();
+        }
 
         var possibleJobs = CollectPossibleSurvivorJobs(comp);
         var (spawners, spawnersLeft) = FindSurvivorSpawners(possibleJobs);
         var candidates = CollectSurvivorCandidates(comp, ev);
 
-        SpawnSurvivorsFromCandidates(comp, ev, candidates, spawners, spawnersLeft);
+        SpawnSurvivorsFromCandidates(comp, ev, candidates, spawners, spawnersLeft, initialPlayerCount);
     }
 
     private List<ProtoId<JobPrototype>> CollectPossibleSurvivorJobs(CMDistressSignalRuleComponent comp)
@@ -129,10 +142,11 @@ public sealed partial class CMDistressSignalRuleSystem
         RulePlayerSpawningEvent ev,
         Dictionary<ProtoId<JobPrototype>, List<NetUserId>[]> candidates,
         Dictionary<ProtoId<JobPrototype>, List<EntityUid>> spawners,
-        Dictionary<ProtoId<JobPrototype>, List<EntityUid>> spawnersLeft)
+        Dictionary<ProtoId<JobPrototype>, List<EntityUid>> spawnersLeft,
+        int initialPlayerCount)
     {
         var priorities = Enum.GetValues<JobPriority>().Length;
-        var totalSurvivors = (int)Math.Clamp((int)Math.Round(ev.PlayerPool.Count / _marinesPerSurvivor), _minimumSurvivors, _maximumSurvivors);
+        var totalSurvivors = (int)Math.Clamp((int)Math.Round(initialPlayerCount / _marinesPerSurvivor), _minimumSurvivors, _maximumSurvivors);
         var selected = 0;
 
         for (var i = priorities - 1; i >= 0; i--)
@@ -187,12 +201,20 @@ public sealed partial class CMDistressSignalRuleSystem
         var playerId = _random.Pick(list);
         if (!_player.TryGetSessionById(playerId, out var player))
         {
+            list.Remove(playerId);
             spawnedId = default;
             return false;
         }
 
-        var spawnAsJob = DetermineSurvivorJob(job, playerId, comp, out var stop);
+        var spawnAsJob = DetermineSurvivorJob(job, playerId, comp, out var scenarioSuccess, out var stop);
         if (stop)
+        {
+            spawnedId = default;
+            return false;
+        }
+
+        var selectRandomVariant = SelectedPlanetMap?.Comp.SelectRandomSurvivorVariant ?? false;
+        if (!DecrementOriginalJobSlot(job, comp, selectRandomVariant, scenarioSuccess, ref spawnAsJob))
         {
             spawnedId = default;
             return false;
@@ -230,21 +252,19 @@ public sealed partial class CMDistressSignalRuleSystem
         ProtoId<JobPrototype> job,
         NetUserId playerId,
         CMDistressSignalRuleComponent comp,
+        out bool scenarioSuccess,
         out bool stop)
     {
         stop = false;
         var spawnAsJob = job;
-        var selectRandomVariant = SelectedPlanetMap?.Comp.SelectRandomSurvivorVariant ?? false;
 
-        if (TryGetScenarioJob(job, playerId, comp, ref spawnAsJob, ref stop))
+        scenarioSuccess = TryGetScenarioJob(job, playerId, comp, ref spawnAsJob, ref stop);
+        if (stop)
             return spawnAsJob;
 
-        if (TryGetVariantJob(job, playerId, comp, ref spawnAsJob, ref stop, selectRandomVariant))
-            return spawnAsJob;
-
-        if (!DecrementSurvivorJobSlot(job, comp, selectRandomVariant, ref spawnAsJob))
+        if (!scenarioSuccess)
         {
-            stop = true;
+            CheckVariantJob(job, playerId, comp, ref spawnAsJob, ref stop);
         }
 
         return spawnAsJob;
@@ -287,43 +307,21 @@ public sealed partial class CMDistressSignalRuleSystem
         return true;
     }
 
-    private bool TryGetVariantJob(
+    /// <summary>
+    /// Checks if a variant job can be assigned. Matches legacy: iterates in order, picks first allowed.
+    /// Does NOT use random selection — selectRandomVariant only affects DecrementOriginalJobSlot.
+    /// </summary>
+    private void CheckVariantJob(
         ProtoId<JobPrototype> job,
         NetUserId playerId,
         CMDistressSignalRuleComponent comp,
         ref ProtoId<JobPrototype> spawnAsJob,
-        ref bool stop,
-        bool selectRandomVariant)
+        ref bool stop)
     {
         if (comp.SurvivorJobVariants == null ||
             !comp.SurvivorJobVariants.TryGetValue(job, out var variants))
         {
-            return false;
-        }
-
-        if (selectRandomVariant)
-        {
-            var allowedIndices = new List<int>();
-            for (var j = 0; j < variants.Count; j++)
-            {
-                var (vJob, vAmount) = variants[j];
-                if (vAmount != -1 && vAmount <= 0)
-                    continue;
-
-                if (IsJobAllowed(playerId, vJob))
-                    allowedIndices.Add(j);
-            }
-
-            if (allowedIndices.Count > 0)
-            {
-                var chosenIdx = _random.Pick(allowedIndices);
-                spawnAsJob = variants[chosenIdx].Variant;
-                if (variants[chosenIdx].Amount != -1)
-                    variants[chosenIdx] = (variants[chosenIdx].Variant, variants[chosenIdx].Amount - 1);
-                return true;
-            }
-            stop = true;
-            return true;
+            return;
         }
 
         for (var i = 0; i < variants.Count; i++)
@@ -335,7 +333,7 @@ public sealed partial class CMDistressSignalRuleSystem
             if (amount == -1)
             {
                 spawnAsJob = variantJob;
-                return true;
+                return;
             }
 
             if (amount <= 0)
@@ -343,17 +341,21 @@ public sealed partial class CMDistressSignalRuleSystem
 
             variants[i] = (variantJob, amount - 1);
             spawnAsJob = variantJob;
-            return true;
+            return;
         }
 
         stop = true;
-        return true;
     }
 
-    private bool DecrementSurvivorJobSlot(
+    /// <summary>
+    /// Decrements the original job's slot count. Also, handles random variant override when enabled and the scenario didn't succeed.
+    /// This matches legacy behavior where the decrement always targets the original job, not the variant.
+    /// </summary>
+    private bool DecrementOriginalJobSlot(
         ProtoId<JobPrototype> job,
         CMDistressSignalRuleComponent comp,
         bool selectRandomVariant,
+        bool scenarioSuccess,
         ref ProtoId<JobPrototype> spawnAsJob)
     {
         for (var i = 0; i < comp.SurvivorJobs.Count; i++)
@@ -362,7 +364,7 @@ public sealed partial class CMDistressSignalRuleSystem
             if (survJob != job)
                 continue;
 
-            if (selectRandomVariant &&
+            if (!scenarioSuccess && selectRandomVariant &&
                 comp.SurvivorJobVariants != null &&
                 comp.SurvivorJobVariants.TryGetValue(job, out var randomInsertList) &&
                 randomInsertList.Count > 0)

--- a/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.cs
@@ -53,6 +53,7 @@ using Content.Shared.GameTicking.Components;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Nutrition.EntitySystems;
+using Content.Shared.Roles;
 using Robust.Server.Audio;
 using Robust.Server.Containers;
 using Robust.Server.GameObjects;
@@ -132,6 +133,7 @@ public sealed partial class CMDistressSignalRuleSystem : GameRuleSystem<CMDistre
     [Dependency] private readonly HungerSystem _hunger = default!;
     [Dependency] private readonly ScalingSystem _scaling = default!;
     [Dependency] private readonly SharedXenoConstructionSystem _xenoConstruction = default!;
+    [Dependency] private readonly SharedRoleSystem _roles = default!;
 
     private readonly HashSet<string> _operationNames = new();
     private readonly HashSet<string> _operationPrefixes = new();
@@ -278,9 +280,6 @@ public sealed partial class CMDistressSignalRuleSystem : GameRuleSystem<CMDistre
 
     private void OnMapLoading(LoadingMapsEvent ev)
     {
-        if (SelectedPlanetMap != null)
-            return;
-
         SelectRandomPlanet();
         GameTicker.UpdateInfoText();
     }
@@ -344,6 +343,23 @@ public sealed partial class CMDistressSignalRuleSystem : GameRuleSystem<CMDistre
             time >= component.EndAtAllClear)
         {
             _roundEnd.EndRound();
+            return;
+        }
+
+        if (_xenoEvolution.HasLiving<XenoEvolutionGranterComponent>(1))
+            component.QueenDiedCheck = null;
+
+        if (component.QueenDiedCheck == null)
+            return;
+
+        if (time >= component.QueenDiedCheck)
+        {
+            if (component.Hijack)
+                EndRound(component, DistressSignalRuleResult.MinorXenoVictory);
+            else if (_xenoEvolution.HasLiving<XenoComponent>(4))
+                EndRound(component, DistressSignalRuleResult.MinorMarineVictory);
+            else
+                EndRound(component, DistressSignalRuleResult.MajorMarineVictory, "rmc-distress-signal-majormarinevictory-timeout");
         }
     }
 


### PR DESCRIPTION
## About the PR
Fixes dropships not spawning after round restarts (forgot to reset _spawnedDropships in cleanup). Also restores survivor spawning and other logic that was accidentally dropped during a previous refactor, adapted to the new architecture.

## Why / Balance
No balance changes

## Technical details
RoundEnd.cs
- Added _spawnedDropships = false to OnRoundRestartCleanup - the actual bug fix
- Removed dead if (distress.QueenDiedCheck == null) return; - dead code after ??= on value type
- Reformatted OnStartAttempt profile casting
- Reformatted OnMobStateChanged
Hijack.cs
- Renamed StunAllMarinesOnAlmayer → StunAllEntitiesOnAlmayer (stuns non-xeno, not just marines)
- Added XML docs and clarifying comments
Helpers.cs
- Restored IsJobAllowed method - shared ban/playtime check, was lost in refactor
- Added XML docs for SetFriendlyHives
- Added TODO comment for SpawnAdminAreas (from old code)
Spawning.cs
- Uses shared IsJobAllowed instead of inline lambda
- Restored: _adminLog.Add for xeno corpse spawn
- Restored: null check on _dropship.FlyTo
- Restored + adapted: special fax handling from planet prototype
- SquadIds loop: .Where() → explicit if
- Moved AlmayerComponent/hunger inside squad != null guard
- Log message for job slot scaling
Survivors.cs (NEW FILE)
- Restored survivor spawning - was missing after refactor
- Job collection, priority-based candidate assignment, spawner selection
- Variant/scenario jobs with slot tracking
- Deduplication via RemoveCandidateFromAllLists
- Fallback to civilian spawners
Planet.cs
- Restored TODO about delaying landing zone gas
CMDistressSignalRuleSystem.cs
- Added SharedRoleSystem dependency (used in Survivors)
- Restored: planet selection in OnMapLoading (removed early return)
- Restored: QueenDiedCheck handling in ActiveTick
- Restored: EndRoundForQueenDeath helper

## Media
None.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
No cl