### PR TITLE
Kutjevo parity map changes and survivor spawn togethers

### DIFF
--- a/Resources/Maps/_RMC14/Inserts/Kutjevo/surv_spawn_bar.yml
+++ b/Resources/Maps/_RMC14/Inserts/Kutjevo/surv_spawn_bar.yml
@@ -1,0 +1,480 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 264.0.2
+  forkId: ""
+  forkVersion: ""
+  time: 04/16/2026 20:53:51
+  entityCount: 67
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  0: Space
+  198: CMFloorPlating
+  8: RMCFloorKutjevoMulti0
+  3: RMCFloorKutjevoPurple3_0
+  10: RMCFloorKutjevoPurple3_1
+  7: RMCFloorKutjevoPurple3_2
+  5: RMCFloorKutjevoPurple3_3
+  9: RMCFloorKutjevoPurple4_0
+  11: RMCFloorKutjevoPurple4_1
+  2: RMCFloorKutjevoPurple4_2
+  4: RMCFloorKutjevoPurple4_3
+  6: RMCFloorKutjevoTan1
+  1: RMCFloorPlatingKutjevo
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: grid
+    - type: Transform
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: AQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAACAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAQAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAABQAAAAAAAAYAAAAAAAAGAAAAAAAABgAAAAAAAAYAAAAAAAAHAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAUAAAAAAAAGAAAAAAAABgAAAAAAAAYAAAAAAAAGAAAAAAAABwAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAFAAAAAAAABgAAAAAAAAYAAAAAAAAGAAAAAAAABgAAAAAAAAcAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAACQAAAAAAAAoAAAAAAAAKAAAAAAAACgAAAAAAAAoAAAAAAAALAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAIAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            cleanable: True
+            color: '#FFFFFFFF'
+            id: Dirt
+          decals:
+            1: 2,5
+            2: 3,5
+            3: 3,4
+            4: 6,1
+            5: 5,1
+            6: 4,1
+            7: 5,2
+            8: 6,2
+            9: 6,4
+            10: 6,5
+            11: 5,5
+            12: 5,4
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtLight
+          decals:
+            14: 4,4
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtMedium
+          decals:
+            13: 2,2
+    - type: GridAtmosphere
+      version: 2
+      data:
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: ImplicitRoof
+- proto: CMAirlockMaint
+  entities:
+  - uid: 23
+    components:
+    - type: Transform
+      pos: 5.5,6.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,2.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,3.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+- proto: CMApcNoPower
+  entities:
+  - uid: 29
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,5.5
+      parent: 1
+    - type: SpriteSetRenderOrder
+      offset: -0.5,-1.5
+- proto: CMBarricadeMetal
+  entities:
+  - uid: 34
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,3.5
+      parent: 1
+- proto: CMRodMetal1
+  entities:
+  - uid: 30
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+- proto: CMSpawnPointSurvivor
+  entities:
+  - uid: 31
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+- proto: CMTableAlmayer
+  entities:
+  - uid: 49
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 1
+- proto: CMTableWoodenGambling
+  entities:
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+- proto: CMVendorBooze
+  entities:
+  - uid: 28
+    components:
+    - type: Transform
+      pos: 5.5,5.5
+      parent: 1
+- proto: DiceBag
+  entities:
+  - uid: 32
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+- proto: LGBTQFlag
+  entities:
+  - uid: 48
+    components:
+    - type: Transform
+      pos: 4.5,6.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 60
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+- proto: RMCBarricadeWood
+  entities:
+  - uid: 37
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+- proto: RMCDecalSpawnerBloodSplatters
+  entities:
+  - uid: 61
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 62
+    components:
+    - type: Transform
+      pos: 6.5,3.5
+      parent: 1
+  - uid: 63
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+- proto: RMCSecureCaseDouble
+  entities:
+  - uid: 36
+    components:
+    - type: Transform
+      pos: 6.5,5.5
+      parent: 1
+- proto: RMCSecureCaseSmall
+  entities:
+  - uid: 46
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 1
+- proto: RMCSpawnerIntelScience
+  entities:
+  - uid: 58
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+- proto: RMCSpawnerRandomTools
+  entities:
+  - uid: 67
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+- proto: RMCStool
+  entities:
+  - uid: 54
+    components:
+    - type: Transform
+      pos: 6.5,5.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: 6.5,1.5
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+- proto: RMCWallKutjevo
+  entities:
+  - uid: 14
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      pos: 7.5,4.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      pos: 4.5,6.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      pos: 6.5,6.5
+      parent: 1
+- proto: RMCWallKutjevoReinforced
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 3
+    components:
+    - type: Transform
+      pos: 7.5,6.5
+      parent: 1
+  - uid: 4
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 5
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 6
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+- proto: RMCWindowFrameKutjevoReinforced
+  entities:
+  - uid: 13
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+- proto: RMCWindowKutjevoReinforced
+  entities:
+  - uid: 7
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 1
+- proto: SnapPopBox
+  entities:
+  - uid: 42
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+...

