### PR TITLE
Impenetrable resin - Shivas

### DIFF
--- a/Resources/Maps/_RMC14/shiva.yml
+++ b/Resources/Maps/_RMC14/shiva.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 264.0.2
   forkId: ""
   forkVersion: ""
-  time: 04/20/2026 01:31:12
-  entityCount: 17433
+  time: 04/24/2026 10:29:50
+  entityCount: 17557
 maps:
 - 1
 grids:
@@ -47636,6 +47636,21 @@ entities:
     - type: Transform
       pos: 119.5,11.5
       parent: 1
+  - uid: 17493
+    components:
+    - type: Transform
+      pos: 123.5,142.5
+      parent: 1
+  - uid: 17495
+    components:
+    - type: Transform
+      pos: 122.5,142.5
+      parent: 1
+  - uid: 17496
+    components:
+    - type: Transform
+      pos: 124.5,144.5
+      parent: 1
 - proto: CMRodMetal
   entities:
   - uid: 2042
@@ -53603,26 +53618,6 @@ entities:
     - type: Transform
       pos: 180.5,148.5
       parent: 1
-  - uid: 3171
-    components:
-    - type: Transform
-      pos: 194.5,120.5
-      parent: 1
-  - uid: 3172
-    components:
-    - type: Transform
-      pos: 195.5,120.5
-      parent: 1
-  - uid: 3173
-    components:
-    - type: Transform
-      pos: 205.5,112.5
-      parent: 1
-  - uid: 3174
-    components:
-    - type: Transform
-      pos: 205.5,108.5
-      parent: 1
   - uid: 3175
     components:
     - type: Transform
@@ -53632,26 +53627,6 @@ entities:
     components:
     - type: Transform
       pos: 175.5,53.5
-      parent: 1
-  - uid: 3177
-    components:
-    - type: Transform
-      pos: 152.5,16.5
-      parent: 1
-  - uid: 3178
-    components:
-    - type: Transform
-      pos: 152.5,13.5
-      parent: 1
-  - uid: 3179
-    components:
-    - type: Transform
-      pos: 152.5,9.5
-      parent: 1
-  - uid: 3180
-    components:
-    - type: Transform
-      pos: 152.5,7.5
       parent: 1
   - uid: 3181
     components:
@@ -53665,17 +53640,227 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 151.5,45.5
       parent: 1
-  - uid: 3183
+- proto: DoorXenoResinImpenetrable
+  entities:
+  - uid: 2200
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
+      pos: 195.5,120.5
+      parent: 1
+  - uid: 2201
+    components:
+    - type: Transform
+      pos: 194.5,120.5
+      parent: 1
+  - uid: 2202
+    components:
+    - type: Transform
+      pos: 205.5,112.5
+      parent: 1
+  - uid: 2203
+    components:
+    - type: Transform
+      pos: 205.5,108.5
+      parent: 1
+  - uid: 2204
+    components:
+    - type: Transform
+      pos: 152.5,16.5
+      parent: 1
+  - uid: 3171
+    components:
+    - type: Transform
+      pos: 152.5,13.5
+      parent: 1
+  - uid: 3172
+    components:
+    - type: Transform
+      pos: 152.5,9.5
+      parent: 1
+  - uid: 16994
+    components:
+    - type: Transform
+      pos: 152.5,7.5
+      parent: 1
+  - uid: 16997
+    components:
+    - type: Transform
+      pos: 148.5,46.5
+      parent: 1
+  - uid: 16998
+    components:
+    - type: Transform
       pos: 148.5,43.5
       parent: 1
-  - uid: 3184
+  - uid: 17132
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 148.5,46.5
+      pos: 148.5,31.5
+      parent: 1
+  - uid: 17133
+    components:
+    - type: Transform
+      pos: 148.5,32.5
+      parent: 1
+  - uid: 17140
+    components:
+    - type: Transform
+      pos: 164.5,57.5
+      parent: 1
+  - uid: 17142
+    components:
+    - type: Transform
+      pos: 171.5,58.5
+      parent: 1
+  - uid: 17143
+    components:
+    - type: Transform
+      pos: 171.5,57.5
+      parent: 1
+  - uid: 17444
+    components:
+    - type: Transform
+      pos: 175.5,60.5
+      parent: 1
+  - uid: 17445
+    components:
+    - type: Transform
+      pos: 178.5,59.5
+      parent: 1
+  - uid: 17447
+    components:
+    - type: Transform
+      pos: 187.5,52.5
+      parent: 1
+  - uid: 17448
+    components:
+    - type: Transform
+      pos: 186.5,52.5
+      parent: 1
+  - uid: 17451
+    components:
+    - type: Transform
+      pos: 195.5,56.5
+      parent: 1
+  - uid: 17452
+    components:
+    - type: Transform
+      pos: 194.5,56.5
+      parent: 1
+  - uid: 17454
+    components:
+    - type: Transform
+      pos: 197.5,56.5
+      parent: 1
+  - uid: 17455
+    components:
+    - type: Transform
+      pos: 198.5,56.5
+      parent: 1
+  - uid: 17456
+    components:
+    - type: Transform
+      pos: 206.5,56.5
+      parent: 1
+  - uid: 17457
+    components:
+    - type: Transform
+      pos: 208.5,56.5
+      parent: 1
+  - uid: 17460
+    components:
+    - type: Transform
+      pos: 171.5,118.5
+      parent: 1
+  - uid: 17461
+    components:
+    - type: Transform
+      pos: 172.5,118.5
+      parent: 1
+  - uid: 17467
+    components:
+    - type: Transform
+      pos: 152.5,123.5
+      parent: 1
+  - uid: 17468
+    components:
+    - type: Transform
+      pos: 154.5,123.5
+      parent: 1
+  - uid: 17474
+    components:
+    - type: Transform
+      pos: 148.5,135.5
+      parent: 1
+  - uid: 17475
+    components:
+    - type: Transform
+      pos: 148.5,133.5
+      parent: 1
+  - uid: 17476
+    components:
+    - type: Transform
+      pos: 148.5,147.5
+      parent: 1
+  - uid: 17477
+    components:
+    - type: Transform
+      pos: 148.5,149.5
+      parent: 1
+  - uid: 17480
+    components:
+    - type: Transform
+      pos: 147.5,156.5
+      parent: 1
+  - uid: 17482
+    components:
+    - type: Transform
+      pos: 147.5,129.5
+      parent: 1
+  - uid: 17486
+    components:
+    - type: Transform
+      pos: 147.5,143.5
+      parent: 1
+  - uid: 17487
+    components:
+    - type: Transform
+      pos: 147.5,142.5
+      parent: 1
+  - uid: 17489
+    components:
+    - type: Transform
+      pos: 199.5,116.5
+      parent: 1
+  - uid: 17492
+    components:
+    - type: Transform
+      pos: 181.5,117.5
+      parent: 1
+  - uid: 17494
+    components:
+    - type: Transform
+      pos: 180.5,117.5
+      parent: 1
+  - uid: 17529
+    components:
+    - type: Transform
+      pos: 198.5,119.5
+      parent: 1
+  - uid: 17530
+    components:
+    - type: Transform
+      pos: 199.5,119.5
+      parent: 1
+  - uid: 17554
+    components:
+    - type: Transform
+      pos: 147.5,37.5
+      parent: 1
+  - uid: 17555
+    components:
+    - type: Transform
+      pos: 147.5,38.5
       parent: 1
 - proto: DrinkGlass
   entities:
@@ -54425,6 +54610,11 @@ entities:
     - type: InsideEntityStorage
 - proto: RCMWallShivaFab
   entities:
+  - uid: 3178
+    components:
+    - type: Transform
+      pos: 197.5,120.5
+      parent: 1
   - uid: 3216
     components:
     - type: Transform
@@ -59715,11 +59905,6 @@ entities:
     components:
     - type: Transform
       pos: 196.5,120.5
-      parent: 1
-  - uid: 4206
-    components:
-    - type: Transform
-      pos: 197.5,120.5
       parent: 1
   - uid: 4207
     components:
@@ -106973,25 +107158,20 @@ entities:
       parent: 1
 - proto: RMCBoxShotgunBuckshot
   entities:
+  - uid: 3184
+    components:
+    - type: Transform
+      pos: 122.52727,144.7435
+      parent: 1
+  - uid: 4206
+    components:
+    - type: Transform
+      pos: 122.579346,144.48291
+      parent: 1
   - uid: 13315
     components:
     - type: Transform
       pos: 6.5,147.5
-      parent: 1
-  - uid: 13316
-    components:
-    - type: Transform
-      pos: 166.5,151.5
-      parent: 1
-  - uid: 13317
-    components:
-    - type: Transform
-      pos: 166.6099,151.34616
-      parent: 1
-  - uid: 13318
-    components:
-    - type: Transform
-      pos: 167.5,151.5
       parent: 1
 - proto: RMCBoxShotgunSlugs
   entities:
@@ -106999,16 +107179,6 @@ entities:
     components:
     - type: Transform
       pos: 102.5,69.5
-      parent: 1
-  - uid: 13320
-    components:
-    - type: Transform
-      pos: 164.5,152.5
-      parent: 1
-  - uid: 13321
-    components:
-    - type: Transform
-      pos: 164.6875,152.375
       parent: 1
   - uid: 17438
     components:
@@ -110296,6 +110466,358 @@ entities:
     - type: Transform
       pos: 37.5,124.5
       parent: 1
+- proto: RMCFogWall30
+  entities:
+  - uid: 3179
+    components:
+    - type: Transform
+      pos: 148.5,140.5
+      parent: 1
+  - uid: 3180
+    components:
+    - type: Transform
+      pos: 148.5,145.5
+      parent: 1
+  - uid: 3183
+    components:
+    - type: Transform
+      pos: 148.5,139.5
+      parent: 1
+  - uid: 13316
+    components:
+    - type: Transform
+      pos: 162.5,118.5
+      parent: 1
+  - uid: 13317
+    components:
+    - type: Transform
+      pos: 163.5,118.5
+      parent: 1
+  - uid: 13318
+    components:
+    - type: Transform
+      pos: 159.5,118.5
+      parent: 1
+  - uid: 13320
+    components:
+    - type: Transform
+      pos: 158.5,118.5
+      parent: 1
+  - uid: 13321
+    components:
+    - type: Transform
+      pos: 168.5,118.5
+      parent: 1
+  - uid: 14035
+    components:
+    - type: Transform
+      pos: 148.5,126.5
+      parent: 1
+  - uid: 14036
+    components:
+    - type: Transform
+      pos: 148.5,124.5
+      parent: 1
+  - uid: 14881
+    components:
+    - type: Transform
+      pos: 158.5,121.5
+      parent: 1
+  - uid: 15604
+    components:
+    - type: Transform
+      pos: 148.5,136.5
+      parent: 1
+  - uid: 15605
+    components:
+    - type: Transform
+      pos: 148.5,125.5
+      parent: 1
+  - uid: 15606
+    components:
+    - type: Transform
+      pos: 148.5,132.5
+      parent: 1
+  - uid: 16276
+    components:
+    - type: Transform
+      pos: 148.5,127.5
+      parent: 1
+  - uid: 16277
+    components:
+    - type: Transform
+      pos: 148.5,137.5
+      parent: 1
+  - uid: 16279
+    components:
+    - type: Transform
+      pos: 164.5,118.5
+      parent: 1
+  - uid: 16280
+    components:
+    - type: Transform
+      pos: 167.5,118.5
+      parent: 1
+  - uid: 16281
+    components:
+    - type: Transform
+      pos: 148.5,131.5
+      parent: 1
+  - uid: 16282
+    components:
+    - type: Transform
+      pos: 148.5,138.5
+      parent: 1
+  - uid: 16283
+    components:
+    - type: Transform
+      pos: 158.5,122.5
+      parent: 1
+  - uid: 16284
+    components:
+    - type: Transform
+      pos: 158.5,119.5
+      parent: 1
+  - uid: 16285
+    components:
+    - type: Transform
+      pos: 165.5,118.5
+      parent: 1
+  - uid: 16287
+    components:
+    - type: Transform
+      pos: 160.5,118.5
+      parent: 1
+  - uid: 16288
+    components:
+    - type: Transform
+      pos: 158.5,120.5
+      parent: 1
+  - uid: 16289
+    components:
+    - type: Transform
+      pos: 161.5,118.5
+      parent: 1
+  - uid: 16290
+    components:
+    - type: Transform
+      pos: 166.5,118.5
+      parent: 1
+  - uid: 16291
+    components:
+    - type: Transform
+      pos: 149.5,150.5
+      parent: 1
+  - uid: 16292
+    components:
+    - type: Transform
+      pos: 149.5,146.5
+      parent: 1
+  - uid: 17459
+    components:
+    - type: Transform
+      pos: 175.5,118.5
+      parent: 1
+  - uid: 17506
+    components:
+    - type: Transform
+      pos: 148.5,151.5
+      parent: 1
+  - uid: 17507
+    components:
+    - type: Transform
+      pos: 148.5,152.5
+      parent: 1
+  - uid: 17508
+    components:
+    - type: Transform
+      pos: 148.5,153.5
+      parent: 1
+  - uid: 17509
+    components:
+    - type: Transform
+      pos: 148.5,154.5
+      parent: 1
+  - uid: 17510
+    components:
+    - type: Transform
+      pos: 148.5,158.5
+      parent: 1
+  - uid: 17511
+    components:
+    - type: Transform
+      pos: 176.5,118.5
+      parent: 1
+  - uid: 17512
+    components:
+    - type: Transform
+      pos: 177.5,117.5
+      parent: 1
+  - uid: 17513
+    components:
+    - type: Transform
+      pos: 178.5,117.5
+      parent: 1
+  - uid: 17514
+    components:
+    - type: Transform
+      pos: 179.5,117.5
+      parent: 1
+  - uid: 17515
+    components:
+    - type: Transform
+      pos: 182.5,117.5
+      parent: 1
+  - uid: 17516
+    components:
+    - type: Transform
+      pos: 183.5,117.5
+      parent: 1
+  - uid: 17517
+    components:
+    - type: Transform
+      pos: 184.5,117.5
+      parent: 1
+  - uid: 17518
+    components:
+    - type: Transform
+      pos: 185.5,117.5
+      parent: 1
+  - uid: 17519
+    components:
+    - type: Transform
+      pos: 186.5,117.5
+      parent: 1
+  - uid: 17520
+    components:
+    - type: Transform
+      pos: 187.5,117.5
+      parent: 1
+  - uid: 17521
+    components:
+    - type: Transform
+      pos: 189.5,118.5
+      parent: 1
+  - uid: 17522
+    components:
+    - type: Transform
+      pos: 190.5,118.5
+      parent: 1
+  - uid: 17523
+    components:
+    - type: Transform
+      pos: 191.5,118.5
+      parent: 1
+  - uid: 17524
+    components:
+    - type: Transform
+      pos: 192.5,118.5
+      parent: 1
+  - uid: 17525
+    components:
+    - type: Transform
+      pos: 193.5,118.5
+      parent: 1
+  - uid: 17526
+    components:
+    - type: Transform
+      pos: 193.5,119.5
+      parent: 1
+  - uid: 17527
+    components:
+    - type: Transform
+      pos: 196.5,120.5
+      parent: 1
+  - uid: 17528
+    components:
+    - type: Transform
+      pos: 200.5,118.5
+      parent: 1
+  - uid: 17532
+    components:
+    - type: Transform
+      pos: 200.5,113.5
+      parent: 1
+  - uid: 17533
+    components:
+    - type: Transform
+      pos: 201.5,113.5
+      parent: 1
+  - uid: 17534
+    components:
+    - type: Transform
+      pos: 202.5,113.5
+      parent: 1
+  - uid: 17535
+    components:
+    - type: Transform
+      pos: 203.5,113.5
+      parent: 1
+  - uid: 17536
+    components:
+    - type: Transform
+      pos: 204.5,113.5
+      parent: 1
+  - uid: 17537
+    components:
+    - type: Transform
+      pos: 170.5,56.5
+      parent: 1
+  - uid: 17538
+    components:
+    - type: Transform
+      pos: 169.5,56.5
+      parent: 1
+  - uid: 17539
+    components:
+    - type: Transform
+      pos: 168.5,56.5
+      parent: 1
+  - uid: 17540
+    components:
+    - type: Transform
+      pos: 167.5,56.5
+      parent: 1
+  - uid: 17541
+    components:
+    - type: Transform
+      pos: 166.5,56.5
+      parent: 1
+  - uid: 17542
+    components:
+    - type: Transform
+      pos: 162.5,56.5
+      parent: 1
+  - uid: 17543
+    components:
+    - type: Transform
+      pos: 176.5,60.5
+      parent: 1
+  - uid: 17544
+    components:
+    - type: Transform
+      pos: 177.5,60.5
+      parent: 1
+  - uid: 17545
+    components:
+    - type: Transform
+      pos: 153.5,56.5
+      parent: 1
+  - uid: 17546
+    components:
+    - type: Transform
+      pos: 148.5,47.5
+      parent: 1
+  - uid: 17547
+    components:
+    - type: Transform
+      pos: 148.5,48.5
+      parent: 1
+  - uid: 17548
+    components:
+    - type: Transform
+      pos: 148.5,49.5
+      parent: 1
 - proto: RMCFoodGoldenApple
   entities:
   - uid: 13826
@@ -111525,15 +112047,15 @@ entities:
     - type: InsideEntityStorage
 - proto: RMCGrenadeIncendiary
   entities:
-  - uid: 14035
+  - uid: 17497
     components:
     - type: Transform
-      pos: 166.5,153.5
+      pos: 124.477165,144.55753
       parent: 1
-  - uid: 14036
+  - uid: 17498
     components:
     - type: Transform
-      pos: 166.375,153.4375
+      pos: 124.58654,144.46371
       parent: 1
 - proto: RMCHandcuffs
   entities:
@@ -117140,18 +117662,6 @@ entities:
     components:
     - type: Transform
       pos: 208.5,119.5
-      parent: 1
-- proto: RMCPacketGrenadeFlashBang
-  entities:
-  - uid: 14880
-    components:
-    - type: Transform
-      pos: 165.64478,154.36482
-      parent: 1
-  - uid: 14881
-    components:
-    - type: Transform
-      pos: 165.40833,154.62837
       parent: 1
 - proto: RMCPersonalDesktop
   entities:
@@ -125403,6 +125913,11 @@ entities:
       parent: 1
 - proto: RMCSpeedLoader357Hollowpoint
   entities:
+  - uid: 14880
+    components:
+    - type: Transform
+      pos: 121.985596,144.40994
+      parent: 1
   - uid: 16274
     components:
     - type: Transform
@@ -125413,90 +125928,25 @@ entities:
     - type: Transform
       pos: 7.5,146.5
       parent: 1
-  - uid: 16276
-    components:
-    - type: Transform
-      pos: 167.69739,153.28792
-      parent: 1
-  - uid: 16277
-    components:
-    - type: Transform
-      pos: 169.6921,151.25623
-      parent: 1
   - uid: 16278
     components:
     - type: Transform
-      pos: 167.69739,153.28792
-      parent: 1
-  - uid: 16279
-    components:
-    - type: Transform
-      pos: 164.67609,153.26534
-      parent: 1
-  - uid: 16280
-    components:
-    - type: Transform
-      pos: 164.67609,153.26534
-      parent: 1
-  - uid: 16281
-    components:
-    - type: Transform
-      pos: 169.6921,151.25623
-      parent: 1
-  - uid: 16282
-    components:
-    - type: Transform
-      pos: 169.5,151.5
-      parent: 1
-  - uid: 16283
-    components:
-    - type: Transform
-      pos: 169.5,151.5
-      parent: 1
-  - uid: 16284
-    components:
-    - type: Transform
-      pos: 168.5,151.5
-      parent: 1
-  - uid: 16285
-    components:
-    - type: Transform
-      pos: 168.5,151.5
+      pos: 121.97518,144.70181
       parent: 1
   - uid: 16286
     components:
     - type: Transform
       pos: 157.5,151.5
       parent: 1
-  - uid: 16287
+  - uid: 17504
     components:
     - type: Transform
-      pos: 164.5,153.5
+      pos: 121.52404,142.46233
       parent: 1
-  - uid: 16288
+  - uid: 17505
     components:
     - type: Transform
-      pos: 167.5,153.5
-      parent: 1
-  - uid: 16289
-    components:
-    - type: Transform
-      pos: 167.5,153.5
-      parent: 1
-  - uid: 16290
-    components:
-    - type: Transform
-      pos: 168.65004,151.26831
-      parent: 1
-  - uid: 16291
-    components:
-    - type: Transform
-      pos: 168.65004,151.26831
-      parent: 1
-  - uid: 16292
-    components:
-    - type: Transform
-      pos: 164.5,153.5
+      pos: 121.445915,142.60304
       parent: 1
 - proto: RMCSprayBottleSpaceCleaner
   entities:
@@ -129470,45 +129920,30 @@ entities:
     - type: Transform
       pos: 86.5,82.5
       parent: 1
-  - uid: 16992
-    components:
-    - type: Transform
-      pos: 164.64386,154.32887
-      parent: 1
   - uid: 16993
     components:
     - type: Transform
       pos: 8.5,147.5
       parent: 1
-  - uid: 16994
-    components:
-    - type: Transform
-      pos: 167.5,154.5
-      parent: 1
-  - uid: 16995
-    components:
-    - type: Transform
-      pos: 166.5,154.5
-      parent: 1
-  - uid: 16996
-    components:
-    - type: Transform
-      pos: 164.5,154.5
-      parent: 1
-  - uid: 16997
-    components:
-    - type: Transform
-      pos: 166.66437,154.31105
-      parent: 1
-  - uid: 16998
-    components:
-    - type: Transform
-      pos: 167.64978,154.28786
-      parent: 1
   - uid: 16999
     components:
     - type: Transform
       pos: 86.5,94.5
+      parent: 1
+  - uid: 17499
+    components:
+    - type: Transform
+      pos: 123.61779,142.38414
+      parent: 1
+  - uid: 17500
+    components:
+    - type: Transform
+      pos: 123.58654,142.63431
+      parent: 1
+  - uid: 17501
+    components:
+    - type: Transform
+      pos: 123.61779,142.5405
       parent: 1
 - proto: RMCWeaponRifleM54C
   entities:
@@ -129581,16 +130016,6 @@ entities:
       parent: 1
 - proto: RMCWeaponShotgunHG3712
   entities:
-  - uid: 17004
-    components:
-    - type: Transform
-      pos: 165.75336,151.3539
-      parent: 1
-  - uid: 17005
-    components:
-    - type: Transform
-      pos: 165.57904,151.54774
-      parent: 1
   - uid: 17006
     components:
     - type: Transform
@@ -129620,6 +130045,16 @@ entities:
     components:
     - type: Transform
       pos: 99.73503,13.136038
+      parent: 1
+  - uid: 17502
+    components:
+    - type: Transform
+      pos: 122.695915,142.4154
+      parent: 1
+  - uid: 17503
+    components:
+    - type: Transform
+      pos: 122.68029,142.5874
       parent: 1
 - proto: RMCWeaponShotgunType23
   entities:
@@ -130256,21 +130691,6 @@ entities:
     - type: Transform
       pos: 176.5,149.5
       parent: 1
-  - uid: 17131
-    components:
-    - type: Transform
-      pos: 205.5,111.5
-      parent: 1
-  - uid: 17132
-    components:
-    - type: Transform
-      pos: 205.5,110.5
-      parent: 1
-  - uid: 17133
-    components:
-    - type: Transform
-      pos: 205.5,109.5
-      parent: 1
   - uid: 17134
     components:
     - type: Transform
@@ -130291,35 +130711,10 @@ entities:
     - type: Transform
       pos: 172.5,53.5
       parent: 1
-  - uid: 17138
-    components:
-    - type: Transform
-      pos: 152.5,8.5
-      parent: 1
   - uid: 17139
     components:
     - type: Transform
       pos: 152.5,12.5
-      parent: 1
-  - uid: 17140
-    components:
-    - type: Transform
-      pos: 152.5,14.5
-      parent: 1
-  - uid: 17141
-    components:
-    - type: Transform
-      pos: 152.5,15.5
-      parent: 1
-  - uid: 17142
-    components:
-    - type: Transform
-      pos: 148.5,44.5
-      parent: 1
-  - uid: 17143
-    components:
-    - type: Transform
-      pos: 148.5,45.5
       parent: 1
   - uid: 17144
     components:
@@ -130330,6 +130725,233 @@ entities:
     components:
     - type: Transform
       pos: 151.5,46.5
+      parent: 1
+- proto: WallXenoResinImpenetrable
+  entities:
+  - uid: 3173
+    components:
+    - type: Transform
+      pos: 152.5,8.5
+      parent: 1
+  - uid: 3174
+    components:
+    - type: Transform
+      pos: 148.5,44.5
+      parent: 1
+  - uid: 3177
+    components:
+    - type: Transform
+      pos: 148.5,45.5
+      parent: 1
+  - uid: 16686
+    components:
+    - type: Transform
+      pos: 205.5,109.5
+      parent: 1
+  - uid: 16698
+    components:
+    - type: Transform
+      pos: 205.5,110.5
+      parent: 1
+  - uid: 16992
+    components:
+    - type: Transform
+      pos: 205.5,111.5
+      parent: 1
+  - uid: 16995
+    components:
+    - type: Transform
+      pos: 152.5,14.5
+      parent: 1
+  - uid: 16996
+    components:
+    - type: Transform
+      pos: 152.5,15.5
+      parent: 1
+  - uid: 17004
+    components:
+    - type: Transform
+      pos: 148.5,30.5
+      parent: 1
+  - uid: 17005
+    components:
+    - type: Transform
+      pos: 148.5,34.5
+      parent: 1
+  - uid: 17131
+    components:
+    - type: Transform
+      pos: 148.5,33.5
+      parent: 1
+  - uid: 17138
+    components:
+    - type: Transform
+      pos: 163.5,57.5
+      parent: 1
+  - uid: 17141
+    components:
+    - type: Transform
+      pos: 165.5,57.5
+      parent: 1
+  - uid: 17446
+    components:
+    - type: Transform
+      pos: 178.5,60.5
+      parent: 1
+  - uid: 17449
+    components:
+    - type: Transform
+      pos: 185.5,52.5
+      parent: 1
+  - uid: 17450
+    components:
+    - type: Transform
+      pos: 188.5,52.5
+      parent: 1
+  - uid: 17453
+    components:
+    - type: Transform
+      pos: 196.5,56.5
+      parent: 1
+  - uid: 17458
+    components:
+    - type: Transform
+      pos: 207.5,56.5
+      parent: 1
+  - uid: 17462
+    components:
+    - type: Transform
+      pos: 170.5,118.5
+      parent: 1
+  - uid: 17463
+    components:
+    - type: Transform
+      pos: 173.5,118.5
+      parent: 1
+  - uid: 17464
+    components:
+    - type: Transform
+      pos: 149.5,123.5
+      parent: 1
+  - uid: 17465
+    components:
+    - type: Transform
+      pos: 150.5,123.5
+      parent: 1
+  - uid: 17466
+    components:
+    - type: Transform
+      pos: 151.5,123.5
+      parent: 1
+  - uid: 17469
+    components:
+    - type: Transform
+      pos: 153.5,123.5
+      parent: 1
+  - uid: 17470
+    components:
+    - type: Transform
+      pos: 155.5,123.5
+      parent: 1
+  - uid: 17471
+    components:
+    - type: Transform
+      pos: 156.5,123.5
+      parent: 1
+  - uid: 17472
+    components:
+    - type: Transform
+      pos: 157.5,123.5
+      parent: 1
+  - uid: 17473
+    components:
+    - type: Transform
+      pos: 148.5,134.5
+      parent: 1
+  - uid: 17478
+    components:
+    - type: Transform
+      pos: 148.5,148.5
+      parent: 1
+  - uid: 17479
+    components:
+    - type: Transform
+      pos: 147.5,157.5
+      parent: 1
+  - uid: 17481
+    components:
+    - type: Transform
+      pos: 147.5,155.5
+      parent: 1
+  - uid: 17483
+    components:
+    - type: Transform
+      pos: 147.5,128.5
+      parent: 1
+  - uid: 17484
+    components:
+    - type: Transform
+      pos: 147.5,130.5
+      parent: 1
+  - uid: 17485
+    components:
+    - type: Transform
+      pos: 147.5,141.5
+      parent: 1
+  - uid: 17488
+    components:
+    - type: Transform
+      pos: 147.5,144.5
+      parent: 1
+  - uid: 17490
+    components:
+    - type: Transform
+      pos: 199.5,115.5
+      parent: 1
+  - uid: 17491
+    components:
+    - type: Transform
+      pos: 199.5,117.5
+      parent: 1
+  - uid: 17531
+    components:
+    - type: Transform
+      pos: 197.5,119.5
+      parent: 1
+  - uid: 17549
+    components:
+    - type: Transform
+      pos: 147.5,34.5
+      parent: 1
+  - uid: 17550
+    components:
+    - type: Transform
+      pos: 147.5,40.5
+      parent: 1
+  - uid: 17551
+    components:
+    - type: Transform
+      pos: 147.5,35.5
+      parent: 1
+  - uid: 17552
+    components:
+    - type: Transform
+      pos: 147.5,36.5
+      parent: 1
+  - uid: 17553
+    components:
+    - type: Transform
+      pos: 147.5,39.5
+      parent: 1
+  - uid: 17556
+    components:
+    - type: Transform
+      pos: 147.5,41.5
+      parent: 1
+  - uid: 17557
+    components:
+    - type: Transform
+      pos: 147.5,42.5
       parent: 1
 - proto: WaterCooler
   entities:

--- a/Resources/Maps/_RMC14/shiva.yml
+++ b/Resources/Maps/_RMC14/shiva.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 264.0.2
   forkId: ""
   forkVersion: ""
-  time: 04/24/2026 10:29:50
-  entityCount: 17557
+  time: 04/24/2026 21:25:19
+  entityCount: 17667
 maps:
 - 1
 grids:
@@ -106,6 +106,7 @@ tilemap:
   76: PlatingDamaged
   92: RMCFloorCement8
   95: RMCFloorHybrisaBlackAlt
+  14: RMCFloorPlatingScorched
   654: RMCPlanetIce0
   655: RMCPlanetIce1
   656: RMCPlanetIce2
@@ -479,7 +480,7 @@ entities:
           version: 7
         7,9:
           ind: 7,9
-          tiles: DQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAANAAAAAAAADUAAAAAAAA1AAAAAAAANQAAAAAAADYAAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAADoAQAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAA6AEAAAAAAA0AAAAAAADoAQAAAAAADQAAAAAAAA0AAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAA0AAAAAAAANAAAAAAAA6AEAAAAAAOgBAAAAAADoAQAAAAAA6AEAAAAAAOgBAAAAAADoAQAAAAAA6AEAAAAAAOgBAAAAAADoAQAAAAAA6AEAAAAAAOgBAAAAAADoAQAAAAAA6AEAAAAAAOgBAAAAAADoAQAAAAAADQAAAAAAANUBAAAAAADVAQAAAAAA1QEAAAAAANUBAAAAAADVAQAAAAAA1QEAAAAAANUBAAAAAADVAQAAAAAA1QEAAAAAANUBAAAAAADVAQAAAAAA1QEAAAAAANUBAAAAAADVAQAAAAAA6AEAAAAAAA0AAAAAAADVAQAAAAAA1QEAAAAAANUBAAAAAADVAQAAAAAA1QEAAAAAANUBAAAAAADVAQAAAAAA1QEAAAAAANUBAAAAAADVAQAAAAAA1QEAAAAAANUBAAAAAADVAQAAAAAA1QEAAAAAAOgBAAAAAAANAAAAAAAA6AEAAAAAAOgBAAAAAADoAQAAAAAA6AEAAAAAAOgBAAAAAADoAQAAAAAA6AEAAAAAAOgBAAAAAADoAQAAAAAA6AEAAAAAAOgBAAAAAADoAQAAAAAA1QEAAAAAANUBAAAAAADoAQAAAAAADQAAAAAAAAEAAAAAAADVAQAAAAAA1QEAAAAAANUBAAAAAADVAQAAAAAA1QEAAAAAANUBAAAAAAABAAAAAAAA1QEAAAAAANUBAAAAAAABAAAAAAAA6AEAAAAAANUBAAAAAADVAQAAAAAADQAAAAAAAA0AAAAAAAABAAAAAAAA1QEAAAAAANUBAAAAAADVAQAAAAAA1QEAAAAAANUBAAAAAADVAQAAAAAAAQAAAAAAANUBAAAAAADVAQAAAAAAAQAAAAAAAOgBAAAAAADVAQAAAAAA1QEAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAA1QEAAAAAANUBAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAANUBAAAAAADVAQAAAAAAAQAAAAAAAAEAAAAAAAANAAAAAAAAYQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAABhAAAAAAAADQAAAAAAAA0AAAAAAAABAAAAAAAA1QEAAAAAANUBAAAAAADVAQAAAAAA1QEAAAAAANUBAAAAAADVAQAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAAYQAAAAAAAGEAAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAAAQAAAAAAANUBAAAAAADVAQAAAAAA1QEAAAAAANUBAAAAAADVAQAAAAAA1QEAAAAAAA0AAAAAAABhAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAGEAAAAAAAANAAAAAAAADQAAAAAAAAEAAAAAAAABAAAAAAAA1QEAAAAAAAEAAAAAAAABAAAAAAAA1QEAAAAAAEYAAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAANUBAAAAAAABAAAAAAAAAQAAAAAAANUBAAAAAAABAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA==
+          tiles: DQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAANAAAAAAAADUAAAAAAAA1AAAAAAAANQAAAAAAADYAAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAADoAQAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAA6AEAAAAAAA4AAAAAAADoAQAAAAAADQAAAAAAAA0AAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAA0AAAAAAAANAAAAAAAA6AEAAAAAAOgBAAAAAADoAQAAAAAA6AEAAAAAAOgBAAAAAADoAQAAAAAA6AEAAAAAAOgBAAAAAADoAQAAAAAA6AEAAAAAAOgBAAAAAADoAQAAAAAA6AEAAAAAAOgBAAAAAADoAQAAAAAADQAAAAAAANUBAAAAAADVAQAAAAAA1QEAAAAAANUBAAAAAADVAQAAAAAA1QEAAAAAANUBAAAAAADVAQAAAAAA1QEAAAAAANUBAAAAAADVAQAAAAAA1QEAAAAAANUBAAAAAADVAQAAAAAA6AEAAAAAAA0AAAAAAADVAQAAAAAA1QEAAAAAANUBAAAAAADVAQAAAAAA1QEAAAAAANUBAAAAAADVAQAAAAAA1QEAAAAAANUBAAAAAADVAQAAAAAA1QEAAAAAANUBAAAAAADVAQAAAAAA1QEAAAAAAOgBAAAAAAANAAAAAAAA6AEAAAAAAOgBAAAAAADoAQAAAAAA6AEAAAAAAOgBAAAAAADoAQAAAAAA6AEAAAAAAOgBAAAAAADoAQAAAAAA6AEAAAAAAOgBAAAAAADoAQAAAAAA1QEAAAAAANUBAAAAAADoAQAAAAAADQAAAAAAAAEAAAAAAADVAQAAAAAA1QEAAAAAANUBAAAAAADVAQAAAAAA1QEAAAAAANUBAAAAAAABAAAAAAAA1QEAAAAAANUBAAAAAAABAAAAAAAA6AEAAAAAANUBAAAAAADVAQAAAAAADQAAAAAAAA0AAAAAAAABAAAAAAAA1QEAAAAAANUBAAAAAADVAQAAAAAA1QEAAAAAANUBAAAAAADVAQAAAAAAAQAAAAAAANUBAAAAAADVAQAAAAAAAQAAAAAAAOgBAAAAAADVAQAAAAAA1QEAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAA1QEAAAAAANUBAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAANUBAAAAAADVAQAAAAAAAQAAAAAAAAEAAAAAAAANAAAAAAAAYQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAABhAAAAAAAADQAAAAAAAA0AAAAAAAABAAAAAAAA1QEAAAAAANUBAAAAAADVAQAAAAAA1QEAAAAAANUBAAAAAADVAQAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAAYQAAAAAAAGEAAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAAAQAAAAAAANUBAAAAAADVAQAAAAAA1QEAAAAAANUBAAAAAADVAQAAAAAA1QEAAAAAAA0AAAAAAABhAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAGEAAAAAAAANAAAAAAAADQAAAAAAAAEAAAAAAAABAAAAAAAA1QEAAAAAAAEAAAAAAAABAAAAAAAA1QEAAAAAAEYAAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAANUBAAAAAAABAAAAAAAAAQAAAAAAANUBAAAAAAABAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA==
           version: 7
         7,7:
           ind: 7,7
