### PR TITLE
Wide swings now filter out and prioritize what to hit

### DIFF
--- a/Content.Shared/Storage/Components/SharedEntityStorageComponent.cs
+++ b/Content.Shared/Storage/Components/SharedEntityStorageComponent.cs
@@ -20,7 +20,6 @@ public abstract partial class SharedEntityStorageComponent : Component
     ///     Collision masks that get removed when the storage gets opened.
     /// </summary>
     public readonly int MasksToRemove = (int) (
-        CollisionGroup.Opaque |           // RMC14, prevents open crates/lockers from being wide swing targets.
         CollisionGroup.MidImpassable |
         CollisionGroup.HighImpassable |
         CollisionGroup.LowImpassable);

--- a/Content.Shared/Storage/Components/SharedEntityStorageComponent.cs
+++ b/Content.Shared/Storage/Components/SharedEntityStorageComponent.cs
@@ -20,6 +20,7 @@ public abstract partial class SharedEntityStorageComponent : Component
     ///     Collision masks that get removed when the storage gets opened.
     /// </summary>
     public readonly int MasksToRemove = (int) (
+        CollisionGroup.Opaque |           // RMC14, prevents open crates/lockers from being wide swing targets.
         CollisionGroup.MidImpassable |
         CollisionGroup.HighImpassable |
         CollisionGroup.LowImpassable);

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -94,6 +94,10 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
     /// </summary>
     public const float GracePeriod = 0.05f;
 
+    private EntityQuery<MobStateComponent> _mobStateQuery;
+    private EntityQuery<PhysicsComponent> _physicsQuery;
+    private EntityQuery<DirectionalAttackBlockerComponent> _directionalAttackBlockerQuery;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -113,6 +117,10 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         SubscribeAllEvent<LightAttackEvent>(OnLightAttack);
         SubscribeAllEvent<DisarmAttackEvent>(OnDisarmAttack);
         SubscribeAllEvent<StopAttackEvent>(OnStopAttack);
+
+        _mobStateQuery = GetEntityQuery<MobStateComponent>();
+        _physicsQuery = GetEntityQuery<PhysicsComponent>();
+        _directionalAttackBlockerQuery = GetEntityQuery<DirectionalAttackBlockerComponent>();
 
 #if DEBUG
         SubscribeLocalEvent<MeleeWeaponComponent,