--- a/Resources/Maps/_RMC14/Inserts/Kutjevo/surv_spawn_medical.yml
+++ b/Resources/Maps/_RMC14/Inserts/Kutjevo/surv_spawn_medical.yml
@@ -1,0 +1,338 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 264.0.2
+  forkId: ""
+  forkVersion: ""
+  time: 04/16/2026 21:03:13
+  entityCount: 42
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  0: Space
+  198: CMFloorPlating
+  2: RMCFloorKutjevoCyan1
+  1: RMCFloorKutjevoTan1
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: grid
+    - type: Transform
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: AQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAACAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAACAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            cleanable: True
+            color: '#FFFFFFFF'
+            id: Dirt
+          decals:
+            1: 3,4
+            2: 3,5
+            3: 4,4
+            4: 4,5
+            5: 2,5
+            6: 1,0
+            7: 0,0
+            8: 0,1
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtHeavy
+          decals:
+            10: 3,0
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtLight
+          decals:
+            9: 1,4
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtMedium
+          decals:
+            11: 5,2
+    - type: GridAtmosphere
+      version: 2
+      data:
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: ImplicitRoof
+- proto: Bedroll
+  entities:
+  - uid: 31
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+- proto: CMFilingCabinet
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+- proto: CMPottedPlant21
+  entities:
+  - uid: 4
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+- proto: CMRack
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+- proto: CMSpawnPointSurvivor
+  entities:
+  - uid: 19
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+- proto: RMCBarricadeWood
+  entities:
+  - uid: 8
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+- proto: RMCCrateBottledWaterX50
+  entities:
+  - uid: 40
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+- proto: RMCDecalSpawnerBloodSplatters
+  entities:
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+- proto: RMCDecalSpawnerXenoSplatters
+  entities:
+  - uid: 38
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
+- proto: RMCDirtBandageProp2
+  entities:
+  - uid: 32
+    components:
+    - type: Transform
+      pos: 3.0636744,3.344342
+      parent: 1
+- proto: RMCDirtBandageProp6
+  entities:
+  - uid: 33
+    components:
+    - type: Transform
+      pos: 3.6730494,3.203717
+      parent: 1
+- proto: RMCLightFixtureOffset
+  entities:
+  - uid: 5
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,4.5
+      parent: 1
+- proto: RMCPlankWood1
+  entities:
+  - uid: 41
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+- proto: RMCSpawnerCorpseColonistKutjevoBust
+  entities:
+  - uid: 34
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+- proto: RMCSpawnerIntelClose
+  entities:
+  - uid: 6
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+- proto: RMCSpawnerIntelScience
+  entities:
+  - uid: 7
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+...

