### PR TITLE
Add quick mode for target mode on dropship weapons console

### DIFF
--- a/Content.Client/_RMC14/Dropship/Weapon/DropshipWeaponsBui.cs
+++ b/Content.Client/_RMC14/Dropship/Weapon/DropshipWeaponsBui.cs
@@ -229,14 +229,15 @@ public sealed class DropshipWeaponsBui : RMCPopOutBui<DropshipWeaponsWindow>
         // var vector = Loc.GetString("rmc-dropship-weapons-vector");
         var quick = ButtonAction("quick",
             _ => SendPredictedMessage(new DropshipTerminalWeaponsQuickModeMsg(first, !compScreen.QuickMode)));
-        var north = ButtonAction("north",
-            _ => SendPredictedMessage(new DropshipTerminalWeaponsAdjustOffsetMsg(Direction.North)));
-        var south = ButtonAction("south",
-            _ => SendPredictedMessage(new DropshipTerminalWeaponsAdjustOffsetMsg(Direction.South)));
-        var east = ButtonAction("east",
-            _ => SendPredictedMessage(new DropshipTerminalWeaponsAdjustOffsetMsg(Direction.East)));
-        var west = ButtonAction("west",
-            _ => SendPredictedMessage(new DropshipTerminalWeaponsAdjustOffsetMsg(Direction.West)));
+        // TODO RMC14 fire missions: restore these quick-mode vector buttons when fire missions are implemented.
+        // var north = ButtonAction("north",
+        //     _ => SendPredictedMessage(new DropshipTerminalWeaponsAdjustOffsetMsg(Direction.North)));
+        // var south = ButtonAction("south",
+        //     _ => SendPredictedMessage(new DropshipTerminalWeaponsAdjustOffsetMsg(Direction.South)));
+        // var east = ButtonAction("east",
+        //     _ => SendPredictedMessage(new DropshipTerminalWeaponsAdjustOffsetMsg(Direction.East)));
+        // var west = ButtonAction("west",
+        //     _ => SendPredictedMessage(new DropshipTerminalWeaponsAdjustOffsetMsg(Direction.West)));
         var nightVisionOn = ButtonAction("night-vision-on",
             _ => SendPredictedMessage(new DropshipTerminalWeaponsNightVisionMsg(true)));
         var nightVisionOff = ButtonAction("night-vision-off",
@@ -267,7 +268,7 @@ public sealed class DropshipWeaponsBui : RMCPopOutBui<DropshipWeaponsWindow>
             TryGetWeapons(first, out var one, out var two, out var three, out var four, out _, out _, out _, out _, out _);
             screen.TopRow.SetData(fire, quick, four: previous, five: next);
             screen.LeftRow.SetData(one, two, three, four);
-            screen.BottomRow.SetData(exit, north, south, east, west);
+            screen.BottomRow.SetData(exit);
             screen.ScreenLabel.Text = TargetAcquisition();
         }
 

