### PR TITLE
Additional Kutjevto Alt LZ1 Insert turrets

### DIFF
--- a/Resources/Maps/_RMC14/Inserts/Kutjevo/lz1alternative.yml
+++ b/Resources/Maps/_RMC14/Inserts/Kutjevo/lz1alternative.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 264.0.2
   forkId: ""
   forkVersion: ""
-  time: 04/21/2026 15:23:44
-  entityCount: 1094
+  time: 04/21/2026 15:45:41
+  entityCount: 1098
 maps: []
 grids:
 - 1
@@ -4918,2987 +4918,3007 @@ entities:
   - uid: 501
     components:
     - type: Transform
-      pos: 8.5,31.5
-      parent: 1
-  - uid: 1090
-    components:
-    - type: Transform
       pos: 15.5,43.5
       parent: 1
-  - uid: 1091
-    components:
-    - type: Transform
-      pos: 8.5,23.5
-      parent: 1
-  - uid: 1092
-    components:
-    - type: Transform
-      pos: 27.5,18.5
-      parent: 1
-  - uid: 1093
-    components:
-    - type: Transform
-      pos: 28.5,28.5
-      parent: 1
-  - uid: 1094
-    components:
-    - type: Transform
-      pos: 28.5,34.5
-      parent: 1
-- proto: RMCWallKutjevoHull
-  entities:
   - uid: 502
     components:
     - type: Transform
-      pos: 7.5,46.5
+      pos: 9.5,18.5
       parent: 1
   - uid: 503
     components:
     - type: Transform
-      pos: 14.5,49.5
+      pos: 31.5,39.5
       parent: 1
   - uid: 504
     components:
     - type: Transform
-      pos: 14.5,48.5
+      pos: 28.5,28.5
       parent: 1
   - uid: 505
     components:
     - type: Transform
-      pos: 13.5,48.5
+      pos: 28.5,34.5
       parent: 1
+  - uid: 1094
+    components:
+    - type: Transform
+      pos: 28.5,18.5
+      parent: 1
+  - uid: 1095
+    components:
+    - type: Transform
+      pos: 17.5,18.5
+      parent: 1
+  - uid: 1096
+    components:
+    - type: Transform
+      pos: 8.5,24.5
+      parent: 1
+  - uid: 1097
+    components:
+    - type: Transform
+      pos: 8.5,30.5
+      parent: 1
+  - uid: 1098
+    components:
+    - type: Transform
+      pos: 32.5,23.5
+      parent: 1
+- proto: RMCWallKutjevoHull
+  entities:
   - uid: 506
     components:
     - type: Transform
-      pos: 12.5,48.5
+      pos: 7.5,46.5
       parent: 1
   - uid: 507
     components:
     - type: Transform
-      pos: 11.5,48.5
+      pos: 14.5,49.5
       parent: 1
   - uid: 508
     components:
     - type: Transform
-      pos: 10.5,48.5
+      pos: 14.5,48.5
       parent: 1
   - uid: 509
     components:
     - type: Transform
-      pos: 9.5,48.5
+      pos: 13.5,48.5
       parent: 1
   - uid: 510
     components:
     - type: Transform
-      pos: 8.5,48.5
+      pos: 12.5,48.5
       parent: 1
   - uid: 511
     components:
     - type: Transform
-      pos: 7.5,48.5
+      pos: 11.5,48.5
       parent: 1
   - uid: 512
     components:
     - type: Transform
-      pos: 7.5,45.5
+      pos: 10.5,48.5
       parent: 1
   - uid: 513
     components:
     - type: Transform
-      pos: 7.5,44.5
+      pos: 9.5,48.5
       parent: 1
   - uid: 514
     components:
     - type: Transform
-      pos: 7.5,43.5
+      pos: 8.5,48.5
       parent: 1
   - uid: 515
     components:
     - type: Transform
-      pos: 7.5,42.5
+      pos: 7.5,48.5
       parent: 1
   - uid: 516
     components:
     - type: Transform
-      pos: 7.5,41.5
+      pos: 7.5,45.5
       parent: 1
   - uid: 517
     components:
     - type: Transform
-      pos: 7.5,40.5
+      pos: 7.5,44.5
       parent: 1
   - uid: 518
     components:
     - type: Transform
-      pos: 7.5,39.5
+      pos: 7.5,43.5
       parent: 1
   - uid: 519
     components:
     - type: Transform
-      pos: 7.5,38.5
+      pos: 7.5,42.5
       parent: 1
   - uid: 520
     components:
     - type: Transform
-      pos: 7.5,37.5
+      pos: 7.5,41.5
       parent: 1
   - uid: 521
     components:
     - type: Transform
-      pos: 7.5,36.5
+      pos: 7.5,40.5
       parent: 1
   - uid: 522
     components:
     - type: Transform
-      pos: 7.5,35.5
+      pos: 7.5,39.5
       parent: 1
   - uid: 523
     components:
     - type: Transform
-      pos: 7.5,34.5
+      pos: 7.5,38.5
       parent: 1
   - uid: 524
     components:
     - type: Transform
-      pos: 7.5,33.5
+      pos: 7.5,37.5
       parent: 1
   - uid: 525
     components:
     - type: Transform
-      pos: 7.5,32.5
+      pos: 7.5,36.5
       parent: 1
   - uid: 526
     components:
     - type: Transform
-      pos: 7.5,47.5
+      pos: 7.5,35.5
       parent: 1
   - uid: 527
     components:
     - type: Transform
-      pos: 7.5,23.5
+      pos: 7.5,34.5
       parent: 1
   - uid: 528
     components:
     - type: Transform
-      pos: 7.5,22.5
+      pos: 7.5,33.5
       parent: 1
   - uid: 529
     components:
     - type: Transform
-      pos: 7.5,21.5
+      pos: 7.5,32.5
       parent: 1
   - uid: 530
     components:
     - type: Transform
-      pos: 7.5,20.5
+      pos: 7.5,47.5
       parent: 1
   - uid: 531
     components:
     - type: Transform
-      pos: 7.5,19.5
+      pos: 7.5,23.5
       parent: 1
   - uid: 532
     components:
     - type: Transform
-      pos: 7.5,18.5
+      pos: 7.5,22.5
       parent: 1
   - uid: 533
     components:
     - type: Transform
-      pos: 7.5,17.5
+      pos: 7.5,21.5
       parent: 1
   - uid: 534
     components:
     - type: Transform
-      pos: 7.5,16.5
+      pos: 7.5,20.5
       parent: 1
   - uid: 535
     components:
     - type: Transform
-      pos: 8.5,16.5
+      pos: 7.5,19.5
       parent: 1
   - uid: 536
     components:
     - type: Transform
-      pos: 19.5,49.5
+      pos: 7.5,18.5
       parent: 1
   - uid: 537
     components:
     - type: Transform
-      pos: 19.5,48.5
+      pos: 7.5,17.5
       parent: 1
   - uid: 538
     components:
     - type: Transform
-      pos: 20.5,48.5
+      pos: 7.5,16.5
       parent: 1
   - uid: 539
     components:
     - type: Transform
-      pos: 21.5,48.5
+      pos: 8.5,16.5
       parent: 1
   - uid: 540
     components:
     - type: Transform
-      pos: 22.5,48.5
+      pos: 19.5,49.5
       parent: 1
   - uid: 541
     components:
     - type: Transform
-      pos: 23.5,48.5
+      pos: 19.5,48.5
       parent: 1
   - uid: 542
     components:
     - type: Transform
-      pos: 24.5,48.5
+      pos: 20.5,48.5
       parent: 1
   - uid: 543
     components:
     - type: Transform
-      pos: 25.5,49.5
+      pos: 21.5,48.5
       parent: 1
   - uid: 544
     components:
     - type: Transform
-      pos: 25.5,48.5
+      pos: 22.5,48.5
       parent: 1
   - uid: 545
     components:
     - type: Transform
-      pos: 25.5,47.5
+      pos: 23.5,48.5
       parent: 1
   - uid: 546
     components:
     - type: Transform
-      pos: 27.5,47.5
+      pos: 24.5,48.5
       parent: 1
   - uid: 547
     components:
     - type: Transform
-      pos: 28.5,47.5
+      pos: 25.5,49.5
       parent: 1
   - uid: 548
     components:
     - type: Transform
-      pos: 26.5,47.5
+      pos: 25.5,48.5
       parent: 1
   - uid: 549
+    components:
+    - type: Transform
+      pos: 25.5,47.5
+      parent: 1
+  - uid: 550
+    components:
+    - type: Transform
+      pos: 27.5,47.5
+      parent: 1
+  - uid: 551
+    components:
+    - type: Transform
+      pos: 28.5,47.5
+      parent: 1
+  - uid: 552
+    components:
+    - type: Transform
+      pos: 26.5,47.5
+      parent: 1
+  - uid: 553
     components:
     - type: Transform
       pos: 28.5,46.5
       parent: 1
 - proto: RMCWallKutjevoReinforced
   entities:
-  - uid: 550
+  - uid: 554
     components:
     - type: Transform
       pos: 29.5,47.5
       parent: 1
-  - uid: 551
+  - uid: 555
     components:
     - type: Transform
       pos: 29.5,46.5
       parent: 1
-  - uid: 552
+  - uid: 556
     components:
     - type: Transform
       pos: 34.5,47.5
       parent: 1
-  - uid: 553
+  - uid: 557
     components:
     - type: Transform
       pos: 35.5,46.5
       parent: 1
-  - uid: 554
+  - uid: 558
     components:
     - type: Transform
       pos: 35.5,47.5
       parent: 1
-  - uid: 555
+  - uid: 559
     components:
     - type: Transform
       pos: 34.5,46.5
       parent: 1
-  - uid: 556
+  - uid: 560
     components:
     - type: Transform
       pos: 36.5,47.5
       parent: 1
-  - uid: 557
+  - uid: 561
     components:
     - type: Transform
       pos: 37.5,47.5
       parent: 1
-  - uid: 558
+  - uid: 562
     components:
     - type: Transform
       pos: 38.5,47.5
       parent: 1
-  - uid: 559
+  - uid: 563
     components:
     - type: Transform
       pos: 43.5,46.5
       parent: 1
-  - uid: 560
+  - uid: 564
     components:
     - type: Transform
       pos: 43.5,47.5
       parent: 1
-  - uid: 561
+  - uid: 565
     components:
     - type: Transform
       pos: 35.5,45.5
       parent: 1
-  - uid: 562
+  - uid: 566
     components:
     - type: Transform
       pos: 35.5,44.5
       parent: 1
-  - uid: 563
+  - uid: 567
     components:
     - type: Transform
       pos: 35.5,39.5
       parent: 1
-  - uid: 564
+  - uid: 568
     components:
     - type: Transform
       pos: 34.5,39.5
       parent: 1
-  - uid: 565
+  - uid: 569
     components:
     - type: Transform
       pos: 35.5,35.5
       parent: 1
-  - uid: 566
+  - uid: 570
     components:
     - type: Transform
       pos: 34.5,35.5
       parent: 1
-  - uid: 567
+  - uid: 571
     components:
     - type: Transform
       pos: 33.5,35.5
       parent: 1
-  - uid: 568
+  - uid: 572
     components:
     - type: Transform
       pos: 30.5,34.5
       parent: 1
-  - uid: 569
+  - uid: 573
     components:
     - type: Transform
       pos: 31.5,34.5
       parent: 1
-  - uid: 570
+  - uid: 574
     components:
     - type: Transform
       pos: 32.5,34.5
       parent: 1
-  - uid: 571
+  - uid: 575
     components:
     - type: Transform
       pos: 33.5,34.5
       parent: 1
-  - uid: 572
+  - uid: 576
     components:
     - type: Transform
       pos: 30.5,32.5
       parent: 1
-  - uid: 573
+  - uid: 577
     components:
     - type: Transform
       pos: 30.5,31.5
       parent: 1
-  - uid: 574
+  - uid: 578
     components:
     - type: Transform
       pos: 31.5,31.5
       parent: 1
-  - uid: 575
+  - uid: 579
     components:
     - type: Transform
       pos: 33.5,31.5
       parent: 1
-  - uid: 576
+  - uid: 580
     components:
     - type: Transform
       pos: 32.5,31.5
       parent: 1
-  - uid: 577
+  - uid: 581
     components:
     - type: Transform
       pos: 33.5,33.5
       parent: 1
-  - uid: 578
+  - uid: 582
     components:
     - type: Transform
       pos: 33.5,32.5
       parent: 1
-  - uid: 579
+  - uid: 583
     components:
     - type: Transform
       pos: 33.5,30.5
       parent: 1
-  - uid: 580
+  - uid: 584
     components:
     - type: Transform
       pos: 33.5,29.5
       parent: 1
-  - uid: 581
+  - uid: 585
     components:
     - type: Transform
       pos: 33.5,28.5
       parent: 1
-  - uid: 582
+  - uid: 586
     components:
     - type: Transform
       pos: 33.5,27.5
       parent: 1
-  - uid: 583
+  - uid: 587
     components:
     - type: Transform
       pos: 32.5,28.5
       parent: 1
-  - uid: 584
+  - uid: 588
     components:
     - type: Transform
       pos: 31.5,28.5
       parent: 1
-  - uid: 585
+  - uid: 589
     components:
     - type: Transform
       pos: 30.5,28.5
       parent: 1
-  - uid: 586
+  - uid: 590
     components:
     - type: Transform
       pos: 30.5,29.5
       parent: 1
-  - uid: 587
+  - uid: 591
     components:
     - type: Transform
       pos: 34.5,27.5
       parent: 1
-  - uid: 588
+  - uid: 592
     components:
     - type: Transform
       pos: 35.5,27.5
       parent: 1
-  - uid: 589
+  - uid: 593
     components:
     - type: Transform
       pos: 34.5,23.5
       parent: 1
-  - uid: 590
+  - uid: 594
     components:
     - type: Transform
       pos: 35.5,23.5
       parent: 1
-  - uid: 591
+  - uid: 595
     components:
     - type: Transform
       pos: 35.5,18.5
       parent: 1
-  - uid: 592
+  - uid: 596
     components:
     - type: Transform
       pos: 35.5,17.5
       parent: 1
-  - uid: 593
+  - uid: 597
     components:
     - type: Transform
       pos: 35.5,16.5
       parent: 1
-  - uid: 594
+  - uid: 598
     components:
     - type: Transform
       pos: 34.5,16.5
       parent: 1
-  - uid: 595
+  - uid: 599
     components:
     - type: Transform
       pos: 33.5,16.5
       parent: 1
-  - uid: 596
+  - uid: 600
     components:
     - type: Transform
       pos: 32.5,16.5
       parent: 1
-  - uid: 597
+  - uid: 601
     components:
     - type: Transform
       pos: 32.5,15.5
       parent: 1
-  - uid: 598
+  - uid: 602
     components:
     - type: Transform
       pos: 32.5,14.5
       parent: 1
-  - uid: 599
+  - uid: 603
     components:
     - type: Transform
       pos: 28.5,16.5
       parent: 1
-  - uid: 600
+  - uid: 604
     components:
     - type: Transform
       pos: 28.5,14.5
       parent: 1
-  - uid: 601
+  - uid: 605
     components:
     - type: Transform
       pos: 27.5,16.5
       parent: 1
-  - uid: 602
+  - uid: 606
     components:
     - type: Transform
       pos: 27.5,15.5
       parent: 1
-  - uid: 603
+  - uid: 607
     components:
     - type: Transform
       pos: 27.5,14.5
       parent: 1
-  - uid: 604
+  - uid: 608
     components:
     - type: Transform
       pos: 28.5,15.5
       parent: 1
-  - uid: 605
+  - uid: 609
     components:
     - type: Transform
       pos: 27.5,13.5
       parent: 1
-  - uid: 606
+  - uid: 610
     components:
     - type: Transform
       pos: 27.5,12.5
       parent: 1
-  - uid: 607
+  - uid: 611
     components:
     - type: Transform
       pos: 26.5,12.5
       parent: 1
-  - uid: 608
+  - uid: 612
     components:
     - type: Transform
       pos: 26.5,11.5
       parent: 1
-  - uid: 609
+  - uid: 613
     components:
     - type: Transform
       pos: 26.5,10.5
       parent: 1
-  - uid: 610
+  - uid: 614
     components:
     - type: Transform
       pos: 22.5,10.5
       parent: 1
-  - uid: 611
+  - uid: 615
     components:
     - type: Transform
       pos: 22.5,11.5
       parent: 1
-  - uid: 612
+  - uid: 616
     components:
     - type: Transform
       pos: 21.5,11.5
       parent: 1
-  - uid: 613
+  - uid: 617
     components:
     - type: Transform
       pos: 20.5,11.5
       parent: 1
-  - uid: 614
+  - uid: 618
     components:
     - type: Transform
       pos: 20.5,10.5
       parent: 1
-  - uid: 615
+  - uid: 619
     components:
     - type: Transform
       pos: 21.5,16.5
       parent: 1
-  - uid: 616
+  - uid: 620
     components:
     - type: Transform
       pos: 20.5,16.5
       parent: 1
-  - uid: 617
+  - uid: 621
     components:
     - type: Transform
       pos: 23.5,16.5
       parent: 1
-  - uid: 618
+  - uid: 622
     components:
     - type: Transform
       pos: 14.5,16.5
       parent: 1
-  - uid: 619
+  - uid: 623
     components:
     - type: Transform
       pos: 13.5,16.5
       parent: 1
-  - uid: 620
+  - uid: 624
     components:
     - type: Transform
       pos: 13.5,15.5
       parent: 1
-  - uid: 621
+  - uid: 625
     components:
     - type: Transform
       pos: 13.5,14.5
       parent: 1
-  - uid: 622
+  - uid: 626
     components:
     - type: Transform
       pos: 13.5,13.5
       parent: 1
-  - uid: 623
+  - uid: 627
     components:
     - type: Transform
       pos: 13.5,12.5
       parent: 1
-  - uid: 624
+  - uid: 628
     components:
     - type: Transform
       pos: 13.5,11.5
       parent: 1
-  - uid: 625
+  - uid: 629
     components:
     - type: Transform
       pos: 14.5,11.5
       parent: 1
-  - uid: 626
+  - uid: 630
     components:
     - type: Transform
       pos: 14.5,10.5
       parent: 1
 - proto: RMCWallKutjevoRock
   entities:
-  - uid: 627
+  - uid: 631
     components:
     - type: Transform
       pos: 7.5,49.5
       parent: 1
-  - uid: 628
+  - uid: 632
     components:
     - type: Transform
       pos: 1.5,48.5
       parent: 1
-  - uid: 629
+  - uid: 633
     components:
     - type: Transform
       pos: 1.5,47.5
       parent: 1
-  - uid: 630
+  - uid: 634
     components:
     - type: Transform
       pos: 1.5,46.5
       parent: 1
-  - uid: 631
+  - uid: 635
     components:
     - type: Transform
       pos: 1.5,45.5
       parent: 1
-  - uid: 632
+  - uid: 636
     components:
     - type: Transform
       pos: 1.5,44.5
       parent: 1
-  - uid: 633
+  - uid: 637
     components:
     - type: Transform
       pos: 1.5,43.5
       parent: 1
-  - uid: 634
+  - uid: 638
     components:
     - type: Transform
       pos: 1.5,42.5
       parent: 1
-  - uid: 635
+  - uid: 639
     components:
     - type: Transform
       pos: 1.5,41.5
       parent: 1
-  - uid: 636
+  - uid: 640
     components:
     - type: Transform
       pos: 1.5,40.5
       parent: 1
-  - uid: 637
+  - uid: 641
     components:
     - type: Transform
       pos: 1.5,39.5
       parent: 1
-  - uid: 638
+  - uid: 642
     components:
     - type: Transform
       pos: 1.5,38.5
       parent: 1
-  - uid: 639
+  - uid: 643
     components:
     - type: Transform
       pos: 1.5,37.5
       parent: 1
-  - uid: 640
+  - uid: 644
     components:
     - type: Transform
       pos: 1.5,36.5
       parent: 1
-  - uid: 641
+  - uid: 645
     components:
     - type: Transform
       pos: 1.5,35.5
       parent: 1
-  - uid: 642
+  - uid: 646
     components:
     - type: Transform
       pos: 1.5,34.5
       parent: 1
-  - uid: 643
+  - uid: 647
     components:
     - type: Transform
       pos: 1.5,33.5
       parent: 1
-  - uid: 644
+  - uid: 648
     components:
     - type: Transform
       pos: 1.5,32.5
       parent: 1
-  - uid: 645
+  - uid: 649
     components:
     - type: Transform
       pos: 1.5,31.5
       parent: 1
-  - uid: 646
+  - uid: 650
     components:
     - type: Transform
       pos: 1.5,30.5
       parent: 1
-  - uid: 647
+  - uid: 651
     components:
     - type: Transform
       pos: 1.5,29.5
       parent: 1
-  - uid: 648
+  - uid: 652
     components:
     - type: Transform
       pos: 1.5,28.5
       parent: 1
-  - uid: 649
+  - uid: 653
     components:
     - type: Transform
       pos: 1.5,27.5
       parent: 1
-  - uid: 650
+  - uid: 654
     components:
     - type: Transform
       pos: 1.5,26.5
       parent: 1
-  - uid: 651
+  - uid: 655
     components:
     - type: Transform
       pos: 1.5,25.5
       parent: 1
-  - uid: 652
+  - uid: 656
     components:
     - type: Transform
       pos: 1.5,24.5
       parent: 1
-  - uid: 653
+  - uid: 657
     components:
     - type: Transform
       pos: 1.5,23.5
       parent: 1
-  - uid: 654
+  - uid: 658
     components:
     - type: Transform
       pos: 1.5,22.5
       parent: 1
-  - uid: 655
+  - uid: 659
     components:
     - type: Transform
       pos: 1.5,21.5
       parent: 1
-  - uid: 656
+  - uid: 660
     components:
     - type: Transform
       pos: 1.5,20.5
       parent: 1
-  - uid: 657
+  - uid: 661
     components:
     - type: Transform
       pos: 1.5,19.5
       parent: 1
-  - uid: 658
+  - uid: 662
     components:
     - type: Transform
       pos: 1.5,18.5
       parent: 1
-  - uid: 659
+  - uid: 663
     components:
     - type: Transform
       pos: 1.5,17.5
       parent: 1
-  - uid: 660
+  - uid: 664
     components:
     - type: Transform
       pos: 1.5,16.5
       parent: 1
-  - uid: 661
+  - uid: 665
     components:
     - type: Transform
       pos: 1.5,15.5
       parent: 1
-  - uid: 662
+  - uid: 666
     components:
     - type: Transform
       pos: 1.5,14.5
       parent: 1
-  - uid: 663
+  - uid: 667
     components:
     - type: Transform
       pos: 1.5,13.5
       parent: 1
-  - uid: 664
+  - uid: 668
     components:
     - type: Transform
       pos: 1.5,12.5
       parent: 1
-  - uid: 665
+  - uid: 669
     components:
     - type: Transform
       pos: 1.5,11.5
       parent: 1
-  - uid: 666
+  - uid: 670
     components:
     - type: Transform
       pos: 1.5,10.5
       parent: 1
-  - uid: 667
+  - uid: 671
     components:
     - type: Transform
       pos: 1.5,9.5
       parent: 1
-  - uid: 668
+  - uid: 672
     components:
     - type: Transform
       pos: 1.5,8.5
       parent: 1
-  - uid: 669
+  - uid: 673
     components:
     - type: Transform
       pos: 1.5,7.5
       parent: 1
-  - uid: 670
+  - uid: 674
     components:
     - type: Transform
       pos: 1.5,6.5
       parent: 1
-  - uid: 671
+  - uid: 675
     components:
     - type: Transform
       pos: 1.5,5.5
       parent: 1
-  - uid: 672
+  - uid: 676
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 1
-  - uid: 673
+  - uid: 677
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 1
-  - uid: 674
+  - uid: 678
     components:
     - type: Transform
       pos: 2.5,49.5
       parent: 1
-  - uid: 675
+  - uid: 679
     components:
     - type: Transform
       pos: 2.5,48.5
       parent: 1
-  - uid: 676
+  - uid: 680
     components:
     - type: Transform
       pos: 2.5,47.5
       parent: 1
-  - uid: 677
+  - uid: 681
     components:
     - type: Transform
       pos: 2.5,46.5
       parent: 1
-  - uid: 678
+  - uid: 682
     components:
     - type: Transform
       pos: 2.5,45.5
       parent: 1
-  - uid: 679
+  - uid: 683
     components:
     - type: Transform
       pos: 2.5,44.5
       parent: 1
-  - uid: 680
+  - uid: 684
     components:
     - type: Transform
       pos: 2.5,43.5
       parent: 1
-  - uid: 681
+  - uid: 685
     components:
     - type: Transform
       pos: 2.5,42.5
       parent: 1
-  - uid: 682
+  - uid: 686
     components:
     - type: Transform
       pos: 2.5,41.5
       parent: 1
-  - uid: 683
+  - uid: 687
     components:
     - type: Transform
       pos: 2.5,40.5
       parent: 1
-  - uid: 684
+  - uid: 688
     components:
     - type: Transform
       pos: 2.5,39.5
       parent: 1
-  - uid: 685
+  - uid: 689
     components:
     - type: Transform
       pos: 2.5,38.5
       parent: 1
-  - uid: 686
+  - uid: 690
     components:
     - type: Transform
       pos: 2.5,37.5
       parent: 1
-  - uid: 687
+  - uid: 691
     components:
     - type: Transform
       pos: 2.5,36.5
       parent: 1
-  - uid: 688
+  - uid: 692
     components:
     - type: Transform
       pos: 2.5,35.5
       parent: 1
-  - uid: 689
+  - uid: 693
     components:
     - type: Transform
       pos: 2.5,34.5
       parent: 1
-  - uid: 690
+  - uid: 694
     components:
     - type: Transform
       pos: 2.5,33.5
       parent: 1
-  - uid: 691
+  - uid: 695
     components:
     - type: Transform
       pos: 2.5,32.5
       parent: 1
-  - uid: 692
+  - uid: 696
     components:
     - type: Transform
       pos: 2.5,31.5
       parent: 1
-  - uid: 693
+  - uid: 697
     components:
     - type: Transform
       pos: 2.5,30.5
       parent: 1
-  - uid: 694
+  - uid: 698
     components:
     - type: Transform
       pos: 2.5,29.5
       parent: 1
-  - uid: 695
+  - uid: 699
     components:
     - type: Transform
       pos: 2.5,28.5
       parent: 1