--- a/Resources/Maps/_RMC14/Inserts/Kutjevo/surv_spawn_north_botany.yml
+++ b/Resources/Maps/_RMC14/Inserts/Kutjevo/surv_spawn_north_botany.yml
@@ -1,0 +1,449 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 264.0.2
+  forkId: ""
+  forkVersion: ""
+  time: 04/16/2026 21:26:25
+  entityCount: 55
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  0: Space
+  198: CMFloorPlating
+  5: RMCFloorKutjevoGreen1
+  6: RMCFloorKutjevoMulti1
+  4: RMCFloorKutjevoMulti2
+  2: RMCFloorKutjevoTan1
+  1: RMCFloorKutjevoTanMulti0
+  3: RMCFloorResearchContainmentFloor2North
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: grid
+    - type: Transform
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: AQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABQAAAAAAAAEAAAAAAAAFAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAUAAAAAAAABAAAAAAAABQAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAADAAAAAAAABgAAAAAAAAMAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            cleanable: True
+            color: '#FFFFFFFF'
+            id: Dirt
+          decals:
+            9: 3,3
+            10: 4,3
+            11: 4,4
+            12: 3,4
+            13: 3,5
+            14: 4,5
+            15: 2,3
+            16: 2,4
+            17: 4,6
+            18: 3,6
+            19: 4,7
+            21: 0,1
+            22: 0,0
+            23: 1,0
+            24: 0,2
+            25: 2,0
+            26: 2,1
+            27: 1,1
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtHeavyMonotile
+          decals:
+            20: 1,6
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtLight
+          decals:
+            1: 1,1
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtMedium
+          decals:
+            2: 5,2
+    - type: GridAtmosphere
+      version: 2
+      data:
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: ImplicitRoof
+- proto: CMSpawnPointSurvivor
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 3
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 4
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 5
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+- proto: CMTableAlmayer
+  entities:
+  - uid: 17
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+- proto: RMCBarricadeWood
+  entities:
+  - uid: 10
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,6.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,0.5
+      parent: 1
+- proto: RMCCigaretteSpent
+  entities:
+  - uid: 51
+    components:
+    - type: Transform
+      pos: 2.5605211,3.3817134
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      pos: 2.7636461,3.2254634
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      pos: 2.6855211,2.9754634
+      parent: 1
+- proto: RMCDecalSpawnerBloodSplatters
+  entities:
+  - uid: 36
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+- proto: RMCDecalSpawnerGibsDrone
+  entities:
+  - uid: 6
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+- proto: RMCDecalSpawnerXenoSplatters
+  entities:
+  - uid: 40
+    components:
+    - type: Transform
+      pos: 3.5,7.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      pos: 6.5,2.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+- proto: RMCFlashlightLantern
+  entities:
+  - uid: 7
+    components:
+    - type: Transform
+      pos: 2.247179,3.6439216
+      parent: 1
+- proto: RMCSecureCaseStrapped
+  entities:
+  - uid: 45
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+- proto: RMCShutterAlmayerOpen
+  entities:
+  - uid: 22
+    components:
+    - type: MetaData
+      name: Botany North Shutters
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 1
+    - type: RMCPodDoor
+      id: kutjevo_hydlock_west
+  - uid: 25
+    components:
+    - type: MetaData
+      name: Botany North Shutters
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 1
+    - type: RMCPodDoor
+      id: kutjevo_hydlock_west
+  - uid: 26
+    components:
+    - type: MetaData
+      name: Botany North Shutters
+    - type: Transform
+      pos: 3.5,7.5
+      parent: 1
+    - type: RMCPodDoor
+      id: kutjevo_hydlock_west
+  - uid: 27
+    components:
+    - type: MetaData
+      name: Botany North Shutters
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+    - type: RMCPodDoor
+      id: kutjevo_hydlock_west
+  - uid: 28
+    components:
+    - type: MetaData
+      name: Botany North Shutters
+    - type: Transform
+      pos: 4.5,7.5
+      parent: 1
+    - type: RMCPodDoor
+      id: kutjevo_hydlock_west
+  - uid: 29
+    components:
+    - type: MetaData
+      name: Botany North Shutters
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+    - type: RMCPodDoor
+      id: kutjevo_hydlock_west
+  - uid: 30
+    components:
+    - type: MetaData
+      name: Botany North Shutters
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+    - type: RMCPodDoor
+      id: kutjevo_hydlock_west
+  - uid: 31
+    components:
+    - type: MetaData
+      name: Botany North Shutters
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+    - type: RMCPodDoor
+      id: kutjevo_hydlock_west
+  - uid: 32
+    components:
+    - type: MetaData
+      name: Botany North Shutters
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+    - type: RMCPodDoor
+      id: kutjevo_hydlock_west
+  - uid: 33
+    components:
+    - type: MetaData
+      name: Botany North Shutters
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+    - type: RMCPodDoor
+      id: kutjevo_hydlock_west
+- proto: RMCSpawnerCorpseWeYaGoonKutjevo
+  entities:
+  - uid: 9
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+- proto: RMCToolboxElectricalFilled
+  entities:
+  - uid: 50
+    components:
+    - type: Transform
+      pos: 2.3680243,2.4579592
+      parent: 1
+...

