### PR TITLE
Prevent expanding weeds through barricades

### DIFF
--- a/Content.Server/_RMC14/Xenonids/Weeds/XenoWeedsSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Weeds/XenoWeedsSystem.cs
@@ -10,6 +10,7 @@ using Content.Shared.Atmos;
 using Content.Shared.Coordinates;
 using Content.Shared.Damage;
 using Content.Shared.Maps;
+using Content.Shared.Physics;
 using Content.Shared.Tag;
 using Robust.Server.GameObjects;
 using Robust.Shared.Map.Components;
@@ -115,7 +116,7 @@ public sealed class XenoWeedsSystem : SharedXenoWeedsSystem
                     }
                 }
 
-                if (DirectionBlocker.IsDirectionBlocked(uid, cardinal))
+                if (DirectionBlocker.IsDirectionBlocked(uid, cardinal, collisionGroup: CollisionGroup.BarricadeImpassable))
                     blocked = true;
 
                 if (blocked)

--- a/Content.Server/_RMC14/Xenonids/Weeds/XenoWeedsSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Weeds/XenoWeedsSystem.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using System.Numerics;
 using Content.Server.Atmos.Components;
 using Content.Server.Spreader;
@@ -11,11 +10,9 @@ using Content.Shared.Atmos;
 using Content.Shared.Coordinates;
 using Content.Shared.Damage;
 using Content.Shared.Maps;
-using Content.Shared.Physics;
 using Content.Shared.Tag;
 using Robust.Server.GameObjects;
 using Robust.Shared.Map.Components;
-using Robust.Shared.Physics;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
@@ -32,7 +29,6 @@ public sealed class XenoWeedsSystem : SharedXenoWeedsSystem
     [Dependency] private readonly AppearanceSystem _appearance = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly TurfSystem _turf = default!;
-    [Dependency] private readonly PhysicsSystem _physics = default!;
 
     private static readonly ProtoId<TagPrototype> IgnoredTag = "SpreaderIgnore";
 
@@ -119,13 +115,7 @@ public sealed class XenoWeedsSystem : SharedXenoWeedsSystem
                     }
                 }
 
-                // Do a raycast to see if any entities with offset fixtures are blocking the spread
-                var weedPosition = _transform.GetMoverCoordinates(uid).Position;
-                var ray = new CollisionRay(weedPosition, cardinal.CardinalToIntVec(), (int)CollisionGroup.BarricadeImpassable);
-                var intersect = _physics.IntersectRayWithPredicate(Transform(uid).MapID, ray, 0.6f, e => !Transform(e).Anchored);
-                var results = intersect.Select(r => r.HitEntity).ToHashSet();
-
-                if (results.Count > 0)
+                if (DirectionBlocker.IsDirectionBlocked(uid, cardinal))
                     blocked = true;
 
                 if (blocked)
@@ -158,7 +148,7 @@ public sealed class XenoWeedsSystem : SharedXenoWeedsSystem
                     break;
                 }
 
-                if (!CanSpreadWeedsPopup(grid, neighbor, null, weeds.SpreadsOnSemiWeedable))
+                if (!CanSpreadWeedsPopup(grid, neighbor, null, uid, weeds.SpreadsOnSemiWeedable))
                     continue;
 
                 if (weedsToReplace != null)

--- a/Content.Shared/_RMC14/Barricade/SharedDirectionalAttackBlockSystem.cs
+++ b/Content.Shared/_RMC14/Barricade/SharedDirectionalAttackBlockSystem.cs
@@ -152,8 +152,8 @@ public abstract class SharedDirectionalAttackBlockSystem : EntitySystem
         if (direction == Vector2.Zero)
             return false;
 
-        var weedPosition = _transform.GetMoverCoordinates(origin).Position;
-        var ray = new CollisionRay(weedPosition, direction, (int) collisionGroup);
+        var originPosition = _transform.GetMoverCoordinates(origin).Position;
+        var ray = new CollisionRay(originPosition, direction, (int) collisionGroup);
         var intersect = _physics.IntersectRayWithPredicate(Transform(origin).MapID, ray, checkRange, e => !Transform(e).Anchored);
         var results = intersect.Select(r => r.HitEntity).ToHashSet();
 

--- a/Content.Shared/_RMC14/Barricade/SharedDirectionalAttackBlockSystem.cs
+++ b/Content.Shared/_RMC14/Barricade/SharedDirectionalAttackBlockSystem.cs
@@ -1,16 +1,23 @@
+using System.Linq;
+using System.Numerics;
 using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.Random;
 using Content.Shared._RMC14.Weapons.Melee;
