### PR TITLE
forecon sgo gets m1911

### DIFF
--- a/Resources/Prototypes/_RMC14/Catalog/Fills/Clothing/belt.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Fills/Clothing/belt.yml
@@ -483,9 +483,9 @@
   components:
   - type: StorageFill
     contents:
-    - id: CMMagazinePistolM1984
+    - id: CMMagazinePistolM1911
       amount: 2
-    - id: CMWeaponPistolM1984
+    - id: CMWeaponPistolM1911
 
 - type: entity
   parent: RMCBeltHolsterSMGPouch


### PR DESCRIPTION
## About the PR
recon SGO gets an m1911 and 2 mags in their belt like intended instead of an m1984

## Why / Balance
i missed this in my original m1911 pr, oopsie

## Technical details
2 lines of yaml

## Media

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
not player facing