--- a/Resources/Maps/_RMC14/Inserts/Kutjevo/surv_spawn_powerplant.yml
+++ b/Resources/Maps/_RMC14/Inserts/Kutjevo/surv_spawn_powerplant.yml
@@ -1,0 +1,377 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 264.0.2
+  forkId: ""
+  forkVersion: ""
+  time: 04/16/2026 21:57:46
+  entityCount: 46
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  0: Space
+  198: CMFloorPlating
+  1: RMCFloorKutjevoOrange1
+  4: RMCFloorKutjevoOrange3_0
+  12: RMCFloorKutjevoOrange3_1
+  10: RMCFloorKutjevoOrange3_2
+  9: RMCFloorKutjevoOrange3_3
+  8: RMCFloorKutjevoOrange3_4
+  6: RMCFloorKutjevoOrange3_5
+  11: RMCFloorKutjevoOrange3_6
+  13: RMCFloorKutjevoOrange3_7
+  3: RMCFloorKutjevoOrange4_2
+  5: RMCFloorKutjevoOrange4_3
+  7: RMCFloorKutjevoTan1
+  2: RMCFloorPlatingKutjevo
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: grid
+    - type: Transform
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: AQAAAAAAAAEAAAAAAAACAAAAAAAAAwAAAAAAAAQAAAAAAAAEAAAAAAAABQAAAAAAAAIAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAAEAAAAAAAABAAAAAAAAAYAAAAAAAAHAAAAAAAABwAAAAAAAAgAAAAAAAAEAAAAAAAABAAAAAAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAKAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACQAAAAAAAAcAAAAAAAALAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAA0AAAAAAAAHAAAAAAAACgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            cleanable: True
+            color: '#FFFFFFFF'
+            id: Dirt
+          decals:
+            5: 2,3
+            6: 3,3
+            7: 4,3
+            8: 4,2
+            9: 3,2
+            10: 3,1
+            11: 2,1
+            12: 3,0
+            13: 4,0
+            14: 8,0
+            15: 9,0
+            16: 9,1
+            17: 0,2
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtHeavy
+          decals:
+            1: 1,2
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtHeavyMonotile
+          decals:
+            4: 9,0
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtLight
+          decals:
+            2: 4,1
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtMedium
+          decals:
+            3: 8,2
+    - type: GridAtmosphere
+      version: 2
+      data:
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: ImplicitRoof
+- proto: Bedroll
+  entities:
+  - uid: 22
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+- proto: CMRack
+  entities:
+  - uid: 4
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 5
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 1
+- proto: CMSheetMetal30
+  entities:
+  - uid: 6
+    components:
+    - type: Transform
+      pos: 8.5,0.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+- proto: CMSpawnPointSurvivor
+  entities:
+  - uid: 31
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      pos: 9.5,1.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      pos: 7.5,2.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 6.5,1.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      pos: 6.5,3.5
+      parent: 1
+- proto: CMTableAlmayer
+  entities:
+  - uid: 8
+    components:
+    - type: Transform
+      pos: 8.5,0.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      pos: 9.5,0.5
+      parent: 1
+- proto: RMCBarrelGreen
+  entities:
+  - uid: 21
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,3.5
+      parent: 1
+- proto: RMCBarricadeWood
+  entities:
+  - uid: 15
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,3.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,3.5
+      parent: 1
+- proto: RMCBoxShotgunBuckshot
+  entities:
+  - uid: 7
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 1
+- proto: RMCCrateLarge
+  entities:
+  - uid: 13
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+- proto: RMCDecalSpawnerBloodSplatters
+  entities:
+  - uid: 24
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 1
+- proto: RMCDecalSpawnerXenoSplatters
+  entities:
+  - uid: 29
+    components:
+    - type: Transform
+      pos: 9.5,3.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+- proto: RMCDirtBandageProp6
+  entities:
+  - uid: 28
+    components:
+    - type: Transform
+      pos: 7.777819,1.1113521
+      parent: 1
+- proto: RMCLightFixtureOffset
+  entities:
+  - uid: 42
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,3.5
+      parent: 1
+- proto: RMCPlushieMoth
+  entities:
+  - uid: 25
+    components:
+    - type: Transform
+      pos: 4.730225,3.001977
+      parent: 1
+- proto: RMCSpawnerIntelClose
+  entities:
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 9.5,0.5
+      parent: 1
+- proto: RMCWallKutjevo
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 1
+  - uid: 3
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+...