+using Content.Shared.Atmos;
 using Content.Shared.Damage;
 using Content.Shared.Mobs.Components;
+using Content.Shared.Physics;
 using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.Map;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Systems;
 using Robust.Shared.Timing;
 
 namespace Content.Shared._RMC14.Barricade;
 
 public abstract class SharedDirectionalAttackBlockSystem : EntitySystem
 {
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
 
@@ -123,5 +130,33 @@ public abstract class SharedDirectionalAttackBlockSystem : EntitySystem
         // Only block if the leap originates from a location that is at most one ordinal direction away from the direction the blocker is facing (135 degree cone).
         // For example, if the blocker is facing North, the leap will be blocked if it originates from a position to the South-West, South, or South-East of the blocker.
         return relativeDiff is 3 or 4 or 5; // Opposite directions
+    }
+
+    public bool IsDirectionBlocked(EntityUid origin, AtmosDirection cardinal, float checkRange = 0.6f, CollisionGroup collisionGroup = CollisionGroup.BarricadeImpassable)
+    {
+        return IsDirectionBlocked(origin, cardinal.CardinalToIntVec(), checkRange, collisionGroup);
+    }
+
+    /// <summary>
+    ///     Uses a raycast to determine if a direction from the origin is obstructed.
+    /// </summary>
+    /// <param name="origin">The entity from which the ray is cast.</param>
+    /// <param name="direction">The direction to check.</param>
+    /// <param name="checkRange">The maximum distance to check for a blocking entity.</param>
+    /// <param name="collisionGroup">The collision group used to filter blocking entities.</param>
+    /// <returns>
+    ///     True if at least one valid blocking entity is detected within range, otherwise false.
+    /// </returns>
+    public bool IsDirectionBlocked(EntityUid origin, Vector2 direction, float checkRange = 0.6f, CollisionGroup collisionGroup = CollisionGroup.BarricadeImpassable)
+    {
+        if (direction == Vector2.Zero)
+            return false;
+
+        var weedPosition = _transform.GetMoverCoordinates(origin).Position;
+        var ray = new CollisionRay(weedPosition, direction, (int) collisionGroup);
+        var intersect = _physics.IntersectRayWithPredicate(Transform(origin).MapID, ray, checkRange, e => !Transform(e).Anchored);
+        var results = intersect.Select(r => r.HitEntity).ToHashSet();
+
+        return results.Count > 0;
     }
 }

--- a/Content.Shared/_RMC14/Barricade/SharedDirectionalAttackBlockSystem.cs
+++ b/Content.Shared/_RMC14/Barricade/SharedDirectionalAttackBlockSystem.cs
@@ -132,7 +132,7 @@ public abstract class SharedDirectionalAttackBlockSystem : EntitySystem
         return relativeDiff is 3 or 4 or 5; // Opposite directions
     }
 
-    public bool IsDirectionBlocked(EntityUid origin, AtmosDirection cardinal, float checkRange = 0.6f, CollisionGroup collisionGroup = CollisionGroup.BarricadeImpassable)
+    public bool IsDirectionBlocked(EntityUid origin, AtmosDirection cardinal, float checkRange = 0.6f, CollisionGroup collisionGroup = CollisionGroup.BarricadeImpassable | CollisionGroup.BulletImpassable)
     {
         return IsDirectionBlocked(origin, cardinal.CardinalToIntVec(), checkRange, collisionGroup);
     }
@@ -147,7 +147,7 @@ public abstract class SharedDirectionalAttackBlockSystem : EntitySystem
     /// <returns>
     ///     True if at least one valid blocking entity is detected within range, otherwise false.
     /// </returns>
-    public bool IsDirectionBlocked(EntityUid origin, Vector2 direction, float checkRange = 0.6f, CollisionGroup collisionGroup = CollisionGroup.BarricadeImpassable)
+    public bool IsDirectionBlocked(EntityUid origin, Vector2 direction, float checkRange = 0.6f, CollisionGroup collisionGroup = CollisionGroup.BarricadeImpassable | CollisionGroup.BulletImpassable)
     {
         if (direction == Vector2.Zero)
             return false;

--- a/Content.Shared/_RMC14/Xenonids/Construction/Events/XenoExpandWeedsActionEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/Events/XenoExpandWeedsActionEvent.cs
@@ -17,4 +17,7 @@ public sealed partial class XenoExpandWeedsActionEvent : WorldTargetActionEvent
 
     [DataField, AutoNetworkedField]
     public FixedPoint2 SourcePlasmaCost = 260;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan NodePlaceCooldown = TimeSpan.FromSeconds(7);
 }

