### PR TITLE
Pump sentries automatically undeploy on green or blue alert

### DIFF
--- a/Content.Shared/_RMC14/Dropship/Utility/Components/RMCEquipmentDeployerComponent.cs
+++ b/Content.Shared/_RMC14/Dropship/Utility/Components/RMCEquipmentDeployerComponent.cs
@@ -69,7 +69,7 @@ public sealed partial class RMCEquipmentDeployerComponent : Component
     ///     The minimum alert level required to activate the deployer.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public RMCAlertLevels AlertLevelRequired;
+    public RMCAlertLevels? AlertLevelRequired;
 
     /// <summary>
     ///     Blacklist for entities not allowed to use the deployer.

--- a/Content.Shared/_RMC14/Dropship/Utility/Systems/SharedRMCEquipmentDeployerSystem.cs
+++ b/Content.Shared/_RMC14/Dropship/Utility/Systems/SharedRMCEquipmentDeployerSystem.cs
@@ -33,10 +33,25 @@ public abstract partial class SharedRMCEquipmentDeployerSystem : EntitySystem
 
     public override void Initialize()
     {
+        SubscribeLocalEvent<RMCAlertLevelChangedEvent>(OnAlertLevelChanged);
+
         SubscribeLocalEvent<RMCEquipmentDeployerComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<RMCEquipmentDeployerComponent, InteractHandEvent>(OnInteract);
         SubscribeLocalEvent<RMCEquipmentDeployerComponent, EntGotInsertedIntoContainerMessage>(OnInserted);
         SubscribeLocalEvent<RMCEquipmentDeployerComponent, EntGotRemovedFromContainerMessage>(OnRemovedFromContainer);
+    }
+
+    private void OnAlertLevelChanged(ref RMCAlertLevelChangedEvent ev)
+    {
+        var query = EntityQueryEnumerator<RMCEquipmentDeployerComponent>();
+        while (query.MoveNext(out var uid, out var deployer))
+        {
+            if (deployer.AlertLevelRequired == null || !deployer.IsDeployed)
+                continue;
+
+            if (deployer.AlertLevelRequired > ev.Level)
+                TryDeploy(uid, false);
+        }
     }
 
     private void OnMapInit(Entity<RMCEquipmentDeployerComponent> ent, ref MapInitEvent args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Pump sentries automatically undeploy on green or blue alert.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Currently you can already do this manually, but I rarely see people do it.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon.
- tweak: Pump sentries now automatically undeploy on green and blue alert.