--- a/Resources/Maps/_RMC14/Inserts/Kutjevo/surv_spawn_south_botany.yml
+++ b/Resources/Maps/_RMC14/Inserts/Kutjevo/surv_spawn_south_botany.yml
@@ -1,0 +1,506 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 264.0.2
+  forkId: ""
+  forkVersion: ""
+  time: 04/16/2026 22:17:49
+  entityCount: 68
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  0: Space
+  198: CMFloorPlating
+  4: RMCFloorKutjevoGreen2
+  1: RMCFloorKutjevoMulti1
+  5: RMCFloorKutjevoTan1
+  2: RMCFloorKutjevoTanMulti0
+  3: RMCFloorPlatingKutjevo
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: grid
+    - type: Transform
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: AQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAFAAAAAAAABQAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAFAAAAAAAABQAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABQAAAAAAAAUAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABQAAAAAAAAUAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAUAAAAAAAAFAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#FFFFFFFF'
+            id: Dirt
+          decals:
+            30: 3,3
+            31: 3,2
+        - node:
+            cleanable: True
+            color: '#FFFFFFFF'
+            id: Dirt
+          decals:
+            5: 6,6
+            6: 7,6
+            7: 7,5
+            8: 6,5
+            9: 7,4
+            10: 8,4
+            11: 8,5
+            12: 8,0
+            13: 7,0
+            14: 8,1
+            15: 7,1
+            16: 9,2
+            17: 9,1
+            18: 8,2
+            19: 0,6
+            20: 0,5
+            21: 0,4
+            22: 1,4
+            23: 2,2
+            24: 1,2
+            25: 0,2
+            26: 2,1
+            27: 1,1
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtHeavy
+          decals:
+            2: 9,5
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtLight
+          decals:
+            3: 4,3
+            4: 5,6
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtMedium
+          decals:
+            1: 2,6
+    - type: GridAtmosphere
+      version: 2
+      data:
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: ImplicitRoof
+- proto: Bedroll
+  entities:
+  - uid: 40
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+- proto: CMBloodPack
+  entities:
+  - uid: 42
+    components:
+    - type: Transform
+      pos: 1.7625928,4.6691375
+      parent: 1
+- proto: CMHydroponicsTray
+  entities:
+  - uid: 13
+    components:
+    - type: Transform
+      pos: 9.5,4.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      pos: 5.5,6.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      pos: 4.5,6.5
+      parent: 1
+- proto: CMSpawnPointSurvivor
+  entities:
+  - uid: 48
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      pos: 5.5,5.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      pos: 6.5,3.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: 8.5,4.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+- proto: CMTableAlmayer
+  entities:
+  - uid: 8
+    components:
+    - type: Transform
+      pos: 7.5,6.5
+      parent: 1
+- proto: RMCBarrelRed
+  entities:
+  - uid: 60
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+- proto: RMCBarrelWhite
+  entities:
+  - uid: 61
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+- proto: RMCBarrelYellow
+  entities:
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+- proto: RMCBarricadeWood
+  entities:
+  - uid: 9
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,6.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,6.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,5.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,1.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,2.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      pos: 8.5,0.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,0.5
+      parent: 1
+- proto: RMCBoxShotgunBuckshot
+  entities:
+  - uid: 39
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 1
+- proto: RMCCrateBlackmarketFireArmsHidden
+  entities:
+  - uid: 62
+    components:
+    - type: Transform
+      pos: 7.5,2.5
+      parent: 1
+- proto: RMCDecalSpawnerBloodSplatters
+  entities:
+  - uid: 28
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      pos: 8.5,5.5
+      parent: 1
+- proto: RMCDecalSpawnerXenoSplatters
+  entities:
+  - uid: 30
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+- proto: RMCDirtBandageProp3
+  entities:
+  - uid: 46
+    components:
+    - type: Transform
+      pos: 2.0609312,5.1907997
+      parent: 1
+- proto: RMCDirtBandageProp8
+  entities:
+  - uid: 47
+    components:
+    - type: Transform
+      pos: 3.1859312,4.9095497
+      parent: 1
+- proto: RMCLightFixtureSmallOffset
+  entities:
+  - uid: 34
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: 7.5,4.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,2.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,6.5
+      parent: 1
+- proto: RMCSecureCaseSmall
+  entities:
+  - uid: 63
+    components:
+    - type: Transform
+      pos: 6.5,2.5
+      parent: 1
+- proto: RMCSpawnerCorpseWeYaGoonKutjevo
+  entities:
+  - uid: 41
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+- proto: RMCStairsKutjevo
+  entities:
+  - uid: 65
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      pos: 6.5,3.5
+      parent: 1
+- proto: RMCStool
+  entities:
+  - uid: 25
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 1
+- proto: RMCWallKutjevo
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 3
+    components:
+    - type: Transform
+      pos: 7.5,3.5
+      parent: 1
+- proto: RMCWindowKutjevoReinforced
+  entities:
+  - uid: 4
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 5
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 6
+    components:
+    - type: Transform
+      pos: 8.5,3.5
+      parent: 1
+  - uid: 7
+    components:
+    - type: Transform
+      pos: 9.5,3.5
+      parent: 1
+...

--- a/Resources/Prototypes/_RMC14/Entities/Markers/Inserts/kutjevo.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Markers/Inserts/kutjevo.yml
@@ -1,6 +1,19 @@
-﻿# Kutjevo
+﻿# Kutjevo Base
 - type: entity
+  abstract: true
   parent: RMCMapInsertBase
+  id: RMCMapInsertKutjevoBase
+  suffix: Insert Kutjevo
+  components:
+  - type: MapInsert
+    clearEntities: true
+    clearDecals: true
+    replaceAreas: true
+
+
+# Sprinkles
+- type: entity
+  parent: RMCMapInsertKutjevoBase
   id: RMCMapInsertKutjevoCommunications
   name: SE Checkpoint
   suffix: Insert Kutjevo
@@ -9,12 +22,9 @@
     variations:
     - spawn: "/Maps/_RMC14/Inserts/Kutjevo/communications.yml"
       probability: 0.35
-    clearEntities: true
-    clearDecals: true
-    replaceAreas: true
 
 - type: entity