-  - uid: 696
+  - uid: 700
     components:
     - type: Transform
       pos: 2.5,27.5
       parent: 1
-  - uid: 697
+  - uid: 701
     components:
     - type: Transform
       pos: 2.5,26.5
       parent: 1
-  - uid: 698
+  - uid: 702
     components:
     - type: Transform
       pos: 2.5,25.5
       parent: 1
-  - uid: 699
+  - uid: 703
     components:
     - type: Transform
       pos: 2.5,24.5
       parent: 1
-  - uid: 700
+  - uid: 704
     components:
     - type: Transform
       pos: 2.5,23.5
       parent: 1
-  - uid: 701
+  - uid: 705
     components:
     - type: Transform
       pos: 2.5,22.5
       parent: 1
-  - uid: 702
+  - uid: 706
     components:
     - type: Transform
       pos: 2.5,21.5
       parent: 1
-  - uid: 703
+  - uid: 707
     components:
     - type: Transform
       pos: 2.5,20.5
       parent: 1
-  - uid: 704
+  - uid: 708
     components:
     - type: Transform
       pos: 2.5,19.5
       parent: 1
-  - uid: 705
+  - uid: 709
     components:
     - type: Transform
       pos: 2.5,18.5
       parent: 1
-  - uid: 706
+  - uid: 710
     components:
     - type: Transform
       pos: 2.5,17.5
       parent: 1
-  - uid: 707
+  - uid: 711
     components:
     - type: Transform
       pos: 2.5,16.5
       parent: 1
-  - uid: 708
+  - uid: 712
     components:
     - type: Transform
       pos: 2.5,15.5
       parent: 1
-  - uid: 709
+  - uid: 713
     components:
     - type: Transform
       pos: 2.5,14.5
       parent: 1
-  - uid: 710
+  - uid: 714
     components:
     - type: Transform
       pos: 2.5,13.5
       parent: 1
-  - uid: 711
+  - uid: 715
     components:
     - type: Transform
       pos: 2.5,12.5
       parent: 1
-  - uid: 712
+  - uid: 716
     components:
     - type: Transform
       pos: 2.5,11.5
       parent: 1
-  - uid: 713
+  - uid: 717
     components:
     - type: Transform
       pos: 2.5,10.5
       parent: 1
-  - uid: 714
+  - uid: 718
     components:
     - type: Transform
       pos: 2.5,9.5
       parent: 1
-  - uid: 715
+  - uid: 719
     components:
     - type: Transform
       pos: 2.5,8.5
       parent: 1
-  - uid: 716
+  - uid: 720
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
-  - uid: 717
+  - uid: 721
     components:
     - type: Transform
       pos: 2.5,6.5
       parent: 1
-  - uid: 718
+  - uid: 722
     components:
     - type: Transform
       pos: 2.5,5.5
       parent: 1
-  - uid: 719
+  - uid: 723
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
-  - uid: 720
+  - uid: 724
     components:
     - type: Transform
       pos: 2.5,3.5
       parent: 1
-  - uid: 721
+  - uid: 725
     components:
     - type: Transform
       pos: 3.5,49.5
       parent: 1
-  - uid: 722
+  - uid: 726
     components:
     - type: Transform
       pos: 3.5,48.5
       parent: 1
-  - uid: 723
+  - uid: 727
     components:
     - type: Transform
       pos: 3.5,47.5
       parent: 1
-  - uid: 724
+  - uid: 728
     components:
     - type: Transform
       pos: 3.5,46.5
       parent: 1
-  - uid: 725
+  - uid: 729
     components:
     - type: Transform
       pos: 3.5,45.5
       parent: 1
-  - uid: 726
+  - uid: 730
     components:
     - type: Transform
       pos: 3.5,44.5
       parent: 1
-  - uid: 727
+  - uid: 731
     components:
     - type: Transform
       pos: 3.5,43.5
       parent: 1
-  - uid: 728
+  - uid: 732
     components:
     - type: Transform
       pos: 3.5,42.5
       parent: 1
-  - uid: 729
+  - uid: 733
     components:
     - type: Transform
       pos: 3.5,41.5
       parent: 1
-  - uid: 730
+  - uid: 734
     components:
     - type: Transform
       pos: 3.5,40.5
       parent: 1
-  - uid: 731
+  - uid: 735
     components:
     - type: Transform
       pos: 3.5,39.5
       parent: 1
-  - uid: 732
+  - uid: 736
     components:
     - type: Transform
       pos: 3.5,38.5
       parent: 1
-  - uid: 733
+  - uid: 737
     components:
     - type: Transform
       pos: 3.5,37.5
       parent: 1
-  - uid: 734
+  - uid: 738
     components:
     - type: Transform
       pos: 3.5,36.5
       parent: 1
-  - uid: 735
+  - uid: 739
     components:
     - type: Transform
       pos: 3.5,35.5
       parent: 1
-  - uid: 736
+  - uid: 740
     components:
     - type: Transform
       pos: 3.5,34.5
       parent: 1
-  - uid: 737
+  - uid: 741
     components:
     - type: Transform
       pos: 3.5,33.5
       parent: 1
-  - uid: 738
+  - uid: 742
     components:
     - type: Transform
       pos: 3.5,32.5
       parent: 1
-  - uid: 739
+  - uid: 743
     components:
     - type: Transform
       pos: 3.5,31.5
       parent: 1
-  - uid: 740
+  - uid: 744
     components:
     - type: Transform
       pos: 3.5,30.5
       parent: 1
-  - uid: 741
+  - uid: 745
     components:
     - type: Transform
       pos: 3.5,29.5
       parent: 1
-  - uid: 742
+  - uid: 746
     components:
     - type: Transform
       pos: 3.5,28.5
       parent: 1
-  - uid: 743
+  - uid: 747
     components:
     - type: Transform
       pos: 3.5,27.5
       parent: 1
-  - uid: 744
+  - uid: 748
     components:
     - type: Transform
       pos: 3.5,26.5
       parent: 1
-  - uid: 745
+  - uid: 749
     components:
     - type: Transform
       pos: 3.5,25.5
       parent: 1
-  - uid: 746
+  - uid: 750
     components:
     - type: Transform
       pos: 3.5,24.5
       parent: 1
-  - uid: 747
+  - uid: 751
     components:
     - type: Transform
       pos: 3.5,23.5
       parent: 1
-  - uid: 748
+  - uid: 752
     components:
     - type: Transform
       pos: 3.5,22.5
       parent: 1
-  - uid: 749
+  - uid: 753
     components:
     - type: Transform
       pos: 3.5,21.5
       parent: 1
-  - uid: 750
+  - uid: 754
     components:
     - type: Transform
       pos: 3.5,20.5
       parent: 1
-  - uid: 751
+  - uid: 755
     components:
     - type: Transform
       pos: 3.5,19.5
       parent: 1
-  - uid: 752
+  - uid: 756
     components:
     - type: Transform
       pos: 3.5,18.5
       parent: 1
-  - uid: 753
+  - uid: 757
     components:
     - type: Transform
       pos: 3.5,17.5
       parent: 1
-  - uid: 754
+  - uid: 758
     components:
     - type: Transform
       pos: 3.5,16.5
       parent: 1
-  - uid: 755
+  - uid: 759
     components:
     - type: Transform
       pos: 3.5,15.5
       parent: 1
-  - uid: 756
+  - uid: 760
     components:
     - type: Transform
       pos: 3.5,14.5
       parent: 1
-  - uid: 757
+  - uid: 761
     components:
     - type: Transform
       pos: 3.5,13.5
       parent: 1
-  - uid: 758
+  - uid: 762
     components:
     - type: Transform
       pos: 3.5,12.5
       parent: 1
-  - uid: 759
+  - uid: 763
     components:
     - type: Transform
       pos: 3.5,11.5
       parent: 1
-  - uid: 760
+  - uid: 764
     components:
     - type: Transform
       pos: 3.5,10.5
       parent: 1
-  - uid: 761
+  - uid: 765
     components:
     - type: Transform
       pos: 3.5,9.5
       parent: 1
-  - uid: 762
+  - uid: 766
     components:
     - type: Transform
       pos: 3.5,8.5
       parent: 1
-  - uid: 763
+  - uid: 767
     components:
     - type: Transform
       pos: 3.5,7.5
       parent: 1
-  - uid: 764
+  - uid: 768
     components:
     - type: Transform
       pos: 3.5,6.5
       parent: 1
-  - uid: 765
+  - uid: 769
     components:
     - type: Transform
       pos: 3.5,5.5
       parent: 1
-  - uid: 766
+  - uid: 770
     components:
     - type: Transform
       pos: 3.5,4.5
       parent: 1
-  - uid: 767
+  - uid: 771
     components:
     - type: Transform
       pos: 3.5,3.5
       parent: 1
-  - uid: 768
+  - uid: 772
     components:
     - type: Transform
       pos: 4.5,49.5
       parent: 1
-  - uid: 769
+  - uid: 773
     components:
     - type: Transform
       pos: 4.5,48.5
       parent: 1
-  - uid: 770
+  - uid: 774
     components:
     - type: Transform
       pos: 4.5,47.5
       parent: 1
-  - uid: 771
+  - uid: 775
     components:
     - type: Transform
       pos: 4.5,46.5
       parent: 1
-  - uid: 772
+  - uid: 776
     components:
     - type: Transform
       pos: 4.5,45.5
       parent: 1
-  - uid: 773
+  - uid: 777
     components:
     - type: Transform
       pos: 4.5,44.5
       parent: 1
-  - uid: 774
+  - uid: 778
     components:
     - type: Transform
       pos: 4.5,43.5
       parent: 1
-  - uid: 775
+  - uid: 779
     components:
     - type: Transform
       pos: 4.5,42.5
       parent: 1
-  - uid: 776
+  - uid: 780
     components:
     - type: Transform
       pos: 4.5,41.5
       parent: 1
-  - uid: 777
+  - uid: 781
     components:
     - type: Transform
       pos: 4.5,40.5
       parent: 1
-  - uid: 778
+  - uid: 782
     components:
     - type: Transform
       pos: 4.5,39.5
       parent: 1
-  - uid: 779
+  - uid: 783
     components:
     - type: Transform
       pos: 4.5,38.5
       parent: 1
-  - uid: 780
+  - uid: 784
     components:
     - type: Transform
       pos: 4.5,37.5
       parent: 1
-  - uid: 781
+  - uid: 785
     components:
     - type: Transform
       pos: 4.5,36.5
       parent: 1
-  - uid: 782
+  - uid: 786
     components:
     - type: Transform
       pos: 4.5,35.5
       parent: 1
-  - uid: 783
+  - uid: 787
     components:
     - type: Transform
       pos: 4.5,34.5
       parent: 1
-  - uid: 784
+  - uid: 788
     components:
     - type: Transform
       pos: 4.5,33.5
       parent: 1
-  - uid: 785
+  - uid: 789
     components:
     - type: Transform
       pos: 4.5,32.5
       parent: 1
-  - uid: 786
+  - uid: 790
     components:
     - type: Transform
       pos: 1.5,49.5
       parent: 1
-  - uid: 787
+  - uid: 791
     components:
     - type: Transform
       pos: 4.5,30.5
       parent: 1
-  - uid: 788
+  - uid: 792
     components:
     - type: Transform
       pos: 4.5,29.5
       parent: 1
-  - uid: 789
+  - uid: 793
     components:
     - type: Transform
       pos: 4.5,28.5
       parent: 1
-  - uid: 790
+  - uid: 794
     components:
     - type: Transform
       pos: 4.5,27.5
       parent: 1
-  - uid: 791
+  - uid: 795
     components:
     - type: Transform
       pos: 4.5,26.5
       parent: 1
-  - uid: 792
+  - uid: 796
     components:
     - type: Transform
       pos: 4.5,25.5
       parent: 1
-  - uid: 793
+  - uid: 797
     components:
     - type: Transform
       pos: 4.5,24.5
       parent: 1
-  - uid: 794
+  - uid: 798
     components:
     - type: Transform
       pos: 4.5,23.5
       parent: 1
-  - uid: 795
+  - uid: 799
     components:
     - type: Transform
       pos: 4.5,22.5
       parent: 1
-  - uid: 796
+  - uid: 800
     components:
     - type: Transform
       pos: 4.5,21.5
       parent: 1
-  - uid: 797
+  - uid: 801
     components:
     - type: Transform
       pos: 4.5,20.5
       parent: 1
-  - uid: 798
+  - uid: 802
     components:
     - type: Transform
       pos: 4.5,19.5
       parent: 1
-  - uid: 799
+  - uid: 803
     components:
     - type: Transform
       pos: 4.5,18.5
       parent: 1
-  - uid: 800
+  - uid: 804
     components:
     - type: Transform
       pos: 4.5,17.5
       parent: 1
-  - uid: 801
+  - uid: 805
     components:
     - type: Transform
       pos: 4.5,16.5
       parent: 1
-  - uid: 802
+  - uid: 806
     components:
     - type: Transform
       pos: 4.5,15.5
       parent: 1
-  - uid: 803
+  - uid: 807
     components:
     - type: Transform
       pos: 4.5,14.5
       parent: 1
-  - uid: 804
+  - uid: 808
     components:
     - type: Transform
       pos: 4.5,13.5
       parent: 1
-  - uid: 805
+  - uid: 809
     components:
     - type: Transform
       pos: 4.5,12.5
       parent: 1
-  - uid: 806
+  - uid: 810
     components:
     - type: Transform
       pos: 4.5,11.5
       parent: 1
-  - uid: 807
+  - uid: 811
     components:
     - type: Transform
       pos: 4.5,10.5
       parent: 1
-  - uid: 808
+  - uid: 812
     components:
     - type: Transform
       pos: 4.5,9.5
       parent: 1
-  - uid: 809
+  - uid: 813
     components:
     - type: Transform
       pos: 4.5,8.5
       parent: 1
-  - uid: 810
+  - uid: 814
     components:
     - type: Transform
       pos: 4.5,7.5
       parent: 1
-  - uid: 811
+  - uid: 815
     components:
     - type: Transform
       pos: 4.5,6.5
       parent: 1
-  - uid: 812
+  - uid: 816
     components:
     - type: Transform
       pos: 4.5,5.5
       parent: 1
-  - uid: 813
+  - uid: 817
     components:
     - type: Transform
       pos: 4.5,4.5
       parent: 1
-  - uid: 814
+  - uid: 818
     components:
     - type: Transform
       pos: 4.5,3.5
       parent: 1
-  - uid: 815
+  - uid: 819
     components:
     - type: Transform
       pos: 5.5,49.5
       parent: 1
-  - uid: 816
+  - uid: 820
     components:
     - type: Transform
       pos: 5.5,48.5
       parent: 1
-  - uid: 817
+  - uid: 821
     components:
     - type: Transform
       pos: 5.5,47.5
       parent: 1
-  - uid: 818
+  - uid: 822
     components:
     - type: Transform
       pos: 5.5,46.5
       parent: 1
-  - uid: 819
+  - uid: 823
     components:
     - type: Transform
       pos: 5.5,45.5
       parent: 1
-  - uid: 820
+  - uid: 824
     components:
     - type: Transform
       pos: 5.5,44.5
       parent: 1
-  - uid: 821
+  - uid: 825
     components:
     - type: Transform
       pos: 5.5,43.5
       parent: 1
-  - uid: 822
+  - uid: 826
     components:
     - type: Transform
       pos: 5.5,42.5
       parent: 1
-  - uid: 823
+  - uid: 827
     components:
     - type: Transform
       pos: 5.5,41.5
       parent: 1
-  - uid: 824
+  - uid: 828
     components:
     - type: Transform
       pos: 5.5,40.5
       parent: 1
-  - uid: 825
+  - uid: 829
     components:
     - type: Transform
       pos: 5.5,39.5
       parent: 1
-  - uid: 826
+  - uid: 830
     components:
     - type: Transform
       pos: 5.5,38.5
       parent: 1
-  - uid: 827
+  - uid: 831
     components:
     - type: Transform
       pos: 5.5,37.5
       parent: 1
-  - uid: 828
+  - uid: 832
     components:
     - type: Transform
       pos: 5.5,36.5
       parent: 1
-  - uid: 829
+  - uid: 833
     components:
     - type: Transform
       pos: 5.5,35.5
       parent: 1
-  - uid: 830
+  - uid: 834
     components:
     - type: Transform
       pos: 5.5,34.5
       parent: 1
-  - uid: 831
+  - uid: 835
     components:
     - type: Transform
       pos: 5.5,33.5
       parent: 1
-  - uid: 832
+  - uid: 836
     components:
     - type: Transform
       pos: 5.5,32.5
       parent: 1
-  - uid: 833
+  - uid: 837
     components:
     - type: Transform
       pos: 5.5,31.5
       parent: 1
-  - uid: 834
+  - uid: 838
     components:
     - type: Transform
       pos: 5.5,30.5
       parent: 1
-  - uid: 835
+  - uid: 839
     components:
     - type: Transform
       pos: 5.5,29.5
       parent: 1
-  - uid: 836
+  - uid: 840
     components:
     - type: Transform
       pos: 5.5,28.5
       parent: 1
-  - uid: 837
+  - uid: 841
     components:
     - type: Transform
       pos: 5.5,27.5
       parent: 1
-  - uid: 838
+  - uid: 842
     components:
     - type: Transform
       pos: 5.5,26.5
       parent: 1
-  - uid: 839
+  - uid: 843
     components:
     - type: Transform
       pos: 5.5,25.5
       parent: 1
-  - uid: 840
+  - uid: 844
     components:
     - type: Transform
       pos: 5.5,24.5
       parent: 1
-  - uid: 841
+  - uid: 845
     components:
     - type: Transform
       pos: 5.5,23.5
       parent: 1
-  - uid: 842
+  - uid: 846
     components:
     - type: Transform
       pos: 5.5,22.5
       parent: 1
-  - uid: 843
+  - uid: 847
     components:
     - type: Transform
       pos: 5.5,21.5
       parent: 1
-  - uid: 844
+  - uid: 848
     components:
     - type: Transform
       pos: 5.5,20.5
       parent: 1
-  - uid: 845
+  - uid: 849
     components:
     - type: Transform
       pos: 5.5,19.5
       parent: 1
-  - uid: 846
+  - uid: 850
     components:
     - type: Transform
       pos: 5.5,18.5
       parent: 1
-  - uid: 847
+  - uid: 851
     components:
     - type: Transform
       pos: 5.5,17.5
       parent: 1
-  - uid: 848
+  - uid: 852
     components:
     - type: Transform
       pos: 5.5,16.5
       parent: 1
-  - uid: 849
+  - uid: 853
     components:
     - type: Transform
       pos: 5.5,15.5
       parent: 1
-  - uid: 850
+  - uid: 854
     components:
     - type: Transform
       pos: 5.5,14.5
       parent: 1
-  - uid: 851
+  - uid: 855
     components:
     - type: Transform
       pos: 5.5,13.5
       parent: 1
-  - uid: 852
+  - uid: 856
     components:
     - type: Transform
       pos: 5.5,12.5
       parent: 1
-  - uid: 853
+  - uid: 857
     components:
     - type: Transform
       pos: 5.5,11.5
       parent: 1
-  - uid: 854
+  - uid: 858
     components:
     - type: Transform
       pos: 5.5,10.5
       parent: 1
-  - uid: 855
+  - uid: 859
     components:
     - type: Transform
       pos: 5.5,9.5
       parent: 1
-  - uid: 856
+  - uid: 860
     components:
     - type: Transform
       pos: 5.5,8.5
       parent: 1
-  - uid: 857
+  - uid: 861
     components:
     - type: Transform
       pos: 5.5,7.5
       parent: 1
-  - uid: 858
+  - uid: 862
     components:
     - type: Transform
       pos: 5.5,6.5
       parent: 1
-  - uid: 859
+  - uid: 863
     components:
     - type: Transform
       pos: 5.5,5.5
       parent: 1
-  - uid: 860
+  - uid: 864
     components:
     - type: Transform
       pos: 5.5,4.5
       parent: 1
-  - uid: 861
+  - uid: 865
     components:
     - type: Transform
       pos: 5.5,3.5
       parent: 1
-  - uid: 862
+  - uid: 866
     components:
     - type: Transform
       pos: 4.5,31.5
       parent: 1
-  - uid: 863
+  - uid: 867
     components:
     - type: Transform
       pos: 8.5,49.5
       parent: 1
-  - uid: 864
+  - uid: 868
     components:
     - type: Transform
       pos: 9.5,49.5
       parent: 1
-  - uid: 865
+  - uid: 869
     components:
     - type: Transform
       pos: 10.5,49.5
       parent: 1
-  - uid: 866
+  - uid: 870
     components:
     - type: Transform
       pos: 11.5,49.5
       parent: 1
-  - uid: 867
+  - uid: 871
     components:
     - type: Transform
       pos: 12.5,49.5
       parent: 1
-  - uid: 868
+  - uid: 872
     components:
     - type: Transform
       pos: 13.5,49.5
       parent: 1
-  - uid: 869
+  - uid: 873
     components:
     - type: Transform
       pos: 6.5,49.5
       parent: 1
-  - uid: 870
+  - uid: 874
     components:
     - type: Transform
       pos: 6.5,47.5
       parent: 1
-  - uid: 871
+  - uid: 875
     components:
     - type: Transform
       pos: 6.5,46.5
       parent: 1
-  - uid: 872
+  - uid: 876
     components:
     - type: Transform
       pos: 6.5,45.5
       parent: 1
-  - uid: 873
+  - uid: 877
     components:
     - type: Transform
       pos: 6.5,44.5
       parent: 1
-  - uid: 874
+  - uid: 878
     components:
     - type: Transform
       pos: 6.5,43.5
       parent: 1
-  - uid: 875
+  - uid: 879
     components:
     - type: Transform
       pos: 6.5,42.5
       parent: 1
-  - uid: 876
+  - uid: 880
     components:
     - type: Transform
       pos: 6.5,41.5
       parent: 1
-  - uid: 877
+  - uid: 881
     components:
     - type: Transform
       pos: 6.5,40.5
       parent: 1
-  - uid: 878
+  - uid: 882
     components:
     - type: Transform
       pos: 6.5,39.5
       parent: 1
-  - uid: 879
+  - uid: 883
     components:
     - type: Transform
       pos: 6.5,38.5
       parent: 1
-  - uid: 880
+  - uid: 884
     components:
     - type: Transform
       pos: 6.5,37.5
       parent: 1
-  - uid: 881
+  - uid: 885
     components:
     - type: Transform
       pos: 6.5,36.5
       parent: 1
-  - uid: 882
+  - uid: 886
     components:
     - type: Transform
       pos: 6.5,35.5
       parent: 1
-  - uid: 883
+  - uid: 887
     components:
     - type: Transform
       pos: 6.5,34.5
       parent: 1
-  - uid: 884
+  - uid: 888
     components:
     - type: Transform
       pos: 6.5,33.5
       parent: 1
-  - uid: 885
+  - uid: 889
     components:
     - type: Transform
       pos: 6.5,32.5
       parent: 1
-  - uid: 886
+  - uid: 890
     components:
     - type: Transform
       pos: 6.5,48.5
       parent: 1
-  - uid: 887
+  - uid: 891
     components:
     - type: Transform
       pos: 6.5,24.5
       parent: 1
-  - uid: 888
+  - uid: 892
     components:
     - type: Transform
       pos: 6.5,23.5
       parent: 1
-  - uid: 889
+  - uid: 893
     components:
     - type: Transform
       pos: 6.5,22.5
       parent: 1
-  - uid: 890
+  - uid: 894
     components:
     - type: Transform
       pos: 6.5,21.5
       parent: 1
-  - uid: 891
+  - uid: 895
     components:
     - type: Transform
       pos: 6.5,20.5
       parent: 1
-  - uid: 892
+  - uid: 896
     components:
     - type: Transform
       pos: 6.5,19.5
       parent: 1
-  - uid: 893
+  - uid: 897
     components:
     - type: Transform
       pos: 6.5,18.5
       parent: 1
-  - uid: 894
+  - uid: 898
     components:
     - type: Transform
       pos: 6.5,17.5
       parent: 1
-  - uid: 895
+  - uid: 899
     components:
     - type: Transform
       pos: 6.5,16.5
       parent: 1
-  - uid: 896
+  - uid: 900
     components:
     - type: Transform
       pos: 6.5,15.5
       parent: 1
-  - uid: 897
+  - uid: 901
     components:
     - type: Transform
       pos: 6.5,14.5
       parent: 1
-  - uid: 898
+  - uid: 902
     components:
     - type: Transform
       pos: 6.5,13.5
       parent: 1
-  - uid: 899
+  - uid: 903
     components:
     - type: Transform
       pos: 6.5,12.5
       parent: 1
-  - uid: 900
+  - uid: 904
     components:
     - type: Transform
       pos: 6.5,11.5
       parent: 1
-  - uid: 901
+  - uid: 905
     components:
     - type: Transform
       pos: 6.5,10.5
       parent: 1
-  - uid: 902
+  - uid: 906
     components:
     - type: Transform
       pos: 6.5,9.5
       parent: 1
-  - uid: 903
+  - uid: 907
     components:
     - type: Transform
       pos: 6.5,8.5
       parent: 1
-  - uid: 904
+  - uid: 908
     components:
     - type: Transform
       pos: 6.5,7.5
       parent: 1
-  - uid: 905
+  - uid: 909
     components:
     - type: Transform
       pos: 6.5,6.5
       parent: 1
-  - uid: 906
+  - uid: 910
     components:
     - type: Transform
       pos: 6.5,5.5
       parent: 1
-  - uid: 907
+  - uid: 911
     components:
     - type: Transform
       pos: 6.5,4.5
       parent: 1
-  - uid: 908
+  - uid: 912
     components:
     - type: Transform
       pos: 6.5,25.5
       parent: 1
-  - uid: 909
+  - uid: 913
     components:
     - type: Transform
       pos: 6.5,3.5
       parent: 1
-  - uid: 910
+  - uid: 914
     components:
     - type: Transform
       pos: 7.5,2.5
       parent: 1
-  - uid: 911
+  - uid: 915
     components:
     - type: Transform
       pos: 8.5,2.5
       parent: 1
-  - uid: 912
+  - uid: 916
     components:
     - type: Transform
       pos: 9.5,2.5
       parent: 1
-  - uid: 913
+  - uid: 917
     components:
     - type: Transform
       pos: 10.5,2.5
       parent: 1
