### PR TITLE
Suffix Explosive Pouches

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Pouches/explosive_pouch.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Pouches/explosive_pouch.yml
@@ -20,6 +20,7 @@
 - type: entity
   parent: RMCPouchExplosive
   id: RMCPouchExplosiveFilledPlasticExplosives
+  suffix: C4
   components:
   - type: StorageFill
     contents:
@@ -39,6 +40,7 @@
 - type: entity
   parent: RMCPouchExplosive
   id: RMCPouchExplosiveFilledHEDP
+  suffix: HEDP
   components:
   - type: StorageFill
     contents:
@@ -48,6 +50,7 @@
 - type: entity
   parent: RMCPouchExplosive
   id: RMCPouchExplosiveFilledSPP
+  suffix: SPP, M15
   components:
   - type: StorageFill
     contents:
@@ -57,6 +60,7 @@
 - type: entity
   parent: RMCPouchExplosive
   id: RMCPouchExplosiveFilledC4SPP
+  suffix: SPP, C4
   components:
   - type: StorageFill
     contents:
@@ -66,6 +70,7 @@
 - type: entity
   parent: RMCPouchExplosive
   id: RMCPouchExplosiveFilledHIRR
+  suffix: HIRR
   components:
   - type: StorageFill
     contents:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds some suffixes to pouch fills that were missing them to make things easier to spawn. Skipped suffixing on the "HEFA" one because I feel thats reasonably clear by name

## Why / Balance
Makes Spawning Easier

## Technical details
N/A

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
N/A
