### PR TITLE
fix: upgraded burn and trauma kit stacks

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Medical/healing.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Medical/healing.yml
@@ -407,6 +407,8 @@
     noneOtherPopup: cm-burn-kit-none-other-popup
     noWoundsOnUserPopup: cm-burns-already-treated-self-popup
     noWoundsOnTargetPopup: cm-burns-already-treated-target-popup
+  - type: Stack
+    stackType: CMUpgradedBurnKit
 
 - type: entity
   id: CMUpgradedBurnKit1
@@ -433,6 +435,7 @@
 
 - type: entity
   parent: CMTraumaKit
+  abstract: true
   id: CMUpgradedTraumaKit
   name: upgraded trauma kit
   description: An upgraded trauma treatment kit. Three times as effective as standard-issue, and non-replenishable. Use sparingly on only the most critical wounds.
@@ -447,6 +450,8 @@
     damage: -36
     unskilledDamage: -9
     canUseUnskilled: true
+  - type: Stack
+    stackType: CMUpgradedTraumaKit
 
 - type: entity
   id: CMUpgradedTraumaKit1

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -1487,3 +1487,6 @@ RMCMagazineSMGP90: RMCMagazineSMGPDW90
 # 2026-03-18
 CMWebbingSurgicalGreen: RMCWebbingSurgicalGreen
 CMWebbingSurgicalBlue: RMCWebbingSurgicalBlue
+
+# 2026-03-21
+CMUpgradedTraumaKit: CMUpgradedTraumaKit10


### PR DESCRIPTION
## About the PR

this pr fixes the stacking of the upgraded burn and trauma kits

## Why / Balance

issue reported on discord

## Technical details

they used the stacking of the normal kits before. so depending on how you split and stack em you could turn normal kits into upgraded ones and vice versa.

## Media

before:

https://github.com/user-attachments/assets/cd891464-46d1-4e34-a9e2-cfd206db29ff


after:

https://github.com/user-attachments/assets/d99cfacd-4c99-4539-9941-a26b9cf2aa80



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- fix: Unstacking upgraded burn and trauma kits no longer turns them into normal ones.
