### PR TITLE
Fix burrowers being able to acid things while burrowed.

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Burrow/SharedXenoBurrowSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Burrow/SharedXenoBurrowSystem.cs
@@ -141,7 +141,7 @@ public abstract class SharedXenoBurrowSystem : EntitySystem
 
             if (TryComp<DoAfterComponent>(burrower, out var doAfterComp))
             {
-                foreach (var (doAfterIndex, doAfter) in doAfterComp.DoAfters)
+                foreach (var doAfterIndex in doAfterComp.DoAfters.Keys)
                 {
                     _doAfter.Cancel(burrower, doAfterIndex, doAfterComp);
                 }

--- a/Content.Shared/_RMC14/Xenonids/Burrow/SharedXenoBurrowSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Burrow/SharedXenoBurrowSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared._RMC14.Actions;
 using Content.Shared._RMC14.Areas;
 using Content.Shared._RMC14.Atmos;
 using Content.Shared._RMC14.Pulling;
+using Content.Shared._RMC14.Xenonids.Acid;
 using Content.Shared._RMC14.Xenonids.Rest;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Actions;
@@ -64,12 +65,12 @@ public abstract class SharedXenoBurrowSystem : EntitySystem
         SubscribeLocalEvent<XenoBurrowComponent, InteractionAttemptEvent>(PreventInteraction);
         SubscribeLocalEvent<XenoBurrowComponent, RMCIgniteAttemptEvent>(OnBurrowedCancel);
         SubscribeLocalEvent<XenoBurrowComponent, AttackAttemptEvent>(OnBurrowedCancel);
+        SubscribeLocalEvent<XenoBurrowComponent, DoAfterAttemptEvent<XenoCorrosiveAcidDoAfterEvent>>(OnBurrowedCancel);
 
         SubscribeLocalEvent<XenoBurrowComponent, XenoBurrowActionEvent>(OnBeginBurrow);
         SubscribeLocalEvent<XenoBurrowComponent, XenoBurrowDownDoAfter>(OnFinishBurrow);
         SubscribeLocalEvent<XenoBurrowComponent, BurrowedEvent>(SetBurrow);
         SubscribeLocalEvent<XenoBurrowComponent, XenoBurrowMoveDoAfter>(OnFinishTunnel);
-
     }
 
     private void PreventExamine(Entity<XenoBurrowComponent> burrower, ref ExamineAttemptEvent args)
@@ -137,6 +138,15 @@ public abstract class SharedXenoBurrowSystem : EntitySystem
         if (args.burrowed)
         {
             _transform.AnchorEntity(burrower);
+
+            if (TryComp<DoAfterComponent>(burrower, out var doAfterComp))
+            {
+                foreach (var (doAfterIndex, doAfter) in doAfterComp.DoAfters)
+                {
+                    _doAfter.Cancel(burrower, doAfterIndex, doAfterComp);
+                }
+            }
+
             if (_net.IsServer)
                 _audio.PlayPvs(burrower.Comp.BurrowDownSound, burrower);
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Burrower can no longer acid things while burrowed.

Fixes #9838.

Supersedes #9840. That PR only blocks starting new acid attempts while burrowed. If you start an acid attempt during a burrow do-after, it will not be cancelled when becoming burrowed, and successfully complete while burrowed.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfix/parity.

## Technical details
<!-- Summary of code changes for easier review. -->
On becoming burrowed, all do-afters are cancelled.
On acid attempt, if currently burrowed, the attempt is cancelled.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

https://github.com/user-attachments/assets/b40efef7-03f5-48d0-8e73-f4c7a514af11



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed Burrowers being able to acid things while burrowed.
