### PR TITLE
Impeneterable Resin - Shivas

### DIFF
--- a/Resources/Maps/_RMC14/shiva.yml
+++ b/Resources/Maps/_RMC14/shiva.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 264.0.2
   forkId: ""
   forkVersion: ""
-  time: 04/20/2026 01:31:12
-  entityCount: 17433
+  time: 05/06/2026 08:10:31
+  entityCount: 17733
 maps:
 - 1
 grids:
@@ -511,7 +511,7 @@ entities:
           version: 7
         9,8:
           ind: 9,8
-          tiles: AQAAAAAAANUBAAAAAADVAQAAAAAAAQAAAAAAAA0AAAAAAAA3AAAAAAAAOgAAAAAAAA0AAAAAAAA3AAAAAAAAOQAAAAAAADkAAAAAAAA5AAAAAAAAOQAAAAAAADkAAAAAAAA5AAAAAAAAOQAAAAAAAAEAAAAAAADVAQAAAAAA1QEAAAAAAAEAAAAAAAABAAAAAAAAOAAAAAAAADsAAAAAAAABAAAAAAAAOAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAA1QEAAAAAANUBAAAAAAABAAAAAAAADQAAAAAAADgAAAAAAAA7AAAAAAAADQAAAAAAADgAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAANUBAAAAAADVAQAAAAAAAQAAAAAAAA0AAAAAAAA0AAAAAAAANgAAAAAAAA0AAAAAAAA0AAAAAAAANQAAAAAAADUAAAAAAAA1AAAAAAAANQAAAAAAADUAAAAAAAA1AAAAAAAANQAAAAAAAAEAAAAAAADVAQAAAAAA1QEAAAAAAAEAAAAAAAANAAAAAAAADQAAAAAAAAEAAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAAxAAAAAAAAMQAAAAAAADEAAAAAAAAxAAAAAAAADQAAAAAAAA0AAAAAAAABAAAAAAAA1QEAAAAAANUBAAAAAAABAAAAAAAAMQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAxAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAADEAAAAAAAABAAAAAAAAAQAAAAAAANUBAAAAAADVAQAAAAAAAQAAAAAAADEAAAAAAAANAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAMQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAxAAAAAAAAAQAAAAAAANUBAAAAAADVAQAAAAAA1QEAAAAAAAEAAAAAAAAxAAAAAAAAAQAAAAAAADUAAAAAAAA1AAAAAAAANQAAAAAAADEAAAAAAAA1AAAAAAAANQAAAAAAADUAAAAAAAA1AAAAAAAAMQAAAAAAADUAAAAAAADVAQAAAAAA1QEAAAAAANUBAAAAAAABAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAAAQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAAEAAAAAAAANAAAAAAAADQAAAAAAADEAAAAAAAABAAAAAAAAAQAAAAAAANUBAAAAAADVAQAAAAAAAQAAAAAAAA0AAAAAAABNAAAAAAAATQAAAAAAAE0AAAAAAABNAAAAAAAADQAAAAAAADEAAAAAAAABAAAAAAAAMQAAAAAAAA0AAAAAAAAxAAAAAAAAAQAAAAAAAAEAAAAAAADVAQAAAAAA1QEAAAAAAAEAAAAAAAANAAAAAAAATQAAAAAAAE0AAAAAAABNAAAAAAAATQAAAAAAAA0AAAAAAAAxAAAAAAAAAQAAAAAAADEAAAAAAAANAAAAAAAAMQAAAAAAAAEAAAAAAADVAQAAAAAA1QEAAAAAANUBAAAAAAABAAAAAAAADQAAAAAAAE0AAAAAAABNAAAAAAAATQAAAAAAAE0AAAAAAAANAAAAAAAAMQAAAAAAADEAAAAAAAAxAAAAAAAADQAAAAAAADEAAAAAAAAxAAAAAAAA1QEAAAAAANUBAAAAAADVAQAAAAAAAQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAAAQAAAAAAAAEAAAAAAADVAQAAAAAA1QEAAAAAAAEAAAAAAAANAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAADQAAAAAAADEAAAAAAAAxAAAAAAAAMQAAAAAAADEAAAAAAAAxAAAAAAAADQAAAAAAAAEAAAAAAAABAAAAAAAA1QEAAAAAANUBAAAAAAABAAAAAAAADQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAA0AAAAAAAAxAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAMQAAAAAAAA0AAAAAAAABAAAAAAAAAQAAAAAAANUBAAAAAADVAQAAAAAAAQAAAAAAAA0AAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAMQAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAADEAAAAAAAABAAAAAAAAAQAAAAAAAA==
+          tiles: AQAAAAAAANUBAAAAAADVAQAAAAAAAQAAAAAAAA0AAAAAAAA3AAAAAAAAOgAAAAAAAA0AAAAAAAA3AAAAAAAAOQAAAAAAADkAAAAAAAA5AAAAAAAAOQAAAAAAADkAAAAAAAA5AAAAAAAAOQAAAAAAAAEAAAAAAADVAQAAAAAA1QEAAAAAAAEAAAAAAAABAAAAAAAAOAAAAAAAADsAAAAAAAABAAAAAAAAOAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAA1QEAAAAAANUBAAAAAAABAAAAAAAADQAAAAAAADgAAAAAAAA7AAAAAAAADQAAAAAAADgAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAANUBAAAAAADVAQAAAAAAAQAAAAAAAA0AAAAAAAA0AAAAAAAANgAAAAAAAA0AAAAAAAA0AAAAAAAANQAAAAAAADUAAAAAAAA1AAAAAAAANQAAAAAAADUAAAAAAAA1AAAAAAAANQAAAAAAAAEAAAAAAADVAQAAAAAA1QEAAAAAAAEAAAAAAAANAAAAAAAADQAAAAAAAAEAAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAAxAAAAAAAAMQAAAAAAADEAAAAAAAAxAAAAAAAADQAAAAAAAA0AAAAAAAABAAAAAAAA1QEAAAAAANUBAAAAAAABAAAAAAAAMQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAxAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAADEAAAAAAAABAAAAAAAAAQAAAAAAANUBAAAAAADVAQAAAAAAAQAAAAAAADEAAAAAAAANAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAMQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAxAAAAAAAAAQAAAAAAANUBAAAAAADVAQAAAAAA1QEAAAAAAAEAAAAAAAAxAAAAAAAAAQAAAAAAADUAAAAAAAA1AAAAAAAANQAAAAAAADEAAAAAAAA1AAAAAAAANQAAAAAAADUAAAAAAAA1AAAAAAAAMQAAAAAAADUAAAAAAADVAQAAAAAA1QEAAAAAANUBAAAAAAABAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAAAQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAAEAAAAAAAANAAAAAAAADQAAAAAAADEAAAAAAAABAAAAAAAAAQAAAAAAANUBAAAAAADVAQAAAAAAAQAAAAAAAA0AAAAAAABNAAAAAAAATQAAAAAAAE0AAAAAAABNAAAAAAAADQAAAAAAADEAAAAAAAABAAAAAAAAMQAAAAAAAA0AAAAAAAAxAAAAAAAAAQAAAAAAAAEAAAAAAADVAQAAAAAA1QEAAAAAAAEAAAAAAAANAAAAAAAATQAAAAAAAE0AAAAAAABNAAAAAAAATQAAAAAAAA0AAAAAAAAxAAAAAAAAAQAAAAAAADEAAAAAAAANAAAAAAAAMQAAAAAAAAEAAAAAAADVAQAAAAAA1QEAAAAAANUBAAAAAAABAAAAAAAADQAAAAAAAE0AAAAAAABNAAAAAAAATQAAAAAAAE0AAAAAAAANAAAAAAAAMQAAAAAAADEAAAAAAAAxAAAAAAAADQAAAAAAADEAAAAAAAAxAAAAAAAA1QEAAAAAANUBAAAAAADVAQAAAAAAAQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAAAQAAAAAAAAEAAAAAAADVAQAAAAAA1QEAAAAAAAEAAAAAAAANAAAAAAAAMQAAAAAAADEAAAAAAAAxAAAAAAAADQAAAAAAADEAAAAAAAAxAAAAAAAAMQAAAAAAADEAAAAAAAAxAAAAAAAADQAAAAAAAAEAAAAAAAABAAAAAAAA1QEAAAAAANUBAAAAAAABAAAAAAAADQAAAAAAADEAAAAAAAABAAAAAAAAMQAAAAAAAA0AAAAAAAAxAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAMQAAAAAAAA0AAAAAAAABAAAAAAAAAQAAAAAAANUBAAAAAADVAQAAAAAAAQAAAAAAAA0AAAAAAAAxAAAAAAAAAQAAAAAAADEAAAAAAAABAAAAAAAAMQAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAADEAAAAAAAABAAAAAAAAAQAAAAAAAA==
           version: 7
         8,6:
           ind: 8,6
