### PR TITLE
New Varadero survivor spawn togethers and comms change

### DIFF
--- a/Resources/Maps/_RMC14/Inserts/Varadero/surv_spawn_admin.yml
+++ b/Resources/Maps/_RMC14/Inserts/Varadero/surv_spawn_admin.yml
@@ -1,0 +1,1581 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 264.0.2
+  forkId: ""
+  forkVersion: ""
+  time: 03/04/2026 22:54:30
+  entityCount: 249
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  0: Space
+  198: CMFloorPlating
+  3: CMFloorSteelShivaBlue0
+  13: CMFloorSteelShivaBlue1
+  10: CMFloorSteelShivaBlue2
+  7: CMFloorSteelShivaBlue3
+  4: CMFloorSteelShivaBlue4
+  2: CMFloorSteelShivaBlue5
+  14: CMFloorSteelShivaBlue6
+  12: CMFloorSteelShivaBlue7
+  15: CMFloorSteelShivaBlueFull3
+  8: CMFloorSteelShivaMultiTile
+  9: CMFloorSteelShivaMultiTile4
+  1: CMFloorSteelShivaPlate
+  5: RMCFloorPlatingDamage1
+  6: RMCFloorPlatingDamage3
+  11: RMCFloorPlatingScorched
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: grid
+    - type: Transform
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: xgAAAAAAAMYAAAAAAAABAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAAABAAAAAAAAAQAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAAAAAAAAAAAAAAAAAAAAAMYAAAAAAAACAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAQAAAAAAAAEAAAAAAAADAAAAAAAAAwAAAAAAAAQAAAAAAAAFAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAAAAAABwAAAAAAAAgAAAAAAAAJAAAAAAAACQAAAAAAAAkAAAAAAAAJAAAAAAAACQAAAAAAAAkAAAAAAAAJAAAAAAAACQAAAAAAAAgAAAAAAAAKAAAAAAAAxgAAAAAAAAAAAAAAAAAAAAAAAAAACwAAAAAAAAwAAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAAEAAAAAAAANAAAAAAAAAQAAAAAAAA0AAAAAAAANAAAAAAAADgAAAAAAAMYAAAAAAAAAAAAAAAAAAAAAAAAAAMYAAAAAAADGAAAAAAAAAQAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAAUAAAAAAAABAAAAAAAACwAAAAAAAAEAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADGAAAAAAAAAgAAAAAAAAMAAAAAAAADAAAAAAAAAQAAAAAAAAMAAAAAAAABAAAAAAAAAwAAAAAAAAMAAAAAAAAEAAAAAAAAxgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxgAAAAAAAAcAAAAAAAAIAAAAAAAACAAAAAAAAAkAAAAAAAABAAAAAAAACQAAAAAAAAgAAAAAAAAIAAAAAAAACgAAAAAAAMYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMYAAAAAAAAPAAAAAAAADwAAAAAAAA8AAAAAAAAJAAAAAAAAAQAAAAAAAAkAAAAAAAAPAAAAAAAADwAAAAAAAA8AAAAAAADGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALAAAAAAAADwAAAAAAAAEAAAAAAAABAAAAAAAACQAAAAAAAAEAAAAAAAAJAAAAAAAAAQAAAAAAAAEAAAAAAAAPAAAAAAAAxgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxgAAAAAAAA8AAAAAAAAPAAAAAAAADwAAAAAAAAkAAAAAAAABAAAAAAAACQAAAAAAAA8AAAAAAAAPAAAAAAAADwAAAAAAAMYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMYAAAAAAAAHAAAAAAAACAAAAAAAAAgAAAAAAAAJAAAAAAAAAQAAAAAAAAkAAAAAAAAIAAAAAAAACAAAAAAAAAoAAAAAAAALAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADGAAAAAAAADAAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAAEAAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAAOAAAAAAAAxgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAABQAAAAAAAMYAAAAAAAABAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodTrail1
+          decals:
+            2: 8,0
+            9: 6,12
+            13: 7,9
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodTrail2
+          decals:
+            1: 8,1
+            10: 6,11
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodTrail3
+          decals:
+            4: 2,2
+            6: 0,2
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodTrail4
+          decals:
+            5: 1,2
+            7: 10.362945,10.414187
+            8: 9.47232,10.398562
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodTrail5
+          decals:
+            3: 3,2
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodTrail6
+          decals:
+            11: 6,10
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodTrail7
+          decals:
+            12: 7,10
+    - type: GridAtmosphere
+      version: 2
+      data:
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: ImplicitRoof
+- proto: Bedroll
+  entities:
+  - uid: 198
+    components:
+    - type: Transform
+      pos: 11.550445,10.726687
+      parent: 1
+  - uid: 200
+    components:
+    - type: Transform
+      pos: 11.34732,8.445437
+      parent: 1
+  - uid: 201
+    components:
+    - type: Transform
+      pos: 10.97232,6.7423124
+      parent: 1
+  - uid: 202
+    components:
+    - type: Transform
+      pos: 5.5191946,8.804812
+      parent: 1
+  - uid: 203
+    components:
+    - type: Transform
+      pos: 11.47232,9.195437
+      parent: 1
+  - uid: 204
+    components:
+    - type: Transform
+      pos: 4.8785696,6.3985624
+      parent: 1
+- proto: CigaretteSpent
+  entities:
+  - uid: 196
+    components:
+    - type: Transform
+      pos: 4.8004446,9.586062
+      parent: 1
+  - uid: 197
+    components:
+    - type: Transform
+      pos: 4.7223196,9.320437
+      parent: 1
+- proto: CMAirlockCommand
+  entities:
+  - uid: 60
+    components:
+    - type: Transform
+      pos: 7.5,4.5
+      parent: 1
+  - uid: 61
+    components:
+    - type: Transform
+      pos: 9.5,4.5
+      parent: 1
+- proto: CMAirlockGlassSecurity
+  entities:
+  - uid: 59
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+- proto: CMAirlockMaint
+  entities:
+  - uid: 57
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      pos: 8.5,12.5
+      parent: 1
+- proto: CMBarricadeSandbag
+  entities:
+  - uid: 100
+    components:
+    - type: Transform
+      pos: 10.5,1.5
+      parent: 1
+  - uid: 101
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 102
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 110
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,7.5
+      parent: 1
+  - uid: 129
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 153
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,6.5
+      parent: 1
+- proto: CMChairOfficeDark
+  entities:
+  - uid: 106
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.725918,5.500742
+      parent: 1
+  - uid: 107
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.366543,5.531992
+      parent: 1
+- proto: CMDisposalUnit
+  entities:
+  - uid: 65
+    components:
+    - type: Transform
+      pos: 12.5,5.5
+      parent: 1
+- proto: CMFilingCabinet
+  entities:
+  - uid: 154
+    components:
+    - type: Transform
+      pos: 8.938309,11.603436
+      parent: 1
+  - uid: 161
+    components:
+    - type: Transform
+      pos: 7.5789337,11.978436
+      parent: 1
+  - uid: 165
+    components:
+    - type: Transform
+      pos: 12.700831,6.500079
+      parent: 1
+- proto: CMGirderReinforced
+  entities:
+  - uid: 7
+    components:
+    - type: Transform
+      pos: 3.5,7.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+- proto: CMPaperBin20
+  entities:
+  - uid: 168
+    components:
+    - type: Transform
+      pos: 12.607081,11.750079
+      parent: 1
+  - uid: 184
+    components:
+    - type: Transform
+      pos: 4.8004446,5.7579374
+      parent: 1
+- proto: CMRandomPosterUN
+  entities:
+  - uid: 240
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 241
+    components:
+    - type: Transform
+      pos: 11.5,0.5
+      parent: 1
+  - uid: 243
+    components:
+    - type: Transform
+      pos: 13.5,9.5
+      parent: 1
+- proto: CMRodMetal1
+  entities:
+  - uid: 149
+    components:
+    - type: Transform
+      pos: 1.06985,3.2985058
+      parent: 1
+  - uid: 157
+    components:
+    - type: Transform
+      pos: 6.340988,12.759445
+      parent: 1
+  - uid: 158
+    components:
+    - type: Transform
+      pos: 6.684738,12.08757
+      parent: 1
+- proto: CMShardGlass
+  entities:
+  - uid: 11
+    components:
+    - type: Transform
+      pos: 5.394515,12.707469
+      parent: 1
+  - uid: 143
+    components:
+    - type: Transform
+      pos: 13.4278965,1.7828808
+      parent: 1
+  - uid: 144
+    components:
+    - type: Transform
+      pos: 8.5841465,5.204756
+      parent: 1
+  - uid: 145
+    components:
+    - type: Transform
+      pos: 6.2560215,5.236006
+      parent: 1
+  - uid: 146
+    components:
+    - type: Transform
+      pos: 6.7716465,3.7828808
+      parent: 1
+  - uid: 147
+    components:
+    - type: Transform
+      pos: 7.6643896,0.9078808
+      parent: 1
+  - uid: 148
+    components:
+    - type: Transform
+      pos: 1.272975,3.7985058
+      parent: 1
+  - uid: 155
+    components:
+    - type: Transform
+      pos: 7.619584,12.78275
+      parent: 1
+  - uid: 159
+    components:
+    - type: Transform
+      pos: 13.382595,10.819532
+      parent: 1
+  - uid: 192
+    components:
+    - type: Transform
+      pos: 4.2379446,8.914187
+      parent: 1
+- proto: CMSheetMetal1
+  entities:
+  - uid: 34
+    components:
+    - type: Transform
+      pos: 8.677577,4.480067
+      parent: 1
+- proto: CMSpawnPointSurvivor
+  entities:
+  - uid: 214
+    components:
+    - type: Transform
+      pos: 8.5,10.5
+      parent: 1
+  - uid: 215
+    components:
+    - type: Transform
+      pos: 9.5,9.5
+      parent: 1
+  - uid: 216
+    components:
+    - type: Transform
+      pos: 10.5,9.5
+      parent: 1
+  - uid: 217
+    components:
+    - type: Transform
+      pos: 10.5,8.5
+      parent: 1
+  - uid: 218
+    components:
+    - type: Transform
+      pos: 11.5,6.5
+      parent: 1
+  - uid: 219
+    components:
+    - type: Transform
+      pos: 5.5,7.5
+      parent: 1
+  - uid: 220
+    components:
+    - type: Transform
+      pos: 6.5,8.5
+      parent: 1
+  - uid: 221
+    components:
+    - type: Transform
+      pos: 5.5,10.5
+      parent: 1
+  - uid: 222
+    components:
+    - type: Transform
+      pos: 8.5,7.5
+      parent: 1
+  - uid: 223
+    components:
+    - type: Transform
+      pos: 7.5,6.5
+      parent: 1
+  - uid: 224
+    components:
+    - type: Transform
+      pos: 8.5,3.5
+      parent: 1
+  - uid: 225
+    components:
+    - type: Transform
+      pos: 6.5,2.5
+      parent: 1
+- proto: CMStampApproved
+  entities:
+  - uid: 181
+    components:
+    - type: Transform
+      pos: 12.269195,11.792917
+      parent: 1
+- proto: CMVentPump
+  entities:
+  - uid: 62
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,2.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,10.5
+      parent: 1
+- proto: CMWallReinforced
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 3
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 4
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 5
+    components:
+    - type: Transform
+      pos: 3.5,9.5
+      parent: 1
+  - uid: 6
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      pos: 3.5,11.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      pos: 3.5,12.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      pos: 4.5,12.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 9.5,12.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      pos: 10.5,12.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      pos: 12.5,12.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      pos: 13.5,12.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      pos: 13.5,11.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      pos: 13.5,9.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: 13.5,7.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      pos: 13.5,5.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      pos: 13.5,4.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      pos: 13.5,3.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      pos: 13.5,2.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      pos: 13.5,0.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      pos: 12.5,0.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      pos: 11.5,0.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+- proto: CMWindowWhiteColonyReinforced
+  entities:
+  - uid: 31
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 12.5,4.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: 11.5,4.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      pos: 10.5,4.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      pos: 3.5,10.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      pos: 11.5,12.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      pos: 13.5,8.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      pos: 13.5,6.5
+      parent: 1
+  - uid: 128
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 1
+- proto: DisposalBend
+  entities:
+  - uid: 66
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,5.5
+      parent: 1
+- proto: DisposalPipe
+  entities:
+  - uid: 67
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,5.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      pos: 10.5,4.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      pos: 10.5,3.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      pos: 10.5,2.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      pos: 10.5,1.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      pos: 10.5,0.5
+      parent: 1
+- proto: DisposalTrunk
+  entities:
+  - uid: 73
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,5.5
+      parent: 1
+- proto: RMCAshtray
+  entities:
+  - uid: 195
+    components:
+    - type: Transform
+      pos: 4.7066946,9.289187
+      parent: 1
+- proto: RMCBannerUNWorn
+  entities:
+  - uid: 242
+    components:
+    - type: Transform
+      pos: 10.5,12.5
+      parent: 1
+- proto: RMCBarricadeWood
+  entities:
+  - uid: 98
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 99
+    components:
+    - type: Transform
+      pos: 9.5,1.5
+      parent: 1
+  - uid: 103
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 118
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,10.5
+      parent: 1
+  - uid: 119
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,11.5
+      parent: 1
+  - uid: 122
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,3.5
+      parent: 1
+  - uid: 123
+    components:
+    - type: Transform
+      pos: 10.5,5.5
+      parent: 1
+  - uid: 124
+    components:
+    - type: Transform
+      pos: 11.5,5.5
+      parent: 1
+  - uid: 125
+    components:
+    - type: Transform
+      pos: 6.5,1.5
+      parent: 1
+  - uid: 160
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,10.5
+      parent: 1
+- proto: RMCBasePropCasing1
+  entities:
+  - uid: 137
+    components:
+    - type: Transform
+      pos: 9.4477215,2.1266308
+      parent: 1
+- proto: RMCBasePropCasing11
+  entities:
+  - uid: 138
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.1617517,3.6422558
+      parent: 1
+  - uid: 139
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.8180017,2.2828808
+      parent: 1
+  - uid: 140
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.755502,3.3922558
+      parent: 1
+  - uid: 233
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.153102,5.786218
+      parent: 1
+  - uid: 234
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.699977,5.895593
+      parent: 1
+  - uid: 235
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.356227,10.926844
+      parent: 1
+  - uid: 236
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.293727,10.426844
+      parent: 1
+  - uid: 237
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.887477,6.004968
+      parent: 1
+  - uid: 238
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.481227,7.864343
+      parent: 1
+  - uid: 239
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.762477,7.723718
+      parent: 1
+- proto: RMCBasePropCasing8
+  entities:
+  - uid: 136
+    components:
+    - type: Transform
+      pos: 4.3539715,2.0485058
+      parent: 1
+- proto: RMCBookcase
+  entities:
+  - uid: 97
+    components:
+    - type: Transform
+      pos: 9.5,5.5
+      parent: 1
+- proto: RMCCigarCase
+  entities:
+  - uid: 209
+    components:
+    - type: Transform
+      pos: 7.5348196,7.5391874
+      parent: 1
+- proto: RMCCoffeeMachine
+  entities:
+  - uid: 186
+    components:
+    - type: Transform
+      pos: 11.394195,11.804812
+      parent: 1
+- proto: RMCCrateMini
+  entities:
+  - uid: 189
+    components:
+    - type: Transform
+      pos: 9.683686,7.72937
+      parent: 1
+- proto: RMCDecalSpawnerBloodSplatters
+  entities:
+  - uid: 92
+    components:
+    - type: Transform
+      pos: 7.5,8.5
+      parent: 1
+  - uid: 117
+    components:
+    - type: Transform
+      pos: 7.5,3.5
+      parent: 1
+  - uid: 131
+    components:
+    - type: Transform
+      pos: 8.5,2.5
+      parent: 1
+  - uid: 132
+    components:
+    - type: Transform
+      pos: 11.5,3.5
+      parent: 1
+  - uid: 133
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 134
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 135
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 199
+    components:
+    - type: Transform
+      pos: 11.5,10.5
+      parent: 1
+  - uid: 211
+    components:
+    - type: Transform
+      pos: 8.5,5.5
+      parent: 1
+  - uid: 212
+    components:
+    - type: Transform
+      pos: 8.5,9.5
+      parent: 1
+  - uid: 232
+    components:
+    - type: Transform
+      pos: 11.5,8.5
+      parent: 1
+  - uid: 246
+    components:
+    - type: Transform
+      pos: 10.5,1.5
+      parent: 1
+- proto: RMCDecalSpawnerXenoSplatters
+  entities:
+  - uid: 91
+    components:
+    - type: Transform
+      pos: 5.5,12.5
+      parent: 1
+  - uid: 141
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 142
+    components:
+    - type: Transform
+      pos: 12.5,1.5
+      parent: 1
+  - uid: 248
+    components:
+    - type: Transform
+      pos: 3.5,8.5
+      parent: 1
+- proto: RMCDirtBandageProp3
+  entities:
+  - uid: 213
+    components:
+    - type: Transform
+      pos: 4.861274,10.903267
+      parent: 1
+- proto: RMCDirtBandageProp5
+  entities:
+  - uid: 206
+    components:
+    - type: Transform
+      pos: 5.1910696,8.289187
+      parent: 1
+- proto: RMCDirtBandageProp7
+  entities:
+  - uid: 205
+    components:
+    - type: Transform
+      pos: 11.237945,9.554812
+      parent: 1
+- proto: RMCDoubleDoorCommandGlass
+  entities:
+  - uid: 63
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,0.5
+      parent: 1
+- proto: RMCDrinkCoffee
+  entities:
+  - uid: 183
+    components:
+    - type: Transform
+      pos: 12.28482,9.148562
+      parent: 1
+- proto: RMCFaxColony
+  entities:
+  - uid: 172
+    components:
+    - type: Transform
+      pos: 6.5,9.5
+      parent: 1
+    missingComponents:
+    - ApcPowerReceiver
+    - FaxMachine
+    - ActivatableUI
+    - ActivatableUIRequiresPower
+    - UserInterface
+    - ItemSlots
+    - ContainerContainer
+    - DeviceNetworkRequiresPower
+    - DeviceNetwork
+- proto: RMCFlightRecorderColonyProp
+  entities:
+  - uid: 176
+    components:
+    - type: Transform
+      pos: 10.206695,12.074167
+      parent: 1
+- proto: RMCGasPipeBend
+  entities:
+  - uid: 74
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,2.5
+      parent: 1
+- proto: RMCGasPipeFourway
+  entities:
+  - uid: 96
+    components:
+    - type: Transform
+      pos: 8.5,2.5
+      parent: 1
+- proto: RMCGasPipeStraight
+  entities:
+  - uid: 75
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 77
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,0.5
+      parent: 1
+  - uid: 78
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,1.5
+      parent: 1
+  - uid: 79
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 80
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 81
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,2.5
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,2.5
+      parent: 1
+  - uid: 84
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,2.5
+      parent: 1
+  - uid: 85
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,2.5
+      parent: 1
+  - uid: 86
+    components:
+    - type: Transform
+      pos: 8.5,3.5
+      parent: 1
+  - uid: 87
+    components:
+    - type: Transform
+      pos: 8.5,4.5
+      parent: 1
+  - uid: 88
+    components:
+    - type: Transform
+      pos: 8.5,5.5
+      parent: 1
+  - uid: 89
+    components:
+    - type: Transform
+      pos: 8.5,6.5
+      parent: 1
+  - uid: 90
+    components:
+    - type: Transform
+      pos: 8.5,7.5
+      parent: 1
+  - uid: 93
+    components:
+    - type: Transform
+      pos: 8.5,11.5
+      parent: 1
+  - uid: 94
+    components:
+    - type: Transform
+      pos: 8.5,12.5
+      parent: 1
+- proto: RMCGasPipeTJunction
+  entities:
+  - uid: 95
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,10.5
+      parent: 1
+- proto: RMCGlassesReagentHUDGlasses
+  entities:
+  - uid: 208
+    components:
+    - type: Transform
+      pos: 4.9098196,5.6954374
+      parent: 1
+- proto: RMCIdentificationComputer
+  entities:
+  - uid: 179
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,8.5
+      parent: 1
+- proto: RMCLightFixtureOffset
+  entities:
+  - uid: 226
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,11.5
+      parent: 1
+  - uid: 227
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,9.5
+      parent: 1
+  - uid: 228
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,2.5
+      parent: 1
+  - uid: 229
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,9.5
+      parent: 1
+  - uid: 230
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+- proto: RMCM276ShotgunShellLoadingRig
+  entities:
+  - uid: 163
+    components:
+    - type: Transform
+      pos: 10.966456,7.6267753
+      parent: 1
+- proto: RMCMarkerAreaLabel
+  entities:
+  - uid: 249
+    components:
+    - type: MetaData
+      name: Administration
+    - type: Transform
+      pos: 13.5,2.5
+      parent: 1
+- proto: RMCMREWeYa
+  entities:
+  - uid: 190
+    components:
+    - type: Transform
+      pos: 12.25357,7.7579374
+      parent: 1
+  - uid: 191
+    components:
+    - type: Transform
+      pos: 12.59732,7.6329374
+      parent: 1
+- proto: RMCPersonalDesktop
+  entities:
+  - uid: 177
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.40982,8.496042
+      parent: 1
+- proto: RMCPhotocopier
+  entities:
+  - uid: 156
+    components:
+    - type: Transform
+      pos: 8.250809,11.665936
+      parent: 1
+- proto: RMCPillCanisterInaprovalineNoSkill
+  entities:
+  - uid: 182
+    components:
+    - type: Transform
+      pos: 5.0035696,9.726687
+      parent: 1
+- proto: RMCPlankWood1
+  entities:
+  - uid: 150
+    components:
+    - type: Transform
+      pos: 7.675763,3.6891308
+      parent: 1
+  - uid: 151
+    components:
+    - type: Transform
+      pos: 5.191388,2.8453808
+      parent: 1
+  - uid: 166
+    components:
+    - type: Transform
+      pos: 6.5133314,5.5112615
+      parent: 1
+  - uid: 188
+    components:
+    - type: Transform
+      pos: 7.2937584,11.291071
+      parent: 1
+- proto: RMCPropCommunicationsConsole
+  entities:
+  - uid: 167
+    components:
+    - type: Transform
+      pos: 5.5,9.5
+      parent: 1
+- proto: RMCSecureCaseAmmoMini
+  entities:
+  - uid: 210
+    components:
+    - type: Transform
+      pos: 9.636811,7.151245
+      parent: 1
+- proto: RMCSecureCaseDouble
+  entities:
+  - uid: 121
+    components:
+    - type: Transform
+      pos: 5.491543,3.8440726
+      parent: 1
+- proto: RMCSecureCaseSmall
+  entities:
+  - uid: 152
+    components:
+    - type: Transform
+      pos: 12.548201,3.8453808
+      parent: 1
+- proto: RMCSpawnerCorpseColonist
+  entities:
+  - uid: 26
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+- proto: RMCSpawnerCorpseColonistBust
+  entities:
+  - uid: 231
+    components:
+    - type: Transform
+      pos: 11.5,8.5
+      parent: 1
+- proto: RMCSpawnerCorpseDoctor
+  entities:
+  - uid: 130
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 1
+- proto: RMCSpawnerCorpseEngineer
+  entities:
+  - uid: 126
+    components:
+    - type: Transform
+      pos: 11.5,3.5
+      parent: 1
+  - uid: 245
+    components:
+    - type: Transform
+      pos: 10.5,1.5
+      parent: 1
+- proto: RMCSpawnerIntelFar
+  entities:
+  - uid: 174
+    components:
+    - type: Transform
+      pos: 12.5,11.5
+      parent: 1
+- proto: RMCSpawnerIntelMedium
+  entities:
+  - uid: 173
+    components:
+    - type: Transform
+      pos: 12.5,6.5
+      parent: 1
+  - uid: 178
+    components:
+    - type: Transform
+      pos: 10.5,7.5
+      parent: 1
+  - uid: 193
+    components:
+    - type: Transform
+      pos: 6.5,9.5
+      parent: 1
+- proto: RMCSpawnerIntelScience
+  entities:
+  - uid: 169
+    components:
+    - type: Transform
+      pos: 4.5,9.5
+      parent: 1
+  - uid: 170
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 171
+    components:
+    - type: Transform
+      pos: 11.5,7.5
+      parent: 1
+- proto: RMCStationAlertComputer
+  entities:
+  - uid: 180
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,9.5
+      parent: 1
+- proto: RMCTablePrison
+  entities:
+  - uid: 54
+    components:
+    - type: Transform
+      pos: 5.5,5.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 1
+  - uid: 104
+    components:
+    - type: Transform
+      pos: 6.5,9.5
+      parent: 1
+  - uid: 105
+    components:
+    - type: Transform
+      pos: 5.5,9.5
+      parent: 1
+  - uid: 108
+    components:
+    - type: Transform
+      pos: 4.5,9.5
+      parent: 1
+  - uid: 109
+    components:
+    - type: Transform
+      pos: 4.5,8.5
+      parent: 1
+  - uid: 111
+    components:
+    - type: Transform
+      pos: 12.5,8.5
+      parent: 1
+  - uid: 112
+    components:
+    - type: Transform
+      pos: 12.5,7.5
+      parent: 1
+  - uid: 113
+    components:
+    - type: Transform
+      pos: 12.5,9.5
+      parent: 1
+  - uid: 114
+    components:
+    - type: Transform
+      pos: 10.5,7.5
+      parent: 1
+  - uid: 115
+    components:
+    - type: Transform
+      pos: 11.5,7.5
+      parent: 1
+  - uid: 116
+    components:
+    - type: Transform
+      pos: 11.5,11.5
+      parent: 1
+  - uid: 162
+    components:
+    - type: Transform
+      pos: 12.5,11.5
+      parent: 1
+  - uid: 164
+    components:
+    - type: Transform
+      pos: 7.5,7.5
+      parent: 1
+- proto: RMCTelecomBlackBox
+  entities:
+  - uid: 175
+    components:
+    - type: Transform
+      pos: 10.341456,11.625079
+      parent: 1
+- proto: RMCUnitedNationsCup
+  entities:
+  - uid: 187
+    components:
+    - type: Transform
+      pos: 11.737945,11.507937
+      parent: 1
+- proto: RMCVialBox
+  entities:
+  - uid: 207
+    components:
+    - type: Transform
+      pos: 5.5816946,5.5704374
+      parent: 1
+- proto: RMCWallPropBloodWall
+  entities:
+  - uid: 33
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.592247,4.7171187
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 244
+    components:
+    - type: Transform
+      pos: 5.972641,0.70798016
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 247
+    components:
+    - type: Transform
+      pos: 12.211225,0.68461037
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: RMCWallPropBloodWallAlt
+  entities:
+  - uid: 127
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.722876,4.7610736
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: RMCWaterCooler
+  entities:
+  - uid: 185
+    components:
+    - type: Transform
+      pos: 4.4410696,11.882937
+      parent: 1
+- proto: RMCWaterCoolerStacks
+  entities:
+  - uid: 120
+    components:
+    - type: Transform
+      pos: 4.444668,4.0628223
+      parent: 1
+- proto: RMCWindowFrameColonyReinforced
+  entities:
+  - uid: 32
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      pos: 10.5,0.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      pos: 3.5,8.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      pos: 5.5,12.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      pos: 7.5,12.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      pos: 13.5,10.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      pos: 13.5,1.5
+      parent: 1
+- proto: RMCZippo
+  entities:
+  - uid: 194
+    components:
+    - type: Transform
+      pos: 4.3316946,9.757937
+      parent: 1
+...

