### PR TITLE
Fixed offset light fixtures not offsetting while map is paused.

### DIFF
--- a/Content.Shared/_RMC14/Light/RMCLightOffsetSystem.cs
+++ b/Content.Shared/_RMC14/Light/RMCLightOffsetSystem.cs
@@ -20,7 +20,8 @@ public sealed class RMCLightOffsetSystem : EntitySystem
 
     private void OnLightStartup(Entity<RMCLightOffsetComponent> ent, ref ComponentStartup args)
     {
-        OffsetLight(ent);
+        if (_net.IsClient)
+            OffsetLight(ent);
     }
 
     private void OnLightUpdate<T>(Entity<RMCLightOffsetComponent> ent, ref T args)

--- a/Content.Shared/_RMC14/Light/RMCLightOffsetSystem.cs
+++ b/Content.Shared/_RMC14/Light/RMCLightOffsetSystem.cs
@@ -9,13 +9,18 @@ public sealed class RMCLightOffsetSystem : EntitySystem
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly SharedRMCSpriteSystem _sprite = default!;
 
-    protected readonly HashSet<EntityUid> ToUpdate = new();
-
+    private readonly HashSet<EntityUid> ToUpdate = new();
 
     public override void Initialize()
     {
+        SubscribeLocalEvent<RMCLightOffsetComponent, ComponentStartup>(OnLightStartup);
         SubscribeLocalEvent<RMCLightOffsetComponent, MapInitEvent>(OnLightUpdate);
         SubscribeLocalEvent<RMCLightOffsetComponent, EntParentChangedMessage>(OnLightUpdate);
+    }
+
+    private void OnLightStartup(Entity<RMCLightOffsetComponent> ent, ref ComponentStartup args)
+    {
+        OffsetLight(ent);
     }
 
     private void OnLightUpdate<T>(Entity<RMCLightOffsetComponent> ent, ref T args)
@@ -34,6 +39,11 @@ public sealed class RMCLightOffsetSystem : EntitySystem
         if (TerminatingOrDeleted(ent))
             return;
 
+        OffsetLight(ent);
+    }
+
+    private void OffsetLight(Entity<RMCLightOffsetComponent> ent)
+    {
         var sprite = EnsureComp<SpriteSetRenderOrderComponent>(ent);
         switch (Transform(ent).LocalRotation.GetDir())
         {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed light fixtures not offsetting while map is paused. They now offset without running mapinit.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This will help mappers place the offset light fixtures without having to run mapinit all the time to check placement.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
Screenshot is taken from a paused map in mapping mode.
<img width="167" height="165" alt="Screenshot 2026-04-05 18 01 44_Alex&#39;s Dev Server - Rouny&#39;s Marine Corps 14_002764" src="https://github.com/user-attachments/assets/a606df4c-693a-405c-ba1a-2fa2e981e53f" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Light fixtures not offsetting while map is paused. They now offset without running mapinit.
