### PR TITLE
Paramarine commander skillset

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Hybrisa_Prospera/Paramarines/Para_Commander.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Hybrisa_Prospera/Paramarines/Para_Commander.yml
@@ -19,7 +19,7 @@
             - TSE
         - type: RMCSurvivor
         - type: Skills
-          preset: RMCSkillPresetCommander
+          preset: RMCSkillPresetParaCommander
         - type: RMCAllowSuitStorage
         - type: IntelRescueSurvivorObjective
         - type: MotionDetectorTracked

--- a/Resources/Prototypes/_RMC14/Roles/SkillPresets/para.yml
+++ b/Resources/Prototypes/_RMC14/Roles/SkillPresets/para.yml
@@ -17,7 +17,7 @@
       RMCSkillMedical: 1
       RMCSkillPolice: 0 #RMC Change: Should be 2
       RMCSkillVehicles: 1
-        
+
 - type: entity
   parent: RMCSkillPresetParamarine
   id: RMCSkillPresetParaPilot
@@ -27,7 +27,7 @@
   - type: SkillPreset
     skills:
       RMCSkillPilot: 2
-        
+
 - type: entity
   parent: RMCSkillPresetParamarine
   id: RMCSkillPresetParaEngineer
@@ -39,7 +39,7 @@
       RMCSkillConstruction: 2
       RMCSkillEngineer: 2
       RMCSkillPowerLoader: 1
-        
+
 - type: entity
   parent: RMCSkillPresetParamarine
   id: RMCSkillPresetParaMedic
@@ -51,7 +51,7 @@
       RMCSkillFireman: 3
       RMCSkillMedical: 3
       RMCSkillSurgery: 2
-        
+
 - type: entity
   parent: RMCSkillPresetParamarine
   id: RMCSkillPresetParaLeader
@@ -66,7 +66,7 @@
       RMCSkillLeadership: 1
       RMCSkillPilot: 1
       RMCSkillIntel: 1
-        
+
 - type: entity
   id: RMCSkillPresetParaSynth
   name: Royal Paramarine Synthetic
@@ -91,4 +91,29 @@
       RMCSkillJtac: 1
       RMCSkillIntel: 1
       RMCSkillDomestics: 2
-        
+
+- type: entity
+  parent: RMCSkillPresetParamarine
+  id: RMCSkillPresetParaCommander
+  name: Royal Paramarine Commander
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: SkillPreset
+    skills:
+      RMCSkillCqc: 2
+      RMCSkillConstruction: 2
+      RMCSkillFirearms: 1
+      RMCSkillFireman: 2
+      RMCSkillEndurance: 3
+      RMCSkillEngineer: 2
+      RMCSkillExecution: 1
+      RMCSkillIntel: 2
+      RMCSkillJtac: 4
+      RMCSkillLeadership: 3
+      RMCSkillMedical: 2
+      RMCSkillNavigations: 1
+      RMCSkillOverwatch: 1
+      RMCSkillPolice: 2
+      RMCSkillPowerLoader: 2
+      RMCSkillSurgery: 1
+      RMCSkillVehicles: 2

--- a/Resources/Prototypes/_RMC14/Roles/SkillPresets/para.yml
+++ b/Resources/Prototypes/_RMC14/Roles/SkillPresets/para.yml
@@ -110,7 +110,7 @@
       RMCSkillIntel: 2
       RMCSkillJtac: 4
       RMCSkillLeadership: 3
-      RMCSkillMedical: 2
+      RMCSkillMedical: 3
       RMCSkillNavigations: 1
       RMCSkillOverwatch: 1
       RMCSkillPolice: 2


### PR DESCRIPTION
## About the PR
title

it was using default survco skillset before, very minor differences here like end 3 and lack of smartgun skill

## Why / Balance
parity

## Technical details
yaml

## Media
OUTDATED, MEDICAL 3
<img width="273" height="409" alt="obraz" src="https://github.com/user-attachments/assets/1abedb37-66ce-4115-a02c-86d1bde73035" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Changed Paramarine Commander to use their own parity skillset
