### PR TITLE
Larva rank is now based on overall xeno playtime

### DIFF
--- a/Content.Client/IoC/ClientContentIoC.cs
+++ b/Content.Client/IoC/ClientContentIoC.cs
@@ -17,13 +17,14 @@ using Content.Client.Lobby;
 using Content.Client.Mapping;
 using Content.Client.Parallax.Managers;
 using Content.Client.Players.PlayTimeTracking;
-using Content.Client.Playtime;
 using Content.Client.Players.RateLimiting;
+using Content.Client.Playtime;
 using Content.Client.Replay;
 using Content.Client.Screenshot;
 using Content.Client.Stylesheets;
 using Content.Client.Viewport;
 using Content.Client.Voting;
+using Content.Shared._RMC14.PlayTimeTracking;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Administration.Managers;
 using Content.Shared.Chat;
@@ -70,6 +71,7 @@ namespace Content.Client.IoC
             // RMC14
             collection.Register<LinkAccountManager>();
             collection.Register<RMCPlayTimeManager>();
+            collection.Register<SharedRMCPlayTimeManager, RMCPlayTimeManager>();
             collection.Register<CommendationsManager>();
             collection.Register<TacticalMapSettingsManager>();
         }

--- a/Content.Client/_RMC14/PlayTimeTracking/RMCPlayTimeManager.cs
+++ b/Content.Client/_RMC14/PlayTimeTracking/RMCPlayTimeManager.cs
@@ -11,9 +11,9 @@ public sealed class RMCPlayTimeManager : SharedRMCPlayTimeManager
 
     public event Action? Updated;
 
-    public override void Initialize()
+    protected override void PostInject()
     {
-        base.Initialize();
+        base.PostInject();
         _net.RegisterNetMessage<RMCExcludedTimersMsg>(OnExcludedTimers);
     }
 

--- a/Content.Client/_RMC14/PlayTimeTracking/RMCPlayTimeManager.cs
+++ b/Content.Client/_RMC14/PlayTimeTracking/RMCPlayTimeManager.cs
@@ -1,7 +1,5 @@
 using Content.Shared._RMC14.PlayTimeTracking;
-using Robust.Client.Player;
 using Robust.Shared.Network;
-using Robust.Shared.Player;
 
 namespace Content.Client._RMC14.PlayTimeTracking;
 

--- a/Content.Client/_RMC14/PlayTimeTracking/RMCPlayTimeManager.cs
+++ b/Content.Client/_RMC14/PlayTimeTracking/RMCPlayTimeManager.cs
@@ -1,17 +1,23 @@
-﻿using Content.Shared._RMC14.PlayTimeTracking;
+using Content.Shared._RMC14.PlayTimeTracking;
 using Robust.Client.Player;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
 
 namespace Content.Client._RMC14.PlayTimeTracking;
 
-public sealed class RMCPlayTimeManager : IPostInjectInit
+public sealed class RMCPlayTimeManager : SharedRMCPlayTimeManager
 {
     [Dependency] private readonly INetManager _net = default!;
 
     private readonly HashSet<string> _excluded = [];
 
     public event Action? Updated;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        _net.RegisterNetMessage<RMCExcludedTimersMsg>(OnExcludedTimers);
+    }
 
     private void OnExcludedTimers(RMCExcludedTimersMsg message)
     {
@@ -23,10 +29,5 @@ public sealed class RMCPlayTimeManager : IPostInjectInit
     public bool IsExcluded(string tracker)
     {
         return _excluded.Contains(tracker);
-    }
-
-    void IPostInjectInit.PostInject()
-    {
-        _net.RegisterNetMessage<RMCExcludedTimersMsg>(OnExcludedTimers);
     }
 }

--- a/Content.Client/_RMC14/Xenonids/Hud/XenoHudOverlay.cs
+++ b/Content.Client/_RMC14/Xenonids/Hud/XenoHudOverlay.cs
@@ -72,6 +72,8 @@ public sealed class XenoHudOverlay : Overlay
     private readonly ResPath _rsiPathSlow = new("/Textures/_RMC14/Effects/xeno_stomp.rsi");
     private readonly ResPath _rsiPathFreeze = new("/Textures/_RMC14/Effects/xeno_freeze.rsi");
 