--- a/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
@@ -386,9 +386,6 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
 
         args.Handled = true;
 
-        if (spawnSource)
-            _actions.SetUseDelay(args.Action.Owner, args.NodePlaceCooldown);
-
         if (_net.IsServer)
         {
             var newWeeds = Spawn(toSpawn, coordinates);

--- a/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
@@ -336,22 +336,25 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
             return;
         }
 
-        Entity<XenoWeedsComponent> adjacent = default;
+        List <Entity<XenoWeedsComponent>> adjacentNodes = new ();
         if (existing == null)
         {
             var canSpread = false;
             foreach (var direction in _rmcMap.CardinalDirections)
             {
-                if (!_rmcMap.HasAnchoredEntityEnumerator(coordinates, out adjacent, direction))
+                if (!_rmcMap.HasAnchoredEntityEnumerator(coordinates, out Entity<XenoWeedsComponent> adjacent, direction))
                     continue;
+
+                adjacentNodes.Add(adjacent);
 
                 if (!_xenoWeeds.CanSpreadWeedsPopup(grid, coordinates.Position, xeno, adjacent, false, true))
                     continue;
 
                 canSpread = true;
+                break;
             }
 
-            if (adjacent == default)
+            if (adjacentNodes.Count == 0)
             {
                 _popup.PopupClient("You can only plant weeds if there is a nearby node.",
                     args.Target,
@@ -393,7 +396,7 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
             _hive.SetSameHive(xeno.Owner, newWeeds);
 
             if (existing == null)
-                _xenoWeeds.AssignSource(newWeeds, adjacent.Comp?.Source ?? adjacent);
+                _xenoWeeds.AssignSource(newWeeds, adjacentNodes.Last().Comp.Source ?? adjacentNodes.Last());
         }
 
         _audio.PlayPredicted(xeno.Comp.BuildSound, coordinates, xeno);

--- a/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
@@ -293,8 +293,7 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
             return;
         }
 
-        var tile = _mapSystem.CoordinatesToTile(gridUid, gridComp, coordinates);
-        if (!_xenoWeeds.CanSpreadWeedsPopup(grid, tile, xeno, args.UseOnSemiWeedable, true))
+        if (!_xenoWeeds.CanSpreadWeedsPopup(grid, coordinates.Position, xeno, null, args.UseOnSemiWeedable, true))
             return;
 
         if (!_xenoWeeds.CanPlaceWeedsPopup(xeno, grid, coordinates, args.LimitDistance))
@@ -340,10 +339,16 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
         Entity<XenoWeedsComponent> adjacent = default;
         if (existing == null)
         {
+            var canSpread = false;
             foreach (var direction in _rmcMap.CardinalDirections)
             {
-                if (_rmcMap.HasAnchoredEntityEnumerator(coordinates, out adjacent, direction))
-                    break;
+                if (!_rmcMap.HasAnchoredEntityEnumerator(coordinates, out adjacent, direction))
+                    continue;
+
+                if (!_xenoWeeds.CanSpreadWeedsPopup(grid, coordinates.Position, xeno, adjacent, false, true))
+                    continue;
+
+                canSpread = true;
             }
 
             if (adjacent == default)
@@ -355,13 +360,20 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
 
                 return;
             }
+
+            if (!canSpread)
+            {
+                _popup.PopupClient("An obstacle is preventing the weeds from spreading",
+                    args.Target,
+                    xeno,
+                    PopupType.MediumCaution);
+
+                return;
+            }
         }
 
-        var toSpawn = existing == null ? args.Expand : args.Source;
-        var tile = _mapSystem.CoordinatesToTile(gridUid, gridComp, coordinates);
-        if (!_xenoWeeds.CanSpreadWeedsPopup(grid, tile, xeno, false, true))
-            return;
-
+        var spawnSource = existing != null;
+        var toSpawn = !spawnSource ? args.Expand : args.Source;
         if (!_xenoWeeds.CanPlaceWeedsPopup(xeno, grid, coordinates, false))
             return;
 
@@ -370,6 +382,10 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
             return;
 
         args.Handled = true;