@@ -571,7 +571,7 @@ entities:
           version: 7
         9,9:
           ind: 9,9
-          tiles: AQAAAAAAANUBAAAAAADVAQAAAAAAAQAAAAAAAA0AAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAANAAAAAAAAMQAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAADEAAAAAAAANAAAAAAAAAQAAAAAAAAEAAAAAAADVAQAAAAAA1QEAAAAAAAEAAAAAAAANAAAAAAAADQAAAAAAAAEAAAAAAAABAAAAAAAADQAAAAAAADEAAAAAAAAxAAAAAAAAMQAAAAAAADEAAAAAAAAxAAAAAAAADQAAAAAAAAEAAAAAAAABAAAAAAAA1QEAAAAAANUBAAAAAAABAAAAAAAAAQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAABAAAAAAAAAQAAAAAAANUBAAAAAADVAQAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAADEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAADVAQAAAAAA1QEAAAAAAAEAAAAAAAABAAAAAAAATAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAxAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAA1QEAAAAAANUBAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAA1AAAAAAAANQAAAAAAADUAAAAAAAA1AAAAAAAAMQAAAAAAADUAAAAAAAA1AAAAAAAANQAAAAAAADUAAAAAAAA1AAAAAAAAAQAAAAAAANUBAAAAAADVAQAAAAAAAQAAAAAAAAEAAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAADAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAAAwAAAAAAAAEAAAAAAADVAQAAAAAA1QEAAAAAAAEAAAAAAAANAAAAAAAADQAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAANAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAABAAAAAAAA1QEAAAAAANUBAAAAAAABAAAAAAAADQAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAADQAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAQAAAAAAANUBAAAAAADVAQAAAAAAAQAAAAAAAA0AAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAA0AAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAEAAAAAAADVAQAAAAAA1QEAAAAAAAEAAAAAAAANAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAANAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAADVAQAAAAAA1QEAAAAAANUBAAAAAADVAQAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAA1QEAAAAAANUBAAAAAADVAQAAAAAA1QEAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAANUBAAAAAAABAAAAAAAAAQAAAAAAANUBAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAADVAQAAAAAA1QEAAAAAANUBAAAAAADVAQAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA==
+          tiles: AQAAAAAAANUBAAAAAADVAQAAAAAAAQAAAAAAAA0AAAAAAAAxAAAAAAAAAQAAAAAAADEAAAAAAAANAAAAAAAAMQAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAADEAAAAAAAANAAAAAAAAAQAAAAAAAAEAAAAAAADVAQAAAAAA1QEAAAAAAAEAAAAAAAANAAAAAAAADQAAAAAAADEAAAAAAAAxAAAAAAAADQAAAAAAADEAAAAAAAAxAAAAAAAAMQAAAAAAADEAAAAAAAAxAAAAAAAADQAAAAAAAAEAAAAAAAABAAAAAAAA1QEAAAAAANUBAAAAAAABAAAAAAAAAQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAABAAAAAAAAAQAAAAAAANUBAAAAAADVAQAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAADEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAADVAQAAAAAA1QEAAAAAAAEAAAAAAAABAAAAAAAATAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAxAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAA1QEAAAAAANUBAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAA1AAAAAAAANQAAAAAAADUAAAAAAAA1AAAAAAAAMQAAAAAAADUAAAAAAAA1AAAAAAAANQAAAAAAADUAAAAAAAA1AAAAAAAAAQAAAAAAANUBAAAAAADVAQAAAAAAAQAAAAAAAAEAAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAADAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAAAwAAAAAAAAEAAAAAAADVAQAAAAAA1QEAAAAAAAEAAAAAAAANAAAAAAAADQAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAANAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAABAAAAAAAA1QEAAAAAANUBAAAAAAABAAAAAAAADQAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAADQAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAQAAAAAAANUBAAAAAADVAQAAAAAAAQAAAAAAAA0AAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAA0AAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAEAAAAAAADVAQAAAAAA1QEAAAAAAAEAAAAAAAANAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAANAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAADVAQAAAAAA1QEAAAAAANUBAAAAAADVAQAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAA1QEAAAAAANUBAAAAAADVAQAAAAAA1QEAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAANUBAAAAAAABAAAAAAAAAQAAAAAAANUBAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAADVAQAAAAAA1QEAAAAAANUBAAAAAADVAQAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA0AAAAAAAANAAAAAAAADQAAAAAAAA==
           version: 7
         10,9:
           ind: 10,9
@@ -44030,11 +44030,6 @@ entities:
     - type: Transform
       pos: 149.5,142.5
       parent: 1
-  - uid: 1377
-    components:
-    - type: Transform
-      pos: 149.5,143.5
-      parent: 1
   - uid: 1378
     components:
     - type: Transform
@@ -45012,11 +45007,6 @@ entities:
     components:
     - type: Transform
       pos: 206.5,122.5
-      parent: 1
-  - uid: 1564
-    components:
-    - type: Transform
-      pos: 207.5,124.5
       parent: 1
   - uid: 1565
     components:
@@ -53613,69 +53603,482 @@ entities:
     - type: Transform
       pos: 195.5,120.5
       parent: 1
-  - uid: 3173
+- proto: DoorXenoResinImpenetrable
+  entities:
+  - uid: 1564
+    components:
+    - type: Transform
+      pos: 207.5,124.5
+      parent: 1
+  - uid: 2200
     components:
     - type: Transform
       pos: 205.5,112.5
       parent: 1
-  - uid: 3174
+  - uid: 2201
     components:
     - type: Transform
       pos: 205.5,108.5
       parent: 1
-  - uid: 3175
+  - uid: 2202
     components:
     - type: Transform
       pos: 171.5,53.5
       parent: 1
-  - uid: 3176
+  - uid: 2203
     components:
     - type: Transform
       pos: 175.5,53.5
       parent: 1
-  - uid: 3177
+  - uid: 2204
     components:
     - type: Transform
       pos: 152.5,16.5
       parent: 1
-  - uid: 3178
+  - uid: 3173
     components:
     - type: Transform
       pos: 152.5,13.5
       parent: 1
-  - uid: 3179
+  - uid: 3174
     components:
     - type: Transform
       pos: 152.5,9.5
       parent: 1
-  - uid: 3180
+  - uid: 3175
     components:
     - type: Transform
       pos: 152.5,7.5
       parent: 1
-  - uid: 3181
+  - uid: 3176
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 151.5,44.5
       parent: 1
-  - uid: 3182
+  - uid: 3177
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 151.5,45.5
       parent: 1
-  - uid: 3183
+  - uid: 3178
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 148.5,43.5
       parent: 1