+    private readonly int _maxDisplayRank = 6;
+
     public XenoHudOverlay()
     {
         IoCManager.InjectDependencies(this);
@@ -273,7 +275,7 @@ public sealed class XenoHudOverlay : Overlay
         var ranks = _entity.EntityQueryEnumerator<XenoRankComponent, SpriteComponent, TransformComponent>();
         while (ranks.MoveNext(out var uid, out var comp, out var sprite, out var xform))
         {
-            if (comp.Rank < 2 || comp.Rank > 6 || _xenoMaturingQuery.HasComp(uid))
+            if (comp.Rank < 2 || _xenoMaturingQuery.HasComp(uid))
                 continue;
 
             if (xform.MapID != args.MapId)
@@ -296,7 +298,9 @@ public sealed class XenoHudOverlay : Overlay
             var matrix = Matrix3x2.Multiply(rotationMatrix, scaledWorld);
             handle.SetTransform(matrix);
 
-            var icon = new Rsi(_rsiPath, $"hudxenoupgrade{comp.Rank}");
+            var displayRank = Math.Min(comp.Rank, _maxDisplayRank);
+
+            var icon = new Rsi(_rsiPath, $"hudxenoupgrade{displayRank}");
             var texture = _sprite.GetFrame(icon, _timing.CurTime);
 
             var yOffset = (bounds.Height + sprite.Offset.Y) / 2f - (float) texture.Height / EyeManager.PixelsPerMeter * bounds.Height;

--- a/Content.Server/IoC/ServerContentIoC.cs
+++ b/Content.Server/IoC/ServerContentIoC.cs
@@ -30,6 +30,7 @@ using Content.Server.ServerInfo;
 using Content.Server.ServerUpdates;
 using Content.Server.Voting.Managers;
 using Content.Server.Worldgen.Tools;
+using Content.Shared._RMC14.PlayTimeTracking;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Administration.Managers;
 using Content.Shared.Chat;
@@ -90,6 +91,7 @@ namespace Content.Server.IoC
             // RMC14
             IoCManager.Register<LinkAccountManager>();
             IoCManager.Register<RMCPlayTimeManager>();
+            IoCManager.Register<SharedRMCPlayTimeManager, RMCPlayTimeManager>();
             IoCManager.Register<RMCDiscordManager>();
             IoCManager.Register<MentorManager>();
             IoCManager.Register<CommendationManager>();

--- a/Content.Server/_RMC14/NewPlayer/NewPlayerSystem.cs
+++ b/Content.Server/_RMC14/NewPlayer/NewPlayerSystem.cs
@@ -2,7 +2,6 @@ using Content.Server._RMC14.PlayTimeTracking;
 using Content.Server.Players.PlayTimeTracking;
 using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.NewPlayer;
-using Content.Shared._RMC14.PlayTimeTracking;
 using Content.Shared.GameTicking;
 using Content.Shared.Roles;
 using Robust.Shared.Configuration;

--- a/Content.Server/_RMC14/NewPlayer/NewPlayerSystem.cs
+++ b/Content.Server/_RMC14/NewPlayer/NewPlayerSystem.cs
@@ -1,9 +1,9 @@
-﻿using System.Collections.Immutable;
+using Content.Server._RMC14.PlayTimeTracking;
 using Content.Server.Players.PlayTimeTracking;
 using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.NewPlayer;
+using Content.Shared._RMC14.PlayTimeTracking;
 using Content.Shared.GameTicking;
-using Content.Shared.Players.PlayTimeTracking;
 using Content.Shared.Roles;
 using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
@@ -16,9 +16,7 @@ public sealed class NewPlayerSystem : EntitySystem
     [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] private readonly PlayTimeTrackingManager _playtimeManager = default!;
     [Dependency] private readonly IPrototypeManager _prototypes = default!;
-
-    private ImmutableHashSet<ProtoId<PlayTimeTrackerPrototype>> _humanoidTrackers =
-        ImmutableHashSet<ProtoId<PlayTimeTrackerPrototype>>.Empty;
+    [Dependency] private readonly RMCPlayTimeManager _rmcPlaytime = default!;
 
     private TimeSpan _newPlayerTimeTotal;
     private TimeSpan _newPlayerTimeJob;
@@ -26,43 +24,26 @@ public sealed class NewPlayerSystem : EntitySystem
 
     public override void Initialize()
     {
-        SubscribeLocalEvent<PrototypesReloadedEventArgs>(OnPrototypesReloaded);
-
         SubscribeLocalEvent<NewPlayerLabelComponent, PlayerSpawnCompleteEvent>(OnPlayerSpawnComplete);
-
-        ReloadPrototypes();
 
         Subs.CVar(_config, RMCCVars.RMCNewPlayerTimeTotalHours, v => _newPlayerTimeTotal = TimeSpan.FromHours(v), true);
         Subs.CVar(_config, RMCCVars.RMCNewPlayerTimeJobHours, v => _newPlayerTimeJob = TimeSpan.FromHours(v), true);
         Subs.CVar(_config, RMCCVars.RMCBrandNewPlayerTimeJobHours, v => _brandNewPlayerTimeJob = TimeSpan.FromHours(v), true);
     }
 
-    private void OnPrototypesReloaded(PrototypesReloadedEventArgs ev)
-    {
-        if (ev.WasModified<PlayTimeTrackerPrototype>())
-            ReloadPrototypes();
-    }
-
     private void OnPlayerSpawnComplete(Entity<NewPlayerLabelComponent> ent, ref PlayerSpawnCompleteEvent args)
     {
         if (args.JobId is not { } jobId ||
             !_prototypes.TryIndex(jobId, out JobPrototype? job) ||
-            !_humanoidTrackers.Contains(job.PlayTimeTracker))
+            !_rmcPlaytime.IsHumanJob(job.PlayTimeTracker))
         {
             return;
         }
 
         try
         {
-            var times = _playtimeManager.GetPlayTimes(args.Player);
-            var totalTime = TimeSpan.Zero;
-            foreach (var time in times)
-            {
-                if (_humanoidTrackers.Contains(time.Key))
-                    totalTime += time.Value;
-            }
-
-            var jobTime = times.GetValueOrDefault(job.PlayTimeTracker);
+            var totalTime = _rmcPlaytime.GetTotalHumanPlaytime(args.Player);
+            var jobTime = _playtimeManager.GetPlayTimeForTracker(args.Player, job.PlayTimeTracker);
             var newTotal = totalTime < _newPlayerTimeTotal;
             var newJob = jobTime <= _newPlayerTimeJob;
             var brandNewJob = jobTime <= _brandNewPlayerTimeJob;
@@ -91,17 +72,5 @@ public sealed class NewPlayerSystem : EntitySystem
         {
             Log.Error($"Error getting new player playtime:\n{e}");
         }
-    }
-
-    private void ReloadPrototypes()
-    {
-        var jobs = new HashSet<ProtoId<PlayTimeTrackerPrototype>>();
-        foreach (var job in _prototypes.EnumeratePrototypes<PlayTimeTrackerPrototype>())
-        {
-            if (job.IsHumanoid)
-                jobs.Add(job.ID);
-        }
-
-        _humanoidTrackers = jobs.ToImmutableHashSet();
     }
 }

--- a/Content.Server/_RMC14/PlayTimeTracking/RMCPlayTimeManager.cs
+++ b/Content.Server/_RMC14/PlayTimeTracking/RMCPlayTimeManager.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading;
+using System.Threading;
 using System.Threading.Tasks;
 using Content.Server.Database;
 using Content.Shared._RMC14.PlayTimeTracking;
@@ -10,7 +10,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Server._RMC14.PlayTimeTracking;
 
-public sealed class RMCPlayTimeManager : IPostInjectInit
+public sealed class RMCPlayTimeManager : SharedRMCPlayTimeManager
 {
     [Dependency] private readonly IServerDbManager _db = default!;
     [Dependency] private readonly INetManager _net = default!;
@@ -18,6 +18,16 @@ public sealed class RMCPlayTimeManager : IPostInjectInit
     [Dependency] private readonly UserDbDataManager _userDb = default!;
 
     private readonly Dictionary<NetUserId, HashSet<string>> _excluded = [];
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _net.RegisterNetMessage<RMCExcludedTimersMsg>();
+        _userDb.AddOnLoadPlayer(LoadData);
+        _userDb.AddOnFinishLoad(FinishLoad);
+        _userDb.AddOnPlayerDisconnect(ClientDisconnected);
+    }
 
     private async Task LoadData(ICommonSession player, CancellationToken cancel)
     {
@@ -91,13 +101,5 @@ public sealed class RMCPlayTimeManager : IPostInjectInit
         }
 
         return true;
-    }
-
-    void IPostInjectInit.PostInject()
-    {
-        _net.RegisterNetMessage<RMCExcludedTimersMsg>();
-        _userDb.AddOnLoadPlayer(LoadData);
-        _userDb.AddOnFinishLoad(FinishLoad);
-        _userDb.AddOnPlayerDisconnect(ClientDisconnected);
     }
 }

