### PR TITLE
Fix the tesla coil sentry's range being too short.

### DIFF
--- a/Content.Shared/_RMC14/Sentry/TeslaCoil/TeslaCoilComponent.cs
+++ b/Content.Shared/_RMC14/Sentry/TeslaCoil/TeslaCoilComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared._RMC14.Maths;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
@@ -24,7 +25,7 @@ public sealed partial class RMCTeslaCoilComponent : Component
     /// Maximum range the coil can target entities.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float Range = 3f;
+    public float Range = RMCMathExtensions.CircleAreaFromSquareAbilityRange(3);
 
     /// <summary>
     /// Maximum number of targets the coil can hit simultaneously per firing sequence.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Increased the range of all tesla coil sentries from 3 to 3.9493.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity range is a 7x7 grid, which has a surface area of 49. A circle with a radius of 3.9493 also has a surface area of 49.


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix: Increased Tesla Coil range from 3 to 3.95 tiles.
