### PR TITLE
Fix weed spread through barricades

### DIFF
--- a/Content.Server/_RMC14/Xenonids/Weeds/XenoWeedsSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Weeds/XenoWeedsSystem.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using System.Numerics;
 using Content.Server.Atmos.Components;
 using Content.Server.Spreader;
@@ -11,11 +10,9 @@ using Content.Shared.Atmos;
 using Content.Shared.Coordinates;
 using Content.Shared.Damage;
 using Content.Shared.Maps;
-using Content.Shared.Physics;
 using Content.Shared.Tag;
 using Robust.Server.GameObjects;
 using Robust.Shared.Map.Components;
-using Robust.Shared.Physics;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
@@ -32,8 +29,6 @@ public sealed class XenoWeedsSystem : SharedXenoWeedsSystem
     [Dependency] private readonly AppearanceSystem _appearance = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly TurfSystem _turf = default!;
-    [Dependency] private readonly PhysicsSystem _physics = default!;
-
     private static readonly ProtoId<TagPrototype> IgnoredTag = "SpreaderIgnore";
 
     private readonly List<EntityUid> _anchored = new();
@@ -119,13 +114,7 @@ public sealed class XenoWeedsSystem : SharedXenoWeedsSystem
                     }
                 }
 
-                // Do a raycast to see if any entities with offset fixtures are blocking the spread
-                var weedPosition = _transform.GetMoverCoordinates(uid).Position;
-                var ray = new CollisionRay(weedPosition, cardinal.CardinalToIntVec(), (int)CollisionGroup.BarricadeImpassable);
-                var intersect = _physics.IntersectRayWithPredicate(Transform(uid).MapID, ray, 0.6f, e => !Transform(e).Anchored);
-                var results = intersect.Select(r => r.HitEntity).ToHashSet();
-
-                if (results.Count > 0)
+                if (!CanSpreadWeedsBetween(uid.ToCoordinates(), _map.GridTileToLocal(grid, grid, neighbor)))
                     blocked = true;
 
                 if (blocked)

--- a/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
@@ -337,17 +337,42 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
             return;
         }
 
+        var tile = _mapSystem.CoordinatesToTile(gridUid, gridComp, coordinates);
+        var targetCenter = _mapSystem.GridTileToLocal(grid, gridComp, tile);
         Entity<XenoWeedsComponent> adjacent = default;
         if (existing == null)
         {
+            var foundAdjacent = false;
             foreach (var direction in _rmcMap.CardinalDirections)
             {
-                if (_rmcMap.HasAnchoredEntityEnumerator(coordinates, out adjacent, direction))
+                using var nearby = _rmcMap.GetAnchoredEntitiesEnumerator<XenoWeedsComponent>(coordinates, direction);
+                while (nearby.MoveNext(out var nearbyWeeds) &&
+                       TryComp(nearbyWeeds, out XenoWeedsComponent? nearbyWeedsComp))
+                {
+                    foundAdjacent = true;
+                    if (!_xenoWeeds.CanSpreadWeedsBetween(nearbyWeeds.ToCoordinates(), targetCenter))
+                        continue;
+
+                    adjacent = (nearbyWeeds, nearbyWeedsComp);
+                    break;
+                }
+
+                if (adjacent != default)
                     break;
             }
 
             if (adjacent == default)
             {
+                if (foundAdjacent)
+                {
+                    _popup.PopupClient(Loc.GetString("cm-xeno-construction-failed-weeds"),
+                        args.Target,
+                        xeno,
+                        PopupType.SmallCaution);
+
+                    return;
+                }
+
                 _popup.PopupClient("You can only plant weeds if there is a nearby node.",
                     args.Target,
                     xeno,
@@ -358,7 +383,6 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
         }
 
         var toSpawn = existing == null ? args.Expand : args.Source;
-        var tile = _mapSystem.CoordinatesToTile(gridUid, gridComp, coordinates);
         if (!_xenoWeeds.CanSpreadWeedsPopup(grid, tile, xeno, false, true))
             return;
 

--- a/Content.Shared/_RMC14/Xenonids/Weeds/SharedXenoWeedsSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Weeds/SharedXenoWeedsSystem.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using Content.Shared._RMC14.Areas;
 using Content.Shared._RMC14.Armor;
 using Content.Shared._RMC14.CCVar;
@@ -32,6 +33,7 @@ using Robust.Shared.Containers;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Network;
+using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Physics.Systems;
@@ -44,6 +46,8 @@ namespace Content.Shared._RMC14.Xenonids.Weeds;
 
 public abstract class SharedXenoWeedsSystem : EntitySystem
 {
+    private const float MinimumSpreadBlockRayLength = 0.6f;
+
     [Dependency] private readonly AreaSystem _area = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly IConfigurationManager _config = default!;
@@ -441,6 +445,33 @@ public abstract class SharedXenoWeedsSystem : EntitySystem
             return null;
 
         return GetWeedsOnFloor((gridId, grid), coordinates, sourceOnly);
+    }
+
+    public bool CanSpreadWeedsBetween(EntityCoordinates source, EntityCoordinates target)
+    {
+        var sourceMap = _transform.ToMapCoordinates(_transform.GetMoverCoordinates(source));
+        var targetMap = _transform.ToMapCoordinates(_transform.GetMoverCoordinates(target));
+        if (sourceMap.MapId != targetMap.MapId)
+            return false;
+
+        var direction = targetMap.Position - sourceMap.Position;
+        if (direction == Vector2.Zero)
+            return true;
+
+        var distance = direction.Length();
+        var ray = new CollisionRay(sourceMap.Position, direction.Normalized(), (int) CollisionGroup.BarricadeImpassable);
+        var intersect = _physics.IntersectRayWithPredicate(
+            sourceMap.MapId,
+            ray,
+            MathF.Max(MinimumSpreadBlockRayLength, distance),
+            ent => !Transform(ent).Anchored);
+
+        foreach (var _ in intersect)
+        {
+            return false;
+        }
+
+        return true;
     }
 
     public bool IsOnWeeds(Entity<TransformComponent?> entity)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Fixes xeno weeds being able to spread through barricade collision when using Queen `Expand Weeds`.

Previously, manual `Expand Weeds` could place weeds onto a barricade tile from the blocked/front side or use nearby weeds through a barricade, effectively letting weeds pass through closed barricade collision.

Manual `Expand Weeds` now uses the same barricade spread rule as automatic weed spreading. Closed folding barricades block weeds from spreading through their closed/front side, while still allowing weeds to spread onto the barricade tile from an unblocked side or when the barricade is open.

Related to #9735 and #9258.

## Why / Balance

Barricades already block automatic weed spread through their impassable collision. Manual `Expand Weeds` could bypass that by spreading onto a barricade tile from the blocked side or by using nearby weeds through a barricade, which let queens extend weeds past intended barricade defenses.

This keeps Queen Eye visibility unchanged: seeing a tile through weeds vision does not by itself mean weeds can spread through barricade collision.

## Technical details

Adds `SharedXenoWeedsSystem.CanSpreadWeedsBetween(source, target)`, which raycasts between the source weeds and target tile using `CollisionGroup.BarricadeImpassable`.

`XenoWeedsSystem.Update` now uses that helper instead of its local duplicated barricade raycast.

`OnXenoExpandWeedsAction` now searches for an adjacent weeds tile that can actually spread into the target tile. If adjacent weeds exist but every path is blocked, the expand fails with the existing generic weeds failure popup.

## Media

N/A, small gameplay fix.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

- fix: Fixed Queen Expand Weeds spreading weeds through barricade collision