### PR TITLE
Fix equipped armor pickup bypassing unequip delay

### DIFF
--- a/Content.Shared/_RMC14/Hands/RMCHandsSystem.cs
+++ b/Content.Shared/_RMC14/Hands/RMCHandsSystem.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Content.Shared._RMC14.Storage;
+using Content.Shared.Clothing.Components;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
@@ -21,6 +22,8 @@ namespace Content.Shared._RMC14.Hands;
 
 public abstract class RMCHandsSystem : EntitySystem
 {
+    private static readonly SpriteSpecifier.Texture PickupIcon = new(new ResPath("/Textures/Interface/VerbIcons/pickup.svg.192dpi.png"));
+
     [Dependency] private readonly SharedContainerSystem _container = default!;
     [Dependency] private readonly SharedHandsSystem _hands = default!;
     [Dependency] private readonly InventorySystem _inventory = default!;
@@ -39,6 +42,9 @@ public abstract class RMCHandsSystem : EntitySystem
         SubscribeLocalEvent<DropHeldOnIncapacitateComponent, MobStateChangedEvent>(OnDropMobStateChanged);
         SubscribeLocalEvent<RMCStorageEjectHandComponent, GetVerbsEvent<AlternativeVerb>>(OnStorageEjectHandVerbs);
         SubscribeLocalEvent<DropOnUseInHandComponent, UseInHandEvent>(OnDropOnUseInHand);
+        SubscribeLocalEvent<ClothingComponent, GetVerbsEvent<InteractionVerb>>(OnClothingGetInteractionVerbs, after: [typeof(SharedItemSystem)]);
+        SubscribeLocalEvent<ClothingComponent, InteractHandEvent>(OnClothingInteractHand, before: [typeof(SharedItemSystem)]);
+        SubscribeLocalEvent<ClothingComponent, ContainerGettingInsertedAttemptEvent>(OnClothingGettingInsertedAttempt);
     }
 
     private void OnXenoHandsMapInit(Entity<GiveHandsComponent> ent, ref MapInitEvent args)
@@ -156,6 +162,95 @@ public abstract class RMCHandsSystem : EntitySystem
     private void OnDropOnUseInHand(Entity<DropOnUseInHandComponent> ent, ref UseInHandEvent args)
     {
         _hands.TryDrop(args.User, ent);
+    }
+
+    private void OnClothingGetInteractionVerbs(Entity<ClothingComponent> ent, ref GetVerbsEvent<InteractionVerb> args)
+    {
+        if (args.Hands == null ||
+            args.Using != null ||
+            !args.CanAccess ||
+            !args.CanInteract ||
+            !CanStartDelayedInventoryPickup(ent, args.User, args.Hands))
+        {
+            return;
+        }
+
+        var user = args.User;
+        InteractionVerb verb = new()
+        {
+            Text = Loc.GetString("pick-up-verb-get-data-text-inventory"),
+            Icon = PickupIcon,
+            Act = () => TryStartDelayedInventoryPickup(ent, user),
+        };
+
+        args.Verbs.Add(verb);
+    }
+
+    private void OnClothingInteractHand(Entity<ClothingComponent> ent, ref InteractHandEvent args)
+    {
+        if (args.Handled ||
+            !CanStartDelayedInventoryPickup(ent, args.User))
+        {
+            return;
+        }
+
+        args.Handled = true;
+        TryStartDelayedInventoryPickup(ent, args.User);
+    }
+
+    private void OnClothingGettingInsertedAttempt(Entity<ClothingComponent> ent, ref ContainerGettingInsertedAttemptEvent args)
+    {
+        if (args.Cancelled)
+            return;
+
+        var user = args.Container.Owner;
+        if (!_hands.TryGetHand(user, args.Container.ID, out _) ||
+            !TryGetDelayedInventoryPickupSlot(ent, user, out _))
+        {
+            return;
+        }
+
+        args.Cancel();
+    }
+
+    private bool CanStartDelayedInventoryPickup(Entity<ClothingComponent> ent, EntityUid user, HandsComponent? hands = null)
+    {
+        return TryGetEmptyActiveHand(user, hands) &&
+               TryGetDelayedInventoryPickupSlot(ent, user, out var slot) &&
+               _inventory.CanUnequip(user, user, slot, out _);
+    }
+
+    private bool TryGetEmptyActiveHand(EntityUid user, HandsComponent? hands = null)
+    {
+        return Resolve(user, ref hands, false) &&
+               hands.ActiveHandId != null &&
+               _hands.HandIsEmpty((user, hands), hands.ActiveHandId);
+    }
+
+    private void TryStartDelayedInventoryPickup(Entity<ClothingComponent> ent, EntityUid user)
+    {
+        if (!TryGetDelayedInventoryPickupSlot(ent, user, out var slot))
+            return;
+
+        if (_inventory.TryUnequip(user, user, slot, checkDoafter: true, triggerHandContact: true))
+            _hands.TryPickupAnyHand(user, ent.Owner);
+    }
+
+    private bool TryGetDelayedInventoryPickupSlot(Entity<ClothingComponent> ent, EntityUid user, out string slot)
+    {
+        slot = string.Empty;
+
+        if (ent.Comp.UnequipDelay <= TimeSpan.Zero ||
+            !_container.TryGetContainingContainer((ent.Owner, null), out var container) ||
+            container.Owner != user ||
+            !_inventory.TryGetSlot(user, container.ID, out var slotDefinition) ||
+            (ent.Comp.Slots & slotDefinition.SlotFlags) == 0)
+        {
+            return false;
+        }
+
+        slot = slotDefinition.Name;
+        return true;
     }
 
     public bool IsPickupByAllowed(Entity<WhitelistPickupByComponent?> item, Entity<WhitelistPickupComponent?> user)


### PR DESCRIPTION
## About the PR

Fixes an issue where equipped RMC clothing/armor with an unequip delay could be moved to the hand instantly through the vanilla right-click "pick up / put in hand" interaction, bypassing the intended unequip do-after.

## Why / Balance

This makes the vanilla hand pickup path follow the same behavior as the RMC unequip action. Armor that is meant to take time to remove now consistently uses the unequip delay and can be interrupted by movement.

No balance change beyond enforcing the already intended unequip delay.

## Technical details

Adds an RMC-side interception for delayed equipped clothing in `RMCHandsSystem`.

When delayed clothing is equipped in the user's inventory and the active hand is empty, the RMC interaction starts the normal inventory unequip flow with `checkDoafter: true` instead of allowing the vanilla instant hand pickup path.

Also blocks direct insertion of delayed equipped clothing into hand containers while it is still equipped, preventing the bypass without modifying upstream/shared item behavior.

## Media

Not required, small behavior fix.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

- fix: Fixed some equipped armor being removable instantly through the vanilla hand pickup interaction.