### PR TITLE
Add factional flares to SPP SOF and SPP Airborne

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/SPP_SOF/spp_sof_base.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/SPP_SOF/spp_sof_base.yml
@@ -33,7 +33,7 @@
     id: RMCIDSPP
     ears: RMCHeadsetDistressSPP # TODO RMC14 replace this with a 121/RECON headset after 8602 is merged
     pocket1: RMCPouchFirstAidSplintsGauzeOintment
-    pocket2: RMCPouchFlareFilled
+    pocket2: RMCPouchFlareR44Filled
   storage:
     back:
     - CMSheetMetal20

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Trijent_Dam/SPPCrashlanding/spp_crashland_base.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Trijent_Dam/SPPCrashlanding/spp_crashland_base.yml
@@ -26,7 +26,7 @@
     id: RMCIDSPP
     ears: RMCHeadsetSPPCrashland
     pocket1: RMCPouchFirstAidSplintsGauzeOintment
-    pocket2: RMCPouchFlareFilled
+    pocket2: RMCPouchFlareR44Filled
 
 - type: entity
   id: RMCSurvivorPresetSPPCrashlandWeaponOnly
@@ -63,7 +63,7 @@
       - [ RMCOuterClothingExternalWebbingSPPSurvivor, RMCFlashlight ] # 3/5ths chance for webbing
       - [ RMCArmorSPPSupportSurvivorFill ]
     - # Headwear // TODO RMC14 implement random chance here in a less ugly way
-      - [ ArmorHelmetSPP ] # 2/9 chance 
+      - [ ArmorHelmetSPP ] # 2/9 chance
       - [ CMHeadCapSPP ] # 3/9 chance
       - [ CMHeadCapSPPBeret ] # 2/9 chance
       - [ CMHeadCapSPPUshanka ] # 2/9 chance
@@ -89,7 +89,7 @@
       - [ RMCOuterClothingExternalWebbingSPPSurvivor, RMCFlashlight ] # 3/5ths chance for webbing
       - [ RMCArmorSPPSupportSurvivorFill ]
     - # Headwear // TODO RMC14 implement random chance here in a less ugly way
-      - [ ArmorHelmetSPP ] # 2/9 chance 
+      - [ ArmorHelmetSPP ] # 2/9 chance
       - [ CMHeadCapSPP ] # 3/9 chance
       - [ CMHeadCapSPPBeret ] # 2/9 chance
       - [ CMHeadCapSPPUshanka ] # 2/9 chance


### PR DESCRIPTION
## About the PR
Replaces marine flare pouches with R44 flare pouches where applicable in SPP Airborne and SPP SOF loadouts.

## Why / Balance
This is a non parity change but it is purely cosmetic and does not affect balance. Factions should use their unique flares for sovl

## Technical details
Yaml

## Media
<img width="593" height="395" alt="obraz" src="https://github.com/user-attachments/assets/040ed5cb-e9e4-4d9c-93a2-b7c9b3e91365" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: SPP SOF and SPP Airborne now start with SPP flare pouches instead of UNMC flare pouches.