-  - uid: 3184
+  - uid: 3179
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 148.5,46.5
+      parent: 1
+  - uid: 16686
+    components:
+    - type: Transform
+      pos: 148.5,44.5
+      parent: 1
+  - uid: 16698
+    components:
+    - type: Transform
+      pos: 148.5,45.5
+      parent: 1
+  - uid: 17131
+    components:
+    - type: Transform
+      pos: 151.5,43.5
+      parent: 1
+  - uid: 17132
+    components:
+    - type: Transform
+      pos: 151.5,46.5
+      parent: 1
+  - uid: 17136
+    components:
+    - type: Transform
+      pos: 167.5,21.5
+      parent: 1
+  - uid: 17137
+    components:
+    - type: Transform
+      pos: 169.5,21.5
+      parent: 1
+  - uid: 17138
+    components:
+    - type: Transform
+      pos: 168.5,21.5
+      parent: 1
+  - uid: 17458
+    components:
+    - type: Transform
+      pos: 147.5,39.5
+      parent: 1
+  - uid: 17459
+    components:
+    - type: Transform
+      pos: 147.5,38.5
+      parent: 1
+  - uid: 17460
+    components:
+    - type: Transform
+      pos: 147.5,37.5
+      parent: 1
+  - uid: 17461
+    components:
+    - type: Transform
+      pos: 147.5,36.5
+      parent: 1
+  - uid: 17486
+    components:
+    - type: Transform
+      pos: 164.5,57.5
+      parent: 1
+  - uid: 17514
+    components:
+    - type: Transform
+      pos: 198.5,45.5
+      parent: 1
+  - uid: 17515
+    components:
+    - type: Transform
+      pos: 198.5,43.5
+      parent: 1
+  - uid: 17516
+    components:
+    - type: Transform
+      pos: 198.5,44.5
+      parent: 1
+  - uid: 17523
+    components:
+    - type: Transform
+      pos: 197.5,29.5
+      parent: 1
+  - uid: 17525
+    components:
+    - type: Transform
+      pos: 203.5,25.5
+      parent: 1
+  - uid: 17526
+    components:
+    - type: Transform
+      pos: 204.5,25.5
+      parent: 1
+  - uid: 17529
+    components:
+    - type: Transform
+      pos: 209.5,24.5
+      parent: 1
+  - uid: 17530
+    components:
+    - type: Transform
+      pos: 208.5,24.5
+      parent: 1
+  - uid: 17531
+    components:
+    - type: Transform
+      pos: 207.5,24.5
+      parent: 1
+  - uid: 17532
+    components:
+    - type: Transform
+      pos: 206.5,24.5
+      parent: 1
+  - uid: 17534
+    components:
+    - type: Transform
+      pos: 203.5,20.5
+      parent: 1
+  - uid: 17535
+    components:
+    - type: Transform
+      pos: 204.5,20.5
+      parent: 1
+  - uid: 17536
+    components:
+    - type: Transform
+      pos: 207.5,21.5
+      parent: 1
+  - uid: 17537
+    components:
+    - type: Transform
+      pos: 208.5,21.5
+      parent: 1
+  - uid: 17540
+    components:
+    - type: Transform
+      pos: 214.5,18.5
+      parent: 1
+  - uid: 17541
+    components:
+    - type: Transform
+      pos: 215.5,18.5
+      parent: 1
+  - uid: 17542
+    components:
+    - type: Transform
+      pos: 216.5,18.5
+      parent: 1
+  - uid: 17543
+    components:
+    - type: Transform
+      pos: 193.5,17.5
+      parent: 1
+  - uid: 17544
+    components:
+    - type: Transform
+      pos: 193.5,16.5
+      parent: 1
+  - uid: 17545
+    components:
+    - type: Transform
+      pos: 193.5,10.5
+      parent: 1
+  - uid: 17546
+    components:
+    - type: Transform
+      pos: 193.5,9.5
+      parent: 1
+  - uid: 17547
+    components:
+    - type: Transform
+      pos: 193.5,8.5
+      parent: 1
+  - uid: 17548
+    components:
+    - type: Transform
+      pos: 209.5,119.5
+      parent: 1
+  - uid: 17549
+    components:
+    - type: Transform
+      pos: 207.5,123.5
+      parent: 1
+  - uid: 17550
+    components:
+    - type: Transform
+      pos: 207.5,122.5
+      parent: 1
+  - uid: 17551
+    components:
+    - type: Transform
+      pos: 209.5,118.5
+      parent: 1
+  - uid: 17553
+    components:
+    - type: Transform
+      pos: 212.5,132.5
+      parent: 1
+  - uid: 17554
+    components:
+    - type: Transform
+      pos: 211.5,132.5
+      parent: 1
+  - uid: 17555
+    components:
+    - type: Transform
+      pos: 210.5,132.5
+      parent: 1
+  - uid: 17556
+    components:
+    - type: Transform
+      pos: 215.5,132.5
+      parent: 1
+  - uid: 17557
+    components:
+    - type: Transform
+      pos: 217.5,132.5
+      parent: 1
+  - uid: 17558
+    components:
+    - type: Transform
+      pos: 216.5,132.5
+      parent: 1
+  - uid: 17559
+    components:
+    - type: Transform
+      pos: 213.5,139.5
+      parent: 1
+  - uid: 17560
+    components:
+    - type: Transform
+      pos: 214.5,139.5
+      parent: 1
+  - uid: 17561
+    components:
+    - type: Transform
+      pos: 215.5,139.5
+      parent: 1
+  - uid: 17565
+    components:
+    - type: Transform
+      pos: 194.5,120.5
+      parent: 1
+  - uid: 17566
+    components:
+    - type: Transform
+      pos: 195.5,120.5
+      parent: 1
+  - uid: 17567
+    components:
+    - type: Transform
+      pos: 199.5,116.5
+      parent: 1
+  - uid: 17580
+    components:
+    - type: Transform
+      pos: 198.5,119.5
+      parent: 1
+  - uid: 17581
+    components:
+    - type: Transform
+      pos: 199.5,119.5
+      parent: 1
+  - uid: 17582
+    components:
+    - type: Transform
+      pos: 194.5,120.5
+      parent: 1
+  - uid: 17583
+    components:
+    - type: Transform
+      pos: 195.5,120.5
+      parent: 1
+  - uid: 17603
+    components:
+    - type: Transform
+      pos: 180.5,117.5
+      parent: 1
+  - uid: 17604
+    components:
+    - type: Transform
+      pos: 181.5,117.5
+      parent: 1
+  - uid: 17670
+    components:
+    - type: Transform
+      pos: 153.5,126.5
+      parent: 1
+  - uid: 17671
+    components:
+    - type: Transform
+      pos: 170.5,125.5
+      parent: 1
+  - uid: 17672
+    components:
+    - type: Transform
+      pos: 171.5,125.5
+      parent: 1
+  - uid: 17673
+    components:
+    - type: Transform
+      pos: 172.5,125.5
+      parent: 1
+  - uid: 17676
+    components:
+    - type: Transform
+      pos: 152.5,129.5
+      parent: 1
+  - uid: 17681
+    components:
+    - type: Transform
+      pos: 152.5,133.5
+      parent: 1
+  - uid: 17682
+    components:
+    - type: Transform
+      pos: 152.5,134.5
+      parent: 1
+  - uid: 17683
+    components:
+    - type: Transform
+      pos: 152.5,135.5
+      parent: 1
+  - uid: 17692
+    components:
+    - type: Transform
+      pos: 153.5,143.5
+      parent: 1
+  - uid: 17696
+    components:
+    - type: Transform
+      pos: 151.5,147.5
+      parent: 1
+  - uid: 17697
+    components:
+    - type: Transform
+      pos: 151.5,149.5
+      parent: 1
+  - uid: 17698
+    components:
+    - type: Transform
+      pos: 151.5,148.5
+      parent: 1
+  - uid: 17711
+    components:
+    - type: Transform
+      pos: 149.5,156.5
+      parent: 1
+  - uid: 17713
+    components:
+    - type: Transform
+      pos: 176.5,150.5
+      parent: 1
+  - uid: 17714
+    components:
+    - type: Transform
+      pos: 176.5,148.5
+      parent: 1
+  - uid: 17715
+    components:
+    - type: Transform
+      pos: 180.5,150.5
+      parent: 1
+  - uid: 17716
+    components:
+    - type: Transform
+      pos: 180.5,148.5
+      parent: 1
+  - uid: 17719
+    components:
+    - type: Transform
+      pos: 198.5,149.5
+      parent: 1
+  - uid: 17720
+    components:
+    - type: Transform
+      pos: 198.5,148.5
+      parent: 1
+  - uid: 17721
+    components:
+    - type: Transform
+      pos: 198.5,147.5
+      parent: 1
+  - uid: 17722
+    components:
+    - type: Transform
+      pos: 202.5,151.5
+      parent: 1
+  - uid: 17723
+    components:
+    - type: Transform
+      pos: 202.5,152.5
+      parent: 1
+  - uid: 17724
+    components:
+    - type: Transform
+      pos: 202.5,153.5
+      parent: 1
+  - uid: 17725
+    components:
+    - type: Transform
+      pos: 204.5,156.5
+      parent: 1
+  - uid: 17732
+    components:
+    - type: Transform
+      pos: 204.5,143.5
+      parent: 1
+  - uid: 17733
+    components:
+    - type: Transform
+      pos: 204.5,142.5
       parent: 1
 - proto: DrinkGlass
   entities:
@@ -89787,12 +90190,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 163.5,21.5
       parent: 1
-  - uid: 10012
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 164.5,21.5
-      parent: 1
   - uid: 10013
     components:
     - type: Transform
@@ -106981,18 +107378,23 @@ entities:
   - uid: 13316
     components:
     - type: Transform
-      pos: 166.5,151.5
+      pos: 150.50838,145.36969
       parent: 1
   - uid: 13317
     components:
     - type: Transform
-      pos: 166.6099,151.34616
+      pos: 151.46672,145.26544
       parent: 1
   - uid: 13318
     components:
     - type: Transform