-  - uid: 914
+  - uid: 918
     components:
     - type: Transform
       pos: 11.5,2.5
       parent: 1
-  - uid: 915
+  - uid: 919
     components:
     - type: Transform
       pos: 8.5,1.5
       parent: 1
-  - uid: 916
+  - uid: 920
     components:
     - type: Transform
       pos: 9.5,1.5
       parent: 1
-  - uid: 917
+  - uid: 921
     components:
     - type: Transform
       pos: 10.5,1.5
       parent: 1
-  - uid: 918
+  - uid: 922
     components:
     - type: Transform
       pos: 11.5,1.5
       parent: 1
-  - uid: 919
+  - uid: 923
     components:
     - type: Transform
       pos: 12.5,1.5
       parent: 1
-  - uid: 920
+  - uid: 924
     components:
     - type: Transform
       pos: 7.5,1.5
       parent: 1
-  - uid: 921
+  - uid: 925
     components:
     - type: Transform
       pos: 13.5,1.5
       parent: 1
-  - uid: 922
+  - uid: 926
     components:
     - type: Transform
       pos: 17.5,1.5
       parent: 1
-  - uid: 923
+  - uid: 927
     components:
     - type: Transform
       pos: 19.5,1.5
       parent: 1
-  - uid: 924
+  - uid: 928
     components:
     - type: Transform
       pos: 20.5,1.5
       parent: 1
-  - uid: 925
+  - uid: 929
     components:
     - type: Transform
       pos: 21.5,1.5
       parent: 1
-  - uid: 926
+  - uid: 930
     components:
     - type: Transform
       pos: 18.5,1.5
       parent: 1
-  - uid: 927
+  - uid: 931
     components:
     - type: Transform
       pos: 18.5,2.5
       parent: 1
-  - uid: 928
+  - uid: 932
     components:
     - type: Transform
       pos: 19.5,2.5
       parent: 1
-  - uid: 929
+  - uid: 933
     components:
     - type: Transform
       pos: 20.5,2.5
       parent: 1
-  - uid: 930
+  - uid: 934
     components:
     - type: Transform
       pos: 31.5,0.5
       parent: 1
-  - uid: 931
+  - uid: 935
     components:
     - type: Transform
       pos: 30.5,1.5
       parent: 1
-  - uid: 932
+  - uid: 936
     components:
     - type: Transform
       pos: 29.5,1.5
       parent: 1
-  - uid: 933
+  - uid: 937
     components:
     - type: Transform
       pos: 28.5,1.5
       parent: 1
-  - uid: 934
+  - uid: 938
     components:
     - type: Transform
       pos: 27.5,1.5
       parent: 1
-  - uid: 935
+  - uid: 939
     components:
     - type: Transform
       pos: 39.5,9.5
       parent: 1
-  - uid: 936
+  - uid: 940
     components:
     - type: Transform
       pos: 38.5,9.5
       parent: 1
-  - uid: 937
+  - uid: 941
     components:
     - type: Transform
       pos: 39.5,10.5
       parent: 1
-  - uid: 938
+  - uid: 942
     components:
     - type: Transform
       pos: 10.5,4.5
       parent: 1
-  - uid: 939
+  - uid: 943
     components:
     - type: Transform
       pos: 10.5,5.5
       parent: 1
-  - uid: 940
+  - uid: 944
     components:
     - type: Transform
       pos: 10.5,6.5
       parent: 1
-  - uid: 941
+  - uid: 945
     components:
     - type: Transform
       pos: 10.5,7.5
       parent: 1
-  - uid: 942
+  - uid: 946
     components:
     - type: Transform
       pos: 10.5,8.5
       parent: 1
-  - uid: 943
+  - uid: 947
     components:
     - type: Transform
       pos: 10.5,9.5
       parent: 1
-  - uid: 944
+  - uid: 948
     components:
     - type: Transform
       pos: 10.5,10.5
       parent: 1
-  - uid: 945
+  - uid: 949
     components:
     - type: Transform
       pos: 10.5,11.5
       parent: 1
-  - uid: 946
+  - uid: 950
     components:
     - type: Transform
       pos: 10.5,12.5
       parent: 1
-  - uid: 947
+  - uid: 951
     components:
     - type: Transform
       pos: 10.5,13.5
       parent: 1
-  - uid: 948
+  - uid: 952
     components:
     - type: Transform
       pos: 10.5,14.5
       parent: 1
-  - uid: 949
+  - uid: 953
     components:
     - type: Transform
       pos: 9.5,4.5
       parent: 1
-  - uid: 950
+  - uid: 954
     components:
     - type: Transform
       pos: 9.5,5.5
       parent: 1
-  - uid: 951
+  - uid: 955
     components:
     - type: Transform
       pos: 9.5,6.5
       parent: 1
-  - uid: 952
+  - uid: 956
     components:
     - type: Transform
       pos: 9.5,7.5
       parent: 1
-  - uid: 953
+  - uid: 957
     components:
     - type: Transform
       pos: 9.5,8.5
       parent: 1
-  - uid: 954
+  - uid: 958
     components:
     - type: Transform
       pos: 9.5,9.5
       parent: 1
-  - uid: 955
+  - uid: 959
     components:
     - type: Transform
       pos: 9.5,10.5
       parent: 1
-  - uid: 956
+  - uid: 960
     components:
     - type: Transform
       pos: 9.5,11.5
       parent: 1
-  - uid: 957
+  - uid: 961
     components:
     - type: Transform
       pos: 9.5,12.5
       parent: 1
-  - uid: 958
+  - uid: 962
     components:
     - type: Transform
       pos: 9.5,13.5
       parent: 1
-  - uid: 959
+  - uid: 963
     components:
     - type: Transform
       pos: 9.5,14.5
       parent: 1
-  - uid: 960
+  - uid: 964
     components:
     - type: Transform
       pos: 8.5,3.5
       parent: 1
-  - uid: 961
+  - uid: 965
     components:
     - type: Transform
       pos: 8.5,4.5
       parent: 1
-  - uid: 962
+  - uid: 966
     components:
     - type: Transform
       pos: 8.5,5.5
       parent: 1
-  - uid: 963
+  - uid: 967
     components:
     - type: Transform
       pos: 8.5,6.5
       parent: 1
-  - uid: 964
+  - uid: 968
     components:
     - type: Transform
       pos: 8.5,7.5
       parent: 1
-  - uid: 965
+  - uid: 969
     components:
     - type: Transform
       pos: 8.5,8.5
       parent: 1
-  - uid: 966
+  - uid: 970
     components:
     - type: Transform
       pos: 8.5,9.5
       parent: 1
-  - uid: 967
+  - uid: 971
     components:
     - type: Transform
       pos: 8.5,10.5
       parent: 1
-  - uid: 968
+  - uid: 972
     components:
     - type: Transform
       pos: 8.5,11.5
       parent: 1
-  - uid: 969
+  - uid: 973
     components:
     - type: Transform
       pos: 8.5,12.5
       parent: 1
-  - uid: 970
+  - uid: 974
     components:
     - type: Transform
       pos: 8.5,13.5
       parent: 1
-  - uid: 971
+  - uid: 975
     components:
     - type: Transform
       pos: 8.5,14.5
       parent: 1
-  - uid: 972
+  - uid: 976
     components:
     - type: Transform
       pos: 7.5,3.5
       parent: 1
-  - uid: 973
+  - uid: 977
     components:
     - type: Transform
       pos: 7.5,4.5
       parent: 1
-  - uid: 974
+  - uid: 978
     components:
     - type: Transform
       pos: 7.5,5.5
       parent: 1
-  - uid: 975
+  - uid: 979
     components:
     - type: Transform
       pos: 7.5,6.5
       parent: 1
-  - uid: 976
+  - uid: 980
     components:
     - type: Transform
       pos: 7.5,7.5
       parent: 1
-  - uid: 977
+  - uid: 981
     components:
     - type: Transform
       pos: 7.5,8.5
       parent: 1
-  - uid: 978
+  - uid: 982
     components:
     - type: Transform
       pos: 9.5,3.5
       parent: 1
-  - uid: 979
+  - uid: 983
     components:
     - type: Transform
       pos: 10.5,3.5
       parent: 1
-  - uid: 980
+  - uid: 984
     components:
     - type: Transform
       pos: 7.5,9.5
       parent: 1
-  - uid: 981
+  - uid: 985
     components:
     - type: Transform
       pos: 7.5,10.5
       parent: 1
-  - uid: 982
+  - uid: 986
     components:
     - type: Transform
       pos: 7.5,11.5
       parent: 1
-  - uid: 983
+  - uid: 987
     components:
     - type: Transform
       pos: 7.5,12.5
       parent: 1
-  - uid: 984
+  - uid: 988
     components:
     - type: Transform
       pos: 7.5,13.5
       parent: 1
-  - uid: 985
+  - uid: 989
     components:
     - type: Transform
       pos: 7.5,14.5
       parent: 1
-  - uid: 986
+  - uid: 990
     components:
     - type: Transform
       pos: 11.5,15.5
       parent: 1
-  - uid: 987
+  - uid: 991
     components:
     - type: Transform
       pos: 11.5,14.5
       parent: 1
-  - uid: 988
+  - uid: 992
     components:
     - type: Transform
       pos: 11.5,13.5
       parent: 1
-  - uid: 989
+  - uid: 993
     components:
     - type: Transform
       pos: 12.5,15.5
       parent: 1
-  - uid: 990
+  - uid: 994
     components:
     - type: Transform
       pos: 12.5,14.5
       parent: 1
-  - uid: 991
+  - uid: 995
     components:
     - type: Transform
       pos: 12.5,13.5
       parent: 1
-  - uid: 992
+  - uid: 996
     components:
     - type: Transform
       pos: 11.5,7.5
       parent: 1
-  - uid: 993
+  - uid: 997
     components:
     - type: Transform
       pos: 11.5,8.5
       parent: 1
-  - uid: 994
+  - uid: 998
     components:
     - type: Transform
       pos: 11.5,9.5
       parent: 1
-  - uid: 995
+  - uid: 999
     components:
     - type: Transform
       pos: 11.5,10.5
       parent: 1
-  - uid: 996
+  - uid: 1000
     components:
     - type: Transform
       pos: 11.5,11.5
       parent: 1
-  - uid: 997
+  - uid: 1001
     components:
     - type: Transform
       pos: 11.5,12.5
       parent: 1
-  - uid: 998
+  - uid: 1002
     components:
     - type: Transform
       pos: 12.5,9.5
       parent: 1
-  - uid: 999
+  - uid: 1003
     components:
     - type: Transform
       pos: 12.5,10.5
       parent: 1
-  - uid: 1000
+  - uid: 1004
     components:
     - type: Transform
       pos: 12.5,11.5
       parent: 1
-  - uid: 1001
+  - uid: 1005
     components:
     - type: Transform
       pos: 12.5,12.5
       parent: 1
-  - uid: 1002
+  - uid: 1006
     components:
     - type: Transform
       pos: 13.5,10.5
       parent: 1
-  - uid: 1003
+  - uid: 1007
     components:
     - type: Transform
       pos: 8.5,15.5
       parent: 1
-  - uid: 1004
+  - uid: 1008
     components:
     - type: Transform
       pos: 7.5,15.5
       parent: 1
-  - uid: 1005
+  - uid: 1009
     components:
     - type: Transform
       pos: 43.5,31.5
       parent: 1
-  - uid: 1006
+  - uid: 1010
     components:
     - type: Transform
       pos: 42.5,31.5
       parent: 1
-  - uid: 1007
+  - uid: 1011
     components:
     - type: Transform
       pos: 41.5,31.5
       parent: 1
-  - uid: 1008
+  - uid: 1012
     components:
     - type: Transform
       pos: 40.5,31.5
       parent: 1
-  - uid: 1009
+  - uid: 1013
     components:
     - type: Transform
       pos: 41.5,30.5
       parent: 1
-  - uid: 1010
+  - uid: 1014
     components:
     - type: Transform
       pos: 40.5,30.5
       parent: 1
-  - uid: 1011
+  - uid: 1015
     components:
     - type: Transform
       pos: 42.5,32.5
       parent: 1
-  - uid: 1012
+  - uid: 1016
     components:
     - type: Transform
       pos: 43.5,32.5
       parent: 1
-  - uid: 1013
+  - uid: 1017
     components:
     - type: Transform
       pos: 43.5,33.5
       parent: 1
-  - uid: 1014
+  - uid: 1018
     components:
     - type: Transform
       pos: 43.5,34.5
       parent: 1
-  - uid: 1015
+  - uid: 1019
     components:
     - type: Transform
       pos: 43.5,38.5
       parent: 1
-  - uid: 1016
+  - uid: 1020
     components:
     - type: Transform
       pos: 43.5,39.5
       parent: 1
-  - uid: 1017
+  - uid: 1021
     components:
     - type: Transform
       pos: 42.5,39.5
       parent: 1
-  - uid: 1018
+  - uid: 1022
     components:
     - type: Transform
       pos: 42.5,38.5
       parent: 1
-  - uid: 1019
+  - uid: 1023
     components:
     - type: Transform
       pos: 41.5,39.5
       parent: 1
-  - uid: 1020
+  - uid: 1024
     components:
     - type: Transform
       pos: 41.5,38.5
       parent: 1
-  - uid: 1021
+  - uid: 1025
     components:
     - type: Transform
       pos: 40.5,38.5
       parent: 1
-  - uid: 1022
+  - uid: 1026
     components:
     - type: Transform
       pos: 41.5,37.5
       parent: 1
-  - uid: 1023
+  - uid: 1027
     components:
     - type: Transform
       pos: 23.5,3.5
       parent: 1
-  - uid: 1024
+  - uid: 1028
     components:
     - type: Transform
       pos: 22.5,4.5
       parent: 1
-  - uid: 1025
+  - uid: 1029
     components:
     - type: Transform
       pos: 23.5,4.5
       parent: 1
-  - uid: 1026
+  - uid: 1030
     components:
     - type: Transform
       pos: 23.5,5.5
       parent: 1
-  - uid: 1027
+  - uid: 1031
     components:
     - type: Transform
       pos: 23.5,6.5
       parent: 1
-  - uid: 1028
+  - uid: 1032
     components:
     - type: Transform
       pos: 22.5,5.5
       parent: 1
-  - uid: 1029
+  - uid: 1033
     components:
     - type: Transform
       pos: 24.5,6.5
       parent: 1
-  - uid: 1030
+  - uid: 1034
     components:
     - type: Transform
       pos: 25.5,6.5
       parent: 1
-  - uid: 1031
+  - uid: 1035
     components:
     - type: Transform
       pos: 25.5,5.5
       parent: 1
-  - uid: 1032
+  - uid: 1036
     components:
     - type: Transform
       pos: 26.5,5.5
       parent: 1
-  - uid: 1033
+  - uid: 1037
     components:
     - type: Transform
       pos: 24.5,5.5
       parent: 1
-  - uid: 1034
+  - uid: 1038
     components:
     - type: Transform
       pos: 26.5,4.5
       parent: 1
-  - uid: 1035
+  - uid: 1039
     components:
     - type: Transform
       pos: 24.5,4.5
       parent: 1
-  - uid: 1036
+  - uid: 1040
     components:
     - type: Transform
       pos: 37.5,46.5
       parent: 1
-  - uid: 1037
+  - uid: 1041
     components:
     - type: Transform
       pos: 38.5,46.5
       parent: 1
-  - uid: 1038
+  - uid: 1042
     components:
     - type: Transform
       pos: 36.5,46.5
       parent: 1
-  - uid: 1039
+  - uid: 1043
     components:
     - type: Transform
       pos: 38.5,45.5
       parent: 1
-  - uid: 1040
+  - uid: 1044
     components:
     - type: Transform
       pos: 37.5,45.5
       parent: 1
-  - uid: 1041
+  - uid: 1045
     components:
     - type: Transform
       pos: 36.5,45.5
       parent: 1
-  - uid: 1042
+  - uid: 1046
     components:
     - type: Transform
       pos: 36.5,44.5
       parent: 1
-  - uid: 1043
+  - uid: 1047
     components:
     - type: Transform
       pos: 27.5,10.5
       parent: 1
-  - uid: 1044
+  - uid: 1048
     components:
     - type: Transform
       pos: 27.5,11.5
       parent: 1
-  - uid: 1045
+  - uid: 1049
     components:
     - type: Transform
       pos: 28.5,11.5
       parent: 1
-  - uid: 1046
+  - uid: 1050
     components:
     - type: Transform
       pos: 28.5,12.5
       parent: 1
-  - uid: 1047
+  - uid: 1051
     components:
     - type: Transform
       pos: 28.5,13.5
       parent: 1
-  - uid: 1048
+  - uid: 1052
     components:
     - type: Transform
       pos: 33.5,14.5
       parent: 1
-  - uid: 1049
+  - uid: 1053
     components:
     - type: Transform
       pos: 34.5,14.5
       parent: 1
-  - uid: 1050
+  - uid: 1054
     components:
     - type: Transform
       pos: 34.5,15.5
       parent: 1
-  - uid: 1051
+  - uid: 1055
     components:
     - type: Transform
       pos: 33.5,15.5
       parent: 1
-  - uid: 1052
+  - uid: 1056
     components:
     - type: Transform
       pos: 35.5,15.5
       parent: 1
-  - uid: 1053
+  - uid: 1057
     components:
     - type: Transform
       pos: 35.5,29.5
       parent: 1
-  - uid: 1054
+  - uid: 1058
     components:
     - type: Transform
       pos: 35.5,28.5
       parent: 1
-  - uid: 1055
+  - uid: 1059
     components:
     - type: Transform
       pos: 34.5,28.5
       parent: 1
-  - uid: 1056
+  - uid: 1060
     components:
     - type: Transform
       pos: 34.5,29.5
       parent: 1
-  - uid: 1057
+  - uid: 1061
     components:
     - type: Transform
       pos: 34.5,30.5
       parent: 1
-  - uid: 1058
+  - uid: 1062
     components:
     - type: Transform
       pos: 34.5,31.5
       parent: 1
-  - uid: 1059
+  - uid: 1063
     components:
     - type: Transform
       pos: 34.5,32.5
       parent: 1
-  - uid: 1060
+  - uid: 1064
     components:
     - type: Transform
       pos: 34.5,33.5
       parent: 1
-  - uid: 1061
+  - uid: 1065
     components:
     - type: Transform
       pos: 34.5,34.5
       parent: 1
-  - uid: 1062
+  - uid: 1066
     components:
     - type: Transform
       pos: 35.5,32.5
       parent: 1
-  - uid: 1063
+  - uid: 1067
     components:
     - type: Transform
       pos: 35.5,33.5
       parent: 1
-  - uid: 1064
+  - uid: 1068
     components:
     - type: Transform
       pos: 35.5,34.5
       parent: 1
 - proto: RMCWallKutjevoRockBorder
   entities:
-  - uid: 1065
+  - uid: 1069
     components:
     - type: Transform
       pos: 22.5,49.5
       parent: 1
-  - uid: 1066
+  - uid: 1070
     components:
     - type: Transform
       pos: 20.5,49.5
       parent: 1
-  - uid: 1067
+  - uid: 1071
     components:
     - type: Transform
       pos: 21.5,49.5
       parent: 1
-  - uid: 1068
+  - uid: 1072
     components:
     - type: Transform
       pos: 23.5,49.5
       parent: 1
-  - uid: 1069
+  - uid: 1073
     components:
     - type: Transform
       pos: 24.5,49.5
       parent: 1
 - proto: RMCWeaponRevolver38Magnum
   entities:
-  - uid: 1070
+  - uid: 1074
     components:
     - type: Transform
       pos: 32.5,33.5
       parent: 1
 - proto: RMCWeaponRevolverSpearhead
   entities:
-  - uid: 1071
+  - uid: 1075
     components:
     - type: Transform
       pos: 26.5,34.5
       parent: 1
 - proto: RMCWindowFrameKutjevoReinforced
   entities:
-  - uid: 1072
+  - uid: 1076
     components:
     - type: Transform
       pos: 34.5,37.5
       parent: 1
-  - uid: 1073
+  - uid: 1077
     components:
     - type: Transform
       pos: 34.5,38.5
       parent: 1
 - proto: RMCWindowKutjevoHull
   entities:
-  - uid: 1074
+  - uid: 1078
     components:
     - type: Transform
       pos: 15.5,49.5
       parent: 1
-  - uid: 1075
+  - uid: 1079
     components:
     - type: Transform
       pos: 16.5,49.5
       parent: 1
-  - uid: 1076
+  - uid: 1080
     components:
     - type: Transform
       pos: 17.5,49.5
       parent: 1
-  - uid: 1077
+  - uid: 1081
     components:
     - type: Transform
       pos: 18.5,49.5
       parent: 1
 - proto: RMCWindowKutjevoReinforced
   entities:
-  - uid: 1078
+  - uid: 1082
     components:
     - type: Transform
       pos: 24.5,10.5
       parent: 1
-  - uid: 1079
+  - uid: 1083
     components:
     - type: Transform
       pos: 25.5,10.5
       parent: 1
-  - uid: 1080
+  - uid: 1084
     components:
     - type: Transform
       pos: 23.5,10.5
       parent: 1
-  - uid: 1081
+  - uid: 1085
     components:
     - type: Transform
       pos: 24.5,16.5
       parent: 1
-  - uid: 1082
+  - uid: 1086
     components:
     - type: Transform
       pos: 26.5,16.5
       parent: 1
-  - uid: 1083
+  - uid: 1087
     components:
     - type: Transform
       pos: 25.5,16.5
       parent: 1
-  - uid: 1084
+  - uid: 1088
     components:
     - type: Transform
       pos: 34.5,24.5
       parent: 1
-  - uid: 1085
+  - uid: 1089
     components:
     - type: Transform
       pos: 34.5,25.5
       parent: 1
-  - uid: 1086
+  - uid: 1090
     components:
     - type: Transform
       pos: 34.5,26.5
       parent: 1
-  - uid: 1087
+  - uid: 1091
     components:
     - type: Transform
       pos: 34.5,36.5
       parent: 1
-  - uid: 1088
+  - uid: 1092
     components:
     - type: Transform
       pos: 21.5,15.5
       parent: 1
-  - uid: 1089
+  - uid: 1093
     components:
     - type: Transform
       pos: 21.5,12.5

--- a/Resources/Maps/_RMC14/Inserts/Kutjevo/lz1alternative.yml
+++ b/Resources/Maps/_RMC14/Inserts/Kutjevo/lz1alternative.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 264.0.2
   forkId: ""
   forkVersion: ""
-  time: 01/25/2026 23:03:17
-  entityCount: 1085
+  time: 04/21/2026 15:23:44
+  entityCount: 1094
 maps: []
 grids:
 - 1
@@ -1984,11 +1984,15 @@ entities:
     - type: Transform
       pos: 14.5,47.5
       parent: 1
+    - type: HideLayerClothing
+      slots: null
   - uid: 3
     components:
     - type: Transform
       pos: 8.5,29.5
       parent: 1
+    - type: HideLayerClothing
+      slots: null
 - proto: BonsaiTree01
   entities:
   - uid: 4
@@ -2021,7 +2025,7 @@ entities:
       parent: 1
 - proto: CMApcNoPower
   entities:
-  - uid: 1083
+  - uid: 8
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2031,31 +2035,31 @@ entities:
       offset: -0.5,-1.5
 - proto: CMChair
   entities:
-  - uid: 8
+  - uid: 9
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,13.5
       parent: 1
-  - uid: 9
+  - uid: 10
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,14.5
       parent: 1
-  - uid: 10
+  - uid: 11
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 12.5,47.5
       parent: 1
-  - uid: 11
+  - uid: 12
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,46.5
       parent: 1
-  - uid: 12
+  - uid: 13
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2063,31 +2067,31 @@ entities:
       parent: 1
 - proto: CMChairFolded
   entities:
-  - uid: 13
+  - uid: 14
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,13.5
       parent: 1
-  - uid: 14
+  - uid: 15
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,14.5
       parent: 1
-  - uid: 15
+  - uid: 16
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 25.5,45.5
       parent: 1
-  - uid: 16
+  - uid: 17
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,47.5
       parent: 1
-  - uid: 17
+  - uid: 18
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2095,13 +2099,13 @@ entities:
       parent: 1
 - proto: CMChairOfficeWhite
   entities:
-  - uid: 18
+  - uid: 19
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 22.5,13.5
       parent: 1
-  - uid: 19
+  - uid: 20
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2109,185 +2113,185 @@ entities:
       parent: 1
 - proto: CMFence
   entities:
-  - uid: 20
+  - uid: 21
     components:
     - type: Transform
       pos: 43.5,45.5
       parent: 1
-  - uid: 21
+  - uid: 22
     components:
     - type: Transform
       pos: 43.5,44.5
       parent: 1
-  - uid: 22
+  - uid: 23
     components:
     - type: Transform
       pos: 43.5,43.5
       parent: 1
-  - uid: 23
+  - uid: 24
     components:
     - type: Transform
       pos: 43.5,42.5
       parent: 1
-  - uid: 24
+  - uid: 25
     components:
     - type: Transform
       pos: 43.5,41.5
       parent: 1
-  - uid: 25
+  - uid: 26
     components:
     - type: Transform
       pos: 43.5,40.5
       parent: 1
-  - uid: 26
+  - uid: 27
     components:
     - type: Transform
       pos: 43.5,37.5
       parent: 1
-  - uid: 27
+  - uid: 28
     components:
     - type: Transform
       pos: 43.5,36.5
       parent: 1
-  - uid: 28
+  - uid: 29
     components:
     - type: Transform
       pos: 43.5,35.5
       parent: 1
-  - uid: 29
+  - uid: 30
     components:
     - type: Transform
       pos: 41.5,29.5
       parent: 1
-  - uid: 30
+  - uid: 31
     components:
     - type: Transform
       pos: 41.5,27.5
       parent: 1
-  - uid: 31
+  - uid: 32
     components:
     - type: Transform
       pos: 41.5,26.5
       parent: 1
-  - uid: 32
+  - uid: 33
     components:
     - type: Transform
       pos: 41.5,25.5
       parent: 1
-  - uid: 33
+  - uid: 34
     components:
     - type: Transform
       pos: 41.5,24.5
       parent: 1
-  - uid: 34
+  - uid: 35
     components:
     - type: Transform
       pos: 41.5,23.5
       parent: 1
-  - uid: 35
+  - uid: 36
     components:
     - type: Transform
       pos: 41.5,22.5
       parent: 1