--- a/Resources/Maps/_RMC14/Inserts/Varadero/surv_spawn_chapel.yml
+++ b/Resources/Maps/_RMC14/Inserts/Varadero/surv_spawn_chapel.yml
@@ -1,0 +1,897 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 264.0.2
+  forkId: ""
+  forkVersion: ""
+  time: 04/20/2026 02:20:43
+  entityCount: 147
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  0: Space
+  198: CMFloorPlating
+  5: CMFloorSteelShivaPlate
+  1: RMCFloorPlatingDamage1
+  4: RMCFloorPlatingDamage3
+  2: RMCFloorPlatingThermite
+  3: RMCWoodInside
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: grid
+    - type: Transform
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: xgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAAQAAAAAAAAIAAAAAAAABAAAAAAAAxgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMYAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAEAAAAAAAABAAAAAAAABAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADGAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAAEAAAAAAAABAAAAAAAAAMAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxgAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxgAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMYAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes: []
+    - type: GridAtmosphere
+      version: 2
+      data:
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: ImplicitRoof
+- proto: Bedroll
+  entities:
+  - uid: 81
+    components:
+    - type: Transform
+      pos: 5.5,6.5
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 1
+- proto: BedrollFolded
+  entities:
+  - uid: 71
+    components:
+    - type: Transform
+      pos: 4.5,6.5
+      parent: 1
+- proto: CMAirlockMaint
+  entities:
+  - uid: 25
+    components:
+    - type: MetaData
+      name: Underground Maintenance
+    - type: Transform
+      pos: 3.5,8.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: MetaData
+      name: Underground Chapel
+    - type: Transform
+      pos: 8.5,8.5
+      parent: 1
+- proto: CMBloodPack
+  entities:
+  - uid: 135
+    components:
+    - type: Transform
+      pos: 5.810378,7.411272
+      parent: 1
+- proto: CMCarpetPrison
+  entities:
+  - uid: 30
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      pos: 3.5,7.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      pos: 4.5,6.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      pos: 4.5,7.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      pos: 5.5,5.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      pos: 5.5,6.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: 5.5,7.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      pos: 6.5,5.5
+      parent: 1
+  - uid: 60
+    components:
+    - type: Transform
+      pos: 6.5,6.5
+      parent: 1
+  - uid: 61
+    components:
+    - type: Transform
+      pos: 6.5,7.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      pos: 7.5,4.5
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      pos: 7.5,6.5
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      pos: 7.5,7.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      pos: 8.5,3.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      pos: 8.5,4.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      pos: 8.5,6.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      pos: 8.5,7.5
+      parent: 1
+  - uid: 74
+    components:
+    - type: Transform
+      pos: 9.5,2.5
+      parent: 1
+  - uid: 75
+    components:
+    - type: Transform
+      pos: 9.5,3.5
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      pos: 9.5,4.5
+      parent: 1
+  - uid: 77
+    components:
+    - type: Transform
+      pos: 9.5,5.5
+      parent: 1
+  - uid: 78
+    components:
+    - type: Transform
+      pos: 9.5,6.5
+      parent: 1
+  - uid: 79
+    components:
+    - type: Transform
+      pos: 9.5,7.5
+      parent: 1
+  - uid: 80
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 98
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+- proto: CMChairWoodWings
+  entities:
+  - uid: 115
+    components:
+    - type: Transform
+      pos: 8.5,7.5
+      parent: 1
+  - uid: 116
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,2.5
+      parent: 1
+  - uid: 117
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 118
+    components:
+    - type: Transform
+      pos: 6.5,3.5
+      parent: 1
+  - uid: 119
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 120
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,5.5
+      parent: 1
+- proto: CMDoubleDoorGenericGlass
+  entities:
+  - uid: 27
+    components:
+    - type: MetaData
+      name: Underground Chapel
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: MetaData
+      name: Underground Chapel
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,4.5
+      parent: 1
+- proto: CMPaper
+  entities:
+  - uid: 125
+    components:
+    - type: Transform
+      pos: 1.6633801,5.9402695
+      parent: 1
+- proto: CMPottedPlant22
+  entities:
+  - uid: 128
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 129
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 130
+    components:
+    - type: Transform
+      pos: 7.5,7.5
+      parent: 1
+  - uid: 131
+    components:
+    - type: Transform
+      pos: 1.9397812,3.209324
+      parent: 1
+- proto: CMRodMetal1
+  entities:
+  - uid: 63
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 1
+- proto: CMShardGlass
+  entities:
+  - uid: 57
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 1
+- proto: CMSpawnPointSurvivor
+  entities:
+  - uid: 136
+    components:
+    - type: Transform
+      pos: 5.5,5.5
+      parent: 1
+  - uid: 137
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 138
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 139
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 140
+    components:
+    - type: Transform
+      pos: 8.5,7.5
+      parent: 1
+  - uid: 141
+    components:
+    - type: Transform
+      pos: 9.5,5.5
+      parent: 1
+  - uid: 142
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 1
+  - uid: 143
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 1
+  - uid: 144
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 145
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 146
+    components:
+    - type: Transform
+      pos: 8.5,3.5
+      parent: 1
+  - uid: 147
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 1
+- proto: CMTableWooden
+  entities:
+  - uid: 88
+    components:
+    - type: Transform
+      pos: 4.5,7.5
+      parent: 1
+  - uid: 89
+    components:
+    - type: Transform
+      pos: 3.5,7.5
+      parent: 1
+  - uid: 90
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 91
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 108
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 109
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 110
+    components:
+    - type: Transform
+      pos: 5.5,7.5
+      parent: 1
+  - uid: 112
+    components:
+    - type: Transform
+      pos: 6.5,7.5
+      parent: 1
+- proto: CMVentPump
+  entities:
+  - uid: 92
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,5.5
+      parent: 1
+- proto: CMWallMetal
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 3
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 4
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 5
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 6
+    components:
+    - type: Transform
+      pos: 1.5,8.5
+      parent: 1
+  - uid: 7
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      pos: 7.5,8.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      pos: 9.5,8.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+- proto: CMWardrobeBlack
+  entities:
+  - uid: 126
+    components:
+    - type: Transform
+      pos: 9.5,1.5
+      parent: 1
+- proto: CMWindowWhiteColony
+  entities:
+  - uid: 10
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      pos: 6.5,8.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      pos: 5.5,8.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      pos: 4.5,8.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      pos: 9.5,0.5
+      parent: 1
+- proto: RMCBarricadeWood
+  entities:
+  - uid: 62
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,3.5
+      parent: 1
+  - uid: 84
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,6.5
+      parent: 1
+  - uid: 85
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 86
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 87
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,7.5
+      parent: 1
+  - uid: 107
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 114
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,7.5
+      parent: 1
+- proto: RMCBible
+  entities:
+  - uid: 113
+    components:
+    - type: Transform
+      pos: 4.5,7.5
+      parent: 1
+- proto: RMCDirtBandageProp3
+  entities:
+  - uid: 134
+    components:
+    - type: Transform
+      pos: 5.857253,6.145647
+      parent: 1
+- proto: RMCDirtBandageProp6
+  entities:
+  - uid: 133
+    components:
+    - type: Transform
+      pos: 6.044753,6.614397
+      parent: 1
+- proto: RMCDrinkAlcoholVodkaChessBlackBishop
+  entities:
+  - uid: 124
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+- proto: RMCGasPipeBend
+  entities:
+  - uid: 106
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,2.5
+      parent: 1
+- proto: RMCGasPipeStraight
+  entities:
+  - uid: 93
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,5.5
+      parent: 1
+  - uid: 94
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 95
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 96
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 97
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 99
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 100
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 101
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 102
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,2.5
+      parent: 1
+  - uid: 103
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,2.5
+      parent: 1
+  - uid: 104
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,2.5
+      parent: 1
+  - uid: 105
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,2.5
+      parent: 1
+- proto: RMCGasPipeTJunction
+  entities:
+  - uid: 47
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+- proto: RMCGrenadeMolotov
+  entities:
+  - uid: 20
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 111
+    components:
+    - type: Transform
+      pos: 1.706346,6.6537356
+      parent: 1
+- proto: RMCLampCandelabra
+  entities:
+  - uid: 22
+    components:
+    - type: Transform
+      pos: 3.5,7.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      pos: 6.5,7.5
+      parent: 1
+- proto: RMCLightFixtureOffset
+  entities:
+  - uid: 121
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 122
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 123
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,5.5
+      parent: 1
+- proto: RMCMarkerAreaLabel
+  entities:
+  - uid: 28
+    components:
+    - type: MetaData
+      name: Chapel
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+- proto: RMCPlankWood1
+  entities:
+  - uid: 50
+    components:
+    - type: Transform
+      pos: 6.5,1.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 1
+- proto: RMCSpawnerCorpseColonist
+  entities:
+  - uid: 132
+    components:
+    - type: Transform
+      pos: 5.5,6.5
+      parent: 1
+- proto: RMCSpawnerIntelClose
+  entities:
+  - uid: 127
+    components:
+    - type: Transform
+      pos: 9.5,1.5
+      parent: 1
+...

