### PR TITLE
Shiva hive loot moving and survivor spawn together inserts

### DIFF
--- a/Resources/Maps/_RMC14/Inserts/Shiva/surv_spawn_botany.yml
+++ b/Resources/Maps/_RMC14/Inserts/Shiva/surv_spawn_botany.yml
@@ -1,0 +1,341 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 264.0.2
+  forkId: ""
+  forkVersion: ""
+  time: 04/16/2026 23:57:31
+  entityCount: 41
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  0: Space
+  198: CMFloorPlating
+  4: CMFloorSteelShivaGreen0
+  6: CMFloorSteelShivaGreen1
+  2: CMFloorSteelShivaGreen3
+  7: CMFloorSteelShivaGreenCorners1
+  5: CMFloorSteelShivaGreenCorners3
+  1: CMFloorSteelShivaPlate
+  3: CMPlanetWood
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: grid
+    - type: Transform
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: AQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAADAAAAAAAAAwAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAAAAAABgAAAAAAAAYAAAAAAAAGAAAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAADAAAAAAAAAwAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            cleanable: True
+            color: '#FFFFFFFF'
+            id: Dirt
+          decals:
+            5: 0,3
+            6: 0,4
+            7: 1,3
+            8: 3,1
+            9: 3,0
+            10: 2,0
+            11: 4,1
+            12: 4,0
+            13: 4,6
+            14: 3,6
+            15: 3,5
+            16: 2,4
+            17: 3,4
+            18: 2,5
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtHeavyMonotile
+          decals:
+            1: 1,0
+            2: 1,6
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtLight
+          decals:
+            4: 4,2
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtMedium
+          decals:
+            3: 1,5
+    - type: GridAtmosphere
+      version: 2
+      data:
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: ImplicitRoof
+- proto: BarbedWire1
+  entities:
+  - uid: 27
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+- proto: Bedroll
+  entities:
+  - uid: 22
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+- proto: CMApcNoPower
+  entities:
+  - uid: 15
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,2.5
+      parent: 1
+    - type: SpriteSetRenderOrder
+      offset: -0.7,-0.4
+- proto: CMBarricadeMetal
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 3
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 4
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 5
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 6
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 7
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,6.5
+      parent: 1
+- proto: CMBloodPack
+  entities:
+  - uid: 25
+    components:
+    - type: Transform
+      pos: 0.42758656,2.1582735
+      parent: 1
+- proto: CMFilingCabinetTall
+  entities:
+  - uid: 13
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+- proto: CMSpawnPointSurvivor
+  entities:
+  - uid: 30
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 1
+- proto: RMCDecalSpawnerBloodSplatters
+  entities:
+  - uid: 19
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+- proto: RMCDecalSpawnerXenoSplatters
+  entities:
+  - uid: 20
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+- proto: RMCDirtBandageProp3
+  entities:
+  - uid: 24
+    components:
+    - type: Transform
+      pos: 1.2244616,1.431711
+      parent: 1
+- proto: RMCDirtBandageProp6
+  entities:
+  - uid: 18
+    components:
+    - type: Transform
+      pos: 0.70883656,1.947336
+      parent: 1
+- proto: RMCItemPoolBuckshot
+  entities:
+  - uid: 17
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+- proto: RMCSpawnerCorpseSecurity
+  entities:
+  - uid: 26
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+- proto: RMCSpawnerIntelScience
+  entities:
+  - uid: 14
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+...

