### PR TITLE
[Fix] Squad tracker no longer keeps resetting to FTL

### DIFF
--- a/Content.Shared/_RMC14/Tracker/SquadLeader/SquadLeaderTrackerComponent.cs
+++ b/Content.Shared/_RMC14/Tracker/SquadLeader/SquadLeaderTrackerComponent.cs
@@ -21,6 +21,9 @@ public sealed partial class SquadLeaderTrackerComponent : Component
     public ProtoId<TrackerModePrototype>? Mode;
 
     [DataField, AutoNetworkedField]
+    public bool ManualMode;
+
+    [DataField, AutoNetworkedField]
     public EntityUid? Target;
 
     [DataField, AutoNetworkedField]

--- a/Content.Shared/_RMC14/Tracker/SquadLeader/SquadLeaderTrackerSystem.cs
+++ b/Content.Shared/_RMC14/Tracker/SquadLeader/SquadLeaderTrackerSystem.cs
@@ -115,6 +115,7 @@ public sealed class SquadLeaderTrackerSystem : EntitySystem
 
         var leaderTracker = EnsureComp<SquadLeaderTrackerComponent>(args.Equipee);
         leaderTracker.TrackerModes = ent.Comp.TrackerModes;
+        leaderTracker.ManualMode = false;
         SetMode((args.Equipee, leaderTracker), ent.Comp.DefaultMode);
         Dirty(args.Equipee, leaderTracker);
     }
@@ -204,6 +205,7 @@ public sealed class SquadLeaderTrackerSystem : EntitySystem
             else
                 SetTarget(ent, null);
 
+            ent.Comp.ManualMode = true;
             SetMode(ent, args.Mode);
         }
         // There are multiple entities of the selected role, open a new ui window to choose which entity should be tracked.
@@ -238,6 +240,7 @@ public sealed class SquadLeaderTrackerSystem : EntitySystem
 
     private void OnLeaderTrackerSelectTargetEvent(Entity<SquadLeaderTrackerComponent> ent, ref LeaderTrackerSelectTargetEvent args)
     {
+        ent.Comp.ManualMode = true;
         SetTarget(ent, GetEntity(args.Target));
         SetMode(ent, args.Mode);
         Dirty(ent);
@@ -434,15 +437,15 @@ public sealed class SquadLeaderTrackerSystem : EntitySystem
 
             if (_squadLeaderTrackerQuery.TryComp(member, out var tempTracker))
             {
-                if (fireteam.Leader != null)
+                if (fireteam.Leader != null &&
+                    (!tempTracker.ManualMode || tempTracker.Mode == FireteamLeader))
                 {
                     if (TryGetEntity(fireteam?.Leader?.Id, out var fireteamLeaderUid))
                     {
                         if (fireteamLeaderUid != member)
                         {
-                            ProtoId<TrackerModePrototype> mode = "FireteamLeader";
                             SetTarget((member, tempTracker), fireteamLeaderUid);
-                            SetMode((member, tempTracker), mode);
+                            SetMode((member, tempTracker), FireteamLeader);
                         }
                     }
                 }
@@ -755,7 +758,7 @@ public sealed class SquadLeaderTrackerSystem : EntitySystem
             if (!_squadLeaderTrackerQuery.TryComp(member, out var tracker))
                 continue;
 
-            _ui.SetUiState(member, SquadLeaderTrackerUI.Key, 
+            _ui.SetUiState(member, SquadLeaderTrackerUI.Key,
                 new SquadLeaderTrackerBoundUserInterfaceState(objectives));
         }
     }


### PR DESCRIPTION
## About the PR
Fixes  #9335 Fixes #9533 Fixes #8033 while keeping the intentions of PR #7788 
No Fireteams assigned; everyone automatically tracks SL as per usual.
Marine (without manually setting a Tracker) added to Fireteam with a Lead; it will auto track the Lead.
Marine (manually set something to track), no overrides.  Manual mode essentially. 
(_If FTL is manually selected it will auto change to whomever is assigned Leader of that team_)

Taking off the headset and putting it on basically acts like turning it on and off again which resets the auto fireteam tracking assignments.

## Why / Balance
Everyone would have at some point been super confused why their trackers were being reset constantly, sometimes causing utter chaos.
Bugfixes are good!

## Technical details
added a "ManualMode" to the component that fixes all the tracking issues.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Squad tracker no longer constantly resets itself to a FTL.