-  - uid: 36
+  - uid: 37
     components:
     - type: Transform
       pos: 41.5,21.5
       parent: 1
-  - uid: 37
+  - uid: 38
     components:
     - type: Transform
       pos: 41.5,28.5
       parent: 1
 - proto: CMGirder
   entities:
-  - uid: 38
+  - uid: 39
     components:
     - type: Transform
       pos: 7.5,31.5
       parent: 1
-  - uid: 39
+  - uid: 40
     components:
     - type: Transform
       pos: 12.5,16.5
       parent: 1
-  - uid: 40
+  - uid: 41
     components:
     - type: Transform
       pos: 7.5,24.5
       parent: 1
 - proto: CMPaper
   entities:
-  - uid: 46
+  - uid: 42
     components:
     - type: Transform
       pos: 21.324476,14.1429205
       parent: 1
 - proto: CMPaperBin30
   entities:
-  - uid: 47
+  - uid: 43
     components:
     - type: Transform
       pos: 21.636976,14.7366705
       parent: 1
 - proto: CMPen
   entities:
-  - uid: 48
+  - uid: 44
     components:
     - type: Transform
       pos: 21.672268,13.343409
       parent: 1
-  - uid: 49
+  - uid: 45
     components:
     - type: Transform
       pos: 24.484768,15.405909
       parent: 1
 - proto: CMPottedPlant29
   entities:
-  - uid: 50
+  - uid: 46
     components:
     - type: Transform
       pos: 14.5,15.5
       parent: 1
-  - uid: 51
+  - uid: 47
     components:
     - type: Transform
       pos: 27.5,46.5
       parent: 1
-  - uid: 52
+  - uid: 48
     components:
     - type: Transform
       pos: 32.5,27.5
       parent: 1
 - proto: CMRack
   entities:
-  - uid: 53
+  - uid: 49
     components:
     - type: Transform
       pos: 26.5,14.5
       parent: 1
-  - uid: 54
+  - uid: 50
     components:
     - type: Transform
       pos: 11.5,47.5
       parent: 1
 - proto: CMSemioticBathmens
   entities:
-  - uid: 55
+  - uid: 51
     components:
     - type: Transform
       pos: 30.5,29.5
       parent: 1
 - proto: CMSemioticBathwomens
   entities:
-  - uid: 56
+  - uid: 52
     components:
     - type: Transform
       pos: 30.5,32.5
       parent: 1
 - proto: CMSemioticFlightcontrol
   entities:
-  - uid: 57
+  - uid: 53
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2295,25 +2299,25 @@ entities:
       parent: 1
 - proto: CMSemioticHazard
   entities:
-  - uid: 58
+  - uid: 54
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 43.5247,47.55419
       parent: 1
-  - uid: 59
+  - uid: 55
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 38.852825,47.55419
       parent: 1
-  - uid: 60
+  - uid: 56
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 34.49345,47.52294
       parent: 1
-  - uid: 61
+  - uid: 57
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2321,25 +2325,25 @@ entities:
       parent: 1
 - proto: CMSemioticLandingzone
   entities:
-  - uid: 62
+  - uid: 58
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 14.5,10.5
       parent: 1
-  - uid: 63
+  - uid: 59
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.885622,10.519172
       parent: 1
-  - uid: 64
+  - uid: 60
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 35.875347,27.53891
       parent: 1
-  - uid: 65
+  - uid: 61
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2347,60 +2351,60 @@ entities:
       parent: 1
 - proto: CMShardGlass
   entities:
-  - uid: 66
+  - uid: 62
     components:
     - type: Transform
       pos: 34.5,38.5
       parent: 1
-  - uid: 67
+  - uid: 63
     components:
     - type: Transform
       pos: 34.5,37.5
       parent: 1
-  - uid: 68
+  - uid: 64
     components:
     - type: Transform
       pos: 33.5,38.5
       parent: 1
-  - uid: 69
+  - uid: 65
     components:
     - type: Transform
       pos: 33.5,37.5
       parent: 1
-  - uid: 70
+  - uid: 66
     components:
     - type: Transform
       pos: 32.5,38.5
       parent: 1
-  - uid: 71
+  - uid: 67
     components:
     - type: Transform
       pos: 32.5,36.5
       parent: 1
-  - uid: 72
+  - uid: 68
     components:
     - type: Transform
       pos: 35.5,37.5
       parent: 1
-  - uid: 73
+  - uid: 69
     components:
     - type: Transform
       pos: 35.5,38.5
       parent: 1
-  - uid: 74
+  - uid: 70
     components:
     - type: Transform
       pos: 36.5,38.5
       parent: 1
 - proto: CMSinkEmpty
   entities:
-  - uid: 75
+  - uid: 71
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 31.233452,29.574705
       parent: 1
-  - uid: 76
+  - uid: 72
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2408,20 +2412,20 @@ entities:
       parent: 1
 - proto: CMStampDenied
   entities:
-  - uid: 77
+  - uid: 73
     components:
     - type: Transform
       pos: 21.5,13.5
       parent: 1
 - proto: CMToiletEmpty
   entities:
-  - uid: 78
+  - uid: 74
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 32.5,29.5
       parent: 1
-  - uid: 79
+  - uid: 75
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2429,347 +2433,347 @@ entities:
       parent: 1
 - proto: CMVendorCoffee
   entities:
-  - uid: 80
+  - uid: 76
     components:
     - type: Transform
       pos: 30.5,27.5
       parent: 1
 - proto: CMVendorCola
   entities:
-  - uid: 81
+  - uid: 77
     components:
     - type: Transform
       pos: 31.5,27.5
       parent: 1
 - proto: CMWallShuttleOrange
   entities:
-  - uid: 82
+  - uid: 78
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
-  - uid: 83
+  - uid: 79
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 1
-  - uid: 84
+  - uid: 80
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 1
-  - uid: 85
+  - uid: 81
     components:
     - type: Transform
       pos: 0.5,7.5
       parent: 1
-  - uid: 86
+  - uid: 82
     components:
     - type: Transform
       pos: 0.5,8.5
       parent: 1
-  - uid: 87
+  - uid: 83
     components:
     - type: Transform
       pos: 0.5,9.5
       parent: 1
-  - uid: 88
+  - uid: 84
     components:
     - type: Transform
       pos: 0.5,10.5
       parent: 1
-  - uid: 89
+  - uid: 85
     components:
     - type: Transform
       pos: 0.5,11.5
       parent: 1
-  - uid: 90
+  - uid: 86
     components:
     - type: Transform
       pos: 0.5,12.5
       parent: 1
-  - uid: 91
+  - uid: 87
     components:
     - type: Transform
       pos: 0.5,13.5
       parent: 1
-  - uid: 92
+  - uid: 88
     components:
     - type: Transform
       pos: 0.5,14.5
       parent: 1
-  - uid: 93
+  - uid: 89
     components:
     - type: Transform
       pos: 0.5,15.5
       parent: 1
-  - uid: 94
+  - uid: 90
     components:
     - type: Transform
       pos: 0.5,16.5
       parent: 1
-  - uid: 95
+  - uid: 91
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 1
-  - uid: 96
+  - uid: 92
     components:
     - type: Transform
       pos: 0.5,17.5
       parent: 1
-  - uid: 97
+  - uid: 93
     components:
     - type: Transform
       pos: 0.5,18.5
       parent: 1
-  - uid: 98
+  - uid: 94
     components:
     - type: Transform
       pos: 0.5,19.5
       parent: 1
-  - uid: 99
+  - uid: 95
     components:
     - type: Transform
       pos: 0.5,20.5
       parent: 1
-  - uid: 100
+  - uid: 96
     components:
     - type: Transform
       pos: 0.5,21.5
       parent: 1
-  - uid: 101
+  - uid: 97
     components:
     - type: Transform
       pos: 0.5,22.5
       parent: 1
-  - uid: 102
+  - uid: 98
     components:
     - type: Transform
       pos: 0.5,23.5
       parent: 1
-  - uid: 103
+  - uid: 99
     components:
     - type: Transform
       pos: 0.5,24.5
       parent: 1
-  - uid: 104
+  - uid: 100
     components:
     - type: Transform
       pos: 0.5,25.5
       parent: 1
-  - uid: 105
+  - uid: 101
     components:
     - type: Transform
       pos: 0.5,26.5
       parent: 1
-  - uid: 106
+  - uid: 102
     components:
     - type: Transform
       pos: 0.5,27.5
       parent: 1
-  - uid: 107
+  - uid: 103
     components:
     - type: Transform
       pos: 0.5,28.5
       parent: 1
-  - uid: 108
+  - uid: 104
     components:
     - type: Transform
       pos: 0.5,29.5
       parent: 1
-  - uid: 109
+  - uid: 105
     components:
     - type: Transform
       pos: 0.5,30.5
       parent: 1
-  - uid: 110
+  - uid: 106
     components:
     - type: Transform
       pos: 0.5,31.5
       parent: 1
-  - uid: 111
+  - uid: 107
     components:
     - type: Transform
       pos: 0.5,32.5
       parent: 1
-  - uid: 112
+  - uid: 108
     components:
     - type: Transform
       pos: 0.5,33.5
       parent: 1
-  - uid: 113
+  - uid: 109
     components:
     - type: Transform
       pos: 0.5,34.5
       parent: 1
-  - uid: 114
+  - uid: 110
     components:
     - type: Transform
       pos: 0.5,35.5
       parent: 1
-  - uid: 115
+  - uid: 111
     components:
     - type: Transform
       pos: 0.5,36.5
       parent: 1
-  - uid: 116
+  - uid: 112
     components:
     - type: Transform
       pos: 0.5,37.5
       parent: 1
-  - uid: 117
+  - uid: 113
     components:
     - type: Transform
       pos: 0.5,38.5
       parent: 1
-  - uid: 118
+  - uid: 114
     components:
     - type: Transform
       pos: 0.5,39.5
       parent: 1
-  - uid: 119
+  - uid: 115
     components:
     - type: Transform
       pos: 0.5,40.5
       parent: 1
-  - uid: 120
+  - uid: 116
     components:
     - type: Transform
       pos: 0.5,41.5
       parent: 1
-  - uid: 121
+  - uid: 117
     components:
     - type: Transform
       pos: 0.5,42.5
       parent: 1
-  - uid: 122
+  - uid: 118
     components:
     - type: Transform
       pos: 0.5,43.5
       parent: 1
-  - uid: 123
+  - uid: 119
     components:
     - type: Transform
       pos: 0.5,44.5
       parent: 1
-  - uid: 124
+  - uid: 120
     components:
     - type: Transform
       pos: 0.5,45.5
       parent: 1
-  - uid: 125
+  - uid: 121
     components:
     - type: Transform
       pos: 0.5,46.5
       parent: 1
-  - uid: 126
+  - uid: 122
     components:
     - type: Transform
       pos: 0.5,47.5
       parent: 1
-  - uid: 127
+  - uid: 123
     components:
     - type: Transform
       pos: 0.5,48.5
       parent: 1
-  - uid: 128
+  - uid: 124
     components:
     - type: Transform
       pos: 0.5,49.5
       parent: 1
 - proto: CMWarningCone
   entities:
-  - uid: 129
+  - uid: 125
     components:
     - type: Transform
       pos: 10.544077,46.008255
       parent: 1
-  - uid: 130
+  - uid: 126
     components:
     - type: Transform
       pos: 8.653452,45.93013
       parent: 1
-  - uid: 131
+  - uid: 127
     components:
     - type: Transform
       pos: 8.215952,45.39888
       parent: 1
-  - uid: 132
+  - uid: 128
     components:
     - type: Transform
       pos: 20.496614,48.008255
       parent: 1
-  - uid: 133
+  - uid: 129
     components:
     - type: Transform
       pos: 21.69974,46.86763
       parent: 1
-  - uid: 134
+  - uid: 130
     components:
     - type: Transform
       pos: 27.594095,40.89644
       parent: 1
-  - uid: 135
+  - uid: 131
     components:
     - type: Transform
       pos: 27.062845,40.537064
       parent: 1
-  - uid: 136
+  - uid: 132
     components:
     - type: Transform
       pos: 27.594095,38.037064
       parent: 1
-  - uid: 137
+  - uid: 133
     components:
     - type: Transform
       pos: 31.094095,39.52144
       parent: 1
-  - uid: 138
+  - uid: 134
     components:
     - type: Transform
       pos: 9.157572,27.583323
       parent: 1
-  - uid: 139
+  - uid: 135
     components:
     - type: Transform
       pos: 8.595072,26.927073
       parent: 1
-  - uid: 140
+  - uid: 136
     components:
     - type: Transform
       pos: 8.454447,24.755198
       parent: 1
 - proto: CMWebbingBlack
   entities:
-  - uid: 142
+  - uid: 138
     components:
     - type: Transform
-      parent: 141
+      parent: 137
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: CMWindoorSecure
   entities:
-  - uid: 151
+  - uid: 147
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 21.5,14.5
       parent: 1
-  - uid: 152
+  - uid: 148
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 21.5,13.5
       parent: 1
-  - uid: 153
+  - uid: 149
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 21.5,13.5
       parent: 1
-  - uid: 154
+  - uid: 150
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2777,20 +2781,20 @@ entities:
       parent: 1
 - proto: DiceBag
   entities:
-  - uid: 155
+  - uid: 151
     components:
     - type: Transform
       pos: 13.546082,47.736397
       parent: 1
 - proto: RMCAirlockRustedWhite
   entities:
-  - uid: 156
+  - uid: 152
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 30.5,33.5
       parent: 1
-  - uid: 157
+  - uid: 153
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2798,528 +2802,530 @@ entities:
       parent: 1
 - proto: RMCArmorHelmetPMCKutjevoSecurity
   entities:
-  - uid: 158
+  - uid: 154
     components:
     - type: Transform
       pos: 24.703518,15.827784
       parent: 1
+    - type: HideLayerClothing
+      slots: null
 - proto: RMCArmorSecurity
   entities:
-  - uid: 143
+  - uid: 139
     components:
     - type: Transform
-      parent: 141
+      parent: 137
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 159
+  - uid: 155
     components:
     - type: Transform
       pos: 26.5,14.5
       parent: 1
-  - uid: 160
+  - uid: 156
     components:
     - type: Transform
       pos: 26.5,14.5
       parent: 1
-  - uid: 161
+  - uid: 157
     components:
     - type: Transform
       pos: 26.5,14.5
       parent: 1
 - proto: RMCAshtray
   entities:
-  - uid: 162
+  - uid: 158
     components:
     - type: Transform
       pos: 13.387615,46.68013
       parent: 1
 - proto: RMCBarrelBlue
   entities:
-  - uid: 163
+  - uid: 159
     components:
     - type: Transform
       pos: 8.5,41.5
       parent: 1
-  - uid: 164
+  - uid: 160
     components:
     - type: Transform
       pos: 34.5,44.5
       parent: 1
-  - uid: 165
+  - uid: 161
     components:
     - type: Transform
       pos: 29.5,41.5
       parent: 1
-  - uid: 166
+  - uid: 162
     components:
     - type: Transform
       pos: 27.5,23.5
       parent: 1
-  - uid: 167
+  - uid: 163
     components:
     - type: Transform
       pos: 8.5,21.5
       parent: 1
 - proto: RMCBarrelGreen
   entities:
-  - uid: 168
+  - uid: 164
     components:
     - type: Transform
       pos: 30.5,41.5
       parent: 1
-  - uid: 169
+  - uid: 165
     components:
     - type: Transform
       pos: 27.5,22.5
       parent: 1
 - proto: RMCBarrelWhite
   entities:
-  - uid: 170
+  - uid: 166
     components:
     - type: Transform
       pos: 34.5,45.5
       parent: 1
-  - uid: 171
+  - uid: 167
     components:
     - type: Transform
       pos: 21.5,47.5
       parent: 1
-  - uid: 172
+  - uid: 168
     components:
     - type: Transform
       pos: 8.5,40.5
       parent: 1
-  - uid: 173
+  - uid: 169
     components:
     - type: Transform
       pos: 30.5,35.5
       parent: 1
-  - uid: 174
+  - uid: 170
     components:
     - type: Transform
       pos: 31.5,25.5
       parent: 1
-  - uid: 175
+  - uid: 171
     components:
     - type: Transform
       pos: 8.5,20.5
       parent: 1
 - proto: RMCBarricadeWood
   entities:
-  - uid: 176
+  - uid: 172
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 30.5,47.5
       parent: 1
-  - uid: 177
+  - uid: 173
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 31.5,47.5
       parent: 1
-  - uid: 178
+  - uid: 174
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 32.5,46.5
       parent: 1
-  - uid: 179
+  - uid: 175
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 33.5,46.5
       parent: 1
-  - uid: 180
+  - uid: 176
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 34.5,43.5
       parent: 1
-  - uid: 181
+  - uid: 177
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 34.5,42.5
       parent: 1
-  - uid: 182
+  - uid: 178
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 33.5,41.5
       parent: 1
-  - uid: 183
+  - uid: 179
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 33.5,40.5
       parent: 1
-  - uid: 184
+  - uid: 180
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 34.5,22.5
       parent: 1
-  - uid: 185
+  - uid: 181
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 34.5,19.5
       parent: 1
-  - uid: 186
+  - uid: 182
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 33.5,21.5
       parent: 1
-  - uid: 187
+  - uid: 183
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 33.5,20.5
       parent: 1
-  - uid: 188
+  - uid: 184
     components:
     - type: Transform
       pos: 29.5,16.5
       parent: 1
-  - uid: 189
+  - uid: 185
     components:
     - type: Transform
       pos: 30.5,16.5
       parent: 1
-  - uid: 190
+  - uid: 186
     components:
     - type: Transform
       pos: 31.5,17.5
       parent: 1
-  - uid: 191
+  - uid: 187
     components:
     - type: Transform
       pos: 15.5,12.5
       parent: 1
-  - uid: 192
+  - uid: 188
     components:
     - type: Transform
       pos: 17.5,12.5
       parent: 1
-  - uid: 193
+  - uid: 189
     components:
     - type: Transform
       pos: 18.5,12.5
       parent: 1
-  - uid: 194
+  - uid: 190
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,13.5
       parent: 1
-  - uid: 195
+  - uid: 191
     components:
     - type: Transform
       pos: 19.5,14.5
       parent: 1
-  - uid: 196
+  - uid: 192
     components:
     - type: Transform
       pos: 15.5,17.5
       parent: 1
-  - uid: 197
+  - uid: 193
     components:
     - type: Transform
       pos: 17.5,17.5
       parent: 1
-  - uid: 198
+  - uid: 194
     components:
     - type: Transform
       pos: 18.5,17.5
       parent: 1
-  - uid: 199
+  - uid: 195
     components:
     - type: Transform
       pos: 19.5,17.5
       parent: 1
 - proto: RMCBasePropCasing11
   entities:
-  - uid: 200
+  - uid: 196
     components:
     - type: Transform
       pos: 31.5,32.5
       parent: 1
-  - uid: 201
+  - uid: 197
     components:
     - type: Transform
       pos: 26.5,25.5
       parent: 1
-  - uid: 202
+  - uid: 198
     components:
     - type: Transform
       pos: 28.5,28.5
       parent: 1
-  - uid: 203
+  - uid: 199
     components:
     - type: Transform
       pos: 26.5,32.5
       parent: 1
-  - uid: 204
+  - uid: 200
     components:
     - type: Transform
       pos: 25.5,34.5
       parent: 1
-  - uid: 205
+  - uid: 201
     components:
     - type: Transform
       pos: 26.5,36.5
       parent: 1
 - proto: RMCCigaretteSpent
   entities:
-  - uid: 206
+  - uid: 202
     components:
     - type: Transform
       pos: 12.5,46.5
       parent: 1
-  - uid: 207
+  - uid: 203
     components:
     - type: Transform
       pos: 13.5,45.5
       parent: 1
-  - uid: 208
+  - uid: 204
     components:
     - type: Transform
       pos: 14.5,47.5
       parent: 1
-  - uid: 209
+  - uid: 205
     components:
     - type: Transform
       pos: 14.5,47.5
       parent: 1
 - proto: RMCCoffeeCupFilled
   entities:
-  - uid: 210
+  - uid: 206
     components:
     - type: Transform
       pos: 24.281643,15.780909
       parent: 1
-  - uid: 211
+  - uid: 207
     components:
     - type: Transform
       pos: 24.871351,15.4866705
       parent: 1
 - proto: RMCContainerApocraphyLeft
   entities:
-  - uid: 212
+  - uid: 208
     components:
     - type: Transform
       pos: 8.5,47.5
       parent: 1
 - proto: RMCContainerApocraphyMiddle
   entities:
-  - uid: 213
+  - uid: 209
     components:
     - type: Transform
       pos: 29.5,22.5
       parent: 1
 - proto: RMCContainerFerretLeft
   entities:
-  - uid: 214
+  - uid: 210
     components:
     - type: Transform
       pos: 28.5,39.5
       parent: 1
 - proto: RMCContainerFerretMiddle
   entities:
-  - uid: 215
+  - uid: 211
     components:
     - type: Transform
       pos: 29.5,39.5
       parent: 1
 - proto: RMCContainerFerretRight
   entities:
-  - uid: 216
+  - uid: 212
     components:
     - type: Transform
       pos: 30.5,39.5
       parent: 1
 - proto: RMCContainerGreenRight
   entities:
-  - uid: 217
+  - uid: 213
     components:
     - type: Transform
       pos: 31.5,23.5
       parent: 1
 - proto: RMCContainerPathosLeft
   entities:
-  - uid: 218
+  - uid: 214
     components:
     - type: Transform
       pos: 29.5,23.5
       parent: 1
 - proto: RMCContainerPathosMiddle
   entities:
-  - uid: 219
+  - uid: 215
     components:
     - type: Transform
       pos: 30.5,23.5
       parent: 1
 - proto: RMCContainerRedLeft
   entities:
-  - uid: 220
+  - uid: 216
     components:
     - type: Transform
       pos: 28.5,22.5
       parent: 1
 - proto: RMCContainerRedMiddle
   entities:
-  - uid: 221
+  - uid: 217
     components:
     - type: Transform
       pos: 9.5,47.5
       parent: 1
 - proto: RMCContainerRedRight
   entities:
-  - uid: 222
+  - uid: 218
     components:
     - type: Transform
       pos: 10.5,47.5
       parent: 1
-  - uid: 223
+  - uid: 219
     components:
     - type: Transform
       pos: 30.5,22.5
       parent: 1
 - proto: RMCContainerShortRedLeft
   entities:
-  - uid: 224
+  - uid: 220
     components:
     - type: Transform
       pos: 23.5,47.5
       parent: 1
 - proto: RMCContainerShortRedRight
   entities:
-  - uid: 225
+  - uid: 221
     components:
     - type: Transform
       pos: 24.5,47.5
       parent: 1
 - proto: RMCContainerShortTanLeft
   entities:
-  - uid: 226
+  - uid: 222
     components:
     - type: Transform
       pos: 28.5,38.5
       parent: 1
 - proto: RMCContainerShortTanRight
   entities:
-  - uid: 227
+  - uid: 223
     components:
     - type: Transform
       pos: 29.5,38.5
       parent: 1
 - proto: RMCContainerWeYaGreyLeft
   entities:
-  - uid: 228
+  - uid: 224
     components:
     - type: Transform
       pos: 8.5,46.5
       parent: 1
 - proto: RMCContainerWeYaGreyRight
   entities:
-  - uid: 229
+  - uid: 225
     components:
     - type: Transform
       pos: 9.5,46.5
       parent: 1
 - proto: RMCCrateLarge
   entities:
-  - uid: 230
+  - uid: 226
     components:
     - type: Transform
       pos: 10.5,46.5
       parent: 1
-  - uid: 231
+  - uid: 227
     components:
     - type: Transform
       pos: 13.5,47.5
       parent: 1
-  - uid: 232
+  - uid: 228
     components:
     - type: Transform
       pos: 13.5,46.5
       parent: 1
-  - uid: 233
+  - uid: 229
     components:
     - type: Transform
       pos: 30.5,38.5
       parent: 1
-  - uid: 234
+  - uid: 230
     components:
     - type: Transform
       pos: 28.5,37.5
       parent: 1
-  - uid: 235
+  - uid: 231
     components:
     - type: Transform
       pos: 31.5,22.5
       parent: 1
-  - uid: 236
+  - uid: 232
     components:
     - type: Transform
       pos: 8.5,39.5
       parent: 1
 - proto: RMCCrateMini
   entities:
-  - uid: 237
+  - uid: 233
     components:
     - type: Transform
       pos: 28.569923,37.92571
       parent: 1
-  - uid: 238
+  - uid: 234
     components:
     - type: Transform
       pos: 29.319923,37.61321
       parent: 1
 - proto: RMCEntityDesertWaterShallow
   entities:
-  - uid: 239
+  - uid: 235
     components:
     - type: Transform
       pos: 11.5,4.5
       parent: 1
-  - uid: 240
+  - uid: 236
     components:
     - type: Transform
       pos: 12.5,3.5
       parent: 1
-  - uid: 241
+  - uid: 237
     components:
     - type: Transform
       pos: 13.5,3.5
       parent: 1
-  - uid: 242
+  - uid: 238
     components:
     - type: Transform
       pos: 14.5,2.5
       parent: 1
-  - uid: 243
+  - uid: 239
     components:
     - type: Transform
       pos: 15.5,2.5
       parent: 1
-  - uid: 244
+  - uid: 240
     components:
     - type: Transform
       pos: 16.5,2.5
       parent: 1
 - proto: RMCEntityDesertWaterShallowCornerEdge
   entities:
-  - uid: 245
+  - uid: 241
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,3.5
       parent: 1
-  - uid: 246
+  - uid: 242
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3327,25 +3333,25 @@ entities:
       parent: 1
 - proto: RMCEntityDesertWaterShallowEdge
   entities:
-  - uid: 247
+  - uid: 243
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,2.5
       parent: 1
-  - uid: 248
+  - uid: 244
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 14.5,1.5
       parent: 1
-  - uid: 249
+  - uid: 245
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 15.5,1.5
       parent: 1
-  - uid: 250
+  - uid: 246
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3353,135 +3359,135 @@ entities:
       parent: 1
 - proto: RMCGrassTallCornerDesert
   entities:
-  - uid: 251
+  - uid: 247
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 22.5,2.5
       parent: 1
-  - uid: 252
+  - uid: 248
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 26.5,2.5
       parent: 1
-  - uid: 253
+  - uid: 249
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 24.5,2.5
       parent: 1