--- a/Resources/Maps/_RMC14/Inserts/Shiva/surv_spawn_church.yml
+++ b/Resources/Maps/_RMC14/Inserts/Shiva/surv_spawn_church.yml
@@ -1,0 +1,652 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 264.0.2
+  forkId: ""
+  forkVersion: ""
+  time: 04/16/2026 23:42:48
+  entityCount: 92
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  0: Space
+  198: CMFloorPlating
+  1: CMPlanetWood
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: grid
+    - type: Transform
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: xgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            cleanable: True
+            color: '#FFFFFFFF'
+            id: Dirt
+          decals:
+            1: 0,8
+            2: 0,7
+            3: 1,7
+            4: 1,6
+            5: 2,6
+            6: 2,4
+            7: 2,2
+            8: 3,1
+            9: 4,1
+            10: 5,1
+            11: 5,0
+            12: 5,2
+            13: 6,1
+            14: 6,3
+            15: 6,2
+            16: 7,8
+            17: 6,7
+            18: 7,7
+            19: 0,2
+            20: 0,1
+            21: 1,1
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodSplatter4
+          decals:
+            25: 3,8
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodTrail3
+          decals:
+            22: 6,8
+            23: 5,8
+            24: 4,8
+    - type: GridAtmosphere
+      version: 2
+      data:
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: ImplicitRoof
+- proto: Bedroll
+  entities:
+  - uid: 66
+    components:
+    - type: Transform
+      pos: 3.5,8.5
+      parent: 1
+- proto: CarpetChapel
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 4
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,7.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,7.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,7.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,5.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,2.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,6.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,4.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,6.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,7.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,7.5
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,5.5
+      parent: 1
+- proto: CMChair
+  entities:
+  - uid: 44
+    components:
+    - type: Transform
+      pos: 7.5,8.5
+      parent: 1
+- proto: CMChairWood
+  entities:
+  - uid: 51
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,2.5
+      parent: 1
+- proto: CMPottedPlant26
+  entities:
+  - uid: 60
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 62
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+- proto: CMRodMetal1
+  entities:
+  - uid: 61
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+- proto: CMShardGlass
+  entities:
+  - uid: 63
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 1
+- proto: CMSpawnPointSurvivor
+  entities:
+  - uid: 79
+    components:
+    - type: Transform
+      pos: 3.5,7.5
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      pos: 4.5,7.5
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      pos: 8.5,7.5
+      parent: 1
+  - uid: 84
+    components:
+    - type: Transform
+      pos: 7.5,2.5
+      parent: 1
+  - uid: 85
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 86
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 87
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 88
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 89
+    components:
+    - type: Transform
+      pos: 5.5,5.5
+      parent: 1
+  - uid: 90
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 1
+  - uid: 91
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 92
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 1
+- proto: CMTableWooden
+  entities:
+  - uid: 56
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,1.5
+      parent: 1
+- proto: CMWardrobeBlack
+  entities:
+  - uid: 52
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 1
+- proto: CMWindowShiva
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 5
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+- proto: FoodPacketChocolateTrash
+  entities:
+  - uid: 76
+    components:
+    - type: Transform
+      pos: 1.6452336,1.6470547
+      parent: 1
+- proto: RCMWallShivaFab
+  entities:
+  - uid: 8
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      pos: 8.5,0.5
+      parent: 1
+- proto: RCMWallShivaReinforcedFab
+  entities:
+  - uid: 6
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 1
+- proto: RMCBarricadeWood
+  entities:
+  - uid: 13
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,7.5
+      parent: 1
+- proto: RMCCigaretteSpent
+  entities:
+  - uid: 78
+    components:
+    - type: Transform
+      pos: 2.6296086,8.862111
+      parent: 1
+  - uid: 80
+    components:
+    - type: Transform
+      pos: 4.3171086,1.8777361
+      parent: 1
+  - uid: 81
+    components:
+    - type: Transform
+      pos: 4.528046,1.7371111
+      parent: 1
+- proto: RMCCrateLarge
+  entities:
+  - uid: 72
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      pos: 8.5,4.5
+      parent: 1
+- proto: RMCDirtBandageProp2
+  entities:
+  - uid: 67
+    components:
+    - type: Transform
+      pos: 3.5710678,7.96835
+      parent: 1
+- proto: RMCDirtBandageProp8
+  entities:
+  - uid: 68
+    components:
+    - type: Transform
+      pos: 5.586693,7.8511624
+      parent: 1
+- proto: RMCFoodPacketBarcaridineTrash
+  entities:
+  - uid: 74
+    components:
+    - type: Transform
+      pos: 8.535858,4.7876797
+      parent: 1
+- proto: RMCFoodPacketEATBarTrash
+  entities:
+  - uid: 77
+    components:
+    - type: Transform
+      pos: 2.5124211,8.678305
+      parent: 1
+- proto: RMCFoodPacketHotdogTrash
+  entities:
+  - uid: 75
+    components:
+    - type: Transform
+      pos: 1.7624211,1.6939297
+      parent: 1
+- proto: RMCLamp
+  entities:
+  - uid: 47
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+- proto: RMCLightFixtureDouble
+  entities:
+  - uid: 48
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,5.5
+      parent: 1
+- proto: RMCPlankWood1
+  entities:
+  - uid: 65
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+- proto: RMCSpaceHeater
+  entities:
+  - uid: 70
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      pos: 8.5,6.5
+      parent: 1
+- proto: RMCSpawnerCorpseColonist
+  entities:
+  - uid: 69
+    components:
+    - type: Transform
+      pos: 3.5,8.5
+      parent: 1
+- proto: RMCSpawnerIntelClose
+  entities:
+  - uid: 54
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 1
+- proto: RMCSpawnerIntelMedium
+  entities:
+  - uid: 55
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 1
+- proto: RMCWindowFrameShiva
+  entities:
+  - uid: 7
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+...

--- a/Resources/Maps/_RMC14/Inserts/Shiva/surv_spawn_command_centre.yml
+++ b/Resources/Maps/_RMC14/Inserts/Shiva/surv_spawn_command_centre.yml
@@ -1,0 +1,375 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 264.0.2
+  forkId: ""
+  forkVersion: ""
+  time: 04/16/2026 23:50:43
+  entityCount: 48
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  0: Space
+  198: CMFloorPlating
+  2: CMFloorSteelShiva
+  1: CMFloorSteelShivaBlueFull3
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: grid
+    - type: Transform
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: AQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAgAAAAAAAAIAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAQAAAAAAAAIAAAAAAAACAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAABAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAQAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAEAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            cleanable: True
+            color: '#FFFFFFFF'
+            id: Dirt
+          decals:
+            4: 4,5
+            5: 4,4
+            6: 2,5
+            7: 3,5
+            8: 2,4
+            9: 3,3
+            10: 4,3
+            11: 3,4
+            12: 5,3
+            13: 5,4
+            14: 6,3
+            15: 6,4
+            16: 4,0
+            17: 5,0
+            18: 2,0
+            19: 2,1
+            20: 1,0
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtHeavy
+          decals:
+            3: 0,5
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtHeavyMonotile
+          decals:
+            2: 5,2
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtLight
+          decals:
+            1: 2,1
+    - type: GridAtmosphere
+      version: 2
+      data:
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: ImplicitRoof
+- proto: CMChairComfyBlue
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 3
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 4
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+- proto: CMSheetMetal1
+  entities:
+  - uid: 16
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+- proto: CMSpawnPointSurvivor
+  entities:
+  - uid: 37
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      pos: 6.5,1.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+- proto: FoodPacketChocolateTrash
+  entities:
+  - uid: 31
+    components:
+    - type: Transform
+      pos: 5.3726945,5.481761
+      parent: 1
+- proto: RMCBarrelBlue
+  entities:
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 5.5,6.5
+      parent: 1
+- proto: RMCBarrelGreen
+  entities:
+  - uid: 36
+    components:
+    - type: Transform
+      pos: 4.5,6.5
+      parent: 1
+- proto: RMCBarricadeWood
+  entities:
+  - uid: 12
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,0.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,3.5
+      parent: 1
+- proto: RMCCigaretteSpent
+  entities:
+  - uid: 33
+    components:
+    - type: Transform
+      pos: 6.3101945,3.6770732
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: 6.474257,3.4661357
+      parent: 1
+- proto: RMCDecalSpawnerBloodSplatters
+  entities:
+  - uid: 24
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 1
+- proto: RMCDecalSpawnerXenoSplatters
+  entities:
+  - uid: 28
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+- proto: RMCDirtBandageProp2
+  entities:
+  - uid: 30
+    components:
+    - type: Transform
+      pos: 5.489882,3.4192607
+      parent: 1
+- proto: RMCFoodPacketCheeseburgerTrash
+  entities:
+  - uid: 32
+    components:
+    - type: Transform
+      pos: 5.4195695,4.7551985
+      parent: 1
+- proto: RMCLightFixtureDouble
+  entities:
+  - uid: 11
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,6.5
+      parent: 1
+- proto: RMCTablePrison
+  entities:
+  - uid: 5
+    components:
+    - type: Transform
+      pos: 6.5,5.5
+      parent: 1
+  - uid: 6
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 1
+  - uid: 7
+    components:
+    - type: Transform
+      pos: 5.5,5.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      pos: 6.5,3.5
+      parent: 1
+...