-      pos: 167.5,151.5
+      pos: 151.57088,143.8895
       parent: 1
+    - type: UserInterface
+      actors:
+        enum.StorageUiKey.Key:
+        - invalid
+    - type: ActiveUserInterface
 - proto: RMCBoxShotgunSlugs
   entities:
   - uid: 13319
@@ -107008,7 +107410,7 @@ entities:
   - uid: 13321
     components:
     - type: Transform
-      pos: 164.6875,152.375
+      pos: 164.82597,152.41467
       parent: 1
   - uid: 17438
     components:
@@ -110296,6 +110698,943 @@ entities:
     - type: Transform
       pos: 37.5,124.5
       parent: 1
+- proto: RMCFogWallWeed30
+  entities:
+  - uid: 17144
+    components:
+    - type: Transform
+      pos: 161.5,33.5
+      parent: 1
+  - uid: 17145
+    components:
+    - type: Transform
+      pos: 160.5,33.5
+      parent: 1
+  - uid: 17444
+    components:
+    - type: Transform
+      pos: 159.5,33.5
+      parent: 1
+  - uid: 17445
+    components:
+    - type: Transform
+      pos: 158.5,33.5
+      parent: 1
+  - uid: 17446
+    components:
+    - type: Transform
+      pos: 157.5,33.5
+      parent: 1
+  - uid: 17447
+    components:
+    - type: Transform
+      pos: 156.5,33.5
+      parent: 1
+  - uid: 17448
+    components:
+    - type: Transform
+      pos: 155.5,33.5
+      parent: 1
+  - uid: 17449
+    components:
+    - type: Transform
+      pos: 154.5,33.5
+      parent: 1
+  - uid: 17450
+    components:
+    - type: Transform
+      pos: 153.5,33.5
+      parent: 1
+  - uid: 17451
+    components:
+    - type: Transform
+      pos: 152.5,33.5
+      parent: 1
+  - uid: 17452
+    components:
+    - type: Transform
+      pos: 152.5,34.5
+      parent: 1
+  - uid: 17453
+    components:
+    - type: Transform
+      pos: 152.5,35.5
+      parent: 1
+  - uid: 17454
+    components:
+    - type: Transform
+      pos: 151.5,35.5
+      parent: 1
+  - uid: 17455
+    components:
+    - type: Transform
+      pos: 150.5,35.5
+      parent: 1
+  - uid: 17456
+    components:
+    - type: Transform
+      pos: 149.5,35.5
+      parent: 1
+  - uid: 17457
+    components:
+    - type: Transform
+      pos: 148.5,35.5
+      parent: 1
+  - uid: 17464
+    components:
+    - type: Transform
+      pos: 148.5,40.5
+      parent: 1
+  - uid: 17465
+    components:
+    - type: Transform
+      pos: 148.5,41.5
+      parent: 1
+  - uid: 17466
+    components:
+    - type: Transform
+      pos: 148.5,42.5
+      parent: 1
+  - uid: 17467
+    components:
+    - type: Transform
+      pos: 148.5,47.5
+      parent: 1
+  - uid: 17468
+    components:
+    - type: Transform
+      pos: 148.5,48.5
+      parent: 1
+  - uid: 17469
+    components:
+    - type: Transform
+      pos: 148.5,49.5
+      parent: 1
+  - uid: 17470
+    components:
+    - type: Transform
+      pos: 153.5,56.5
+      parent: 1
+  - uid: 17471
+    components:
+    - type: Transform
+      pos: 154.5,56.5
+      parent: 1
+  - uid: 17472
+    components:
+    - type: Transform
+      pos: 155.5,56.5
+      parent: 1
+  - uid: 17473
+    components:
+    - type: Transform
+      pos: 156.5,56.5
+      parent: 1
+  - uid: 17474
+    components:
+    - type: Transform
+      pos: 157.5,56.5
+      parent: 1
+  - uid: 17475
+    components:
+    - type: Transform
+      pos: 159.5,56.5
+      parent: 1
+  - uid: 17476
+    components:
+    - type: Transform
+      pos: 158.5,56.5
+      parent: 1
+  - uid: 17477
+    components:
+    - type: Transform
+      pos: 160.5,56.5
+      parent: 1
+  - uid: 17478
+    components:
+    - type: Transform
+      pos: 161.5,56.5
+      parent: 1
+  - uid: 17479
+    components:
+    - type: Transform
+      pos: 162.5,56.5
+      parent: 1
+  - uid: 17480
+    components:
+    - type: Transform
+      pos: 166.5,56.5
+      parent: 1
+  - uid: 17481
+    components:
+    - type: Transform
+      pos: 167.5,56.5
+      parent: 1
+  - uid: 17482
+    components:
+    - type: Transform
+      pos: 168.5,56.5
+      parent: 1
+  - uid: 17483
+    components:
+    - type: Transform
+      pos: 169.5,56.5
+      parent: 1
+  - uid: 17484
+    components:
+    - type: Transform
+      pos: 170.5,56.5
+      parent: 1
+  - uid: 17485
+    components:
+    - type: Transform
+      pos: 171.5,56.5
+      parent: 1
+  - uid: 17489
+    components:
+    - type: Transform
+      pos: 170.5,55.5
+      parent: 1
+  - uid: 17490
+    components:
+    - type: Transform
+      pos: 170.5,54.5
+      parent: 1
+  - uid: 17491
+    components:
+    - type: Transform
+      pos: 177.5,54.5
+      parent: 1
+  - uid: 17492
+    components:
+    - type: Transform
+      pos: 176.5,54.5
+      parent: 1
+  - uid: 17493
+    components:
+    - type: Transform
+      pos: 184.5,56.5
+      parent: 1
+  - uid: 17494
+    components:
+    - type: Transform
+      pos: 185.5,56.5
+      parent: 1
+  - uid: 17495
+    components:
+    - type: Transform
+      pos: 186.5,56.5
+      parent: 1
+  - uid: 17496
+    components:
+    - type: Transform
+      pos: 187.5,56.5
+      parent: 1
+  - uid: 17497
+    components:
+    - type: Transform
+      pos: 188.5,56.5
+      parent: 1
+  - uid: 17498
+    components:
+    - type: Transform
+      pos: 198.5,51.5
+      parent: 1
+  - uid: 17499
+    components:
+    - type: Transform
+      pos: 197.5,51.5
+      parent: 1
+  - uid: 17500
+    components:
+    - type: Transform
+      pos: 196.5,51.5
+      parent: 1
+  - uid: 17501
+    components:
+    - type: Transform
+      pos: 196.5,50.5
+      parent: 1
+  - uid: 17502
+    components:
+    - type: Transform
+      pos: 196.5,49.5
+      parent: 1
+  - uid: 17503
+    components:
+    - type: Transform
+      pos: 196.5,48.5
+      parent: 1
+  - uid: 17504
+    components:
+    - type: Transform
+      pos: 197.5,48.5
+      parent: 1
+  - uid: 17505
+    components:
+    - type: Transform
+      pos: 197.5,49.5
+      parent: 1
+  - uid: 17506
+    components:
+    - type: Transform
+      pos: 197.5,50.5
+      parent: 1
+  - uid: 17507
+    components:
+    - type: Transform
+      pos: 198.5,50.5
+      parent: 1
+  - uid: 17508
+    components:
+    - type: Transform
+      pos: 205.5,51.5
+      parent: 1
+  - uid: 17509
+    components:
+    - type: Transform
+      pos: 206.5,51.5
+      parent: 1
+  - uid: 17510
+    components:
+    - type: Transform
+      pos: 207.5,51.5
+      parent: 1
+  - uid: 17511
+    components:
+    - type: Transform
+      pos: 207.5,50.5
+      parent: 1
+  - uid: 17512
+    components:
+    - type: Transform
+      pos: 206.5,50.5
+      parent: 1
+  - uid: 17513
+    components:
+    - type: Transform
+      pos: 205.5,50.5
+      parent: 1
+  - uid: 17520
+    components:
+    - type: Transform
+      pos: 207.5,44.5
+      parent: 1
+  - uid: 17521
+    components:
+    - type: Transform
+      pos: 207.5,43.5
+      parent: 1
+  - uid: 17522
+    components:
+    - type: Transform
+      pos: 207.5,42.5
+      parent: 1
+  - uid: 17570
+    components:
+    - type: Transform
+      pos: 200.5,114.5
+      parent: 1
+  - uid: 17571
+    components:
+    - type: Transform
+      pos: 200.5,113.5
+      parent: 1
+  - uid: 17572
+    components:
+    - type: Transform
+      pos: 201.5,113.5
+      parent: 1
+  - uid: 17573
+    components:
+    - type: Transform
+      pos: 202.5,113.5
+      parent: 1
+  - uid: 17574
+    components:
+    - type: Transform
+      pos: 203.5,113.5
+      parent: 1
+  - uid: 17575
+    components:
+    - type: Transform
+      pos: 204.5,113.5
+      parent: 1
+  - uid: 17576
+    components:
+    - type: Transform
+      pos: 205.5,113.5
+      parent: 1
+  - uid: 17577
+    components:
+    - type: Transform
+      pos: 200.5,118.5
+      parent: 1
+  - uid: 17578
+    components:
+    - type: Transform
+      pos: 200.5,119.5
+      parent: 1
+  - uid: 17579
+    components:
+    - type: Transform
+      pos: 200.5,120.5
+      parent: 1
+  - uid: 17584
+    components:
+    - type: Transform
+      pos: 197.5,120.5
+      parent: 1
+  - uid: 17585
+    components:
+    - type: Transform
+      pos: 196.5,120.5
+      parent: 1
+  - uid: 17586
+    components:
+    - type: Transform
+      pos: 193.5,119.5
+      parent: 1
+  - uid: 17587
+    components:
+    - type: Transform
+      pos: 193.5,118.5
+      parent: 1
+  - uid: 17588
+    components:
+    - type: Transform
+      pos: 192.5,118.5
+      parent: 1
+  - uid: 17589
+    components:
+    - type: Transform
+      pos: 191.5,118.5
+      parent: 1
+  - uid: 17590
+    components:
+    - type: Transform
+      pos: 190.5,118.5
+      parent: 1
+  - uid: 17591
+    components:
+    - type: Transform
+      pos: 189.5,118.5
+      parent: 1
+  - uid: 17592
+    components:
+    - type: Transform
+      pos: 188.5,118.5
+      parent: 1
+  - uid: 17593
+    components:
+    - type: Transform
+      pos: 187.5,118.5
+      parent: 1
+  - uid: 17594
+    components:
+    - type: Transform
+      pos: 187.5,117.5
+      parent: 1
+  - uid: 17595
+    components:
+    - type: Transform
+      pos: 186.5,117.5
+      parent: 1
+  - uid: 17596
+    components:
+    - type: Transform
+      pos: 185.5,117.5
+      parent: 1
+  - uid: 17597
+    components:
+    - type: Transform
+      pos: 184.5,117.5
+      parent: 1
+  - uid: 17598
+    components:
+    - type: Transform
+      pos: 183.5,117.5
+      parent: 1
+  - uid: 17599
+    components:
+    - type: Transform
+      pos: 182.5,117.5
+      parent: 1
+  - uid: 17600
+    components:
+    - type: Transform
+      pos: 182.5,118.5
+      parent: 1
+  - uid: 17601
+    components:
+    - type: Transform
+      pos: 179.5,118.5
+      parent: 1
+  - uid: 17602
+    components:
+    - type: Transform
+      pos: 179.5,117.5
+      parent: 1
+  - uid: 17605
+    components:
+    - type: Transform
+      pos: 178.5,117.5
+      parent: 1
+  - uid: 17606
+    components:
+    - type: Transform
+      pos: 177.5,117.5
+      parent: 1
+  - uid: 17607
+    components:
+    - type: Transform
+      pos: 177.5,118.5
+      parent: 1
+  - uid: 17608
+    components:
+    - type: Transform
+      pos: 176.5,118.5
+      parent: 1
+  - uid: 17609
+    components:
+    - type: Transform
+      pos: 175.5,118.5
+      parent: 1
+  - uid: 17610
+    components:
+    - type: Transform
+      pos: 174.5,118.5
+      parent: 1
+  - uid: 17611
+    components:
+    - type: Transform
+      pos: 174.5,119.5
+      parent: 1
+  - uid: 17612
+    components:
+    - type: Transform
+      pos: 174.5,120.5
+      parent: 1
+  - uid: 17613
+    components:
+    - type: Transform
+      pos: 175.5,120.5
+      parent: 1
+  - uid: 17614
+    components:
+    - type: Transform
+      pos: 176.5,120.5
+      parent: 1
+  - uid: 17615
+    components:
+    - type: Transform
+      pos: 176.5,121.5
+      parent: 1
+  - uid: 17616
+    components:
+    - type: Transform
+      pos: 177.5,121.5
+      parent: 1
+  - uid: 17617
+    components:
+    - type: Transform
+      pos: 177.5,123.5
+      parent: 1
+  - uid: 17618
+    components:
+    - type: Transform
+      pos: 177.5,122.5
+      parent: 1
+  - uid: 17619
+    components:
+    - type: Transform
+      pos: 177.5,124.5
+      parent: 1
+  - uid: 17620
+    components:
+    - type: Transform
+      pos: 176.5,124.5
+      parent: 1
+  - uid: 17621
+    components:
+    - type: Transform
+      pos: 176.5,125.5
+      parent: 1
+  - uid: 17622
+    components:
+    - type: Transform
+      pos: 176.5,126.5
+      parent: 1
+  - uid: 17623
+    components:
+    - type: Transform
+      pos: 176.5,127.5
+      parent: 1
+  - uid: 17624
+    components:
+    - type: Transform
+      pos: 176.5,128.5
+      parent: 1
+  - uid: 17625
+    components:
+    - type: Transform
+      pos: 176.5,129.5
+      parent: 1
+  - uid: 17626
+    components:
+    - type: Transform
+      pos: 175.5,129.5
+      parent: 1
+  - uid: 17627
+    components:
+    - type: Transform
+      pos: 174.5,129.5
+      parent: 1
+  - uid: 17628
+    components:
+    - type: Transform
+      pos: 174.5,128.5
+      parent: 1
+  - uid: 17629
+    components:
+    - type: Transform
+      pos: 173.5,128.5
+      parent: 1
+  - uid: 17630
+    components:
+    - type: Transform
+      pos: 173.5,127.5
+      parent: 1
+  - uid: 17631
+    components:
+    - type: Transform
+      pos: 173.5,126.5
+      parent: 1
+  - uid: 17632
+    components:
+    - type: Transform
+      pos: 169.5,126.5
+      parent: 1
+  - uid: 17633
+    components:
+    - type: Transform
+      pos: 169.5,127.5
+      parent: 1
+  - uid: 17634
+    components:
+    - type: Transform
+      pos: 169.5,128.5
+      parent: 1
+  - uid: 17635
+    components:
+    - type: Transform
+      pos: 168.5,128.5
+      parent: 1
+  - uid: 17636
+    components:
+    - type: Transform
+      pos: 167.5,127.5
+      parent: 1
+  - uid: 17637
+    components:
+    - type: Transform
+      pos: 167.5,128.5
+      parent: 1
+  - uid: 17638
+    components:
+    - type: Transform
+      pos: 167.5,126.5
+      parent: 1
+  - uid: 17639
+    components:
+    - type: Transform
+      pos: 167.5,124.5
+      parent: 1
+  - uid: 17640
+    components:
+    - type: Transform
+      pos: 167.5,122.5
+      parent: 1
+  - uid: 17641
+    components:
+    - type: Transform
+      pos: 167.5,121.5
+      parent: 1
+  - uid: 17642
+    components:
+    - type: Transform
+      pos: 167.5,120.5
+      parent: 1
+  - uid: 17643
+    components:
+    - type: Transform
+      pos: 167.5,119.5
+      parent: 1
+  - uid: 17644
+    components:
+    - type: Transform
+      pos: 167.5,123.5
+      parent: 1
+  - uid: 17645
+    components:
+    - type: Transform
+      pos: 167.5,118.5
+      parent: 1
+  - uid: 17646
+    components:
+    - type: Transform
+      pos: 166.5,118.5
+      parent: 1
+  - uid: 17647
+    components:
+    - type: Transform
+      pos: 165.5,118.5
+      parent: 1
+  - uid: 17648
+    components:
+    - type: Transform
+      pos: 164.5,118.5
+      parent: 1
+  - uid: 17649
+    components:
+    - type: Transform
+      pos: 163.5,118.5
+      parent: 1
+  - uid: 17650
+    components:
+    - type: Transform
+      pos: 162.5,118.5
+      parent: 1
+  - uid: 17651
+    components:
+    - type: Transform
+      pos: 161.5,118.5
+      parent: 1
+  - uid: 17652
+    components:
+    - type: Transform
+      pos: 160.5,118.5
+      parent: 1
+  - uid: 17653
+    components:
+    - type: Transform
+      pos: 159.5,118.5
+      parent: 1
+  - uid: 17654
+    components:
+    - type: Transform
+      pos: 158.5,118.5
+      parent: 1
+  - uid: 17655
+    components:
+    - type: Transform
+      pos: 158.5,119.5
+      parent: 1
+  - uid: 17656
+    components:
+    - type: Transform
+      pos: 158.5,120.5
+      parent: 1
+  - uid: 17657
+    components:
+    - type: Transform
+      pos: 158.5,121.5
+      parent: 1
+  - uid: 17658
+    components:
+    - type: Transform
+      pos: 158.5,122.5
+      parent: 1
+  - uid: 17659
+    components:
+    - type: Transform
+      pos: 158.5,123.5
+      parent: 1
+  - uid: 17660
+    components:
+    - type: Transform
+      pos: 158.5,124.5
+      parent: 1
+  - uid: 17661
+    components:
+    - type: Transform
+      pos: 158.5,125.5
+      parent: 1
+  - uid: 17662
+    components:
+    - type: Transform
+      pos: 158.5,126.5
+      parent: 1
+  - uid: 17663
+    components:
+    - type: Transform
+      pos: 158.5,127.5
+      parent: 1
+  - uid: 17664
+    components:
+    - type: Transform
+      pos: 157.5,127.5
+      parent: 1
+  - uid: 17665
+    components:
+    - type: Transform
+      pos: 156.5,127.5
+      parent: 1
+  - uid: 17666
+    components:
+    - type: Transform
+      pos: 155.5,127.5
+      parent: 1
+  - uid: 17667
+    components:
+    - type: Transform
+      pos: 154.5,127.5
+      parent: 1
+  - uid: 17678
+    components:
+    - type: Transform
+      pos: 151.5,128.5
+      parent: 1
+  - uid: 17679
+    components:
+    - type: Transform
+      pos: 151.5,131.5
+      parent: 1
+  - uid: 17680
+    components:
+    - type: Transform
+      pos: 151.5,132.5
+      parent: 1
+  - uid: 17684
+    components:
+    - type: Transform
+      pos: 153.5,136.5
+      parent: 1
+  - uid: 17685
+    components:
+    - type: Transform
+      pos: 153.5,137.5
+      parent: 1
+  - uid: 17686
+    components:
+    - type: Transform
+      pos: 153.5,138.5
+      parent: 1
+  - uid: 17687
+    components:
+    - type: Transform
+      pos: 153.5,139.5
+      parent: 1
+  - uid: 17688
+    components:
+    - type: Transform
+      pos: 153.5,140.5
+      parent: 1
+  - uid: 17689
+    components:
+    - type: Transform
+      pos: 152.5,140.5
+      parent: 1
+  - uid: 17690
+    components:
+    - type: Transform
+      pos: 152.5,141.5
+      parent: 1
+  - uid: 17691
+    components:
+    - type: Transform
+      pos: 152.5,142.5
+      parent: 1
+  - uid: 17693
+    components:
+    - type: Transform
+      pos: 152.5,144.5
+      parent: 1
+  - uid: 17694
+    components:
+    - type: Transform
+      pos: 152.5,145.5
+      parent: 1
+  - uid: 17699
+    components:
+    - type: Transform
+      pos: 151.5,146.5
+      parent: 1
+  - uid: 17700
+    components:
+    - type: Transform
+      pos: 151.5,150.5
+      parent: 1
+  - uid: 17701
+    components:
+    - type: Transform
+      pos: 150.5,150.5
+      parent: 1
+  - uid: 17702
+    components:
+    - type: Transform
+      pos: 149.5,150.5
+      parent: 1
+  - uid: 17703
+    components:
+    - type: Transform
+      pos: 149.5,151.5
+      parent: 1
+  - uid: 17704
+    components:
+    - type: Transform
+      pos: 148.5,151.5
+      parent: 1
+  - uid: 17705
+    components:
+    - type: Transform
+      pos: 148.5,152.5
+      parent: 1
+  - uid: 17706
+    components:
+    - type: Transform
+      pos: 148.5,153.5
+      parent: 1
+  - uid: 17707
+    components:
+    - type: Transform
+      pos: 148.5,154.5
+      parent: 1
+  - uid: 17708
+    components:
+    - type: Transform
+      pos: 148.5,155.5
+      parent: 1
+  - uid: 17709
+    components:
+    - type: Transform
+      pos: 148.5,157.5
+      parent: 1
+  - uid: 17710
+    components:
+    - type: Transform
+      pos: 148.5,158.5
+      parent: 1
+  - uid: 17728
+    components:
+    - type: Transform
+      pos: 199.5,146.5
+      parent: 1
+  - uid: 17729
+    components:
+    - type: Transform
+      pos: 200.5,146.5
+      parent: 1
+  - uid: 17730
+    components:
+    - type: Transform
+      pos: 201.5,146.5
+      parent: 1
+  - uid: 17731
+    components:
+    - type: Transform
+      pos: 202.5,146.5
+      parent: 1
 - proto: RMCFoodGoldenApple
   entities:
   - uid: 13826
