### PR TITLE
Tweak: Xeno eggs abort infection if you leave a 4x4 radius or no other hosts is in that area

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
@@ -86,6 +86,9 @@ public sealed class XenoEggSystem : EntitySystem
     private static readonly ProtoId<TagPrototype> AirlockTag = "Airlock";
     private static readonly ProtoId<TagPrototype> StructureTag = "Structure";
 
+    // Expanded infection range once egg is triggered (4x4 area)
+    private const float EggOpeningInfectRange = 2.0f;
+
     private EntityQuery<StepTriggerComponent> _stepTriggerQuery;
 
     public override void Initialize()
@@ -983,12 +986,48 @@ public sealed class XenoEggSystem : EntitySystem
 
                 if (egg.InfectTarget != null)
                 {
-                    if (!_interaction.InRangeUnobstructed(uid, egg.InfectTarget.Value))
+                    if (!_interaction.InRangeUnobstructed(uid, egg.InfectTarget.Value, EggOpeningInfectRange))
                     {
-                        // Target left the radius before the parasite could latch = abort infection
-                        egg.InfectTarget = null;
+                        // Original target left, try to find another valid target nearby
+                        EntityUid? newTarget = null;
+
+                        var infectableQuery = EntityQueryEnumerator<InfectableComponent>();
+                        while (infectableQuery.MoveNext(out var candidate, out var infectable))
+                        {
+                            if (infectable.BeingInfected || _mobState.IsDead(candidate) || HasComp<VictimInfectedComponent>(candidate))
+                                continue;
+
+                            if (!_interaction.InRangeUnobstructed(uid, candidate, EggOpeningInfectRange))
+                                continue;
+
+                            newTarget = candidate;
+                            break;
+                        }
+
+                        if (newTarget != null)
+                        {
+                            egg.InfectTarget = newTarget;
+                        }
+                        else
+                        {
+                            // No valid targets, hugger returns to egg
+                            egg.InfectTarget = null;
+                            if (egg.SpawnedCreature != null)
+                            {
+                                QueueDel(egg.SpawnedCreature.Value);
+                                egg.SpawnedCreature = null;
+                            }
+
+                            egg.OpenAt = null;
+                            SetEggState((uid, egg), XenoEggState.Grown);
+                            Dirty(uid, egg);
+                            continue;
+                        }
                     }
-                    else if (TryComp<XenoParasiteComponent>(egg.SpawnedCreature, out var para))
+
+                    if (egg.InfectTarget != null &&
+                        _interaction.InRangeUnobstructed(uid, egg.InfectTarget.Value, EggOpeningInfectRange) &&
+                        TryComp<XenoParasiteComponent>(egg.SpawnedCreature, out var para))
                     {
                         _parasite.Infect((egg.SpawnedCreature.Value, para), egg.InfectTarget.Value, force: true);
                         _stun.TryParalyze(egg.InfectTarget.Value, egg.KnockdownTime, true);

--- a/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
@@ -986,9 +986,15 @@ public sealed class XenoEggSystem : EntitySystem
 
                 if (egg.InfectTarget != null)
                 {
-                    if (!_interaction.InRangeUnobstructed(uid, egg.InfectTarget.Value, EggOpeningInfectRange))
+                    // Check distance only, walls do NOT let you escape the hugger if you're still in range
+                    var eggPos = _transform.GetMapCoordinates(uid);
+                    var targetPos = _transform.GetMapCoordinates(egg.InfectTarget.Value);
+                    var inRange = eggPos.MapId == targetPos.MapId &&
+                                  (targetPos.Position - eggPos.Position).Length() <= EggOpeningInfectRange;
+
+                    if (!inRange)
                     {
-                        // Original target left, try to find another valid target nearby
+                        // Original target left the radius, search for a new host
                         EntityUid? newTarget = null;
 
                         var infectableQuery = EntityQueryEnumerator<InfectableComponent>();
@@ -1026,7 +1032,6 @@ public sealed class XenoEggSystem : EntitySystem
                     }
 
                     if (egg.InfectTarget != null &&
-                        _interaction.InRangeUnobstructed(uid, egg.InfectTarget.Value, EggOpeningInfectRange) &&
                         TryComp<XenoParasiteComponent>(egg.SpawnedCreature, out var para))
                     {
                         _parasite.Infect((egg.SpawnedCreature.Value, para), egg.InfectTarget.Value, force: true);

--- a/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
@@ -983,7 +983,12 @@ public sealed class XenoEggSystem : EntitySystem
 
                 if (egg.InfectTarget != null)
                 {
-                    if (TryComp<XenoParasiteComponent>(egg.SpawnedCreature, out var para))
+                    if (!_interaction.InRangeUnobstructed(uid, egg.InfectTarget.Value))
+                    {
+                        // Target left the radius before the parasite could latch = abort infection
+                        egg.InfectTarget = null;
+                    }
+                    else if (TryComp<XenoParasiteComponent>(egg.SpawnedCreature, out var para))
                     {
                         _parasite.Infect((egg.SpawnedCreature.Value, para), egg.InfectTarget.Value, force: true);
                         _stun.TryParalyze(egg.InfectTarget.Value, egg.KnockdownTime, true);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
When you trigger the egg its affected radius will increase from a 3x3 to 4x4 so that its harder to outrun it in heavy armor. 
If the poor soul who activated leaves the 4x4 radius the egg will search for a new hosts in the 4x4 radius which isnt blocked by a wall.
If the poor soul who activated it re-enters the area in the just the right time they will get infected instead of somebody else
The 3x3 area around an egg is a confirmed hug zone, if you trigger the egg and don't leave that radius, infection is guaranteed. This is relevant in situations where an egg is placed near a wall and a player repeatedly walks in and out of its line of sight, as long as they stay within the 3x3 trigger radius after the initial trigger, they will be infected.
If no host is found it will instantly go back into the egg.
This will make playing around eggs a smoother Marine experience and less of a WTF moment

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
If you activate a Egg, you are guarantee to get infected unless you act fast enough and break it in a 2 second timeframe.
This leads to moments where you walk into a airlock, peek, walk out and still get infected. 
This only leads to more confusion and players instantly asking themself or others in LOOC what just happend or how this was possible. 
Eggs right now are also really punishing with how long they can stay off-weeds. You always fear to get basically round/combat removed by either being dragged off or going shipside for surgery when you peek a door or corners.
to note is that this will heavily weaken xenos like eggsac carrier and oppressors who heavily rely on this "feature" to secure captures, as they now need to make sure that the marine stays inside that radius.

## Technical details
<!-- Summary of code changes for easier review. -->
added a few lines of .cs code

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

https://github.com/user-attachments/assets/80ddc067-f74e-4712-a2a8-ec8e9326c179


https://github.com/user-attachments/assets/74905a9b-9ace-4bc0-ba2a-f550511c574e


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Triggering a xeno egg increases its infection radius by one tile. If the host who triggered it leaves this radius, the egg will seek out a new target within range. If none is found, the hugger instantly retreats back into the egg