--- a/Resources/Maps/_RMC14/Inserts/Shiva/surv_spawn_crisis_centre.yml
+++ b/Resources/Maps/_RMC14/Inserts/Shiva/surv_spawn_crisis_centre.yml
@@ -1,0 +1,401 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 264.0.2
+  forkId: ""
+  forkVersion: ""
+  time: 04/17/2026 00:09:25
+  entityCount: 53
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  0: Space
+  198: CMFloorPlating
+  5: CMFloorSteelShivaPlate
+  6: CMPlanetWood
+  4: RMCFloorPlatingDamage1
+  3: RMCFloorPlatingDamage3
+  1: RMCPlanetSnow2
+  2: RMCPlanetSnow3
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: grid
+    - type: Transform
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: AQAAAAAAAAIAAAAAAAABAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAMAAAAAAAACAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAAwAAAAAAAAMAAAAAAAAEAAAAAAAAAwAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAADGAAAAAAAABQAAAAAAAAMAAAAAAAAEAAAAAAAABAAAAAAAAAMAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAAAAYAAAAAAAAFAAAAAAAAAwAAAAAAAAUAAAAAAAAGAAAAAAAABQAAAAAAAAMAAAAAAADGAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAAGAAAAAAAAAwAAAAAAAAQAAAAAAAADAAAAAAAABgAAAAAAAAYAAAAAAAAFAAAAAAAAxgAAAAAAAMYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFAAAAAAAABgAAAAAAAAUAAAAAAAADAAAAAAAABQAAAAAAAAYAAAAAAAAGAAAAAAAABQAAAAAAAMYAAAAAAADGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#FFFFFFFF'
+            id: Dirt
+          decals:
+            1: 1,4
+            2: 1,3
+            3: 2,3
+            4: 2,2
+            5: 1,2
+            6: 6,4
+            7: 6,5
+            8: 5,4
+            9: 7,5
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtHeavyMonotile
+          decals:
+            10: 2,5
+            11: 7,4
+    - type: GridAtmosphere
+      version: 2
+      data:
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: ImplicitRoof
+- proto: CMApcNoPower
+  entities:
+  - uid: 37
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,0.5
+      parent: 1
+    - type: SpriteSetRenderOrder
+      offset: -0.5,-1.5
+- proto: CMChairComfyOrange
+  entities:
+  - uid: 30
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+- proto: CMDisposalUnit
+  entities:
+  - uid: 7
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+- proto: CMFilingCabinet
+  entities:
+  - uid: 18
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+- proto: CMLockerBase
+  entities:
+  - uid: 14
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+- proto: CMRodMetal1
+  entities:
+  - uid: 26
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 1
+- proto: CMSheetMetal1
+  entities:
+  - uid: 25
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+- proto: CMSpawnPointSurvivor
+  entities:
+  - uid: 24
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      pos: 7.5,3.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      pos: 7.5,4.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 1
+- proto: CMTableWooden
+  entities:
+  - uid: 17
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 1
+- proto: RCMWallShivaFab
+  entities:
+  - uid: 8
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 1
+- proto: RCMWallShivaIce
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      pos: 9.5,4.5
+      parent: 1
+  - uid: 3
+    components:
+    - type: Transform
+      pos: 9.5,5.5
+      parent: 1
+- proto: RCMWallShivaReinforcedFab
+  entities:
+  - uid: 4
+    components:
+    - type: Transform
+      pos: 8.5,4.5
+      parent: 1
+  - uid: 5
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 6
+    components:
+    - type: Transform
+      pos: 8.5,5.5
+      parent: 1
+- proto: RMCBarrelRed
+  entities:
+  - uid: 34
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+- proto: RMCBarricadeWood
+  entities:
+  - uid: 13
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,5.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,2.5
+      parent: 1
+- proto: RMCFoodPacketBarcaridineTrash
+  entities:
+  - uid: 52
+    components:
+    - type: Transform
+      pos: 0.46164083,4.7522726
+      parent: 1
+- proto: RMCFoodPacketBurritoTrash
+  entities:
+  - uid: 53
+    components:
+    - type: Transform
+      pos: 5.8757033,4.0491476
+      parent: 1
+- proto: RMCFoodPacketEATBarTrash
+  entities:
+  - uid: 45
+    components:
+    - type: Transform
+      pos: 5.383516,5.52571
+      parent: 1
+- proto: RMCLamp
+  entities:
+  - uid: 27
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 1
+- proto: RMCLightStickRedSmall
+  entities:
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 9.5,2.5
+      parent: 1
+- proto: RMCPlankWood1
+  entities:
+  - uid: 31
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+- proto: RMCSecureCase
+  entities:
+  - uid: 32
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+- proto: RMCSecureCaseDouble
+  entities:
+  - uid: 33
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+- proto: RMCSpawnerIntelClose
+  entities:
+  - uid: 16
+    components:
+    - type: Transform
+      pos: 7.5,4.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+- proto: RMCSpawnerIntelMedium
+  entities:
+  - uid: 15
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+- proto: RMCWeaponRifleM54CE2
+  entities:
+  - uid: 28
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+...