@@ -111528,12 +112867,12 @@ entities:
   - uid: 14035
     components:
     - type: Transform
-      pos: 166.5,153.5
+      pos: 150.57529,145.28629
       parent: 1
   - uid: 14036
     components:
     - type: Transform
-      pos: 166.375,153.4375
+      pos: 151.51279,145.36969
       parent: 1
 - proto: RMCHandcuffs
   entities:
@@ -117146,7 +118485,7 @@ entities:
   - uid: 14880
     components:
     - type: Transform
-      pos: 165.64478,154.36482
+      pos: 165.69588,154.23001
       parent: 1
   - uid: 14881
     components:
@@ -124189,6 +125528,11 @@ entities:
       parent: 1
 - proto: RMCSpawnerCorpseSecurity
   entities:
+  - uid: 1377
+    components:
+    - type: Transform
+      pos: 150.5,143.5
+      parent: 1
   - uid: 16036
     components:
     - type: Transform
@@ -124198,11 +125542,6 @@ entities:
     components:
     - type: Transform
       pos: 112.5,82.5
-      parent: 1
-  - uid: 16038
-    components:
-    - type: Transform
-      pos: 174.5,153.5
       parent: 1
 - proto: RMCSpawnerCorpseWeYaGoon
   entities:
@@ -125441,7 +126780,7 @@ entities:
   - uid: 16281
     components:
     - type: Transform
