### PR TITLE
Gave the M2C a deploy delay

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/HMGs/weapon_mounts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/HMGs/weapon_mounts.yml
@@ -272,7 +272,7 @@
     mountOnDeploy: true
     mountExclusionAreaSize: 0
     barricadeExclusionAreaSize: 2
-    assembleDelay: 0.5
+    assembleDelay: 3
     undeploySound: null
     acidableWhileUndeployed: true
   - type: Tag


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed the deploy delay from 0.5 seconds to 3 seconds.
## Why / Balance
I think of HMGs as more of a preparation than a gun you just instantly plop down the second you feel slightly threatened. 
Three seconds is a good amount of time for an actual humanoid to to set up the tripod and climb on, maybe even not enough. An M2C wielder could just deploy it right at the front and kill the queen before it even overheats. That is BS.

## Media

<img width="426" height="240" alt="newm2c" src="https://github.com/user-attachments/assets/7a3c7f13-659e-4103-9edb-62d8b4abc6db" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The M2C now has a 3 second delay before deploying.

