### PR TITLE
Many xenonid abilities will rewind the target to where they got hit

### DIFF
--- a/Content.Shared/_RMC14/Movement/SharedRMCLagCompensationSystem.cs
+++ b/Content.Shared/_RMC14/Movement/SharedRMCLagCompensationSystem.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared._RMC14.CCVar;
+using System.Numerics;
+using Content.Shared._RMC14.CCVar;
 using Content.Shared.Coordinates;
 using Robust.Shared.Configuration;
 using Robust.Shared.Map;
@@ -20,6 +21,7 @@ public abstract class SharedRMCLagCompensationSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _transform = default!;
 
     public float MarginTiles { get; private set; }
+    public float PredictionCoordinateDeviation { get; private set; }
 
     private EntityQuery<ActorComponent> _actorQuery;
 
@@ -34,6 +36,7 @@ public abstract class SharedRMCLagCompensationSystem : EntitySystem
         SubscribeNetworkEvent<RMCSetLastRealTickEvent>(OnSetLastRealTick);
 
         Subs.CVar(_config, RMCCVars.RMCLagCompensationMarginTiles, v => MarginTiles = v, true);
+        Subs.CVar(_config, RMCCVars.RMCGunPredictionCoordinateDeviation, v => PredictionCoordinateDeviation = v, true);
     }
 
     private void OnSetLastRealTick(RMCSetLastRealTickEvent msg, EntitySessionEventArgs args)
@@ -154,5 +157,53 @@ public abstract class SharedRMCLagCompensationSystem : EntitySystem
     {
         var coordinates = _transform.ToMapCoordinates(GetCoordinates(target, session));
         return Collides(target, projectile, coordinates);
+    }
+
+    public bool TryGetAcceptedHitCoordinates(
+        Entity<FixturesComponent?> target,
+        Entity<PhysicsComponent?> collider,
+        ICommonSession session,
+        MapCoordinates clientCoordinates,
+        out MapCoordinates acceptedCoordinates)
+    {
+        var serverCoordinates = _transform.ToMapCoordinates(GetCoordinates(target, session));
+        var clientCoordinatesValid = clientCoordinates.MapId == serverCoordinates.MapId &&
+                                     clientCoordinates.InRange(serverCoordinates, PredictionCoordinateDeviation);
+
+        if (clientCoordinatesValid && Collides(target, collider, clientCoordinates))
+        {
+            acceptedCoordinates = clientCoordinates;
+            return true;
+        }
+
+        if (Collides(target, collider, serverCoordinates))
+        {
+            acceptedCoordinates = serverCoordinates;
+            return true;
+        }
+
+        acceptedCoordinates = default;
+        return false;
+    }
+
+    public void RewindEntityToCoordinates(EntityUid target, MapCoordinates coordinates)
+    {
+        if (_net.IsClient)
+            return;
+
+        if (!TryComp(target, out TransformComponent? xform))
+            return;
+
+        var current = _transform.GetMapCoordinates(target, xform);
+        if (current.MapId != coordinates.MapId)
+            return;
+
+        _transform.SetCoordinates(target, xform, _transform.ToCoordinates(xform.ParentUid, coordinates));
+
+        if (TryComp(target, out PhysicsComponent? physics))
+        {
+            _physics.SetLinearVelocity(target, Vector2.Zero, body: physics);
+            _physics.SetAngularVelocity(target, 0, body: physics);
+        }
     }
 }

--- a/Content.Shared/_RMC14/Xenonids/Leap/XenoLeapPredictedHitEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Leap/XenoLeapPredictedHitEvent.cs
@@ -1,11 +1,13 @@
-﻿using Robust.Shared.Serialization;
+using Robust.Shared.Map;
+using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 
 namespace Content.Shared._RMC14.Xenonids.Leap;
 
 [Serializable, NetSerializable]
-public sealed class XenoLeapPredictedHitEvent(NetEntity target, GameTick lastRealTick) : EntityEventArgs
+public sealed class XenoLeapPredictedHitEvent(NetEntity target, MapCoordinates targetCoordinates, GameTick lastRealTick) : EntityEventArgs
 {
     public readonly NetEntity Target = target;
+    public readonly MapCoordinates TargetCoordinates = targetCoordinates;
     public readonly GameTick LastRealTick = lastRealTick;
 }

--- a/Content.Shared/_RMC14/Xenonids/Leap/XenoLeapSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Leap/XenoLeapSystem.cs
@@ -3,7 +3,6 @@ using System.Numerics;
 using Content.Shared._RMC14.Barricade;
 using Content.Shared._RMC14.Barricade.Components;
 using Content.Shared._RMC14.CameraShake;
-using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Damage.ObstacleSlamming;
 using Content.Shared._RMC14.Entrenching;
 using Content.Shared._RMC14.Movement;
@@ -41,7 +40,6 @@ using Content.Shared.Stunnable;
 using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