--- a/Resources/Maps/_RMC14/Inserts/Varadero/surv_spawn_dorms.yml
+++ b/Resources/Maps/_RMC14/Inserts/Varadero/surv_spawn_dorms.yml
@@ -1,0 +1,1665 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 264.0.2
+  forkId: ""
+  forkVersion: ""
+  time: 03/05/2026 03:12:53
+  entityCount: 260
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  0: Space
+  198: CMFloorPlating
+  4: CMFloorSteelShivaMultiTile
+  1: CMFloorSteelShivaMultiTile4
+  3: CMFloorSteelShivaPlate
+  8: RMCFloorHybrisaRedCarpetOrange
+  7: RMCFloorHybrisaWood
+  9: RMCFloorPlatingDamage1
+  2: RMCFloorPlatingDamage2
+  5: RMCFloorPlatingDamage3
+  6: RMCFloorPlatingScorched
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: grid
+    - type: Transform
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: xgAAAAAAAMYAAAAAAAABAAAAAAAAAgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAAEAAAAAAAABAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMYAAAAAAAADAAAAAAAAAwAAAAAAAAQAAAAAAAAEAAAAAAAAxgAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAQAAAAAAAAEAAAAAAAAxgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFAAAAAAAAAwAAAAAAAAMAAAAAAAAEAAAAAAAABAAAAAAAAMYAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAAEAAAAAAAABAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxgAAAAAAAAMAAAAAAAADAAAAAAAABAAAAAAAAAQAAAAAAADGAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAABAAAAAAAAAQAAAAAAADGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMYAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAAxgAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAAxgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADGAAAAAAAABwAAAAAAAAgAAAAAAAAIAAAAAAAABwAAAAAAAAYAAAAAAAAHAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAABwAAAAAAAMYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAAAAcAAAAAAAAIAAAAAAAACAAAAAAAAAcAAAAAAAAFAAAAAAAABwAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAcAAAAAAAAFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAHAAAAAAAACAAAAAAAAAgAAAAAAAAHAAAAAAAAxgAAAAAAAAcAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAHAAAAAAAAxgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAMYAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAMYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAAYAAAAAAAAFAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodTrail3
+          decals:
+            14: 7,8
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodTrail4
+          decals:
+            3: 0,7
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodTrail5
+          decals:
+            13: 8,8
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodTrail6
+          decals:
+            1: 1,6
+            9: 7,9
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodTrail7
+          decals:
+            2: 1,7
+            10: 8,9
+        - node:
+            color: '#FFFFFFFF'
+            id: burnt1
+          decals:
+            6: 6,5
+            7: 1,7
+        - node:
+            color: '#FFFFFFFF'
+            id: burnt3
+          decals:
+            5: 6,6
+        - node:
+            color: '#FFFFFFFF'
+            id: burnt4
+          decals:
+            4: 4,5
+    - type: GridAtmosphere
+      version: 2
+      data:
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: ImplicitRoof
+- proto: ActionToggleLight
+  entities:
+  - uid: 77
+    mapInit: true
+    paused: true
+    components:
+    - type: Transform
+      parent: 76
+    - type: Action
+      originalIconColor: '#FFFFFFFF'
+      container: 76
+  - uid: 80
+    mapInit: true
+    paused: true
+    components:
+    - type: Transform
+      parent: 79
+    - type: Action
+      originalIconColor: '#FFFFFFFF'
+      container: 79
+- proto: CigaretteSpent
+  entities:
+  - uid: 165
+    components:
+    - type: Transform
+      pos: 6.7086115,2.7210865
+      parent: 1
+- proto: CMApcNoPower
+  entities:
+  - uid: 239
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,1.5
+      parent: 1
+    - type: SpriteSetRenderOrder
+      offset: -0.7,-0.4
+- proto: CMBarricadeSandbag
+  entities:
+  - uid: 30
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,8.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+- proto: CMBeltMarine
+  entities:
+  - uid: 176
+    components:
+    - type: Transform
+      pos: 9.0211115,7.4085865
+      parent: 1
+- proto: CMBeltMedical
+  entities:
+  - uid: 141
+    components:
+    - type: Transform
+      parent: 140
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: CMChair
+  entities:
+  - uid: 99
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 100
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 136
+    components:
+    - type: Transform
+      pos: 6.5,3.5
+      parent: 1
+  - uid: 146
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,1.5
+      parent: 1
+  - uid: 179
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,5.5
+      parent: 1
+- proto: CMClosetBase
+  entities:
+  - uid: 140
+    components:
+    - type: Transform
+      pos: 10.5,3.5
+      parent: 1
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 141
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: CMDrinkCanBobdaPineapple
+  entities:
+  - uid: 166
+    components:
+    - type: Transform
+      pos: 6.3804865,2.5648365
+      parent: 1
+- proto: CMFilingCabinetChest
+  entities:
+  - uid: 59
+    components:
+    - type: Transform
+      pos: 1.2640419,5.7367115
+      parent: 1
+  - uid: 81
+    components:
+    - type: Transform
+      pos: 3.2896128,9
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      pos: 3.7583628,9
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      pos: 4.717167,7.9242115
+      parent: 1
+  - uid: 84
+    components:
+    - type: Transform
+      pos: 4.701542,7.5023365
+      parent: 1
+  - uid: 137
+    components:
+    - type: Transform
+      pos: 9.314443,4.5335865
+      parent: 1
+  - uid: 138
+    components:
+    - type: Transform
+      pos: 9.814443,4.5335865
+      parent: 1
+  - uid: 139
+    components:
+    - type: Transform
+      pos: 10.7398615,7.9554615
+      parent: 1
+  - uid: 149
+    components:
+    - type: Transform
+      pos: 10.7242365,7.5023365
+      parent: 1
+  - uid: 169
+    components:
+    - type: Transform
+      pos: 9.7711115,8.9085865
+      parent: 1
+- proto: CMGirder
+  entities:
+  - uid: 6
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: 11.5,1.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      pos: 5.5,7.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      pos: 9.5,9.5
+      parent: 1
+- proto: CMLinenBin
+  entities:
+  - uid: 39
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 145
+    components:
+    - type: Transform
+      pos: 10.5,1.5
+      parent: 1
+- proto: CMLockerBase
+  entities:
+  - uid: 71
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+- proto: CMMagazineRifleM4SPR
+  entities:
+  - uid: 111
+    components:
+    - type: Transform
+      pos: 4.336488,1.9388456
+      parent: 1
+  - uid: 162
+    components:
+    - type: Transform
+      pos: 9.4273615,3.3148365
+      parent: 1
+  - uid: 167
+    components:
+    - type: Transform
+      pos: 10.1148615,7.9085865
+      parent: 1
+- proto: CMMagazineRifleM54C
+  entities:
+  - uid: 75
+    components:
+    - type: Transform
+      pos: 2.9458628,5.2669706
+      parent: 1
+  - uid: 147
+    components:
+    - type: Transform
+      pos: 6.7086115,5.8773365
+      parent: 1
+- proto: CMOverheadPipe
+  entities:
+  - uid: 182
+    components:
+    - type: Transform
+      pos: 5.5,7.5
+      parent: 1
+  - uid: 183
+    components:
+    - type: Transform
+      pos: 5.5,6.5
+      parent: 1
+  - uid: 184
+    components:
+    - type: Transform
+      pos: 5.5,5.5
+      parent: 1
+- proto: CMPen
+  entities:
+  - uid: 118
+    components:
+    - type: Transform
+      pos: 2.5687118,4.7200956
+      parent: 1
+- proto: CMRack
+  entities:
+  - uid: 69
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 142
+    components:
+    - type: Transform
+      pos: 9.5,3.5
+      parent: 1
+  - uid: 143
+    components:
+    - type: Transform
+      pos: 8.5,3.5
+      parent: 1
+- proto: CMRandomPosterUN
+  entities:
+  - uid: 220
+    components:
+    - type: Transform
+      pos: 5.5,8.5
+      parent: 1
+  - uid: 221
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 222
+    components:
+    - type: Transform
+      pos: 11.5,7.5
+      parent: 1
+  - uid: 223
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 1
+- proto: CMShardGlass
+  entities:
+  - uid: 7
+    components:
+    - type: Transform
+      pos: 0.4921155,8.732412
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      pos: 4.805238,2.826715
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      pos: 10.7086115,6.5960865
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      pos: 6.522296,9.798033
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      pos: 1.1483655,6.6542873
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      pos: 6.195863,2.357965
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      pos: 3.4458628,0.81109
+      parent: 1
+  - uid: 121
+    components:
+    - type: Transform
+      pos: 0.58433676,2.7824073
+      parent: 1
+  - uid: 122
+    components:
+    - type: Transform
+      pos: 1.5374618,2.0480323
+      parent: 1
+  - uid: 153
+    components:
+    - type: Transform
+      pos: 10.5367365,2.9554615
+      parent: 1
+  - uid: 181
+    components:
+    - type: Transform
+      pos: 8.1148615,9.1742115
+      parent: 1
+- proto: CMShellShotgunBuckshot
+  entities:
+  - uid: 112
+    components:
+    - type: Transform
+      pos: 3.3208628,8.204471
+      parent: 1
+  - uid: 113
+    components:
+    - type: Transform
+      pos: 3.5864878,7.9700956
+      parent: 1
+- proto: CMSpawnPointSurvivor
+  entities:
+  - uid: 249
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 250
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 251
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 252
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 253
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 254
+    components:
+    - type: Transform
+      pos: 7.5,2.5
+      parent: 1
+  - uid: 255
+    components:
+    - type: Transform
+      pos: 7.5,3.5
+      parent: 1
+  - uid: 256
+    components:
+    - type: Transform
+      pos: 7.5,7.5
+      parent: 1
+  - uid: 257
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 1
+  - uid: 258
+    components:
+    - type: Transform
+      pos: 9.5,7.5
+      parent: 1
+  - uid: 259
+    components:
+    - type: Transform
+      pos: 5.5,6.5
+      parent: 1
+  - uid: 260
+    components:
+    - type: Transform
+      pos: 9.5,2.5
+      parent: 1
+- proto: CMTableWooden
+  entities:
+  - uid: 61
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 144
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,2.5
+      parent: 1
+  - uid: 148
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,5.5
+      parent: 1
+- proto: CMTarbackCigarSpent
+  entities:
+  - uid: 164
+    components:
+    - type: Transform
+      pos: 6.8179865,3.0960865
+      parent: 1
+- proto: CMVendorChess
+  entities:
+  - uid: 128
+    components:
+    - type: Transform
+      pos: 6.5,7.5
+      parent: 1
+- proto: CMVentPump
+  entities:
+  - uid: 87
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 127
+    components:
+    - type: Transform
+      pos: 8.5,5.5
+      parent: 1
+- proto: CMWallMetal
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 3
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 4
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 5
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      pos: 0.5,9.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      pos: 3.5,9.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      pos: 4.5,9.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 5.5,9.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      pos: 11.5,7.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      pos: 11.5,3.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      pos: 11.5,5.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      pos: 11.5,0.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      pos: 10.5,0.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      pos: 5.5,8.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      pos: 11.5,9.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      pos: 10.5,9.5
+      parent: 1
+- proto: CMWarningCone
+  entities:
+  - uid: 230
+    components:
+    - type: Transform
+      pos: 6.0309544,6.067163
+      parent: 1
+- proto: CMWindowWhiteColony
+  entities:
+  - uid: 32
+    components:
+    - type: Transform
+      pos: 9.5,0.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: 11.5,4.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: 11.5,8.5
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      pos: 2.5,9.5
+      parent: 1
+- proto: RMCArmorVest
+  entities:
+  - uid: 175
+    components:
+    - type: Transform
+      pos: 7.8023615,4.7523365
+      parent: 1
+- proto: RMCAshtray
+  entities:
+  - uid: 163
+    components:
+    - type: Transform
+      pos: 6.5992365,2.7210865
+      parent: 1
+- proto: RMCBarricadeWireRail
+  entities:
+  - uid: 47
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,3.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,3.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,3.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,3.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,3.5
+      parent: 1
+- proto: RMCBarricadeWood
+  entities:
+  - uid: 51
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 63
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 124
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,9.5
+      parent: 1
+  - uid: 150
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,2.5
+      parent: 1
+  - uid: 151
+    components:
+    - type: Transform
+      pos: 9.5,1.5
+      parent: 1
+  - uid: 173
+    components:
+    - type: Transform
+      pos: 8.5,2.5
+      parent: 1
+  - uid: 174
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,6.5
+      parent: 1
+- proto: RMCBasePropCasing11
+  entities:
+  - uid: 227
+    components:
+    - type: Transform
+      pos: 4.5153294,5.535913
+      parent: 1
+  - uid: 228
+    components:
+    - type: Transform
+      pos: 2.7028294,3.317163
+      parent: 1
+  - uid: 231
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.609079,8.864038
+      parent: 1
+  - uid: 232
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.999704,8.504663
+      parent: 1
+  - uid: 233
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.155954,5.098413
+      parent: 1
+- proto: RMCBasePropCasing4
+  entities:
+  - uid: 226
+    components:
+    - type: Transform
+      pos: 2.9684544,2.082788
+      parent: 1
+- proto: RMCBasePropCasing8
+  entities:
+  - uid: 229
+    components:
+    - type: Transform
+      pos: 7.5465794,8.035913
+      parent: 1
+- proto: RMCBasePropCasing9
+  entities:
+  - uid: 78
+    components:
+    - type: Transform
+      pos: 1.3590794,7.629663
+      parent: 1
+- proto: RMCBedBunkBlue
+  entities:
+  - uid: 54
+    components:
+    - type: Transform
+      pos: 4.5,8.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      pos: 1.5,8.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 60
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 62
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 85
+    components:
+    - type: Transform
+      pos: 4.5,6.5
+      parent: 1
+- proto: RMCBedBunkGreen
+  entities:
+  - uid: 88
+    components:
+    - type: Transform
+      pos: 8.5,4.5
+      parent: 1
+  - uid: 123
+    components:
+    - type: Transform
+      pos: 6.5,8.5
+      parent: 1
+  - uid: 125
+    components:
+    - type: Transform
+      pos: 10.5,8.5
+      parent: 1
+  - uid: 126
+    components:
+    - type: Transform
+      pos: 10.5,6.5
+      parent: 1
+  - uid: 129
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 1
+  - uid: 130
+    components:
+    - type: Transform
+      pos: 10.5,4.5
+      parent: 1
+  - uid: 135
+    components:
+    - type: Transform
+      pos: 8.5,6.5
+      parent: 1
+- proto: RMCBibleHEFA
+  entities:
+  - uid: 115
+    components:
+    - type: Transform
+      pos: 2.5687118,8.595096
+      parent: 1
+- proto: RMCBoonie
+  entities:
+  - uid: 158
+    components:
+    - type: Transform
+      pos: 9.3961115,3.5492115
+      parent: 1
+- proto: RMCCalendarUNMC
+  entities:
+  - uid: 160
+    components:
+    - type: Transform
+      pos: 3.5,9.5
+      parent: 1
+- proto: RMCCoatBomberGrey
+  entities:
+  - uid: 106
+    components:
+    - type: Transform
+      pos: 4.492738,6.4388456
+      parent: 1
+- proto: RMCCurtainRed
+  entities:
+  - uid: 66
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 1
+- proto: RMCDecalSpawnerBloodSplatters
+  entities:
+  - uid: 189
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 1
+  - uid: 190
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 219
+    components:
+    - type: Transform
+      pos: 8.5,8.5
+      parent: 1
+  - uid: 246
+    components:
+    - type: Transform
+      pos: 6.5,8.5
+      parent: 1
+  - uid: 247
+    components:
+    - type: Transform
+      pos: 9.5,6.5
+      parent: 1
+  - uid: 248
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+- proto: RMCDecalSpawnerXenoSplatters
+  entities:
+  - uid: 68
+    components:
+    - type: Transform
+      pos: 8.5,0.5
+      parent: 1
+  - uid: 132
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 133
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 1
+  - uid: 134
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 155
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 1
+  - uid: 188
+    components:
+    - type: Transform
+      pos: 7.5,9.5
+      parent: 1
+- proto: RMCDirtBandageProp2
+  entities:
+  - uid: 237
+    components:
+    - type: Transform
+      pos: 10.02251,2.848413
+      parent: 1
+- proto: RMCDirtBandageProp3
+  entities:
+  - uid: 236
+    components:
+    - type: Transform
+      pos: 8.499704,5.785913
+      parent: 1
+- proto: RMCDirtBandageProp4
+  entities:
+  - uid: 235
+    components:
+    - type: Transform
+      pos: 2.5934544,7.895288
+      parent: 1
+- proto: RMCDrinkAlcoholSake
+  entities:
+  - uid: 101
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.1155868,7.1263456
+      parent: 1
+  - uid: 102
+    components:
+    - type: Transform
+      pos: 2.3187118,4.9700956
+      parent: 1
+- proto: RMCExtendedEmergencyOxygenTankFilled
+  entities:
+  - uid: 157
+    components:
+    - type: Transform
+      pos: 9.6148615,3.5335865
+      parent: 1
+- proto: RMCGasPipeStraight
+  entities:
+  - uid: 89
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 90
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 91
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 92
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 93
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 94
+    components:
+    - type: Transform
+      pos: 8.5,4.5
+      parent: 1
+  - uid: 95
+    components:
+    - type: Transform
+      pos: 8.5,3.5
+      parent: 1
+  - uid: 96
+    components:
+    - type: Transform
+      pos: 8.5,2.5
+      parent: 1
+  - uid: 97
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 1
+  - uid: 98
+    components:
+    - type: Transform
+      pos: 8.5,0.5
+      parent: 1
+- proto: RMCHardHat
+  entities:
+  - uid: 76
+    components:
+    - type: Transform
+      pos: 4.6715794,2.457788
+      parent: 1
+    - type: HandheldLight
+      toggleActionEntity: 77
+    - type: ContainerContainer
+      containers:
+        storagebase: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+        actions: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 77
+    - type: ActionsContainer
+- proto: RMCHardhatRed
+  entities:
+  - uid: 79
+    components:
+    - type: Transform
+      pos: 4.3590794,2.598413
+      parent: 1
+    - type: HandheldLight
+      toggleActionEntity: 80
+    - type: ContainerContainer
+      containers:
+        storagebase: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+        actions: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 80
+    - type: ActionsContainer
+- proto: RMCHeadCapPatrol
+  entities:
+  - uid: 109
+    components:
+    - type: Transform
+      pos: 2.5864878,5.7513456
+      parent: 1
+- proto: RMCHelmetGarbRosary
+  entities:
+  - uid: 86
+    components:
+    - type: Transform
+      pos: 1.5396128,4.4857206
+      parent: 1
+- proto: RMCJacketWindbreakerGrey
+  entities:
+  - uid: 186
+    components:
+    - type: Transform
+      pos: 10.6304865,8.3773365
+      parent: 1
+- proto: RMCLightFixtureOffset
+  entities:
+  - uid: 180
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 240
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,3.5
+      parent: 1
+  - uid: 241
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 242
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,5.5
+      parent: 1
+  - uid: 243
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,8.5
+      parent: 1
+  - uid: 244
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,8.5
+      parent: 1
+- proto: RMCMagazineBootsN131
+  entities:
+  - uid: 108
+    components:
+    - type: Transform
+      pos: 4.648988,4.5169706
+      parent: 1
+- proto: RMCMarkerAreaLabel
+  entities:
+  - uid: 238
+    components:
+    - type: MetaData
+      name: Dorms
+    - type: Transform
+      pos: 5.5,5.5
+      parent: 1
+- proto: RMCMarshalCMBUniform
+  entities:
+  - uid: 74
+    components:
+    - type: Transform
+      pos: 1.4927378,1.5638456
+      parent: 1
+- proto: RMCMaskBalaclava
+  entities:
+  - uid: 185
+    components:
+    - type: Transform
+      pos: 6.4898615,4.4398365
+      parent: 1
+- proto: RMCMaskScarfGray
+  entities:
+  - uid: 159
+    components:
+    - type: Transform
+      pos: 10.4586115,1.4710865
+      parent: 1
+- proto: RMCMREWeYa
+  entities:
+  - uid: 103
+    components:
+    - type: Transform
+      pos: 9.452829,4.832788
+      parent: 1
+  - uid: 234
+    components:
+    - type: Transform
+      pos: 2.4059544,4.520288
+      parent: 1
+- proto: RMCOverheadLatticeHorizontal12
+  entities:
+  - uid: 191
+    components:
+    - type: Transform
+      pos: 1.5,8.5
+      parent: 1
+  - uid: 192
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 193
+    components:
+    - type: Transform
+      pos: 3.5,8.5
+      parent: 1
+  - uid: 194
+    components:
+    - type: Transform
+      pos: 4.5,8.5
+      parent: 1
+  - uid: 195
+    components:
+    - type: Transform
+      pos: 6.5,8.5
+      parent: 1
+  - uid: 196
+    components:
+    - type: Transform
+      pos: 7.5,8.5
+      parent: 1
+  - uid: 197
+    components:
+    - type: Transform
+      pos: 8.5,8.5
+      parent: 1
+  - uid: 198
+    components:
+    - type: Transform
+      pos: 9.5,8.5
+      parent: 1
+  - uid: 199
+    components:
+    - type: Transform
+      pos: 10.5,8.5
+      parent: 1
+  - uid: 200
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 201
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 202
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 203
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 204
+    components:
+    - type: Transform
+      pos: 6.5,1.5
+      parent: 1
+  - uid: 205
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 1
+  - uid: 206
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 1
+  - uid: 207
+    components:
+    - type: Transform
+      pos: 9.5,1.5
+      parent: 1
+  - uid: 208
+    components:
+    - type: Transform
+      pos: 10.5,1.5
+      parent: 1
+  - uid: 209
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 210
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 211
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 212
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 213
+    components:
+    - type: Transform
+      pos: 5.5,5.5
+      parent: 1
+  - uid: 214
+    components:
+    - type: Transform
+      pos: 6.5,5.5
+      parent: 1
+  - uid: 215
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 1
+  - uid: 216
+    components:
+    - type: Transform
+      pos: 8.5,5.5
+      parent: 1
+  - uid: 217
+    components:
+    - type: Transform
+      pos: 9.5,5.5
+      parent: 1
+  - uid: 218
+    components:
+    - type: Transform
+      pos: 10.5,5.5
+      parent: 1
+- proto: RMCPersonalDesktop
+  entities:
+  - uid: 178
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5054865,5.6585865
+      parent: 1
+- proto: RMCPillCanisterBicaridineNoSkill
+  entities:
+  - uid: 107
+    components:
+    - type: Transform
+      pos: 3.7114878,9.188846
+      parent: 1
+- proto: RMCPillCanisterInaprovalineNoSkill
+  entities:
+  - uid: 177
+    components:
+    - type: Transform
+      pos: 10.7554865,5.5335865
+      parent: 1
+- proto: RMCPillCanisterKelotaneNoSkill
+  entities:
+  - uid: 104
+    components:
+    - type: Transform
+      pos: 1.2583628,6.0794706
+      parent: 1
+- proto: RMCPlankWood1
+  entities:
+  - uid: 131
+    components:
+    - type: Transform
+      pos: 2.3858495,1.3917823
+      parent: 1
+  - uid: 154
+    components:
+    - type: Transform
+      pos: 8.0054865,1.2835865
+      parent: 1
+- proto: RMCPlushieSharkBlue
+  entities:
+  - uid: 105
+    components:
+    - type: Transform
+      pos: 4.461488,8.766971
+      parent: 1
+- proto: RMCSpawnerCorpseColonist
+  entities:
+  - uid: 187
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 1
+- proto: RMCSpawnerCorpseColonistBust
+  entities:
+  - uid: 119
+    components:
+    - type: Transform
+      pos: 1.5,8.5
+      parent: 1
+- proto: RMCSpawnerIntelMedium
+  entities:
+  - uid: 116
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 117
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 168
+    components:
+    - type: Transform
+      pos: 3.5,8.5
+      parent: 1
+  - uid: 170
+    components:
+    - type: Transform
+      pos: 9.5,8.5
+      parent: 1
+  - uid: 171
+    components:
+    - type: Transform
+      pos: 10.5,7.5
+      parent: 1
+  - uid: 172
+    components:
+    - type: Transform
+      pos: 6.5,1.5
+      parent: 1
+- proto: RMCSpawnerRandomAttachment
+  entities:
+  - uid: 156
+    components:
+    - type: Transform
+      pos: 8.5,3.5
+      parent: 1
+- proto: RMCStreamerPole
+  entities:
+  - uid: 224
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,1.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 225
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,1.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: RMCWallPropBloodWallAlt
+  entities:
+  - uid: 120
+    components:
+    - type: Transform
+      pos: 1.6780868,9.532408
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: RMCWeaponRifleM54C
+  entities:
+  - uid: 114
+    components:
+    - type: Transform
+      pos: 1.9146128,2.9075956
+      parent: 1
+  - uid: 161
+    components:
+    - type: Transform
+      pos: 7.0992365,6.6273365
+      parent: 1
+- proto: RMCWindowFrameColony
+  entities:
+  - uid: 31
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 11.5,6.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      pos: 6.5,9.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 152
+    components:
+    - type: Transform
+      pos: 11.5,2.5
+      parent: 1
+- proto: RMCWoodClock
+  entities:
+  - uid: 245
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,3.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: WeaponRifleM4SPRFilled
+  entities:
+  - uid: 110
+    components:
+    - type: Transform
+      pos: 1.8052378,7.5325956
+      parent: 1
+...

