### PR TITLE
[Fix] Parasite barricade collision door fix

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
@@ -391,10 +391,7 @@ public abstract partial class SharedXenoParasiteSystem : EntitySystem
         if (TryComp(ent, out FixturesComponent? fixtures))
         {
             var fixture = fixtures.Fixtures.First();
-            if ((fixture.Value.CollisionMask & (int) CollisionGroup.AirlockLayer & (int) CollisionGroup.BarricadeImpassable) != 0)
-                return;
-
-            _physics.SetCollisionMask(ent, fixture.Key, fixture.Value, fixture.Value.CollisionMask ^ (int) ThrownCollisionGroup);
+            _physics.SetCollisionMask(ent, fixture.Key, fixture.Value, fixture.Value.CollisionMask & ~(int) ThrownCollisionGroup);
         }
     }
 


### PR DESCRIPTION
## About the PR
Fixes #9552 

## Why / Balance
XOR caused collision layers to be re-toggled causing the bug.
Which is why hitting barricade caused parasite to be unable to walk through doors and only leaping without hitting anything fixed it.

## Technical details
XOR toggles ON if OFF; OFF if ON. 
OnParasiteLeapStopped (which happens when hitting barbed barricade)reverted parasite collision back to normal after leap hits barricade,
OnParasiteLands runs as well causing XOR logic to turn it back on causing the bug.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed parasites not being able to walk through doors after colliding with barbed metal barricades.

