### PR TITLE
Give all squad marine roles CO/XO trackers

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/marine_headsets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/marine_headsets.yml
@@ -9,6 +9,8 @@
     trackerModes:
     - SquadLeader
     - FireteamLeader
+    - CommandingOfficer
+    - ExecutiveOfficer
     - SeniorEnlistedAdvisor
     - PrimaryLandingZone
   - type: GrantTacMapAlert


### PR DESCRIPTION
## About the PR
Title

## Why / Balance
Requested in https://discord.com/channels/1168210010233376858/1495665676722110464, personally I feel like this would be a general good QOL for marines and would not have any significant impact to the balance.

## Technical details
2 lines of YAML, the placement in the tracker list is the only thing I am iffy about, I think it where it was placed should not mess anyone up, but if the placement is an issue that can be changed.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: All squad marines now have a CO and XO tracker