--- a/Resources/Maps/_RMC14/Inserts/Varadero/surv_spawn_engineering.yml
+++ b/Resources/Maps/_RMC14/Inserts/Varadero/surv_spawn_engineering.yml
@@ -1,0 +1,827 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 264.0.2
+  forkId: ""
+  forkVersion: ""
+  time: 04/20/2026 02:38:09
+  entityCount: 120
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  0: Space
+  198: CMFloorPlating
+  4: CMFloorSteelShivaMultiTile
+  1: CMFloorSteelShivaPlate
+  5: CMFloorSteelShivaYellow0
+  3: CMFloorSteelShivaYellow1
+  7: CMFloorSteelShivaYellow2
+  6: CMFloorSteelShivaYellow3
+  2: CMFloorSteelShivaYellowFull3
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: grid
+    - type: Transform
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: xgAAAAAAAMYAAAAAAADGAAAAAAAAAQAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMYAAAAAAAACAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAgAAAAAAAMYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMYAAAAAAAACAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAAAgAAAAAAAMYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAAEAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADGAAAAAAAAAgAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAACAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxgAAAAAAAAYAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABwAAAAAAAMYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMYAAAAAAAAGAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAcAAAAAAADGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADGAAAAAAAAAgAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAACAAAAAAAAxgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxgAAAAAAAMYAAAAAAADGAAAAAAAAxgAAAAAAAAEAAAAAAADGAAAAAAAAxgAAAAAAAMYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            cleanable: True
+            color: '#FFFFFFFF'
+            id: Dirt
+          decals:
+            6: 2,1
+            7: 1,1
+            8: 2,2
+            9: 4,3
+            10: 4,4
+            11: 7,9
+            12: 8,9
+            13: 8,8
+            14: 7,8
+            19: 7,1
+            20: 8,1
+            21: 8,2
+            22: 3,8
+            23: 3,9
+            24: 4,9
+            25: 5,9
+            26: 8,7
+            27: 6,7
+            28: 5,6
+            29: 5,7
+            30: 4,6
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtHeavyMonotile
+          decals:
+            15: 8,6
+            16: 1,4
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtLight
+          decals:
+            18: 6,9
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtMedium
+          decals:
+            17: 6,1
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodTrail1
+          decals:
+            3: 3,0
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodTrail3
+          decals:
+            1: 4,1
+        - node:
+            color: '#FFFFFFFF'
+            id: RMCDecalBloodTrail8
+          decals:
+            2: 3,1
+    - type: GridAtmosphere
+      version: 2
+      data:
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: ImplicitRoof
+- proto: Bedroll
+  entities:
+  - uid: 85
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 86
+    components:
+    - type: Transform
+      pos: 3.5,7.5
+      parent: 1
+  - uid: 92
+    components:
+    - type: Transform
+      pos: 7.5,4.5
+      parent: 1
+  - uid: 94
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 1
+- proto: CMAirlockEngineerLocked
+  entities:
+  - uid: 43
+    components:
+    - type: MetaData
+      name: Underground Engineering Locker Room
+    - type: Transform
+      pos: 6.5,10.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: MetaData
+      name: Underground Engineering Locker Room
+    - type: Transform
+      pos: 5.5,5.5
+      parent: 1
+- proto: CMAirlockMaint
+  entities:
+  - uid: 38
+    components:
+    - type: MetaData
+      name: Underground Maintenance
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+- proto: CMApcNoPower
+  entities:
+  - uid: 65
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,9.5
+      parent: 1
+    - type: SpriteSetRenderOrder
+      offset: -0.5,-1.5
+- proto: CMClosetRadiationFilled
+  entities:
+  - uid: 80
+    components:
+    - type: Transform
+      pos: 3.5,9.5
+      parent: 1
+- proto: CMDoubleDoorGenericGlass
+  entities:
+  - uid: 39
+    components:
+    - type: MetaData
+      name: Underground Power Substation
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 40
+    components:
+    - type: MetaData
+      name: Underground Power Substation
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: MetaData
+      name: Underground Power Substation
+    - type: Transform
+      pos: 9.5,3.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: MetaData
+      name: Underground Power Substation
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,2.5
+      parent: 1
+- proto: CMLockerEngineer
+  entities:
+  - uid: 71
+    components:
+    - type: Transform
+      pos: 8.5,9.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      pos: 7.5,9.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      pos: 8.5,8.5
+      parent: 1
+- proto: CMPaper
+  entities:
+  - uid: 107
+    components:
+    - type: Transform
+      pos: 3.3269753,6.9341407
+      parent: 1
+- proto: CMPottedPlant22
+  entities:
+  - uid: 81
+    components:
+    - type: Transform
+      pos: 2.2495089,4.5787926
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      pos: 2.7026339,4.4850426
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      pos: 3.0776339,4.7350426
+      parent: 1
+  - uid: 84
+    components:
+    - type: Transform
+      pos: 8.095752,4.7506676
+      parent: 1
+- proto: CMRack
+  entities:
+  - uid: 76
+    components:
+    - type: Transform
+      pos: 5.5,9.5
+      parent: 1
+  - uid: 77
+    components:
+    - type: Transform
+      pos: 4.5,9.5
+      parent: 1
+- proto: CMSpawnPointSurvivor
+  entities:
+  - uid: 108
+    components:
+    - type: Transform
+      pos: 5.5,8.5
+      parent: 1
+  - uid: 109
+    components:
+    - type: Transform
+      pos: 5.5,7.5
+      parent: 1
+  - uid: 110
+    components:
+    - type: Transform
+      pos: 6.5,7.5
+      parent: 1
+  - uid: 111
+    components:
+    - type: Transform
+      pos: 6.5,8.5
+      parent: 1
+  - uid: 112
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 113
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 114
+    components:
+    - type: Transform
+      pos: 6.5,3.5
+      parent: 1
+  - uid: 115
+    components:
+    - type: Transform
+      pos: 6.5,2.5
+      parent: 1
+  - uid: 116
+    components:
+    - type: Transform
+      pos: 3.5,7.5
+      parent: 1
+  - uid: 117
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 118
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 1
+  - uid: 119
+    components:
+    - type: Transform
+      pos: 8.5,3.5
+      parent: 1
+- proto: CMVentPump
+  entities:
+  - uid: 46
+    components:
+    - type: Transform
+      pos: 5.5,8.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+- proto: CMWallReinforced
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 3
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 4
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 5
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 1
+  - uid: 6
+    components:
+    - type: Transform
+      pos: 8.5,0.5
+      parent: 1
+  - uid: 7
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      pos: 9.5,0.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      pos: 9.5,5.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      pos: 8.5,5.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      pos: 9.5,7.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 9.5,8.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      pos: 9.5,10.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      pos: 9.5,9.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      pos: 3.5,10.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      pos: 2.5,9.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+- proto: CMWindowWhiteColonyReinforced
+  entities:
+  - uid: 25
+    components:
+    - type: Transform
+      pos: 4.5,10.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      pos: 5.5,10.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      pos: 7.5,10.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      pos: 8.5,10.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      pos: 6.5,5.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: 9.5,4.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      pos: 9.5,1.5
+      parent: 1
+- proto: FoodPacketChocolateTrash
+  entities:
+  - uid: 103
+    components:
+    - type: Transform
+      pos: 3.6223044,8.679695
+      parent: 1
+- proto: RMCBarricadeWood
+  entities:
+  - uid: 87
+    components:
+    - type: Transform
+      pos: 8.5,7.5
+      parent: 1
+  - uid: 88
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 89
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,4.5
+      parent: 1
+  - uid: 90
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,3.5
+      parent: 1
+  - uid: 100
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 101
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 102
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,4.5
+      parent: 1
+- proto: RMCDecalSpawnerBloodSplatters
+  entities:
+  - uid: 95
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 96
+    components:
+    - type: Transform
+      pos: 6.5,3.5
+      parent: 1
+- proto: RMCDecalSpawnerXenoSplatters
+  entities:
+  - uid: 97
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 98
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 99
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+- proto: RMCFoodPacketBoonieTrash
+  entities:
+  - uid: 106
+    components:
+    - type: Transform
+      pos: 7.7332253,8.902891
+      parent: 1
+- proto: RMCFoodPacketBurritoTrash
+  entities:
+  - uid: 120
+    components:
+    - type: Transform
+      pos: 6.8815193,7.9241595
+      parent: 1
+- proto: RMCFoodPacketCheeseburgerTrash
+  entities:
+  - uid: 104
+    components:
+    - type: Transform
+      pos: 4.7687964,4.5874805
+      parent: 1
+- proto: RMCFoodPacketEATBarTrash
+  entities:
+  - uid: 105
+    components:
+    - type: Transform
+      pos: 3.8738503,6.7778907
+      parent: 1
+- proto: RMCGasPipeFourway
+  entities:
+  - uid: 62
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 1
+- proto: RMCGasPipeStraight
+  entities:
+  - uid: 48
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,7.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,6.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,5.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,4.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,2.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,2.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,2.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,2.5
+      parent: 1
+  - uid: 60
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 61
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,2.5
+      parent: 1
+- proto: RMCGasPipeTJunction
+  entities:
+  - uid: 63
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,2.5
+      parent: 1
+- proto: RMCLightFixtureOffset
+  entities:
+  - uid: 66
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,4.5
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,8.5
+      parent: 1
+- proto: RMCPlankWood1
+  entities:
+  - uid: 45
+    components:
+    - type: Transform
+      pos: 7.5,6.5
+      parent: 1
+- proto: RMCSpawnerCorpseEngineer
+  entities:
+  - uid: 93
+    components:
+    - type: Transform
+      pos: 7.5,4.5
+      parent: 1
+- proto: RMCSpawnerIntelClose
+  entities:
+  - uid: 74
+    components:
+    - type: Transform
+      pos: 7.5,9.5
+      parent: 1
+  - uid: 75
+    components:
+    - type: Transform
+      pos: 8.5,8.5
+      parent: 1
+- proto: RMCToolboxElectricalFilled
+  entities:
+  - uid: 78
+    components:
+    - type: Transform
+      pos: 4.5,9.5
+      parent: 1
+- proto: RMCToolboxMechanical
+  entities:
+  - uid: 79
+    components:
+    - type: Transform
+      pos: 5.5,9.5
+      parent: 1
+- proto: RMCWallPropBloodWallAlt
+  entities:
+  - uid: 91
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,5.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+...

