### PR TITLE
tweak: FTL and aSL orders

### DIFF
--- a/Content.Shared/_RMC14/Marines/Orders/SharedMarineOrdersSystem.cs
+++ b/Content.Shared/_RMC14/Marines/Orders/SharedMarineOrdersSystem.cs
@@ -2,6 +2,7 @@ using Content.Shared._RMC14.Evasion;
 using Content.Shared._RMC14.Marines.Skills;
 using Content.Shared.Actions;
 using Content.Shared.Damage;
+using Content.Shared.FixedPoint;
 using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Mobs.Systems;
@@ -160,7 +161,7 @@ public abstract class SharedMarineOrdersSystem : EntitySystem
             return false;
         }
 
-        var level = Math.Max(1, _skills.GetSkill(orders.Owner, orders.Comp.Skill));
+        var level = Math.Max(0.5, _skills.GetSkill(orders.Owner, orders.Comp.Skill));
         var duration = orders.Comp.Duration * (level + 1);
 
         _actions.SetCooldown(orders.Comp.FocusActionEntity, orders.Comp.Cooldown);
@@ -184,7 +185,7 @@ public abstract class SharedMarineOrdersSystem : EntitySystem
     /// <summary>
     /// Adds an order component to an entity. If the order already exists then the multiplier and duration is overriden.
     /// </summary>
-    private void AddOrder<T>(Entity<MarineComponent> receiver, int multiplier, TimeSpan duration) where T : IOrderComponent, new()
+    private void AddOrder<T>(Entity<MarineComponent> receiver, FixedPoint2 multiplier, TimeSpan duration) where T : IOrderComponent, new()
     {
         var time = _timing.CurTime;
         var comp = EnsureComp<T>(receiver);

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/fireteam_leader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/fireteam_leader.yml
@@ -44,6 +44,7 @@
     - type: CMVendorUser
       id: CMFireteamLeader
       points: 45
+    - type: MarineOrders
     - type: SquadArmorWearer
     - type: JobPrefix
       prefix: cm-job-prefix-fireteam-leader


### PR DESCRIPTION
## About the PR

Currently anyone with the orders component can give our orders as if they had leadership level 1. This PR gives everyone without a leadership level a level of 0.5 and gives FTLs the ability to always use orders.

## Why / Balance

1. Loosing resources (in this case a SL or FTL) as a marine should be more impactful in comparison to the xenos. (Marines now start with 3 people that can give out orders per squad. Similar as how there are multiple xenos in a group giving pheromones.)
2. The FTL is the role leading up to the SL. Being able to give out buffs at a lesser level should help in that and leading a fireteam. (I see some players not utilizing orders to the fullest, giving a learning role for them should help in my opinion.)
3. This is an alternative to #8816. Instead of a rework and buffing the leadership of SLs, this PR only nerfs it for aSLs.

## Technical details

- Gave the MarineOrdersComponent to FTLs
- Reduced the minimum order level from 1 to 0.5

## Media

Running-speeds with medium (33%) armor for the "Move"-Order.

New:

|Leadership|Duration|Speed|Speed Change|
|---|---|---|---|
|No Buff||3.33||
|0|15s|3.4965|+5%|
|1|20s|3.663|+10%|
|2|30s|3.996|+20%|
|3|40s|4.329|+30%|

Old: Leadership 0 would be the same as level 1.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: FTLs can now always give orders.
- tweak: Orders by aSLs and FTLs are now weaker than those of an SL.