--- a/Resources/Maps/_RMC14/Inserts/Shiva/surv_spawn_garage.yml
+++ b/Resources/Maps/_RMC14/Inserts/Shiva/surv_spawn_garage.yml
@@ -1,0 +1,346 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 264.0.2
+  forkId: ""
+  forkVersion: ""
+  time: 04/17/2026 00:17:55
+  entityCount: 39
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  0: Space
+  198: CMFloorPlating
+  1: CMFloorSteelShiva
+  3: CMFloorSteelShivaYellow1
+  4: CMFloorSteelShivaYellow2
+  5: CMFloorSteelShivaYellow6
+  2: CMFloorSteelShivaYellowFull3
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: grid
+    - type: Transform
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: AQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            cleanable: True
+            angle: 3.141592653589793 rad
+            color: '#FFFFFFFF'
+            id: Dirt
+          decals:
+            12: 4,2
+            13: 5,3
+            14: 5,2
+            15: 6,2
+            16: 6,3
+            17: 6,4
+            18: 7,4
+            19: 7,3
+            20: 8,3
+            21: 8,4
+            22: 9,4
+            23: 9,3
+            24: 8,2
+            25: 2,1
+            26: 2,2
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtHeavy
+          decals:
+            9: 1,3
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtHeavyMonotile
+          decals:
+            10: 9,0
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtLight
+          decals:
+            11: 7,1
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalHybrisaWarningNorth
+          decals:
+            1: 8,1
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineW
+          decals:
+            2: 1,1
+            3: 2,1
+            4: 3,1
+            5: 4,1
+            6: 5,1
+            7: 6,1
+            8: 7,1
+    - type: GridAtmosphere
+      version: 2
+      data:
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: ImplicitRoof
+- proto: CMClosetToolFilled
+  entities:
+  - uid: 9
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 1
+- proto: CMDisposalUnit
+  entities:
+  - uid: 39
+    components:
+    - type: Transform
+      pos: 9.5,4.5
+      parent: 1
+- proto: CMSpawnPointSurvivor
+  entities:
+  - uid: 27
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      pos: 7.5,3.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      pos: 8.5,0.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      pos: 6.5,3.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      pos: 6.5,2.5
+      parent: 1
+- proto: CMTable
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 4
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,2.5
+      parent: 1
+- proto: RMCBarricadeWood
+  entities:
+  - uid: 14
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,1.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,0.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,2.5
+      parent: 1
+- proto: RMCCigaretteSpent
+  entities:
+  - uid: 24
+    components:
+    - type: Transform
+      pos: 2.389018,4.778857
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      pos: 2.529643,4.8491697
+      parent: 1
+- proto: RMCDecalSpawnerBloodSplatters
+  entities:
+  - uid: 5
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 6
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+- proto: RMCDecalSpawnerXenoSplatters
+  entities:
+  - uid: 21
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+- proto: RMCDirtBandageProp6
+  entities:
+  - uid: 25
+    components:
+    - type: Transform
+      pos: 5.6127353,2.5054197
+      parent: 1
+- proto: RMCDirtBandageProp7
+  entities:
+  - uid: 23
+    components:
+    - type: Transform
+      pos: 5.3783603,2.6460447
+      parent: 1
+- proto: RMCItemPoolBuckshot
+  entities:
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 7.5,2.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      pos: 8.5,3.5
+      parent: 1
+- proto: RMCLightFixtureDouble
+  entities:
+  - uid: 7
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,4.5
+      parent: 1
+- proto: RMCSpawnerCorpseEngineer
+  entities:
+  - uid: 11
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 1
+- proto: RMCSpawnerIntelClose
+  entities:
+  - uid: 10
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 1
+- proto: RMCTankReagentFuel
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+...

--- a/Resources/Maps/_RMC14/shiva.yml
+++ b/Resources/Maps/_RMC14/shiva.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 264.0.2
   forkId: ""
   forkVersion: ""
-  time: 04/17/2026 23:44:13
-  entityCount: 17434
+  time: 04/20/2026 01:31:12
+  entityCount: 17433
 maps:
 - 1
 grids:
@@ -121503,23 +121503,23 @@ entities:
       parent: 1
 - proto: RMCPropVehicleTruckSnow
   entities:
-  - uid: 15604
+  - uid: 2197
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 117.5,43.5
+      pos: 118,45
       parent: 1
-  - uid: 15605
+  - uid: 2198
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 99.5,12.5
+      pos: 100,13
       parent: 1
-  - uid: 15606
+  - uid: 2199
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 117.5,44.5
+      pos: 118,44
       parent: 1
 - proto: RMCRackParts
   entities:
@@ -127756,10 +127756,10 @@ entities:
       parent: 1
 - proto: RMCTurretGaussSpaceborne
   entities:
-  - uid: 16686
+  - uid: 2196
     components:
     - type: Transform
-      pos: 15.5,49.5
+      pos: 15.5,48.5
       parent: 1
   - uid: 16687
     components:
@@ -127823,11 +127823,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 17.5,118.5
-      parent: 1
-  - uid: 16698
-    components:
-    - type: Transform
-      pos: 21.5,16.5
       parent: 1
   - uid: 16699
     components:

--- a/Resources/Maps/_RMC14/shiva.yml
+++ b/Resources/Maps/_RMC14/shiva.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 264.0.2
   forkId: ""
   forkVersion: ""
-  time: 04/17/2026 00:44:28
-  entityCount: 17438
+  time: 04/17/2026 23:44:13
+  entityCount: 17434
 maps:
 - 1
 grids:
@@ -116744,40 +116744,12 @@ entities:
     - type: Transform
       pos: 3.5,110.5
       parent: 1
-- proto: RMCMapInsertShivaSurvSpawnBotany
+- proto: RMCMapInsertShivaSurvSpawnTogether
   entities:
-  - uid: 17446
-    components:
-    - type: Transform
-      pos: 97.5,93.5
-      parent: 1
-- proto: RMCMapInsertShivaSurvSpawnChurch
-  entities:
-  - uid: 17448
+  - uid: 2195
     components:
     - type: Transform
       pos: 113.5,129.5
-      parent: 1
-- proto: RMCMapInsertShivaSurvSpawnCommandCentre
-  entities:
-  - uid: 17447
-    components:
-    - type: Transform
-      pos: 116.5,108.5
-      parent: 1
-- proto: RMCMapInsertShivaSurvSpawnCrisisCentre
-  entities:
-  - uid: 17444
-    components:
-    - type: Transform
-      pos: 113.5,67.5
-      parent: 1
-- proto: RMCMapInsertShivaSurvSpawnGarage
-  entities:
-  - uid: 17445
-    components:
-    - type: Transform
-      pos: 141.5,83.5
       parent: 1
 - proto: RMCMarkerAreaLabel
   entities:

--- a/Resources/Maps/_RMC14/shiva.yml
+++ b/Resources/Maps/_RMC14/shiva.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 264.0.2
   forkId: ""
   forkVersion: ""
-  time: 02/17/2026 10:10:56
-  entityCount: 17428
+  time: 04/17/2026 00:44:28
+  entityCount: 17438
 maps:
 - 1
 grids:
@@ -37446,11 +37446,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 142.5,130.5
       parent: 1
-  - uid: 172
-    components:
-    - type: Transform
-      pos: 120.5,138.5
-      parent: 1
   - uid: 173
     components:
     - type: Transform
