### PR TITLE
Hybrisa Pipe Network and Hive Loot Moving

### DIFF
--- a/Resources/Prototypes/_RMC14/Tiles/Hybrisa/basic_tiles.yml
+++ b/Resources/Prototypes/_RMC14/Tiles/Hybrisa/basic_tiles.yml
@@ -177,6 +177,7 @@
   id: RMCPlanetHybrisaAsphalt
   name: asphalt
   sprite: /Textures/_RMC14/Tiles/hybrisa/asphalt_old.png
+  isSubfloor: false
 
 - type: tile
   parent: RMCPlanetHybrisaAsphalt
@@ -223,6 +224,7 @@
   id: RMCPlanetHybrisaCement
   name: cement
   sprite: /Textures/_RMC14/Tiles/hybrisa/cement1.png
+  isSubfloor: false
 
 - type: tile
   parent: RMCPlanetHybrisaCement
@@ -239,6 +241,7 @@
   id: RMCPlanetHybrisaSidewalk
   name: sidewalk
   sprite: /Textures/_RMC14/Tiles/hybrisa/sidewalkfull.png
+  isSubfloor: false
 
 - type: tile
   parent: RMCPlanetHybrisaSidewalk

--- a/Resources/Prototypes/_RMC14/Tiles/Planet/base.yml
+++ b/Resources/Prototypes/_RMC14/Tiles/Planet/base.yml
@@ -23,7 +23,7 @@
   sprite: /Textures/_RMC14/Tiles/planet/sand.png
 
 - type: tile
-  parent: CMPlanetBase
+  parent: CMTileBase
   id: CMPlanetWood
   name: tiles-cm-wood
   sprite: /Textures/_RMC14/Tiles/planet/wood/wood.png

--- a/Resources/Prototypes/_RMC14/Tiles/Planet/strata.yml
+++ b/Resources/Prototypes/_RMC14/Tiles/Planet/strata.yml
@@ -8,6 +8,7 @@
   footstepSounds:
     collection: FootstepHull
   canDig: false
+  isSubfloor: false
 
 - type: tile
   parent: CMPlanetStrata


### PR DESCRIPTION
## About the PR
Added Hybrisa's pipe network, removed celestia queen spawn and created a new one at south-east caves, removed surv spawn at south-east caves and moved nearby loot to Biogen, added some props across the map, fixed some tiles showing pipes through them, minor changes to Dynagrid

## Why / Balance
Parity for the pipe network, dynagrid changes, and props.

Celestia queen spawn was removed because it was incredibly bad: a queen spawn with no weeds, no nearby larva, and a survivor spawning 15 tiles away, most queens would tunnel out upon getting this spawn to go to caves.

Survivor spawn was removed from south-east caves because it was a guarenteed death sentence for a new survivor player, and even experienced ones would often be drone rushed down. The nearby loot was moved to biogen.

New queen spawn in south-east caves now that the survivor is evicted to replace the celestia one, it has a tunnel nearby and is safe due to the caves lockdown.

Non-parity changes seen and approved by Cro.

## Technical details
yml

## Media
Pipe network
<img width="1287" height="915" alt="Screenshot 2026-04-12 115924" src="https://github.com/user-attachments/assets/c337987d-d345-42d9-9ca8-95d8324cc5ea" />
<img width="1240" height="945" alt="Screenshot 2026-04-12 112914" src="https://github.com/user-attachments/assets/b609deee-7bf1-4d3e-abdf-c3fbb7487f67" />

Survivor spawn removed and new queen spawn in the south-east caves. SLAW moved to south-east Biogen and turret spawner to biogen dropship.
<img width="734" height="459" alt="Screenshot 2026-04-12 111607" src="https://github.com/user-attachments/assets/e7467e2f-acdc-4e91-bb56-1345aaac36cf" />
<img width="506" height="486" alt="image" src="https://github.com/user-attachments/assets/3259e6f1-191f-4f12-8d42-d07332ac14cc" />
SLAW moved to this closet in the corner
<img width="308" height="332" alt="image" src="https://github.com/user-attachments/assets/09cd4ad1-54a3-4d69-99e9-742dc6f851f9" />



Dynagrid got some minor internal changes, the corridoor around the generators is now more open with a few walls removed.
<img width="1031" height="841" alt="Screenshot 2026-04-12 111454" src="https://github.com/user-attachments/assets/fd3e5d4c-3fe5-4893-9277-90a7f413758f" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: CatAndHats
- add: Added the pipe network to Hybrisa Prospera
- tweak: The Hybrisa Prospera Celestia queen spawn has been removed and in its place is a queen spawn in south-east caves, the survivor spawn in that area has been removed and the nearby loot moved to biogen armoury and biogen dropship.
- tweak: Hybrisa Prospera's Dynagrid has recieved minor internal changes to tear down a few walls in the coridoor south and west of the generators.
