### PR TITLE
Gun loot spawner fixes

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Markers/Spawners/Random/guns.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Markers/Spawners/Random/guns.yml
@@ -293,9 +293,10 @@
     - RMCWeaponMar50LMG: RMCMagazineMar50LMG
     - WeaponShotgunCustomBuilt: RMCSpawnerRandomShotgunBoxes
     - RMCWeaponLauncherDisposable: RMCSpawnerRandomRocketsDisposable
-    - RMCWeaponRifleM54C: CMMagazineRifleM54C
+    - RMCWeaponFlamer: RMCTankFlamer
     - WeaponShotgunM890: RMCSpawnerRandomShotgunBoxes
     - RMCWeaponLauncherM85A1: RMCSpawnerRandomGrenadePackets
+    - RMCMK80: CMMagazinePistolMK80
 
 - type: entity
   parent: RMCSpawnerRandomGunSpecial
@@ -417,7 +418,7 @@
     - RMCPacketGrenadeIncendiaryFilled
     - RMCPacketGrenadeSmokeFilled
     # TODO Foam grenade packet
-    - RMCPacketGrenadeWhitePhosphorusCompound
+    - RMCPacketGrenadeWhitePhosphorusCompoundFilled
     # TODO phosphorus grenades packet SPP
     - CMPacketGrenadeFragOldFilled
     - RMCPacketGrenadeM74AGMFFilled


### PR DESCRIPTION
## About the PR
Random grenade packet spawner now correctly spawns full WP nade packets instead of empty ones

Special gun loot spawner now spawns MK80s and M34 incinerator units, no longer spawns M54Cs


## Why / Balance
Parity
<img width="611" height="233" alt="obraz" src="https://github.com/user-attachments/assets/1ae1d587-225a-48d2-a6a9-000e11aa2bca" />


## Technical details
yaml

## Media

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: Special gun loot spawner no longer spawns M54C's
- tweak: Special gun loot spawner now spawns M34 incinerator units and MK80 pistols
- fix: Fixed random grenade packet spawner spawning empty WP nade packets instead of full packets