-      pos: 169.6921,151.25623
+      pos: 150.56683,145.34488
       parent: 1
   - uid: 16282
     components:
@@ -125451,7 +126790,7 @@ entities:
   - uid: 16283
     components:
     - type: Transform
-      pos: 169.5,151.5
+      pos: 151.44183,145.40742
       parent: 1
   - uid: 16284
     components:
@@ -129473,8 +130812,16 @@ entities:
   - uid: 16992
     components:
     - type: Transform
-      pos: 164.64386,154.32887
+      pos: 150.50838,143.97289
       parent: 1
+    - type: RMCWeaponAccuracy
+      modifiedAccuracyMultiplier: 0.85
+    - type: UseDelay
+      delays:
+        RMCWieldDelay:
+          endTime: 89.1916437
+          startTime: 649.7993502
+          length: 0.4
   - uid: 16993
     components:
     - type: Transform
@@ -129488,8 +130835,16 @@ entities:
   - uid: 16995
     components:
     - type: Transform
-      pos: 166.5,154.5
+      pos: 150.52968,145.69633
       parent: 1
+    - type: RMCWeaponAccuracy
+      modifiedAccuracyMultiplier: 0.85
+    - type: UseDelay
+      delays:
+        RMCWieldDelay:
+          endTime: 89.1916437
+          startTime: 645.3660213
+          length: 0.4
   - uid: 16996
     components:
     - type: Transform
@@ -129498,8 +130853,16 @@ entities:
   - uid: 16997
     components:
     - type: Transform
-      pos: 166.66437,154.31105
+      pos: 151.30052,145.73802
       parent: 1
+    - type: RMCWeaponAccuracy
+      modifiedAccuracyMultiplier: 0.85
+    - type: UseDelay
+      delays:
+        RMCWieldDelay:
+          endTime: 89.1916437
+          startTime: 644.8993551
+          length: 0.4
   - uid: 16998
     components:
     - type: Transform
