### PR TITLE
FORECON CO now gets a belt for their choice of sidearm

### DIFF
--- a/Content.Shared/Station/SharedStationSpawningSystem.cs
+++ b/Content.Shared/Station/SharedStationSpawningSystem.cs
@@ -88,7 +88,7 @@ public abstract class SharedStationSpawningSystem : EntitySystem
     public void EquipStartingGear(EntityUid entity, LoadoutPrototype loadout, bool raiseEvent = true)
     {
         EquipStartingGear(entity, loadout.StartingGear, raiseEvent);
-        EquipStartingGear(entity, (IEquipmentLoadout) loadout, raiseEvent);
+        EquipStartingGear(entity, (IEquipmentLoadout)loadout, raiseEvent);
     }
 
     /// <summary>
@@ -105,7 +105,7 @@ public abstract class SharedStationSpawningSystem : EntitySystem
     /// </summary>
     public void EquipStartingGear(EntityUid entity, StartingGearPrototype? startingGear, bool raiseEvent = true)
     {
-        EquipStartingGear(entity, (IEquipmentLoadout?) startingGear, raiseEvent);
+        EquipStartingGear(entity, (IEquipmentLoadout?)startingGear, raiseEvent);
     }
 
     /// <summary>
@@ -125,12 +125,21 @@ public abstract class SharedStationSpawningSystem : EntitySystem
         {
             foreach (var slot in slotDefinitions)
             {
+                // RMC14: Loadouts get overriden by starting gear.
+                // Allows roles to prevent loadout items from spawning with the character.
                 var equipmentStr = startingGear.GetGear(slot.Name);
                 if (!string.IsNullOrEmpty(equipmentStr))
                 {
+                    if (InventorySystem.TryGetSlotEntity(entity, slot.Name, out var existing))
+                    {
+                        InventorySystem.TryUnequip(entity, slot.Name, force: true, silent: true);
+                        QueueDel(existing.Value);
+                    }
+
                     var equipmentEntity = Spawn(equipmentStr, xform.Coordinates);
                     InventorySystem.TryEquip(entity, equipmentEntity, slot.Name, silent: true, force: true);
                 }
+
             }
         }
 
@@ -207,7 +216,7 @@ public abstract class SharedStationSpawningSystem : EntitySystem
                 if (!PrototypeManager.TryIndex(items.Prototype, out var loadoutPrototype))
                     return null;
 
-                var gear = ((IEquipmentLoadout) loadoutPrototype).GetGear(slot);
+                var gear = ((IEquipmentLoadout)loadoutPrototype).GetGear(slot);
                 if (gear != string.Empty)
                     return gear;
             }

--- a/Resources/Prototypes/_RMC14/Catalog/Fills/Clothing/belt.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Fills/Clothing/belt.yml
@@ -689,6 +689,17 @@
 
 - type: entity
   parent: RMCBeltHolsterPistol
+  id: RMCD50WinterWyvernBeltForeconFilled
+  suffix: Filled, Winter Wyvern, Forecon
+  components:
+  - type: StorageFill
+    contents:
+    - id: RMCMagazinePistolHandcannon
+      amount: 3
+    - id: RMCWeaponPistolHandcannonWinterWyvern
+
+- type: entity
+  parent: RMCBeltHolsterPistol
   id: GoldHandcannonBeltFilled
   suffix: Filled, Gold Handcannon
   components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/commander.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/commander.yml
@@ -1,4 +1,4 @@
-﻿- type: job
+- type: job
   parent: RMCSurvivorForeconBase
   id: RMCSurvivorForeconCommander
   name: rmc-job-name-forecon-commander
@@ -49,7 +49,6 @@
   parent: RMCGearForeconBase
   id: RMCGearForeconCommander
   equipment:
-    belt: RMCMatebaBeltForeconFilled
     outerClothing: RMCJacketWindbreakerForeconFilled
     back: RMCSatchelMarineForeconSurvivorCommanderFill
     id: CMIDCardGold