-  - uid: 254
+  - uid: 250
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 27.5,3.5
       parent: 1
-  - uid: 255
+  - uid: 251
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 29.5,3.5
       parent: 1
-  - uid: 256
+  - uid: 252
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 30.5,3.5
       parent: 1
-  - uid: 257
+  - uid: 253
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 30.5,5.5
       parent: 1
-  - uid: 258
+  - uid: 254
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 28.5,6.5
       parent: 1
-  - uid: 259
+  - uid: 255
     components:
     - type: Transform
       pos: 19.5,3.5
       parent: 1
-  - uid: 260
+  - uid: 256
     components:
     - type: Transform
       pos: 21.5,4.5
       parent: 1
-  - uid: 261
+  - uid: 257
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 28.5,9.5
       parent: 1
-  - uid: 262
+  - uid: 258
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 29.5,10.5
       parent: 1
-  - uid: 263
+  - uid: 259
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 29.5,12.5
       parent: 1
-  - uid: 264
+  - uid: 260
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 26.5,9.5
       parent: 1
-  - uid: 265
+  - uid: 261
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 36.5,23.5
       parent: 1
-  - uid: 266
+  - uid: 262
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 36.5,26.5
       parent: 1
-  - uid: 267
+  - uid: 263
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 36.5,27.5
       parent: 1
-  - uid: 268
+  - uid: 264
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 36.5,25.5
       parent: 1
-  - uid: 269
+  - uid: 265
     components:
     - type: Transform
       pos: 40.5,32.5
       parent: 1
-  - uid: 270
+  - uid: 266
     components:
     - type: Transform
       pos: 41.5,34.5
       parent: 1
-  - uid: 271
+  - uid: 267
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 35.5,38.5
       parent: 1
-  - uid: 272
+  - uid: 268
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 36.5,37.5
       parent: 1
-  - uid: 273
+  - uid: 269
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3489,171 +3495,171 @@ entities:
       parent: 1
 - proto: RMCGrassTallDesert
   entities:
-  - uid: 274
+  - uid: 270
     components:
     - type: Transform
       pos: 41.5,32.5
       parent: 1
-  - uid: 275
+  - uid: 271
     components:
     - type: Transform
       pos: 21.5,3.5
       parent: 1
-  - uid: 276
+  - uid: 272
     components:
     - type: Transform
       pos: 21.5,2.5
       parent: 1
-  - uid: 277
+  - uid: 273
     components:
     - type: Transform
       pos: 22.5,3.5
       parent: 1
-  - uid: 278
+  - uid: 274
     components:
     - type: Transform
       pos: 24.5,3.5
       parent: 1
-  - uid: 279
+  - uid: 275
     components:
     - type: Transform
       pos: 26.5,3.5
       parent: 1
-  - uid: 280
+  - uid: 276
     components:
     - type: Transform
       pos: 25.5,3.5
       parent: 1
-  - uid: 281
+  - uid: 277
     components:
     - type: Transform
       pos: 25.5,4.5
       parent: 1
-  - uid: 282
+  - uid: 278
     components:
     - type: Transform
       pos: 27.5,4.5
       parent: 1
-  - uid: 283
+  - uid: 279
     components:
     - type: Transform
       pos: 27.5,5.5
       parent: 1
-  - uid: 284
+  - uid: 280
     components:
     - type: Transform
       pos: 28.5,5.5
       parent: 1
-  - uid: 285
+  - uid: 281
     components:
     - type: Transform
       pos: 29.5,4.5
       parent: 1
-  - uid: 286
+  - uid: 282
     components:
     - type: Transform
       pos: 28.5,10.5
       parent: 1
-  - uid: 287
+  - uid: 283
     components:
     - type: Transform
       pos: 35.5,24.5
       parent: 1
-  - uid: 288
+  - uid: 284
     components:
     - type: Transform
       pos: 35.5,25.5
       parent: 1
-  - uid: 289
+  - uid: 285
     components:
     - type: Transform
       pos: 35.5,26.5
       parent: 1
-  - uid: 290
+  - uid: 286
     components:
     - type: Transform
       pos: 42.5,33.5
       parent: 1
-  - uid: 291
+  - uid: 287
     components:
     - type: Transform
       pos: 35.5,37.5
       parent: 1
-  - uid: 292
+  - uid: 288
     components:
     - type: Transform
       pos: 35.5,36.5
       parent: 1
 - proto: RMCGrassTallSidesDesert
   entities:
-  - uid: 293
+  - uid: 289
     components:
     - type: Transform
       pos: 20.5,3.5
       parent: 1
-  - uid: 294
+  - uid: 290
     components:
     - type: Transform
       pos: 26.5,6.5
       parent: 1
-  - uid: 295
+  - uid: 291
     components:
     - type: Transform
       pos: 27.5,6.5
       parent: 1
-  - uid: 296
+  - uid: 292
     components:
     - type: Transform
       pos: 29.5,5.5
       parent: 1
-  - uid: 297
+  - uid: 293
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 30.5,4.5
       parent: 1
-  - uid: 298
+  - uid: 294
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 28.5,4.5
       parent: 1
-  - uid: 299
+  - uid: 295
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 25.5,2.5
       parent: 1
-  - uid: 300
+  - uid: 296
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 27.5,9.5
       parent: 1
-  - uid: 301
+  - uid: 297
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 29.5,11.5
       parent: 1
-  - uid: 302
+  - uid: 298
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 36.5,24.5
       parent: 1
-  - uid: 303
+  - uid: 299
     components:
     - type: Transform
       pos: 42.5,34.5
       parent: 1
-  - uid: 304
+  - uid: 300
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 41.5,33.5
       parent: 1
-  - uid: 305
+  - uid: 301
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3661,14 +3667,14 @@ entities:
       parent: 1
 - proto: RMCHardHat
   entities:
-  - uid: 306
+  - uid: 302
     components:
     - type: Transform
       pos: 9.5,17.5
       parent: 1
 - proto: RMCIdentificationComputer
   entities:
-  - uid: 307
+  - uid: 303
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3676,114 +3682,114 @@ entities:
       parent: 1
 - proto: RMCJumpsuitVeteranPMCKutjevo
   entities:
-  - uid: 144
+  - uid: 140
     components:
     - type: Transform
-      parent: 141
+      parent: 137
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: RMCLightFixtureOffset
   entities:
-  - uid: 308
+  - uid: 304
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,47.5
       parent: 1
-  - uid: 309
+  - uid: 305
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,47.5
       parent: 1
-  - uid: 310
+  - uid: 306
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 26.5,46.5
       parent: 1
-  - uid: 311
+  - uid: 307
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,22.5
       parent: 1
-  - uid: 312
+  - uid: 308
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 33.5,39.5
       parent: 1
-  - uid: 313
+  - uid: 309
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 33.5,23.5
       parent: 1
-  - uid: 314
+  - uid: 310
     components:
     - type: Transform
       pos: 33.5,17.5
       parent: 1
-  - uid: 315
+  - uid: 311
     components:
     - type: Transform
       pos: 27.5,17.5
       parent: 1
-  - uid: 316
+  - uid: 312
     components:
     - type: Transform
       pos: 21.5,17.5
       parent: 1
-  - uid: 317
+  - uid: 313
     components:
     - type: Transform
       pos: 13.5,17.5
       parent: 1
-  - uid: 318
+  - uid: 314
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 14.5,14.5
       parent: 1
-  - uid: 319
+  - uid: 315
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 26.5,14.5
       parent: 1
-  - uid: 320
+  - uid: 316
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 23.5,15.5
       parent: 1
-  - uid: 321
+  - uid: 317
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,18.5
       parent: 1
-  - uid: 322
+  - uid: 318
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,33.5
       parent: 1
-  - uid: 323
+  - uid: 319
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,37.5
       parent: 1
-  - uid: 324
+  - uid: 320
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,41.5
       parent: 1
-  - uid: 325
+  - uid: 321
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3791,31 +3797,31 @@ entities:
       parent: 1
 - proto: RMCLightFixtureSmallOffset
   entities:
-  - uid: 41
+  - uid: 322
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 29.5,34.5
       parent: 1
-  - uid: 42
+  - uid: 323
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 29.5,28.5
       parent: 1
-  - uid: 43
+  - uid: 324
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 31.5,33.5
       parent: 1
-  - uid: 44
+  - uid: 325
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 31.5,30.5
       parent: 1
-  - uid: 45
+  - uid: 326
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3823,7 +3829,7 @@ entities:
       parent: 1
 - proto: RMCLockerPoliceSoro
   entities:
-  - uid: 141
+  - uid: 137
     components:
     - type: Transform
       pos: 26.5,13.5
@@ -3834,65 +3840,65 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 144
-          - 150
-          - 149
-          - 148
-          - 147
+          - 140
           - 146
+          - 145
+          - 144
           - 143
           - 142
-          - 145
+          - 139
+          - 138
+          - 141
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
 - proto: RMCMagazineRifleM16
   entities:
+  - uid: 141
+    components:
+    - type: Transform
+      parent: 137
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 142
+    components:
+    - type: Transform
+      parent: 137
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 143
+    components:
+    - type: Transform
+      parent: 137
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 144
+    components:
+    - type: Transform
+      parent: 137
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
   - uid: 145
     components:
     - type: Transform
-      parent: 141
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 146
-    components:
-    - type: Transform
-      parent: 141
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 147
-    components:
-    - type: Transform
-      parent: 141
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 148
-    components:
-    - type: Transform
-      parent: 141
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 149
-    components:
-    - type: Transform
-      parent: 141
+      parent: 137
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: RMCMirror
   entities:
-  - uid: 326
+  - uid: 327
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 32.5,31.5
       parent: 1
-  - uid: 327
+  - uid: 328
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3900,177 +3906,177 @@ entities:
       parent: 1
 - proto: RMCNanoMedLimited
   entities:
-  - uid: 328
+  - uid: 329
     components:
     - type: Transform
       pos: 25.5,47.5
       parent: 1
 - proto: RMCParasiteProp
   entities:
-  - uid: 329
+  - uid: 330
     components:
     - type: Transform
       pos: 8.5,29.5
       parent: 1
-  - uid: 330
+  - uid: 331
     components:
     - type: Transform
       pos: 15.5,47.5
       parent: 1
-  - uid: 331
+  - uid: 332
     components:
     - type: Transform
       pos: 30.5,25.5
       parent: 1
-  - uid: 332
+  - uid: 333
     components:
     - type: Transform
       pos: 31.5,21.5
       parent: 1
 - proto: RMCPickaxe
   entities:
-  - uid: 333
+  - uid: 334
     components:
     - type: Transform
       pos: 6.5,26.5
       parent: 1
-  - uid: 334
+  - uid: 335
     components:
     - type: Transform
       pos: 9.5,15.5
       parent: 1
 - proto: RMCPlankWood1
   entities:
-  - uid: 335
+  - uid: 336
     components:
     - type: Transform
       pos: 30.5,46.5
       parent: 1
-  - uid: 336
+  - uid: 337
     components:
     - type: Transform
       pos: 32.5,47.5
       parent: 1
-  - uid: 337
+  - uid: 338
     components:
     - type: Transform
       pos: 33.5,43.5
       parent: 1
-  - uid: 338
+  - uid: 339
     components:
     - type: Transform
       pos: 34.5,41.5
       parent: 1
-  - uid: 339
+  - uid: 340
     components:
     - type: Transform
       pos: 34.5,40.5
       parent: 1
-  - uid: 340
+  - uid: 341
     components:
     - type: Transform
       pos: 32.5,39.5
       parent: 1
-  - uid: 341
+  - uid: 342
     components:
     - type: Transform
       pos: 33.5,38.5
       parent: 1
-  - uid: 342
+  - uid: 343
     components:
     - type: Transform
       pos: 33.5,37.5
       parent: 1
-  - uid: 343
+  - uid: 344
     components:
     - type: Transform
       pos: 27.5,38.5
       parent: 1
-  - uid: 344
+  - uid: 345
     components:
     - type: Transform
       pos: 30.5,37.5
       parent: 1
-  - uid: 345
+  - uid: 346
     components:
     - type: Transform
       pos: 12.5,46.5
       parent: 1
-  - uid: 346
+  - uid: 347
     components:
     - type: Transform
       pos: 28.5,35.5
       parent: 1
-  - uid: 347
+  - uid: 348
     components:
     - type: Transform
       pos: 34.5,21.5
       parent: 1
-  - uid: 348
+  - uid: 349
     components:
     - type: Transform
       pos: 34.5,20.5
       parent: 1
-  - uid: 349
+  - uid: 350
     components:
     - type: Transform
       pos: 32.5,22.5
       parent: 1
-  - uid: 350
+  - uid: 351
     components:
     - type: Transform
       pos: 30.5,21.5
       parent: 1
-  - uid: 351
+  - uid: 352
     components:
     - type: Transform
       pos: 31.5,16.5
       parent: 1
-  - uid: 352
+  - uid: 353
     components:
     - type: Transform
       pos: 19.5,12.5
       parent: 1
-  - uid: 353
+  - uid: 354
     components:
     - type: Transform
       pos: 16.5,12.5
       parent: 1
-  - uid: 354
+  - uid: 355
     components:
     - type: Transform
       pos: 16.5,17.5
       parent: 1
-  - uid: 355
+  - uid: 356
     components:
     - type: Transform
       pos: 17.5,18.5
       parent: 1
-  - uid: 356
+  - uid: 357
     components:
     - type: Transform
       pos: 18.5,20.5
       parent: 1
-  - uid: 357
+  - uid: 358
     components:
     - type: Transform
       pos: 20.5,17.5
       parent: 1
 - proto: RMCPlatformKutjevoCornerSmall
   entities:
-  - uid: 358
+  - uid: 359
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 39.5,18.5
       parent: 1
-  - uid: 359
+  - uid: 360
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 39.5,12.5
       parent: 1
-  - uid: 360
+  - uid: 361
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4078,114 +4084,114 @@ entities:
       parent: 1
 - proto: RMCPlatformKutjevoRock
   entities:
-  - uid: 361
+  - uid: 362
     components:
     - type: Transform
       pos: 14.5,1.5
       parent: 1
-  - uid: 362
+  - uid: 363
     components:
     - type: Transform
       pos: 15.5,1.5
       parent: 1
-  - uid: 363
-    components:
-    - type: Transform
-      pos: 16.5,1.5
-      parent: 1
   - uid: 364
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 11.5,6.5
+      pos: 16.5,1.5
       parent: 1
   - uid: 365
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 11.5,4.5
+      pos: 11.5,6.5
       parent: 1
   - uid: 366
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 11.5,3.5
+      pos: 11.5,4.5
       parent: 1
   - uid: 367
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 11.5,5.5
+      pos: 11.5,3.5
       parent: 1
   - uid: 368
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 12.5,8.5
+      pos: 11.5,5.5
       parent: 1
   - uid: 369
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 12.5,7.5
+      pos: 12.5,8.5
       parent: 1
   - uid: 370
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 13.5,9.5
+      pos: 12.5,7.5
       parent: 1
   - uid: 371
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 12.5,2.5
+      pos: 13.5,9.5
       parent: 1
   - uid: 372
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 14.5,1.5
+      pos: 12.5,2.5
       parent: 1
   - uid: 373
     components:
     - type: Transform
-      pos: 17.5,2.5
+      rot: -1.5707963267948966 rad
+      pos: 14.5,1.5
       parent: 1
   - uid: 374
+    components:
+    - type: Transform
+      pos: 17.5,2.5
+      parent: 1
+  - uid: 375
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,1.5
       parent: 1
-  - uid: 375
+  - uid: 376
     components:
     - type: Transform
       pos: 12.5,2.5
       parent: 1
-  - uid: 376
+  - uid: 377
     components:
     - type: Transform
       pos: 13.5,2.5
       parent: 1
-  - uid: 377
-    components:
-    - type: Transform
-      pos: 11.5,3.5
-      parent: 1
   - uid: 378
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 11.5,6.5
+      pos: 11.5,3.5
       parent: 1
   - uid: 379
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 12.5,8.5
+      pos: 11.5,6.5
       parent: 1
   - uid: 380
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,8.5
+      parent: 1
+  - uid: 381
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4193,34 +4199,34 @@ entities:
       parent: 1
 - proto: RMCPlatformKutjevoRockCornerSmall
   entities:
-  - uid: 381
+  - uid: 382
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 12.5,3.5
       parent: 1
-  - uid: 382
+  - uid: 383
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,2.5
       parent: 1
-  - uid: 383
+  - uid: 384
     components:
     - type: Transform
       pos: 12.5,6.5
       parent: 1
-  - uid: 384
+  - uid: 385
     components:
     - type: Transform
       pos: 13.5,8.5
       parent: 1
-  - uid: 385
+  - uid: 386
     components:
     - type: Transform
       pos: 14.5,9.5
       parent: 1
-  - uid: 386
+  - uid: 387
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4228,13 +4234,13 @@ entities:
       parent: 1
 - proto: RMCPlatformKutjevoSM
   entities:
-  - uid: 387
+  - uid: 388
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 39.5,11.5
       parent: 1
-  - uid: 388
+  - uid: 389
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4242,7 +4248,7 @@ entities:
       parent: 1
 - proto: RMCPodDoorButtonBigRed
   entities:
-  - uid: 389
+  - uid: 390
     components:
     - type: MetaData
       name: Hydroponics East Lock Override
@@ -4252,7 +4258,7 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 390
+  - uid: 391
     components:
     - type: MetaData
       name: ics West Lock Override
@@ -4262,7 +4268,7 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 391
+  - uid: 392
     components:
     - type: MetaData
       name: Hydroponics East Lock Override
@@ -4272,7 +4278,7 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 392
+  - uid: 393
     components:
     - type: MetaData
       name: Hydroponics East Lock Override
@@ -4282,7 +4288,7 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 393
+  - uid: 394
     components:
     - type: MetaData
       name: ics West Lock Override
@@ -4292,7 +4298,7 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 394
+  - uid: 395
     components:
     - type: MetaData
       name: ics West Lock Override
@@ -4304,7 +4310,7 @@ entities:
       fixtures: {}
 - proto: RMCPropCommunicationsConsole
   entities:
-  - uid: 395
+  - uid: 396
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4312,236 +4318,236 @@ entities:
       parent: 1
 - proto: RMCPropVehicleTruckMining
   entities:
-  - uid: 396
+  - uid: 397
     components:
     - type: Transform
       pos: 8,28
       parent: 1
 - proto: RMCSecureCase
   entities:
-  - uid: 397
+  - uid: 398
     components:
     - type: Transform
       pos: 27.5,41.5
       parent: 1
 - proto: RMCSecureCaseAmmoMini
   entities:
-  - uid: 398
+  - uid: 399
     components:
     - type: Transform
       pos: 29.413673,24.621338
       parent: 1
 - proto: RMCSecureCaseDouble
   entities:
-  - uid: 399
+  - uid: 400
     components:
     - type: Transform
       pos: 22.5,47.5
       parent: 1
-  - uid: 400
+  - uid: 401
     components:
     - type: Transform
       pos: 28.5,41.5
       parent: 1
-  - uid: 401
+  - uid: 402
     components:
     - type: Transform
       pos: 28.5,24.5
       parent: 1
-  - uid: 402
+  - uid: 403
     components:
     - type: Transform
       pos: 32.5,35.5
       parent: 1
 - proto: RMCSecureCaseMedicalSmall
   entities:
-  - uid: 403
+  - uid: 404
     components:
     - type: Transform
       pos: 29.913673,24.511963
       parent: 1
 - proto: RMCSecureCaseMini
   entities:
-  - uid: 404
+  - uid: 405
     components:
     - type: Transform
       pos: 22.5,46.5
       parent: 1
 - proto: RMCSecureCaseSmall
   entities:
-  - uid: 405
+  - uid: 406
     components:
     - type: Transform
       pos: 31.5,35.5
       parent: 1
 - proto: RMCSecurityCameraConsole
   entities:
-  - uid: 406
+  - uid: 407
     components:
     - type: Transform
       pos: 25.5,15.5
       parent: 1
 - proto: RMCShutterAlmayerOpen
   entities:
-  - uid: 407
+  - uid: 408
     components:
     - type: Transform
       pos: 15.5,11.5
       parent: 1
-  - uid: 408
+  - uid: 409
     components:
     - type: Transform
       pos: 16.5,11.5
       parent: 1
-  - uid: 409
+  - uid: 410
     components:
     - type: Transform
       pos: 17.5,11.5
       parent: 1
-  - uid: 410
+  - uid: 411
     components:
     - type: Transform
       pos: 18.5,11.5
       parent: 1
-  - uid: 411
+  - uid: 412
     components:
     - type: Transform
       pos: 19.5,11.5
       parent: 1
-  - uid: 412
+  - uid: 413
     components:
     - type: Transform
       pos: 15.5,16.5
       parent: 1
-  - uid: 413
+  - uid: 414
     components:
     - type: Transform
       pos: 16.5,16.5
       parent: 1
-  - uid: 414
+  - uid: 415
     components:
     - type: Transform
       pos: 17.5,16.5
       parent: 1
-  - uid: 415
+  - uid: 416
     components:
     - type: Transform
       pos: 19.5,16.5
       parent: 1
-  - uid: 416
+  - uid: 417
     components:
     - type: Transform
       pos: 18.5,16.5
       parent: 1
-  - uid: 417
+  - uid: 418
     components:
     - type: Transform
       pos: 24.5,10.5
       parent: 1
-  - uid: 418
+  - uid: 419
     components:
     - type: Transform
       pos: 25.5,10.5
       parent: 1
-  - uid: 419
+  - uid: 420
     components:
     - type: Transform
       pos: 23.5,10.5
       parent: 1
-  - uid: 420
+  - uid: 421
     components:
     - type: Transform
       pos: 29.5,15.5
       parent: 1
-  - uid: 421
+  - uid: 422
     components:
     - type: Transform
       pos: 30.5,15.5
       parent: 1
-  - uid: 422
-    components:
-    - type: Transform
-      pos: 31.5,15.5
-      parent: 1
   - uid: 423
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 35.5,21.5
+      pos: 31.5,15.5
       parent: 1
   - uid: 424
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 35.5,20.5
+      pos: 35.5,21.5
       parent: 1
   - uid: 425
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 35.5,19.5
+      pos: 35.5,20.5
       parent: 1
   - uid: 426
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 35.5,22.5
+      pos: 35.5,19.5
       parent: 1
   - uid: 427
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 34.5,26.5
+      pos: 35.5,22.5
       parent: 1
   - uid: 428
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 34.5,24.5
+      pos: 34.5,26.5
       parent: 1
   - uid: 429
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 34.5,25.5
+      pos: 34.5,24.5
       parent: 1
   - uid: 430
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 34.5,36.5
+      pos: 34.5,25.5
       parent: 1
   - uid: 431
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 34.5,37.5
+      pos: 34.5,36.5
       parent: 1
   - uid: 432
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 34.5,38.5
+      pos: 34.5,37.5
       parent: 1
   - uid: 433
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 35.5,40.5
+      pos: 34.5,38.5
       parent: 1
   - uid: 434
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 35.5,41.5
+      pos: 35.5,40.5
       parent: 1
   - uid: 435
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 35.5,42.5
+      pos: 35.5,41.5
       parent: 1
   - uid: 436
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 35.5,42.5
+      parent: 1
+  - uid: 437
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4549,25 +4555,25 @@ entities:
       parent: 1
 - proto: RMCSmallFloodlight
   entities:
-  - uid: 437
+  - uid: 438
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 23.5,43.5
       parent: 1
-  - uid: 438
+  - uid: 439
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,43.5
       parent: 1
-  - uid: 439
+  - uid: 440
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,20.5
       parent: 1
-  - uid: 440
+  - uid: 441
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4575,135 +4581,135 @@ entities:
       parent: 1
 - proto: RMCSpawnerCorpseColonistKutjevo
   entities:
-  - uid: 441
+  - uid: 442
     components:
     - type: Transform
       pos: 32.5,32.5
       parent: 1
 - proto: RMCSpawnerIntelClose
   entities:
-  - uid: 442
+  - uid: 443
     components:
     - type: Transform
       pos: 11.5,47.5
       parent: 1
-  - uid: 443
+  - uid: 444
     components:
     - type: Transform
       pos: 26.5,14.5
       parent: 1
 - proto: RMCSpawnerRandomToolbox
   entities:
-  - uid: 444
+  - uid: 445
     components:
     - type: Transform
       pos: 11.5,47.5
       parent: 1
 - proto: RMCStairsKutjevo
   entities:
-  - uid: 445
+  - uid: 446
     components:
     - type: Transform
       pos: 42.5,47.5
       parent: 1
-  - uid: 446
+  - uid: 447
     components:
     - type: Transform
       pos: 41.5,47.5
       parent: 1
-  - uid: 447
+  - uid: 448
     components:
     - type: Transform
       pos: 40.5,47.5
       parent: 1
-  - uid: 448
-    components:
-    - type: Transform
-      pos: 39.5,47.5
-      parent: 1
   - uid: 449
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 36.5,42.5
+      pos: 39.5,47.5
       parent: 1
   - uid: 450
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 36.5,41.5
+      pos: 36.5,42.5
       parent: 1
   - uid: 451
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 36.5,40.5
+      pos: 36.5,41.5
       parent: 1
   - uid: 452
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 36.5,21.5
+      pos: 36.5,40.5
       parent: 1
   - uid: 453
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 36.5,20.5
+      pos: 36.5,21.5
       parent: 1
   - uid: 454
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 36.5,19.5
+      pos: 36.5,20.5
       parent: 1
   - uid: 455
     components:
     - type: Transform
-      pos: 29.5,14.5
+      rot: 1.5707963267948966 rad
+      pos: 36.5,19.5
       parent: 1
   - uid: 456
     components:
     - type: Transform
-      pos: 30.5,14.5
+      pos: 29.5,14.5
       parent: 1
   - uid: 457
     components:
     - type: Transform
-      pos: 31.5,14.5
+      pos: 30.5,14.5
       parent: 1
   - uid: 458
     components:
     - type: Transform
-      pos: 15.5,10.5
+      pos: 31.5,14.5
       parent: 1
   - uid: 459
     components:
     - type: Transform
-      pos: 16.5,10.5
+      pos: 15.5,10.5
       parent: 1
   - uid: 460
     components:
     - type: Transform
-      pos: 17.5,10.5
+      pos: 16.5,10.5
       parent: 1
   - uid: 461
     components:
     - type: Transform