@@ -129584,13 +130947,29 @@ entities:
   - uid: 17004
     components:
     - type: Transform
-      pos: 165.75336,151.3539
+      pos: 150.53107,145.51775
       parent: 1
+    - type: RMCWeaponAccuracy
+      modifiedAccuracyMultiplier: 0.35
+    - type: UseDelay
+      delays:
+        RMCWieldDelay:
+          endTime: 89.1916437
+          startTime: 630.4660362
+          length: 0.4
   - uid: 17005
     components:
     - type: Transform
-      pos: 165.57904,151.54774
+      pos: 151.48941,145.55945
       parent: 1
+    - type: RMCWeaponAccuracy
+      modifiedAccuracyMultiplier: 0.35
+    - type: UseDelay
+      delays:
+        RMCWieldDelay:
+          endTime: 89.1916437
+          startTime: 632.999367
+          length: 0.4
   - uid: 17006
     components:
     - type: Transform
@@ -130256,80 +131635,247 @@ entities:
     - type: Transform
       pos: 176.5,149.5
       parent: 1
-  - uid: 17131
-    components:
-    - type: Transform
-      pos: 205.5,111.5
-      parent: 1
-  - uid: 17132
-    components:
-    - type: Transform
-      pos: 205.5,110.5
-      parent: 1
-  - uid: 17133
-    components:
-    - type: Transform
-      pos: 205.5,109.5
-      parent: 1
   - uid: 17134
     components:
     - type: Transform
       pos: 176.5,53.5
-      parent: 1
-  - uid: 17135
-    components:
-    - type: Transform
-      pos: 174.5,53.5
-      parent: 1
-  - uid: 17136
-    components:
-    - type: Transform
-      pos: 173.5,53.5
-      parent: 1
-  - uid: 17137
-    components:
-    - type: Transform
-      pos: 172.5,53.5
-      parent: 1
-  - uid: 17138
-    components:
-    - type: Transform
-      pos: 152.5,8.5
       parent: 1
   - uid: 17139
     components:
     - type: Transform
       pos: 152.5,12.5
       parent: 1
-  - uid: 17140
+- proto: WallXenoResinImpenetrable
+  entities:
+  - uid: 3180
+    components:
+    - type: Transform
+      pos: 164.5,21.5
+      parent: 1
+  - uid: 3181
+    components:
+    - type: Transform
+      pos: 205.5,111.5
+      parent: 1
+  - uid: 3182
+    components:
+    - type: Transform
+      pos: 205.5,110.5
+      parent: 1
+  - uid: 3183
+    components:
+    - type: Transform
+      pos: 205.5,109.5
+      parent: 1
+  - uid: 3184
+    components:
+    - type: Transform
+      pos: 174.5,53.5
+      parent: 1
+  - uid: 10012
+    components:
+    - type: Transform
+      pos: 173.5,53.5
+      parent: 1
+  - uid: 15604
+    components:
+    - type: Transform
+      pos: 172.5,53.5
+      parent: 1
+  - uid: 15605
+    components:
+    - type: Transform
+      pos: 152.5,8.5
+      parent: 1
+  - uid: 15606
     components:
     - type: Transform
       pos: 152.5,14.5
       parent: 1
-  - uid: 17141
+  - uid: 16038
     components:
     - type: Transform
       pos: 152.5,15.5
       parent: 1
+  - uid: 17133
+    components:
+    - type: Transform
+      pos: 165.5,21.5
+      parent: 1
+  - uid: 17135
+    components:
+    - type: Transform
+      pos: 166.5,21.5
+      parent: 1
+  - uid: 17140
+    components:
+    - type: Transform
+      pos: 170.5,21.5
+      parent: 1
+  - uid: 17141
+    components:
+    - type: Transform
+      pos: 171.5,21.5
+      parent: 1
   - uid: 17142
     components:
     - type: Transform
-      pos: 148.5,44.5
+      pos: 172.5,21.5
       parent: 1
   - uid: 17143
     components:
     - type: Transform
-      pos: 148.5,45.5
+      pos: 173.5,21.5
       parent: 1
-  - uid: 17144
+  - uid: 17462
     components:
     - type: Transform
-      pos: 151.5,43.5
+      pos: 147.5,35.5
       parent: 1
-  - uid: 17145
+  - uid: 17463
     components:
     - type: Transform
-      pos: 151.5,46.5
+      pos: 147.5,40.5
+      parent: 1
+  - uid: 17487
+    components:
+    - type: Transform
+      pos: 163.5,57.5
+      parent: 1
+  - uid: 17488
+    components:
+    - type: Transform
+      pos: 165.5,57.5
+      parent: 1
+  - uid: 17517
+    components:
+    - type: Transform
+      pos: 198.5,46.5
+      parent: 1
+  - uid: 17518
+    components:
+    - type: Transform
+      pos: 207.5,45.5
+      parent: 1
+  - uid: 17519
+    components:
+    - type: Transform
+      pos: 207.5,41.5
+      parent: 1
+  - uid: 17524
+    components:
+    - type: Transform
+      pos: 196.5,29.5
+      parent: 1
+  - uid: 17527
+    components:
+    - type: Transform
+      pos: 202.5,25.5
+      parent: 1
+  - uid: 17528
+    components:
+    - type: Transform
+      pos: 205.5,25.5
+      parent: 1
+  - uid: 17533
+    components:
+    - type: Transform
+      pos: 205.5,24.5
+      parent: 1
+  - uid: 17538
+    components:
+    - type: Transform
+      pos: 206.5,21.5
+      parent: 1
+  - uid: 17539
+    components:
+    - type: Transform
+      pos: 209.5,21.5
+      parent: 1
+  - uid: 17552
+    components:
+    - type: Transform
+      pos: 209.5,120.5
+      parent: 1
+  - uid: 17562
+    components:
+    - type: Transform
+      pos: 212.5,139.5
+      parent: 1
+  - uid: 17563
+    components:
+    - type: Transform
+      pos: 216.5,139.5
+      parent: 1
+  - uid: 17564
+    components:
+    - type: Transform
+      pos: 217.5,139.5
+      parent: 1
+  - uid: 17568
+    components:
+    - type: Transform
+      pos: 199.5,117.5
+      parent: 1
+  - uid: 17569
+    components:
+    - type: Transform
+      pos: 199.5,115.5
+      parent: 1
+  - uid: 17668
+    components:
+    - type: Transform
+      pos: 152.5,126.5
+      parent: 1
+  - uid: 17669
+    components:
+    - type: Transform
+      pos: 154.5,126.5
+      parent: 1
+  - uid: 17674
+    components:
+    - type: Transform
+      pos: 169.5,125.5
+      parent: 1
+  - uid: 17675
+    components:
+    - type: Transform
+      pos: 173.5,125.5
+      parent: 1
+  - uid: 17677
+    components:
+    - type: Transform
+      pos: 152.5,130.5
+      parent: 1
+  - uid: 17695
+    components:
+    - type: Transform
+      pos: 153.5,142.5
+      parent: 1
+  - uid: 17712
+    components:
+    - type: Transform
+      pos: 149.5,157.5
+      parent: 1
+  - uid: 17717
+    components:
+    - type: Transform
+      pos: 176.5,149.5
+      parent: 1
+  - uid: 17718
+    components:
+    - type: Transform
+      pos: 180.5,149.5
+      parent: 1
+  - uid: 17726
+    components:
+    - type: Transform
+      pos: 204.5,157.5
+      parent: 1
+  - uid: 17727
+    components:
+    - type: Transform
+      pos: 204.5,155.5
       parent: 1
 - proto: WaterCooler
   entities:

--- a/Resources/Maps/_RMC14/shiva.yml
+++ b/Resources/Maps/_RMC14/shiva.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 264.0.2
   forkId: ""
   forkVersion: ""
-  time: 05/06/2026 08:10:31
-  entityCount: 17733
+  time: 05/11/2026 11:02:34
+  entityCount: 17737
 maps:
 - 1
 grids:
@@ -47616,6 +47616,16 @@ entities:
     - type: Transform
       pos: 178.5,146.5
       parent: 1
+  - uid: 13318
+    components:
+    - type: Transform
+      pos: 150.5,145.5
+      parent: 1
+  - uid: 16995
+    components:
+    - type: Transform
+      pos: 151.5,145.5
+      parent: 1
   - uid: 17002
     components:
     - type: Transform
@@ -53679,6 +53689,11 @@ entities:
     components:
     - type: Transform
       pos: 148.5,45.5