@@ -47636,21 +47637,6 @@ entities:
     - type: Transform
       pos: 119.5,11.5
       parent: 1
-  - uid: 17493
-    components:
-    - type: Transform
-      pos: 123.5,142.5
-      parent: 1
-  - uid: 17495
-    components:
-    - type: Transform
-      pos: 122.5,142.5
-      parent: 1
-  - uid: 17496
-    components:
-    - type: Transform
-      pos: 124.5,144.5
-      parent: 1
 - proto: CMRodMetal
   entities:
   - uid: 2042
@@ -47979,6 +47965,24 @@ entities:
       rot: 3.141592653589793 rad
       pos: 116.5,83.5
       parent: 1
+  - uid: 17631
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 124.6351,145.35677
+      parent: 1
+  - uid: 17632
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 124.958015,144.51244
+      parent: 1
+  - uid: 17633
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 124.65594,146.00305
+      parent: 1
 - proto: CMSheetMetal1
   entities:
   - uid: 2101
@@ -48273,6 +48277,32 @@ entities:
     components:
     - type: Transform
       pos: 129.5,58.5
+      parent: 1
+- proto: CMShellShotgunBuckshot1
+  entities:
+  - uid: 17622
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 123.07203,148.94724
+      parent: 1
+  - uid: 17623
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 125.561615,150.5525
+      parent: 1
+  - uid: 17624
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 124.092865,146.97711
+      parent: 1
+  - uid: 17625
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 121.561615,146.35168
       parent: 1
 - proto: CMShellShotgunIncendiary
   entities:
@@ -51884,11 +51914,6 @@ entities:
     - type: Transform
       pos: 122.5,145.5
       parent: 1
-  - uid: 2841
-    components:
-    - type: Transform
-      pos: 124.5,145.5
-      parent: 1
   - uid: 2842
     components:
     - type: Transform
@@ -53596,6 +53621,18 @@ entities:
     - type: Transform
       pos: 190.5,157.5
       parent: 1
+- proto: DecalSpawnerBloodSplatters
+  entities:
+  - uid: 17600
+    components:
+    - type: Transform
+      pos: 124.5,148.5
+      parent: 1
+  - uid: 17601
+    components:
+    - type: Transform
+      pos: 123.5,149.5
+      parent: 1
 - proto: DoorXenoResin
   entities:
   - uid: 3167
@@ -53618,15 +53655,10 @@ entities:
     - type: Transform
       pos: 180.5,148.5
       parent: 1
-  - uid: 3175
-    components:
-    - type: Transform
-      pos: 171.5,53.5
-      parent: 1
   - uid: 3176
     components:
     - type: Transform
-      pos: 175.5,53.5
+      pos: 152.5,16.5
       parent: 1
   - uid: 3181
     components:
@@ -53639,6 +53671,21 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 151.5,45.5
+      parent: 1
+  - uid: 3184
+    components:
+    - type: Transform
+      pos: 152.5,13.5
+      parent: 1
+  - uid: 4206
+    components:
+    - type: Transform
+      pos: 152.5,9.5
+      parent: 1
+  - uid: 8786
+    components:
+    - type: Transform
+      pos: 152.5,7.5
       parent: 1
 - proto: DoorXenoResinImpenetrable
   entities:
@@ -53662,25 +53709,15 @@ entities:
     - type: Transform
       pos: 205.5,108.5
       parent: 1
-  - uid: 2204
+  - uid: 3173
     components:
     - type: Transform
-      pos: 152.5,16.5
+      pos: 171.5,53.5
       parent: 1
-  - uid: 3171
+  - uid: 3175
     components:
     - type: Transform
-      pos: 152.5,13.5
-      parent: 1
-  - uid: 3172
-    components:
-    - type: Transform
-      pos: 152.5,9.5
-      parent: 1
-  - uid: 16994
-    components:
-    - type: Transform
-      pos: 152.5,7.5
+      pos: 175.5,53.5
       parent: 1
   - uid: 16997
     components:
@@ -53692,100 +53729,15 @@ entities:
     - type: Transform
       pos: 148.5,43.5
       parent: 1
-  - uid: 17132
+  - uid: 17134
     components:
     - type: Transform
-      pos: 148.5,31.5
-      parent: 1
-  - uid: 17133
-    components:
-    - type: Transform
-      pos: 148.5,32.5
+      pos: 171.5,125.5
       parent: 1
   - uid: 17140
     components:
     - type: Transform
       pos: 164.5,57.5
-      parent: 1
-  - uid: 17142
-    components:
-    - type: Transform
-      pos: 171.5,58.5
-      parent: 1
-  - uid: 17143
-    components:
-    - type: Transform
-      pos: 171.5,57.5
-      parent: 1
-  - uid: 17444
-    components:
-    - type: Transform
-      pos: 175.5,60.5
-      parent: 1
-  - uid: 17445
-    components:
-    - type: Transform
-      pos: 178.5,59.5
-      parent: 1
-  - uid: 17447
-    components:
-    - type: Transform
-      pos: 187.5,52.5
-      parent: 1
-  - uid: 17448
-    components:
-    - type: Transform
-      pos: 186.5,52.5
-      parent: 1
-  - uid: 17451
-    components:
-    - type: Transform
-      pos: 195.5,56.5
-      parent: 1
-  - uid: 17452
-    components:
-    - type: Transform
-      pos: 194.5,56.5
-      parent: 1
-  - uid: 17454
-    components:
-    - type: Transform
-      pos: 197.5,56.5
-      parent: 1
-  - uid: 17455
-    components:
-    - type: Transform
-      pos: 198.5,56.5
-      parent: 1
-  - uid: 17456
-    components:
-    - type: Transform
-      pos: 206.5,56.5
-      parent: 1
-  - uid: 17457
-    components:
-    - type: Transform
-      pos: 208.5,56.5
-      parent: 1
-  - uid: 17460
-    components:
-    - type: Transform
-      pos: 171.5,118.5
-      parent: 1
-  - uid: 17461
-    components:
-    - type: Transform
-      pos: 172.5,118.5
-      parent: 1
-  - uid: 17467
-    components:
-    - type: Transform
-      pos: 152.5,123.5
-      parent: 1
-  - uid: 17468
-    components:
-    - type: Transform
-      pos: 154.5,123.5
       parent: 1
   - uid: 17474
     components:
@@ -53842,6 +53794,16 @@ entities:
     - type: Transform
       pos: 180.5,117.5
       parent: 1
+  - uid: 17500
+    components:
+    - type: Transform
+      pos: 168.5,125.5
+      parent: 1
+  - uid: 17503
+    components:
+    - type: Transform
+      pos: 153.5,126.5
+      parent: 1
   - uid: 17529
     components:
     - type: Transform
@@ -53861,6 +53823,46 @@ entities:
     components:
     - type: Transform
       pos: 147.5,38.5
+      parent: 1
+  - uid: 17558
+    components:
+    - type: Transform
+      pos: 163.5,10.5
+      parent: 1
+  - uid: 17559
+    components:
+    - type: Transform
+      pos: 163.5,11.5
+      parent: 1
+  - uid: 17562
+    components:
+    - type: Transform
+      pos: 163.5,3.5
+      parent: 1
+  - uid: 17563
+    components:
+    - type: Transform
+      pos: 163.5,4.5
+      parent: 1
+  - uid: 17575
+    components:
+    - type: Transform
+      pos: 168.5,22.5
+      parent: 1
+  - uid: 17576
+    components:
+    - type: Transform
+      pos: 167.5,22.5
+      parent: 1
+  - uid: 17582
+    components:
+    - type: Transform
+      pos: 156.5,32.5
+      parent: 1
+  - uid: 17584
+    components:
+    - type: Transform
+      pos: 155.5,32.5
       parent: 1
 - proto: DrinkGlass
   entities:
@@ -83477,12 +83479,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 141.5,24.5
       parent: 1
-  - uid: 8786
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 141.5,23.5
-      parent: 1
   - uid: 8787
     components:
     - type: Transform
@@ -86544,11 +86540,6 @@ entities:
     components:
     - type: Transform
       pos: 210.5,59.5
-      parent: 1
-  - uid: 9340
-    components:
-    - type: Transform
-      pos: 209.5,56.5
       parent: 1
   - uid: 9341
     components:
@@ -95031,6 +95022,11 @@ entities:
     components:
     - type: Transform
       pos: 214.5,110.5
+      parent: 1
+  - uid: 17132
+    components:
+    - type: Transform
+      pos: 209.5,56.5
       parent: 1
 - proto: RCMWallShivaInvincibleFab
   entities:
@@ -107062,6 +107058,177 @@ entities:
     - type: Transform
       pos: 121.5,56.5
       parent: 1