@@ -820,15 +828,15 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
                 // In short, we should hit the closest entity, UNLESS we can hit a mob, in which case we hit the mob.
                 // To accomplish this, we find the first object that either is a mob or would block our attack.
                 var firstPriorityResult = filteredResults.FirstOrNull(
-                    x => HasComp<MobStateComponent>(x.HitEntity)  // mobs
-                      || (CompOrNull<PhysicsComponent>(x.HitEntity)?.CollisionLayer & (int)CollisionGroup.InteractImpassable) != 0  // walls, windows, etc
-                      || HasComp<DirectionalAttackBlockerComponent>(x.HitEntity)  // barricades
+                    x => _mobStateQuery.HasComp(x.HitEntity) // mobs
+                      || ((_physicsQuery.CompOrNull(x.HitEntity)?.CollisionLayer ?? 0) & (int)CollisionGroup.InteractImpassable) != 0  // walls, windows, etc
+                      || _directionalAttackBlockerQuery.HasComp(x.HitEntity)  // barricades
                 );
 
                 // If the found object is a mob, we target it. Otherwise we target the first object we found.
                 var target = filteredResults.First();
                 if (firstPriorityResult is { } result &&
-                    HasComp<MobStateComponent>(result.HitEntity))
+                    _mobStateQuery.HasComp(result.HitEntity))
                 {
                     target = result;
                 }

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -813,9 +813,9 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
 
             if (res.Count != 0)
             {
-                // Ignore dead mobs, entites from the same hive, and open entity containers (lockers, crates, etc).
+                // Ignore dead mobs, mobs from the same hive, and open entity containers (lockers, crates, etc).
                 var filteredResults = res.Where(x => !MobState.IsDead(x.HitEntity))
-                    .Where(x => !_hive.FromSameHive(ignore, x.HitEntity))
+                    .Where(x => !(_mobStateQuery.HasComp(x.HitEntity) && _hive.FromSameHive(ignore, x.HitEntity)))
                     .Where(x => !_storageSystem.IsOpen(x.HitEntity));
 
                 if (filteredResults.Count() <= 0)

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -121,9 +121,11 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         SubscribeAllEvent<DisarmAttackEvent>(OnDisarmAttack);
         SubscribeAllEvent<StopAttackEvent>(OnStopAttack);
 
+        // RMC14 start
         _mobStateQuery = GetEntityQuery<MobStateComponent>();
         _physicsQuery = GetEntityQuery<PhysicsComponent>();
         _directionalAttackBlockerQuery = GetEntityQuery<DirectionalAttackBlockerComponent>();
+        // RMC14 end
 
 #if DEBUG
         SubscribeLocalEvent<MeleeWeaponComponent,

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -72,12 +72,13 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
     [Dependency] protected readonly SharedPopupSystem PopupSystem = default!;
     [Dependency] protected readonly SharedTransformSystem TransformSystem = default!;
     [Dependency] private   readonly SharedStaminaSystem _stamina = default!;
-    [Dependency] private   readonly SharedXenoHiveSystem _hive = default!;
-    [Dependency] private   readonly SharedEntityStorageSystem _storageSystem = default!;
 
-    // RMC14
+    // RMC14 start
     [Dependency] private readonly IConfigurationManager _configuration = default!;
+    [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
     [Dependency] private readonly SharedRMCMeleeWeaponSystem _rmcMelee = default!;
+    [Dependency] private readonly SharedEntityStorageSystem _storage = default!;
+    // RMC14 end
 
     private const int AttackMask = (int) (CollisionGroup.MobMask | CollisionGroup.Opaque);
 
@@ -94,9 +95,11 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
     /// </summary>
     public const float GracePeriod = 0.05f;
 
+    // RMC14 start
     private EntityQuery<MobStateComponent> _mobStateQuery;
     private EntityQuery<PhysicsComponent> _physicsQuery;
     private EntityQuery<DirectionalAttackBlockerComponent> _directionalAttackBlockerQuery;
+    // RMC14 end
 
     public override void Initialize()
     {
@@ -813,10 +816,11 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
 
             if (res.Count != 0)
             {
+                // RMC14 start
                 // Ignore dead mobs, mobs from the same hive, and open entity containers (lockers, crates, etc).
                 var filteredResults = res.Where(x => !MobState.IsDead(x.HitEntity))
                     .Where(x => !(_mobStateQuery.HasComp(x.HitEntity) && _hive.FromSameHive(ignore, x.HitEntity)))
-                    .Where(x => !_storageSystem.IsOpen(x.HitEntity));
+                    .Where(x => !_storage.IsOpen(x.HitEntity));
 
                 if (filteredResults.Count() <= 0)
                 {
@@ -828,7 +832,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
                 // In short, we should hit the closest entity, UNLESS we can hit a mob, in which case we hit the mob.
                 // To accomplish this, we find the first object that either is a mob or would block our attack.
                 var firstPriorityResult = filteredResults.FirstOrNull(
-                    x => _mobStateQuery.HasComp(x.HitEntity) // mobs
+                    x => _mobStateQuery.HasComp(x.HitEntity)  // mobs
                       || ((_physicsQuery.CompOrNull(x.HitEntity)?.CollisionLayer ?? 0) & (int)CollisionGroup.InteractImpassable) != 0  // walls, windows, etc
                       || _directionalAttackBlockerQuery.HasComp(x.HitEntity)  // barricades
                 );
@@ -840,6 +844,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
                 {
                     target = result;
                 }
+                // RMC14 end
 
                 // If there's exact distance overlap, we simply have to deal with all overlapping objects to avoid selecting randomly.
                 var resChecked = filteredResults.Where(x => x.Distance.Equals(target.Distance));

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -28,6 +28,7 @@ using Content.Shared.Mobs.Systems;
 using Content.Shared.Physics;
 using Content.Shared.Popups;
 using Content.Shared.StatusEffect;
+using Content.Shared.Storage.EntitySystems;
 using Content.Shared.Weapons.Melee.Components;
 using Content.Shared.Weapons.Melee.Events;
 using Content.Shared.Weapons.Ranged.Components;
@@ -72,6 +73,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
     [Dependency] protected readonly SharedTransformSystem TransformSystem = default!;
     [Dependency] private   readonly SharedStaminaSystem _stamina = default!;
     [Dependency] private   readonly SharedXenoHiveSystem _hive = default!;
+    [Dependency] private   readonly SharedEntityStorageSystem _storageSystem = default!;
 
     // RMC14
     [Dependency] private readonly IConfigurationManager _configuration = default!;
@@ -803,9 +805,10 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
 
             if (res.Count != 0)
             {
-                // Ignore dead mobs and entites from the same hive.
+                // Ignore dead mobs, entites from the same hive, and open entity containers (lockers, crates, etc).
                 var filteredResults = res.Where(x => !MobState.IsDead(x.HitEntity))
-                    .Where(x => !_hive.FromSameHive(ignore, x.HitEntity));
+                    .Where(x => !_hive.FromSameHive(ignore, x.HitEntity))
+                    .Where(x => !_storageSystem.IsOpen(x.HitEntity));
 
                 if (filteredResults.Count() <= 0)
                 {

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -45,6 +45,7 @@ using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
+using Robust.Shared.Utility;
 using ItemToggleMeleeWeaponComponent = Content.Shared.Item.ItemToggle.Components.ItemToggleMeleeWeaponComponent;
 
 namespace Content.Shared.Weapons.Melee;
@@ -802,19 +803,35 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
 
             if (res.Count != 0)
             {
-                var filteredResults = res.Where(x => !MobState.IsDead(x.HitEntity))                                                   // Ignore dead mobs.
-                    .Where(x => !_hive.FromSameHive(ignore, x.HitEntity))                                                             // Ignore entities from the same hive.
-                    .OrderBy(x => !(HasComp<MobStateComponent>(x.HitEntity)                                                           // Prioritize (non-dead) mobs,
-                        || (CompOrNull<PhysicsComponent>(x.HitEntity)?.CollisionLayer & (int)CollisionGroup.InteractImpassable) != 0  // interact impassable objects (walls, windows, etc),
-                        || HasComp<DirectionalAttackBlockerComponent>(x.HitEntity)));                                                 // and directional blockers (barricades), without priority between them.
+                // Ignore dead mobs and entites from the same hive.
+                var filteredResults = res.Where(x => !MobState.IsDead(x.HitEntity))
+                    .Where(x => !_hive.FromSameHive(ignore, x.HitEntity));
 
                 if (filteredResults.Count() <= 0)
                 {
                     continue;
                 }
 
+                // We prioritize non-dead mobs, but we also have to make sure we don't hit past barricades or entities
+                // that block interactions over them, such as walls, windows, windoors, closed airlocks, etc.
+                // In short, we should hit the closest entity, UNLESS we can hit a mob, in which case we hit the mob.
+                // To accomplish this, we find the first object that either is a mob or would block our attack.
+                var firstPriorityResult = filteredResults.FirstOrNull(
+                    x => HasComp<MobStateComponent>(x.HitEntity)  // mobs
+                      || (CompOrNull<PhysicsComponent>(x.HitEntity)?.CollisionLayer & (int)CollisionGroup.InteractImpassable) != 0  // walls, windows, etc
+                      || HasComp<DirectionalAttackBlockerComponent>(x.HitEntity)  // barricades
+                );
+
+                // If the found object is a mob, we target it. Otherwise we target the first object we found.
+                var target = filteredResults.First();
+                if (firstPriorityResult is { } result &&
+                    HasComp<MobStateComponent>(result.HitEntity))
+                {
+                    target = result;
+                }
+
                 // If there's exact distance overlap, we simply have to deal with all overlapping objects to avoid selecting randomly.
-                var resChecked = filteredResults.Where(x => x.Distance.Equals(filteredResults.First().Distance));
+                var resChecked = filteredResults.Where(x => x.Distance.Equals(target.Distance));
                 foreach (var r in resChecked)
                 {
                     if (Interaction.InRangeUnobstructed(ignore, r.HitEntity, range + 0.1f, overlapCheck: false))

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -1,9 +1,11 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Numerics;
+using Content.Shared._RMC14.Barricade;
 using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Tackle;
 using Content.Shared._RMC14.Weapons.Melee;
+using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Actions.Events;
 using Content.Shared.Administration.Components;
@@ -37,6 +39,7 @@ using Robust.Shared.Configuration;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Physics;
+using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
@@ -67,6 +70,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
     [Dependency] protected readonly SharedPopupSystem PopupSystem = default!;
     [Dependency] protected readonly SharedTransformSystem TransformSystem = default!;
     [Dependency] private   readonly SharedStaminaSystem _stamina = default!;
+    [Dependency] private   readonly SharedXenoHiveSystem _hive = default!;
 
     // RMC14
     [Dependency] private readonly IConfigurationManager _configuration = default!;
@@ -798,8 +802,19 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
 
             if (res.Count != 0)
             {
+                var filteredResults = res.Where(x => !MobState.IsDead(x.HitEntity))                                                   // Ignore dead mobs.
+                    .Where(x => !_hive.FromSameHive(ignore, x.HitEntity))                                                             // Ignore entities from the same hive.
+                    .OrderBy(x => !(HasComp<MobStateComponent>(x.HitEntity)                                                           // Prioritize (non-dead) mobs,
+                        || (CompOrNull<PhysicsComponent>(x.HitEntity)?.CollisionLayer & (int)CollisionGroup.InteractImpassable) != 0  // interact impassable objects (walls, windows, etc),
+                        || HasComp<DirectionalAttackBlockerComponent>(x.HitEntity)));                                                 // and directional blockers (barricades), without priority between them.
+
+                if (filteredResults.Count() <= 0)
+                {
+                    continue;
+                }
+
                 // If there's exact distance overlap, we simply have to deal with all overlapping objects to avoid selecting randomly.
-                var resChecked = res.Where(x => x.Distance.Equals(res[0].Distance));
+                var resChecked = filteredResults.Where(x => x.Distance.Equals(filteredResults.First().Distance));
                 foreach (var r in resChecked)
                 {
                     if (Interaction.InRangeUnobstructed(ignore, r.HitEntity, range + 0.1f, overlapCheck: false))


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Resolves #6214.

Wide swings now filter out and prioritize mobs in order to behave more in line with the user's intention.

- Dead bodies will be ignored entirely when wide swinging.
- Open containers (lockers, crates) will be ignored entirely when wide swinging.
- Xenos from the same hive will be ignored entirely when wide swinging.
- Mobs will be targeted first if possible. Otherwise the nearest object will be hit as normal.


## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Many entities were blocking wide swings in surprising ways. Most notably in my experience, wide swings get blocked by dead bodies, open crates, and open lockers. Most players would expect a wide swing to hit the person standing on top of the dead body, rather than the dead body. With this change, wide swings work in more situations where they are expected to work. Namely, if it is possible to attack them by sprite clicking, a wide swing can also hit them.

Xenos also suffer from bodyblocking from behind. Even if you're ahead of a xeno, if the xeno behind you is overlapped enough, your wide swing will be blocked by them because they overlap the center of your sprite. Disabling wide swings from interacting with them fixes this. This will make stacking up and attacking things like barricades and walls easier to do, and wide swinging in combat with other xenos around will be more effective. This doesn't raise the maximum effectiveness of xenos though, since xenos could already work around this by sprite clicking instead, which works fine even when many xenos are stacked together.

Marines receive the same benefits, for the situations where they are wide swinging their weapons. Most notably, marines can wide swing tables to hit xenos hiding underneath (if there are any).

## Technical details
<!-- Summary of code changes for easier review. -->
ArcRayCast in SharedMeleeWeaponSystem now filters out dead entities, xenos from the same hive, and open containers.
It also tries to find a mob to prioritize, and targets it if it should be possible to hit it (no barricades or walls in the way).

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

### Old behavior:

https://github.com/user-attachments/assets/2604d54b-b6ce-49f5-9098-4b4beea1e45e

### New behavior:

https://github.com/user-attachments/assets/c29238ad-7fbc-408d-88bf-b8d618def874


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Dead bodies no longer get hit by or block wide swings.
- fix: Open containers (lockers, crates, etc) no longer get hit by or block wide swings.
- tweak: Xenos no longer block each others' wide swings.
- tweak: Wide swings now prioritize hitting mobs (xenos, marines, rats, etc) if it is possible to hit them.