+      parent: 1
+  - uid: 17005
+    components:
+    - type: Transform
+      pos: 168.5,125.5
       parent: 1
   - uid: 17131
     components:
@@ -107375,26 +107390,6 @@ entities:
     - type: Transform
       pos: 6.5,147.5
       parent: 1
-  - uid: 13316
-    components:
-    - type: Transform
-      pos: 150.50838,145.36969
-      parent: 1
-  - uid: 13317
-    components:
-    - type: Transform
-      pos: 151.46672,145.26544
-      parent: 1
-  - uid: 13318
-    components:
-    - type: Transform
-      pos: 151.57088,143.8895
-      parent: 1
-    - type: UserInterface
-      actors:
-        enum.StorageUiKey.Key:
-        - invalid
-    - type: ActiveUserInterface
 - proto: RMCBoxShotgunSlugs
   entities:
   - uid: 13319
@@ -111635,6 +111630,21 @@ entities:
     - type: Transform
       pos: 202.5,146.5
       parent: 1
+  - uid: 17734
+    components:
+    - type: Transform
+      pos: 151.5,127.5
+      parent: 1
+  - uid: 17735
+    components:
+    - type: Transform
+      pos: 151.5,130.5
+      parent: 1
+  - uid: 17736
+    components:
+    - type: Transform
+      pos: 152.5,127.5
+      parent: 1
 - proto: RMCFoodGoldenApple
   entities:
   - uid: 13826
@@ -112864,15 +112874,25 @@ entities:
     - type: InsideEntityStorage
 - proto: RMCGrenadeIncendiary
   entities:
+  - uid: 13317
+    components:
+    - type: Transform
+      pos: 150.52666,145.26996
+      parent: 1
   - uid: 14035
     components:
     - type: Transform
-      pos: 150.57529,145.28629
+      pos: 151.56831,145.29774
       parent: 1
-  - uid: 14036
+  - uid: 16283
     components:
     - type: Transform
-      pos: 151.51279,145.36969
+      pos: 150.52666,145.26996
+      parent: 1
+  - uid: 17737
+    components:
+    - type: Transform
+      pos: 151.58221,145.29774
       parent: 1
 - proto: RMCHandcuffs
   entities:
@@ -113416,6 +113436,11 @@ entities:
       parent: 1
 - proto: RMCItemPoolBuckshot
   entities:
+  - uid: 14036
+    components:
+    - type: Transform
+      pos: 151.5,145.5
+      parent: 1
   - uid: 14123
     components:
     - type: Transform
@@ -113645,6 +113670,11 @@ entities:
     components:
     - type: Transform
       pos: 99.5,112.5
+      parent: 1
+  - uid: 16281
+    components:
+    - type: Transform
+      pos: 150.5,145.5
       parent: 1
   - uid: 17012
     components:
@@ -126502,6 +126532,18 @@ entities:
     - type: Transform
       pos: 174.5,47.5
       parent: 1
+- proto: RMCSpawnerRandomGunShotgun
+  entities:
+  - uid: 16992
+    components:
+    - type: Transform
+      pos: 151.5,145.5
+      parent: 1
+  - uid: 16997
+    components:
+    - type: Transform
+      pos: 150.5,145.5
+      parent: 1
 - proto: RMCSpawnerRandomPowercell
   entities:
   - uid: 16228
@@ -126777,20 +126819,10 @@ entities:
     - type: Transform
       pos: 164.67609,153.26534
       parent: 1
-  - uid: 16281
-    components:
-    - type: Transform
-      pos: 150.56683,145.34488
-      parent: 1
   - uid: 16282
     components:
     - type: Transform
       pos: 169.5,151.5
-      parent: 1
-  - uid: 16283
-    components:
-    - type: Transform
-      pos: 151.44183,145.40742
       parent: 1
   - uid: 16284
     components:
@@ -130799,6 +130831,11 @@ entities:
       parent: 1
 - proto: RMCWeaponRevolverSpearhead
   entities:
+  - uid: 13316
+    components:
+    - type: Transform
+      pos: 151.51276,145.42284
+      parent: 1
   - uid: 16990
     components:
     - type: Transform
@@ -130809,19 +130846,6 @@ entities:
     - type: Transform
       pos: 86.5,82.5
       parent: 1
-  - uid: 16992
-    components:
-    - type: Transform
-      pos: 150.50838,143.97289
-      parent: 1
-    - type: RMCWeaponAccuracy
-      modifiedAccuracyMultiplier: 0.85
-    - type: UseDelay
-      delays:
-        RMCWieldDelay:
-          endTime: 89.1916437
-          startTime: 649.7993502
-          length: 0.4
   - uid: 16993
     components:
     - type: Transform
@@ -130832,37 +130856,11 @@ entities:
     - type: Transform
       pos: 167.5,154.5
       parent: 1
-  - uid: 16995
-    components:
-    - type: Transform
-      pos: 150.52968,145.69633
-      parent: 1
-    - type: RMCWeaponAccuracy
-      modifiedAccuracyMultiplier: 0.85
-    - type: UseDelay
-      delays:
-        RMCWieldDelay:
-          endTime: 89.1916437
-          startTime: 645.3660213
-          length: 0.4
   - uid: 16996
     components:
     - type: Transform
       pos: 164.5,154.5
       parent: 1
-  - uid: 16997
-    components:
-    - type: Transform
-      pos: 151.30052,145.73802
-      parent: 1
-    - type: RMCWeaponAccuracy
-      modifiedAccuracyMultiplier: 0.85
-    - type: UseDelay
-      delays:
-        RMCWieldDelay:
-          endTime: 89.1916437
-          startTime: 644.8993551
-          length: 0.4
   - uid: 16998
     components:
     - type: Transform
@@ -130872,6 +130870,11 @@ entities:
     components:
     - type: Transform
       pos: 86.5,94.5
+      parent: 1
+  - uid: 17004
+    components:
+    - type: Transform
+      pos: 150.48499,145.36725
       parent: 1
 - proto: RMCWeaponRifleM54C
   entities:
@@ -130944,32 +130947,6 @@ entities:
       parent: 1
 - proto: RMCWeaponShotgunHG3712
   entities:
-  - uid: 17004
-    components:
-    - type: Transform
-      pos: 150.53107,145.51775
-      parent: 1
-    - type: RMCWeaponAccuracy
-      modifiedAccuracyMultiplier: 0.35
-    - type: UseDelay
-      delays:
-        RMCWieldDelay:
-          endTime: 89.1916437
-          startTime: 630.4660362
-          length: 0.4
-  - uid: 17005
-    components:
-    - type: Transform
-      pos: 151.48941,145.55945
-      parent: 1
-    - type: RMCWeaponAccuracy
-      modifiedAccuracyMultiplier: 0.35
-    - type: UseDelay
-      delays:
-        RMCWieldDelay:
-          endTime: 89.1916437
-          startTime: 632.999367
-          length: 0.4
   - uid: 17006
     components:
     - type: Transform


### PR DESCRIPTION
## About the PR
[Followed up from the benched PR](https://github.com/RMC-14/RMC-14/pull/9722)

## Why / Balance
Pretty much the same + my suggestions as his.

Only difference is I moved the armory loot a bit closer to it's original spot, the prior suggested spot was much too easier or quicker to obtain.

## Technical details


## Media
<img width="1027" height="1320" alt="image" src="https://github.com/user-attachments/assets/28ad918d-12d9-4060-bc13-a32c62a165ac" />
<img width="1342" height="1306" alt="image" src="https://github.com/user-attachments/assets/8538d208-d4fa-4b12-a7df-77a8d913a95d" />
<img width="882" height="1129" alt="image" src="https://github.com/user-attachments/assets/44aedf68-d675-4e45-9faa-aec3defab4be" />
<img width="1844" height="1230" alt="image" src="https://github.com/user-attachments/assets/1e59085f-caa7-4426-8fb9-8e5458113438" />
<img width="1148" height="814" alt="image" src="https://github.com/user-attachments/assets/f663b071-6a5f-42e7-90ba-0415e2a4a147" />
<img width="1016" height="690" alt="image" src="https://github.com/user-attachments/assets/12ceb8d9-7d64-4581-b70f-28ba60282cbe" />
<img width="1472" height="853" alt="image" src="https://github.com/user-attachments/assets/4a380be0-b3ff-4f1c-a1a8-aa01deec3ca0" />
<img width="790" height="647" alt="image" src="https://github.com/user-attachments/assets/032ff9ec-05d2-4306-a270-49b318f2d8e3" />


## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: timed Impenetrable walls on shivas