-using Robust.Shared.Configuration;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Physics;
@@ -59,7 +57,6 @@ public sealed class XenoLeapSystem : EntitySystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly BlindableSystem _blindable = default!;
     [Dependency] private readonly SharedBroadphaseSystem _broadphase = default!;
-    [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
@@ -85,7 +82,6 @@ public sealed class XenoLeapSystem : EntitySystem
 
     private EntityQuery<PhysicsComponent> _physicsQuery;
     private EntityQuery<FixturesComponent> _fixturesQuery;
-    private float _coordinateDeviation;
 
     public override void Initialize()
     {
@@ -111,8 +107,6 @@ public sealed class XenoLeapSystem : EntitySystem
         SubscribeLocalEvent<XenoLeapingComponent, PhysicsSleepEvent>(OnXenoLeapingPhysicsSleep);
         SubscribeLocalEvent<XenoLeapingComponent, StartPullAttemptEvent>(OnXenoLeapingStartPullAttempt);
         SubscribeLocalEvent<XenoLeapingComponent, PullAttemptEvent>(OnXenoLeapingPullAttempt);
-
-        Subs.CVar(_config, RMCCVars.RMCGunPredictionCoordinateDeviation, v => _coordinateDeviation = v, true);
     }
 
     private void OnPredictedHit(XenoLeapPredictedHitEvent msg, EntitySessionEventArgs args)
@@ -132,45 +126,20 @@ public sealed class XenoLeapSystem : EntitySystem
                 return;
 
             _rmcLagCompensation.SetLastRealTick(args.SenderSession.UserId, msg.LastRealTick);
-
-            var serverCoordinates = _transform.ToMapCoordinates(_rmcLagCompensation.GetCoordinates(target, args.SenderSession));
-            var clientCoordinates = msg.TargetCoordinates;
-            var clientCoordinatesValid = clientCoordinates.MapId == serverCoordinates.MapId &&
-                                         clientCoordinates.InRange(serverCoordinates, _coordinateDeviation);
-            var serverSampleHit = _rmcLagCompensation.Collides(target, ent, serverCoordinates);
-            var clientSampleHit = clientCoordinatesValid &&
-                                  _rmcLagCompensation.Collides(target, ent, clientCoordinates);
-
-            if (clientSampleHit)
-                RewindTargetToPredictedHitSample(target, clientCoordinates);
-            else if (serverSampleHit)
-                RewindTargetToPredictedHitSample(target, serverCoordinates);
-            else
+            if (!_rmcLagCompensation.TryGetAcceptedHitCoordinates(
+                    target,
+                    ent,
+                    args.SenderSession,
+                    msg.TargetCoordinates,
+                    out var acceptedCoordinates))
+            {
                 return;
+            }
+
+            _rmcLagCompensation.RewindEntityToCoordinates(target, acceptedCoordinates);
         }
 
         ApplyLeapingHitEffects((ent, leaping), target);
-    }
-
-    private void RewindTargetToPredictedHitSample(EntityUid target, MapCoordinates coordinates)
-    {
-        if (_net.IsClient)
-            return;
-
-        if (!TryComp(target, out TransformComponent? xform))
-            return;
-
-        var current = _transform.GetMapCoordinates(target, xform);
-        if (current.MapId != coordinates.MapId)
-            return;
-
-        _transform.SetCoordinates(target, xform, _transform.ToCoordinates(xform.ParentUid, coordinates));
-
-        if (_physicsQuery.TryGetComponent(target, out var physics))
-        {
-            _physics.SetLinearVelocity(target, Vector2.Zero, body: physics);
-            _physics.SetAngularVelocity(target, 0, body: physics);
-        }
     }
 
     private void OnXenoLeapAction(Entity<XenoLeapComponent> xeno, ref XenoLeapActionEvent args)

--- a/Content.Shared/_RMC14/Xenonids/Leap/XenoLeapSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Leap/XenoLeapSystem.cs
@@ -3,6 +3,7 @@ using System.Numerics;
 using Content.Shared._RMC14.Barricade;
 using Content.Shared._RMC14.Barricade.Components;
 using Content.Shared._RMC14.CameraShake;
+using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Damage.ObstacleSlamming;
 using Content.Shared._RMC14.Entrenching;
 using Content.Shared._RMC14.Movement;
@@ -40,6 +41,7 @@ using Content.Shared.Stunnable;
 using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Configuration;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Physics;
@@ -57,6 +59,7 @@ public sealed class XenoLeapSystem : EntitySystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly BlindableSystem _blindable = default!;
     [Dependency] private readonly SharedBroadphaseSystem _broadphase = default!;
