### PR TITLE
Allow Alt Click Unbuckle.

### DIFF
--- a/Content.Shared/Buckle/SharedBuckleSystem.Interaction.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Interaction.cs
@@ -20,7 +20,6 @@ public abstract partial class SharedBuckleSystem
 
         SubscribeLocalEvent<BuckleComponent, InteractHandEvent>(OnBuckleInteractHand, before: [typeof(InteractionPopupSystem)]);
         SubscribeLocalEvent<BuckleComponent, GetVerbsEvent<InteractionVerb>>(AddUnbuckleVerb);
-        SubscribeLocalEvent<BuckleComponent, GetVerbsEvent<AlternativeVerb>>(AddAltUnbuckleVerb); // RMC 14 Edit.
     }
 
     private void OnCanDropTarget(EntityUid uid, StrapComponent component, ref CanDropTargetEvent args)
@@ -242,29 +241,5 @@ public abstract partial class SharedBuckleSystem
 
         args.Verbs.Add(verb);
     }
-
-    // RMC 14 Edit start
-    // This isn't worth splitting up into methods and helpers, your upstreamer will hate you for changing code here that much.
-    // Add Unbuckle verb on ALT interact so alt-cllick interact picks this up as a verb and executes it.
-    private void AddAltUnbuckleVerb(EntityUid uid, BuckleComponent component, GetVerbsEvent<AlternativeVerb> args)
-    {
-
-        if (!args.CanAccess || !args.CanInteract || !component.Buckled)
-            return;
-
-        if (!CanUnbuckle((uid, component), args.User, false))
-            return;
-
-        AlternativeVerb verb = new()
-        {
-            Act = () => TryUnbuckle(uid, args.User, buckleComp: component),
-            Text = Loc.GetString("verb-categories-unbuckle"),
-            Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/unbuckle.svg.192dpi.png"))
-        };
-
-        args.Verbs.Add(verb);
-
-    }
-    // RMC 14 Edit end.
 
 }

--- a/Content.Shared/Buckle/SharedBuckleSystem.Interaction.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Interaction.cs
@@ -20,6 +20,7 @@ public abstract partial class SharedBuckleSystem
 
         SubscribeLocalEvent<BuckleComponent, InteractHandEvent>(OnBuckleInteractHand, before: [typeof(InteractionPopupSystem)]);
         SubscribeLocalEvent<BuckleComponent, GetVerbsEvent<InteractionVerb>>(AddUnbuckleVerb);
+        SubscribeLocalEvent<BuckleComponent, GetVerbsEvent<AlternativeVerb>>(AddAltUnbuckleVerb); // RMC 14 Edit.
     }
 
     private void OnCanDropTarget(EntityUid uid, StrapComponent component, ref CanDropTargetEvent args)
@@ -241,5 +242,29 @@ public abstract partial class SharedBuckleSystem
 
         args.Verbs.Add(verb);
     }
+
+    // RMC 14 Edit start
+    // This isn't worth splitting up into methods and helpers, your upstreamer will hate you for changing code here that much.
+    // Add Unbuckle verb on ALT interact so alt-cllick interact picks this up as a verb and executes it.
+    private void AddAltUnbuckleVerb(EntityUid uid, BuckleComponent component, GetVerbsEvent<AlternativeVerb> args)
+    {
+
+        if (!args.CanAccess || !args.CanInteract || !component.Buckled)
+            return;
+
+        if (!CanUnbuckle((uid, component), args.User, false))
+            return;
+
+        AlternativeVerb verb = new()
+        {
+            Act = () => TryUnbuckle(uid, args.User, buckleComp: component),
+            Text = Loc.GetString("verb-categories-unbuckle"),
+            Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/unbuckle.svg.192dpi.png"))
+        };
+
+        args.Verbs.Add(verb);
+
+    }
+    // RMC 14 Edit end.
 
 }

--- a/Content.Shared/_RMC14/Buckle/RMCBuckleSystem.cs
+++ b/Content.Shared/_RMC14/Buckle/RMCBuckleSystem.cs
@@ -7,8 +7,10 @@ using Content.Shared.Interaction;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Popups;
 using Content.Shared.Shuttles.Components;
+using Content.Shared.Verbs;
 using Content.Shared.Whitelist;
 using Robust.Shared.Physics.Events;
+using Robust.Shared.Utility;
 
 namespace Content.Shared._RMC14.Buckle;
 
@@ -30,6 +32,7 @@ public sealed class RMCBuckleSystem : EntitySystem
         SubscribeLocalEvent<BuckleComponent, AttemptMobTargetCollideEvent>(OnBuckleAttemptMobTargetCollide);
         SubscribeLocalEvent<StrapComponent, EntParentChangedMessage>(OnBuckleParentChanged);
         SubscribeLocalEvent<StrapComponent, CombatModeShouldHandInteractEvent>(OnStrapCombatModeShouldHandInteract);
+        SubscribeLocalEvent<BuckleComponent, GetVerbsEvent<AlternativeVerb>>(AddAltUnbuckleVerb);
     }
 
     private void OnBuckleClimbableStrapped(Entity<BuckleClimbableComponent> ent, ref StrappedEvent args)
@@ -107,6 +110,24 @@ public sealed class RMCBuckleSystem : EntitySystem
         }
 
         return false;
+    }
+    
+    private void AddAltUnbuckleVerb(EntityUid uid, BuckleComponent component, GetVerbsEvent<AlternativeVerb> args)
+    {
+
+        if (!args.CanAccess || !args.CanInteract || !component.Buckled)
+            return;
+
+        if (!_buckle.CanUnbuckle((uid, component), args.User, false))
+            return;
+
+        AlternativeVerb verb = new()
+        {
+            Act = () => _buckle.TryUnbuckle(uid, args.User, buckleComp: component),
+            Text = Loc.GetString("verb-categories-unbuckle"),
+            Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/unbuckle.svg.192dpi.png"))
+        };
+        args.Verbs.Add(verb);
     }
 
     public override void Update(float frameTime)


### PR DESCRIPTION
## About the PR

Lets you alt-click buckled ents to unbuckle them regardless of held item.

## Why / Balance

Its annoying to do so via right click -> verb. If we can already do this  via that, I see no reason to not have this as a quick alt-click option

## Technical details

Adds a verb when alt interacting with an entity with Bucklecomponent. You will never see it, but AltInteract handles verbs on alt interact.

Touches upstream code files, but it is just a handler for it, can be moved to _RMC14 but for convenience and clarity i say keep it here. Edits commented.

## Media

Media is compressed to shit because 10 MB github upload limits SMH L bozo i guess. Looks visible on my end.

https://github.com/user-attachments/assets/58927860-5b94-4e25-91b4-8ff54dfed3ad



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: You can now unbuckle people by alt-clicking them.
