### PR TITLE
Set Dev Env Inital Dropship Fuel Time to 0

### DIFF
--- a/Resources/ConfigPresets/Build/development.toml
+++ b/Resources/ConfigPresets/Build/development.toml
@@ -46,6 +46,7 @@ see_own_notes = true
 [rmc]
 automatic_commander_promotion = false
 planet_map_vote = false
+dropship_initial_delay_minutes = 0
 
 [ic]
 # random_characters = true


### PR DESCRIPTION
## About the PR
Sets the inital fuel time from 15 to 0 for the dev environment

## Why / Balance
This should probably be the default to test things, especially for newer people messing with cvars is a bit daunting,  and if for whatever reason it matters its easier to reapply it once then remove it for those more familiar with how things work

## Technical details
Single line toml change

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
N/A
