### PR TITLE
BURN THE WORLD!

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Spray/SprayAcidVulnerablyComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Spray/SprayAcidVulnerablyComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.Spray;
+
+/// <summary>
+/// Marks an entity as vulnerable to xeno spray acid.
+/// Used by <see cref="XenoSprayAcidSystem"/> to determine
+/// whether SprayAcidedComponent should be applied.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class SprayAcidVulnerableComponent : Component
+{
+}

--- a/Content.Shared/_RMC14/Xenonids/Spray/XenoSprayAcidSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Spray/XenoSprayAcidSystem.cs
@@ -153,7 +153,7 @@ public sealed class XenoSprayAcidSystem : EntitySystem
     private void TryAcid(Entity<XenoSprayAcidComponent> acid, EntityUid target)
     {
         var time = _timing.CurTime;
-        if (!_barricadeQuery.HasComp(target))
+        if (!HasComp<SprayAcidVulnerableComponent>(target))
             return;
 
         var comp = EnsureComp<SprayAcidedComponent>(target);

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/cigarette.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/cigarette.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: Cigarette
-  parent: BaseCigar
+  parent: RMCBaseCigar
   name: cigarette
   description: A roll of tobacco and nicotine.
   components:
@@ -28,7 +28,7 @@
 
 - type: entity
   id: SoakedCigarette
-  parent: BaseCigar
+  parent: RMCBaseCigar
   name: cigarette
   suffix: Soaked
   description: A roll of tobacco and nicotine soaked in some chemical.

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/base_smokeables.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/base_smokeables.yml
@@ -40,6 +40,33 @@
         reagents:
           - ReagentId: Nicotine
             Quantity: 10
+  - type: Flammable
+    intensity: 10
+    fireSpread: true
+    canResistFire: false
+    alwaysCombustible: true
+    canExtinguish: true 
+    damage:
+      types:
+        Heat: 1
+  - type: FireVisuals
+    sprite: Effects/fire.rsi
+    normalState: fire
+  - type: Damageable
+    damageModifierSet: Wood
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 15
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          Ash:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
 
 - type: entity
   parent: BaseSmokable

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/base_smokeables.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/base_smokeables.yml
@@ -40,33 +40,6 @@
         reagents:
           - ReagentId: Nicotine
             Quantity: 10
-  - type: Flammable
-    intensity: 10
-    fireSpread: true
-    canResistFire: false
-    alwaysCombustible: true
-    canExtinguish: true 
-    damage:
-      types:
-        Heat: 1
-  - type: FireVisuals
-    sprite: Effects/fire.rsi
-    normalState: fire
-  - type: Damageable
-    damageModifierSet: Wood
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 15
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          Ash:
-            min: 1
-            max: 1
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
 
 - type: entity
   parent: BaseSmokable

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Smokeables/rmc_base_smokeables.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Smokeables/rmc_base_smokeables.yml
@@ -1,0 +1,31 @@
+- type: entity
+  parent: BaseCigar
+  id: RMCBaseCigar
+  components:
+  - type: Flammable
+    intensity: 10
+    fireSpread: true
+    canResistFire: false
+    alwaysCombustible: true
+    canExtinguish: true 
+    damage:
+      types:
+        Heat: 1
+  - type: FireVisuals
+    sprite: Effects/fire.rsi
+    normalState: fire
+  - type: Damageable
+    damageModifierSet: Wood
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 15
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          Ash:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Tools/flares.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Tools/flares.yml
@@ -19,6 +19,7 @@
     tags:
     - Flare
     - RMCFlare
+  - type: IgnitionSource
   - type: ExpendableLight
     spentName: expendable-light-spent-flare-name
     spentDesc: expendable-light-spent-flare-desc

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Flamethrowers/m34_flamer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Flamethrowers/m34_flamer.yml
@@ -54,6 +54,7 @@
     light: 0.69
     medium: 0.75
     heavy: 0.806
+  - type: IgnitionSource
   - type: GunRequiresWield
   - type: RMCFlamerAmmoProvider
   - type: MagazineVisuals

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Flora/tallgrass.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Flora/tallgrass.yml
@@ -25,7 +25,6 @@
     timeToApply: 1
     MeltTimeMult: 0.1
     structure: true
-  - type: XenoCrusherChargable
   - type: Flammable
     fireSpread: false
     maximumFireStacks: 0.5
@@ -40,7 +39,6 @@
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
-  
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Flora/tallgrass.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Flora/tallgrass.yml
@@ -21,6 +21,11 @@
         path: /Audio/Effects/chop.ogg
         params:
           variation: 0.05
+  - type: Corrodible
+    timeToApply: 1
+    MeltTimeMult: 0.1
+    structure: true
+  - type: XenoCrusherChargable
   - type: Flammable
     fireSpread: false
     maximumFireStacks: 0.5
@@ -35,6 +40,7 @@
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
+  
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Flora/tallgrass.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Flora/tallgrass.yml
@@ -31,6 +31,7 @@
     damage:
       types:
         Heat: 1
+  - type: SprayAcidVulnerable
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Flora/tallgrass.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Flora/tallgrass.yml
@@ -23,7 +23,7 @@
           variation: 0.05
   - type: Corrodible
     timeToApply: 1
-    MeltTimeMult: 0.1
+    meltTimeMult: 0.1
     structure: true
   - type: Flammable
     fireSpread: false

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Flora/tallgrass.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Flora/tallgrass.yml
@@ -21,6 +21,12 @@
         path: /Audio/Effects/chop.ogg
         params:
           variation: 0.05
+  - type: Flammable
+    fireSpread: false
+    maximumFireStacks: 0.5
+    damage:
+      types:
+        Heat: 1
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Walls/Barricades/barricade_base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Walls/Barricades/barricade_base.yml
@@ -60,6 +60,7 @@
             visible: false
   - type: DamageMultiplierFlags
     flags: Breaching
+  - type: SprayAcidVulnerable
   - type: InvulnerabilityTime
     whitelist:
       components:

--- a/Resources/Prototypes/_RMC14/Entities/Tiles/tile_fire.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Tiles/tile_fire.yml
@@ -18,7 +18,7 @@
         layer:
         - MobMask
         hard: false
-  - type: AlwaysHotComponent
+  - type: AlwaysHot 
   - type: Sprite
     sprite: _RMC14/Effects/fire.rsi
     noRot: true

--- a/Resources/Prototypes/_RMC14/Entities/Tiles/tile_fire.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Tiles/tile_fire.yml
@@ -18,6 +18,7 @@
         layer:
         - MobMask
         hard: false
+  - type: AlwaysHotComponent
   - type: Sprite
     sprite: _RMC14/Effects/fire.rsi
     noRot: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Enhanced capabilities regarding fire and burning objects, and the addition of the ability to use acid spray not only on barricades and people (now i see, mice are immune to acid spray :D)

## Why / Balance
For the most part, it's just for fun, and it's a shame you can't set something on fire

## Technical details
I mostly just updated the .yml configuration files, but I had to rewrite a bit of Spray Acid

## Media
<img width="194" height="200" alt="image" src="https://github.com/user-attachments/assets/487392f6-fb9c-4251-8ebc-13f3006be0e9" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl: Cintet
- add You can light a item with napalm
- add You can light a item with flare
- add Item turn to ash if you throw them into napalm
- add Cigarettes will light up if you light it a second time, or if you light the butt
- add Tallgrass now catches fire upon contact with napalm
- add Tallgrass now dissolving in the acid
- tweak Spray Acid can now be used on more than just barricades thanks to the new SprayAcidVulnerable component

