### PR TITLE
Fix gun group penalties not always refreshing

### DIFF
--- a/Content.Shared/_RMC14/Weapons/Ranged/RMCGunGroupPenaltySystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/RMCGunGroupPenaltySystem.cs
@@ -3,6 +3,7 @@ using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Projectiles;
 using Content.Shared.Weapons.Ranged.Events;
 using Content.Shared.Weapons.Ranged.Systems;
+using Robust.Shared.Containers;
 
 namespace Content.Shared._RMC14.Weapons.Ranged;
 
@@ -22,6 +23,8 @@ public sealed class RMCGunGroupPenaltySystem : EntitySystem
 
         SubscribeLocalEvent<GunGroupPenaltyComponent, GotEquippedHandEvent>(OnGroupSpreadPenaltyEquippedHand);
         SubscribeLocalEvent<GunGroupPenaltyComponent, GotUnequippedHandEvent>(OnGroupSpreadPenaltyUnequippedHand);
+        SubscribeLocalEvent<GunGroupPenaltyComponent, EntParentChangedMessage>(OnGroupSpreadPenaltyParentChanged);
+        SubscribeLocalEvent<GunGroupPenaltyComponent, EntGotInsertedIntoContainerMessage>(OnInsertedIntoContainer);
         SubscribeLocalEvent<GunGroupPenaltyComponent, GunRefreshModifiersEvent>(OnGroupSpreadPenaltyRefreshModifiers);
         SubscribeLocalEvent<GunGroupPenaltyComponent, AmmoShotEvent>(OnGroupSpreadPenaltyAmmoShot, before: [typeof(CMGunSystem)]);
     }
@@ -34,6 +37,25 @@ public sealed class RMCGunGroupPenaltySystem : EntitySystem
     private void OnGroupSpreadPenaltyUnequippedHand(Entity<GunGroupPenaltyComponent> ent, ref GotUnequippedHandEvent args)
     {
         RefreshGunHolderModifiers(ent);
+    }
+
+    private void OnGroupSpreadPenaltyParentChanged(Entity<GunGroupPenaltyComponent> ent, ref EntParentChangedMessage args)
+    {
+        if (args.OldParent == null)
+            return;
+
+        foreach (var held in _hands.EnumerateHeld(args.OldParent.Value))
+        {
+            _gun.RefreshModifiers(held);
+        }
+    }
+
+    private void OnInsertedIntoContainer(Entity<GunGroupPenaltyComponent> ent, ref EntGotInsertedIntoContainerMessage args)
+    {
+        foreach (var held in _hands.EnumerateHeld(args.Container.Owner))
+        {
+            _gun.RefreshModifiers(held);
+        }
     }
 
     private void OnGroupSpreadPenaltyRefreshModifiers(Entity<GunGroupPenaltyComponent> ent, ref GunRefreshModifiersEvent args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Gun modifiers now refresh on all guns in a user's hands after another gun they were holding is dropped or reparented.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug fix. It mostly affected M63's with an armbrace, it would keep the dual wield penalty after picking up a gun with the other hand until you undid the brace or did any other action that refreshed modifiers(swapping attachment, wielding/unwielding etc.).

## Technical details
<!-- Summary of code changes for easier review. -->
GotUnequipped runs before reparenting, this means the gun that's not dropped refreshed it's modifiers while the other gun was still in the hand.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix: Fixed guns not always losing their dual wielding penalty after dropping one of the guns.