--- a/Content.Server/_RMC14/PlayTimeTracking/RMCPlayTimeManager.cs
+++ b/Content.Server/_RMC14/PlayTimeTracking/RMCPlayTimeManager.cs
@@ -19,9 +19,9 @@ public sealed class RMCPlayTimeManager : SharedRMCPlayTimeManager
 
     private readonly Dictionary<NetUserId, HashSet<string>> _excluded = [];
 
-    public override void Initialize()
+    protected override void PostInject()
     {
-        base.Initialize();
+        base.PostInject();
 
         _net.RegisterNetMessage<RMCExcludedTimersMsg>();
         _userDb.AddOnLoadPlayer(LoadData);

--- a/Content.Server/_RMC14/Xenonids/XenoRoleSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/XenoRoleSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server._RMC14.PlayTimeTracking;
 using Content.Server.GameTicking;
 using Content.Server.Mind;
 using Content.Server.Players.PlayTimeTracking;
@@ -31,6 +32,7 @@ public sealed class XenoRoleSystem : EntitySystem
     [Dependency] private readonly PlayTimeTrackingManager _playTimeManager = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly PvsOverrideSystem _pvsOverride = default!;
+    [Dependency] private readonly RMCPlayTimeManager _rmcPlaytime = default!;
     [Dependency] private readonly RoleSystem _role = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
 
@@ -43,6 +45,8 @@ public sealed class XenoRoleSystem : EntitySystem
     private TimeSpan _rankSixTime;
 
     private readonly List<Entity<XenoComponent>> _toUpdate = new();
+
+    private readonly ProtoId<JobPrototype> _larvaJobProtoId = "CMXenoLarva";
 
     public override void Initialize()
     {
@@ -129,7 +133,19 @@ public sealed class XenoRoleSystem : EntitySystem
             return;
 
         var time = TimeSpan.Zero;
-        if (_prototype.TryIndex(jobId, out JobPrototype? job) &&
+        if (jobId == _larvaJobProtoId)
+        {
+            // Larva's rank is determined by TOTAL xeno playtime, NOT larva playtime.
+            try
+            {
+                time = _rmcPlaytime.GetTotalXenoPlaytime(player);
+            }
+            catch (Exception e)
+            {
+                Log.Error($"Error reading total xeno playtime:\n{e}");
+            }
+        }
+        else if (_prototype.TryIndex(jobId, out JobPrototype? job) &&
             _playTimeManager.TryGetTrackerTime(player, job.PlayTimeTracker, out var nullableTime))
         {
             time = nullableTime.Value;

--- a/Content.Server/_RMC14/Xenonids/XenoRoleSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/XenoRoleSystem.cs
@@ -37,6 +37,7 @@ public sealed class XenoRoleSystem : EntitySystem
     [Dependency] private readonly IGameTiming _timing = default!;
 
     private TimeSpan _disconnectedXenoGhostRoleTime;
+    private float _larvaRankScaleFactor = 1.0f;
 
     // TODO RMC14 you know what you have to do
     private TimeSpan _rankTwoTime;
@@ -66,6 +67,7 @@ public sealed class XenoRoleSystem : EntitySystem
 
         SubscribeLocalEvent<XenoRankComponent, RefreshNameModifiersEvent>(OnRankRefreshName, before: new[] { typeof(SharedXenoNameSystem) });
 
+        Subs.CVar(_config, RMCCVars.RMCPlaytimeLarvaRankScaleFactor, v => _larvaRankScaleFactor = v, true);
         Subs.CVar(_config, RMCCVars.RMCPlaytimeBronzeMedalTimeHours, v => _rankTwoTime = TimeSpan.FromHours(v), true);
         Subs.CVar(_config, RMCCVars.RMCPlaytimeSilverMedalTimeHours, v => _rankThreeTime = TimeSpan.FromHours(v), true);
         Subs.CVar(_config, RMCCVars.RMCPlaytimeGoldMedalTimeHours, v => _rankFourTime = TimeSpan.FromHours(v), true);
@@ -142,10 +144,10 @@ public sealed class XenoRoleSystem : EntitySystem
         var time = TimeSpan.Zero;
         if (jobId == _larvaJobProtoId)
         {
-            // Larva's rank is determined by TOTAL xeno playtime, NOT larva playtime.
+            // Larva's rank is determined by TOTAL xeno playtime, NOT larva playtime, adjusted by scale factor
             try
             {
-                time = _rmcPlaytime.GetTotalXenoPlaytime(player);
+                time = _rmcPlaytime.GetTotalXenoPlaytime(player) / _larvaRankScaleFactor;
             }
             catch (Exception e)
             {

--- a/Content.Server/_RMC14/Xenonids/XenoRoleSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/XenoRoleSystem.cs
@@ -38,11 +38,15 @@ public sealed class XenoRoleSystem : EntitySystem
 
     private TimeSpan _disconnectedXenoGhostRoleTime;
 
+    // TODO RMC14 you know what you have to do
     private TimeSpan _rankTwoTime;
     private TimeSpan _rankThreeTime;
     private TimeSpan _rankFourTime;
     private TimeSpan _rankFiveTime;
     private TimeSpan _rankSixTime;
+    private TimeSpan _rankSevenTime;
+    private TimeSpan _rankEightTime;
+    private TimeSpan _rankNineTime;
 
     private readonly List<Entity<XenoComponent>> _toUpdate = new();
 
@@ -67,6 +71,9 @@ public sealed class XenoRoleSystem : EntitySystem
         Subs.CVar(_config, RMCCVars.RMCPlaytimeGoldMedalTimeHours, v => _rankFourTime = TimeSpan.FromHours(v), true);
         Subs.CVar(_config, RMCCVars.RMCPlaytimePlatinumMedalTimeHours, v => _rankFiveTime = TimeSpan.FromHours(v), true);
         Subs.CVar(_config, RMCCVars.RMCPlaytimeRubyMedalTimeHours, v => _rankSixTime = TimeSpan.FromHours(v), true);
+        Subs.CVar(_config, RMCCVars.RMCPlaytimeAmethystMedalTimeHours, v => _rankSevenTime = TimeSpan.FromHours(v), true);
+        Subs.CVar(_config, RMCCVars.RMCPlaytimeEmeraldMedalTimeHours, v => _rankEightTime = TimeSpan.FromHours(v), true);
+        Subs.CVar(_config, RMCCVars.RMCPlaytimePrismaticMedalTimeHours, v => _rankNineTime = TimeSpan.FromHours(v), true);
         Subs.CVar(_config, RMCCVars.RMCDisconnectedXenoGhostRoleTimeSeconds, v => _disconnectedXenoGhostRoleTime = TimeSpan.FromSeconds(v), true);
     }
 
@@ -154,6 +161,12 @@ public sealed class XenoRoleSystem : EntitySystem
         int rank;
         if (!profile.PlaytimePerks)
             rank = 1;
+        else if (time > _rankNineTime)
+            rank = 9;
+        else if (time > _rankEightTime)
+            rank = 8;
+        else if (time > _rankSevenTime)
+            rank = 7;
         else if (time > _rankSixTime)
             rank = 6;
         else if (time > _rankFiveTime)

--- a/Content.Shared/Entry/EntryPoint.cs
+++ b/Content.Shared/Entry/EntryPoint.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using Content.Shared._RMC14.PlayTimeTracking;
 using Content.Shared.Humanoid.Markings;
 using Content.Shared.IoC;
 using Content.Shared.Maps;
@@ -46,6 +47,13 @@ namespace Content.Shared.Entry
 
             InitTileDefinitions();
             IoCManager.Resolve<MarkingManager>().Initialize();
+
+            // RMC14
+            // RMC14 TODO this is only here because we need prototypes to be loaded by the
+            // prototype manager, which apparently they are at this point. It's very sus but
+            // I couldn't find a better way, MarkingManager is the only manager that does
+            // something similar, and you can see it right above.
+            IoCManager.Resolve<SharedRMCPlayTimeManager>().Initialize();
 
 #if DEBUG
             var configMan = IoCManager.Resolve<IConfigurationManager>();

--- a/Content.Shared/Entry/EntryPoint.cs
+++ b/Content.Shared/Entry/EntryPoint.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
-using Content.Shared._RMC14.PlayTimeTracking;
 using Content.Shared.Humanoid.Markings;
 using Content.Shared.IoC;
 using Content.Shared.Maps;
@@ -47,13 +46,6 @@ namespace Content.Shared.Entry
 
             InitTileDefinitions();
             IoCManager.Resolve<MarkingManager>().Initialize();
-
-            // RMC14
-            // TODO RMC14 this is only here because we need prototypes to be loaded by the
-            // prototype manager, which apparently they are at this point. It's very sus but
-            // I couldn't find a better way, MarkingManager is the only manager that does
-            // something similar, and you can see it right above.
-            IoCManager.Resolve<SharedRMCPlayTimeManager>().Initialize();
 
 #if DEBUG
             var configMan = IoCManager.Resolve<IConfigurationManager>();

--- a/Content.Shared/Entry/EntryPoint.cs
+++ b/Content.Shared/Entry/EntryPoint.cs
@@ -49,7 +49,7 @@ namespace Content.Shared.Entry
             IoCManager.Resolve<MarkingManager>().Initialize();
 
             // RMC14
-            // RMC14 TODO this is only here because we need prototypes to be loaded by the
+            // TODO RMC14 this is only here because we need prototypes to be loaded by the
             // prototype manager, which apparently they are at this point. It's very sus but
             // I couldn't find a better way, MarkingManager is the only manager that does
             // something similar, and you can see it right above.

--- a/Content.Shared/_RMC14/CCVar/RMCCVars.cs
+++ b/Content.Shared/_RMC14/CCVar/RMCCVars.cs
@@ -265,6 +265,9 @@ public sealed partial class RMCCVars : CVars
     public static readonly CVarDef<int> RMCBurrowedLarvaEvolutionPointsPer =
         CVarDef.Create("rmc.burrowed_larva_evolution_points_per", 250, CVar.REPLICATED | CVar.SERVER);
 
+    public static readonly CVarDef<float> RMCPlaytimeLarvaRankScaleFactor =
+        CVarDef.Create("rmc.playtime_larva_rank_scale_factor", 3.0f, CVar.REPLICATED | CVar.SERVER);
+
     public static readonly CVarDef<int> RMCPlaytimeBronzeMedalTimeHours =
         CVarDef.Create("rmc.playtime_bronze_medal_time_hours", 10, CVar.REPLICATED | CVar.SERVER);
 

--- a/Content.Shared/_RMC14/PlayTimeTracking/SharedRMCPlayTimeManager.cs
+++ b/Content.Shared/_RMC14/PlayTimeTracking/SharedRMCPlayTimeManager.cs
@@ -1,0 +1,109 @@
+using System.Collections.Frozen;
+using System.Collections.Immutable;
+using System.Linq;
+using Content.Shared.Players.PlayTimeTracking;
+using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._RMC14.PlayTimeTracking;
+
+public abstract class SharedRMCPlayTimeManager
+{
+    [Dependency] private readonly ISharedPlaytimeManager _playtime = default!;
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
+
+    private FrozenSet<ProtoId<PlayTimeTrackerPrototype>> _xenoJobs = [];
+    private FrozenSet<ProtoId<PlayTimeTrackerPrototype>> _humanJobs = [];
+
+    // RMC14 TODO we use this Initialize function that's called in EntryPoint instead of implementing
+    // IPostInjectInit because prototypes aren't loaded during IPostInjectInit
+    public virtual void Initialize()
+    {
+        ReloadPrototypes();
+        _prototype.PrototypesReloaded += OnPrototypesReloaded;
+    }
+
+    /// <summary>
+    /// Returns the total player playtime for all human jobs.
+    /// </summary>
+    /// <param name="playerSession">test</param>
+    /// <param name="jobs"></param>
+    /// <exception cref="InvalidOperationException">Thrown if the player's playtime data is not yet loaded.</exception>
+    /// <returns>The total time the player has spent as a human.</returns>
+    public TimeSpan GetTotalHumanPlaytime(ICommonSession playerSession)
+    {
+        return GetTotalPlaytime(playerSession, _humanJobs);
+    }
+
+    /// <summary>
+    /// Returns the total player playtime for all xeno jobs.
+    /// </summary>
+    /// <param name="playerSession">test</param>
+    /// <param name="jobs"></param>
+    /// <exception cref="InvalidOperationException">Thrown if the player's playtime data is not yet loaded.</exception>
+    /// <returns>The total time the player has spent as a xeno.</returns>
+    public TimeSpan GetTotalXenoPlaytime(ICommonSession playerSession)
+    {
+        return GetTotalPlaytime(playerSession, _xenoJobs);
+    }
+
+    public bool IsHumanJob(string jobId)
+    {
+        return _humanJobs.Contains(jobId);
+    }
+
+    public bool IsXenoJob(string jobId)
+    {
+        return _xenoJobs.Contains(jobId);
+    }
+
+    /// <summary>
+    /// Returns the total player playtime for a set of jobs.
+    /// </summary>
+    /// <param name="playerSession">test</param>
+    /// <param name="jobs"></param>
+    /// <exception cref="InvalidOperationException">Thrown if the player's playtime data is not yet loaded.</exception>
+    /// <returns>The total time the player has spent in those jobs.</returns>
+    public TimeSpan GetTotalPlaytime(ICommonSession playerSession, IEnumerable<ProtoId<PlayTimeTrackerPrototype>> jobs)
+    {
+        IReadOnlyDictionary<string, TimeSpan> playTimes;
+
+        playTimes = _playtime.GetPlayTimes(playerSession);
+
+        var totalTime = TimeSpan.Zero;
+        foreach (var (jobId, jobTime) in playTimes)
+        {
+            if (!jobs.Contains(jobId))
+                continue;
+
+            totalTime += jobTime;
+        }
+
+        return totalTime;
+    }
+
+    private void OnPrototypesReloaded(PrototypesReloadedEventArgs args)
+    {
+        if (args.WasModified<PlayTimeTrackerPrototype>())
+            ReloadPrototypes();
+    }
+
+    private void ReloadPrototypes()
+    {
+        var jobs = new HashSet<ProtoId<PlayTimeTrackerPrototype>>();
+        foreach (var job in _prototype.EnumeratePrototypes<PlayTimeTrackerPrototype>())
+        {
+            if (job.IsHumanoid)
+                jobs.Add(job.ID);
+        }
+        _humanJobs = jobs.ToFrozenSet();
+
+        jobs.Clear();
+        foreach (var job in _prototype.EnumeratePrototypes<PlayTimeTrackerPrototype>())
+        {
+            if (job.IsXeno)
+                jobs.Add(job.ID);
+        }
+        _xenoJobs = jobs.ToFrozenSet();
+    }
+}

--- a/Content.Shared/_RMC14/PlayTimeTracking/SharedRMCPlayTimeManager.cs
+++ b/Content.Shared/_RMC14/PlayTimeTracking/SharedRMCPlayTimeManager.cs
@@ -15,7 +15,7 @@ public abstract class SharedRMCPlayTimeManager
     private FrozenSet<ProtoId<PlayTimeTrackerPrototype>> _xenoJobs = [];
     private FrozenSet<ProtoId<PlayTimeTrackerPrototype>> _humanJobs = [];
 
-    // RMC14 TODO we use this Initialize function that's called in EntryPoint instead of implementing
+    // TODO RMC14 we use this Initialize function that's called in EntryPoint instead of implementing
     // IPostInjectInit because prototypes aren't loaded during IPostInjectInit
     public virtual void Initialize()
     {

--- a/Content.Shared/_RMC14/PlayTimeTracking/SharedRMCPlayTimeManager.cs
+++ b/Content.Shared/_RMC14/PlayTimeTracking/SharedRMCPlayTimeManager.cs
@@ -12,7 +12,7 @@ public abstract class SharedRMCPlayTimeManager : IPostInjectInit
     [Dependency] private readonly ISharedPlaytimeManager _playtime = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
 
-    private bool _jobsDataLoaded = false;
+    private bool _jobsDataLoaded;
     private FrozenSet<ProtoId<PlayTimeTrackerPrototype>> _xenoJobs = [];
     private FrozenSet<ProtoId<PlayTimeTrackerPrototype>> _humanJobs = [];
 
@@ -49,11 +49,13 @@ public abstract class SharedRMCPlayTimeManager : IPostInjectInit
 
     public bool IsHumanJob(string jobId)
     {
+        EnsurePrototypesLoaded();
         return _humanJobs.Contains(jobId);
     }
 
     public bool IsXenoJob(string jobId)
     {
+        EnsurePrototypesLoaded();
         return _xenoJobs.Contains(jobId);
     }
 
@@ -68,9 +70,7 @@ public abstract class SharedRMCPlayTimeManager : IPostInjectInit
     {
         EnsurePrototypesLoaded();
 
-        IReadOnlyDictionary<string, TimeSpan> playTimes;
-
-        playTimes = _playtime.GetPlayTimes(playerSession);
+        var playTimes = _playtime.GetPlayTimes(playerSession);
 
         var totalTime = TimeSpan.Zero;
         foreach (var (jobId, jobTime) in playTimes)
@@ -98,21 +98,19 @@ public abstract class SharedRMCPlayTimeManager : IPostInjectInit
 
     private void ReloadPrototypes()
     {
-        var jobs = new HashSet<ProtoId<PlayTimeTrackerPrototype>>();
+        var humanJobs = new HashSet<ProtoId<PlayTimeTrackerPrototype>>();
+        var xenoJobs = new HashSet<ProtoId<PlayTimeTrackerPrototype>>();
+
         foreach (var job in _prototype.EnumeratePrototypes<PlayTimeTrackerPrototype>())
         {
             if (job.IsHumanoid)
-                jobs.Add(job.ID);
-        }
-        _humanJobs = jobs.ToFrozenSet();
-
-        jobs.Clear();
-        foreach (var job in _prototype.EnumeratePrototypes<PlayTimeTrackerPrototype>())
-        {
+                humanJobs.Add(job.ID);
             if (job.IsXeno)
-                jobs.Add(job.ID);
+                xenoJobs.Add(job.ID);
         }
-        _xenoJobs = jobs.ToFrozenSet();
+
+        _humanJobs = humanJobs.ToFrozenSet();
+        _xenoJobs = xenoJobs.ToFrozenSet();
 
         _jobsDataLoaded = true;
     }

--- a/Content.Shared/_RMC14/PlayTimeTracking/SharedRMCPlayTimeManager.cs
+++ b/Content.Shared/_RMC14/PlayTimeTracking/SharedRMCPlayTimeManager.cs
@@ -7,19 +7,19 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Shared._RMC14.PlayTimeTracking;
 
-public abstract class SharedRMCPlayTimeManager
+public abstract class SharedRMCPlayTimeManager : IPostInjectInit
 {
     [Dependency] private readonly ISharedPlaytimeManager _playtime = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
 
+    private bool _jobsDataLoaded = false;
     private FrozenSet<ProtoId<PlayTimeTrackerPrototype>> _xenoJobs = [];
     private FrozenSet<ProtoId<PlayTimeTrackerPrototype>> _humanJobs = [];
 
-    // TODO RMC14 we use this Initialize function that's called in EntryPoint instead of implementing
-    // IPostInjectInit because prototypes aren't loaded during IPostInjectInit
-    public virtual void Initialize()
+    void IPostInjectInit.PostInject() => PostInject();
+
+    protected virtual void PostInject()
     {
-        ReloadPrototypes();
         _prototype.PrototypesReloaded += OnPrototypesReloaded;
     }
 
@@ -66,6 +66,8 @@ public abstract class SharedRMCPlayTimeManager
     /// <returns>The total time the player has spent in those jobs.</returns>
     public TimeSpan GetTotalPlaytime(ICommonSession playerSession, IEnumerable<ProtoId<PlayTimeTrackerPrototype>> jobs)
     {
+        EnsurePrototypesLoaded();
+
         IReadOnlyDictionary<string, TimeSpan> playTimes;
 
         playTimes = _playtime.GetPlayTimes(playerSession);
@@ -80,6 +82,12 @@ public abstract class SharedRMCPlayTimeManager
         }
 
         return totalTime;
+    }
+
+    private void EnsurePrototypesLoaded()
+    {
+        if (!_jobsDataLoaded)
+            ReloadPrototypes();
     }
 
     private void OnPrototypesReloaded(PrototypesReloadedEventArgs args)
@@ -105,5 +113,7 @@ public abstract class SharedRMCPlayTimeManager
                 jobs.Add(job.ID);
         }
         _xenoJobs = jobs.ToFrozenSet();
+
+        _jobsDataLoaded = true;
     }
 }

--- a/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonSystem.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using System.Linq;
 using Content.Shared._RMC14.Areas;
 using Content.Shared._RMC14.Atmos;
@@ -10,6 +10,7 @@ using Content.Shared._RMC14.GameTicking;
 using Content.Shared._RMC14.Map;
 using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.Marines.Announce;
+using Content.Shared._RMC14.PlayTimeTracking;
 using Content.Shared._RMC14.Repairable;
 using Content.Shared._RMC14.Rules;
 using Content.Shared._RMC14.Xenonids.Announce;
@@ -21,9 +22,7 @@ using Content.Shared.Examine;
 using Content.Shared.GameTicking;
 using Content.Shared.Mind;
 using Content.Shared.Mobs.Systems;
-using Content.Shared.Players.PlayTimeTracking;
 using Content.Shared.Popups;
-using Content.Shared.Roles;
 using Robust.Shared.Configuration;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
@@ -49,13 +48,13 @@ public sealed class HiveBoonSystem : EntitySystem
     [Dependency] private readonly SharedMindSystem _mind = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly INetManager _net = default!;
-    [Dependency] private readonly ISharedPlaytimeManager _playtime = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly SharedRMCGameTickerSystem _rmcGameTicker = default!;
     [Dependency] private readonly RMCMapSystem _rmcMap = default!;
     [Dependency] private readonly RMCPlanetSystem _rmcPlanet = default!;
+    [Dependency] private readonly SharedRMCPlayTimeManager _rmcPlaytime = default!;
     [Dependency] private readonly ISerializationManager _serialization = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedXenoAnnounceSystem _xenoAnnounce = default!;
@@ -79,8 +78,6 @@ public sealed class HiveBoonSystem : EntitySystem
     private TimeSpan _kingVoteStartHatchingTime;
 
     private EntityQuery<ExcludedFromKingVoteComponent> _excludedFromKingVoteQuery;
-
-    private readonly HashSet<ProtoId<PlayTimeTrackerPrototype>> _xenoJobs = new();
 
     public override void Initialize()
     {
@@ -352,13 +349,6 @@ public sealed class HiveBoonSystem : EntitySystem
 
     private void StartKingVote(Entity<HiveKingCocoonComponent> cocoon)
     {
-        _xenoJobs.Clear();
-        foreach (var prototype in _prototype.EnumeratePrototypes<PlayTimeTrackerPrototype>())
-        {
-            if (prototype.IsXeno)
-                _xenoJobs.Add(prototype.ID);
-        }
-
         var options = new List<DialogOption>();
         var canVoteList = new List<EntityUid>();
         var netCocoon = GetNetEntity(cocoon);
@@ -404,27 +394,16 @@ public sealed class HiveBoonSystem : EntitySystem
         }
 
         canVote = true;
-        IReadOnlyDictionary<string, TimeSpan> playTimes;
+
         try
         {
-            playTimes = _playtime.GetPlayTimes(xeno.Comp.PlayerSession);
+            if (_rmcPlaytime.GetTotalXenoPlaytime(xeno.Comp.PlayerSession) < _kingVoteCandidateTimeRequired)
+                return;
         }
         catch
         {
             return;
         }
-
-        var totalTime = TimeSpan.Zero;
-        foreach (var (jobId, jobTime) in playTimes)
-        {
-            if (!_xenoJobs.Contains(jobId))
-                continue;
-
-            totalTime += jobTime;
-        }
-
-        if (totalTime < _kingVoteCandidateTimeRequired)
-            return;
 
         canBeKing = true;
     }

--- a/Content.Shared/_RMC14/Xenonids/Name/SharedXenoNameSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Name/SharedXenoNameSystem.cs
@@ -19,7 +19,6 @@ public abstract class SharedXenoNameSystem : EntitySystem
     [Dependency] private readonly SharedMindSystem _mind = default!;
     [Dependency] private readonly NameModifierSystem _nameModifier = default!;
     [Dependency] private readonly INetManager _net = default!;
-    [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly SharedRMCPlayTimeManager _rmcPlaytime = default!;
 
     private const string DefaultPrefix = "XX";

--- a/Content.Shared/_RMC14/Xenonids/Name/SharedXenoNameSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Name/SharedXenoNameSystem.cs
@@ -1,5 +1,6 @@
-﻿using Content.Shared._RMC14.CCVar;
+using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.IdentityManagement;
+using Content.Shared._RMC14.PlayTimeTracking;
 using Content.Shared._RMC14.Xenonids.Evolution;
 using Content.Shared.Mind;
 using Content.Shared.Mind.Components;
@@ -18,8 +19,8 @@ public abstract class SharedXenoNameSystem : EntitySystem
     [Dependency] private readonly SharedMindSystem _mind = default!;
     [Dependency] private readonly NameModifierSystem _nameModifier = default!;
     [Dependency] private readonly INetManager _net = default!;
-    [Dependency] private readonly ISharedPlaytimeManager _playtime = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly SharedRMCPlayTimeManager _rmcPlaytime = default!;
 
     private const string DefaultPrefix = "XX";
 
@@ -119,15 +120,7 @@ public abstract class SharedXenoNameSystem : EntitySystem
         var xenoPlaytime = TimeSpan.Zero;
         try
         {
-            var times = _playtime.GetPlayTimes(player);
-            foreach (var (id, time) in times)
-            {
-                if (_prototype.TryIndex(id, out PlayTimeTrackerPrototype? tracker) &&
-                    tracker.IsXeno)
-                {
-                    xenoPlaytime += time;
-                }
-            }
+            xenoPlaytime = _rmcPlaytime.GetTotalXenoPlaytime(player);
         }
         catch (Exception e)
         {

--- a/Content.Shared/_RMC14/Xenonids/Name/SharedXenoNameSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Name/SharedXenoNameSystem.cs
@@ -5,11 +5,9 @@ using Content.Shared._RMC14.Xenonids.Evolution;
 using Content.Shared.Mind;
 using Content.Shared.Mind.Components;
 using Content.Shared.NameModifier.EntitySystems;
-using Content.Shared.Players.PlayTimeTracking;
 using Robust.Shared.Configuration;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
-using Robust.Shared.Prototypes;
 
 namespace Content.Shared._RMC14.Xenonids.Name;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Larva rank is now determined by overall xeno hours, instead of larva hours.

Will need #9824 for more meaningful larva titles (many larvas are going to become apex or higher).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Time spent as a larva is unproductive, doesn't need to be rewarded, and isn't a useful metric. Time spent as a xeno is a much more meaningful metric.

## Technical details
<!-- Summary of code changes for easier review. -->
Refactored xeno/human overall playtime calculations into SharedRMCPlayTimeManager.
Larvas now calculate rank off of the player's total xeno hours.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Larva rank is now based off overall xeno playtime, instead of larva playtime.