+- proto: RMCBasePropCasing11
+  entities:
+  - uid: 17458
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 124.75953,146.65398
+      parent: 1
+  - uid: 17459
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 124.63453,147.03966
+      parent: 1
+  - uid: 17460
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 124.66578,146.94585
+      parent: 1
+  - uid: 17462
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 124.249115,147.43576
+      parent: 1
+  - uid: 17605
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 123.936615,146.41422
+      parent: 1
+  - uid: 17606
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 125.07203,150.40657
+      parent: 1
+  - uid: 17607
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 125.342865,150.07301
+      parent: 1
+  - uid: 17608
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 125.092865,149.47885
+      parent: 1
+  - uid: 17609
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 124.592865,149.07231
+      parent: 1
+  - uid: 17610
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 123.780365,148.6345
+      parent: 1
+  - uid: 17611
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 123.436615,148.53027
+      parent: 1
+  - uid: 17612
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 123.967865,148.88469
+      parent: 1
+  - uid: 17613
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 123.88453,149.66647
+      parent: 1
+  - uid: 17614
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 123.51995,150.29192
+      parent: 1
+  - uid: 17615
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 124.374115,149.55182
+      parent: 1
+  - uid: 17616
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 125.155365,148.30095
+      parent: 1
+  - uid: 17617
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 125.030365,148.64494
+      parent: 1
+  - uid: 17618
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 124.842865,148.98892
+      parent: 1
+  - uid: 17619
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 124.499115,149.10359
+      parent: 1
+  - uid: 17620
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 124.1762,147.93611
+      parent: 1
+  - uid: 17621
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 123.82203,148.08205
+      parent: 1
+  - uid: 17638
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 127.14713,154.74759
+      parent: 1
+  - uid: 17639
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 125.95963,155.21666
+      parent: 1
+  - uid: 17640
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 124.95963,154.63292
+      parent: 1
+  - uid: 17641
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 123.69921,154.73715
+      parent: 1
+  - uid: 17642
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 128.70963,154.68504
+      parent: 1
+  - uid: 17643
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 127.61588,156.37372
+      parent: 1
+- proto: RMCBasePropCasing5
+  entities:
+  - uid: 17461
+    components:
+    - type: Transform
+      pos: 124.530365,147.82117
+      parent: 1
 - proto: RMCBeakerHighCapacity
   entities:
   - uid: 13299
@@ -107158,20 +107325,20 @@ entities:
       parent: 1
 - proto: RMCBoxShotgunBuckshot
   entities:
-  - uid: 3184
-    components:
-    - type: Transform
-      pos: 122.52727,144.7435
-      parent: 1
-  - uid: 4206
-    components:
-    - type: Transform
-      pos: 122.579346,144.48291
-      parent: 1
   - uid: 13315
     components:
     - type: Transform
       pos: 6.5,147.5
+      parent: 1
+  - uid: 17452
+    components:
+    - type: Transform
+      pos: 125.33245,146.6902
+      parent: 1
+  - uid: 17453
+    components:
+    - type: Transform
+      pos: 122.436615,149.55676
       parent: 1
 - proto: RMCBoxShotgunSlugs
   entities:
@@ -108942,6 +109109,68 @@ entities:
     - type: Transform
       pos: 100.5,118.5
       parent: 1
+- proto: RMCCrateWeapons
+  entities:
+  - uid: 17455
+    components:
+    - type: Transform
+      pos: 122.5,149.5
+      parent: 1
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PolygonShape
+            radius: 0.01
+            vertices:
+            - -0.4,-0.4
+            - 0.4,-0.4
+            - 0.4,0.29
+            - -0.4,0.29
+          mask:
+          - Impassable
+          - HighImpassable
+          - LowImpassable
+          layer:
+          - Opaque
+          density: 50
+          hard: True
+          restitution: 0
+          friction: 0.4
+    - type: EntityStorage
+      open: True
+      removedMasks: 20
+    - type: PlaceableSurface
+      isPlaceable: True
+  - uid: 17626
+    components:
+    - type: Transform
+      pos: 121.5,148.5
+      parent: 1
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PolygonShape
+            radius: 0.01
+            vertices:
+            - -0.4,-0.4
+            - 0.4,-0.4
+            - 0.4,0.29
+            - -0.4,0.29
+          mask:
+          - Impassable
+          - HighImpassable
+          - LowImpassable
+          layer:
+          - Opaque
+          density: 50
+          hard: True
+          restitution: 0
+          friction: 0.4
+    - type: EntityStorage
+      open: True
+      removedMasks: 20
+    - type: PlaceableSurface
+      isPlaceable: True
 - proto: RMCCrayonBox
   entities:
   - uid: 13587
@@ -109007,6 +109236,70 @@ entities:
     components:
     - type: Transform
       pos: 173.5,157.5
+      parent: 1
+- proto: RMCDecalSpawnerBloodSplatters
+  entities:
+  - uid: 17597
+    components:
+    - type: Transform
+      pos: 122.5,147.5
+      parent: 1
+  - uid: 17598
+    components:
+    - type: Transform
+      pos: 124.5,149.5
+      parent: 1
+  - uid: 17599
+    components:
+    - type: Transform
+      pos: 125.5,147.5
+      parent: 1
+  - uid: 17603
+    components:
+    - type: Transform
+      pos: 122.5,146.5
+      parent: 1
+  - uid: 17604
+    components:
+    - type: Transform
+      pos: 123.5,147.5
+      parent: 1
+  - uid: 17645
+    components:
+    - type: Transform
+      pos: 124.5,154.5
+      parent: 1
+  - uid: 17646
+    components:
+    - type: Transform
+      pos: 125.5,155.5
+      parent: 1
+  - uid: 17647
+    components:
+    - type: Transform
+      pos: 127.5,154.5
+      parent: 1
+- proto: RMCDecalSpawnerXenoSplatters
+  entities:
+  - uid: 17594
+    components:
+    - type: Transform
+      pos: 124.5,150.5
+      parent: 1
+  - uid: 17595
+    components:
+    - type: Transform
+      pos: 123.5,152.5
+      parent: 1
+  - uid: 17596
+    components:
+    - type: Transform
+      pos: 125.5,152.5
+      parent: 1
+  - uid: 17602
+    components:
+    - type: Transform
+      pos: 125.5,148.5
       parent: 1
 - proto: RMCDrinkAlcoholRum
   entities:
@@ -110503,20 +110796,10 @@ entities:
     - type: Transform
       pos: 158.5,118.5
       parent: 1
-  - uid: 13321
+  - uid: 14880
     components:
     - type: Transform
-      pos: 168.5,118.5
-      parent: 1
-  - uid: 14035
-    components:
-    - type: Transform
-      pos: 148.5,126.5
-      parent: 1
-  - uid: 14036
-    components:
-    - type: Transform
-      pos: 148.5,124.5
+      pos: 170.5,54.5
       parent: 1
   - uid: 14881
     components:
@@ -110527,11 +110810,6 @@ entities:
     components:
     - type: Transform
       pos: 148.5,136.5
-      parent: 1
-  - uid: 15605
-    components:
-    - type: Transform
-      pos: 148.5,125.5
       parent: 1
   - uid: 15606
     components:
@@ -110547,6 +110825,11 @@ entities:
     components:
     - type: Transform
       pos: 148.5,137.5
+      parent: 1
+  - uid: 16278
+    components:
+    - type: Transform
+      pos: 185.5,56.5
       parent: 1
   - uid: 16279
     components:
@@ -110613,10 +110896,120 @@ entities:
     - type: Transform
       pos: 149.5,146.5
       parent: 1
-  - uid: 17459
+  - uid: 16994
     components:
     - type: Transform
-      pos: 175.5,118.5
+      pos: 186.5,56.5
+      parent: 1
+  - uid: 16995
+    components:
+    - type: Transform
+      pos: 196.5,50.5
+      parent: 1
+  - uid: 16996
+    components:
+    - type: Transform
+      pos: 196.5,49.5
+      parent: 1
+  - uid: 17004
+    components:
+    - type: Transform
+      pos: 198.5,51.5
+      parent: 1
+  - uid: 17005
+    components:
+    - type: Transform
+      pos: 196.5,51.5
+      parent: 1
+  - uid: 17131
+    components:
+    - type: Transform
+      pos: 207.5,51.5
+      parent: 1
+  - uid: 17135
+    components:
+    - type: Transform
+      pos: 149.5,127.5
+      parent: 1
+  - uid: 17136
+    components:
+    - type: Transform
+      pos: 151.5,127.5
+      parent: 1
+  - uid: 17142
+    components:
+    - type: Transform
+      pos: 205.5,51.5
+      parent: 1
+  - uid: 17445
+    components:
+    - type: Transform
+      pos: 167.5,119.5
+      parent: 1
+  - uid: 17446
+    components:
+    - type: Transform
+      pos: 158.5,126.5
+      parent: 1
+  - uid: 17447
+    components:
+    - type: Transform
+      pos: 158.5,124.5
+      parent: 1
+  - uid: 17448
+    components:
+    - type: Transform
+      pos: 158.5,125.5
+      parent: 1
+  - uid: 17449
+    components:
+    - type: Transform
+      pos: 170.5,56.5
+      parent: 1
+  - uid: 17450
+    components:
+    - type: Transform
+      pos: 196.5,48.5
+      parent: 1
+  - uid: 17451
+    components:
+    - type: Transform
+      pos: 177.5,53.5
+      parent: 1
+  - uid: 17493
+    components:
+    - type: Transform
+      pos: 170.5,55.5
+      parent: 1
+  - uid: 17495
+    components:
+    - type: Transform
+      pos: 187.5,56.5
+      parent: 1
+  - uid: 17496
+    components:
+    - type: Transform
+      pos: 184.5,56.5
+      parent: 1
+  - uid: 17497
+    components:
+    - type: Transform
+      pos: 197.5,51.5
+      parent: 1
+  - uid: 17498
+    components:
+    - type: Transform
+      pos: 206.5,51.5
+      parent: 1
+  - uid: 17504
+    components:
+    - type: Transform
+      pos: 150.5,127.5
+      parent: 1
+  - uid: 17505
+    components:
+    - type: Transform
+      pos: 155.5,127.5
       parent: 1
   - uid: 17506
     components:
@@ -110761,7 +111154,7 @@ entities:
   - uid: 17537
     components:
     - type: Transform
-      pos: 170.5,56.5
+      pos: 156.5,127.5
       parent: 1
   - uid: 17538
     components:
@@ -110791,12 +111184,7 @@ entities:
   - uid: 17543
     components:
     - type: Transform
-      pos: 176.5,60.5
-      parent: 1
-  - uid: 17544
-    components:
-    - type: Transform
-      pos: 177.5,60.5
+      pos: 157.5,127.5
       parent: 1
   - uid: 17545
     components:
@@ -110817,6 +111205,176 @@ entities:
     components:
     - type: Transform
       pos: 148.5,49.5
+      parent: 1
+  - uid: 17564
+    components:
+    - type: Transform
+      pos: 163.5,5.5
+      parent: 1
+  - uid: 17565
+    components:
+    - type: Transform
+      pos: 163.5,6.5
+      parent: 1
+  - uid: 17566
+    components:
+    - type: Transform
+      pos: 163.5,7.5
+      parent: 1
+  - uid: 17567
+    components:
+    - type: Transform
+      pos: 163.5,2.5
+      parent: 1
+  - uid: 17568
+    components:
+    - type: Transform
+      pos: 163.5,14.5
+      parent: 1
+  - uid: 17569
+    components:
+    - type: Transform
+      pos: 163.5,17.5
+      parent: 1
+  - uid: 17570
+    components:
+    - type: Transform
+      pos: 163.5,18.5
+      parent: 1
+  - uid: 17571
+    components:
+    - type: Transform
+      pos: 163.5,19.5
+      parent: 1
+  - uid: 17572
+    components:
+    - type: Transform
+      pos: 163.5,20.5
+      parent: 1
+  - uid: 17588
+    components:
+    - type: Transform
+      pos: 152.5,33.5
+      parent: 1
+  - uid: 17589
+    components:
+    - type: Transform
+      pos: 152.5,34.5
+      parent: 1
+  - uid: 17590
+    components:
+    - type: Transform
+      pos: 151.5,35.5
+      parent: 1
+  - uid: 17591
+    components:
+    - type: Transform
+      pos: 150.5,35.5
+      parent: 1
+  - uid: 17592
+    components:
+    - type: Transform
+      pos: 149.5,35.5
+      parent: 1
+  - uid: 17648
+    components:
+    - type: Transform
+      pos: 158.5,123.5
+      parent: 1
+  - uid: 17649
+    components:
+    - type: Transform
+      pos: 167.5,120.5
+      parent: 1
+  - uid: 17650
+    components:
+    - type: Transform
+      pos: 167.5,121.5
+      parent: 1
+  - uid: 17651
+    components:
+    - type: Transform
+      pos: 167.5,122.5
+      parent: 1
+  - uid: 17652
+    components:
+    - type: Transform
+      pos: 167.5,123.5
+      parent: 1
+  - uid: 17653
+    components:
+    - type: Transform
+      pos: 169.5,126.5
+      parent: 1
+  - uid: 17654
+    components:
+    - type: Transform
+      pos: 173.5,126.5
+      parent: 1
+  - uid: 17655
+    components:
+    - type: Transform
+      pos: 173.5,127.5
+      parent: 1
+  - uid: 17656
+    components:
+    - type: Transform
+      pos: 174.5,128.5
+      parent: 1
+  - uid: 17657
+    components:
+    - type: Transform
+      pos: 175.5,129.5
+      parent: 1
+  - uid: 17658
+    components:
+    - type: Transform
+      pos: 176.5,128.5
+      parent: 1
+  - uid: 17659
+    components:
+    - type: Transform
+      pos: 176.5,127.5
+      parent: 1
+  - uid: 17660
+    components:
+    - type: Transform
+      pos: 176.5,126.5
+      parent: 1
+  - uid: 17661
+    components:
+    - type: Transform
+      pos: 176.5,125.5
+      parent: 1
+  - uid: 17662
+    components:
+    - type: Transform
+      pos: 177.5,123.5
+      parent: 1
+  - uid: 17663
+    components:
+    - type: Transform
+      pos: 177.5,122.5
+      parent: 1
+  - uid: 17664
+    components:
+    - type: Transform
+      pos: 176.5,121.5
+      parent: 1
+  - uid: 17665
+    components:
+    - type: Transform
+      pos: 176.5,124.5
+      parent: 1
+  - uid: 17666
+    components:
+    - type: Transform
+      pos: 176.5,120.5
+      parent: 1
+  - uid: 17667
+    components:
+    - type: Transform
+      pos: 176.5,119.5
       parent: 1
 - proto: RMCFoodGoldenApple
   entities:
@@ -112047,15 +112605,15 @@ entities:
     - type: InsideEntityStorage
 - proto: RMCGrenadeIncendiary
   entities:
-  - uid: 17497
+  - uid: 17627
     components:
     - type: Transform
-      pos: 124.477165,144.55753
+      pos: 121.48964,148.39555
       parent: 1
-  - uid: 17498
+  - uid: 17628
     components:
     - type: Transform
-      pos: 124.58654,144.46371
+      pos: 121.67714,148.46852
       parent: 1
 - proto: RMCHandcuffs
   entities:
@@ -117662,6 +118220,38 @@ entities:
     components:
     - type: Transform
       pos: 208.5,119.5
+      parent: 1
+- proto: RMCParasiteProp
+  entities:
+  - uid: 14036
+    components:
+    - type: Transform
+      pos: 123.64908,151.9266
+      parent: 1
+  - uid: 17593
+    components:
+    - type: Transform
+      pos: 124.9095,151.12398
+      parent: 1
+  - uid: 17634
+    components:
+    - type: Transform
+      pos: 126.65755,154.60165
+      parent: 1
+  - uid: 17635
+    components:
+    - type: Transform
+      pos: 129.11588,155.42514
+      parent: 1
+  - uid: 17636
+    components:
+    - type: Transform
+      pos: 124.63671,156.62389
+      parent: 1
+  - uid: 17637
+    components:
+    - type: Transform
+      pos: 132.99088,154.63292
       parent: 1
 - proto: RMCPersonalDesktop
   entities:
@@ -124699,6 +125289,16 @@ entities:
       parent: 1
 - proto: RMCSpawnerCorpseSecurity
   entities:
+  - uid: 14035
+    components:
+    - type: Transform
+      pos: 122.5,147.5
+      parent: 1
+  - uid: 15605
+    components:
+    - type: Transform
+      pos: 124.5,149.5
+      parent: 1
   - uid: 16036
     components:
     - type: Transform
@@ -125913,10 +126513,15 @@ entities:
       parent: 1
 - proto: RMCSpeedLoader357Hollowpoint
   entities:
-  - uid: 14880
+  - uid: 2204
     components:
     - type: Transform
-      pos: 121.985596,144.40994
+      pos: 122.499115,149.43169
+      parent: 1
+  - uid: 2841
+    components:
+    - type: Transform
+      pos: 122.499115,149.43169
       parent: 1
   - uid: 16274
     components:
@@ -125928,25 +126533,20 @@ entities:
     - type: Transform
       pos: 7.5,146.5
       parent: 1
-  - uid: 16278
-    components:
-    - type: Transform
-      pos: 121.97518,144.70181
-      parent: 1
   - uid: 16286
     components:
     - type: Transform
       pos: 157.5,151.5
       parent: 1
-  - uid: 17504
+  - uid: 17456
     components:
     - type: Transform
-      pos: 121.52404,142.46233
+      pos: 125.342865,150.04669
       parent: 1
-  - uid: 17505
+  - uid: 17457
     components:
     - type: Transform
-      pos: 121.445915,142.60304
+      pos: 122.499115,149.43169
       parent: 1
 - proto: RMCSprayBottleSpaceCleaner
   entities:
@@ -129930,20 +130530,25 @@ entities:
     - type: Transform
       pos: 86.5,94.5
       parent: 1
-  - uid: 17499
+  - uid: 17143
     components:
     - type: Transform
-      pos: 123.61779,142.38414
+      pos: 125.561615,149.3066
       parent: 1
-  - uid: 17500
+  - uid: 17444
     components:
     - type: Transform
-      pos: 123.58654,142.63431
+      pos: 123.16578,146.62766
       parent: 1
-  - uid: 17501
+  - uid: 17629
     components:
     - type: Transform
-      pos: 123.61779,142.5405
+      pos: 121.48964,148.55191
+      parent: 1
+  - uid: 17630
+    components:
+    - type: Transform
+      pos: 121.58339,148.42683
       parent: 1
 - proto: RMCWeaponRifleM54C
   entities:
@@ -130016,6 +130621,11 @@ entities:
       parent: 1
 - proto: RMCWeaponShotgunHG3712
   entities:
+  - uid: 3171
+    components:
+    - type: Transform
+      pos: 122.561615,149.53592
+      parent: 1
   - uid: 17006
     components:
     - type: Transform
@@ -130046,15 +130656,10 @@ entities:
     - type: Transform
       pos: 99.73503,13.136038
       parent: 1
-  - uid: 17502
+  - uid: 17454
     components:
     - type: Transform
-      pos: 122.695915,142.4154
-      parent: 1
-  - uid: 17503
-    components:
-    - type: Transform
-      pos: 122.68029,142.5874
+      pos: 123.405365,148.4414
       parent: 1
 - proto: RMCWeaponShotgunType23
   entities:
@@ -130108,6 +130713,11 @@ entities:
       parent: 1
 - proto: RMCWindowFrameShiva
   entities:
+  - uid: 3172
+    components:
+    - type: Transform
+      pos: 124.5,145.5
+      parent: 1
   - uid: 17018
     components:
     - type: Transform
@@ -130691,25 +131301,10 @@ entities:
     - type: Transform
       pos: 176.5,149.5
       parent: 1
-  - uid: 17134
-    components:
-    - type: Transform
-      pos: 176.5,53.5
-      parent: 1
-  - uid: 17135
-    components:
-    - type: Transform
-      pos: 174.5,53.5
-      parent: 1
-  - uid: 17136
-    components:
-    - type: Transform
-      pos: 173.5,53.5
-      parent: 1
   - uid: 17137
     components:
     - type: Transform
-      pos: 172.5,53.5
+      pos: 152.5,14.5
       parent: 1
   - uid: 17139
     components:
@@ -130726,13 +131321,18 @@ entities:
     - type: Transform
       pos: 151.5,46.5
       parent: 1
-- proto: WallXenoResinImpenetrable
-  entities:
-  - uid: 3173
+  - uid: 17467
     components:
     - type: Transform
       pos: 152.5,8.5
       parent: 1
+  - uid: 17469
+    components:
+    - type: Transform
+      pos: 152.5,15.5
+      parent: 1
+- proto: WallXenoResinImpenetrable
+  entities:
   - uid: 3174
     components:
     - type: Transform
@@ -130742,6 +131342,16 @@ entities:
     components:
     - type: Transform
       pos: 148.5,45.5
+      parent: 1
+  - uid: 9340
+    components:
+    - type: Transform
+      pos: 159.5,32.5
+      parent: 1
+  - uid: 13321
+    components:
+    - type: Transform
+      pos: 160.5,32.5
       parent: 1
   - uid: 16686
     components:
@@ -130758,30 +131368,10 @@ entities:
     - type: Transform
       pos: 205.5,111.5
       parent: 1
-  - uid: 16995
+  - uid: 17133
     components:
     - type: Transform
-      pos: 152.5,14.5
-      parent: 1
-  - uid: 16996
-    components:
-    - type: Transform
-      pos: 152.5,15.5
-      parent: 1
-  - uid: 17004
-    components:
-    - type: Transform
-      pos: 148.5,30.5
-      parent: 1
-  - uid: 17005
-    components:
-    - type: Transform
-      pos: 148.5,34.5
-      parent: 1
-  - uid: 17131
-    components:
-    - type: Transform
-      pos: 148.5,33.5
+      pos: 172.5,125.5
       parent: 1
   - uid: 17138
     components:
@@ -130793,75 +131383,45 @@ entities:
     - type: Transform
       pos: 165.5,57.5
       parent: 1
-  - uid: 17446
-    components:
-    - type: Transform
-      pos: 178.5,60.5
-      parent: 1
-  - uid: 17449
-    components:
-    - type: Transform
-      pos: 185.5,52.5
-      parent: 1
-  - uid: 17450
-    components:
-    - type: Transform
-      pos: 188.5,52.5
-      parent: 1
-  - uid: 17453
-    components:
-    - type: Transform
-      pos: 196.5,56.5
-      parent: 1
-  - uid: 17458
-    components:
-    - type: Transform
-      pos: 207.5,56.5
-      parent: 1
-  - uid: 17462
-    components:
-    - type: Transform
-      pos: 170.5,118.5
-      parent: 1
   - uid: 17463
     components:
     - type: Transform
-      pos: 173.5,118.5
+      pos: 176.5,53.5
       parent: 1
   - uid: 17464
     components:
     - type: Transform
-      pos: 149.5,123.5
+      pos: 174.5,53.5
       parent: 1
   - uid: 17465
     components:
     - type: Transform
-      pos: 150.5,123.5
+      pos: 173.5,53.5
       parent: 1
   - uid: 17466
     components:
     - type: Transform
-      pos: 151.5,123.5
+      pos: 172.5,53.5
       parent: 1
-  - uid: 17469
+  - uid: 17468
     components:
     - type: Transform
-      pos: 153.5,123.5
+      pos: 163.5,8.5
       parent: 1
   - uid: 17470
     components:
     - type: Transform
-      pos: 155.5,123.5
+      pos: 158.5,32.5
       parent: 1
   - uid: 17471
     components:
     - type: Transform
-      pos: 156.5,123.5
+      pos: 148.5,34.5
       parent: 1
   - uid: 17472
     components:
     - type: Transform
-      pos: 157.5,123.5
+      pos: 161.5,32.5
       parent: 1
   - uid: 17473
     components:
@@ -130913,15 +131473,35 @@ entities:
     - type: Transform
       pos: 199.5,117.5
       parent: 1
+  - uid: 17499
+    components:
+    - type: Transform
+      pos: 170.5,125.5
+      parent: 1
+  - uid: 17501
+    components:
+    - type: Transform
+      pos: 152.5,126.5
+      parent: 1
+  - uid: 17502
+    components:
+    - type: Transform
+      pos: 154.5,126.5
+      parent: 1
   - uid: 17531
     components:
     - type: Transform
       pos: 197.5,119.5
       parent: 1
-  - uid: 17549
+  - uid: 17544
     components:
     - type: Transform
       pos: 147.5,34.5
+      parent: 1
+  - uid: 17549
+    components:
+    - type: Transform
+      pos: 163.5,9.5
       parent: 1
   - uid: 17550
     components:
@@ -130952,6 +131532,76 @@ entities:
     components:
     - type: Transform
       pos: 147.5,42.5
+      parent: 1
+  - uid: 17560
+    components:
+    - type: Transform
+      pos: 163.5,12.5
+      parent: 1
+  - uid: 17561
+    components:
+    - type: Transform
+      pos: 163.5,13.5
+      parent: 1
+  - uid: 17573
+    components:
+    - type: Transform
+      pos: 169.5,23.5
+      parent: 1
+  - uid: 17574
+    components:
+    - type: Transform
+      pos: 169.5,22.5
+      parent: 1
+  - uid: 17577
+    components:
+    - type: Transform
+      pos: 157.5,32.5
+      parent: 1
+  - uid: 17578
+    components:
+    - type: Transform
+      pos: 165.5,22.5
+      parent: 1
+  - uid: 17579
+    components:
+    - type: Transform
+      pos: 165.5,21.5
+      parent: 1
+  - uid: 17580
+    components:
+    - type: Transform
+      pos: 166.5,22.5
+      parent: 1
+  - uid: 17581
+    components:
+    - type: Transform
+      pos: 170.5,23.5
+      parent: 1
+  - uid: 17583
+    components:
+    - type: Transform
+      pos: 170.5,24.5
+      parent: 1
+  - uid: 17585
+    components:
+    - type: Transform
+      pos: 154.5,32.5
+      parent: 1
+  - uid: 17586
+    components:
+    - type: Transform
+      pos: 153.5,32.5
+      parent: 1
+  - uid: 17587
+    components:
+    - type: Transform
+      pos: 152.5,32.5
+      parent: 1
+  - uid: 17644
+    components:
+    - type: Transform
+      pos: 168.5,124.5
       parent: 1
 - proto: WaterCooler
   entities:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Walls/fog_walls.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Walls/fog_walls.yml
@@ -44,6 +44,15 @@
 
 - type: entity
   parent: RMCFogWall25
+  id: RMCFogWall30
+  suffix: 30 minutes
+  components:
+  - type: TimedDespawn
+    lifetime: 1800
+
+
+- type: entity
+  parent: RMCFogWall25
   id: RMCFogWall15
   suffix: 15 minutes
   components:


### PR DESCRIPTION
## About the PR
Maps impenetrable resin and dense fog onto Shiva's Snowball. Basically the xeno version of LZ turrets, lasts for 30 minutes.

De-looted aurora armory

Adds 30 minute fog wall prototype

## Why / Balance
Survivor rework

## Technical details
mapping and yaml

## Media
Aurora armory loot moved to b-ball sec checkpoint
<img width="931" height="984" alt="obraz" src="https://github.com/user-attachments/assets/8d667660-8dc6-489d-a989-f6424c7c1e57" />

Boundaries
<img width="1011" height="1184" alt="obraz" src="https://github.com/user-attachments/assets/e5945de2-9ae4-4c12-aaf2-5863725f4570" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

- tweak: Shiva's Snowball now features dense fog and impenetrable resin in order to prevent hive diving in early-game scenarios from both survivors and marines.
- tweak: Shiva's Snowball Aurora armory loot has been moved to the B-ball security checkpoint.