--- a/Resources/Maps/_RMC14/Inserts/Varadero/varadero_alt_hospital.yml
+++ b/Resources/Maps/_RMC14/Inserts/Varadero/varadero_alt_hospital.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 264.0.2
   forkId: ""
   forkVersion: ""
-  time: 02/11/2026 23:28:53
-  entityCount: 563
+  time: 04/20/2026 03:10:03
+  entityCount: 562
 maps: []
 grids:
 - 1
@@ -794,13 +794,6 @@ entities:
     components:
     - type: Transform
       pos: 23.645504,12.51382
-      parent: 1
-- proto: CMSpawnPointSurvivor
-  entities:
-  - uid: 520
-    components:
-    - type: Transform
-      pos: 4.5,13.5
       parent: 1
 - proto: CMStampApproved
   entities:
@@ -1958,6 +1951,8 @@ entities:
     - type: Transform
       pos: 9.5,15.5
       parent: 1
+    - type: HideLayerClothing
+      slots: null
 - proto: RMCArmorVest
   entities:
   - uid: 345

--- a/Resources/Maps/_RMC14/Inserts/Varadero/varadero_resturant.yml
+++ b/Resources/Maps/_RMC14/Inserts/Varadero/varadero_resturant.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 264.0.2
   forkId: ""
   forkVersion: ""