--- a/Resources/Prototypes/_RMC14/Roles/Loadouts/Items/RoleSpecific/commanding_officer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Loadouts/Items/RoleSpecific/commanding_officer.yml
@@ -50,6 +50,7 @@
 
 - type: loadout
   id: GoldMatebaRMC
+  dummyEntity: RMCWeaponRevolverMatebaGold
   effects:
   - !type:JobRequirementLoadoutEffect
     requirement:
@@ -62,6 +63,7 @@
 
 - type: loadout
   id: GoldHandcannonRMC
+  dummyEntity: RMCWeaponPistolHandcannonGold
   effects:
   - !type:JobRequirementLoadoutEffect
     requirement:
@@ -74,12 +76,26 @@
 
 - type: loadout
   id: MatebaRMC
+  dummyEntity: RMCWeaponRevolverMateba
   storage:
     back:
     - RMCMatebaCustomizationCaseWeapon
 
 - type: loadout
   id: HandcannonRMC
+  dummyEntity: RMCWeaponPistolHandcannonWinterWyvern
   storage:
     back:
     - RMCWeaponPistolHandcannonWinterWyvern
+
+- type: loadout
+  id: SurvivorMatebaRMC
+  dummyEntity: RMCWeaponRevolverMateba
+  equipment:
+    belt: RMCMatebaBeltForeconFilled
+
+- type: loadout
+  id: SurvivorWinterWyvernRMC
+  dummyEntity: RMCWeaponPistolHandcannonWinterWyvern
+  equipment:
+    belt: RMCD50WinterWyvernBeltForeconFilled

--- a/Resources/Prototypes/_RMC14/Roles/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Loadouts/loadout_groups.yml
@@ -710,6 +710,13 @@
   - GoldMatebaRMC
   - GoldHandcannonRMC
 
+- type: loadoutGroup
+  id: SurvivorCommandingOfficerWeaponRMC
+  name: rmc-loadout-group-role-specific-weapon
+  loadouts:
+  - SurvivorMatebaRMC
+  - SurvivorWinterWyvernRMC
+
 # Corporate Liaison
 - type: loadoutGroup
   id: LiaisonRoleSpecificRMC

--- a/Resources/Prototypes/_RMC14/Roles/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Loadouts/role_loadouts.yml
@@ -986,6 +986,7 @@
   id: JobRMCSurvivorCommandingOfficer
   points: 7
   groups:
+  - SurvivorCommandingOfficerWeaponRMC
   - EyewearRMC
   - MasksRMC
   - PaperworkRMC


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title. Closes #9736.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity, though actual implementation differs a little. 

Instead of pulling the preference from the regular CO role, the Survivor Commander role now has has the option of choosing between the Mateba and Winter Wyvern in their loadout. This enable the FORECON CO to spawn with a belt corresponding to this choice. Note that other Survivor Commander roles still spawn with their normal belt.

## Technical details
<!-- Summary of code changes for easier review. -->
Added loadouts to the Survivor Commander role. Added an appropriate belt prototype for the Winter Wyvern.

In order to facilitate this, spawning logic was modified to explicitly unequip and delete any item already occupying a slot before equipping the replacement. This is needed because loadout items are spawned before starting gear is applied. Now, the loadout sidearm belt is spawned, then if no belt is specified in the roles starting gear, the player will keep that loadout sidearm belt, whereas if the roles starting gear does specify a belt, it will delete the loadout sidearm belt and replace it with the proper belt. This is what allows for the FORECON CO to get their choice of belt, whereas other Survivor Commanders will not get this choice of belt.

This fix applies universally, so any future job that defines a loadout overlapping with their starting gear will benefit. Simply leave the starting gear for that slot empty and they will get their choice of loadout for that slot.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
https://github.com/user-attachments/assets/3efe7435-8209-4f78-bb3c-a4b5af1e1ba8

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: FORECON CO now spawns with their choice of sidearm.