### PR TITLE
Spawn on terminate's spawn coordinates now clamps to a projectile's max range

### DIFF
--- a/Content.Client/_RMC14/Xenonids/Targeting/XenoAbilityPreviewOverlay.cs
+++ b/Content.Client/_RMC14/Xenonids/Targeting/XenoAbilityPreviewOverlay.cs
@@ -642,11 +642,11 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
     {
         if (_prototypes.TryIndex<EntityPrototype>(projectile, out var projectileProto) &&
             projectileProto.TryGetComponent<SpawnOnTerminateComponent>(out var spawn, _componentFactory) &&
-            spawn.ProjectileAdjust)
+            spawn.SpawnOffsetMultiplier > 0)
         {
             var delta = impact.Position - origin.Position;
             if (delta.LengthSquared() > 0f)
-                return impact.Offset(delta.Normalized() * -0.5f);
+                return impact.Offset(delta.Normalized() * spawn.SpawnOffsetMultiplier);
         }
 
         return impact;

--- a/Content.Client/_RMC14/Xenonids/Targeting/XenoAbilityPreviewOverlay.cs
+++ b/Content.Client/_RMC14/Xenonids/Targeting/XenoAbilityPreviewOverlay.cs
@@ -642,11 +642,11 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
     {
         if (_prototypes.TryIndex<EntityPrototype>(projectile, out var projectileProto) &&
             projectileProto.TryGetComponent<SpawnOnTerminateComponent>(out var spawn, _componentFactory) &&
-            spawn.SpawnOffsetMultiplier > 0)
+            spawn.SpawnOffset > 0)
         {
             var delta = impact.Position - origin.Position;
             if (delta.LengthSquared() > 0f)
-                return impact.Offset(delta.Normalized() * spawn.SpawnOffsetMultiplier);
+                return impact.Offset(delta.Normalized() * spawn.SpawnOffset);
         }
 
         return impact;

--- a/Content.Shared/_RMC14/Projectiles/RMCFireProjectileComponent.cs
+++ b/Content.Shared/_RMC14/Projectiles/RMCFireProjectileComponent.cs
@@ -1,6 +1,0 @@
-using Robust.Shared.GameStates;
-
-namespace Content.Shared._RMC14.Projectiles;
-
-[RegisterComponent, NetworkedComponent]
-public sealed partial class RMCFireProjectileComponent : Component;

--- a/Content.Shared/_RMC14/Projectiles/RMCProjectileSystem.cs
+++ b/Content.Shared/_RMC14/Projectiles/RMCProjectileSystem.cs
@@ -44,6 +44,7 @@ public sealed class RMCProjectileSystem : EntitySystem
 
         SubscribeLocalEvent<SpawnOnTerminateComponent, MapInitEvent>(OnSpawnOnTerminatingMapInit);
         SubscribeLocalEvent<SpawnOnTerminateComponent, EntityTerminatingEvent>(OnSpawnOnTerminatingTerminate);
+        SubscribeLocalEvent<SpawnOnTerminateComponent, ProjectileHitEvent>(OnSpawnOnTerminateProjectileHit);
 
         SubscribeLocalEvent<PreventCollideWithDeadComponent, PreventCollideEvent>(OnPreventCollideWithDead);
     }
@@ -221,15 +222,16 @@ public sealed class RMCProjectileSystem : EntitySystem
             {
                 var direction = delta / deltaLength;
 
-                if (TryComp(ent, out ProjectileMaxRangeComponent? projectileMaxRange) && deltaLength > projectileMaxRange.Max)
+                if (TryComp(ent, out ProjectileMaxRangeComponent? projectileMaxRange) &&
+                    deltaLength > projectileMaxRange.Max)
                 {
                     deltaLength = projectileMaxRange.Max;
                     delta = direction * deltaLength;
                     coordinates = origin.Offset(delta);
                 }
 
-                if (ent.Comp.SpawnOffsetMultiplier != 0f)
-                    coordinates = coordinates.Offset(direction * ent.Comp.SpawnOffsetMultiplier);
+                if (ent.Comp.AdjustSpawn && ent.Comp.SpawnOffset != 0f)
+                    coordinates = coordinates.Offset(direction * ent.Comp.SpawnOffset);
             }
         }
 