-      pos: 18.5,10.5
+      pos: 17.5,10.5
       parent: 1
   - uid: 462
     components:
     - type: Transform
-      pos: 19.5,10.5
+      pos: 18.5,10.5
       parent: 1
   - uid: 463
+    components:
+    - type: Transform
+      pos: 19.5,10.5
+      parent: 1
+  - uid: 464
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 34.5,2.5
       parent: 1
-  - uid: 464
+  - uid: 465
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4711,7 +4717,7 @@ entities:
       parent: 1
 - proto: RMCStairsKutjevoLeft
   entities:
-  - uid: 465
+  - uid: 466
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4719,13 +4725,13 @@ entities:
       parent: 1
 - proto: RMCStairsKutjevoLeftHalf
   entities:
-  - uid: 466
+  - uid: 467
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 36.5,39.5
       parent: 1
-  - uid: 467
+  - uid: 468
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4733,13 +4739,13 @@ entities:
       parent: 1
 - proto: RMCStairsKutjevoRight
   entities:
-  - uid: 468
+  - uid: 469
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 36.5,43.5
       parent: 1
-  - uid: 469
+  - uid: 470
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4747,7 +4753,7 @@ entities:
       parent: 1
 - proto: RMCStairsKutjevoRightHalf
   entities:
-  - uid: 470
+  - uid: 471
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4755,73 +4761,73 @@ entities:
       parent: 1
 - proto: RMCTablePrison
   entities:
-  - uid: 471
+  - uid: 472
     components:
     - type: Transform
       pos: 21.5,13.5
       parent: 1
-  - uid: 472
+  - uid: 473
     components:
     - type: Transform
       pos: 21.5,14.5
       parent: 1
-  - uid: 473
+  - uid: 474
     components:
     - type: Transform
       pos: 23.5,11.5
       parent: 1
-  - uid: 474
+  - uid: 475
     components:
     - type: Transform
       pos: 24.5,11.5
       parent: 1
-  - uid: 475
+  - uid: 476
     components:
     - type: Transform
       pos: 25.5,11.5
       parent: 1
-  - uid: 476
+  - uid: 477
     components:
     - type: Transform
       pos: 26.5,15.5
       parent: 1
-  - uid: 477
+  - uid: 478
     components:
     - type: Transform
       pos: 25.5,15.5
       parent: 1
-  - uid: 478
+  - uid: 479
     components:
     - type: Transform
       pos: 24.5,15.5
       parent: 1
 - proto: RMCTallFloodlight
   entities:
-  - uid: 479
+  - uid: 480
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 34.5,5.5
       parent: 1
-  - uid: 480
+  - uid: 481
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 39.5,17.5
       parent: 1
-  - uid: 481
+  - uid: 482
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 39.5,11.5
       parent: 1
-  - uid: 482
+  - uid: 483
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 21.5,10.5
       parent: 1
-  - uid: 483
+  - uid: 484
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4829,3035 +4835,3080 @@ entities:
       parent: 1
 - proto: RMCTurretGaussSpaceborne
   entities:
-  - uid: 484
+  - uid: 485
     components:
     - type: Transform
       pos: 14.5,9.5
       parent: 1
-  - uid: 485
+  - uid: 486
     components:
     - type: Transform
       pos: 20.5,9.5
       parent: 1
-  - uid: 486
+  - uid: 487
     components:
     - type: Transform
       pos: 30.5,9.5
       parent: 1
-  - uid: 487
+  - uid: 488
     components:
     - type: Transform
       pos: 35.5,11.5
       parent: 1
-  - uid: 488
+  - uid: 489
     components:
     - type: Transform
       pos: 37.5,15.5
       parent: 1
-  - uid: 489
+  - uid: 490
     components:
     - type: Transform
       pos: 37.5,37.5
       parent: 1
-  - uid: 490
+  - uid: 491
     components:
     - type: Transform
       pos: 40.5,34.5
       parent: 1
-  - uid: 491
+  - uid: 492
     components:
     - type: Transform
       pos: 41.5,41.5
       parent: 1
-  - uid: 492
+  - uid: 493
     components:
     - type: Transform
       pos: 30.5,42.5
       parent: 1
-  - uid: 493
+  - uid: 494
     components:
     - type: Transform
       pos: 26.5,41.5
       parent: 1
-  - uid: 494
+  - uid: 495
     components:
     - type: Transform
       pos: 26.5,43.5
       parent: 1
-  - uid: 1084
+  - uid: 496
     components:
     - type: Transform
       pos: 39.5,27.5
       parent: 1
-  - uid: 1085
+  - uid: 497
     components:
     - type: Transform
       pos: 38.5,23.5
       parent: 1
-- proto: RMCWallKutjevoHull
-  entities:
-  - uid: 495
-    components:
-    - type: Transform
-      pos: 7.5,46.5
-      parent: 1
-  - uid: 496
-    components:
-    - type: Transform
-      pos: 14.5,49.5
-      parent: 1
-  - uid: 497
-    components:
-    - type: Transform
-      pos: 14.5,48.5
-      parent: 1
   - uid: 498
     components:
     - type: Transform
-      pos: 13.5,48.5
+      pos: 21.5,18.5
       parent: 1
   - uid: 499
     components:
     - type: Transform
-      pos: 12.5,48.5
+      pos: 19.5,43.5
       parent: 1
   - uid: 500
     components:
     - type: Transform
-      pos: 11.5,48.5
+      pos: 13.5,18.5
       parent: 1
   - uid: 501
     components:
     - type: Transform
-      pos: 10.5,48.5
+      pos: 8.5,31.5
       parent: 1
+  - uid: 1090
+    components:
+    - type: Transform
+      pos: 15.5,43.5
+      parent: 1
+  - uid: 1091
+    components:
+    - type: Transform
+      pos: 8.5,23.5
+      parent: 1
+  - uid: 1092
+    components:
+    - type: Transform
+      pos: 27.5,18.5
+      parent: 1
+  - uid: 1093
+    components:
+    - type: Transform
+      pos: 28.5,28.5
+      parent: 1
+  - uid: 1094
+    components:
+    - type: Transform
+      pos: 28.5,34.5
+      parent: 1
+- proto: RMCWallKutjevoHull
+  entities:
   - uid: 502
     components:
     - type: Transform
-      pos: 9.5,48.5
+      pos: 7.5,46.5
       parent: 1
   - uid: 503
     components:
     - type: Transform
-      pos: 8.5,48.5
+      pos: 14.5,49.5
       parent: 1
   - uid: 504
     components:
     - type: Transform
-      pos: 7.5,48.5
+      pos: 14.5,48.5
       parent: 1
   - uid: 505
     components:
     - type: Transform
-      pos: 7.5,45.5
+      pos: 13.5,48.5
       parent: 1
   - uid: 506
     components:
     - type: Transform
-      pos: 7.5,44.5
+      pos: 12.5,48.5
       parent: 1
   - uid: 507
     components:
     - type: Transform
-      pos: 7.5,43.5
+      pos: 11.5,48.5
       parent: 1
   - uid: 508
     components:
     - type: Transform
-      pos: 7.5,42.5
+      pos: 10.5,48.5
       parent: 1
   - uid: 509
     components:
     - type: Transform
-      pos: 7.5,41.5
+      pos: 9.5,48.5
       parent: 1
   - uid: 510
     components:
     - type: Transform
-      pos: 7.5,40.5
+      pos: 8.5,48.5
       parent: 1
   - uid: 511
     components:
     - type: Transform
-      pos: 7.5,39.5
+      pos: 7.5,48.5
       parent: 1
   - uid: 512
     components:
     - type: Transform
-      pos: 7.5,38.5
+      pos: 7.5,45.5
       parent: 1
   - uid: 513
     components:
     - type: Transform
-      pos: 7.5,37.5
+      pos: 7.5,44.5
       parent: 1
   - uid: 514
     components:
     - type: Transform
-      pos: 7.5,36.5
+      pos: 7.5,43.5
       parent: 1
   - uid: 515
     components:
     - type: Transform
-      pos: 7.5,35.5
+      pos: 7.5,42.5
       parent: 1
   - uid: 516
     components:
     - type: Transform
-      pos: 7.5,34.5
+      pos: 7.5,41.5
       parent: 1
   - uid: 517
     components:
     - type: Transform
-      pos: 7.5,33.5
+      pos: 7.5,40.5
       parent: 1
   - uid: 518
     components:
     - type: Transform
-      pos: 7.5,32.5
+      pos: 7.5,39.5
       parent: 1
   - uid: 519
     components:
     - type: Transform
-      pos: 7.5,47.5
+      pos: 7.5,38.5
       parent: 1
   - uid: 520
     components:
     - type: Transform
-      pos: 7.5,23.5
+      pos: 7.5,37.5
       parent: 1
   - uid: 521
     components:
     - type: Transform
-      pos: 7.5,22.5
+      pos: 7.5,36.5
       parent: 1
   - uid: 522
     components:
     - type: Transform
-      pos: 7.5,21.5
+      pos: 7.5,35.5
       parent: 1
   - uid: 523
     components:
     - type: Transform
-      pos: 7.5,20.5
+      pos: 7.5,34.5
       parent: 1
   - uid: 524
     components:
     - type: Transform
-      pos: 7.5,19.5
+      pos: 7.5,33.5
       parent: 1
   - uid: 525
     components:
     - type: Transform
-      pos: 7.5,18.5
+      pos: 7.5,32.5
       parent: 1
   - uid: 526
     components:
     - type: Transform
-      pos: 7.5,17.5
+      pos: 7.5,47.5
       parent: 1
   - uid: 527
     components:
     - type: Transform
-      pos: 7.5,16.5
+      pos: 7.5,23.5
       parent: 1
   - uid: 528
     components:
     - type: Transform
-      pos: 8.5,16.5
+      pos: 7.5,22.5
       parent: 1
   - uid: 529
     components:
     - type: Transform
-      pos: 19.5,49.5
+      pos: 7.5,21.5
       parent: 1
   - uid: 530
     components:
     - type: Transform
-      pos: 19.5,48.5
+      pos: 7.5,20.5
       parent: 1
   - uid: 531
     components:
     - type: Transform
-      pos: 20.5,48.5
+      pos: 7.5,19.5
       parent: 1
   - uid: 532
     components:
     - type: Transform
-      pos: 21.5,48.5
+      pos: 7.5,18.5
       parent: 1
   - uid: 533
     components:
     - type: Transform
-      pos: 22.5,48.5
+      pos: 7.5,17.5
       parent: 1
   - uid: 534
     components:
     - type: Transform
-      pos: 23.5,48.5
+      pos: 7.5,16.5
       parent: 1
   - uid: 535
     components:
     - type: Transform
-      pos: 24.5,48.5
+      pos: 8.5,16.5
       parent: 1
   - uid: 536
     components:
     - type: Transform
-      pos: 25.5,49.5
+      pos: 19.5,49.5
       parent: 1
   - uid: 537
     components:
     - type: Transform
-      pos: 25.5,48.5
+      pos: 19.5,48.5
       parent: 1
   - uid: 538
     components:
     - type: Transform
-      pos: 25.5,47.5
+      pos: 20.5,48.5
       parent: 1
   - uid: 539
     components:
     - type: Transform
-      pos: 27.5,47.5
+      pos: 21.5,48.5
       parent: 1
   - uid: 540
     components:
     - type: Transform
-      pos: 28.5,47.5
+      pos: 22.5,48.5
       parent: 1
   - uid: 541
     components:
     - type: Transform
-      pos: 26.5,47.5
+      pos: 23.5,48.5
       parent: 1
   - uid: 542
+    components:
+    - type: Transform
+      pos: 24.5,48.5
+      parent: 1
+  - uid: 543
+    components:
+    - type: Transform
+      pos: 25.5,49.5
+      parent: 1
+  - uid: 544
+    components:
+    - type: Transform
+      pos: 25.5,48.5
+      parent: 1
+  - uid: 545
+    components:
+    - type: Transform
+      pos: 25.5,47.5
+      parent: 1
+  - uid: 546
+    components:
+    - type: Transform
+      pos: 27.5,47.5
+      parent: 1
+  - uid: 547
+    components:
+    - type: Transform
+      pos: 28.5,47.5
+      parent: 1
+  - uid: 548
+    components:
+    - type: Transform
+      pos: 26.5,47.5
+      parent: 1
+  - uid: 549
     components:
     - type: Transform
       pos: 28.5,46.5
       parent: 1
 - proto: RMCWallKutjevoReinforced
   entities:
-  - uid: 543
+  - uid: 550
     components:
     - type: Transform
       pos: 29.5,47.5
       parent: 1
-  - uid: 544
+  - uid: 551
     components:
     - type: Transform
       pos: 29.5,46.5
       parent: 1
-  - uid: 545
+  - uid: 552
     components:
     - type: Transform
       pos: 34.5,47.5
       parent: 1
-  - uid: 546
+  - uid: 553
     components:
     - type: Transform
       pos: 35.5,46.5
       parent: 1
-  - uid: 547
+  - uid: 554
     components:
     - type: Transform
       pos: 35.5,47.5
       parent: 1
-  - uid: 548
+  - uid: 555
     components:
     - type: Transform
       pos: 34.5,46.5
       parent: 1
-  - uid: 549
+  - uid: 556
     components:
     - type: Transform
       pos: 36.5,47.5
       parent: 1
-  - uid: 550
+  - uid: 557
     components:
     - type: Transform
       pos: 37.5,47.5
       parent: 1
-  - uid: 551
+  - uid: 558
     components:
     - type: Transform
       pos: 38.5,47.5
       parent: 1
-  - uid: 552
+  - uid: 559
     components:
     - type: Transform
       pos: 43.5,46.5
       parent: 1
-  - uid: 553
+  - uid: 560
     components:
     - type: Transform
       pos: 43.5,47.5
       parent: 1
-  - uid: 554
+  - uid: 561
     components:
     - type: Transform
       pos: 35.5,45.5
       parent: 1
-  - uid: 555
+  - uid: 562
     components:
     - type: Transform
       pos: 35.5,44.5
       parent: 1
-  - uid: 556
+  - uid: 563
     components:
     - type: Transform
       pos: 35.5,39.5
       parent: 1
-  - uid: 557
+  - uid: 564
     components:
     - type: Transform
       pos: 34.5,39.5
       parent: 1
-  - uid: 558
+  - uid: 565
     components:
     - type: Transform
       pos: 35.5,35.5
       parent: 1
-  - uid: 559
+  - uid: 566
     components:
     - type: Transform
       pos: 34.5,35.5
       parent: 1
-  - uid: 560
+  - uid: 567
     components:
     - type: Transform
       pos: 33.5,35.5
       parent: 1
-  - uid: 561
+  - uid: 568
     components:
     - type: Transform
       pos: 30.5,34.5
       parent: 1
-  - uid: 562
+  - uid: 569
     components:
     - type: Transform
       pos: 31.5,34.5
       parent: 1
-  - uid: 563
+  - uid: 570
     components:
     - type: Transform
       pos: 32.5,34.5
       parent: 1
-  - uid: 564
+  - uid: 571
     components:
     - type: Transform
       pos: 33.5,34.5
       parent: 1
-  - uid: 565
+  - uid: 572
     components:
     - type: Transform
       pos: 30.5,32.5
       parent: 1
-  - uid: 566
+  - uid: 573
     components:
     - type: Transform
       pos: 30.5,31.5
       parent: 1
-  - uid: 567
+  - uid: 574
     components:
     - type: Transform
       pos: 31.5,31.5
       parent: 1
-  - uid: 568
+  - uid: 575
     components:
     - type: Transform
       pos: 33.5,31.5
       parent: 1
-  - uid: 569
+  - uid: 576
     components:
     - type: Transform
       pos: 32.5,31.5
       parent: 1
-  - uid: 570
+  - uid: 577
     components:
     - type: Transform
       pos: 33.5,33.5
       parent: 1
-  - uid: 571
+  - uid: 578
     components:
     - type: Transform
       pos: 33.5,32.5
       parent: 1
-  - uid: 572
+  - uid: 579
     components:
     - type: Transform
       pos: 33.5,30.5
       parent: 1
-  - uid: 573
+  - uid: 580
     components:
     - type: Transform
       pos: 33.5,29.5
       parent: 1
-  - uid: 574
+  - uid: 581
     components:
     - type: Transform
       pos: 33.5,28.5
       parent: 1
-  - uid: 575
+  - uid: 582
     components:
     - type: Transform
       pos: 33.5,27.5
       parent: 1
-  - uid: 576
+  - uid: 583
     components:
     - type: Transform
       pos: 32.5,28.5
       parent: 1
-  - uid: 577
+  - uid: 584
     components:
     - type: Transform
       pos: 31.5,28.5
       parent: 1
-  - uid: 578
+  - uid: 585
     components:
     - type: Transform
       pos: 30.5,28.5
       parent: 1
-  - uid: 579
+  - uid: 586
     components:
     - type: Transform
       pos: 30.5,29.5
       parent: 1
-  - uid: 580
+  - uid: 587
     components:
     - type: Transform
       pos: 34.5,27.5
       parent: 1
-  - uid: 581
+  - uid: 588
     components:
     - type: Transform
       pos: 35.5,27.5
       parent: 1
-  - uid: 582
+  - uid: 589
     components:
     - type: Transform
       pos: 34.5,23.5
       parent: 1
-  - uid: 583
+  - uid: 590
     components:
     - type: Transform
       pos: 35.5,23.5
       parent: 1
-  - uid: 584
+  - uid: 591
     components:
     - type: Transform
       pos: 35.5,18.5
       parent: 1
-  - uid: 585
+  - uid: 592
     components:
     - type: Transform
       pos: 35.5,17.5
       parent: 1
-  - uid: 586
+  - uid: 593
     components:
     - type: Transform
       pos: 35.5,16.5
       parent: 1
-  - uid: 587
+  - uid: 594
     components:
     - type: Transform
       pos: 34.5,16.5
       parent: 1
-  - uid: 588
+  - uid: 595
     components:
     - type: Transform
       pos: 33.5,16.5
       parent: 1
-  - uid: 589
+  - uid: 596
     components:
     - type: Transform
       pos: 32.5,16.5
       parent: 1
-  - uid: 590
+  - uid: 597
     components:
     - type: Transform
       pos: 32.5,15.5
       parent: 1
-  - uid: 591
+  - uid: 598
     components:
     - type: Transform
       pos: 32.5,14.5
       parent: 1
-  - uid: 592
+  - uid: 599
     components:
     - type: Transform
       pos: 28.5,16.5
       parent: 1
-  - uid: 593
+  - uid: 600
     components:
     - type: Transform
       pos: 28.5,14.5
       parent: 1
-  - uid: 594
+  - uid: 601
     components:
     - type: Transform
       pos: 27.5,16.5
       parent: 1
-  - uid: 595
+  - uid: 602
     components:
     - type: Transform
       pos: 27.5,15.5
       parent: 1
-  - uid: 596
+  - uid: 603
     components:
     - type: Transform
       pos: 27.5,14.5
       parent: 1
-  - uid: 597
+  - uid: 604
     components:
     - type: Transform
       pos: 28.5,15.5
       parent: 1
-  - uid: 598
+  - uid: 605
     components:
     - type: Transform
       pos: 27.5,13.5
       parent: 1
-  - uid: 599
+  - uid: 606
     components:
     - type: Transform
       pos: 27.5,12.5
       parent: 1
-  - uid: 600
+  - uid: 607
     components:
     - type: Transform
       pos: 26.5,12.5
       parent: 1
-  - uid: 601
+  - uid: 608
     components:
     - type: Transform
       pos: 26.5,11.5
       parent: 1
-  - uid: 602
+  - uid: 609
     components:
     - type: Transform
       pos: 26.5,10.5
       parent: 1
-  - uid: 603
+  - uid: 610
     components:
     - type: Transform
       pos: 22.5,10.5
       parent: 1
-  - uid: 604
+  - uid: 611
     components:
     - type: Transform
       pos: 22.5,11.5
       parent: 1
-  - uid: 605
+  - uid: 612
     components:
     - type: Transform
       pos: 21.5,11.5
       parent: 1
-  - uid: 606
+  - uid: 613
     components:
     - type: Transform
       pos: 20.5,11.5
       parent: 1
-  - uid: 607
+  - uid: 614
     components:
     - type: Transform
       pos: 20.5,10.5
       parent: 1
-  - uid: 608
+  - uid: 615
     components:
     - type: Transform
       pos: 21.5,16.5
       parent: 1
-  - uid: 609
+  - uid: 616
     components:
     - type: Transform
       pos: 20.5,16.5
       parent: 1
-  - uid: 610
+  - uid: 617
     components:
     - type: Transform
       pos: 23.5,16.5
       parent: 1
-  - uid: 611
+  - uid: 618
     components:
     - type: Transform
       pos: 14.5,16.5
       parent: 1
-  - uid: 612
+  - uid: 619
     components:
     - type: Transform
       pos: 13.5,16.5
       parent: 1
-  - uid: 613
+  - uid: 620
     components:
     - type: Transform
       pos: 13.5,15.5
       parent: 1
-  - uid: 614
+  - uid: 621
     components:
     - type: Transform
       pos: 13.5,14.5
       parent: 1
-  - uid: 615
+  - uid: 622
     components:
     - type: Transform
       pos: 13.5,13.5
       parent: 1
-  - uid: 616
+  - uid: 623
     components:
     - type: Transform
       pos: 13.5,12.5
       parent: 1
-  - uid: 617
+  - uid: 624
     components:
     - type: Transform
       pos: 13.5,11.5
       parent: 1
-  - uid: 618
+  - uid: 625
     components:
     - type: Transform
       pos: 14.5,11.5
       parent: 1
-  - uid: 619
+  - uid: 626
     components:
     - type: Transform
       pos: 14.5,10.5
       parent: 1
 - proto: RMCWallKutjevoRock
   entities:
-  - uid: 620
+  - uid: 627
     components:
     - type: Transform
       pos: 7.5,49.5
       parent: 1
-  - uid: 621
+  - uid: 628
     components:
     - type: Transform
       pos: 1.5,48.5
       parent: 1
-  - uid: 622
+  - uid: 629
     components:
     - type: Transform
       pos: 1.5,47.5
       parent: 1
-  - uid: 623
+  - uid: 630
     components:
     - type: Transform
       pos: 1.5,46.5
       parent: 1
-  - uid: 624
+  - uid: 631
     components:
     - type: Transform
       pos: 1.5,45.5
       parent: 1
-  - uid: 625
+  - uid: 632
     components:
     - type: Transform
       pos: 1.5,44.5
       parent: 1
-  - uid: 626
+  - uid: 633
     components:
     - type: Transform
       pos: 1.5,43.5
       parent: 1
-  - uid: 627
+  - uid: 634
     components:
     - type: Transform
       pos: 1.5,42.5
       parent: 1
-  - uid: 628
+  - uid: 635
     components:
     - type: Transform
       pos: 1.5,41.5
       parent: 1
-  - uid: 629
+  - uid: 636
     components:
     - type: Transform
       pos: 1.5,40.5
       parent: 1
-  - uid: 630
+  - uid: 637
     components:
     - type: Transform
       pos: 1.5,39.5
       parent: 1
-  - uid: 631
+  - uid: 638
     components:
     - type: Transform
       pos: 1.5,38.5
       parent: 1
-  - uid: 632
+  - uid: 639
     components:
     - type: Transform
       pos: 1.5,37.5
       parent: 1
-  - uid: 633
+  - uid: 640
     components:
     - type: Transform
       pos: 1.5,36.5
       parent: 1
-  - uid: 634
+  - uid: 641
     components:
     - type: Transform
       pos: 1.5,35.5
       parent: 1
-  - uid: 635
+  - uid: 642
     components:
     - type: Transform
       pos: 1.5,34.5
       parent: 1
-  - uid: 636
+  - uid: 643
     components:
     - type: Transform
       pos: 1.5,33.5
       parent: 1
-  - uid: 637
+  - uid: 644
     components:
     - type: Transform
       pos: 1.5,32.5
       parent: 1
-  - uid: 638
+  - uid: 645
     components:
     - type: Transform
       pos: 1.5,31.5
       parent: 1
-  - uid: 639
+  - uid: 646
     components:
     - type: Transform
       pos: 1.5,30.5
       parent: 1
-  - uid: 640
+  - uid: 647
     components:
     - type: Transform
       pos: 1.5,29.5
       parent: 1
-  - uid: 641
+  - uid: 648
     components:
     - type: Transform
       pos: 1.5,28.5
       parent: 1
-  - uid: 642
+  - uid: 649
     components:
     - type: Transform
       pos: 1.5,27.5
       parent: 1
-  - uid: 643
+  - uid: 650
     components:
     - type: Transform
       pos: 1.5,26.5
       parent: 1
-  - uid: 644
+  - uid: 651
     components:
     - type: Transform
       pos: 1.5,25.5
       parent: 1
-  - uid: 645
+  - uid: 652
     components:
     - type: Transform
       pos: 1.5,24.5
       parent: 1
-  - uid: 646
+  - uid: 653
     components:
     - type: Transform
       pos: 1.5,23.5
       parent: 1
-  - uid: 647
+  - uid: 654
     components:
     - type: Transform
       pos: 1.5,22.5
       parent: 1
-  - uid: 648
+  - uid: 655
     components:
     - type: Transform
       pos: 1.5,21.5
       parent: 1
-  - uid: 649
+  - uid: 656
     components:
     - type: Transform
       pos: 1.5,20.5
       parent: 1
-  - uid: 650
+  - uid: 657
     components:
     - type: Transform
       pos: 1.5,19.5
       parent: 1
-  - uid: 651
+  - uid: 658
     components:
     - type: Transform
       pos: 1.5,18.5
       parent: 1
-  - uid: 652
+  - uid: 659
     components:
     - type: Transform
       pos: 1.5,17.5
       parent: 1
-  - uid: 653
+  - uid: 660
     components:
     - type: Transform
       pos: 1.5,16.5
       parent: 1
-  - uid: 654
+  - uid: 661
     components:
     - type: Transform
       pos: 1.5,15.5
       parent: 1
-  - uid: 655
+  - uid: 662
     components:
     - type: Transform
       pos: 1.5,14.5
       parent: 1
-  - uid: 656
+  - uid: 663
     components:
     - type: Transform
       pos: 1.5,13.5
       parent: 1
-  - uid: 657
+  - uid: 664
     components:
     - type: Transform
       pos: 1.5,12.5
       parent: 1
-  - uid: 658
+  - uid: 665
     components:
     - type: Transform
       pos: 1.5,11.5
       parent: 1
