### PR TITLE
Overwatch and xeno watch now show nearby chat

### DIFF
--- a/Content.Server/_RMC14/Overwatch/OverwatchConsoleSystem.cs
+++ b/Content.Server/_RMC14/Overwatch/OverwatchConsoleSystem.cs
@@ -1,4 +1,6 @@
-﻿using Content.Shared._RMC14.Overwatch;
+﻿using Content.Server.Chat.Systems;
+using Content.Shared._RMC14.Overwatch;
+using Content.Shared._RMC14.Xenonids.Watch;
 using Robust.Server.GameObjects;
 using Robust.Shared.Player;
 
@@ -13,10 +15,44 @@ public sealed class OverwatchConsoleSystem : SharedOverwatchConsoleSystem
     {
         base.Initialize();
 
+        SubscribeLocalEvent<ExpandICChatRecipientsEvent>(OnExpandRecipients);
+
         SubscribeLocalEvent<OverwatchCameraComponent, ComponentRemove>(OnWatchedRemove);
         SubscribeLocalEvent<OverwatchCameraComponent, EntityTerminatingEvent>(OnWatchedRemove);
         SubscribeLocalEvent<OverwatchWatchingComponent, ComponentRemove>(OnWatchingRemove);
         SubscribeLocalEvent<OverwatchWatchingComponent, EntityTerminatingEvent>(OnWatchingRemove);
+    }
+
+    private void OnExpandRecipients(ExpandICChatRecipientsEvent ev)
+    {
+        foreach (var session in Player.Sessions)
+        {
+            if (session.AttachedEntity is not { Valid: true } ent)
+                continue;
+
+            if (!TryComp(ent, out OverwatchWatchingComponent? overwatch))
+                overwatch = null;
+
+            if (!TryComp(ent, out XenoWatchingComponent? xenoWatch))
+                xenoWatch = null;
+
+            if (overwatch == null && xenoWatch == null)
+                continue;
+
+            var watched = overwatch?.Watching ?? xenoWatch?.Watching;
+
+            if (watched is not { } target)
+                continue;
+
+            if (!Transform(target).Coordinates.TryDistance(EntityManager,Transform(ev.Source).Coordinates, out var distance))
+                continue;
+
+            if (distance > ev.VoiceRange)
+                continue;
+
+            if (!ev.Recipients.ContainsKey(session))
+                ev.Recipients.Add(session, new ChatSystem.ICChatRecipientData(distance, false));
+        }
     }
 
     private void OnWatchedRemove<T>(Entity<OverwatchCameraComponent> ent, ref T args)

--- a/Content.Server/_RMC14/Overwatch/OverwatchConsoleSystem.cs
+++ b/Content.Server/_RMC14/Overwatch/OverwatchConsoleSystem.cs
@@ -1,5 +1,7 @@
 ﻿using Content.Server.Chat.Systems;
+using Content.Shared._RMC14.Communications;
 using Content.Shared._RMC14.Overwatch;
+using Content.Shared._RMC14.Rules;
 using Content.Shared._RMC14.Xenonids.Watch;
 using Robust.Server.GameObjects;
 using Robust.Shared.Player;