@@ -37587,6 +37582,11 @@ entities:
       parent: 1
 - proto: CMAirlockMaintLockedColony
   entities:
+  - uid: 172
+    components:
+    - type: Transform
+      pos: 120.5,138.5
+      parent: 1
   - uid: 197
     components:
     - type: Transform
@@ -37741,7 +37741,7 @@ entities:
   - uid: 222
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
+      rot: 1.5707963267948966 rad
       pos: 122.5,131.5
       parent: 1
   - uid: 223
@@ -45981,17 +45981,17 @@ entities:
   - uid: 1733
     components:
     - type: Transform
-      pos: 162.5,46.5
+      pos: 67.5,14.5
       parent: 1
-  - uid: 1734
+  - uid: 17001
     components:
     - type: Transform
-      pos: 161.5,47.5
+      pos: 67.5,14.5
       parent: 1
-  - uid: 1735
+  - uid: 17431
     components:
     - type: Transform
-      pos: 163.5,47.5
+      pos: 68.5,4.5
       parent: 1
 - proto: CMMagazineSMGMP5
   entities:
@@ -46786,6 +46786,11 @@ entities:
       parent: 1
 - proto: CMRack
   entities:
+  - uid: 1734
+    components:
+    - type: Transform
+      pos: 119.5,13.5
+      parent: 1
   - uid: 1875
     components:
     - type: Transform
@@ -47621,6 +47626,16 @@ entities:
     - type: Transform
       pos: 178.5,146.5
       parent: 1
+  - uid: 17002
+    components:
+    - type: Transform
+      pos: 119.5,12.5
+      parent: 1
+  - uid: 17432
+    components:
+    - type: Transform
+      pos: 119.5,11.5
+      parent: 1
 - proto: CMRodMetal
   entities:
   - uid: 2042
@@ -47979,10 +47994,8 @@ entities:
   - uid: 2106
     components:
     - type: Transform
-      pos: 204.5625,117.5625
+      pos: 204.5,117.5
       parent: 1
-    - type: Stack
-      count: 25
   - uid: 2107
     components:
     - type: Transform
@@ -48132,11 +48145,6 @@ entities:
       parent: 1
 - proto: CMSheetMetal50
   entities:
-  - uid: 2133
-    components:
-    - type: Transform
-      pos: 179.5,129.5
-      parent: 1
   - uid: 2135
     components:
     - type: Transform
@@ -48151,10 +48159,15 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 2138
+  - uid: 2147
     components:
     - type: Transform
-      pos: 178.5,129.5
+      pos: 121.5,10.5
+      parent: 1
+  - uid: 2148
+    components:
+    - type: Transform
+      pos: 119.5,11.5
       parent: 1
 - proto: CMSheetPhoron
   entities:
@@ -48205,15 +48218,15 @@ entities:
     - type: InsideEntityStorage
 - proto: CMSheetPlasteel30
   entities:
-  - uid: 2147
+  - uid: 17429
     components:
     - type: Transform
-      pos: 179.5,127.5
+      pos: 119.5,13.5
       parent: 1
-  - uid: 2148
+  - uid: 17433
     components:
     - type: Transform
-      pos: 178.5,127.5
+      pos: 119.5,12.5
       parent: 1
 - proto: CMShellShotgunBuckshot
   entities:
@@ -48437,58 +48450,6 @@ entities:
     components:
     - type: Transform
       pos: 18.5,50.5
-      parent: 1
-- proto: CMSpawnPointSurvivor
-  entities:
-  - uid: 2195
-    components:
-    - type: Transform
-      pos: 68.5,46.5
-      parent: 1
-  - uid: 2196
-    components:
-    - type: Transform
-      pos: 93.5,101.5
-      parent: 1
-  - uid: 2197
-    components:
-    - type: Transform
-      pos: 95.5,88.5
-      parent: 1
-  - uid: 2198
-    components:
-    - type: Transform
-      pos: 100.5,114.5
-      parent: 1
-  - uid: 2199
-    components:
-    - type: Transform
-      pos: 104.5,82.5
-      parent: 1
-  - uid: 2200
-    components:
-    - type: Transform
-      pos: 105.5,113.5
-      parent: 1
-  - uid: 2201
-    components:
-    - type: Transform
-      pos: 106.5,51.5
-      parent: 1
-  - uid: 2202
-    components:
-    - type: Transform
-      pos: 115.5,86.5
-      parent: 1
-  - uid: 2203
-    components:
-    - type: Transform
-      pos: 164.5,82.5
-      parent: 1
-  - uid: 2204
-    components:
-    - type: Transform
-      pos: 6.5,133.5
       parent: 1
 - proto: CMSpawnPointXeno
   entities:
@@ -49937,11 +49898,6 @@ entities:
     - type: Transform
       pos: 195.5,87.5
       parent: 1
-  - uid: 2480
-    components:
-    - type: Transform
-      pos: 194.5,87.5
-      parent: 1
   - uid: 2481
     components:
     - type: Transform
@@ -50376,6 +50332,11 @@ entities:
     components:
     - type: Transform
       pos: 209.5,44.5
+      parent: 1
+  - uid: 14125
+    components:
+    - type: Transform
+      pos: 194.5,87.5
       parent: 1
 - proto: CMTableReinforced
   entities:
@@ -107049,10 +107010,10 @@ entities:
     - type: Transform
       pos: 164.6875,152.375
       parent: 1
-  - uid: 13322
+  - uid: 17438
     components:
     - type: Transform
-      pos: 195.6875,92.375
+      pos: 109.5,12.5
       parent: 1
 - proto: RMCBoxSterileMask
   entities:
@@ -111803,6 +111764,34 @@ entities:
     - type: Transform
       pos: 50.5,71.5
       parent: 1
+- proto: RMCIceCrystal
+  entities:
+  - uid: 1735
+    components:
+    - type: Transform
+      pos: 3.5,136.5
+      parent: 1
+- proto: RMCIceCrystal3
+  entities:
+  - uid: 17443
+    components:
+    - type: Transform
+      pos: 3.5,145.5
+      parent: 1
+- proto: RMCIceCrystal6
+  entities:
+  - uid: 17436
+    components:
+    - type: Transform
+      pos: 3.5,142.5
+      parent: 1
+- proto: RMCIceCrystal7
+  entities:
+  - uid: 17439
+    components:
+    - type: Transform
+      pos: 3.5,139.5
+      parent: 1
 - proto: RMCIceSlabTray1
   entities:
   - uid: 14080