--- a/Content.Client/_RMC14/Dropship/Weapon/DropshipWeaponsBui.cs
+++ b/Content.Client/_RMC14/Dropship/Weapon/DropshipWeaponsBui.cs
@@ -152,6 +152,9 @@ public sealed class DropshipWeaponsBui : RMCPopOutBui<DropshipWeaponsWindow>
             var weapon = EntMan.GetEntity(compScreen.Weapon);
             return Loc.GetString("rmc-dropship-weapons-target-strike",
                 ("mode", compScreen.Weapon == null ? "NONE" : "WEAPON"),
+                ("targetMode", Loc.GetString(compScreen.QuickMode
+                    ? "rmc-dropship-weapons-target-mode-quick"
+                    : "rmc-dropship-weapons-target-mode-standard")),
                 ("weapon", weapon == null ? "" : weapon),
                 ("target", terminal.Target == null ? "NONE" : terminal.Target.Value),
                 ("xOffset", terminal.Offset.X),
@@ -224,6 +227,16 @@ public sealed class DropshipWeaponsBui : RMCPopOutBui<DropshipWeaponsWindow>
         var fire = ButtonAction("fire", _ => SendPredictedMessage(new DropshipTerminalWeaponsFireMsg(first)));
         var strike = Button("strike", Strike);
         // var vector = Loc.GetString("rmc-dropship-weapons-vector");
+        var quick = ButtonAction("quick",
+            _ => SendPredictedMessage(new DropshipTerminalWeaponsQuickModeMsg(first, !compScreen.QuickMode)));
+        var north = ButtonAction("north",
+            _ => SendPredictedMessage(new DropshipTerminalWeaponsAdjustOffsetMsg(Direction.North)));
+        var south = ButtonAction("south",
+            _ => SendPredictedMessage(new DropshipTerminalWeaponsAdjustOffsetMsg(Direction.South)));
+        var east = ButtonAction("east",
+            _ => SendPredictedMessage(new DropshipTerminalWeaponsAdjustOffsetMsg(Direction.East)));
+        var west = ButtonAction("west",
+            _ => SendPredictedMessage(new DropshipTerminalWeaponsAdjustOffsetMsg(Direction.West)));
         var nightVisionOn = ButtonAction("night-vision-on",
             _ => SendPredictedMessage(new DropshipTerminalWeaponsNightVisionMsg(true)));
         var nightVisionOff = ButtonAction("night-vision-off",
@@ -248,6 +261,15 @@ public sealed class DropshipWeaponsBui : RMCPopOutBui<DropshipWeaponsWindow>
             _ => SendPredictedMessage(new DropShipTerminalWeaponsEquipmentAutoDeployToggleMsg(first, false)));
         var launch = ButtonAction("fire",
             _ => SendPredictedMessage(new DropShipTerminalWeaponsLaunchOrdnanceMsg(first)));
+
+        void SetQuickTargetControls(DropshipWeaponsButtonData? previous, DropshipWeaponsButtonData? next)
+        {
+            TryGetWeapons(first, out var one, out var two, out var three, out var four, out _, out _, out _, out _, out _);
+            screen.TopRow.SetData(fire, quick, four: previous, five: next);
+            screen.LeftRow.SetData(one, two, three, four);
+            screen.BottomRow.SetData(exit, north, south, east, west);
+            screen.ScreenLabel.Text = TargetAcquisition();
+        }
 
         screen.ScreenLabel.Text = Loc.GetString("rmc-dropship-weapons-main-screen-text");
         screen.ScreenLabel.VerticalAlignment = VAlignment.Stretch;
@@ -315,8 +337,14 @@ public sealed class DropshipWeaponsBui : RMCPopOutBui<DropshipWeaponsWindow>
             case Target:
             {
                 AddTargets(out var previous, out var next);
+                if (compScreen.QuickMode)
+                {
+                    SetQuickTargetControls(previous, next);
+                    break;
+                }
+
                 screen.BottomRow.SetData(exit, five: next);
-                screen.TopRow.SetData(fire, five: previous);
+                screen.TopRow.SetData(fire, quick, five: previous);
                 // TODO RMC14 left two vector
                 screen.LeftRow.SetData(strike);
                 screen.ScreenLabel.Text = TargetAcquisition();
@@ -325,8 +353,14 @@ public sealed class DropshipWeaponsBui : RMCPopOutBui<DropshipWeaponsWindow>
             case Strike:
             {
                 AddTargets(out var previous, out var next);
+                if (compScreen.QuickMode)
+                {
+                    SetQuickTargetControls(previous, next);
+                    break;
+                }
+
                 screen.BottomRow.SetData(exit, five: next);
-                screen.TopRow.SetData(fire, five: previous);
+                screen.TopRow.SetData(fire, quick, five: previous);
                 screen.LeftRow.SetData(cancel, weapon);
                 screen.ScreenLabel.Text = TargetAcquisition();
                 break;
@@ -334,8 +368,14 @@ public sealed class DropshipWeaponsBui : RMCPopOutBui<DropshipWeaponsWindow>
             case StrikeWeapon:
             {
                 AddTargets(out var previous, out var next);
+                if (compScreen.QuickMode)
+                {
+                    SetQuickTargetControls(previous, next);
+                    break;
+                }
+
                 screen.BottomRow.SetData(exit, five: next);
-                screen.TopRow.SetData(fire, five: previous);
+                screen.TopRow.SetData(fire, quick, five: previous);
                 TryGetWeapons(first, out var one, out var two, out var three, out var four, out _, out _, out _, out _, out _);
                 screen.LeftRow.SetData(cancel, one, two, three, four);
                 screen.ScreenLabel.Text = TargetAcquisition();

--- a/Content.Shared/_RMC14/Dropship/Weapon/DropshipTerminalWeaponsComponent.cs
+++ b/Content.Shared/_RMC14/Dropship/Weapon/DropshipTerminalWeaponsComponent.cs
@@ -48,7 +48,8 @@ public sealed partial class DropshipTerminalWeaponsComponent : Component
     public record struct Screen(
         DropshipTerminalWeaponsScreen State,
         NetEntity? Weapon,
-        NetEntity? System
+        NetEntity? System,
+        bool QuickMode
     );
 
     [DataRecord]

--- a/Content.Shared/_RMC14/Dropship/Weapon/DropshipTerminalWeaponsUi.cs
+++ b/Content.Shared/_RMC14/Dropship/Weapon/DropshipTerminalWeaponsUi.cs
@@ -35,6 +35,13 @@ public sealed class DropshipTerminalWeaponsChangeScreenMsg(bool first, DropshipT
 }
 
 [Serializable, NetSerializable]
+public sealed class DropshipTerminalWeaponsQuickModeMsg(bool first, bool enabled) : BoundUserInterfaceMessage
+{
+    public readonly bool First = first;
+    public readonly bool Enabled = enabled;
+}
+
+[Serializable, NetSerializable]
 public sealed class DropshipTerminalWeaponsChooseWeaponMsg(bool first, NetEntity weapon) : BoundUserInterfaceMessage
 {
     public readonly bool First = first;

--- a/Content.Shared/_RMC14/Dropship/Weapon/SharedDropshipWeaponSystem.cs
+++ b/Content.Shared/_RMC14/Dropship/Weapon/SharedDropshipWeaponSystem.cs
@@ -1140,6 +1140,19 @@ public abstract class SharedDropshipWeaponSystem : EntitySystem
 
     private void UpdateTarget(Entity<DropshipTerminalWeaponsComponent> ent, EntityUid target)
     {
+        if (ent.Comp.Target == target)
+        {
+            if (EnsureTargetEye(ent, ent.Comp.Target) is { } currentTargetEye)
+            {
+                _eye.SetOffset(currentTargetEye, ent.Comp.Offset);
+                _eye.SetDrawLight(currentTargetEye, !ent.Comp.NightVision);
+            }
+
+            RefreshWeaponsUI(ent);
+            Dirty(ent);
+            return;
+        }
+
         RemovePvsActors(ent);
         SetTarget(ent, target);
 

--- a/Content.Shared/_RMC14/Dropship/Weapon/SharedDropshipWeaponSystem.cs
+++ b/Content.Shared/_RMC14/Dropship/Weapon/SharedDropshipWeaponSystem.cs
@@ -139,6 +139,7 @@ public abstract class SharedDropshipWeaponSystem : EntitySystem
             subs =>
             {
                 subs.Event<DropshipTerminalWeaponsChangeScreenMsg>(OnWeaponsChangeScreenMsg);
+                subs.Event<DropshipTerminalWeaponsQuickModeMsg>(OnWeaponsQuickModeMsg);
                 subs.Event<DropshipTerminalWeaponsChooseWeaponMsg>(OnWeaponsChooseWeaponMsg);
                 subs.Event<DropshipTerminalWeaponsChooseMedevacMsg>(OnWeaponsChooseMedevacMsg);
                 subs.Event<DropshipTerminalWeaponsChooseFultonMsg>(OnWeaponsChooseFultonMsg);
@@ -499,6 +500,19 @@ public abstract class SharedDropshipWeaponSystem : EntitySystem
 
         if (args.Screen == StrikeWeapon)
             screen.Weapon = null;
+
+        Dirty(ent);
+        RefreshWeaponsUI(ent);
+    }
+
+    private void OnWeaponsQuickModeMsg(Entity<DropshipTerminalWeaponsComponent> ent, ref DropshipTerminalWeaponsQuickModeMsg args)
+    {
+        ref var screen = ref args.First ? ref ent.Comp.ScreenOne : ref ent.Comp.ScreenTwo;
+        if (screen.State is not (Target or Strike or StrikeWeapon))
+            return;
+
+        screen.QuickMode = args.Enabled;
+        screen.State = Target;
 
         Dirty(ent);
         RefreshWeaponsUI(ent);

--- a/Resources/Locale/en-US/_RMC14/dropship/rmc-dropship.ftl
+++ b/Resources/Locale/en-US/_RMC14/dropship/rmc-dropship.ftl
@@ -58,10 +58,11 @@ rmc-dropship-weapons-fire = FIRE
 rmc-dropship-weapons-strike = STRIKE
 rmc-dropship-weapons-vector = VECTOR
 rmc-dropship-weapons-quick = QUICK
-rmc-dropship-weapons-north = NORTH
-rmc-dropship-weapons-south = SOUTH
-rmc-dropship-weapons-east = EAST
-rmc-dropship-weapons-west = WEST
+# TODO RMC14 fire missions: restore these labels with fire mission vector controls.
+# rmc-dropship-weapons-north = NORTH
+# rmc-dropship-weapons-south = SOUTH
+# rmc-dropship-weapons-east = EAST
+# rmc-dropship-weapons-west = WEST
 rmc-dropship-weapons-target-mode-quick = QUICK
 rmc-dropship-weapons-target-mode-standard = STANDARD
 

--- a/Resources/Locale/en-US/_RMC14/dropship/rmc-dropship.ftl
+++ b/Resources/Locale/en-US/_RMC14/dropship/rmc-dropship.ftl
@@ -18,6 +18,8 @@ rmc-dropship-weapons-target-strike = Target Acquisition
 
   Strike mode: {$mode}
 
+  Target mode: {$targetMode}
+
   Strike configuration {$weapon}
 
   Target selected: {$target}
@@ -55,6 +57,13 @@ rmc-dropship-weapons-offset-calibration-does-not-affect-direct-bombardment = Doe
 rmc-dropship-weapons-fire = FIRE
 rmc-dropship-weapons-strike = STRIKE
 rmc-dropship-weapons-vector = VECTOR
+rmc-dropship-weapons-quick = QUICK
+rmc-dropship-weapons-north = NORTH
+rmc-dropship-weapons-south = SOUTH
+rmc-dropship-weapons-east = EAST
+rmc-dropship-weapons-west = WEST
+rmc-dropship-weapons-target-mode-quick = QUICK
+rmc-dropship-weapons-target-mode-standard = STANDARD
 
 rmc-dropship-weapons-night-vision-on = NV-ON
 rmc-dropship-weapons-night-vision-off = NV-OFF


### PR DESCRIPTION
## About the PR

Adds Quick Mode to the dropship weapons console target flow, based on the CMSS13 quick target mode behavior from cmss13-devs/cmss13#10837.

Quick Mode lets operators select an attached direct-fire dropship weapon directly from the target acquisition screen instead of going through the full `STRIKE -> WEAPON` submenu flow. The normal flow is still available and unchanged.

## Why / Balance

This is a usability improvement for CAS operators. It reduces menu friction when swapping between direct-fire weapons while keeping the existing target acquisition and firing requirements intact.

## Technical details

- Added networked per-screen `QuickMode` state to `DropshipTerminalWeaponsComponent.Screen`, so each MFD can independently be in standard or quick target mode.
- Added `DropshipTerminalWeaponsQuickModeMsg` BUI message and shared handling in `SharedDropshipWeaponSystem`.
- Added a `QUICK` button to the target/strike/strike weapon flows.
- In quick mode:
  - top row keeps `FIRE`, `QUICK`, and target pagination controls;
  - left row shows directly selectable attached weapons;
  - right row keeps target selection;
  - bottom row only keeps `EXIT`.
- Added target mode text to the target acquisition readout: `QUICK` / `STANDARD`.
- Left fire mission vector controls commented as TODOs.
- Added a content-side guard for reselecting the already selected target, avoiding unnecessary target PVS remove/add churn when both MFDs interact with the same target.

## Media

<img width="1372" height="1363" alt="image" src="https://github.com/user-attachments/assets/9d7d4211-606a-4d03-a2c7-2e93c7f5bd0c" />


## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

- add: Added quick target mode to the dropship weapons console.