-  - uid: 659
+  - uid: 666
     components:
     - type: Transform
       pos: 1.5,10.5
       parent: 1
-  - uid: 660
+  - uid: 667
     components:
     - type: Transform
       pos: 1.5,9.5
       parent: 1
-  - uid: 661
+  - uid: 668
     components:
     - type: Transform
       pos: 1.5,8.5
       parent: 1
-  - uid: 662
+  - uid: 669
     components:
     - type: Transform
       pos: 1.5,7.5
       parent: 1
-  - uid: 663
+  - uid: 670
     components:
     - type: Transform
       pos: 1.5,6.5
       parent: 1
-  - uid: 664
+  - uid: 671
     components:
     - type: Transform
       pos: 1.5,5.5
       parent: 1
-  - uid: 665
+  - uid: 672
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 1
-  - uid: 666
+  - uid: 673
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 1
-  - uid: 667
+  - uid: 674
     components:
     - type: Transform
       pos: 2.5,49.5
       parent: 1
-  - uid: 668
+  - uid: 675
     components:
     - type: Transform
       pos: 2.5,48.5
       parent: 1
-  - uid: 669
+  - uid: 676
     components:
     - type: Transform
       pos: 2.5,47.5
       parent: 1
-  - uid: 670
+  - uid: 677
     components:
     - type: Transform
       pos: 2.5,46.5
       parent: 1
-  - uid: 671
+  - uid: 678
     components:
     - type: Transform
       pos: 2.5,45.5
       parent: 1
-  - uid: 672
+  - uid: 679
     components:
     - type: Transform
       pos: 2.5,44.5
       parent: 1
-  - uid: 673
+  - uid: 680
     components:
     - type: Transform
       pos: 2.5,43.5
       parent: 1
-  - uid: 674
+  - uid: 681
     components:
     - type: Transform
       pos: 2.5,42.5
       parent: 1
-  - uid: 675
+  - uid: 682
     components:
     - type: Transform
       pos: 2.5,41.5
       parent: 1
-  - uid: 676
+  - uid: 683
     components:
     - type: Transform
       pos: 2.5,40.5
       parent: 1
-  - uid: 677
+  - uid: 684
     components:
     - type: Transform
       pos: 2.5,39.5
       parent: 1
-  - uid: 678
+  - uid: 685
     components:
     - type: Transform
       pos: 2.5,38.5
       parent: 1
-  - uid: 679
+  - uid: 686
     components:
     - type: Transform
       pos: 2.5,37.5
       parent: 1
-  - uid: 680
+  - uid: 687
     components:
     - type: Transform
       pos: 2.5,36.5
       parent: 1
-  - uid: 681
+  - uid: 688
     components:
     - type: Transform
       pos: 2.5,35.5
       parent: 1
-  - uid: 682
+  - uid: 689
     components:
     - type: Transform
       pos: 2.5,34.5
       parent: 1
-  - uid: 683
+  - uid: 690
     components:
     - type: Transform
       pos: 2.5,33.5
       parent: 1
-  - uid: 684
+  - uid: 691
     components:
     - type: Transform
       pos: 2.5,32.5
       parent: 1
-  - uid: 685
+  - uid: 692
     components:
     - type: Transform
       pos: 2.5,31.5
       parent: 1
-  - uid: 686
+  - uid: 693
     components:
     - type: Transform
       pos: 2.5,30.5
       parent: 1
-  - uid: 687
+  - uid: 694
     components:
     - type: Transform
       pos: 2.5,29.5
       parent: 1
-  - uid: 688
+  - uid: 695
     components:
     - type: Transform
       pos: 2.5,28.5
       parent: 1
-  - uid: 689
+  - uid: 696
     components:
     - type: Transform
       pos: 2.5,27.5
       parent: 1
-  - uid: 690
+  - uid: 697
     components:
     - type: Transform
       pos: 2.5,26.5
       parent: 1
-  - uid: 691
+  - uid: 698
     components:
     - type: Transform
       pos: 2.5,25.5
       parent: 1
-  - uid: 692
+  - uid: 699
     components:
     - type: Transform
       pos: 2.5,24.5
       parent: 1
-  - uid: 693
+  - uid: 700
     components:
     - type: Transform
       pos: 2.5,23.5
       parent: 1
-  - uid: 694
+  - uid: 701
     components:
     - type: Transform
       pos: 2.5,22.5
       parent: 1
-  - uid: 695
+  - uid: 702
     components:
     - type: Transform
       pos: 2.5,21.5
       parent: 1
-  - uid: 696
+  - uid: 703
     components:
     - type: Transform
       pos: 2.5,20.5
       parent: 1
-  - uid: 697
+  - uid: 704
     components:
     - type: Transform
       pos: 2.5,19.5
       parent: 1
-  - uid: 698
+  - uid: 705
     components:
     - type: Transform
       pos: 2.5,18.5
       parent: 1
-  - uid: 699
+  - uid: 706
     components:
     - type: Transform
       pos: 2.5,17.5
       parent: 1
-  - uid: 700
+  - uid: 707
     components:
     - type: Transform
       pos: 2.5,16.5
       parent: 1
-  - uid: 701
+  - uid: 708
     components:
     - type: Transform
       pos: 2.5,15.5
       parent: 1
-  - uid: 702
+  - uid: 709
     components:
     - type: Transform
       pos: 2.5,14.5
       parent: 1
-  - uid: 703
+  - uid: 710
     components:
     - type: Transform
       pos: 2.5,13.5
       parent: 1
-  - uid: 704
+  - uid: 711
     components:
     - type: Transform
       pos: 2.5,12.5
       parent: 1
-  - uid: 705
+  - uid: 712
     components:
     - type: Transform
       pos: 2.5,11.5
       parent: 1
-  - uid: 706
+  - uid: 713
     components:
     - type: Transform
       pos: 2.5,10.5
       parent: 1
-  - uid: 707
+  - uid: 714
     components:
     - type: Transform
       pos: 2.5,9.5
       parent: 1
-  - uid: 708
+  - uid: 715
     components:
     - type: Transform
       pos: 2.5,8.5
       parent: 1
-  - uid: 709
+  - uid: 716
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
-  - uid: 710
+  - uid: 717
     components:
     - type: Transform
       pos: 2.5,6.5
       parent: 1
-  - uid: 711
+  - uid: 718
     components:
     - type: Transform
       pos: 2.5,5.5
       parent: 1
-  - uid: 712
+  - uid: 719
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
-  - uid: 713
+  - uid: 720
     components:
     - type: Transform
       pos: 2.5,3.5
       parent: 1
-  - uid: 714
+  - uid: 721
     components:
     - type: Transform
       pos: 3.5,49.5
       parent: 1
-  - uid: 715
+  - uid: 722
     components:
     - type: Transform
       pos: 3.5,48.5
       parent: 1
-  - uid: 716
+  - uid: 723
     components:
     - type: Transform
       pos: 3.5,47.5
       parent: 1
-  - uid: 717
+  - uid: 724
     components:
     - type: Transform
       pos: 3.5,46.5
       parent: 1
-  - uid: 718
+  - uid: 725
     components:
     - type: Transform
       pos: 3.5,45.5
       parent: 1
-  - uid: 719
+  - uid: 726
     components:
     - type: Transform
       pos: 3.5,44.5
       parent: 1
-  - uid: 720
+  - uid: 727
     components:
     - type: Transform
       pos: 3.5,43.5
       parent: 1
-  - uid: 721
+  - uid: 728
     components:
     - type: Transform
       pos: 3.5,42.5
       parent: 1
-  - uid: 722
+  - uid: 729
     components:
     - type: Transform
       pos: 3.5,41.5
       parent: 1
-  - uid: 723
+  - uid: 730
     components:
     - type: Transform
       pos: 3.5,40.5
       parent: 1
-  - uid: 724
+  - uid: 731
     components:
     - type: Transform
       pos: 3.5,39.5
       parent: 1
-  - uid: 725
+  - uid: 732
     components:
     - type: Transform
       pos: 3.5,38.5
       parent: 1
-  - uid: 726
+  - uid: 733
     components:
     - type: Transform
       pos: 3.5,37.5
       parent: 1
-  - uid: 727
+  - uid: 734
     components:
     - type: Transform
       pos: 3.5,36.5
       parent: 1
-  - uid: 728
+  - uid: 735
     components:
     - type: Transform
       pos: 3.5,35.5
       parent: 1
-  - uid: 729
+  - uid: 736
     components:
     - type: Transform
       pos: 3.5,34.5
       parent: 1
-  - uid: 730
+  - uid: 737
     components:
     - type: Transform
       pos: 3.5,33.5
       parent: 1
-  - uid: 731
+  - uid: 738
     components:
     - type: Transform
       pos: 3.5,32.5
       parent: 1
-  - uid: 732
+  - uid: 739
     components:
     - type: Transform
       pos: 3.5,31.5
       parent: 1
-  - uid: 733
+  - uid: 740
     components:
     - type: Transform
       pos: 3.5,30.5
       parent: 1
-  - uid: 734
+  - uid: 741
     components:
     - type: Transform
       pos: 3.5,29.5
       parent: 1
-  - uid: 735
+  - uid: 742
     components:
     - type: Transform
       pos: 3.5,28.5
       parent: 1
-  - uid: 736
+  - uid: 743
     components:
     - type: Transform
       pos: 3.5,27.5
       parent: 1
-  - uid: 737
+  - uid: 744
     components:
     - type: Transform
       pos: 3.5,26.5
       parent: 1
-  - uid: 738
+  - uid: 745
     components:
     - type: Transform
       pos: 3.5,25.5
       parent: 1
-  - uid: 739
+  - uid: 746
     components:
     - type: Transform
       pos: 3.5,24.5
       parent: 1
-  - uid: 740
+  - uid: 747
     components:
     - type: Transform
       pos: 3.5,23.5
       parent: 1
-  - uid: 741
+  - uid: 748
     components:
     - type: Transform
       pos: 3.5,22.5
       parent: 1
-  - uid: 742
+  - uid: 749
     components:
     - type: Transform
       pos: 3.5,21.5
       parent: 1
-  - uid: 743
+  - uid: 750
     components:
     - type: Transform
       pos: 3.5,20.5
       parent: 1
-  - uid: 744
+  - uid: 751
     components:
     - type: Transform
       pos: 3.5,19.5
       parent: 1
-  - uid: 745
+  - uid: 752
     components:
     - type: Transform
       pos: 3.5,18.5
       parent: 1
-  - uid: 746
+  - uid: 753
     components:
     - type: Transform
       pos: 3.5,17.5
       parent: 1
-  - uid: 747
+  - uid: 754
     components:
     - type: Transform
       pos: 3.5,16.5
       parent: 1
-  - uid: 748
+  - uid: 755
     components:
     - type: Transform
       pos: 3.5,15.5
       parent: 1
-  - uid: 749
+  - uid: 756
     components:
     - type: Transform
       pos: 3.5,14.5
       parent: 1
-  - uid: 750
+  - uid: 757
     components:
     - type: Transform
       pos: 3.5,13.5
       parent: 1
-  - uid: 751
+  - uid: 758
     components:
     - type: Transform
       pos: 3.5,12.5
       parent: 1
-  - uid: 752
+  - uid: 759
     components:
     - type: Transform
       pos: 3.5,11.5
       parent: 1
-  - uid: 753
+  - uid: 760
     components:
     - type: Transform
       pos: 3.5,10.5
       parent: 1
-  - uid: 754
+  - uid: 761
     components:
     - type: Transform
       pos: 3.5,9.5
       parent: 1
-  - uid: 755
+  - uid: 762
     components:
     - type: Transform
       pos: 3.5,8.5
       parent: 1
-  - uid: 756
+  - uid: 763
     components:
     - type: Transform
       pos: 3.5,7.5
       parent: 1
-  - uid: 757
+  - uid: 764
     components:
     - type: Transform
       pos: 3.5,6.5
       parent: 1
-  - uid: 758
+  - uid: 765
     components:
     - type: Transform
       pos: 3.5,5.5
       parent: 1
-  - uid: 759
+  - uid: 766
     components:
     - type: Transform
       pos: 3.5,4.5
       parent: 1
-  - uid: 760
+  - uid: 767
     components:
     - type: Transform
       pos: 3.5,3.5
       parent: 1
-  - uid: 761
+  - uid: 768
     components:
     - type: Transform
       pos: 4.5,49.5
       parent: 1
-  - uid: 762
+  - uid: 769
     components:
     - type: Transform
       pos: 4.5,48.5
       parent: 1
-  - uid: 763
+  - uid: 770
     components:
     - type: Transform
       pos: 4.5,47.5
       parent: 1
-  - uid: 764
+  - uid: 771
     components:
     - type: Transform
       pos: 4.5,46.5
       parent: 1
-  - uid: 765
+  - uid: 772
     components:
     - type: Transform
       pos: 4.5,45.5
       parent: 1
-  - uid: 766
+  - uid: 773
     components:
     - type: Transform
       pos: 4.5,44.5
       parent: 1
-  - uid: 767
+  - uid: 774
     components:
     - type: Transform
       pos: 4.5,43.5
       parent: 1
-  - uid: 768
+  - uid: 775
     components:
     - type: Transform
       pos: 4.5,42.5
       parent: 1
-  - uid: 769
+  - uid: 776
     components:
     - type: Transform
       pos: 4.5,41.5
       parent: 1
-  - uid: 770
+  - uid: 777
     components:
     - type: Transform
       pos: 4.5,40.5
       parent: 1
-  - uid: 771
+  - uid: 778
     components:
     - type: Transform
       pos: 4.5,39.5
       parent: 1
-  - uid: 772
+  - uid: 779
     components:
     - type: Transform
       pos: 4.5,38.5
       parent: 1
-  - uid: 773
+  - uid: 780
     components:
     - type: Transform
       pos: 4.5,37.5
       parent: 1
-  - uid: 774
+  - uid: 781
     components:
     - type: Transform
       pos: 4.5,36.5
       parent: 1
-  - uid: 775
+  - uid: 782
     components:
     - type: Transform
       pos: 4.5,35.5
       parent: 1
-  - uid: 776
+  - uid: 783
     components:
     - type: Transform
       pos: 4.5,34.5
       parent: 1
-  - uid: 777
+  - uid: 784
     components:
     - type: Transform
       pos: 4.5,33.5
       parent: 1
-  - uid: 778
+  - uid: 785
     components:
     - type: Transform
       pos: 4.5,32.5
       parent: 1
-  - uid: 779
+  - uid: 786
     components:
     - type: Transform
       pos: 1.5,49.5
       parent: 1
-  - uid: 780
+  - uid: 787
     components:
     - type: Transform
       pos: 4.5,30.5
       parent: 1
-  - uid: 781
+  - uid: 788
     components:
     - type: Transform
       pos: 4.5,29.5
       parent: 1
-  - uid: 782
+  - uid: 789
     components:
     - type: Transform
       pos: 4.5,28.5
       parent: 1
-  - uid: 783
+  - uid: 790
     components:
     - type: Transform
       pos: 4.5,27.5
       parent: 1
-  - uid: 784
+  - uid: 791
     components:
     - type: Transform
       pos: 4.5,26.5
       parent: 1
-  - uid: 785
+  - uid: 792
     components:
     - type: Transform
       pos: 4.5,25.5
       parent: 1
-  - uid: 786
+  - uid: 793
     components:
     - type: Transform
       pos: 4.5,24.5
       parent: 1
-  - uid: 787
+  - uid: 794
     components:
     - type: Transform
       pos: 4.5,23.5
       parent: 1
-  - uid: 788
+  - uid: 795
     components:
     - type: Transform
       pos: 4.5,22.5
       parent: 1
-  - uid: 789
+  - uid: 796
     components:
     - type: Transform
       pos: 4.5,21.5
       parent: 1
-  - uid: 790
+  - uid: 797
     components:
     - type: Transform
       pos: 4.5,20.5
       parent: 1
-  - uid: 791
+  - uid: 798
     components:
     - type: Transform
       pos: 4.5,19.5
       parent: 1
-  - uid: 792
+  - uid: 799
     components:
     - type: Transform
       pos: 4.5,18.5
       parent: 1
-  - uid: 793
+  - uid: 800
     components:
     - type: Transform
       pos: 4.5,17.5
       parent: 1
-  - uid: 794
+  - uid: 801
     components:
     - type: Transform
       pos: 4.5,16.5
       parent: 1
-  - uid: 795
+  - uid: 802
     components:
     - type: Transform
       pos: 4.5,15.5
       parent: 1
-  - uid: 796
+  - uid: 803
     components:
     - type: Transform
       pos: 4.5,14.5
       parent: 1
-  - uid: 797
+  - uid: 804
     components:
     - type: Transform
       pos: 4.5,13.5
       parent: 1
-  - uid: 798
+  - uid: 805
     components:
     - type: Transform
       pos: 4.5,12.5
       parent: 1
-  - uid: 799
+  - uid: 806
     components:
     - type: Transform
       pos: 4.5,11.5
       parent: 1
-  - uid: 800
+  - uid: 807
     components:
     - type: Transform
       pos: 4.5,10.5
       parent: 1
-  - uid: 801
+  - uid: 808
     components:
     - type: Transform
       pos: 4.5,9.5
       parent: 1
-  - uid: 802
+  - uid: 809
     components:
     - type: Transform
       pos: 4.5,8.5
       parent: 1
-  - uid: 803
+  - uid: 810
     components:
     - type: Transform
       pos: 4.5,7.5
       parent: 1
-  - uid: 804
+  - uid: 811
     components:
     - type: Transform
       pos: 4.5,6.5
       parent: 1
-  - uid: 805
+  - uid: 812
     components:
     - type: Transform
       pos: 4.5,5.5
       parent: 1
-  - uid: 806
+  - uid: 813
     components:
     - type: Transform
       pos: 4.5,4.5
       parent: 1
-  - uid: 807
+  - uid: 814
     components:
     - type: Transform
       pos: 4.5,3.5
       parent: 1
-  - uid: 808
+  - uid: 815
     components:
     - type: Transform
       pos: 5.5,49.5
       parent: 1
-  - uid: 809
+  - uid: 816
     components:
     - type: Transform
       pos: 5.5,48.5
       parent: 1
-  - uid: 810
+  - uid: 817
     components:
     - type: Transform
       pos: 5.5,47.5
       parent: 1
-  - uid: 811
+  - uid: 818
     components:
     - type: Transform
       pos: 5.5,46.5
       parent: 1
-  - uid: 812
+  - uid: 819
     components:
     - type: Transform
       pos: 5.5,45.5
       parent: 1
-  - uid: 813
+  - uid: 820
     components:
     - type: Transform
       pos: 5.5,44.5
       parent: 1
-  - uid: 814
+  - uid: 821
     components:
     - type: Transform
       pos: 5.5,43.5
       parent: 1
-  - uid: 815
+  - uid: 822
     components:
     - type: Transform
       pos: 5.5,42.5
       parent: 1
-  - uid: 816
+  - uid: 823
     components:
     - type: Transform
       pos: 5.5,41.5
       parent: 1
-  - uid: 817
+  - uid: 824
     components:
     - type: Transform
       pos: 5.5,40.5
       parent: 1
-  - uid: 818
+  - uid: 825
     components:
     - type: Transform
       pos: 5.5,39.5
       parent: 1
-  - uid: 819
+  - uid: 826
     components:
     - type: Transform
       pos: 5.5,38.5
       parent: 1
-  - uid: 820
+  - uid: 827
     components:
     - type: Transform
       pos: 5.5,37.5
       parent: 1
-  - uid: 821
+  - uid: 828
     components:
     - type: Transform
       pos: 5.5,36.5
       parent: 1
-  - uid: 822
+  - uid: 829
     components:
     - type: Transform
       pos: 5.5,35.5
       parent: 1
-  - uid: 823
+  - uid: 830
     components:
     - type: Transform
       pos: 5.5,34.5
       parent: 1
-  - uid: 824
+  - uid: 831
     components:
     - type: Transform
       pos: 5.5,33.5
       parent: 1
-  - uid: 825
+  - uid: 832
     components:
     - type: Transform
       pos: 5.5,32.5
       parent: 1
-  - uid: 826
+  - uid: 833
     components:
     - type: Transform
       pos: 5.5,31.5
       parent: 1
-  - uid: 827
+  - uid: 834
     components:
     - type: Transform
       pos: 5.5,30.5
       parent: 1
-  - uid: 828
+  - uid: 835
     components:
     - type: Transform
       pos: 5.5,29.5
       parent: 1
-  - uid: 829
+  - uid: 836
     components:
     - type: Transform
       pos: 5.5,28.5
       parent: 1
-  - uid: 830
+  - uid: 837
     components:
     - type: Transform
       pos: 5.5,27.5
       parent: 1
-  - uid: 831
+  - uid: 838
     components:
     - type: Transform
       pos: 5.5,26.5
       parent: 1
-  - uid: 832
+  - uid: 839
     components:
     - type: Transform
       pos: 5.5,25.5
       parent: 1
-  - uid: 833
+  - uid: 840
     components:
     - type: Transform
       pos: 5.5,24.5
       parent: 1
-  - uid: 834
+  - uid: 841
     components:
     - type: Transform
       pos: 5.5,23.5
       parent: 1
-  - uid: 835
+  - uid: 842
     components:
     - type: Transform
       pos: 5.5,22.5
       parent: 1
-  - uid: 836
+  - uid: 843
     components:
     - type: Transform
       pos: 5.5,21.5
       parent: 1
-  - uid: 837
+  - uid: 844
     components:
     - type: Transform
       pos: 5.5,20.5
       parent: 1
-  - uid: 838
+  - uid: 845
     components:
     - type: Transform
       pos: 5.5,19.5
       parent: 1
-  - uid: 839
+  - uid: 846
     components:
     - type: Transform
       pos: 5.5,18.5
       parent: 1
-  - uid: 840
+  - uid: 847
     components:
     - type: Transform
       pos: 5.5,17.5
       parent: 1
-  - uid: 841
+  - uid: 848
     components:
     - type: Transform
       pos: 5.5,16.5
       parent: 1
-  - uid: 842
+  - uid: 849
     components:
     - type: Transform
       pos: 5.5,15.5
       parent: 1
-  - uid: 843
+  - uid: 850
     components:
     - type: Transform
       pos: 5.5,14.5
       parent: 1
-  - uid: 844
+  - uid: 851
     components:
     - type: Transform
       pos: 5.5,13.5
       parent: 1
-  - uid: 845
+  - uid: 852
     components:
     - type: Transform
       pos: 5.5,12.5
       parent: 1
-  - uid: 846
+  - uid: 853
     components:
     - type: Transform
       pos: 5.5,11.5
       parent: 1
-  - uid: 847
+  - uid: 854
     components:
     - type: Transform
       pos: 5.5,10.5
       parent: 1
-  - uid: 848
+  - uid: 855
     components:
     - type: Transform
       pos: 5.5,9.5
       parent: 1
-  - uid: 849
+  - uid: 856
     components:
     - type: Transform
       pos: 5.5,8.5
       parent: 1
-  - uid: 850
+  - uid: 857
     components:
     - type: Transform
       pos: 5.5,7.5
       parent: 1
-  - uid: 851
+  - uid: 858
     components:
     - type: Transform
       pos: 5.5,6.5
       parent: 1
-  - uid: 852
+  - uid: 859
     components:
     - type: Transform
       pos: 5.5,5.5
       parent: 1
-  - uid: 853
+  - uid: 860
     components:
     - type: Transform
       pos: 5.5,4.5
       parent: 1
-  - uid: 854
+  - uid: 861
     components:
     - type: Transform
       pos: 5.5,3.5
       parent: 1
-  - uid: 855
+  - uid: 862
     components:
     - type: Transform
       pos: 4.5,31.5
       parent: 1
-  - uid: 856
+  - uid: 863
     components:
     - type: Transform
       pos: 8.5,49.5
       parent: 1
-  - uid: 857
+  - uid: 864
     components:
     - type: Transform
       pos: 9.5,49.5
       parent: 1
-  - uid: 858
+  - uid: 865
     components:
     - type: Transform
       pos: 10.5,49.5
       parent: 1
-  - uid: 859
+  - uid: 866
     components:
     - type: Transform
       pos: 11.5,49.5
       parent: 1
-  - uid: 860
+  - uid: 867
     components:
     - type: Transform
       pos: 12.5,49.5
       parent: 1
-  - uid: 861
+  - uid: 868
     components:
     - type: Transform
       pos: 13.5,49.5
       parent: 1
-  - uid: 862
+  - uid: 869
     components:
     - type: Transform
       pos: 6.5,49.5
       parent: 1
-  - uid: 863
+  - uid: 870
     components:
     - type: Transform
       pos: 6.5,47.5
       parent: 1
-  - uid: 864
+  - uid: 871
     components:
     - type: Transform
       pos: 6.5,46.5
       parent: 1
-  - uid: 865
+  - uid: 872
     components:
     - type: Transform
       pos: 6.5,45.5
       parent: 1
-  - uid: 866
+  - uid: 873
     components:
     - type: Transform
       pos: 6.5,44.5
       parent: 1
-  - uid: 867
+  - uid: 874
     components:
     - type: Transform
       pos: 6.5,43.5
       parent: 1
-  - uid: 868
+  - uid: 875
     components:
     - type: Transform
       pos: 6.5,42.5
       parent: 1
-  - uid: 869
+  - uid: 876
     components:
     - type: Transform
       pos: 6.5,41.5
       parent: 1
-  - uid: 870
+  - uid: 877
     components:
     - type: Transform
       pos: 6.5,40.5
       parent: 1
-  - uid: 871
+  - uid: 878
     components:
     - type: Transform
       pos: 6.5,39.5
       parent: 1
-  - uid: 872
+  - uid: 879
     components:
     - type: Transform
       pos: 6.5,38.5
       parent: 1
-  - uid: 873
+  - uid: 880
     components:
     - type: Transform
       pos: 6.5,37.5
       parent: 1
-  - uid: 874
+  - uid: 881
     components:
     - type: Transform
       pos: 6.5,36.5
       parent: 1
-  - uid: 875
+  - uid: 882
     components:
     - type: Transform
       pos: 6.5,35.5
       parent: 1
-  - uid: 876
+  - uid: 883
     components:
     - type: Transform
       pos: 6.5,34.5
       parent: 1
-  - uid: 877
+  - uid: 884
     components:
     - type: Transform
       pos: 6.5,33.5
       parent: 1
