### PR TITLE
Fix Echo and Foxtrot SL trackers

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/marine_headsets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/marine_headsets.yml
@@ -352,6 +352,14 @@
       - CMEncryptionKeySquadLeader
   - type: RMCHeadset
     radioTextIncrease: 3
+  - type: GrantSquadLeaderTracker
+    defaultMode: CommandingOfficer
+    trackerModes:
+    - CommandingOfficer
+    - ExecutiveOfficer
+    - SquadLeader
+    - FireteamLeader
+    - PrimaryLandingZone
 
 - type: entity
   parent: CMHeadsetEcho
@@ -366,14 +374,6 @@
       - CMEncryptionKeyJTAC
   - type: RMCHeadset
     radioTextIncrease: 2
-  - type: GrantSquadLeaderTracker
-    defaultMode: CommandingOfficer
-    trackerModes:
-    - CommandingOfficer
-    - ExecutiveOfficer
-    - SquadLeader
-    - FireteamLeader
-    - PrimaryLandingZone
 
 - type: entity
   parent: CMHeadsetEcho
@@ -429,6 +429,14 @@
       - CMEncryptionKeySquadLeader
   - type: RMCHeadset
     radioTextIncrease: 3
+  - type: GrantSquadLeaderTracker
+    defaultMode: CommandingOfficer
+    trackerModes:
+    - CommandingOfficer
+    - ExecutiveOfficer
+    - SquadLeader
+    - FireteamLeader
+    - PrimaryLandingZone
 
 - type: entity
   parent: CMHeadsetFoxtrot
@@ -443,14 +451,6 @@
       - CMEncryptionKeyJTAC
   - type: RMCHeadset
     radioTextIncrease: 2
-  - type: GrantSquadLeaderTracker
-    defaultMode: CommandingOfficer
-    trackerModes:
-    - CommandingOfficer
-    - ExecutiveOfficer
-    - SquadLeader
-    - FireteamLeader
-    - PrimaryLandingZone
 
 - type: entity
   parent: CMHeadsetFoxtrot


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title. Echo and Foxtrot SLs can now track XO/CO instead of their FTLs. Closes #9861.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfix.

## Technical details
<!-- Summary of code changes for easier review. -->
YAML only, the relevant component was added to the team leader rather than the squad leader headsets.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Echo and Foxtrot SLs can now track the XO / CO.