-  time: 02/11/2026 23:28:01
-  entityCount: 166
+  time: 04/20/2026 03:10:39
+  entityCount: 165
 maps: []
 grids:
 - 1
@@ -398,13 +398,6 @@ entities:
     components:
     - type: Transform
       pos: 2.5436602,9.166679
-      parent: 1
-- proto: CMSpawnPointSurvivor
-  entities:
-  - uid: 165
-    components:
-    - type: Transform
-      pos: 2.5,4.5
       parent: 1
 - proto: CMTableAlmayer
   entities:

--- a/Resources/Prototypes/_RMC14/Entities/Markers/Inserts/varadero.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Markers/Inserts/varadero.yml
@@ -59,3 +59,39 @@
     variations:
     - spawn: "/Maps/_RMC14/Inserts/Varadero/engi_hold.yml"
       probability: 0.33
+
+
+# Survivor Scenario Inserts
+- type: entity
+  abstract: true
+  parent: RMCMapInsertVaraderoBase
+  id: RMCMapInsertVaraderoBaseScenario
+  suffix: Insert Varadero
+  components:
+  - type: MapInsert
+    replaceAreas: false
+
+# Regular Surv Spawns
+- type: entity
+  parent: RMCMapInsertVaraderoBaseScenario
+  id: RMCMapInsertVaraderoSurvSpawnTogether
+  name: Together Surv Spawn
+  suffix: Insert Varadero
+  components:
+  - type: MapInsert
+    variations:
+    - spawn: "/Maps/_RMC14/Inserts/Varadero/surv_spawn_dorms.yml"
+      probability: 0.25
+      nightmareScenario: none
+    - spawn: "/Maps/_RMC14/Inserts/Varadero/surv_spawn_admin.yml"
+      probability: 0.25
+      nightmareScenario: none
+      offset: -27,6
+    - spawn: "/Maps/_RMC14/Inserts/Varadero/surv_spawn_engineering.yml"
+      probability: 0.25
+      nightmareScenario: none
+      offset: 16,33
+    - spawn: "/Maps/_RMC14/Inserts/Varadero/surv_spawn_chapel.yml"
+      probability: 0.25
+      nightmareScenario: none
+      offset: -42,38

