### PR TITLE
Minor type 71 fixes

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/type71c.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/type71c.yml
@@ -54,7 +54,7 @@
           - RMCMagazineRifleType71
           - RMCMagazineRifleType71AP
           - RMCMagazineRifleType71HEAP
-        startingItem: RMCMagazineRifleType71
+        startingItem: RMCMagazineRifleType71AP
   - type: GunDamageModifier
     multiplier: 0.8
   - type: AttachableHolder


### PR DESCRIPTION
## About the PR
The AP type 71's on sorokyne are now AP type 71c's

## Why / Balance
parity blast
<img width="754" height="246" alt="obraz" src="https://github.com/user-attachments/assets/b903d7e6-e384-48af-a635-9e4c7a70e740" />

## Technical details
yaml and map

## Media

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: The AP Type 71's on Sorokyne are now AP Type 71C's