### PR TITLE
Powerloader soul (#9772) lore removed

### DIFF
--- a/Content.Client/_RMC14/Buckle/RMCBuckleVisualsSystem.cs
+++ b/Content.Client/_RMC14/Buckle/RMCBuckleVisualsSystem.cs
@@ -14,11 +14,14 @@ public sealed class RMCBuckleVisualsSystem : EntitySystem
 
     public override void Initialize()
     {
-        SubscribeLocalEvent<BuckleComponent, AfterAutoHandleStateEvent>(OnBuckleState);
+        SubscribeLocalEvent<BuckleComponent, AfterAutoHandleStateEvent>(UpdateDrawDepth);
+        SubscribeLocalEvent<StrapComponent, AfterAutoHandleStateEvent>(UpdateDrawDepth);
+
         SubscribeLocalEvent<RMCBuckleDrawDepthComponent, GetDrawDepthEvent>(OnGetDrawDepth, after: [typeof(XenoVisualizerSystem)]);
+        SubscribeLocalEvent<RMCStrapDrawDepthComponent, GetDrawDepthEvent>(OnGetDrawDepth, after: [typeof(XenoVisualizerSystem)]);
     }
 
-    private void OnBuckleState(Entity<BuckleComponent> ent, ref AfterAutoHandleStateEvent args)
+    private void UpdateDrawDepth<T>(Entity<T> ent, ref AfterAutoHandleStateEvent args) where T : IComponent?
     {
         _rmcSprite.UpdateDrawDepth(ent.Owner);
     }
@@ -31,6 +34,14 @@ public sealed class RMCBuckleVisualsSystem : EntitySystem
         {
             args.DrawDepth = (DrawDepth) drawDepth;
         }
+    }
+
+    private void OnGetDrawDepth(Entity<RMCStrapDrawDepthComponent> ent, ref GetDrawDepthEvent args)
+    {
+        if (TryComp(ent, out StrapComponent? strap) && strap.BuckledEntities.Count > 0)
+            args.DrawDepth = ent.Comp.StrappedDepth;
+        else
+            args.DrawDepth = ent.Comp.UnstrappedDepth;
     }
 
     private int? GetDrawDepth(Entity<BuckleComponent> buckle, Entity<StrapComponent> strap)

--- a/Content.Shared/_RMC14/Buckle/RMCBuckleSystem.cs
+++ b/Content.Shared/_RMC14/Buckle/RMCBuckleSystem.cs
@@ -14,6 +14,7 @@ namespace Content.Shared._RMC14.Buckle;
 
 public sealed class RMCBuckleSystem : EntitySystem
 {
+    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly SharedBuckleSystem _buckle = default!;
     [Dependency] private readonly SharedCrashLandSystem _crashLand = default!;
     [Dependency] private readonly EntityLookupSystem _entityLookup = default!;

--- a/Content.Shared/_RMC14/Buckle/RMCStrapDrawDepthComponent.cs
+++ b/Content.Shared/_RMC14/Buckle/RMCStrapDrawDepthComponent.cs
@@ -1,0 +1,14 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Buckle;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(RMCBuckleSystem))]
+public sealed partial class RMCStrapDrawDepthComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public DrawDepth.DrawDepth UnstrappedDepth = DrawDepth.DrawDepth.Mobs;
+
+    [DataField, AutoNetworkedField]
+    public DrawDepth.DrawDepth StrappedDepth = DrawDepth.DrawDepth.Mobs;
+}

--- a/Resources/Prototypes/_RMC14/Entities/Objects/PowerLoader/rmc_power_loader.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/PowerLoader/rmc_power_loader.yml
@@ -1,4 +1,5 @@
-﻿- type: entity
+﻿# Base
+- type: entity
   abstract: true
   id: RMCMechBase
   components:
@@ -9,7 +10,8 @@
     noRot: true
     sprite: _RMC14/Objects/power_loader.rsi
     layers:
-    - state: powerloader
+    - state: powerloader_open
+      map: [ "buckledLayer" ]
   - type: MobMover
   - type: DoAfter
   - type: MeleeWeapon
@@ -54,10 +56,28 @@
   - type: FootstepModifier
     footstepSoundCollection:
       path: /Audio/Mecha/sound_mecha_powerloader_step.ogg
+  - type: RMCAllowStrapMovement
   - type: Strap
+    buckleSound:
+      path: /Audio/_RMC14/Mecha/powerloader_buckle.ogg
+      params:
+        variation: 0.1
+    unbuckleSound:
+      path: /Audio/_RMC14/Mecha/powerloader_unbuckle.ogg
+      params:
+        variation: 0.1
     blacklist:
       components:
       - Xeno
+  - type: RMCStrapDrawDepth
+    unstrappedDepth: Mobs
+    strappedDepth: OverMobs
+  - type: GenericVisualizer
+    visuals:
+      enum.StrapVisuals.State:
+        buckledLayer:
+          True: { state: powerloader_overlay }
+          False: { state: powerloader_open }
   - type: Destructible
     thresholds:
     - trigger:
@@ -75,15 +95,16 @@
       - !type:DoActsBehavior
         acts: ["Destruction"]
 
+# Wreckages
 - type: entity
   id: RMCMechPowerLoaderWreckage
-  name: LU-50 Power loader wreckage
-  description: The wreckage of a LU-50 Power loader.
+  name: LU-50 Power Loader wreckage
+  description: The wreckage of a LU-50 Power Loader.
   components:
   - type: Corrodible
     isCorrodible: true
   - type: Sprite
-    drawdepth: Mobs
+    drawdepth: BelowMobs
     noRot: true
     sprite: _RMC14/Objects/power_loader.rsi
     layers:
@@ -115,11 +136,11 @@
 - type: entity
   parent: RMCMechPowerLoaderWreckage
   id: RMCMechPowerLoaderWreckageGreen
-  name: LU-43 Power loader wreckage
-  description: The wreckage of a LU-43 Power loader.
+  name: Fujin 4100 Power Loader wreckage
+  description: The wreckage of a Fujin 4100 Power Loader.
   components:
   - type: Sprite
-    drawdepth: Mobs
+    drawdepth: BelowMobs
     noRot: true
     sprite: _RMC14/Objects/power_loader.rsi
     layers:
@@ -128,23 +149,23 @@
 - type: entity
   parent: RMCMechPowerLoaderWreckage
   id: RMCMechPowerLoaderWreckageBlue
-  name: LU-52 Power loader wreckage
-  description: The wreckage of a LU-52 Power loader.
+  name: Ferret Heavy Industries Mk4 Power Loader wreckage
+  description: The wreckage of a Ferret Heavy Industries Mk4 Power Loader.
   components:
   - type: Sprite
-    drawdepth: Mobs
+    drawdepth: BelowMobs
     noRot: true
     sprite: _RMC14/Objects/power_loader.rsi
     layers:
     - state: wreck_ft
 
+# Powerloaders
 - type: entity
   parent: RMCMechBase
   id: RMCMechPowerLoader
-  name: LU-50 Power loader
-  description: An old Fujin design refurbished by Weston-Yamada used in warehouses, constructions and military ships everywhere. # TODO RMC14 BETTER DESCRIPTION
+  name: LU-50 Power Loader
+  description: The LU-50 Power Loader is a commercial mechanized exoskeleton used for lifting heavy materials and objects, first designed on October 28, 2025 by the Weston Corporation. An old but trusted design used in warehouses, constructions and military ships everywhere.
   components:
-  - type: RMCAllowStrapMovement
   - type: PowerLoader
     skills:
       all:
@@ -167,29 +188,37 @@
 - type: entity
   parent: RMCMechPowerLoader
   id: RMCMechPowerLoaderGreen
-  name: LU-43 Power loader
-  description: An really old but trusted design used in warehouses, constructions and military ships everywhere. This one has a signature green and yellow livery of Fujin. The label claims they make electronics and machinery, though you’ve never heard of them before. # TODO RMC14 BETTER DESCRIPTION
+  name: Fujin 4100 Power Loader
+  description: The Fujin 4100 Power Loader is a commercial mechanized exoskeleton used for lifting heavy materials and objects based on the LU-50 Power Loader, first designed on October 28, 2025 by the Weston Corporation. An old but trusted design used in warehouses, constructions and military ships everywhere. This one has a signature green and yellow livery of Fujin. The label claims they make electronics and machinery, though you've never heard of them before.
   components:
   - type: Sprite
-    drawdepth: Mobs
-    noRot: true
-    sprite: _RMC14/Objects/power_loader.rsi
     layers:
-    - state: powerloader_jd
+    - state: powerloader_open_jd
+      map: [ "buckledLayer" ]
+  - type: GenericVisualizer
+    visuals:
+      enum.StrapVisuals.State:
+        buckledLayer:
+          True: { state: powerloader_overlay_jd }
+          False: { state: powerloader_open_jd }
   - type: SpawnOnTerminate
     spawn: RMCMechPowerLoaderWreckageGreen
 
 - type: entity
   parent: RMCMechPowerLoader
   id: RMCMechPowerLoaderBlue
-  name: LU-52 Power loader
-  description: A modernized design made to outdo the older models once used in fancy ports and facilities. It was built by Ferret Heavy Industries before they went bankrupt, making these units surprisingly affordable. # TODO RMC14 BETTER DESCRIPTION
+  name: Ferret Heavy Industries Mk4 Power Loader
+  description: The Ferret Heavy Industries Mk4 Power Loader is a commercial mechanized exoskeleton used for lifting heavy materials and objects based on the LU-50, first designed on October 28, 2025 by the Weston Corporation. An old but trusted design used in warehouses, constructions and military ships everywhere. This one has the signature blue and white livery of the now defunct Ferret Heavy Industries that went bankrupt in 2123.
   components:
   - type: Sprite
