### PR TITLE
Fix #2344 MREs opening before being torn open

### DIFF
--- a/Content.Shared/_RMC14/Storage/MRERequireOpenBeforeStorageComponent.cs
+++ b/Content.Shared/_RMC14/Storage/MRERequireOpenBeforeStorageComponent.cs
@@ -1,0 +1,6 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Storage;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class MRERequireOpenBeforeStorageComponent : Component;

--- a/Content.Shared/_RMC14/Storage/RMCStorageSystem.cs
+++ b/Content.Shared/_RMC14/Storage/RMCStorageSystem.cs
@@ -11,6 +11,7 @@ using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Item;
 using Content.Shared.Lock;
+using Content.Shared.Nutrition.EntitySystems;
 using Content.Shared.ParaDrop;
 using Content.Shared.Popups;
 using Content.Shared.Roles;
@@ -38,6 +39,7 @@ public sealed class RMCStorageSystem : EntitySystem
     [Dependency] private readonly SharedItemSystem _item = default!;
     [Dependency] private readonly LockSystem _lock = default!;
     [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly OpenableSystem _openable = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SkillsSystem _skills = default!;
     [Dependency] private readonly SharedStorageSystem _storage = default!;
@@ -90,6 +92,7 @@ public sealed class RMCStorageSystem : EntitySystem
         SubscribeLocalEvent<DropshipHijackStartEvent>(OnLockerHijackStart);
         SubscribeLocalEvent<RMCLockerOpenOnHijackComponent, StorageOpenAttemptEvent>(OnLockerOpenAttempt);
         SubscribeLocalEvent<RMCLockerOpenOnHijackComponent, LockToggleAttemptEvent>(OnLockerLockToggleAttempt);
+        SubscribeLocalEvent<MRERequireOpenBeforeStorageComponent, StorageInteractAttemptEvent>(OnMREInteractAttempt);
 
         Subs.BuiEvents<StorageCloseOnMoveComponent>(StorageUiKey.Key, subs =>
         {
@@ -578,6 +581,14 @@ public sealed class RMCStorageSystem : EntitySystem
     private static void OnLockerOpenAttempt(Entity<RMCLockerOpenOnHijackComponent> ent, ref StorageOpenAttemptEvent args)
     {
         if (ent.Comp.DidHijackStart)
+            return;
+
+        args.Cancelled = true;
+    }
+
+    private void OnMREInteractAttempt(Entity<MRERequireOpenBeforeStorageComponent> ent, ref StorageInteractAttemptEvent args)
+    {
+        if (_openable.IsOpen(ent.Owner))
             return;
 
         args.Cancelled = true;

--- a/Resources/Changelog/Parts/issue2344-mre-open.yml
+++ b/Resources/Changelog/Parts/issue2344-mre-open.yml
@@ -1,0 +1,4 @@
+author: nbstrong
+changes:
+  - type: Fix
+    message: MRE ration packs now have to be torn open before you can access their contents.

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Food/MRE/mre.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Food/MRE/mre.yml
@@ -25,6 +25,7 @@
   - type: Openable
     sound:
       collection: CMFoodRip
+  - type: MRERequireOpenBeforeStorage
   - type: Appearance
   - type: GenericVisualizer
     visuals:


### PR DESCRIPTION
## About the PR
  Fixes RMC-14#2344 by preventing MRE ration packs from exposing their storage contents before they have been torn open.

  ## Why / Balance
  This restores the intended interaction flow for MREs. Before this change, unopened MREs could be accessed through the storage
  verb, which bypassed the tear-open step and exposed duplicate interaction paths.

  ## Technical details
  Adds an opt-in shared storage interaction gate component and applies it to the base `CMMRE` prototype. While the MRE is unopened,
  storage interaction attempts are cancelled; once opened, contents can be accessed normally. This also applies to MRE variants that
  inherit from `CMMRE`.

  ## Media
<img width="336" height="395" alt="image" src="https://github.com/user-attachments/assets/d7cece5a-05ea-48b6-b65d-224b48d0d70c" />

  ## Requirements
  - [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-
  development/codebase-info/pull-request-guidelines.html).
  - [X] I have added media to this PR or it does not require an ingame showcase.
  - [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to
  use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

  **Changelog**
  :cl:
  - fix: MRE ration packs now have to be torn open before you can access their contents.