+    [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
@@ -82,6 +85,7 @@ public sealed class XenoLeapSystem : EntitySystem
 
     private EntityQuery<PhysicsComponent> _physicsQuery;
     private EntityQuery<FixturesComponent> _fixturesQuery;
+    private float _coordinateDeviation;
 
     public override void Initialize()
     {
@@ -107,6 +111,8 @@ public sealed class XenoLeapSystem : EntitySystem
         SubscribeLocalEvent<XenoLeapingComponent, PhysicsSleepEvent>(OnXenoLeapingPhysicsSleep);
         SubscribeLocalEvent<XenoLeapingComponent, StartPullAttemptEvent>(OnXenoLeapingStartPullAttempt);
         SubscribeLocalEvent<XenoLeapingComponent, PullAttemptEvent>(OnXenoLeapingPullAttempt);
+
+        Subs.CVar(_config, RMCCVars.RMCGunPredictionCoordinateDeviation, v => _coordinateDeviation = v, true);
     }
 
     private void OnPredictedHit(XenoLeapPredictedHitEvent msg, EntitySessionEventArgs args)
@@ -126,11 +132,45 @@ public sealed class XenoLeapSystem : EntitySystem
                 return;
 
             _rmcLagCompensation.SetLastRealTick(args.SenderSession.UserId, msg.LastRealTick);
-            if (!_rmcLagCompensation.Collides(target, ent, args.SenderSession))
+
+            var serverCoordinates = _transform.ToMapCoordinates(_rmcLagCompensation.GetCoordinates(target, args.SenderSession));
+            var clientCoordinates = msg.TargetCoordinates;
+            var clientCoordinatesValid = clientCoordinates.MapId == serverCoordinates.MapId &&
+                                         clientCoordinates.InRange(serverCoordinates, _coordinateDeviation);
+            var serverSampleHit = _rmcLagCompensation.Collides(target, ent, serverCoordinates);
+            var clientSampleHit = clientCoordinatesValid &&
+                                  _rmcLagCompensation.Collides(target, ent, clientCoordinates);
+
+            if (clientSampleHit)
+                RewindTargetToPredictedHitSample(target, clientCoordinates);
+            else if (serverSampleHit)
+                RewindTargetToPredictedHitSample(target, serverCoordinates);
+            else
                 return;
         }
 
         ApplyLeapingHitEffects((ent, leaping), target);
+    }
+
+    private void RewindTargetToPredictedHitSample(EntityUid target, MapCoordinates coordinates)
+    {
+        if (_net.IsClient)
+            return;
+
+        if (!TryComp(target, out TransformComponent? xform))
+            return;
+
+        var current = _transform.GetMapCoordinates(target, xform);
+        if (current.MapId != coordinates.MapId)
+            return;
+
+        _transform.SetCoordinates(target, xform, _transform.ToCoordinates(xform.ParentUid, coordinates));
+
+        if (_physicsQuery.TryGetComponent(target, out var physics))
+        {
+            _physics.SetLinearVelocity(target, Vector2.Zero, body: physics);
+            _physics.SetAngularVelocity(target, 0, body: physics);
+        }
     }
 
     private void OnXenoLeapAction(Entity<XenoLeapComponent> xeno, ref XenoLeapActionEvent args)
