### PR TITLE
[PVE] Syracuse pump-action shotgun

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/pve_cases.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/pve_cases.yml
@@ -67,6 +67,38 @@
 
 - type: entity
   parent: RMCBasePVEEquipmentCase
+  id: RMCPVECaseSyracuseShotgun
+  name: Syracuse shotgun case
+  description: A heavy case for storing a Syracuse pump-action shotgun, an all-time classic.
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Storage/PVE_Cases/shotgun.rsi
+  - type: Storage
+    maxItemSize: Ginormous
+    grid:
+    - 0,0,7,1
+    whitelist:
+      tags:
+      - RMCWeaponShotgunSyracuse
+      - RMCHandful
+      - RMCAttachmentM42A1WoodenStock
+  - type: StorageFill
+    contents:
+    - id: RMCWeaponShotgunSyracuse
+    - id: RMCAttachmentM42A1WoodenStock
+    - id: CMShellShotgunBuckshot
+    - id: CMShellShotgunBuckshot
+    - id: CMShellShotgunBuckshot
+    - id: CMShellShotgunBuckshot
+  - type: ItemMapper
+    mapLayers:
+      gun:
+        whitelist:
+          tags:
+          - RMCWeaponShotgunSyracuse
+
+- type: entity
+  parent: RMCBasePVEEquipmentCase
   id: RMCPVECaseM5SPR
   name: M5SPR battle rifle case
   description: A large case for storing an M5SPR, a modified UNMC battle rifle equipped with HV-P Rounds.

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/syracuse_shotgun.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/syracuse_shotgun.yml
@@ -1,0 +1,24 @@
+- type: entity
+  parent: WeaponShotgunM42A1
+  name: Syracuse pump-action shotgun
+  id: RMCWeaponShotgunSyracuse
+  description: A customized Syracuse hunting shotgun. Its wooden stock has been replaced with a bakelite pistol grip, and its barrel and magazine tube have been cut down to half their lengths for easier handling in close quarters at the cost of magazine size, only fitting four shells and one chambered.
+  components:
+  - type: RMCSelectiveFire
+    baseFireModes:
+    - SemiAuto
+    recoilWielded: 2
+    recoilUnwielded: 4
+    scatterWielded: 10
+    scatterUnwielded: 10
+    baseFireRate: 2
+    burstScatterMult: 5
+  - type: BallisticAmmoProvider
+    capacity: 5
+  - type: Tag
+    tags:
+    - RMCWeaponShotgunSyracuse
+    - RMCWeaponShotgun
+
+- type: Tag
+  id: RMCWeaponShotgunSyracuse


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
added the syracuse shotgun, basically just an m42a1 that can fire really quick but only has five shells of capacity

## Why / Balance
intending on using this to replace the m42a2 case on the endeavour as the special shotgun of choice since the m42a2 case is a nothingburger and i believe is meant to be more of a placeholder for when we got our own ithaca we could use, which is what the syracuse is.

## Technical details
just yaml for the gun and its case

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: [PVE] Added the Syracuse pump-action shotgun, a quick firing shotgun with a capacity of five shells. 