-  parent: RMCMapInsertBase
+  parent: RMCMapInsertKutjevoBase
   id: RMCMapInsertKutjevoCleaningProgBotany
   name: Cleaning Botany
   suffix: Insert Kutjevo
@@ -23,12 +33,10 @@
     variations:
     - spawn: "/Maps/_RMC14/Inserts/Kutjevo/cleaningprog_botany.yml"
       probability: 0.25
-    clearEntities: true
-    clearDecals: true
     replaceAreas: false
 
 - type: entity
-  parent: RMCMapInsertBase
+  parent: RMCMapInsertKutjevoBase
   id: RMCMapInsertKutjevoTrappedMonke
   name: Trapped Clown
   suffix: Insert Kutjevo
@@ -42,7 +50,7 @@
     replaceAreas: false
 
 - type: entity
-  parent: RMCMapInsertBase
+  parent: RMCMapInsertKutjevoBase
   id: RMCMapInsertSolarisPlinkingSpotNorthLZ
   name: Plinking Spot North LZ
   suffix: Insert Kutjevo
@@ -56,7 +64,30 @@
     replaceAreas: false
 
 - type: entity
-  parent: RMCMapInsertBase
+  parent: RMCMapInsertKutjevoBase
+  id: RMCMapInsertKutjevoLZ1Alternative
+  name: LZ1 Alternative
+  suffix: Insert Kutjevo
+  components:
+  - type: MapInsert
+    variations:
+    - spawn: "/Maps/_RMC14/Inserts/Kutjevo/lz1alternative.yml"
+      probability: 0.6
+
+
+# Survivor Scenario Inserts
+- type: entity
+  abstract: true
+  parent: RMCMapInsertKutjevoBase
+  id: RMCMapInsertKutjevoBaseScenario
+  suffix: Insert Kutjevo
+  components:
+  - type: MapInsert
+    replaceAreas: false
+
+# CLF Smugglers
+- type: entity
+  parent: RMCMapInsertKutjevoBase
   id: RMCMapInsertKutjevoCLFSmugglers
   name: CLF Smugglers
   suffix: Insert Kutjevo
@@ -66,20 +97,64 @@
     - spawn: "/Maps/_RMC14/Inserts/Kutjevo/clfsmugglers.yml"
       probability: 1
       nightmareScenario: clfsmugglers
-    clearEntities: true
-    clearDecals: true
-    replaceAreas: true
-    
+
+# Regular Surv Spawns
 - type: entity
-  parent: RMCMapInsertBase
-  id: RMCMapInsertKutjevoLZ1Alternative
-  name: LZ1 Alternative
+  parent: RMCMapInsertKutjevoBaseScenario
+  id: RMCMapInsertKutjevoSurvSpawnBar
+  name: Bar Surv Spawn
   suffix: Insert Kutjevo
   components:
   - type: MapInsert
     variations:
-    - spawn: "/Maps/_RMC14/Inserts/Kutjevo/lz1alternative.yml"
-      probability: 0.6
-    clearEntities: true
-    clearDecals: true
-    replaceAreas: true
+    - spawn: "/Maps/_RMC14/Inserts/Kutjevo/surv_spawn_bar.yml"
+      probability: 1
+      nightmareScenario: kutjevo_surv_spawn_bar
+
+- type: entity
+  parent: RMCMapInsertKutjevoBaseScenario
+  id: RMCMapInsertKutjevoSurvSpawnMedical
+  name: Medical Surv Spawn
+  suffix: Insert Kutjevo
+  components:
+  - type: MapInsert
+    variations:
+    - spawn: "/Maps/_RMC14/Inserts/Kutjevo/surv_spawn_medical.yml"
+      probability: 1
+      nightmareScenario: kutjevo_surv_spawn_medical
+
+- type: entity
+  parent: RMCMapInsertKutjevoBaseScenario
+  id: RMCMapInsertKutjevoSurvSpawnNorthBotany
+  name: North Botany Surv Spawn
+  suffix: Insert Kutjevo
+  components:
+  - type: MapInsert
+    variations:
+    - spawn: "/Maps/_RMC14/Inserts/Kutjevo/surv_spawn_north_botany.yml"
+      probability: 1
+      nightmareScenario: kutjevo_surv_spawn_north_botany
+
+- type: entity
+  parent: RMCMapInsertKutjevoBaseScenario
+  id: RMCMapInsertKutjevoSurvSpawnSouthBotany
+  name: South Botany Surv Spawn
+  suffix: Insert Kutjevo
+  components:
+  - type: MapInsert
+    variations:
+    - spawn: "/Maps/_RMC14/Inserts/Kutjevo/surv_spawn_south_botany.yml"
+      probability: 1
+      nightmareScenario: kutjevo_surv_spawn_south_botany
+
+- type: entity
+  parent: RMCMapInsertKutjevoBaseScenario
+  id: RMCMapInsertKutjevoSurvSpawnPowerplant
+  name: Powerplant Surv Spawn
+  suffix: Insert Kutjevo
+  components:
+  - type: MapInsert
+    variations:
+    - spawn: "/Maps/_RMC14/Inserts/Kutjevo/surv_spawn_powerplant.yml"
+      probability: 1
+      nightmareScenario: kutjevo_surv_spawn_powerplant

