### PR TITLE
Removed/Fixed Valkyrie retrieving dead xenonids

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Retrieve/XenoRetrieveSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Retrieve/XenoRetrieveSystem.cs
@@ -62,6 +62,12 @@ public sealed class XenoRetrieveSystem : EntitySystem
             return;
         }
 
+        if (_mobState.IsDead(target))
+        {
+            _popup.PopupClient(Loc.GetString("rmc-xeno-retrieve-dead", ("target", target)), xeno, xeno, PopupType.SmallCaution);
+            return;
+        }
+
         if (Transform(target).Anchored)
         {
             var msg = Loc.GetString("rmc-xeno-retrieve-anchored");


### PR DESCRIPTION
Added check for retrieve ability for if the target is dead and hooked it to the appropriate prompt.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removed the functionality from the Preatorian Valkyrie strain's "Retrieve" ability to pull dead xenonids by adding a check on the action.

## Why / Balance
Stops Valkyries from denying intelligence to marines from dead xenonid corpses, reportedly not able to do so in parity and already present text for the condition on why you can't.

## Technical details
Added a check on-action for the retrieve ability to check if the target is dead, if so stopping the ability and displaying the already present text for it under rmc-xeno-retrieve-dead

## Media

https://github.com/user-attachments/assets/5544c134-9cd0-4200-951d-83cfacd1c0f8



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Removed Valkyrie's ability to retrieve dead xenonids.
