### PR TITLE
Fix Xeno Build Button Click Behavior

### DIFF
--- a/Content.Client/_RMC14/Xenonids/Construction/XenoChooseStructureBui.cs
+++ b/Content.Client/_RMC14/Xenonids/Construction/XenoChooseStructureBui.cs
@@ -45,6 +45,7 @@ public sealed class XenoChooseStructureBui : BoundUserInterface
 
                 var control = new XenoChoiceControl();
                 control.Button.ToggleMode = true;
+                control.Button.Mode = 0;
 
                 var displayId = structureId;
                 var displayName = structure.Name;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Restores the good button click behavior implemented in #5050 that was lost when xeno construction ghost previews were added in #6839

## Why / Balance
From original PR: "QoL. The choose resin structure window is something that is constantly cycled between the in-game space and the buttons, when building and choosing different structures very quickly sometimes your option may not actually select if you're too fast, or your game client is lagging." I noticed it was gone immediately as soon as I started playing again (it's been so long,,,)

It seems like it was dropped accidentally when ToggleMode was added to it, likely with the assumption that they are superfluous/conflict in some way due to the variable names (though they don't actually)

## Technical details
Button.Mode = 0 instead of 1

Despite sharing similar names, Button.ToggleMode and Button.Mode do entirely different things (Button.Mode just controls button click/release behavior)

## Media
It is functional yes

https://github.com/user-attachments/assets/b8c84092-5af0-4bd5-ae3a-c8e882e7db8c


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: The buttons for choose structures have been restored to be more responsive, and will immediately select the option you click on once again.