+
+        if (spawnSource)
+            _actions.SetUseDelay(args.Action.Owner, args.NodePlaceCooldown);
+
         if (_net.IsServer)
         {
             var newWeeds = Spawn(toSpawn, coordinates);

--- a/Content.Shared/_RMC14/Xenonids/Weeds/SharedXenoWeedsSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Weeds/SharedXenoWeedsSystem.cs
@@ -1,23 +1,21 @@
+using System.Numerics;
 using Content.Shared._RMC14.Areas;
 using Content.Shared._RMC14.Armor;
-using Content.Shared._RMC14.CCVar;
+using Content.Shared._RMC14.Barricade;
 using Content.Shared._RMC14.Communications;
 using Content.Shared._RMC14.Entrenching;
 using Content.Shared._RMC14.Map;
 using Content.Shared._RMC14.Power;
 using Content.Shared._RMC14.Xenonids.Announce;
-using Content.Shared._RMC14.Xenonids.Construction;
 using Content.Shared._RMC14.Xenonids.Construction.FloorResin;
 using Content.Shared._RMC14.Xenonids.Construction.ResinHole;
 using Content.Shared._RMC14.Xenonids.Construction.Tunnel;
 using Content.Shared._RMC14.Xenonids.Egg;
 using Content.Shared._RMC14.Xenonids.Hive;
-using Content.Shared._RMC14.Xenonids.ManageHive.Boons;
 using Content.Shared._RMC14.Xenonids.Rest;
 using Content.Shared._RMC14.Xenonids.Designer;
 using Content.Shared.Climbing.Components;
 using Content.Shared.Coordinates;
-using Content.Shared.Coordinates.Helpers;
 using Content.Shared.Damage;
 using Content.Shared.Examine;
 using Content.Shared.GameTicking;
@@ -44,13 +42,12 @@ namespace Content.Shared._RMC14.Xenonids.Weeds;
 
 public abstract class SharedXenoWeedsSystem : EntitySystem
 {
+    [Dependency] protected readonly SharedDirectionalAttackBlockSystem DirectionBlocker = default!;
+
     [Dependency] private readonly AreaSystem _area = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
-    [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] private readonly SharedContainerSystem _container = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
-    [Dependency] private readonly EntityWhitelistSystem _entityWhitelist = default!;
-    [Dependency] private readonly SharedGameTicker _gameTicker = default!;
     [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
     [Dependency] private readonly IMapManager _map = default!;
     [Dependency] private readonly SharedMapSystem _mapSystem = default!;
@@ -64,8 +61,6 @@ public abstract class SharedXenoWeedsSystem : EntitySystem
     [Dependency] private readonly ITileDefinitionManager _tile = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
-    [Dependency] private readonly EntityManager _entities = default!;
-    [Dependency] private readonly SharedXenoAnnounceSystem _xenoAnnounce = default!;
     [Dependency] private readonly WeedboundWallSystem _weedboundWall = default!;
     [Dependency] private readonly DesignerNodeBindingSystem _designerBinding = default!;
 
@@ -515,7 +510,7 @@ public abstract class SharedXenoWeedsSystem : EntitySystem
         Dirty(ent);
     }
 
-    public bool CanSpreadWeedsPopup(Entity<MapGridComponent> grid, Vector2i tile, EntityUid? user, bool semiWeedable = false, bool source = false)
+    public bool CanSpreadWeedsPopup(Entity<MapGridComponent> grid, Vector2 tile, EntityUid? user, EntityUid? spreadFrom, bool semiWeedable = false, bool source = false)
     {
         if (!_mapSystem.TryGetTileRef(grid, grid, tile, out var tileRef) ||
             !_tile.TryGetDefinition(tileRef.Tile.TypeId, out var tileDef) ||
@@ -528,10 +523,20 @@ public abstract class SharedXenoWeedsSystem : EntitySystem
             return false;
         }
 
-        if (!_area.CanResinPopup((grid, grid, null), tile, user))
+        if (!_area.CanResinPopup((grid, grid, null), (Vector2i) tile, user))
             return false;
 
-        var targetTileAnchored = _mapSystem.GetAnchoredEntitiesEnumerator(grid, grid, tile);
+        if (spreadFrom is { } spreadOrigin && !TerminatingOrDeleted(spreadOrigin))
+        {
+            var originPos = _transform.GetMoverCoordinates(spreadOrigin).Position;
+            var direction = (tile - originPos).Normalized();
+
+            // Do a raycast to see if any entities with offset fixtures are blocking the spread
+            if (DirectionBlocker.IsDirectionBlocked(spreadOrigin, direction))
+                return false;
+        }
+
+        var targetTileAnchored = _mapSystem.GetAnchoredEntitiesEnumerator(grid, grid, (Vector2i) tile);
         while (targetTileAnchored.MoveNext(out var uid))
         {
             if (_blockWeedsQuery.HasComp(uid))


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

- The Queen's "Expand Weeds" action no longer works if the only available nearby weed tile is on the other side of a barricade.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix: The Queen's "Expand Weeds" ability no longer expands weeds through barricades.
