### PR TITLE
Killing yourself with a flamethrower no longer deletes the flamethrower.

### DIFF
--- a/Content.Shared/_RMC14/Suicide/RMCSuicideSystem.cs
+++ b/Content.Shared/_RMC14/Suicide/RMCSuicideSystem.cs
@@ -122,6 +122,9 @@ public sealed class RMCSuicideSystem : EntitySystem
 
         foreach (var (bullet, _) in ev.Ammo)
         {
+            if (HasComp<GunComponent>(bullet))
+                continue;
+
             QueueDel(bullet);
         }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Using the suicide verb with a flamethrower no longer deletes the flamethrower.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Resolves #9797 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix: Using the suicide verb with a flamethrower no longer deletes the flamethrower.