--- a/Resources/Prototypes/_RMC14/Entities/rmc_planets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/rmc_planets.yml
@@ -364,6 +364,9 @@
       Telecommunications Array: Repairs required
 
       No further information available at this time."
+    nightmareScenarios: # 100% chance of regular survivors, reduce to 0.9 once CLF survs are in
+    - scenarioName: none
+      scenarioProbability: 1
     survivorJobs:
     - RMCSurvivorCommandingOfficer: 1
     - CMSurvivor: -1


### PR DESCRIPTION
## About the PR
Added survivor spawn togethers to varadero with help from Sharksnake
Change cargo comms to be further south

## Why / Balance
Comms change is Parity and was approved by Cro.
Survivor spawn togethers are a part of the survivor rework.

## Media
Survivor spawn togethers
<img width="924" height="793" alt="image" src="https://github.com/user-attachments/assets/978453c5-72f8-4808-b60e-d30b96fc8d9b" />

Chapel
<img width="467" height="411" alt="Screenshot 2026-04-20 041832" src="https://github.com/user-attachments/assets/8ba82db6-83ef-406e-94be-941a42c38a0a" />

Engineering
<img width="468" height="521" alt="Screenshot 2026-04-20 041950" src="https://github.com/user-attachments/assets/e5e99a68-0bbc-4175-bb69-dc899727870d" />

Dorms by Sharksnake
<img width="559" height="485" alt="Screenshot 2026-04-20 041721" src="https://github.com/user-attachments/assets/a6f25e7b-26aa-4eaa-9efa-0075d2f11d1f" />

Admin by Sharksnake
<img width="673" height="643" alt="Screenshot 2026-04-20 041914" src="https://github.com/user-attachments/assets/3631c6fd-7b1d-49d5-ba2b-5652ac821d9b" />

Parity comms change
<img width="465" height="805" alt="image" src="https://github.com/user-attachments/assets/635e2f8e-2fc9-4b5c-849a-c41aa75753d4" />

<img width="462" height="421" alt="Screenshot 2026-04-20 042033" src="https://github.com/user-attachments/assets/033d3b2c-6b83-4c1f-8647-9752d71f60bb" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: CatAndHats
- add: Added survivor spawn together inserts to New Varadero, with help from SharkSnake88
- tweak: New Varadero Cargo Comms is now further south to make it harder to hold
