### PR TITLE
allow rescued survivors to hear announcements

### DIFF
--- a/Content.Server/_RMC14/Marines/MarineAnnounceSystem.cs
+++ b/Content.Server/_RMC14/Marines/MarineAnnounceSystem.cs
@@ -3,11 +3,11 @@ using Content.Server.Administration.Logs;
 using Content.Server.Chat.Managers;
 using Content.Server.Radio.EntitySystems;
 using Content.Shared._RMC14.Dropship;
+using Content.Shared._RMC14.Intel;
 using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.Marines.Announce;
 using Content.Shared._RMC14.Marines.Squads;
 using Content.Shared._RMC14.Rules;
-using Content.Shared._RMC14.Survivor;
 using Content.Shared.Chat;
 using Content.Shared.Database;
 using Content.Shared.Ghost;
@@ -99,8 +99,7 @@ public sealed class MarineAnnounceSystem : SharedMarineAnnounceSystem
     public override void AnnounceToMarines(
         string message,
         SoundSpecifier? sound = null,
-        Filter? filter = null,
-        bool excludeSurvivors = true)
+        Filter? filter = null)
     {
         filter ??= Filter.Empty()
             .AddWhereAttachedEntity(e =>
@@ -108,9 +107,8 @@ public sealed class MarineAnnounceSystem : SharedMarineAnnounceSystem
                 HasComp<GhostComponent>(e)
             );
 
-        // TODO RMC14
-        if (excludeSurvivors)
-            filter.RemoveWhereAttachedEntity(HasComp<RMCSurvivorComponent>);
+        // Filter out non rescued survivors.
+        filter.RemoveWhereAttachedEntity(HasComp<IntelRescueSurvivorObjectiveComponent>);
 
         _chatManager.ChatMessageToManyFiltered(filter, ChatChannel.Radio, message, message, default, false, true, null);
         _audio.PlayGlobal(sound ?? DefaultAnnouncementSound, filter, true, AudioParams.Default.WithVolume(-2f));

--- a/Content.Shared/_RMC14/Marines/Announce/SharedMarineAnnounceSystem.cs
+++ b/Content.Shared/_RMC14/Marines/Announce/SharedMarineAnnounceSystem.cs
@@ -211,12 +211,10 @@ public abstract class SharedMarineAnnounceSystem : EntitySystem
     /// <param name="message">The content of the announcement.</param>
     /// <param name="sound">GlobalSound for announcement.</param>
     /// <param name="filter">Who should be able to see and hear the announcement.</param>
-    /// <param name="excludeSurvivors">Whether or not to exclude survivors from the list of recipients.</param>
     public virtual void AnnounceToMarines(
         string message,
         SoundSpecifier? sound = null,
-        Filter? filter = null,
-        bool excludeSurvivors = true)
+        Filter? filter = null)
     {
     }
 
@@ -242,15 +240,13 @@ public abstract class SharedMarineAnnounceSystem : EntitySystem
     /// <param name="name">The name to sign the message with, defaults to the name of <see cref="author"/>.</param>
     /// <param name="sound">GlobalSound for announcement.</param>
     /// <param name="filter">Who should be able to see and hear the announcement.</param>
-    /// <param name="excludeSurvivors">Whether or not to exclude survivors from the list of recipients.</param>
     public void AnnounceSigned(
         EntityUid sender,
         string message,
         string? author = null,
         string? name = null,
         SoundSpecifier? sound = null,
-        Filter? filter = null,
-        bool excludeSurvivors = true)
+        Filter? filter = null)
     {
         if (_net.IsClient)
             return;
@@ -259,7 +255,7 @@ public abstract class SharedMarineAnnounceSystem : EntitySystem
         name ??= _rankSystem.GetSpeakerFullRankName(sender) ?? Name(sender);
         var wrappedMessage = Loc.GetString("rmc-announcement-message-signed", ("author", author), ("message", message), ("name", name));
 
-        AnnounceToMarines(wrappedMessage, sound, filter, excludeSurvivors);
+        AnnounceToMarines(wrappedMessage, sound, filter);
         _adminLog.Add(LogType.RMCMarineAnnounce, $"{ToPrettyString(sender):source} marine announced message: {message}");
     }
 

--- a/Content.Shared/_RMC14/Marines/ControlComputer/SharedMarineControlComputerSystem.cs
+++ b/Content.Shared/_RMC14/Marines/ControlComputer/SharedMarineControlComputerSystem.cs
@@ -303,8 +303,7 @@ public abstract class SharedMarineControlComputerSystem : EntitySystem
             args.Message,
             Loc.GetString("rmc-announcement-author-shipside"),
             sound: SharedMarineAnnounceSystem.AresAnnouncementSound,
-            filter: Filter.BroadcastMap(map).RemoveWhereAttachedEntity(e => !HasComp<MarineComponent>(e) && !HasComp<GhostComponent>(e)),
-            excludeSurvivors: false
+            filter: Filter.BroadcastMap(map).RemoveWhereAttachedEntity(e => !HasComp<MarineComponent>(e) && !HasComp<GhostComponent>(e))
         );
     }
 


### PR DESCRIPTION
## About the PR

title

## Why / Balance

- Surv COs can currently hear all announcements as they do not have the `SurvivorComponent`.
- Survivors re-deploying will likely stick with marines that will directly or indirectly communicate any announcements.

## Technical details

- Filter by `IntelRescueSurvivorObjectiveComponent`, which gets removed when touching the Almayer.
- Shipside announcements already included the survivors via `excludeSurvivors: false`, so we can remove that parameter.

## Media

No

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- tweak: Rescued survivors can now hear announcements.