@@ -238,6 +240,18 @@ public sealed class RMCProjectileSystem : EntitySystem
 
         if (ent.Comp.Popup is { } popup)
             _popup.PopupCoordinates(Loc.GetString(popup), coordinates, ent.Comp.PopupType ?? PopupType.Small);
+    }
+
+    private void OnSpawnOnTerminateProjectileHit(Entity<SpawnOnTerminateComponent> ent, ref ProjectileHitEvent args)
+    {
+        ent.Comp.AdjustSpawn = true;
+        Dirty(ent);
+    }
+
+    public void SetSpawnOffset(Entity<SpawnOnTerminateComponent> ent, float offset)
+    {
+        ent.Comp.SpawnOffset = offset;
+        Dirty(ent);
     }
 
     private void OnPreventCollideWithDead(Entity<PreventCollideWithDeadComponent> ent, ref PreventCollideEvent args)

--- a/Content.Shared/_RMC14/Projectiles/RMCProjectileSystem.cs
+++ b/Content.Shared/_RMC14/Projectiles/RMCProjectileSystem.cs
@@ -212,16 +212,24 @@ public sealed class RMCProjectileSystem : EntitySystem
             return;
 
         var coordinates = transform.Coordinates;
-        if (ent.Comp.ProjectileAdjust &&
-            ent.Comp.Origin is { } origin &&
-            coordinates.TryDelta(EntityManager, _transform, origin, out var delta) &&
-            delta.Length() > 0)
+        if (ent.Comp.Origin is { } origin &&
+            coordinates.TryDelta(EntityManager, _transform, origin, out var delta))
         {
-            coordinates = coordinates.Offset(delta.Normalized() / -2);
+            var deltaLength = delta.Length();
 
-            if (HasComp<RMCFireProjectileComponent>(ent))
+            if (deltaLength > 0f)
             {
-                coordinates = coordinates.Offset(delta.Normalized()); // Apparently that works...
+                var direction = delta / deltaLength;
+
+                if (TryComp(ent, out ProjectileMaxRangeComponent? projectileMaxRange) && deltaLength > projectileMaxRange.Max)
+                {
+                    deltaLength = projectileMaxRange.Max;
+                    delta = direction * deltaLength;
+                    coordinates = origin.Offset(delta);
+                }
+
+                if (ent.Comp.SpawnOffsetMultiplier != 0f)
+                    coordinates = coordinates.Offset(direction * ent.Comp.SpawnOffsetMultiplier);
             }
         }
 

--- a/Content.Shared/_RMC14/Projectiles/SpawnOnTerminateComponent.cs
+++ b/Content.Shared/_RMC14/Projectiles/SpawnOnTerminateComponent.cs
@@ -22,5 +22,8 @@ public sealed partial class SpawnOnTerminateComponent : Component
     public PopupType? PopupType;
 
     [DataField, AutoNetworkedField]
-    public float SpawnOffsetMultiplier;
+    public bool AdjustSpawn;
+
+    [DataField, AutoNetworkedField]
+    public float SpawnOffset;
 }

--- a/Content.Shared/_RMC14/Projectiles/SpawnOnTerminateComponent.cs
+++ b/Content.Shared/_RMC14/Projectiles/SpawnOnTerminateComponent.cs
@@ -22,5 +22,5 @@ public sealed partial class SpawnOnTerminateComponent : Component
     public PopupType? PopupType;
 
     [DataField, AutoNetworkedField]
-    public bool ProjectileAdjust = true;
+    public float SpawnOffsetMultiplier = -0.5f;
 }

