### PR TITLE
[RCM] BUGFIX: Tags for Warwick MkVII and F-S Knife

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Revolvers/warwick.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Revolvers/warwick.yml
@@ -5,13 +5,15 @@
   description: The L187 Warwick MkVII top-break revolver is the standard-issue service revolver of the RCM’s Paramarine regiments. Despite the Warwick's archaic design, the MkVII's vacuum-sealed internals, bakelite grips, and .44 magnum chambering keep the weapon relevant and brutally effective.
   suffix: Paramarine
   components:
-    - type: Sprite
-      sprite: _RMC14/Objects/Weapons/Guns/Pistols/warwick.rsi
-    - type: Clothing
-      sprite: _RMC14/Objects/Weapons/Guns/Pistols/warwick.rsi
-    - type: Tag
-      tags:
-      - RMCWeaponRevolverWarwickMkVII
+  - type: Sprite
+    sprite: _RMC14/Objects/Weapons/Guns/Pistols/warwick.rsi
+  - type: Clothing
+    sprite: _RMC14/Objects/Weapons/Guns/Pistols/warwick.rsi
+  - type: Tag
+    tags:
+    - Sidearm
+    - RMCRevolver
+    - RMCWeaponRevolverWarwickMkVII
 
 - type: entity
   parent: RMCWeaponRevolverWarwickMkVII
@@ -19,10 +21,10 @@
   name: Warwick MkVII service revolver
   suffix: Paramarine, Alt
   components:
-    - type: Sprite
-      sprite: _RMC14/Objects/Weapons/Guns/Pistols/warwick_alt.rsi
-    - type: Clothing
-      sprite: _RMC14/Objects/Weapons/Guns/Pistols/warwick_alt.rsi
+  - type: Sprite
+    sprite: _RMC14/Objects/Weapons/Guns/Pistols/warwick_alt.rsi
+  - type: Clothing
+    sprite: _RMC14/Objects/Weapons/Guns/Pistols/warwick_alt.rsi
 
 - type: entity
   parent: RMCWeaponRevolverWarwickMkVII
@@ -31,10 +33,10 @@
   description: The L187 Warwick MkVII top-break revolver is the standard-issue service revolver of the RCM’s Paramarine regiments. This particular variant features a snubnose barrel and reduced profile grip, keeping the weapon compact and light.
   suffix: RCM, Loadout
   components:
-    - type: Sprite
-      sprite: _RMC14/Objects/Weapons/Guns/Pistols/warwick_snub.rsi
-    - type: Clothing
-      sprite: _RMC14/Objects/Weapons/Guns/Pistols/warwick_snub.rsi
+  - type: Sprite
+    sprite: _RMC14/Objects/Weapons/Guns/Pistols/warwick_snub.rsi
+  - type: Clothing
+    sprite: _RMC14/Objects/Weapons/Guns/Pistols/warwick_snub.rsi
 
 - type: Tag
   id: RMCWeaponRevolverWarwickMkVII

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Melee/knife.yml
@@ -232,6 +232,7 @@
     malus: 0.225
   - type: Tag
     tags:
+    - Knife
     - ThrowingKnife
   - type: DeleteOnExplosion
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes tags for the Warwick and Fairbairn-Sykes knife

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug fixing

## Technical details
<!-- Summary of code changes for easier review. -->
YAML

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: The Warwick MkVII revolver now has the correct tags and should fit in appropriate webbings, belts, etc.