### PR TITLE
xeno doors are now held open

### DIFF
--- a/Content.Shared/Doors/Components/DoorComponent.cs
+++ b/Content.Shared/Doors/Components/DoorComponent.cs
@@ -44,13 +44,13 @@ public sealed partial class DoorComponent : Component
 
     //RMC14
     /// <summary>
-    /// Closing time when an open door is prevented from closing
+    /// Closing time when an open door is held open
     /// </summary>
     [AutoNetworkedField, ViewVariables]
     public TimeSpan HoldOpenTime;
 
     /// <summary>
-    /// Closing time when an open door is prevented from closing
+    /// Whether or not the door closing time can be delayed when held open
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public bool CanHoldOpen = false;

--- a/Content.Shared/Doors/Components/DoorComponent.cs
+++ b/Content.Shared/Doors/Components/DoorComponent.cs
@@ -42,6 +42,20 @@ public sealed partial class DoorComponent : Component
     [DataField]
     public TimeSpan CloseTimeTwo = TimeSpan.FromSeconds(0.2f);
 
+    //RMC14
+    /// <summary>
+    /// Closing time when an open door is prevented from closing
+    /// </summary>
+    [AutoNetworkedField, ViewVariables]
+    public TimeSpan HoldOpenTime;
+
+    /// <summary>
+    /// Closing time when an open door is prevented from closing
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public bool CanHoldOpen = false;
+    //RMC14
+
     /// <summary>
     /// Opening time until passable. Total time is this plus <see cref="OpenTimeTwo"/>.
     /// </summary>

--- a/Content.Shared/Doors/Components/DoorComponent.cs
+++ b/Content.Shared/Doors/Components/DoorComponent.cs
@@ -44,10 +44,16 @@ public sealed partial class DoorComponent : Component
 
     //RMC14
     /// <summary>
-    /// Closing time when an open door is held open
+    /// Remaining time an open door is held open
     /// </summary>
     [AutoNetworkedField, ViewVariables]
-    public TimeSpan HoldOpenTime;
+    public TimeSpan HoldOpenDelay;
+
+    /// <summary>
+    /// time the door will be delayed from closing when held open
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan HoldOpenTime = TimeSpan.FromSeconds(5);
 
     /// <summary>
     /// Whether or not the door closing time can be delayed when held open

--- a/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
@@ -121,11 +121,14 @@ public abstract class SharedAirlockSystem : EntitySystem
         if (autoev.Cancelled)
             return;
 
+        //RMC14
         if (door.CanHoldOpen)
         {
+            //if the door can be held open it needs to check every second if it is being held open
             DoorSystem.SetNextStateChange(uid,TimeSpan.FromSeconds(1));
             return;
         }
+        //RMC14
 
         DoorSystem.SetNextStateChange(uid, airlock.AutoCloseDelay * airlock.AutoCloseDelayModifier);
     }

--- a/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
@@ -121,6 +121,12 @@ public abstract class SharedAirlockSystem : EntitySystem
         if (autoev.Cancelled)
             return;
 
+        if (door.CanHoldOpen)
+        {
+            DoorSystem.SetNextStateChange(uid,TimeSpan.FromSeconds(1));
+            return;
+        }
+
         DoorSystem.SetNextStateChange(uid, airlock.AutoCloseDelay * airlock.AutoCloseDelayModifier);
     }
 

--- a/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
@@ -125,7 +125,7 @@ public abstract class SharedAirlockSystem : EntitySystem
         if (door.CanHoldOpen)
         {
             //if the door can be held open it needs to check every second if it is being held open
-            DoorSystem.SetNextStateChange(uid,TimeSpan.FromSeconds(1));
+            DoorSystem.SetNextStateChange(uid, TimeSpan.FromSeconds(1));
             return;
         }
         //RMC14

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -169,7 +169,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
                 //RMC14
                 if (door.CanHoldOpen)
                 {
-                    door.HoldOpenTime = GameTiming.CurTime + TimeSpan.FromSeconds(5);
+                    door.HoldOpenDelay = GameTiming.CurTime + door.HoldOpenTime;
                 }
                 //RMC14
                 break;
@@ -830,11 +830,11 @@ public abstract partial class SharedDoorSystem : EntitySystem
                 //RMC14
                 if (door.CanHoldOpen)
                 {
-                    if (!(time > door.HoldOpenTime))
+                    if (!(time > door.HoldOpenDelay))
                     {
                         if (!CanClose(ent, door))
                         {
-                            door.HoldOpenTime = time + TimeSpan.FromSeconds(5);
+                            door.HoldOpenDelay = time + door.HoldOpenTime;
                         }
                         door.NextStateChange = time + TimeSpan.FromSeconds(1);
                         break;

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -166,6 +166,12 @@ public abstract partial class SharedDoorSystem : EntitySystem
             case DoorState.Opening:
                 _activeDoors.Add((uid, door));
                 door.NextStateChange = GameTiming.CurTime + door.OpenTimeOne;
+                //RMC14
+                if (door.CanHoldOpen)
+                {
+                    door.HoldOpenTime = GameTiming.CurTime + TimeSpan.FromSeconds(5);
+                }
+                //RMC14
                 break;
 
             case DoorState.Closing:
@@ -820,6 +826,22 @@ public abstract partial class SharedDoorSystem : EntitySystem
                 break;
 
             case DoorState.Open:
+
+                //RMC14
+                if (door.CanHoldOpen)
+                {
+                    if (!(time > door.HoldOpenTime))
+                    {
+                        if (!CanClose(ent, door))
+                        {
+                            door.HoldOpenTime = time + TimeSpan.FromSeconds(5);
+                        }
+                        door.NextStateChange = time + TimeSpan.FromSeconds(1);
+                        break;
+                    }
+                }
+                //RMC14
+
                 // This door is open, and queued for an auto-close.
                 if (!TryClose(ent, door))
                 {

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_doors.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_doors.yml
@@ -30,6 +30,7 @@
         layer:
         - AirlockLayer
   - type: Door
+    canHoldOpen: true
     canPry: false
     crushDamage:
       types:
@@ -114,6 +115,7 @@
     - state: closed_unlit
       map: ["enum.DoorVisualLayers.BaseBolted"]
   - type: Door
+    canHoldOpen: true
     crushDamage:
       types:
         Blunt: 15


### PR DESCRIPTION
## About the PR
Xeno doors are now held open for 5 seconds whenever they can't close due to something blocking them

## Why / Balance
Its incredibly annoying when a xeno is holding a door open then leaves at the last second, slamming the door in your face. Theres no way to guarantee 5 seconds unless you close the door and re-open it. Its technically a minor xeno buff but I consider it a QOL change

## Technical details
Added CanHoldOpen flag to doorComponent and set it to true in the xeno doors. Added a HoldOpenDelay variable to track when the door should close. Added a HoldOpenTime variable to set the delay when held open.

The door state update code now resets the HoldOpenDelay when something is blocking it from closing, and prevents the door from closing until HoldOpenDelay is reached.

The airlock system has a check for CanHoldOpen so that it can set the door to update every second

## Media
(https://youtu.be/kcoCVY8_11E)
The right side is with the PR implemented

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: xeno doors are now held open for 5 seconds anytime they are left empty