@@ -8,6 +10,7 @@ namespace Content.Server._RMC14.Overwatch;
 
 public sealed class OverwatchConsoleSystem : SharedOverwatchConsoleSystem
 {
+    [Dependency] private readonly CommunicationsTowerSystem _communicationsTower = default!;
     [Dependency] private readonly SharedEyeSystem _eye = default!;
     [Dependency] private readonly ViewSubscriberSystem _viewSubscriber = default!;
 
@@ -27,14 +30,11 @@ public sealed class OverwatchConsoleSystem : SharedOverwatchConsoleSystem
     {
         foreach (var session in Player.Sessions)
         {
-            if (session.AttachedEntity is not { Valid: true } ent)
+            if (session.AttachedEntity is not { } ent)
                 continue;
 
-            if (!TryComp(ent, out OverwatchWatchingComponent? overwatch))
-                overwatch = null;
-
-            if (!TryComp(ent, out XenoWatchingComponent? xenoWatch))
-                xenoWatch = null;
+            TryComp(ent, out OverwatchWatchingComponent? overwatch);
+            TryComp(ent, out XenoWatchingComponent? xenoWatch);
 
             if (overwatch == null && xenoWatch == null)
                 continue;
@@ -44,7 +44,15 @@ public sealed class OverwatchConsoleSystem : SharedOverwatchConsoleSystem
             if (watched is not { } target)
                 continue;
 
-            if (!Transform(target).Coordinates.TryDistance(EntityManager,Transform(ev.Source).Coordinates, out var distance))
+            var targetCoordinates = TransformSystem.GetMoverCoordinates(target);
+            var targetMap = TransformSystem.GetMap(targetCoordinates);
+            if (overwatch != null && HasComp<RMCPlanetComponent>(targetMap) && targetMap != TransformSystem.GetMap(ent))
+            {
+                if (!_communicationsTower.CanTransmit())
+                    continue;
+            }
+
+            if (!targetCoordinates.TryDistance(EntityManager, Transform(ev.Source).Coordinates, out var distance))
                 continue;
 
             if (distance > ev.VoiceRange)

--- a/Content.Shared/_RMC14/Communications/CommunicationsTowerSystem.cs
+++ b/Content.Shared/_RMC14/Communications/CommunicationsTowerSystem.cs
@@ -235,13 +235,13 @@ public sealed class CommunicationsTowerSystem : EntitySystem
         UpdateAppearance(tower);
     }
 
-    public bool CanTransmit(ProtoId<RadioChannelPrototype> channel)
+    public bool CanTransmit(ProtoId<RadioChannelPrototype>? channel = null)
     {
         var towers = EntityQueryEnumerator<CommunicationsTowerComponent>();
         while (towers.MoveNext(out var tower))
         {
             if (tower.State != CommunicationsTowerState.On ||
-                !tower.Channels.Contains(channel))
+                channel != null && !tower.Channels.Contains(channel.Value))
             {
                 continue;
             }

--- a/Content.Shared/_RMC14/Overwatch/SharedOverwatchConsoleSystem.cs
+++ b/Content.Shared/_RMC14/Overwatch/SharedOverwatchConsoleSystem.cs
@@ -41,6 +41,8 @@ namespace Content.Shared._RMC14.Overwatch;
 
 public abstract class SharedOverwatchConsoleSystem : EntitySystem
 {
+    [Dependency] protected readonly ISharedPlayerManager Player = default!;
+
     [Dependency] private readonly ISharedAdminLogManager _adminLog = default!;
     [Dependency] private readonly AreaSystem _area = default!;
     [Dependency] private readonly IConfigurationManager _config = default!;
@@ -52,7 +54,6 @@ public abstract class SharedOverwatchConsoleSystem : EntitySystem
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly OrbitalCannonSystem _orbitalCannon = default!;
-    [Dependency] private readonly ISharedPlayerManager _player = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly IPrototypeManager _prototypes = default!;
     [Dependency] private readonly SharedCMChatSystem _rmcChat = default!;
@@ -564,7 +565,7 @@ public abstract class SharedOverwatchConsoleSystem : EntitySystem
         _marineAnnounce.AnnounceSquad(Loc.GetString("rmc-overwatch-console-announce-message", ("operatorName", Name(args.Actor)), ("message", message)), squadProto.ID);
 
         var coordinates = _transform.GetMapCoordinates(ent);
-        var players = Filter.Empty().AddInRange(coordinates, 12, _player, EntityManager);
+        var players = Filter.Empty().AddInRange(coordinates, 12, Player, EntityManager);
         players.RemoveWhereAttachedEntity(HasComp<XenoComponent>);
 
         var userMsg = Loc.GetString("rmc-overwatch-console-squad-message-sent", ("squadName", Name(squad.Value)), ("message", message));
@@ -609,7 +610,7 @@ public abstract class SharedOverwatchConsoleSystem : EntitySystem
         _marineAnnounce.AnnounceSquad(Loc.GetString("rmc-overwatch-console-announce-objective-updated", ("operatorName", Name(args.Actor)), ("objectiveType", objectiveTypeName), ("objective", objective)), squadProto.ID);
 
         var coordinates = _transform.GetMapCoordinates(ent);
-        var players = Filter.Empty().AddInRange(coordinates, 12, _player, EntityManager);
+        var players = Filter.Empty().AddInRange(coordinates, 12, Player, EntityManager);
         players.RemoveWhereAttachedEntity(HasComp<XenoComponent>);
 
         var userMsg = Loc.GetString("rmc-overwatch-console-objective-updated", ("squadName", Name(squad.Value)), ("objectiveType", objectiveTypeName), ("objective", objective));
@@ -657,7 +658,7 @@ public abstract class SharedOverwatchConsoleSystem : EntitySystem
         _marineAnnounce.AnnounceSquad(Loc.GetString("rmc-overwatch-console-announce-objective-cancelled", ("operatorName", Name(args.Actor)), ("objectiveType", objectiveTypeName), ("objective", cancelledObjective)), squadProto.ID);
 
         var coordinates = _transform.GetMapCoordinates(ent);
-        var players = Filter.Empty().AddInRange(coordinates, 12, _player, EntityManager);
+        var players = Filter.Empty().AddInRange(coordinates, 12, Player, EntityManager);
         players.RemoveWhereAttachedEntity(HasComp<XenoComponent>);
 
         var userMsg = Loc.GetString("rmc-overwatch-console-objective-cancelled", ("squadName", Name(squad.Value)), ("objectiveType", objectiveTypeName), ("objective", cancelledObjective));
@@ -715,8 +716,8 @@ public abstract class SharedOverwatchConsoleSystem : EntitySystem
 
     private void TryLocalUnwatch(Entity<OverwatchWatchingComponent> ent)
     {
-        if (_net.IsClient && _player.LocalEntity == ent.Owner && _player.LocalSession != null)
-            Unwatch(ent.Owner, _player.LocalSession);
+        if (_net.IsClient && Player.LocalEntity == ent.Owner && Player.LocalSession != null)
+            Unwatch(ent.Owner, Player.LocalSession);
         else if (TryComp(ent, out ActorComponent? actor))
             Unwatch(ent.Owner, actor.PlayerSession);
     }

--- a/Content.Shared/_RMC14/Overwatch/SharedOverwatchConsoleSystem.cs
+++ b/Content.Shared/_RMC14/Overwatch/SharedOverwatchConsoleSystem.cs
@@ -42,6 +42,7 @@ namespace Content.Shared._RMC14.Overwatch;
 public abstract class SharedOverwatchConsoleSystem : EntitySystem
 {
     [Dependency] protected readonly ISharedPlayerManager Player = default!;
+    [Dependency] protected readonly SharedTransformSystem TransformSystem = default!;
 
     [Dependency] private readonly ISharedAdminLogManager _adminLog = default!;
     [Dependency] private readonly AreaSystem _area = default!;
@@ -61,7 +62,6 @@ public abstract class SharedOverwatchConsoleSystem : EntitySystem
     [Dependency] private readonly SharedSupplyDropSystem _supplyDrop = default!;
     [Dependency] private readonly SharedTacticalMapSystem _tacticalMap = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
-    [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
 
     private EntityQuery<ActorComponent> _actor;
@@ -564,7 +564,7 @@ public abstract class SharedOverwatchConsoleSystem : EntitySystem
         _adminLog.Add(LogType.RMCMarineAnnounce, $"{ToPrettyString(args.Actor)} sent {squadProto.Name} squad message: {args.Message}");
         _marineAnnounce.AnnounceSquad(Loc.GetString("rmc-overwatch-console-announce-message", ("operatorName", Name(args.Actor)), ("message", message)), squadProto.ID);
 
-        var coordinates = _transform.GetMapCoordinates(ent);
+        var coordinates = TransformSystem.GetMapCoordinates(ent);
         var players = Filter.Empty().AddInRange(coordinates, 12, Player, EntityManager);
         players.RemoveWhereAttachedEntity(HasComp<XenoComponent>);
 
@@ -609,7 +609,7 @@ public abstract class SharedOverwatchConsoleSystem : EntitySystem
 
         _marineAnnounce.AnnounceSquad(Loc.GetString("rmc-overwatch-console-announce-objective-updated", ("operatorName", Name(args.Actor)), ("objectiveType", objectiveTypeName), ("objective", objective)), squadProto.ID);
 
-        var coordinates = _transform.GetMapCoordinates(ent);
+        var coordinates = TransformSystem.GetMapCoordinates(ent);
         var players = Filter.Empty().AddInRange(coordinates, 12, Player, EntityManager);
         players.RemoveWhereAttachedEntity(HasComp<XenoComponent>);
 
@@ -657,7 +657,7 @@ public abstract class SharedOverwatchConsoleSystem : EntitySystem
 
         _marineAnnounce.AnnounceSquad(Loc.GetString("rmc-overwatch-console-announce-objective-cancelled", ("operatorName", Name(args.Actor)), ("objectiveType", objectiveTypeName), ("objective", cancelledObjective)), squadProto.ID);
 
-        var coordinates = _transform.GetMapCoordinates(ent);
+        var coordinates = TransformSystem.GetMapCoordinates(ent);
         var players = Filter.Empty().AddInRange(coordinates, 12, Player, EntityManager);
         players.RemoveWhereAttachedEntity(HasComp<XenoComponent>);
 
@@ -745,7 +745,7 @@ public abstract class SharedOverwatchConsoleSystem : EntitySystem
 
                     MapCoordinates? leaderCoords = null;
                     if (_squad.TryGetSquadLeader(squadId, out var leader))
-                        leaderCoords = _transform.GetMapCoordinates(leader);
+                        leaderCoords = TransformSystem.GetMapCoordinates(leader);
 
                     while (membersQueue.TryDequeue(out var member))
                     {
@@ -763,7 +763,7 @@ public abstract class SharedOverwatchConsoleSystem : EntitySystem
                             continue;
                         }
 
-                        var coords = _transform.GetMapCoordinates(member);
+                        var coords = TransformSystem.GetMapCoordinates(member);
                         var name = Identity.Name(member, EntityManager);
                         var mobState = _mobStateQuery.CompOrNull(member)?.CurrentState ?? MobState.Alive;
                         var ssd = !_actor.HasComp(member);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
You can see local chat while watching another player through the overwatch console or xeno watch.
If the overwatch target and console are on different maps, local chat is only shown if there is at least one repaired communications tower.


## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

https://github.com/user-attachments/assets/f1d59c82-744f-4186-89e5-7ec1517ff71b


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- tweak: You can now see local chat near the observed player while using the Overwatch Console or Watch Xeno action.