--- a/Resources/Prototypes/_RMC14/Entities/Markers/Inserts/kutjevo.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Markers/Inserts/kutjevo.yml
@@ -101,60 +101,28 @@
 # Regular Surv Spawns
 - type: entity
   parent: RMCMapInsertKutjevoBaseScenario
-  id: RMCMapInsertKutjevoSurvSpawnBar
-  name: Bar Surv Spawn
+  id: RMCMapInsertKutjevoSurvSpawnTogether
+  name: Together Surv Spawn
   suffix: Insert Kutjevo
   components:
   - type: MapInsert
     variations:
     - spawn: "/Maps/_RMC14/Inserts/Kutjevo/surv_spawn_bar.yml"
-      probability: 1
-      nightmareScenario: kutjevo_surv_spawn_bar
-
-- type: entity
-  parent: RMCMapInsertKutjevoBaseScenario
-  id: RMCMapInsertKutjevoSurvSpawnMedical
-  name: Medical Surv Spawn
-  suffix: Insert Kutjevo
-  components:
-  - type: MapInsert
-    variations:
+      probability: 0.2
+      nightmareScenario: none
     - spawn: "/Maps/_RMC14/Inserts/Kutjevo/surv_spawn_medical.yml"
-      probability: 1
-      nightmareScenario: kutjevo_surv_spawn_medical
-
-- type: entity
-  parent: RMCMapInsertKutjevoBaseScenario
-  id: RMCMapInsertKutjevoSurvSpawnNorthBotany
-  name: North Botany Surv Spawn
-  suffix: Insert Kutjevo
-  components:
-  - type: MapInsert
-    variations:
+      probability: 0.2
+      nightmareScenario: none
+      offset: -30,-6
     - spawn: "/Maps/_RMC14/Inserts/Kutjevo/surv_spawn_north_botany.yml"
-      probability: 1
-      nightmareScenario: kutjevo_surv_spawn_north_botany
-
-- type: entity
-  parent: RMCMapInsertKutjevoBaseScenario
-  id: RMCMapInsertKutjevoSurvSpawnSouthBotany
-  name: South Botany Surv Spawn
-  suffix: Insert Kutjevo
-  components:
-  - type: MapInsert
-    variations:
+      probability: 0.2
+      nightmareScenario: none
+      offset: -23,-35
     - spawn: "/Maps/_RMC14/Inserts/Kutjevo/surv_spawn_south_botany.yml"
-      probability: 1
-      nightmareScenario: kutjevo_surv_spawn_south_botany
-
-- type: entity
-  parent: RMCMapInsertKutjevoBaseScenario
-  id: RMCMapInsertKutjevoSurvSpawnPowerplant
-  name: Powerplant Surv Spawn
-  suffix: Insert Kutjevo
-  components:
-  - type: MapInsert
-    variations:
+      probability: 0.2
+      nightmareScenario: none
+      offset: -19,-65
     - spawn: "/Maps/_RMC14/Inserts/Kutjevo/surv_spawn_powerplant.yml"
-      probability: 1
-      nightmareScenario: kutjevo_surv_spawn_powerplant
+      probability: 0.2
+      nightmareScenario: none
+      offset: 0,-44

--- a/Resources/Prototypes/_RMC14/Entities/rmc_planets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/rmc_planets.yml
@@ -401,6 +401,17 @@
     map: /Maps/_RMC14/kutjevo.yml
     camouflage: Desert
     announcement: "An automated distress signal has been received from Weston-Yamada colony Kutjevo Refinery, known for botanical research, export, and raw materials processing and refinement. The UNS Almayer has been dispatched to investigate."
+    nightmareScenarios:
+    - scenarioName: kutjevo_surv_spawn_bar # Reduce this to 0.18 each once CLF survivors are in at 0.1
+      scenarioProbability: 0.2
+    - scenarioName: kutjevo_surv_spawn_medical
+      scenarioProbability: 0.2
+    - scenarioName: kutjevo_surv_spawn_north_botany
+      scenarioProbability: 0.2
+    - scenarioName: kutjevo_surv_spawn_south_botany
+      scenarioProbability: 0.2
+    - scenarioName: kutjevo_surv_spawn_powerplant
+      scenarioProbability: 0.2
     specialFaxes:
       Liaison: RMCPaperWeYaLiaisonBriefingKutjevo
     survivorJobVariants:

--- a/Resources/Prototypes/_RMC14/Entities/rmc_planets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/rmc_planets.yml
@@ -402,16 +402,8 @@
     camouflage: Desert
     announcement: "An automated distress signal has been received from Weston-Yamada colony Kutjevo Refinery, known for botanical research, export, and raw materials processing and refinement. The UNS Almayer has been dispatched to investigate."
     nightmareScenarios:
-    - scenarioName: kutjevo_surv_spawn_bar # Reduce this to 0.18 each once CLF survivors are in at 0.1
-      scenarioProbability: 0.2
-    - scenarioName: kutjevo_surv_spawn_medical
-      scenarioProbability: 0.2
-    - scenarioName: kutjevo_surv_spawn_north_botany
-      scenarioProbability: 0.2
-    - scenarioName: kutjevo_surv_spawn_south_botany
-      scenarioProbability: 0.2
-    - scenarioName: kutjevo_surv_spawn_powerplant
-      scenarioProbability: 0.2
+    - scenarioName: none # Reduce this to 0.9 once CLF survivors are in at 0.1
+      scenarioProbability: 1
     specialFaxes:
       Liaison: RMCPaperWeYaLiaisonBriefingKutjevo
     survivorJobVariants:


### PR DESCRIPTION
## About the PR
Parity map changes to the comms locations, north-west colony grounds, north lz area, and west of medical.

Non-parity survivor spawn togethers added.

## Why / Balance
Comms and map changes approved now after some changes on CM where the comms can no longer spawn within 10 tiles of eachother, and removes the hellchoke that north-west colony grounds currently is.

Survivor spawn togethers are wanted to improve the survivor experience.

Parity map changes and survivor spawn together locations given a thumbs up from Crow.

## Technical details
Kutjevo insert marker file cleaned up

## Media
North LZ Dorms now has another route to cover where rock used to be
<img width="729" height="562" alt="Screenshot 2026-04-16 232125" src="https://github.com/user-attachments/assets/bf2099d8-dd3a-49fa-b108-61532c82386c" />

North LZ eastern entrance now has two dilapidated buildings
<img width="470" height="779" alt="Screenshot 2026-04-16 232137" src="https://github.com/user-attachments/assets/dc163e28-46e4-4529-bf9a-387f966c5857" />

North-west colony grounds is no longer a hellchoke
<img width="1281" height="943" alt="Screenshot 2026-04-16 232211" src="https://github.com/user-attachments/assets/61074b89-f20d-4766-9e52-45da12d089ca" />

Rocks in western medical entrance mostly removed
<img width="636" height="450" alt="Screenshot 2026-04-16 232238" src="https://github.com/user-attachments/assets/67fe7184-6173-4dfb-9324-2012dbc2525f" />

Central comms are mutually exclusive (CM13 map viewer)
<img width="566" height="706" alt="image" src="https://github.com/user-attachments/assets/384b12a7-277d-44f3-a68a-5ebc3f96b17b" />


Survivor spawn togethers
<img width="636" height="816" alt="image" src="https://github.com/user-attachments/assets/b6e1f058-2ec0-4d65-a107-118dafc67132" />

Bar
<img width="361" height="324" alt="Screenshot 2026-04-16 231939" src="https://github.com/user-attachments/assets/085b4d63-e079-45eb-b745-784e5b780993" />

Medical
<img width="427" height="372" alt="Screenshot 2026-04-16 232043" src="https://github.com/user-attachments/assets/a62c8200-0973-45c4-b093-f8ddb2b468f0" />

North Botany
<img width="367" height="368" alt="Screenshot 2026-04-16 232013" src="https://github.com/user-attachments/assets/72aed83a-9d3c-4d38-a187-770384947544" />

South Botany
<img width="559" height="451" alt="Screenshot 2026-04-16 232028" src="https://github.com/user-attachments/assets/7fc0d17f-4296-432b-a5f7-50111859aa2f" />

Powerplant
<img width="531" height="274" alt="Screenshot 2026-04-16 231959" src="https://github.com/user-attachments/assets/741d439f-a9f9-49e4-a6b5-eae79e1260bf" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: CatAndHats
- add: Added survivor spawn together inserts to Kutjevo Refinery
- tweak: Kutjevo North LZ dorms now has an extra route where rock used to be, North LZ eastern entrance now has two dilapidated buildings, North-western colony grounds is no longer a hellchoke and has been widened with multiple new paths, western medical entrance has lost most of the rocks there to open it up, comms spawns have been changed - one will always spawn in the centre two spawns and one will always spawn at the map edge in either the north or south.