@@ -112098,11 +112087,6 @@ entities:
     - type: Transform
       pos: 126.5,12.5
       parent: 1
-  - uid: 14125
-    components:
-    - type: Transform
-      pos: 194.5,87.5
-      parent: 1
   - uid: 14126
     components:
     - type: Transform
@@ -112118,16 +112102,6 @@ entities:
     - type: Transform
       pos: 177.5,120.5
       parent: 1
-  - uid: 14129
-    components:
-    - type: Transform
-      pos: 199.5,87.5
-      parent: 1
-  - uid: 14130
-    components:
-    - type: Transform
-      pos: 198.5,87.5
-      parent: 1
   - uid: 14131
     components:
     - type: Transform
@@ -112137,11 +112111,6 @@ entities:
     components:
     - type: Transform
       pos: 163.5,137.5
-      parent: 1
-  - uid: 14133
-    components:
-    - type: Transform
-      pos: 195.5,87.5
       parent: 1
   - uid: 14134
     components:
@@ -112153,20 +112122,10 @@ entities:
     - type: Transform
       pos: 9.5,138.5
       parent: 1
-  - uid: 14136
-    components:
-    - type: Transform
-      pos: 194.5,88.5
-      parent: 1
   - uid: 14137
     components:
     - type: Transform
       pos: 163.5,138.5
-      parent: 1
-  - uid: 14138
-    components:
-    - type: Transform
-      pos: 194.5,87.5
       parent: 1
   - uid: 14139
     components:
@@ -112347,6 +112306,31 @@ entities:
     components:
     - type: Transform
       pos: 99.5,112.5
+      parent: 1
+  - uid: 17012
+    components:
+    - type: Transform
+      pos: 126.5,21.5
+      parent: 1
+  - uid: 17437
+    components:
+    - type: Transform
+      pos: 107.5,12.5
+      parent: 1
+  - uid: 17440
+    components:
+    - type: Transform
+      pos: 107.5,12.5
+      parent: 1
+  - uid: 17441
+    components:
+    - type: Transform
+      pos: 123.5,20.5
+      parent: 1
+  - uid: 17442
+    components:
+    - type: Transform
+      pos: 123.5,20.5
       parent: 1
 - proto: RMCJumpsuitMarsoc
   entities:
@@ -116717,6 +116701,28 @@ entities:
     - type: Transform
       pos: 123.5,21.5
       parent: 1
+- proto: RMCMagazineSMGType19
+  entities:
+  - uid: 14130
+    components:
+    - type: Transform
+      pos: 121.5,13.5
+      parent: 1
+  - uid: 14133
+    components:
+    - type: Transform
+      pos: 132.5,20.5
+      parent: 1
+  - uid: 14136
+    components:
+    - type: Transform
+      pos: 131.5,21.5
+      parent: 1
+  - uid: 14138
+    components:
+    - type: Transform
+      pos: 121.5,13.5
+      parent: 1
 - proto: RMCMapInsertShivaCLFRaid
   entities:
   - uid: 17350
@@ -116737,6 +116743,41 @@ entities:
     components:
     - type: Transform
       pos: 3.5,110.5
+      parent: 1
+- proto: RMCMapInsertShivaSurvSpawnBotany
+  entities:
+  - uid: 17446
+    components:
+    - type: Transform
+      pos: 97.5,93.5
+      parent: 1
+- proto: RMCMapInsertShivaSurvSpawnChurch
+  entities:
+  - uid: 17448
+    components:
+    - type: Transform
+      pos: 113.5,129.5
+      parent: 1
+- proto: RMCMapInsertShivaSurvSpawnCommandCentre
+  entities:
+  - uid: 17447
+    components:
+    - type: Transform
+      pos: 116.5,108.5
+      parent: 1
+- proto: RMCMapInsertShivaSurvSpawnCrisisCentre
+  entities:
+  - uid: 17444
+    components:
+    - type: Transform
+      pos: 113.5,67.5
+      parent: 1
+- proto: RMCMapInsertShivaSurvSpawnGarage
+  entities:
+  - uid: 17445
+    components:
+    - type: Transform
+      pos: 141.5,83.5
       parent: 1
 - proto: RMCMarkerAreaLabel
   entities:
@@ -123987,6 +124028,23 @@ entities:
     - type: Transform
       pos: 61.5,153.5
       parent: 1
+- proto: RMCSpawnerBombSupply
+  entities:
+  - uid: 2133
+    components:
+    - type: Transform
+      pos: 179.5,127.5
+      parent: 1
+  - uid: 2138
+    components:
+    - type: Transform
+      pos: 178.5,127.5
+      parent: 1
+  - uid: 17434
+    components:
+    - type: Transform
+      pos: 179.5,129.5
+      parent: 1
 - proto: RMCSpawnerCommunicationsTowerOne
   entities:
   - uid: 16006
@@ -129537,15 +129595,15 @@ entities:
     - type: Transform
       pos: 96.5,70.5
       parent: 1
-  - uid: 17001
+  - uid: 14129
     components:
     - type: Transform
-      pos: 161.5,46.5
+      pos: 68.5,5.5
       parent: 1
-  - uid: 17002
+  - uid: 17430
     components:
     - type: Transform
-      pos: 166.5,35.5
+      pos: 66.5,14.5
       parent: 1
 - proto: RMCWeaponRifleM54CStripped
   entities:
@@ -129598,10 +129656,22 @@ entities:
       parent: 1
 - proto: RMCWeaponShotgunType23
   entities:
-  - uid: 17012
+  - uid: 17435
     components:
     - type: Transform
-      pos: 198.5,93.5
+      pos: 108.5,12.5
+      parent: 1
+- proto: RMCWeaponSMGType19
+  entities:
+  - uid: 2480
+    components:
+    - type: Transform
+      pos: 131.5,21.5
+      parent: 1
+  - uid: 13322
+    components:
+    - type: Transform
+      pos: 121.5,13.5
       parent: 1
 - proto: RMCWeaponTaser
   entities:

--- a/Resources/Prototypes/_RMC14/Entities/Markers/Inserts/shiva.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Markers/Inserts/shiva.yml
@@ -66,60 +66,28 @@
 # Regular Surv Spawns
 - type: entity
   parent: RMCMapInsertShivaBaseScenario