@@ -597,7 +637,10 @@ public sealed class XenoLeapSystem : EntitySystem
 
         if (_net.IsClient)
         {
-            var predictedEv = new XenoLeapPredictedHitEvent(GetNetEntity(target), _rmcLagCompensation.GetLastRealTick(null));
+            var predictedEv = new XenoLeapPredictedHitEvent(
+                GetNetEntity(target),
+                _transform.GetMapCoordinates(target),
+                _rmcLagCompensation.GetLastRealTick(null));
             RaiseNetworkEvent(predictedEv);
             if (_timing.InPrediction && _timing.IsFirstTimePredicted)
             {

--- a/Content.Shared/_RMC14/Xenonids/Lunge/XenoLungePredictedHitEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Lunge/XenoLungePredictedHitEvent.cs
@@ -1,11 +1,13 @@
-﻿using Robust.Shared.Serialization;
+using Robust.Shared.Map;
+using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 
 namespace Content.Shared._RMC14.Xenonids.Lunge;
 
 [Serializable, NetSerializable]
-public sealed class XenoLungePredictedHitEvent(NetEntity target, GameTick lastRealTick) : EntityEventArgs
+public sealed class XenoLungePredictedHitEvent(NetEntity target, MapCoordinates targetCoordinates, GameTick lastRealTick) : EntityEventArgs
 {
     public readonly NetEntity Target = target;
+    public readonly MapCoordinates TargetCoordinates = targetCoordinates;
     public readonly GameTick LastRealTick = lastRealTick;
 }

--- a/Content.Shared/_RMC14/Xenonids/Lunge/XenoLungeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Lunge/XenoLungeSystem.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Numerics;
+using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Damage.ObstacleSlamming;
 using Content.Shared._RMC14.Movement;
 using Content.Shared._RMC14.Pulling;
@@ -14,6 +15,8 @@ using Content.Shared.Stunnable;
 using Content.Shared.Throwing;
 using Content.Shared.Weapons.Melee;
 using Content.Shared.Weapons.Melee.Events;
+using Robust.Shared.Configuration;
+using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
@@ -24,6 +27,7 @@ namespace Content.Shared._RMC14.Xenonids.Lunge;
 
 public sealed class XenoLungeSystem : EntitySystem
 {
+    [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly ThrowingSystem _throwing = default!;
@@ -43,6 +47,7 @@ public sealed class XenoLungeSystem : EntitySystem
 
     private EntityQuery<PhysicsComponent> _physicsQuery;
     private EntityQuery<ThrownItemComponent> _thrownItemQuery;
+    private float _coordinateDeviation;
 
     public override void Initialize()
     {
@@ -60,6 +65,8 @@ public sealed class XenoLungeSystem : EntitySystem
         SubscribeLocalEvent<RMCLungeProtectionComponent, XenoLungeHitAttempt>(OnXenoLungeHitAttempt);
 
         SubscribeLocalEvent<XenoLungeStunnedComponent, PullStoppedMessage>(OnXenoLungeStunnedPullStopped);
+
+        Subs.CVar(_config, RMCCVars.RMCGunPredictionCoordinateDeviation, v => _coordinateDeviation = v, true);
     }
 
     private void OnPredictedHit(XenoLungePredictedHitEvent msg, EntitySessionEventArgs args)
@@ -83,7 +90,45 @@ public sealed class XenoLungeSystem : EntitySystem
             return;
 
         _rmcLagCompensation.SetLastRealTick(args.SenderSession.UserId, msg.LastRealTick);
-        ApplyLungeHitEffects((ent, lunging), target, true, false);
+        var serverCoordinates = _transform.ToMapCoordinates(_rmcLagCompensation.GetCoordinates(target, args.SenderSession));
+        var clientCoordinates = msg.TargetCoordinates;
+        var clientCoordinatesValid = clientCoordinates.MapId == serverCoordinates.MapId &&
+                                     clientCoordinates.InRange(serverCoordinates, _coordinateDeviation);
+        var serverSampleHit = _rmcLagCompensation.Collides(target, ent, serverCoordinates);
+        var clientSampleHit = clientCoordinatesValid &&
+                              _rmcLagCompensation.Collides(target, ent, clientCoordinates);
+
+        MapCoordinates acceptedCoordinates;
+        if (clientSampleHit)
+            acceptedCoordinates = clientCoordinates;
+        else if (serverSampleHit)
+            acceptedCoordinates = serverCoordinates;
+        else
+            return;
+
+        RewindTargetToPredictedHitSample(target, acceptedCoordinates);
+        ApplyLungeHitEffects((ent, lunging), target, true, false, acceptedCoordinates);
+    }
+
+    private void RewindTargetToPredictedHitSample(EntityUid target, MapCoordinates coordinates)
+    {
+        if (_net.IsClient)
+            return;
+
+        if (!TryComp(target, out TransformComponent? xform))
+            return;
+
+        var current = _transform.GetMapCoordinates(target, xform);
+        if (current.MapId != coordinates.MapId)
+            return;
+
+        _transform.SetCoordinates(target, xform, _transform.ToCoordinates(xform.ParentUid, coordinates));
+
+        if (_physicsQuery.TryGetComponent(target, out var physics))
+        {
+            _physics.SetLinearVelocity(target, Vector2.Zero, body: physics);
+            _physics.SetAngularVelocity(target, 0, body: physics);
+        }
     }
 
     private void OnXenoLungeAction(Entity<XenoLungeComponent> xeno, ref XenoLungeActionEvent args)
@@ -174,7 +219,7 @@ public sealed class XenoLungeSystem : EntitySystem
         RemCompDeferred<XenoActiveLungeComponent>(ent);
     }
 
-    private bool ApplyLungeHitEffects(Entity<XenoActiveLungeComponent?> xeno, EntityUid targetId, bool stopThrow, bool predicted = true)
+    private bool ApplyLungeHitEffects(Entity<XenoActiveLungeComponent?> xeno, EntityUid targetId, bool stopThrow, bool predicted = true, MapCoordinates? hitCoordinates = null)
     {
         if (!Resolve(xeno, ref xeno.Comp, false))
             return false;
@@ -223,7 +268,10 @@ public sealed class XenoLungeSystem : EntitySystem
 
         if (_net.IsClient && predicted)
         {
-            var predictedEv = new XenoLungePredictedHitEvent(GetNetEntity(targetId), _rmcLagCompensation.GetLastRealTick(null));
+            var predictedEv = new XenoLungePredictedHitEvent(
+                GetNetEntity(targetId),
+                _transform.GetMapCoordinates(targetId),
+                _rmcLagCompensation.GetLastRealTick(null));
             RaiseNetworkEvent(predictedEv);
             if (_timing.InPrediction && _timing.IsFirstTimePredicted)
             {
@@ -233,14 +281,15 @@ public sealed class XenoLungeSystem : EntitySystem
 
         StopLunge(xeno);
 
-        _transform.SetMapCoordinates(targetId, xeno.Comp.TargetCoordinates);
+        var targetCoordinates = hitCoordinates ?? xeno.Comp.TargetCoordinates;
+        _transform.SetMapCoordinates(targetId, targetCoordinates);
 
         // Fixes lunges done when hugging a wall that would otherwise not move you
         var coordinates = _transform.GetMapCoordinates(xeno);
-        if (xeno.Comp.TargetCoordinates.MapId == coordinates.MapId &&
-            !xeno.Comp.TargetCoordinates.InRange(coordinates, 1.25f))
+        if (targetCoordinates.MapId == coordinates.MapId &&
+            !targetCoordinates.InRange(coordinates, 1.25f))
         {
-            var distance = xeno.Comp.TargetCoordinates.Position - coordinates.Position;
+            var distance = targetCoordinates.Position - coordinates.Position;
             var length = distance.Length();
             var newPosition = coordinates.Offset(((float) (length - 1.25) / length) * distance);
             _transform.SetMapCoordinates(xeno, newPosition);

--- a/Content.Shared/_RMC14/Xenonids/Lunge/XenoLungeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Lunge/XenoLungeSystem.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using System.Numerics;
-using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Damage.ObstacleSlamming;
 using Content.Shared._RMC14.Movement;
 using Content.Shared._RMC14.Pulling;
@@ -15,7 +14,6 @@ using Content.Shared.Stunnable;
 using Content.Shared.Throwing;
 using Content.Shared.Weapons.Melee;
 using Content.Shared.Weapons.Melee.Events;
-using Robust.Shared.Configuration;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Physics.Components;
@@ -27,7 +25,6 @@ namespace Content.Shared._RMC14.Xenonids.Lunge;
 
 public sealed class XenoLungeSystem : EntitySystem
 {
-    [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly ThrowingSystem _throwing = default!;
@@ -47,7 +44,6 @@ public sealed class XenoLungeSystem : EntitySystem
 
     private EntityQuery<PhysicsComponent> _physicsQuery;
     private EntityQuery<ThrownItemComponent> _thrownItemQuery;
-    private float _coordinateDeviation;
 
     public override void Initialize()
     {
@@ -65,8 +61,6 @@ public sealed class XenoLungeSystem : EntitySystem
         SubscribeLocalEvent<RMCLungeProtectionComponent, XenoLungeHitAttempt>(OnXenoLungeHitAttempt);
 
         SubscribeLocalEvent<XenoLungeStunnedComponent, PullStoppedMessage>(OnXenoLungeStunnedPullStopped);
-
-        Subs.CVar(_config, RMCCVars.RMCGunPredictionCoordinateDeviation, v => _coordinateDeviation = v, true);
     }
 
     private void OnPredictedHit(XenoLungePredictedHitEvent msg, EntitySessionEventArgs args)
@@ -90,45 +84,18 @@ public sealed class XenoLungeSystem : EntitySystem
             return;
 
         _rmcLagCompensation.SetLastRealTick(args.SenderSession.UserId, msg.LastRealTick);
-        var serverCoordinates = _transform.ToMapCoordinates(_rmcLagCompensation.GetCoordinates(target, args.SenderSession));
-        var clientCoordinates = msg.TargetCoordinates;
-        var clientCoordinatesValid = clientCoordinates.MapId == serverCoordinates.MapId &&
-                                     clientCoordinates.InRange(serverCoordinates, _coordinateDeviation);
-        var serverSampleHit = _rmcLagCompensation.Collides(target, ent, serverCoordinates);
-        var clientSampleHit = clientCoordinatesValid &&
-                              _rmcLagCompensation.Collides(target, ent, clientCoordinates);
-
-        MapCoordinates acceptedCoordinates;
-        if (clientSampleHit)
-            acceptedCoordinates = clientCoordinates;
-        else if (serverSampleHit)
-            acceptedCoordinates = serverCoordinates;
-        else
-            return;
-
-        RewindTargetToPredictedHitSample(target, acceptedCoordinates);
-        ApplyLungeHitEffects((ent, lunging), target, true, false, acceptedCoordinates);
-    }
-
-    private void RewindTargetToPredictedHitSample(EntityUid target, MapCoordinates coordinates)
-    {
-        if (_net.IsClient)
-            return;
-
-        if (!TryComp(target, out TransformComponent? xform))
-            return;
-
-        var current = _transform.GetMapCoordinates(target, xform);
-        if (current.MapId != coordinates.MapId)
-            return;
-
-        _transform.SetCoordinates(target, xform, _transform.ToCoordinates(xform.ParentUid, coordinates));
-
-        if (_physicsQuery.TryGetComponent(target, out var physics))
+        if (!_rmcLagCompensation.TryGetAcceptedHitCoordinates(
+                target,
+                ent,
+                args.SenderSession,
+                msg.TargetCoordinates,
+                out var acceptedCoordinates))
         {
-            _physics.SetLinearVelocity(target, Vector2.Zero, body: physics);
-            _physics.SetAngularVelocity(target, 0, body: physics);
+            return;
         }
+
+        _rmcLagCompensation.RewindEntityToCoordinates(target, acceptedCoordinates);
+        ApplyLungeHitEffects((ent, lunging), target, true, false, acceptedCoordinates);
     }
 
     private void OnXenoLungeAction(Entity<XenoLungeComponent> xeno, ref XenoLungeActionEvent args)

--- a/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileComponent.cs
@@ -8,4 +8,7 @@ public sealed partial class XenoProjectileComponent : Component
 {
     [DataField, AutoNetworkedField]
     public bool DeleteOnFriendlyXeno;
+
+    [DataField, AutoNetworkedField]
+    public bool RewindTargetOnPredictedHit;
 }

--- a/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectilePredictedHitEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectilePredictedHitEvent.cs
@@ -1,12 +1,14 @@
-﻿using Robust.Shared.Serialization;
+using Robust.Shared.Map;
+using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 
 namespace Content.Shared._RMC14.Xenonids.Projectile;
 
 [Serializable, NetSerializable]
-public sealed class XenoProjectilePredictedHitEvent(int id, NetEntity target, GameTick lastRealTick) : EntityEventArgs
+public sealed class XenoProjectilePredictedHitEvent(int id, NetEntity target, MapCoordinates targetCoordinates, GameTick lastRealTick) : EntityEventArgs
 {
     public readonly int Id = id;
     public readonly NetEntity Target = target;
+    public readonly MapCoordinates TargetCoordinates = targetCoordinates;
     public readonly GameTick LastRealTick = lastRealTick;
 }

--- a/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Explosion;
 using Content.Shared._RMC14.Light;
 using Content.Shared._RMC14.Movement;
@@ -18,6 +19,7 @@ using Content.Shared.Weapons.Ranged.Events;
 using Content.Shared.Weapons.Ranged.Systems;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Configuration;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Physics.Components;
@@ -34,6 +36,7 @@ namespace Content.Shared._RMC14.Xenonids.Projectile;
 public sealed class XenoProjectileSystem : EntitySystem
 {
     [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] private readonly SharedGunSystem _gun = default!;
     [Dependency] private readonly SharedGunPredictionSystem _gunPrediction = default!;
     [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
@@ -51,6 +54,8 @@ public sealed class XenoProjectileSystem : EntitySystem
 
     private EntityQuery<ProjectileComponent> _projectileQuery;
     private EntityQuery<PreventAttackLightOffComponent> _preventAttackLightOffQuery;
+    private bool _logHits;
+    private float _coordinateDeviation;
 
     private int _limitHitsId;
 
@@ -73,6 +78,9 @@ public sealed class XenoProjectileSystem : EntitySystem
         SubscribeLocalEvent<XenoProjectileComponent, PreventCollideEvent>(OnPreventCollide);
         SubscribeLocalEvent<XenoProjectileComponent, ProjectileHitEvent>(OnProjectileHit);
         SubscribeLocalEvent<XenoProjectileComponent, CMClusterSpawnedEvent>(OnClusterSpawned);
+
+        Subs.CVar(_config, RMCCVars.RMCGunPredictionCoordinateDeviation, v => _coordinateDeviation = v, true);
+        Subs.CVar(_config, RMCCVars.RMCGunPredictionLogHits, v => _logHits = v, true);
     }
 
     private void OnRoundRestartCleanup(RoundRestartCleanupEvent ev)
@@ -112,10 +120,67 @@ public sealed class XenoProjectileSystem : EntitySystem
             return;
         }
 
-        if (!_rmcLagCompensation.Collides(target, (shot.Value, physics), coordinates))
+        var clientCoordinates = msg.TargetCoordinates;
+        var clientCoordinatesValid = clientCoordinates.MapId == coordinates.MapId &&
+                                     clientCoordinates.InRange(coordinates, _coordinateDeviation);
+        var serverSampleHit = _rmcLagCompensation.Collides(target, (shot.Value, physics), coordinates);
+        var clientSampleHit = clientCoordinatesValid &&
+                              _rmcLagCompensation.Collides(target, (shot.Value, physics), clientCoordinates);
+
+        MapCoordinates acceptedCoordinates;
+        if (clientSampleHit)
+        {
+            acceptedCoordinates = clientCoordinates;
+            LogPredictedHit($"Accepted xeno predicted hit using client sample. Shooter={ToPrettyString(ent)}, Target={ToPrettyString(target)}, Shot={msg.Id}, ServerSample={serverSampleHit}");
+        }
+        else if (serverSampleHit)
+        {
+            acceptedCoordinates = coordinates;
+            LogPredictedHit($"Accepted xeno predicted hit using server sample. Shooter={ToPrettyString(ent)}, Target={ToPrettyString(target)}, Shot={msg.Id}, ClientValid={clientCoordinatesValid}");
+        }
+        else
+        {
             return;
+        }
+
+        if (TryComp(shot, out XenoProjectileComponent? xenoProjectile) &&
+            xenoProjectile.RewindTargetOnPredictedHit)
+        {
+            RewindTargetToPredictedHitSample(target, acceptedCoordinates);
+        }
 
         _projectile.ProjectileCollide((shot.Value, projectile, physics), target, true);
+    }
+
+    private void RewindTargetToPredictedHitSample(EntityUid target, MapCoordinates coordinates)
+    {
+        if (_net.IsClient)
+            return;
+
+        if (!TryComp(target, out TransformComponent? xform))
+            return;
+
+        var current = _transform.GetMapCoordinates(target, xform);
+        if (current.MapId != coordinates.MapId)
+            return;
+
+        _transform.SetCoordinates(target, xform, _transform.ToCoordinates(xform.ParentUid, coordinates));
+
+        if (TryComp(target, out PhysicsComponent? physics))
+        {
+            _physics.SetLinearVelocity(target, Vector2.Zero, body: physics);
+            _physics.SetAngularVelocity(target, 0, body: physics);
+        }
+
+        LogPredictedHit($"Rewound xeno predicted hit target to sample. Target={ToPrettyString(target)}, From={current}, To={coordinates}");
+    }
+
+    private void LogPredictedHit(string message)
+    {
+        Log.Debug(message);
+
+        if (_logHits)
+            Log.Info(message);
     }
 
     private void OnShooterRemove<T>(Entity<XenoProjectileShooterComponent> ent, ref T args)
@@ -155,6 +220,7 @@ public sealed class XenoProjectileSystem : EntitySystem
         var ev = new XenoProjectilePredictedHitEvent(
             shot.Id,
             GetNetEntity(args.OtherEntity),
+            _transform.GetMapCoordinates(args.OtherEntity),
             _rmcLagCompensation.GetLastRealTick(null)
         );
         RaiseNetworkEvent(ev);

--- a/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
@@ -1,5 +1,4 @@
 using System.Numerics;
-using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Explosion;
 using Content.Shared._RMC14.Light;
 using Content.Shared._RMC14.Movement;
@@ -19,7 +18,6 @@ using Content.Shared.Weapons.Ranged.Events;
 using Content.Shared.Weapons.Ranged.Systems;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
-using Robust.Shared.Configuration;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Physics.Components;
@@ -36,7 +34,6 @@ namespace Content.Shared._RMC14.Xenonids.Projectile;
 public sealed class XenoProjectileSystem : EntitySystem
 {
     [Dependency] private readonly SharedAudioSystem _audio = default!;
-    [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] private readonly SharedGunSystem _gun = default!;
     [Dependency] private readonly SharedGunPredictionSystem _gunPrediction = default!;
     [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
@@ -54,8 +51,6 @@ public sealed class XenoProjectileSystem : EntitySystem
 
     private EntityQuery<ProjectileComponent> _projectileQuery;
     private EntityQuery<PreventAttackLightOffComponent> _preventAttackLightOffQuery;
-    private bool _logHits;
-    private float _coordinateDeviation;
 
     private int _limitHitsId;
 
@@ -78,9 +73,6 @@ public sealed class XenoProjectileSystem : EntitySystem
         SubscribeLocalEvent<XenoProjectileComponent, PreventCollideEvent>(OnPreventCollide);
         SubscribeLocalEvent<XenoProjectileComponent, ProjectileHitEvent>(OnProjectileHit);
         SubscribeLocalEvent<XenoProjectileComponent, CMClusterSpawnedEvent>(OnClusterSpawned);
-
-        Subs.CVar(_config, RMCCVars.RMCGunPredictionCoordinateDeviation, v => _coordinateDeviation = v, true);
-        Subs.CVar(_config, RMCCVars.RMCGunPredictionLogHits, v => _logHits = v, true);
     }
 
     private void OnRoundRestartCleanup(RoundRestartCleanupEvent ev)
@@ -112,7 +104,6 @@ public sealed class XenoProjectileSystem : EntitySystem
             return;
 
         _rmcLagCompensation.SetLastRealTick(args.SenderSession.UserId, msg.LastRealTick);
-        var coordinates = _transform.ToMapCoordinates(_rmcLagCompensation.GetCoordinates(target, args.SenderSession));
 
         if (!TryComp(shot, out ProjectileComponent? projectile) ||
             !TryComp(shot, out PhysicsComponent? physics))
@@ -120,25 +111,12 @@ public sealed class XenoProjectileSystem : EntitySystem
             return;
         }
 
-        var clientCoordinates = msg.TargetCoordinates;
-        var clientCoordinatesValid = clientCoordinates.MapId == coordinates.MapId &&
-                                     clientCoordinates.InRange(coordinates, _coordinateDeviation);
-        var serverSampleHit = _rmcLagCompensation.Collides(target, (shot.Value, physics), coordinates);
-        var clientSampleHit = clientCoordinatesValid &&
-                              _rmcLagCompensation.Collides(target, (shot.Value, physics), clientCoordinates);
-
-        MapCoordinates acceptedCoordinates;
-        if (clientSampleHit)
-        {
-            acceptedCoordinates = clientCoordinates;
-            LogPredictedHit($"Accepted xeno predicted hit using client sample. Shooter={ToPrettyString(ent)}, Target={ToPrettyString(target)}, Shot={msg.Id}, ServerSample={serverSampleHit}");
-        }
-        else if (serverSampleHit)
-        {
-            acceptedCoordinates = coordinates;
-            LogPredictedHit($"Accepted xeno predicted hit using server sample. Shooter={ToPrettyString(ent)}, Target={ToPrettyString(target)}, Shot={msg.Id}, ClientValid={clientCoordinatesValid}");
-        }
-        else
+        if (!_rmcLagCompensation.TryGetAcceptedHitCoordinates(
+                target,
+                (shot.Value, physics),
+                args.SenderSession,
+                msg.TargetCoordinates,
+                out var acceptedCoordinates))
         {
             return;
         }
@@ -146,41 +124,10 @@ public sealed class XenoProjectileSystem : EntitySystem
         if (TryComp(shot, out XenoProjectileComponent? xenoProjectile) &&
             xenoProjectile.RewindTargetOnPredictedHit)
         {
-            RewindTargetToPredictedHitSample(target, acceptedCoordinates);
+            _rmcLagCompensation.RewindEntityToCoordinates(target, acceptedCoordinates);
         }
 
         _projectile.ProjectileCollide((shot.Value, projectile, physics), target, true);
-    }
-
-    private void RewindTargetToPredictedHitSample(EntityUid target, MapCoordinates coordinates)
-    {
-        if (_net.IsClient)
-            return;
-
-        if (!TryComp(target, out TransformComponent? xform))
-            return;
-
-        var current = _transform.GetMapCoordinates(target, xform);
-        if (current.MapId != coordinates.MapId)
-            return;
-
-        _transform.SetCoordinates(target, xform, _transform.ToCoordinates(xform.ParentUid, coordinates));
-
-        if (TryComp(target, out PhysicsComponent? physics))
-        {
-            _physics.SetLinearVelocity(target, Vector2.Zero, body: physics);
-            _physics.SetAngularVelocity(target, 0, body: physics);
-        }
-
-        LogPredictedHit($"Rewound xeno predicted hit target to sample. Target={ToPrettyString(target)}, From={current}, To={coordinates}");
-    }
-
-    private void LogPredictedHit(string message)
-    {
-        Log.Debug(message);
-
-        if (_logHits)
-            Log.Info(message);
     }
 
     private void OnShooterRemove<T>(Entity<XenoProjectileShooterComponent> ent, ref T args)

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_projectiles.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_projectiles.yml
@@ -106,6 +106,7 @@
     armorResistsKnockdown: true
   - type: XenoProjectile
     deleteOnFriendlyXeno: true
+    rewindTargetOnPredictedHit: true
   - type: DrainOnHit
   - type: ProjectileMaxRange
     max: 5
@@ -127,6 +128,7 @@
     paralyze: 4
   - type: XenoProjectile
     deleteOnFriendlyXeno: true
+    rewindTargetOnPredictedHit: true
   - type: ProjectileMaxRange
     max: 4
   - type: RMCProjectileAccuracy
@@ -149,6 +151,7 @@
     armorResistsKnockdown: false
   - type: XenoProjectile
     deleteOnFriendlyXeno: true
+    rewindTargetOnPredictedHit: true
   - type: ProjectileMaxRange
     max: 4
 
@@ -455,6 +458,7 @@
         Slash: 40
   - type: XenoProjectile
     deleteOnFriendlyXeno: false
+    rewindTargetOnPredictedHit: true
   - type: RMCProjectileAccuracy
     accuracy: 185
   - type: XenoHookOnHit


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Many xenonid abilities will rewind the target to where they got hit, this prevents the issue for many xenonids where delay between the stun being applied causes the target to be way further away then is intended. This issue is most apparent with runner & lurker.

Lag compensation will now also take into account the clients coordinate sample, this should help with lag compensation. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->
its rewind time
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

### before

https://github.com/user-attachments/assets/0ab379c8-3643-42d4-ae19-7261a33d56ac




### after 

https://github.com/user-attachments/assets/f6dd1049-901b-488e-b889-b9d2f2969d02


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Vixting
- add: Many xenonid abilities that stun the target will now rewind the target to the point where the stun was applied, instead of it being applied at their current position.