--- a/Content.Shared/_RMC14/Projectiles/SpawnOnTerminateComponent.cs
+++ b/Content.Shared/_RMC14/Projectiles/SpawnOnTerminateComponent.cs
@@ -22,5 +22,5 @@ public sealed partial class SpawnOnTerminateComponent : Component
     public PopupType? PopupType;
 
     [DataField, AutoNetworkedField]
-    public float SpawnOffsetMultiplier = -0.5f;
+    public float SpawnOffsetMultiplier;
 }

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/sentry.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/sentry.yml
@@ -133,6 +133,7 @@
       path: /Audio/Weapons/Guns/Hits/bullet_hit.ogg
   - type: SpawnOnTerminate
     spawn: RMCSmokeFireSentry
+    spawnOffsetMultiplier: -0.5
 
 - type: Tag
   id: RMCBulletSentryFireProjectile

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/sentry.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/sentry.yml
@@ -132,7 +132,7 @@
       path: /Audio/Weapons/Guns/Hits/bullet_hit.ogg
   - type: SpawnOnTerminate
     spawn: RMCSmokeFireSentry
-    spawnOffsetMultiplier: -0.5
+    spawnOffsetMultiplier: 0.5
 
 - type: Tag
   id: RMCBulletSentryFireProjectile

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/sentry.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/sentry.yml
@@ -46,7 +46,6 @@
       falloff: 10
 
 - type: entity
-  abstract: true
   parent: RMCBaseBullet
   id: RMCBaseBulletSentryFireProjectile
   name: flaming ball
@@ -55,7 +54,6 @@
   components:
   - type: IgniteOnProjectileHit
   - type: IgnorePredictionHide
-  - type: RMCFireProjectile
   - type: Sprite
     sprite: _RMC14/Objects/Weapons/Guns/Ammunition/Projectiles/firesentry_projectile.rsi
     layers:
@@ -89,6 +87,7 @@
         - BulletImpassable
   - type: TriggerOnCollide
     fixtureID: projectile
+  - type: DeleteOnTrigger
 
 - type: entity
   parent: RMCBaseBulletSentryFireProjectile

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/sentry.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/sentry.yml
@@ -132,7 +132,7 @@
       path: /Audio/Weapons/Guns/Hits/bullet_hit.ogg
   - type: SpawnOnTerminate
     spawn: RMCSmokeFireSentry
-    spawnOffsetMultiplier: 0.5
+    spawnOffset: 0.5
 
 - type: Tag
   id: RMCBulletSentryFireProjectile

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m5_atl_rocket_launcher.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m5_atl_rocket_launcher.yml
@@ -289,6 +289,7 @@
   - type: DeleteOnTrigger
   - type: SpawnOnTerminate
     spawn: RMCSmokeWhitePhosphorus
+    spawnOffsetMultiplier: -0.5
   - type: RMCAreaDamage
     damageArea: 3.5
     falloffDistance: 3.5

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m5_atl_rocket_launcher.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m5_atl_rocket_launcher.yml
@@ -289,7 +289,7 @@
   - type: DeleteOnTrigger
   - type: SpawnOnTerminate
     spawn: RMCSmokeWhitePhosphorus
-    spawnOffsetMultiplier: -0.5
+    spawnOffset: -0.5
   - type: RMCAreaDamage
     damageArea: 3.5
     falloffDistance: 3.5

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m74_airburst_grenades.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m74_airburst_grenades.yml
@@ -268,7 +268,6 @@
   - type: Projectile
     impactEffect: BulletImpactEffect
     deleteOnCollide: false
-    maxFixedRange: 9
     damage:
       types:
         Piercing: 30
@@ -276,7 +275,7 @@
       path: /Audio/Effects/gen_hit.ogg
   - type: SpawnOnTerminate
     spawn: RMCSmoke
-    projectileAdjust: false
+    spawnOffsetMultiplier: 0
   - type: SoundOnTrigger
     sound: /Audio/Effects/smoke.ogg
   - type: DeleteOnTrigger

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m74_airburst_grenades.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m74_airburst_grenades.yml
@@ -275,7 +275,6 @@
       path: /Audio/Effects/gen_hit.ogg
   - type: SpawnOnTerminate
     spawn: RMCSmoke