-    drawdepth: Mobs
-    noRot: true
-    sprite: _RMC14/Objects/power_loader.rsi
     layers:
-    - state: powerloader_ft
+    - state: powerloader_open_ft
+      map: [ "buckledLayer" ]
+  - type: GenericVisualizer
+    visuals:
+      enum.StrapVisuals.State:
+        buckledLayer:
+          True: { state: powerloader_overlay_ft }
+          False: { state: powerloader_open_ft }
   - type: SpawnOnTerminate
     spawn: RMCMechPowerLoaderWreckageBlue

--- a/Resources/Prototypes/_RMC14/Entities/Objects/PowerLoader/rmc_power_loader.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/PowerLoader/rmc_power_loader.yml
@@ -149,8 +149,8 @@
 - type: entity
   parent: RMCMechPowerLoaderWreckage
   id: RMCMechPowerLoaderWreckageBlue
-  name: Ferret Heavy Industries Mk4 Power Loader wreckage
-  description: The wreckage of a Ferret Heavy Industries Mk4 Power Loader.
+  name: LU-52 Power loader wreckage
+  description: The wreckage of a LU-52 Power loader.
   components:
   - type: Sprite
     drawdepth: BelowMobs
@@ -163,8 +163,8 @@
 - type: entity
   parent: RMCMechBase
   id: RMCMechPowerLoader
-  name: LU-50 Power Loader
-  description: The LU-50 Power Loader is a commercial mechanized exoskeleton used for lifting heavy materials and objects, first designed on October 28, 2025 by the Weston Corporation. An old but trusted design used in warehouses, constructions and military ships everywhere.
+  name: LU-50 Power loader
+  description: An old Fujin design refurbished by Weston-Yamada used in warehouses, constructions and military ships everywhere. # TODO RMC14 BETTER DESCRIPTION
   components:
   - type: PowerLoader
     skills:
@@ -188,8 +188,8 @@
 - type: entity
   parent: RMCMechPowerLoader
   id: RMCMechPowerLoaderGreen
-  name: Fujin 4100 Power Loader
-  description: The Fujin 4100 Power Loader is a commercial mechanized exoskeleton used for lifting heavy materials and objects based on the LU-50 Power Loader, first designed on October 28, 2025 by the Weston Corporation. An old but trusted design used in warehouses, constructions and military ships everywhere. This one has a signature green and yellow livery of Fujin. The label claims they make electronics and machinery, though you've never heard of them before.
+  name: LU-43 Power loader
+  description: An really old but trusted design used in warehouses, constructions and military ships everywhere. This one has a signature green and yellow livery of Fujin. The label claims they make electronics and machinery, though you’ve never heard of them before. # TODO RMC14 BETTER DESCRIPTION
   components:
   - type: Sprite
     layers:
@@ -207,8 +207,8 @@
 - type: entity
   parent: RMCMechPowerLoader
   id: RMCMechPowerLoaderBlue
-  name: Ferret Heavy Industries Mk4 Power Loader
-  description: The Ferret Heavy Industries Mk4 Power Loader is a commercial mechanized exoskeleton used for lifting heavy materials and objects based on the LU-50, first designed on October 28, 2025 by the Weston Corporation. An old but trusted design used in warehouses, constructions and military ships everywhere. This one has the signature blue and white livery of the now defunct Ferret Heavy Industries that went bankrupt in 2123.
+  name: LU-52 Power loader
+  description: A modernized design made to outdo the older models once used in fancy ports and facilities. It was built by Ferret Heavy Industries before they went bankrupt, making these units surprisingly affordable. # TODO RMC14 BETTER DESCRIPTION
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/PowerLoader/rmc_power_loader.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/PowerLoader/rmc_power_loader.yml
@@ -136,8 +136,8 @@
 - type: entity
   parent: RMCMechPowerLoaderWreckage
   id: RMCMechPowerLoaderWreckageGreen
-  name: Fujin 4100 Power Loader wreckage
-  description: The wreckage of a Fujin 4100 Power Loader.
+  name: LU-43 Power loader wreckage
+  description: The wreckage of a LU-43 Power loader.
   components:
   - type: Sprite
     drawdepth: BelowMobs


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Original PR from Dutch:
Added the powerloader overlay from CM13, we already had the sprites just needed to add a visualizer
Made the powerloader wrecks layer under mobs
Added the unbuckle and buckle sounds

Finished the '# TODO RMC14 BETTER DESCRIPTION' giving all the powerloaders better description with a bit of new lore
LU-43 was renamed to Fujin 4100 (John Deere Power loader in CM13)
and the Ferret industries power loader (blue one) was given the correct name and description

## Why / Balance
It's cool

## Media


https://github.com/user-attachments/assets/4e21d14d-e2e7-4a88-8789-96d9be326dd0





## Technical details
Adds ``RMCStrapDrawDepthComponent`` for controlling the draw depth of the strap when something is buckled on it

(no cl as already in)