### PR TITLE
M37 attachment visuals

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/m3717.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/m3717.yml
@@ -72,6 +72,12 @@
     tags:
     - RMCWeaponShotgunM3717
     - RMCWeaponShotgun
+  - type: AttachableHolderVisuals
+    offsets:
+      rmc-aslot-barrel: 0.78, .02
+      rmc-aslot-rail: -0.05, 0.125
+      rmc-aslot-stock: -0.52, -0.029
+      rmc-aslot-underbarrel: 0.30, -0.330
 
 - type: Tag
   id: RMCWeaponShotgunM3717


### PR DESCRIPTION
## About the PR
you can see attachments on the m37 now

## Why / Balance
this bothered me deeply

## Technical details
5000 lines of yaml

## Media
<img width="434" height="257" alt="obraz" src="https://github.com/user-attachments/assets/bf402aee-253a-4702-a55b-790a8242e236" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed attachments being invisible on the M37-17 shotgun
