### PR TITLE
add: cryo-marines respawn on cryo

### DIFF
--- a/Content.Server/_RMC14/Intel/Tech/RespawnOnCryoComponent.cs
+++ b/Content.Server/_RMC14/Intel/Tech/RespawnOnCryoComponent.cs
@@ -1,0 +1,12 @@
+using Content.Shared._RMC14.Intel.Tech;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._RMC14.Intel.Tech;
+
+[RegisterComponent]
+[Access(typeof(TechSystem))]
+public sealed partial class RespawnOnCryoComponent : Component
+{
+    [DataField(required: true)]
+    public EntProtoId Spawner;
+}

--- a/Content.Server/_RMC14/Intel/Tech/TechSystem.cs
+++ b/Content.Server/_RMC14/Intel/Tech/TechSystem.cs
@@ -2,6 +2,7 @@ using Content.Server.GameTicking.Events;
 using Content.Server.Ghost.Roles.Components;
 using Content.Server.Humanoid.Components;
 using Content.Server.Spawners.Components;
+using Content.Shared._RMC14.Cryostorage;
 using Content.Shared._RMC14.Intel.Tech;
 using Content.Shared.Humanoid.Prototypes;
 using Robust.Server.GameObjects;
@@ -33,6 +34,7 @@ public sealed class ServerTechSystem : EntitySystem
         SubscribeLocalEvent<TechCryoMarinesEvent>(OnTechCryoMarines);
         SubscribeLocalEvent<TechCryoSpecEvent>(OnTechCryoSpec);
         SubscribeLocalEvent<RoundStartingEvent>(OnRoundStart);
+        SubscribeLocalEvent<RespawnOnCryoComponent, EnteredCryostorageEvent>(OnEnteredCryostorageEvent);
     }
 
     private void OnRoundStart(RoundStartingEvent ev)
@@ -82,5 +84,10 @@ public sealed class ServerTechSystem : EntitySystem
             var choice = _random.Pick(valid);
             Spawn(spawnerId, _transform.GetMapCoordinates(choice));
         }
+    }
+
+    private void OnEnteredCryostorageEvent(Entity<RespawnOnCryoComponent> ent, ref EnteredCryostorageEvent args)
+    {
+        SpawnCryo(ent.Comp.Spawner, 1);
     }
 }

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/ghosts/foxtrot.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/ghosts/foxtrot.yml
@@ -14,6 +14,9 @@
 - type: randomHumanoidSettings
   parent: [RMCCombatTech, RMCFoxtrotBase]
   id: RMCFoxtrotCombatTech
+  components:
+  - type: RespawnOnCryo
+    spawner: RMCRandomHumanoidFoxtrotCombatTech
 
 # fireteam leader
 - type: entity
@@ -31,6 +34,9 @@
 - type: randomHumanoidSettings
   parent: [RMCFireteamLeader, RMCFoxtrotBase]
   id: RMCFoxtrotFireteamLeader
+  components:
+  - type: RespawnOnCryo
+    spawner: RMCRandomHumanoidFoxtrotFireteamLeader
 
 # hospital corpsman
 - type: entity
@@ -48,6 +54,9 @@
 - type: randomHumanoidSettings
   parent: [RMCHospitalCorpsman, RMCFoxtrotBase]
   id: RMCFoxtrotHospitalCorpsman
+  components:
+  - type: RespawnOnCryo
+    spawner: RMCRandomHumanoidFoxtrotHospitalCorpsman
 
 # rifleman
 - type: entity
@@ -65,6 +74,9 @@
 - type: randomHumanoidSettings
   parent: [RMCRifleman, RMCFoxtrotBase]
   id: RMCFoxtrotRifleman
+  components:
+  - type: RespawnOnCryo
+    spawner: RMCRandomHumanoidFoxtrotRifleman
 
 # smart gun operator
 - type: entity
@@ -82,6 +94,9 @@
 - type: randomHumanoidSettings
   parent: [RMCSmartGunOperator, RMCFoxtrotBase]
   id: RMCFoxtrotSmartGunOperator
+  components:
+  - type: RespawnOnCryo
+    spawner: RMCRandomHumanoidFoxtrotSmartGunOperator
 
 # squad leader
 - type: entity
@@ -99,6 +114,9 @@
 - type: randomHumanoidSettings
   parent: [RMCSquadLeader, RMCFoxtrotBase]
   id: RMCFoxtrotSquadLeader
+  components:
+  - type: RespawnOnCryo
+    spawner: RMCRandomHumanoidFoxtrotSquadLeader
 
 # weapons specialist
 - type: entity
@@ -118,3 +136,5 @@
   id: RMCFoxtrotWeaponsSpecialist
   components:
   - type: IgnoreSpecLimits
+  - type: RespawnOnCryo
+    spawner: RMCRandomHumanoidFoxtrotWeaponsSpecialist


### PR DESCRIPTION
## About the PR

When a cryo-marine (foxtrot) enters cryo-sleep a new one will be woken up.

## Why / Balance

Just had a round where the cryo spec disconnected shortly after taking the role.

## Technical details

New component that links the marine with the spawner.

## Media


https://github.com/user-attachments/assets/4e50994d-5cff-497f-9387-9422fc33fb24



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- add: When a foxtrot marine enters cryosleep a new one will be woken up to replace them.