-  id: RMCMapInsertShivaSurvSpawnChurch
-  name: Church Surv Spawn
+  id: RMCMapInsertShivaSurvSpawnTogether
+  name: Together Surv Spawn
   suffix: Insert Shiva
   components:
   - type: MapInsert
     variations:
     - spawn: "/Maps/_RMC14/Inserts/Shiva/surv_spawn_church.yml"
-      probability: 1
-      nightmareScenario: shiva_surv_spawn_church
-
-- type: entity
-  parent: RMCMapInsertShivaBaseScenario
-  id: RMCMapInsertShivaSurvSpawnCommandCentre
-  name: Command Centre Surv Spawn
-  suffix: Insert Shiva
-  components:
-  - type: MapInsert
-    variations:
+      probability: 0.2
+      nightmareScenario: none
     - spawn: "/Maps/_RMC14/Inserts/Shiva/surv_spawn_command_centre.yml"
-      probability: 1
-      nightmareScenario: shiva_surv_spawn_command_centre
-
-- type: entity
-  parent: RMCMapInsertShivaBaseScenario
-  id: RMCMapInsertShivaSurvSpawnBotany
-  name: Botany Surv Spawn
-  suffix: Insert Shiva
-  components:
-  - type: MapInsert
-    variations:
+      probability: 0.2
+      nightmareScenario: none
+      offset: 3,-21
     - spawn: "/Maps/_RMC14/Inserts/Shiva/surv_spawn_botany.yml"
-      probability: 1
-      nightmareScenario: shiva_surv_spawn_botany
-
-- type: entity
-  parent: RMCMapInsertShivaBaseScenario
-  id: RMCMapInsertShivaSurvSpawnCrisisCentre
-  name: Crisis Centre Surv Spawn
-  suffix: Insert Shiva
-  components:
-  - type: MapInsert
-    variations:
+      probability: 0.2
+      nightmareScenario: none
+      offset: -16,-36
     - spawn: "/Maps/_RMC14/Inserts/Shiva/surv_spawn_crisis_centre.yml"
-      probability: 1
-      nightmareScenario: shiva_surv_spawn_crisis_centre
-
-- type: entity
-  parent: RMCMapInsertShivaBaseScenario
-  id: RMCMapInsertShivaSurvSpawnGarage
-  name: Garage Surv Spawn
-  suffix: Insert Shiva
-  components:
-  - type: MapInsert
-    variations:
+      probability: 0.2
+      nightmareScenario: none
+      offset: 0,-62
     - spawn: "/Maps/_RMC14/Inserts/Shiva/surv_spawn_garage.yml"
-      probability: 1
-      nightmareScenario: shiva_surv_spawn_garage
+      probability: 0.2
+      nightmareScenario: none
+      offset: 28,-46

--- a/Resources/Prototypes/_RMC14/Entities/Markers/Inserts/shiva.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Markers/Inserts/shiva.yml
@@ -1,6 +1,19 @@
-﻿# Shiva
+﻿# Shiva Base
 - type: entity
+  abstract: true
   parent: RMCMapInsertBase
+  id: RMCMapInsertShivaBase
+  suffix: Insert Shiva
+  components:
+  - type: MapInsert
+    clearEntities: true
+    clearDecals: true
+    replaceAreas: true
+
+
+# Standalones
+- type: entity
+  parent: RMCMapInsertShivaBase
   id: RMCMapInsertShivaSouthCaves
   name: LZ2 South Caves
   suffix: Insert Shiva
@@ -11,12 +24,21 @@
       probability: 0.30
     - spawn: "/Maps/_RMC14/Inserts/Shiva/destroyed_lz2-south-caves.yml"
       probability: 0.20
-    clearEntities: true
-    clearDecals: true
-    replaceAreas: true
 
+
+# Survivor Scenario Inserts
 - type: entity
-  parent: RMCMapInsertBase
+  abstract: true
+  parent: RMCMapInsertShivaBase
+  id: RMCMapInsertShivaBaseScenario
+  suffix: Insert Shiva
+  components:
+  - type: MapInsert
+    replaceAreas: false
+
+# Panic Room
+- type: entity
+  parent: RMCMapInsertShivaBaseScenario
   id: RMCMapInsertShivaPanicRoomHold
   name: Panic Room Hold
   suffix: Insert Shiva
@@ -27,12 +49,10 @@
       probability: 1
       nightmareScenario: panic_room_hold
       offset: 0,2
-    clearEntities: true
-    clearDecals: true
-    replaceAreas: false
 
+# CLF Raid
 - type: entity
-  parent: RMCMapInsertBase
+  parent: RMCMapInsertShivaBase
   id: RMCMapInsertShivaCLFRaid
   name: CLF Raid
   suffix: Insert Shiva
@@ -42,6 +62,64 @@
     - spawn: "/Maps/_RMC14/Inserts/Shiva/clf_raid_shivas.yml"
       probability: 1
       nightmareScenario: clfraid_shivas
-    clearEntities: true
-    clearDecals: true
-    replaceAreas: true
+
+# Regular Surv Spawns
+- type: entity
+  parent: RMCMapInsertShivaBaseScenario
+  id: RMCMapInsertShivaSurvSpawnChurch
+  name: Church Surv Spawn
+  suffix: Insert Shiva
+  components:
+  - type: MapInsert
+    variations:
+    - spawn: "/Maps/_RMC14/Inserts/Shiva/surv_spawn_church.yml"
+      probability: 1
+      nightmareScenario: shiva_surv_spawn_church
+
+- type: entity
+  parent: RMCMapInsertShivaBaseScenario
+  id: RMCMapInsertShivaSurvSpawnCommandCentre
+  name: Command Centre Surv Spawn
+  suffix: Insert Shiva
+  components:
+  - type: MapInsert
+    variations:
+    - spawn: "/Maps/_RMC14/Inserts/Shiva/surv_spawn_command_centre.yml"
+      probability: 1
+      nightmareScenario: shiva_surv_spawn_command_centre
+
+- type: entity
+  parent: RMCMapInsertShivaBaseScenario
+  id: RMCMapInsertShivaSurvSpawnBotany
+  name: Botany Surv Spawn
+  suffix: Insert Shiva
+  components:
+  - type: MapInsert
+    variations:
+    - spawn: "/Maps/_RMC14/Inserts/Shiva/surv_spawn_botany.yml"
+      probability: 1
+      nightmareScenario: shiva_surv_spawn_botany
+
+- type: entity
+  parent: RMCMapInsertShivaBaseScenario
+  id: RMCMapInsertShivaSurvSpawnCrisisCentre
+  name: Crisis Centre Surv Spawn
+  suffix: Insert Shiva
+  components:
+  - type: MapInsert
+    variations:
+    - spawn: "/Maps/_RMC14/Inserts/Shiva/surv_spawn_crisis_centre.yml"
+      probability: 1
+      nightmareScenario: shiva_surv_spawn_crisis_centre
+
+- type: entity
+  parent: RMCMapInsertShivaBaseScenario
+  id: RMCMapInsertShivaSurvSpawnGarage
+  name: Garage Surv Spawn
+  suffix: Insert Shiva
+  components:
+  - type: MapInsert
+    variations:
+    - spawn: "/Maps/_RMC14/Inserts/Shiva/surv_spawn_garage.yml"
+      probability: 1
+      nightmareScenario: shiva_surv_spawn_garage