-    spawnOffsetMultiplier: 0
   - type: SoundOnTrigger
     sound: /Audio/Effects/smoke.ogg
   - type: DeleteOnTrigger

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m74_airburst_grenades.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m74_airburst_grenades.yml
@@ -268,6 +268,7 @@
   - type: Projectile
     impactEffect: BulletImpactEffect
     deleteOnCollide: false
+    maxFixedRange: 9
     damage:
       types:
         Piercing: 30

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Sentries/sentries.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Sentries/sentries.yml
@@ -430,7 +430,6 @@
   name: UN 45-FM mini sentry
   description: The Mini Flamethrower Sentry Gun automatically tracks and fires upon any target that is wearing an ID not hooked up to the Almayer's systems. Just like the UN 571-C Sentry gun, this sentry has IFF but the fire that lingers doesn't.
   components:
-  - type: RMCFireProjectile
   - type: Sprite
     sprite: _RMC14/Objects/Weapons/Sentries/sentry.rsi
     drawdepth: Mobs
@@ -497,7 +496,6 @@
   name: UN 55-FA assault sentry flamer
   description: The Flamethrower Sentry Gun automatically tracks and fires upon any target that is wearing an ID not hooked up to the Almayer's systems. Just like the UA 571-C Sentry gun, this sentry has IFF but the fire that lingers doesn't.
   components:
-  - type: RMCFireProjectile
   - type: Gun
     fireRate: .33
     projectileSpeed: 20.0
@@ -532,7 +530,6 @@
   name: UN 60-FP plasma sentry
   description: The Plasma Flamethrower Sentry Gun automatically tracks and fires upon any target that is wearing an ID not hooked up to the Almayer's systems. Just like the UA 571-C Sentry gun, this sentry has IFF but the phosphorus that lingers doesn't.
   components:
-  - type: RMCFireProjectile
   - type: Sprite
     sprite: _RMC14/Objects/Weapons/Sentries/sentry.rsi
     drawdepth: Mobs

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_projectiles.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_projectiles.yml
@@ -227,7 +227,7 @@
     spawn: RMCSmokeAcid
     popup: rmc-glob-land
     popupType: LargeCaution
-    spawnOffsetMultiplier: -0.5
+    spawnOffset: -0.5
   - type: ProjectileMaxRange
     max: 10
   - type: XenoSlowingSpitProjectile
@@ -284,7 +284,7 @@
     spawn: RMCSmokeNeurotoxin
     popup: rmc-glob-land
     popupType: LargeCaution
-    spawnOffsetMultiplier: -0.5
+    spawnOffset: -0.5
   - type: ProjectileMaxRange
     max: 10
   - type: XenoSlowingSpitProjectile

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_projectiles.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_projectiles.yml
@@ -227,6 +227,7 @@
     spawn: RMCSmokeAcid
     popup: rmc-glob-land
     popupType: LargeCaution
+    spawnOffsetMultiplier: -0.5
   - type: ProjectileMaxRange
     max: 10
   - type: XenoSlowingSpitProjectile
@@ -283,6 +284,7 @@
     spawn: RMCSmokeNeurotoxin
     popup: rmc-glob-land
     popupType: LargeCaution
+    spawnOffsetMultiplier: -0.5
   - type: ProjectileMaxRange
     max: 10
   - type: XenoSlowingSpitProjectile


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed projectiles with the `SpawnOnTerminateComponent` spawning the prototype past their max range.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug fix.

## Technical details
<!-- Summary of code changes for easier review. -->
When an entity with the `ProjectileMaxRangeComponent` and the `SpawnOnTerminateComponent` is terminated while past it's max range, the prototype is spawned at the coordinates where it's max range was reached, instead of at it's current coordinates.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
No CL, no prototype with this combination of components exists at the moment.
