### PR TITLE
Fix Map Insert Pipes

### DIFF
--- a/Content.Shared/_RMC14/Vents/SharedVentCrawlingSystem.cs
+++ b/Content.Shared/_RMC14/Vents/SharedVentCrawlingSystem.cs
@@ -55,6 +55,7 @@ public abstract class SharedVentCrawlingSystem : EntitySystem
         SubscribeLocalEvent<VentExitComponent, VentExitDoafterEvent>(OnVentExitDoafter);
 
         SubscribeLocalEvent<VentCrawlableComponent, MapInitEvent>(OnVentDuctInit);
+        SubscribeLocalEvent<VentCrawlableComponent, ReAnchorEvent>(OnVentReanchor);
         SubscribeLocalEvent<VentCrawlableComponent, MoveEvent>(OnVentDuctMove);
         SubscribeLocalEvent<VentCrawlableComponent, AnchorStateChangedEvent>(OnVentAnchorChanged);
         SubscribeLocalEvent<VentCrawlableComponent, RMCContainerDestructionEmptyEvent>(OnVentContainerDeletionEmpty);
@@ -87,12 +88,23 @@ public abstract class SharedVentCrawlingSystem : EntitySystem
         if(ent.Comp.Enabled)
             args.VisibilityMask |= (int)VisibilityFlags.Subfloor;
     }
+
     private void OnVentDuctInit(Entity<VentCrawlableComponent> vent, ref MapInitEvent args)
     {
         if (vent.Comp.TravelDirection == PipeDirection.Fourway)
             return;
 
+        vent.Comp.OriginalTravelDirection = vent.Comp.TravelDirection;
         vent.Comp.TravelDirection = vent.Comp.TravelDirection.RotatePipeDirection(Transform(vent).LocalRotation);
+        Dirty(vent);
+    }
+
+    private void OnVentReanchor(Entity<VentCrawlableComponent> vent, ref ReAnchorEvent args)
+    {
+        if (vent.Comp.TravelDirection == PipeDirection.Fourway)
+            return;
+
+        vent.Comp.TravelDirection = vent.Comp.OriginalTravelDirection.RotatePipeDirection(Transform(vent).LocalRotation);
         Dirty(vent);
     }
 

--- a/Content.Shared/_RMC14/Vents/SharedVentCrawlingSystem.cs
+++ b/Content.Shared/_RMC14/Vents/SharedVentCrawlingSystem.cs
@@ -54,7 +54,7 @@ public abstract class SharedVentCrawlingSystem : EntitySystem
 
         SubscribeLocalEvent<VentExitComponent, VentExitDoafterEvent>(OnVentExitDoafter);
 
-        SubscribeLocalEvent<VentCrawlableComponent, MapInitEvent>(OnVentDuctInit);
+        SubscribeLocalEvent<VentCrawlableComponent, ComponentInit>(OnVentDuctInit);
         SubscribeLocalEvent<VentCrawlableComponent, ReAnchorEvent>(OnVentReanchor);
         SubscribeLocalEvent<VentCrawlableComponent, MoveEvent>(OnVentDuctMove);
         SubscribeLocalEvent<VentCrawlableComponent, AnchorStateChangedEvent>(OnVentAnchorChanged);
@@ -89,7 +89,7 @@ public abstract class SharedVentCrawlingSystem : EntitySystem
             args.VisibilityMask |= (int)VisibilityFlags.Subfloor;
     }
 
-    private void OnVentDuctInit(Entity<VentCrawlableComponent> vent, ref MapInitEvent args)
+    private void OnVentDuctInit(Entity<VentCrawlableComponent> vent, ref ComponentInit args)
     {
         if (vent.Comp.TravelDirection == PipeDirection.Fourway)
             return;

--- a/Content.Shared/_RMC14/Vents/SharedVentCrawlingSystem.cs
+++ b/Content.Shared/_RMC14/Vents/SharedVentCrawlingSystem.cs
@@ -91,10 +91,10 @@ public abstract class SharedVentCrawlingSystem : EntitySystem
 
     private void OnVentDuctInit(Entity<VentCrawlableComponent> vent, ref ComponentInit args)
     {
+        vent.Comp.OriginalTravelDirection = vent.Comp.TravelDirection;
         if (vent.Comp.TravelDirection == PipeDirection.Fourway)
             return;
 
-        vent.Comp.OriginalTravelDirection = vent.Comp.TravelDirection;
         vent.Comp.TravelDirection = vent.Comp.TravelDirection.RotatePipeDirection(Transform(vent).LocalRotation);
         Dirty(vent);
     }

--- a/Content.Shared/_RMC14/Vents/VentCrawlableComponent.cs
+++ b/Content.Shared/_RMC14/Vents/VentCrawlableComponent.cs
@@ -20,5 +20,8 @@ public sealed partial class VentCrawlableComponent : Component
     public PipeDirection TravelDirection;
 
     [DataField, AutoNetworkedField]
+    public PipeDirection OriginalTravelDirection;
+
+    [DataField, AutoNetworkedField]
     public SoundSpecifier? TravelSound = new SoundCollectionSpecifier("XenoVentCrawl");
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Rounys no longer get kicked out of vents on map inserts

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes https://github.com/RMC-14/RMC-14/issues/8888

## Technical details
<!-- Summary of code changes for easier review. -->
Update vent travel directions on reanchor. Travel directions can sometimes become desynced from the actual pipe directions during grid merge. Added tracking of original pipe rotation to prevent double rotating pipes which are already correct.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
<img width="1533" height="890" alt="image" src="https://github.com/user-attachments/assets/7b67e383-5adc-4ea0-8e76-2c5c93eb4bb6" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed broken pipes on map inserts.