--- a/Resources/Prototypes/_RMC14/Entities/rmc_planets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/rmc_planets.yml
@@ -167,16 +167,8 @@
     nightmareScenarios:
     - scenarioName: panic_room_hold
       scenarioProbability: 0.1
-    - scenarioName: shiva_surv_spawn_church # 90% chance of regular surv. Reduce to 80% (0.16 each) once CLF survs are in.
-      scenarioProbability: 0.18
-    - scenarioName: shiva_surv_spawn_command_centre
-      scenarioProbability: 0.18
-    - scenarioName: shiva_surv_spawn_botany
-      scenarioProbability: 0.18
-    - scenarioName: shiva_surv_spawn_crisis_centre
-      scenarioProbability: 0.18
-    - scenarioName: shiva_surv_spawn_garage
-      scenarioProbability: 0.18
+    - scenarioName: none # 90% chance of regular surv. Reduce to 80% (0.8) once CLF survs are in.
+      scenarioProbability: 0.9
     survivorJobVariants: # Civ survivor is default one
       CMSurvivorCorporate:
       - RMCSurvivorShivasCorporateLiaison: -1

--- a/Resources/Prototypes/_RMC14/Entities/rmc_planets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/rmc_planets.yml
@@ -167,6 +167,16 @@
     nightmareScenarios:
     - scenarioName: panic_room_hold
       scenarioProbability: 0.1
+    - scenarioName: shiva_surv_spawn_church # 90% chance of regular surv. Reduce to 80% (0.16 each) once CLF survs are in.
+      scenarioProbability: 0.18
+    - scenarioName: shiva_surv_spawn_command_centre
+      scenarioProbability: 0.18
+    - scenarioName: shiva_surv_spawn_botany
+      scenarioProbability: 0.18
+    - scenarioName: shiva_surv_spawn_crisis_centre
+      scenarioProbability: 0.18
+    - scenarioName: shiva_surv_spawn_garage
+      scenarioProbability: 0.18
     survivorJobVariants: # Civ survivor is default one
       CMSurvivorCorporate:
       - RMCSurvivorShivasCorporateLiaison: -1


### PR DESCRIPTION
## About the PR
Moved problematic survivor loot to new locations and added spawn togethers, both non-parity but requested changes

## Why / Balance
Loot being moved in advance of other required changes to help the xeno/survivor situation.

Survivor spawn together inserts wanted to help survivor experience.

Survivor spawn together locations given a thumbs up by crow.

Fixes https://github.com/RMC-14/RMC-14/issues/9275
Fixes https://github.com/RMC-14/RMC-14/issues/9558

## Technical details
Cleaned up Shivas insert marker file

## Media
<img width="1126" height="924" alt="image" src="https://github.com/user-attachments/assets/96cc8a63-473b-420a-8970-6a14f3b923e1" />

Materials and type-19s moved from engineering to fort biceps
<img width="813" height="798" alt="Screenshot 2026-04-17 014203" src="https://github.com/user-attachments/assets/e98cdcdb-3ef1-4316-84c8-c5c0c6339ce8" />

Type-23 moved from disposals to junkyard
<img width="502" height="414" alt="Screenshot 2026-04-17 014214" src="https://github.com/user-attachments/assets/1a11da0e-4263-44c2-adfb-3f0edd77acca" />

MK1s moved from research hab to south of warehouse
<img width="373" height="594" alt="Screenshot 2026-04-17 014225" src="https://github.com/user-attachments/assets/5bfcccb5-0c88-4027-b332-7f7c2ac15b41" />

Survivor spawn togethers
<img width="832" height="905" alt="image" src="https://github.com/user-attachments/assets/dec9a619-1e91-4a35-a4c1-121cb4a0404f" />

Church
<img width="507" height="445" alt="Screenshot 2026-04-17 014142" src="https://github.com/user-attachments/assets/0554dd5f-d9ec-41c4-b28a-ac6717181881" />

Command Centre
<img width="419" height="407" alt="Screenshot 2026-04-17 014106" src="https://github.com/user-attachments/assets/b4aebbb2-5c55-4318-8a98-298c24e1dc03" />

Botany
<img width="391" height="418" alt="Screenshot 2026-04-17 014129" src="https://github.com/user-attachments/assets/7ab8e5d3-4e08-4a4d-8c9e-ddbf8e7d690b" />

Crisis Centre
<img width="498" height="361" alt="Screenshot 2026-04-17 014118" src="https://github.com/user-attachments/assets/ec47e4ee-517a-4e62-8ced-f67ca0225e91" />

Garage
<img width="497" height="375" alt="Screenshot 2026-04-17 014053" src="https://github.com/user-attachments/assets/4e727ba4-e451-46c5-8adb-e50e8c726bf8" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: CatAndHats
- add: Added survivor spawn together inserts to Shiva's Snowball at Church, Command Centre, Botany, Crisis Centre, and Garage
- tweak: Changed survivor loot on Shiva's Snowball. Materials and type-19s moved to Fort Biceps from engineering, Type-23 moved to junkyard from disposals, MK1s moved to south of warehouse from research hab.
- fix: Fixed incorrect vehicle placement on Shiva causing people to get trapped.
