### PR TITLE
[PVE] Buff the Heavy Support Gun

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SmartGuns/smart_gun_pve.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SmartGuns/smart_gun_pve.yml
@@ -136,6 +136,8 @@
     deactivateOnDrop: false
     toggleSound: null
   - type: SmartGun
+  - type: RMCWeaponDamageFalloff
+    rangeFlat: 12
   - type: AttachableHolder
     slots:
       rmc-aslot-rail:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SmartGuns/smart_gun_pve.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SmartGuns/smart_gun_pve.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   parent: [ CMBaseWeaponGun, BaseItem, RMCBaseAttachableHolder ]
   id: RMCSmartGunPVENoCamo
   abstract: true
@@ -62,7 +62,7 @@
     - FullAuto
     recoilWielded: 3
     scatterWielded: 10
-    baseFireRate: 5
+    baseFireRate: 6
     burstScatterMult: 4
     modifiers:
       FullAuto:
@@ -102,7 +102,7 @@
     settings:
     - damage:
         types:
-          Piercing: 30
+          Piercing: 35
       armorPiercing: 0
       name: rmc-toggleable-ammo-highly-precise
       icon:
@@ -110,7 +110,7 @@
         state: ammo_swap_normal
     - damage:
         types:
-          Piercing: 20
+          Piercing: 25
       armorPiercing: 40
       name: rmc-toggleable-ammo-armor-shredding
       icon:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SmartGuns/smart_gun_pve.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SmartGuns/smart_gun_pve.yml
@@ -189,8 +189,24 @@
   description: "The actual firearm in the Support Gun System. Essentially a heavy, mobile machinegun.\n\nThis model appears to have been overtuned, packing a greater punch than usual. Watch where you point this thing."
   suffix: PVE, Overtuned
   components:
-  - type: GunDamageModifier
-    multiplier: 1.5
+  - type: GunToggleableAmmo
+    settings:
+    - damage:
+        types:
+          Piercing: 60
+      armorPiercing: 10
+      name: rmc-toggleable-ammo-highly-precise
+      icon:
+        sprite: _RMC14/Actions/marine_smart_gun_actions.rsi
+        state: ammo_swap_normal
+    - damage:
+        types:
+          Piercing: 50
+      armorPiercing: 40
+      name: rmc-toggleable-ammo-armor-shredding
+      icon:
+        sprite: _RMC14/Actions/marine_smart_gun_actions.rsi
+        state: ammo_swap_ap
 
 - type: entity
   parent: RMCSmartGunPVENoCamo

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SmartGuns/smart_gun_pve.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SmartGuns/smart_gun_pve.yml
@@ -183,6 +183,16 @@
       Urban: "#acb8c7"
 
 - type: entity
+  parent: RMCSmartGunPVE
+  id: RMCSmartGunOvertunedPVE
+  name: ML66OT heavy support gun
+  description: "The actual firearm in the Support Gun System. Essentially a heavy, mobile machinegun.\n\nThis model appears to have been overtuned, packing a greater punch than usual. Watch where you point this thing."
+  suffix: PVE, Overtuned
+  components:
+  - type: GunDamageModifier
+    multiplier: 1.5
+
+- type: entity
   parent: RMCSmartGunPVENoCamo
   id: RMCSmartGunPMCPVE
   name: ML79A heavy support gun


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Buffs PVE HSGs across the board
Adds the ML66OT - an overtuned HSG requested by @Shromply

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Currently, the ML66A HSG is a weak weapon, outpaced in both DPS and range by the M54C. This PR addresses both, buffing RMCSmartGunPVENoCamo by increasing the DPS from 150 @ 0 AP / 100 @ 40 AP to 210 @ 0AP / 150 @ 40 AP, and decreasing falloff from 4 @ 7 tiles / 9999 @ 12 tiles to 4 @ 19 tiles / 9999 @ 24 tiles.

## Technical details
<!-- Summary of code changes for easier review. -->
YAML

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: [PVE] Added the ML66OT, an incredibly effective heavy support gun issued only at the discretion of Company Command.
- tweak: [PVE] Increased the range, fire rate, and impact of heavy support guns, making them significantly more effective.
