### PR TITLE
forecon skill fixes

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/marksman.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/marksman.yml
@@ -14,14 +14,14 @@
     components:
     - type: Skills
       skills:
-        RMCSkillEngineer: 1
+        RMCSkillEngineer: 2
         RMCSkillConstruction: 0
         RMCSkillMeleeWeapons: 1
         RMCSkillCqc: 1
         RMCSkillFireman: 1
         RMCSkillFirearms: 1
         RMCSkillSpecialistWeapons: 1
-        RMCSkillJtac: 1
+        RMCSkillJtac: 2
         RMCSkillMedical: 1
         RMCSkillEndurance: 2
         RMCSkillLeadership: 0

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/rifleman.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/rifleman.yml
@@ -9,14 +9,14 @@
     components:
     - type: Skills
       skills:
-        RMCSkillEngineer: 1
+        RMCSkillEngineer: 2
         RMCSkillConstruction: 0
         RMCSkillMeleeWeapons: 1
         RMCSkillCqc: 1
         RMCSkillFireman: 1
         RMCSkillFirearms: 1
         RMCSkillMedical: 1
-        RMCSkillJtac: 1
+        RMCSkillJtac: 2
         RMCSkillEndurance: 2
         RMCSkillLeadership: 0
         RMCSkillVehicles: 0

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/smart_gun_operator.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/smart_gun_operator.yml
@@ -14,14 +14,14 @@
     components:
     - type: Skills
       skills:
-        RMCSkillEngineer: 1
+        RMCSkillEngineer: 2
         RMCSkillConstruction: 0
         RMCSkillMeleeWeapons: 1
         RMCSkillCqc: 1
         RMCSkillFireman: 1
         RMCSkillFirearms: 1
         RMCSkillSmartGun: 1
-        RMCSkillJtac: 1
+        RMCSkillJtac: 2
         RMCSkillMedical: 1
         RMCSkillEndurance: 2
         RMCSkillLeadership: 0

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/sniper.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/sniper.yml
@@ -10,14 +10,14 @@
     components:
     - type: Skills
       skills:
-        RMCSkillEngineer: 1
+        RMCSkillEngineer: 2
         RMCSkillConstruction: 0
         RMCSkillMeleeWeapons: 1
         RMCSkillCqc: 1
         RMCSkillFireman: 1
         RMCSkillFirearms: 1
         RMCSkillSpecialistWeapons: 1
-        RMCSkillJtac: 1
+        RMCSkillJtac: 2
         RMCSkillMedical: 1
         RMCSkillEndurance: 2
         RMCSkillLeadership: 0

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/squad_leader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/squad_leader.yml
@@ -19,14 +19,14 @@
     components:
     - type: Skills
       skills:
-        RMCSkillEngineer: 1
+        RMCSkillEngineer: 2
         RMCSkillConstruction: 0
         RMCSkillMeleeWeapons: 1
         RMCSkillCqc: 2
         RMCSkillFireman: 2
         RMCSkillFirearms: 1
         RMCSkillPolice: 1
-        RMCSkillJtac: 1
+        RMCSkillJtac: 2
         RMCSkillMedical: 1
         RMCSkillEndurance: 2
         RMCSkillLeadership: 1

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/support_technician.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/support_technician.yml
@@ -20,13 +20,13 @@
     components:
     - type: Skills
       skills:
-        RMCSkillEngineer: 1
+        RMCSkillEngineer: 2
         RMCSkillConstruction: 2
         RMCSkillMeleeWeapons: 1
         RMCSkillCqc: 1
         RMCSkillFireman: 1
         RMCSkillFirearms: 1
-        RMCSkillJtac: 1
+        RMCSkillJtac: 2
         RMCSkillMedical: 2
         RMCSkillSurgery: 1
         RMCSkillEndurance: 2


### PR DESCRIPTION
## About the PR
all forecon survs now get engi 2 and jtac 2

no this doesnt change the skills into presets because i just wanna change the skills right now and turn all surv roles into presets in 1 bigger pr

## Why / Balance
parity

(shared across all forecon roles)
<img width="398" height="229" alt="obraz" src="https://github.com/user-attachments/assets/6d26a570-f638-48ad-9d87-caecf30223a6" />

<img width="212" height="22" alt="obraz" src="https://github.com/user-attachments/assets/8c223528-1019-4a43-8422-cfaac0b3c97e" />
<img width="974" height="79" alt="obraz" src="https://github.com/user-attachments/assets/81abdff7-e1bc-4157-85a1-51f06b80fe9b" />

## Technical details
yaml warrior

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: All FORECON survivor roles now have Engineering 2 (1 -> 2) and JTAC 2 (1 -> 2)
