### PR TITLE
[FIX] Superceded by #9866

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Acid/SharedXenoAcidSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Acid/SharedXenoAcidSystem.cs
@@ -31,6 +31,7 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.Physics;
 using Content.Shared.Chemistry.Components.SolutionManager;
 using Content.Shared._RMC14.Chemistry;
+using Content.Shared._RMC14.Xenonids.Burrow;
 
 namespace Content.Shared._RMC14.Xenonids.Acid;
 
@@ -136,6 +137,9 @@ public abstract class SharedXenoAcidSystem : EntitySystem
                 return;
             }
         }
+
+        if (TryComp<XenoBurrowComponent>(xeno, out var burrow) && burrow.Active)
+            return;
 
         if (xeno.Owner != args.Performer ||
             !CheckCorrodiblePopupsWithReplacement(xeno, target, args.Strength, out var time, out var _))


### PR DESCRIPTION
## About the PR
Fixes burrowers being able to acid things whilst burrowed.

## Why / Balance
Bug and unintended mechanic. 

## Technical details
adds an early return in the Acid System which checks if burrower is burrowed.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:

- fix: Fixed Burrowers being able to acid whilst burrowed.