-  - uid: 878
+  - uid: 885
     components:
     - type: Transform
       pos: 6.5,32.5
       parent: 1
-  - uid: 879
+  - uid: 886
     components:
     - type: Transform
       pos: 6.5,48.5
       parent: 1
-  - uid: 880
+  - uid: 887
     components:
     - type: Transform
       pos: 6.5,24.5
       parent: 1
-  - uid: 881
+  - uid: 888
     components:
     - type: Transform
       pos: 6.5,23.5
       parent: 1
-  - uid: 882
+  - uid: 889
     components:
     - type: Transform
       pos: 6.5,22.5
       parent: 1
-  - uid: 883
+  - uid: 890
     components:
     - type: Transform
       pos: 6.5,21.5
       parent: 1
-  - uid: 884
+  - uid: 891
     components:
     - type: Transform
       pos: 6.5,20.5
       parent: 1
-  - uid: 885
+  - uid: 892
     components:
     - type: Transform
       pos: 6.5,19.5
       parent: 1
-  - uid: 886
+  - uid: 893
     components:
     - type: Transform
       pos: 6.5,18.5
       parent: 1
-  - uid: 887
+  - uid: 894
     components:
     - type: Transform
       pos: 6.5,17.5
       parent: 1
-  - uid: 888
+  - uid: 895
     components:
     - type: Transform
       pos: 6.5,16.5
       parent: 1
-  - uid: 889
+  - uid: 896
     components:
     - type: Transform
       pos: 6.5,15.5
       parent: 1
-  - uid: 890
+  - uid: 897
     components:
     - type: Transform
       pos: 6.5,14.5
       parent: 1
-  - uid: 891
+  - uid: 898
     components:
     - type: Transform
       pos: 6.5,13.5
       parent: 1
-  - uid: 892
+  - uid: 899
     components:
     - type: Transform
       pos: 6.5,12.5
       parent: 1
-  - uid: 893
+  - uid: 900
     components:
     - type: Transform
       pos: 6.5,11.5
       parent: 1
-  - uid: 894
+  - uid: 901
     components:
     - type: Transform
       pos: 6.5,10.5
       parent: 1
-  - uid: 895
+  - uid: 902
     components:
     - type: Transform
       pos: 6.5,9.5
       parent: 1
-  - uid: 896
+  - uid: 903
     components:
     - type: Transform
       pos: 6.5,8.5
       parent: 1
-  - uid: 897
+  - uid: 904
     components:
     - type: Transform
       pos: 6.5,7.5
       parent: 1
-  - uid: 898
+  - uid: 905
     components:
     - type: Transform
       pos: 6.5,6.5
       parent: 1
-  - uid: 899
+  - uid: 906
     components:
     - type: Transform
       pos: 6.5,5.5
       parent: 1
-  - uid: 900
+  - uid: 907
     components:
     - type: Transform
       pos: 6.5,4.5
       parent: 1
-  - uid: 901
+  - uid: 908
     components:
     - type: Transform
       pos: 6.5,25.5
       parent: 1
-  - uid: 902
+  - uid: 909
     components:
     - type: Transform
       pos: 6.5,3.5
       parent: 1
-  - uid: 903
+  - uid: 910
     components:
     - type: Transform
       pos: 7.5,2.5
       parent: 1
-  - uid: 904
+  - uid: 911
     components:
     - type: Transform
       pos: 8.5,2.5
       parent: 1
-  - uid: 905
+  - uid: 912
     components:
     - type: Transform
       pos: 9.5,2.5
       parent: 1
-  - uid: 906
+  - uid: 913
     components:
     - type: Transform
       pos: 10.5,2.5
       parent: 1
-  - uid: 907
+  - uid: 914
     components:
     - type: Transform
       pos: 11.5,2.5
       parent: 1
-  - uid: 908
+  - uid: 915
     components:
     - type: Transform
       pos: 8.5,1.5
       parent: 1
-  - uid: 909
+  - uid: 916
     components:
     - type: Transform
       pos: 9.5,1.5
       parent: 1
-  - uid: 910
+  - uid: 917
     components:
     - type: Transform
       pos: 10.5,1.5
       parent: 1
-  - uid: 911
+  - uid: 918
     components:
     - type: Transform
       pos: 11.5,1.5
       parent: 1
-  - uid: 912
+  - uid: 919
     components:
     - type: Transform
       pos: 12.5,1.5
       parent: 1
-  - uid: 913
+  - uid: 920
     components:
     - type: Transform
       pos: 7.5,1.5
       parent: 1
-  - uid: 914
+  - uid: 921
     components:
     - type: Transform
       pos: 13.5,1.5
       parent: 1
-  - uid: 915
+  - uid: 922
     components:
     - type: Transform
       pos: 17.5,1.5
       parent: 1
-  - uid: 916
+  - uid: 923
     components:
     - type: Transform
       pos: 19.5,1.5
       parent: 1
-  - uid: 917
+  - uid: 924
     components:
     - type: Transform
       pos: 20.5,1.5
       parent: 1
-  - uid: 918
+  - uid: 925
     components:
     - type: Transform
       pos: 21.5,1.5
       parent: 1
-  - uid: 919
+  - uid: 926
     components:
     - type: Transform
       pos: 18.5,1.5
       parent: 1
-  - uid: 920
+  - uid: 927
     components:
     - type: Transform
       pos: 18.5,2.5
       parent: 1
-  - uid: 921
+  - uid: 928
     components:
     - type: Transform
       pos: 19.5,2.5
       parent: 1
-  - uid: 922
+  - uid: 929
     components:
     - type: Transform
       pos: 20.5,2.5
       parent: 1
-  - uid: 923
+  - uid: 930
     components:
     - type: Transform
       pos: 31.5,0.5
       parent: 1
-  - uid: 924
+  - uid: 931
     components:
     - type: Transform
       pos: 30.5,1.5
       parent: 1
-  - uid: 925
+  - uid: 932
     components:
     - type: Transform
       pos: 29.5,1.5
       parent: 1
-  - uid: 926
+  - uid: 933
     components:
     - type: Transform
       pos: 28.5,1.5
       parent: 1
-  - uid: 927
+  - uid: 934
     components:
     - type: Transform
       pos: 27.5,1.5
       parent: 1
-  - uid: 928
+  - uid: 935
     components:
     - type: Transform
       pos: 39.5,9.5
       parent: 1
-  - uid: 929
+  - uid: 936
     components:
     - type: Transform
       pos: 38.5,9.5
       parent: 1
-  - uid: 930
+  - uid: 937
     components:
     - type: Transform
       pos: 39.5,10.5
       parent: 1
-  - uid: 931
+  - uid: 938
     components:
     - type: Transform
       pos: 10.5,4.5
       parent: 1
-  - uid: 932
+  - uid: 939
     components:
     - type: Transform
       pos: 10.5,5.5
       parent: 1
-  - uid: 933
+  - uid: 940
     components:
     - type: Transform
       pos: 10.5,6.5
       parent: 1
-  - uid: 934
+  - uid: 941
     components:
     - type: Transform
       pos: 10.5,7.5
       parent: 1
-  - uid: 935
+  - uid: 942
     components:
     - type: Transform
       pos: 10.5,8.5
       parent: 1
-  - uid: 936
+  - uid: 943
     components:
     - type: Transform
       pos: 10.5,9.5
       parent: 1
-  - uid: 937
+  - uid: 944
     components:
     - type: Transform
       pos: 10.5,10.5
       parent: 1
-  - uid: 938
+  - uid: 945
     components:
     - type: Transform
       pos: 10.5,11.5
       parent: 1
-  - uid: 939
+  - uid: 946
     components:
     - type: Transform
       pos: 10.5,12.5
       parent: 1
-  - uid: 940
+  - uid: 947
     components:
     - type: Transform
       pos: 10.5,13.5
       parent: 1
-  - uid: 941
+  - uid: 948
     components:
     - type: Transform
       pos: 10.5,14.5
       parent: 1
-  - uid: 942
+  - uid: 949
     components:
     - type: Transform
       pos: 9.5,4.5
       parent: 1
-  - uid: 943
+  - uid: 950
     components:
     - type: Transform
       pos: 9.5,5.5
       parent: 1
-  - uid: 944
+  - uid: 951
     components:
     - type: Transform
       pos: 9.5,6.5
       parent: 1
-  - uid: 945
+  - uid: 952
     components:
     - type: Transform
       pos: 9.5,7.5
       parent: 1
-  - uid: 946
+  - uid: 953
     components:
     - type: Transform
       pos: 9.5,8.5
       parent: 1
-  - uid: 947
+  - uid: 954
     components:
     - type: Transform
       pos: 9.5,9.5
       parent: 1
-  - uid: 948
+  - uid: 955
     components:
     - type: Transform
       pos: 9.5,10.5
       parent: 1
-  - uid: 949
+  - uid: 956
     components:
     - type: Transform
       pos: 9.5,11.5
       parent: 1
-  - uid: 950
+  - uid: 957
     components:
     - type: Transform
       pos: 9.5,12.5
       parent: 1
-  - uid: 951
+  - uid: 958
     components:
     - type: Transform
       pos: 9.5,13.5
       parent: 1
-  - uid: 952
+  - uid: 959
     components:
     - type: Transform
       pos: 9.5,14.5
       parent: 1
-  - uid: 953
+  - uid: 960
     components:
     - type: Transform
       pos: 8.5,3.5
       parent: 1
-  - uid: 954
+  - uid: 961
     components:
     - type: Transform
       pos: 8.5,4.5
       parent: 1
-  - uid: 955
+  - uid: 962
     components:
     - type: Transform
       pos: 8.5,5.5
       parent: 1
-  - uid: 956
+  - uid: 963
     components:
     - type: Transform
       pos: 8.5,6.5
       parent: 1
-  - uid: 957
+  - uid: 964
     components:
     - type: Transform
       pos: 8.5,7.5
       parent: 1
-  - uid: 958
+  - uid: 965
     components:
     - type: Transform
       pos: 8.5,8.5
       parent: 1
-  - uid: 959
+  - uid: 966
     components:
     - type: Transform
       pos: 8.5,9.5
       parent: 1
-  - uid: 960
+  - uid: 967
     components:
     - type: Transform
       pos: 8.5,10.5
       parent: 1
-  - uid: 961
+  - uid: 968
     components:
     - type: Transform
       pos: 8.5,11.5
       parent: 1
-  - uid: 962
+  - uid: 969
     components:
     - type: Transform
       pos: 8.5,12.5
       parent: 1
-  - uid: 963
+  - uid: 970
     components:
     - type: Transform
       pos: 8.5,13.5
       parent: 1
-  - uid: 964
+  - uid: 971
     components:
     - type: Transform
       pos: 8.5,14.5
       parent: 1
-  - uid: 965
+  - uid: 972
     components:
     - type: Transform
       pos: 7.5,3.5
       parent: 1
-  - uid: 966
+  - uid: 973
     components:
     - type: Transform
       pos: 7.5,4.5
       parent: 1
-  - uid: 967
+  - uid: 974
     components:
     - type: Transform
       pos: 7.5,5.5
       parent: 1
-  - uid: 968
+  - uid: 975
     components:
     - type: Transform
       pos: 7.5,6.5
       parent: 1
-  - uid: 969
+  - uid: 976
     components:
     - type: Transform
       pos: 7.5,7.5
       parent: 1
-  - uid: 970
+  - uid: 977
     components:
     - type: Transform
       pos: 7.5,8.5
       parent: 1
-  - uid: 971
+  - uid: 978
     components:
     - type: Transform
       pos: 9.5,3.5
       parent: 1
-  - uid: 972
+  - uid: 979
     components:
     - type: Transform
       pos: 10.5,3.5
       parent: 1
-  - uid: 973
+  - uid: 980
     components:
     - type: Transform
       pos: 7.5,9.5
       parent: 1
-  - uid: 974
+  - uid: 981
     components:
     - type: Transform
       pos: 7.5,10.5
       parent: 1
-  - uid: 975
+  - uid: 982
     components:
     - type: Transform
       pos: 7.5,11.5
       parent: 1
-  - uid: 976
+  - uid: 983
     components:
     - type: Transform
       pos: 7.5,12.5
       parent: 1
-  - uid: 977
+  - uid: 984
     components:
     - type: Transform
       pos: 7.5,13.5
       parent: 1
-  - uid: 978
+  - uid: 985
     components:
     - type: Transform
       pos: 7.5,14.5
       parent: 1
-  - uid: 979
+  - uid: 986
     components:
     - type: Transform
       pos: 11.5,15.5
       parent: 1
-  - uid: 980
+  - uid: 987
     components:
     - type: Transform
       pos: 11.5,14.5
       parent: 1
-  - uid: 981
+  - uid: 988
     components:
     - type: Transform
       pos: 11.5,13.5
       parent: 1
-  - uid: 982
+  - uid: 989
     components:
     - type: Transform
       pos: 12.5,15.5
       parent: 1
-  - uid: 983
+  - uid: 990
     components:
     - type: Transform
       pos: 12.5,14.5
       parent: 1
-  - uid: 984
+  - uid: 991
     components:
     - type: Transform
       pos: 12.5,13.5
       parent: 1
-  - uid: 985
+  - uid: 992
     components:
     - type: Transform
       pos: 11.5,7.5
       parent: 1
-  - uid: 986
+  - uid: 993
     components:
     - type: Transform
       pos: 11.5,8.5
       parent: 1
-  - uid: 987
+  - uid: 994
     components:
     - type: Transform
       pos: 11.5,9.5
       parent: 1
-  - uid: 988
+  - uid: 995
     components:
     - type: Transform
       pos: 11.5,10.5
       parent: 1
-  - uid: 989
+  - uid: 996
     components:
     - type: Transform
       pos: 11.5,11.5
       parent: 1
-  - uid: 990
+  - uid: 997
     components:
     - type: Transform
       pos: 11.5,12.5
       parent: 1
-  - uid: 991
+  - uid: 998
     components:
     - type: Transform
       pos: 12.5,9.5
       parent: 1
-  - uid: 992
+  - uid: 999
     components:
     - type: Transform
       pos: 12.5,10.5
       parent: 1
-  - uid: 993
+  - uid: 1000
     components:
     - type: Transform
       pos: 12.5,11.5
       parent: 1
-  - uid: 994
+  - uid: 1001
     components:
     - type: Transform
       pos: 12.5,12.5
       parent: 1
-  - uid: 995
+  - uid: 1002
     components:
     - type: Transform
       pos: 13.5,10.5
       parent: 1
-  - uid: 996
+  - uid: 1003
     components:
     - type: Transform
       pos: 8.5,15.5
       parent: 1
-  - uid: 997
+  - uid: 1004
     components:
     - type: Transform
       pos: 7.5,15.5
       parent: 1
-  - uid: 998
+  - uid: 1005
     components:
     - type: Transform
       pos: 43.5,31.5
       parent: 1
-  - uid: 999
+  - uid: 1006
     components:
     - type: Transform
       pos: 42.5,31.5
       parent: 1
-  - uid: 1000
+  - uid: 1007
     components:
     - type: Transform
       pos: 41.5,31.5
       parent: 1
-  - uid: 1001
+  - uid: 1008
     components:
     - type: Transform
       pos: 40.5,31.5
       parent: 1
-  - uid: 1002
+  - uid: 1009
     components:
     - type: Transform
       pos: 41.5,30.5
       parent: 1
-  - uid: 1003
+  - uid: 1010
     components:
     - type: Transform
       pos: 40.5,30.5
       parent: 1
-  - uid: 1004
+  - uid: 1011
     components:
     - type: Transform
       pos: 42.5,32.5
       parent: 1
-  - uid: 1005
+  - uid: 1012
     components:
     - type: Transform
       pos: 43.5,32.5
       parent: 1
-  - uid: 1006
+  - uid: 1013
     components:
     - type: Transform
       pos: 43.5,33.5
       parent: 1
-  - uid: 1007
+  - uid: 1014
     components:
     - type: Transform
       pos: 43.5,34.5
       parent: 1
-  - uid: 1008
+  - uid: 1015
     components:
     - type: Transform
       pos: 43.5,38.5
       parent: 1
-  - uid: 1009
+  - uid: 1016
     components:
     - type: Transform
       pos: 43.5,39.5
       parent: 1
-  - uid: 1010
+  - uid: 1017
     components:
     - type: Transform
       pos: 42.5,39.5
       parent: 1
-  - uid: 1011
+  - uid: 1018
     components:
     - type: Transform
       pos: 42.5,38.5
       parent: 1
-  - uid: 1012
+  - uid: 1019
     components:
     - type: Transform
       pos: 41.5,39.5
       parent: 1
-  - uid: 1013
+  - uid: 1020
     components:
     - type: Transform
       pos: 41.5,38.5
       parent: 1
-  - uid: 1014
+  - uid: 1021
     components:
     - type: Transform
       pos: 40.5,38.5
       parent: 1
-  - uid: 1015
+  - uid: 1022
     components:
     - type: Transform
       pos: 41.5,37.5
       parent: 1
-  - uid: 1016
+  - uid: 1023
     components:
     - type: Transform
       pos: 23.5,3.5
       parent: 1
-  - uid: 1017
+  - uid: 1024
     components:
     - type: Transform
       pos: 22.5,4.5
       parent: 1
-  - uid: 1018
+  - uid: 1025
     components:
     - type: Transform
       pos: 23.5,4.5
       parent: 1
-  - uid: 1019
+  - uid: 1026
     components:
     - type: Transform
       pos: 23.5,5.5
       parent: 1
-  - uid: 1020
+  - uid: 1027
     components:
     - type: Transform
       pos: 23.5,6.5
       parent: 1
-  - uid: 1021
+  - uid: 1028
     components:
     - type: Transform
       pos: 22.5,5.5
       parent: 1
-  - uid: 1022
+  - uid: 1029
     components:
     - type: Transform
       pos: 24.5,6.5
       parent: 1
-  - uid: 1023
+  - uid: 1030
     components:
     - type: Transform
       pos: 25.5,6.5
       parent: 1
-  - uid: 1024
+  - uid: 1031
     components:
     - type: Transform
       pos: 25.5,5.5
       parent: 1
-  - uid: 1025
+  - uid: 1032
     components:
     - type: Transform
       pos: 26.5,5.5
       parent: 1
-  - uid: 1026
+  - uid: 1033
     components:
     - type: Transform
       pos: 24.5,5.5
       parent: 1
-  - uid: 1027
+  - uid: 1034
     components:
     - type: Transform
       pos: 26.5,4.5
       parent: 1
-  - uid: 1028
+  - uid: 1035
     components:
     - type: Transform
       pos: 24.5,4.5
       parent: 1
-  - uid: 1029
+  - uid: 1036
     components:
     - type: Transform
       pos: 37.5,46.5
       parent: 1
-  - uid: 1030
+  - uid: 1037
     components:
     - type: Transform
       pos: 38.5,46.5
       parent: 1
-  - uid: 1031
+  - uid: 1038
     components:
     - type: Transform
       pos: 36.5,46.5
       parent: 1
-  - uid: 1032
+  - uid: 1039
     components:
     - type: Transform
       pos: 38.5,45.5
       parent: 1
-  - uid: 1033
+  - uid: 1040
     components:
     - type: Transform
       pos: 37.5,45.5
       parent: 1
-  - uid: 1034
+  - uid: 1041
     components:
     - type: Transform
       pos: 36.5,45.5
       parent: 1
-  - uid: 1035
+  - uid: 1042
     components:
     - type: Transform
       pos: 36.5,44.5
       parent: 1
-  - uid: 1036
+  - uid: 1043
     components:
     - type: Transform
       pos: 27.5,10.5
       parent: 1
-  - uid: 1037
+  - uid: 1044
     components:
     - type: Transform
       pos: 27.5,11.5
       parent: 1
-  - uid: 1038
+  - uid: 1045
     components:
     - type: Transform
       pos: 28.5,11.5
       parent: 1
-  - uid: 1039
+  - uid: 1046
     components:
     - type: Transform
       pos: 28.5,12.5
       parent: 1
-  - uid: 1040
+  - uid: 1047
     components:
     - type: Transform
       pos: 28.5,13.5
       parent: 1
-  - uid: 1041
+  - uid: 1048
     components:
     - type: Transform
       pos: 33.5,14.5
       parent: 1
-  - uid: 1042
+  - uid: 1049
     components:
     - type: Transform
       pos: 34.5,14.5
       parent: 1
-  - uid: 1043
+  - uid: 1050
     components:
     - type: Transform
       pos: 34.5,15.5
       parent: 1
-  - uid: 1044
+  - uid: 1051
     components:
     - type: Transform
       pos: 33.5,15.5
       parent: 1
-  - uid: 1045
+  - uid: 1052
     components:
     - type: Transform
       pos: 35.5,15.5
       parent: 1
-  - uid: 1046
+  - uid: 1053
     components:
     - type: Transform
       pos: 35.5,29.5
       parent: 1
-  - uid: 1047
+  - uid: 1054
     components:
     - type: Transform
       pos: 35.5,28.5
       parent: 1
-  - uid: 1048
+  - uid: 1055
     components:
     - type: Transform
       pos: 34.5,28.5
       parent: 1
-  - uid: 1049
+  - uid: 1056
     components:
     - type: Transform
       pos: 34.5,29.5
       parent: 1
-  - uid: 1050
+  - uid: 1057
     components:
     - type: Transform
       pos: 34.5,30.5
       parent: 1
-  - uid: 1051
+  - uid: 1058
     components:
     - type: Transform
       pos: 34.5,31.5
       parent: 1
-  - uid: 1052
+  - uid: 1059
     components:
     - type: Transform
       pos: 34.5,32.5
       parent: 1
-  - uid: 1053
+  - uid: 1060
     components:
     - type: Transform
       pos: 34.5,33.5
       parent: 1
-  - uid: 1054
+  - uid: 1061
     components:
     - type: Transform
       pos: 34.5,34.5
       parent: 1
-  - uid: 1055
+  - uid: 1062
     components:
     - type: Transform
       pos: 35.5,32.5
       parent: 1
-  - uid: 1056
+  - uid: 1063
     components:
     - type: Transform
       pos: 35.5,33.5
       parent: 1
-  - uid: 1057
+  - uid: 1064
     components:
     - type: Transform
       pos: 35.5,34.5
       parent: 1
 - proto: RMCWallKutjevoRockBorder
   entities:
-  - uid: 1058
+  - uid: 1065
     components:
     - type: Transform
       pos: 22.5,49.5
       parent: 1
-  - uid: 1059
+  - uid: 1066
     components:
     - type: Transform
       pos: 20.5,49.5
       parent: 1
-  - uid: 1060
+  - uid: 1067
     components:
     - type: Transform
       pos: 21.5,49.5
       parent: 1
-  - uid: 1061
+  - uid: 1068
     components:
     - type: Transform
       pos: 23.5,49.5
       parent: 1
-  - uid: 1062
+  - uid: 1069
     components:
     - type: Transform
       pos: 24.5,49.5
       parent: 1
 - proto: RMCWeaponRevolver38Magnum
   entities:
-  - uid: 1063
+  - uid: 1070
     components:
     - type: Transform
       pos: 32.5,33.5
       parent: 1
 - proto: RMCWeaponRevolverSpearhead
   entities:
-  - uid: 1064
+  - uid: 1071
     components:
     - type: Transform
       pos: 26.5,34.5
       parent: 1
 - proto: RMCWindowFrameKutjevoReinforced
   entities:
-  - uid: 1065
+  - uid: 1072
     components:
     - type: Transform
       pos: 34.5,37.5
       parent: 1
-  - uid: 1066
+  - uid: 1073
     components:
     - type: Transform
       pos: 34.5,38.5
       parent: 1
 - proto: RMCWindowKutjevoHull
   entities:
-  - uid: 1067
+  - uid: 1074
     components:
     - type: Transform
       pos: 15.5,49.5
       parent: 1
-  - uid: 1068
+  - uid: 1075
     components:
     - type: Transform
       pos: 16.5,49.5
       parent: 1
-  - uid: 1069
+  - uid: 1076
     components:
     - type: Transform
       pos: 17.5,49.5
       parent: 1
-  - uid: 1070
+  - uid: 1077
     components:
     - type: Transform
       pos: 18.5,49.5
       parent: 1
 - proto: RMCWindowKutjevoReinforced
   entities:
-  - uid: 1071
+  - uid: 1078
     components:
     - type: Transform
       pos: 24.5,10.5
       parent: 1
-  - uid: 1072
+  - uid: 1079
     components:
     - type: Transform
       pos: 25.5,10.5
       parent: 1
-  - uid: 1073
+  - uid: 1080
     components:
     - type: Transform
       pos: 23.5,10.5
       parent: 1
-  - uid: 1074
+  - uid: 1081
     components:
     - type: Transform
       pos: 24.5,16.5
       parent: 1
-  - uid: 1075
+  - uid: 1082
     components:
     - type: Transform
       pos: 26.5,16.5
       parent: 1
-  - uid: 1076
+  - uid: 1083
     components:
     - type: Transform
       pos: 25.5,16.5
       parent: 1
-  - uid: 1077
+  - uid: 1084
     components:
     - type: Transform
       pos: 34.5,24.5
       parent: 1
-  - uid: 1078
+  - uid: 1085
     components:
     - type: Transform
       pos: 34.5,25.5
       parent: 1
-  - uid: 1079
+  - uid: 1086
     components:
     - type: Transform
       pos: 34.5,26.5
       parent: 1
-  - uid: 1080
+  - uid: 1087
     components:
     - type: Transform
       pos: 34.5,36.5
       parent: 1
-  - uid: 1081
+  - uid: 1088
     components:
     - type: Transform
       pos: 21.5,15.5
       parent: 1
-  - uid: 1082
+  - uid: 1089
     components:
     - type: Transform
       pos: 21.5,12.5
       parent: 1
 - proto: WeaponRifleM16
   entities:
-  - uid: 150
+  - uid: 146
     components:
     - type: Transform
-      parent: 141
+      parent: 137
     - type: ContainerContainer
       containers:
         gun_magazine: !type:ContainerSlot


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Add more turrets to the LZ1 alternate insert on Kutjevo

## Why / Balance
Unintended gaps
You can still technically hide in the checkpoint area and bathrooms, but any movement into the inner LZ will be covered now.

## Technical details
Mapping

## Media
<img width="924" height="877" alt="image" src="https://github.com/user-attachments/assets/5f756da1-7698-45c7-8708-057fe864bfe8" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl: PursuitinAshes
- tweak: Added more turrets to the alternate LZ1 insert on Kutjevo.
