### PR TITLE
Burst fire stops if a gun is inside a container

### DIFF
--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.AutoFire.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.AutoFire.cs
@@ -32,6 +32,22 @@ public sealed partial class GunSystem
             else if (gun.BurstActivated)
             {
                 var parent = TransformSystem.GetParentUid(uid);
+
+                //RMC14 Stop burst fire when inside a bag o holster.
+                if (!HasComp<DamageableComponent>(parent) &&
+                    Containers.TryGetOuterContainer(uid, Transform(uid), out var outerParent))
+                {
+                    if (HasComp<DamageableComponent>(outerParent.Owner))
+                    {
+                        gun.BurstActivated = false;
+                        gun.BurstShotsCount = 0;
+                        gun.NextFire += TimeSpan.FromSeconds(gun.BurstCooldown);
+                        Dirty(uid, gun);
+                        continue;
+                    }
+                }
+                //RMC14
+
                 if (HasComp<DamageableComponent>(parent))
                     AttemptShoot(parent, uid, gun, gun.ShootCoordinates ?? new EntityCoordinates(uid, gun.DefaultDirection));
                 else

--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.AutoFire.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.AutoFire.cs
@@ -33,7 +33,7 @@ public sealed partial class GunSystem
             {
                 var parent = TransformSystem.GetParentUid(uid);
 
-                //RMC14 Stop burst fire when inside a bag o holster.
+                //RMC14 Stop burst fire when inside a bag or holster.
                 if (!HasComp<DamageableComponent>(parent) &&
                     Containers.TryGetOuterContainer(uid, Transform(uid), out var outerParent))
                 {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Putting a gun inside a bag or holster mid-burst now stops it from firing.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Because the bag was treated as the gun’s shooter, putting the gun into your bag mid-burst caused the shots to hit yourself.
Resolves #9810 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix:  Putting a gun inside a bag or holster mid-burst now prevents it from shooting.
