### PR TITLE
Added Evolution, Adaptability, Aggression, and Fortification Boons.

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Blitz/XenoBlitzSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Blitz/XenoBlitzSystem.cs
@@ -112,7 +112,7 @@ public sealed class XenoBlitzSystem : EntitySystem
 
             hits++;
 
-            var myDamage = _damage.TryChangeDamage(hit, _xeno.TryApplyXenoSlashDamageMultiplier(hit, xeno.Comp.Damage), origin: xeno, tool: xeno);
+            var myDamage = _damage.TryChangeDamage(hit, _xeno.ApplyXenoMeleeDamageModifiers(xeno, hit, xeno.Comp.Damage), origin: xeno, tool: xeno);
             if (myDamage?.GetTotal() > FixedPoint2.Zero)
             {
                 var filter = Filter.Pvs(hit, entityManager: EntityManager).RemoveWhereAttachedEntity(o => o == xeno.Owner);

--- a/Content.Shared/_RMC14/Xenonids/Brutalize/XenoBrutalizeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Brutalize/XenoBrutalizeSystem.cs
@@ -60,7 +60,7 @@ public sealed class XenoBrutalizeSystem : EntitySystem
 
             currHits++;
 
-            var myDamage = _damageable.TryChangeDamage(extra, _xeno.TryApplyXenoSlashDamageMultiplier(extra, damage), origin: xeno, tool: xeno);
+            var myDamage = _damageable.TryChangeDamage(extra, _xeno.ApplyXenoMeleeDamageModifiers(xeno, extra, damage), origin: xeno, tool: xeno);
             if (myDamage?.GetTotal() > FixedPoint2.Zero)
             {
                 var filter = Filter.Pvs(extra, entityManager: EntityManager).RemoveWhereAttachedEntity(o => o == xeno.Owner);

--- a/Content.Shared/_RMC14/Xenonids/Charge/XenoChargeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Charge/XenoChargeSystem.cs
@@ -390,7 +390,7 @@ _thrownItemQuery.TryGetComponent(xeno, out var thrown))
 
         }
 
-        var damage = _damageable.TryChangeDamage(targetId, _xeno.TryApplyXenoSlashDamageMultiplier(targetId, structDamage), origin: xeno, tool: xeno);
+        var damage = _damageable.TryChangeDamage(targetId, _xeno.ApplyXenoMeleeDamageModifiers(xeno, targetId, structDamage), origin: xeno, tool: xeno);
         if (damage?.GetTotal() > FixedPoint2.Zero)
         {
             var filter = Filter.Pvs(targetId, entityManager: EntityManager).RemoveWhereAttachedEntity(o => o == xeno.Owner);

--- a/Content.Shared/_RMC14/Xenonids/Construction/EggMorpher/EggMorpherComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/EggMorpher/EggMorpherComponent.cs
@@ -47,6 +47,9 @@ public sealed partial class EggMorpherComponent : Component
     public TimeSpan OviSpawnCooldown = TimeSpan.FromSeconds(60);
 
     [DataField, AutoNetworkedField]
+    public TimeSpan FortifiedSpawnCooldown = TimeSpan.FromSeconds(30);
+
+    [DataField, AutoNetworkedField]
     public TimeSpan? NextSpawnAt;
 
     [DataField, AutoNetworkedField]

--- a/Content.Shared/_RMC14/Xenonids/Construction/EggMorpher/EggMorpherSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/EggMorpher/EggMorpherSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared._RMC14.Xenonids.Egg;
 using Content.Shared._RMC14.Xenonids.Hive;
+using Content.Shared._RMC14.Xenonids.ManageHive.Boons;
 using Content.Shared._RMC14.Xenonids.Parasite;
 using Content.Shared._RMC14.Xenonids.Projectile.Parasite;
 using Content.Shared._RMC14.Synth;
@@ -22,6 +23,7 @@ public sealed partial class EggMorpherSystem : EntitySystem
 {
     [Dependency] private readonly IGameTiming _time = default!;
     [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
+    [Dependency] private readonly HiveBoonSystem _boon = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly INetManager _net = default!;
@@ -269,6 +271,9 @@ public sealed partial class EggMorpherSystem : EntitySystem
 
     private TimeSpan GetParasiteSpawnCooldown(Entity<EggMorpherComponent> eggMorpher)
     {
+        if (_boon.HasActiveBoon<HiveBoonFortificationComponent>(eggMorpher.Owner))
+            return eggMorpher.Comp.FortifiedSpawnCooldown;
+
         if (_hive.GetHive(eggMorpher.Owner) is not { } hive)
         {
             return eggMorpher.Comp.StandardSpawnCooldown;

--- a/Content.Shared/_RMC14/Xenonids/Construction/PlasmaTree/PlasmaTreeComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/PlasmaTree/PlasmaTreeComponent.cs
@@ -12,6 +12,12 @@ public sealed partial class PlasmaTreeComponent : Component
     public FixedPoint2 PlasmaAmount = 75;
 
     [DataField, AutoNetworkedField]
+    public FixedPoint2 FortifiedPlasmaAmount = 200;
+
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 FortifiedSelfHeal = 25;
+
+    [DataField, AutoNetworkedField]
     public float PlasmaRange = 1.5F;
 
     [DataField, AutoNetworkedField]

--- a/Content.Shared/_RMC14/Xenonids/Construction/PlasmaTree/PlasmaTreeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/PlasmaTree/PlasmaTreeSystem.cs
@@ -1,7 +1,11 @@
+using Content.Shared._RMC14.Damage;
 using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared._RMC14.Xenonids.Hive;
+using Content.Shared._RMC14.Xenonids.ManageHive.Boons;
 using Content.Shared._RMC14.Xenonids.Rest;
+using Content.Shared.Damage;
 using Content.Shared.DoAfter;
+using Content.Shared.FixedPoint;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Popups;
@@ -19,6 +23,9 @@ public sealed class PlasmaTreeSystem : EntitySystem
     [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly XenoPlasmaSystem _plasma = default!;
+    [Dependency] private readonly HiveBoonSystem _boon = default!;
+    [Dependency] private readonly DamageableSystem _damageable = default!;
+    [Dependency] private readonly SharedRMCDamageableSystem _rmcDamageable = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly MobStateSystem _mob = default!;
     [Dependency] private readonly INetManager _net = default!;
@@ -70,6 +77,7 @@ public sealed class PlasmaTreeSystem : EntitySystem
         }
 
         plasmaTree.Comp.NextPlasmaAt = _time.CurTime + plasmaTree.Comp.PlasmaCooldown;
+        HealFortifiedStructure(plasmaTree);
 
         if (possibleTargets.Count == 0)
             return;
@@ -109,6 +117,26 @@ public sealed class PlasmaTreeSystem : EntitySystem
         if (args.Handled || args.Cancelled || args.Target == null)
             return;
 
-        _plasma.RegenPlasma(args.Target.Value, plasmaTree.Comp.PlasmaAmount);
+        _plasma.RegenPlasma(args.Target.Value, GetPlasmaAmount(plasmaTree));
+    }
+
+    private FixedPoint2 GetPlasmaAmount(Entity<PlasmaTreeComponent> plasmaTree)
+    {
+        return _boon.HasActiveBoon<HiveBoonFortificationComponent>(plasmaTree.Owner)
+            ? plasmaTree.Comp.FortifiedPlasmaAmount
+            : plasmaTree.Comp.PlasmaAmount;
+    }
+
+    private void HealFortifiedStructure(Entity<PlasmaTreeComponent> plasmaTree)
+    {
+        if (!_boon.HasActiveBoon<HiveBoonFortificationComponent>(plasmaTree.Owner) ||
+            !TryComp(plasmaTree.Owner, out DamageableComponent? damageable) ||
+            damageable.TotalDamage <= FixedPoint2.Zero)
+        {
+            return;
+        }
+
+        var heal = -_rmcDamageable.DistributeTypesTotal((plasmaTree.Owner, damageable), plasmaTree.Comp.FortifiedSelfHeal);
+        _damageable.TryChangeDamage(plasmaTree.Owner, heal, true, damageable: damageable);
     }
 }

--- a/Content.Shared/_RMC14/Xenonids/Construction/RecoveryNode/RecoveryNodeComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/RecoveryNode/RecoveryNodeComponent.cs
@@ -11,6 +11,12 @@ public sealed partial class RecoveryNodeComponent : Component
     public FixedPoint2 HealAmount = 25;
 
     [DataField, AutoNetworkedField]
+    public FixedPoint2 FortifiedHealAmount = 100;
+
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 FortifiedSelfHeal = 25;
+
+    [DataField, AutoNetworkedField]
     public float HealRange = 1.5F;
 
     [DataField, AutoNetworkedField]

--- a/Content.Shared/_RMC14/Xenonids/Construction/RecoveryNode/RecoveryNodeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/RecoveryNode/RecoveryNodeSystem.cs
@@ -1,9 +1,12 @@
+using Content.Shared._RMC14.Damage;
 using Content.Shared._RMC14.Xenonids.Heal;
 using Content.Shared._RMC14.Xenonids.Hive;
+using Content.Shared._RMC14.Xenonids.ManageHive.Boons;
 using Content.Shared._RMC14.Xenonids.Rest;
 using Content.Shared.Coordinates;
 using Content.Shared.Damage;
 using Content.Shared.DoAfter;
+using Content.Shared.FixedPoint;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Popups;
@@ -26,8 +29,10 @@ public sealed partial class RecoveryNodeSystem : EntitySystem
     [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly SharedXenoHealSystem _heal = default!;
+    [Dependency] private readonly HiveBoonSystem _boon = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
+    [Dependency] private readonly SharedRMCDamageableSystem _rmcDamageable = default!;
     [Dependency] private readonly MobStateSystem _mob = default!;
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly SharedDoAfterSystem _doafter = default!;
@@ -78,6 +83,7 @@ public sealed partial class RecoveryNodeSystem : EntitySystem
         }
 
         recoveryNode.Comp.NextHealAt = _time.CurTime + recoveryNode.Comp.HealCooldown;
+        HealFortifiedStructure(recoveryNode);
 
         if (possibleTargets.Count == 0)
             return;
@@ -106,6 +112,26 @@ public sealed partial class RecoveryNodeSystem : EntitySystem
         if (args.Handled || args.Cancelled || args.Target == null)
             return;
 
-        _heal.Heal(args.Target.Value, recoveryNode.Comp.HealAmount);
+        _heal.Heal(args.Target.Value, GetHealAmount(recoveryNode));
+    }
+
+    private FixedPoint2 GetHealAmount(Entity<RecoveryNodeComponent> recoveryNode)
+    {
+        return _boon.HasActiveBoon<HiveBoonFortificationComponent>(recoveryNode.Owner)
+            ? recoveryNode.Comp.FortifiedHealAmount
+            : recoveryNode.Comp.HealAmount;
+    }
+
+    private void HealFortifiedStructure(Entity<RecoveryNodeComponent> recoveryNode)
+    {
+        if (!_boon.HasActiveBoon<HiveBoonFortificationComponent>(recoveryNode.Owner) ||
+            !TryComp(recoveryNode.Owner, out DamageableComponent? damageable) ||
+            damageable.TotalDamage <= FixedPoint2.Zero)
+        {
+            return;
+        }
+
+        var heal = -_rmcDamageable.DistributeTypesTotal((recoveryNode.Owner, damageable), recoveryNode.Comp.FortifiedSelfHeal);
+        _damageable.TryChangeDamage(recoveryNode.Owner, heal, true, damageable: damageable);
     }
 }

--- a/Content.Shared/_RMC14/Xenonids/Dislocate/XenoDislocateSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Dislocate/XenoDislocateSystem.cs
@@ -63,7 +63,7 @@ public sealed class XenoDislocateSystem : EntitySystem
                          HasComp<StunnedComponent>(targetId) ||
                          _standing.IsDown(targetId);
 
-        var damage = _damageable.TryChangeDamage(targetId, xeno.Comp.Damage, ignoreResistances: isDebuffed, origin: xeno, tool: xeno);
+        var damage = _damageable.TryChangeDamage(targetId, _xeno.ApplyXenoMeleeDamageModifiers(xeno, targetId, xeno.Comp.Damage), ignoreResistances: isDebuffed, origin: xeno, tool: xeno);
         if (damage?.GetTotal() > FixedPoint2.Zero)
         {
             var filter = Filter.Pvs(targetId, entityManager: EntityManager).RemoveWhereAttachedEntity(o => o == xeno.Owner);

--- a/Content.Shared/_RMC14/Xenonids/Eviscerate/XenoEviscerateSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Eviscerate/XenoEviscerateSystem.cs
@@ -119,7 +119,7 @@ public sealed class XenoEviscerateSystem : EntitySystem
 
             _rmcPulling.TryStopAllPullsFromAndOn(mob);
 
-            _damageable.TryChangeDamage(mob, _xeno.TryApplyXenoSlashDamageMultiplier(mob, damage), origin: xeno, tool: xeno);
+            _damageable.TryChangeDamage(mob, _xeno.ApplyXenoMeleeDamageModifiers(xeno, mob, damage), origin: xeno, tool: xeno);
 
             var filter = Filter.Pvs(mob, entityManager: EntityManager);
             _colorFlash.RaiseEffect(Color.Red, new List<EntityUid> { mob }, filter);

--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoBaseCasteComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoBaseCasteComponent.cs
@@ -1,0 +1,11 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.Evolution;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(XenoEvolutionSystem))]
+public sealed partial class XenoBaseCasteComponent : Component
+{
+    [DataField]
+    public bool Enabled = true;
+}

--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
@@ -1,8 +1,15 @@
 using System.Linq;
 using Content.Shared._RMC14.CCVar;
+using Content.Shared._RMC14.Dialog;
+using Content.Shared._RMC14.Xenonids.Burrow;
+using Content.Shared._RMC14.Xenonids.Crest;
 using Content.Shared._RMC14.Xenonids.Announce;
 using Content.Shared._RMC14.Xenonids.Egg;
+using Content.Shared._RMC14.Xenonids.Fortify;
 using Content.Shared._RMC14.Xenonids.Hive;
+using Content.Shared._RMC14.Xenonids.Invisibility;
+using Content.Shared._RMC14.Xenonids.ManageHive.Boons;
+using Content.Shared._RMC14.Xenonids.Strain;
 using Content.Shared._RMC14.Xenonids.Weeds;
 using Content.Shared.Actions;
 using Content.Shared.Administration.Logs;
@@ -43,6 +50,7 @@ public sealed class XenoEvolutionSystem : EntitySystem
     [Dependency] private readonly ClimbSystem _climb = default!;
     [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] private readonly IComponentFactory _compFactory = default!;
+    [Dependency] private readonly DialogSystem _dialog = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
     [Dependency] private readonly SharedGameTicker _gameTicker = default!;
@@ -56,6 +64,7 @@ public sealed class XenoEvolutionSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
     [Dependency] private readonly SharedXenoAnnounceSystem _xenoAnnounce = default!;
+    [Dependency] private readonly HiveBoonSystem _xenoBoon = default!;
     [Dependency] private readonly SharedXenoHiveSystem _xenoHive = default!;
     [Dependency] private readonly SharedHandsSystem _hands = default!;
     [Dependency] private readonly SharedContainerSystem _container = default!;
@@ -90,6 +99,8 @@ public sealed class XenoEvolutionSystem : EntitySystem
         SubscribeLocalEvent<XenoEvolutionGranterComponent, NewXenoEvolvedEvent>(OnGranterEvolved);
 
         SubscribeLocalEvent<XenoOvipositorChangedEvent>(OnOvipositorChanged);
+        SubscribeLocalEvent<XenoComponent, XenoTransmuteActionEvent>(OnXenoTransmuteAction);
+        SubscribeLocalEvent<XenoComponent, XenoTransmuteChosenEvent>(OnXenoTransmuteChosen);
 
         Subs.BuiEvents<XenoEvolutionComponent>(XenoEvolutionUIKey.Key,
             subs =>
@@ -135,7 +146,7 @@ public sealed class XenoEvolutionSystem : EntitySystem
         args.Handled = true;
         _ui.OpenUi(xeno.Owner, XenoEvolutionUIKey.Key, xeno);
 
-        var state = new XenoEvolveBuiState(LackingOvipositor());
+        var state = new XenoEvolveBuiState(LackingOvipositor(xeno.Owner));
         _ui.SetUiState(xeno.Owner, XenoEvolutionUIKey.Key, state);
     }
 
@@ -301,11 +312,48 @@ public sealed class XenoEvolutionSystem : EntitySystem
             return;
 
         var xenos = EntityQueryEnumerator<ActorComponent, XenoEvolutionComponent>();
-        var state = new XenoEvolveBuiState(LackingOvipositor());
         while (xenos.MoveNext(out var uid, out _, out _))
         {
+            var state = new XenoEvolveBuiState(LackingOvipositor(uid));
             _ui.SetUiState(uid, XenoEvolutionUIKey.Key, state);
         }
+    }
+
+    private void OnXenoTransmuteAction(Entity<XenoComponent> xeno, ref XenoTransmuteActionEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        args.Handled = true;
+
+        if (!CanTransmutePopup(xeno))
+            return;
+
+        var current = Prototype(xeno.Owner)?.ID;
+        var choices = new List<DialogOption>();
+        foreach (var prototype in _prototypes.EnumeratePrototypes<EntityPrototype>())
+        {
+            if (prototype.ID == current ||
+                !IsBaseTransmuteCaste(prototype) ||
+                !prototype.TryGetComponent(out XenoComponent? xenoComp, _compFactory) ||
+                xenoComp.Tier != xeno.Comp.Tier)
+            {
+                continue;
+            }
+
+            choices.Add(new DialogOption(prototype.Name, new XenoTransmuteChosenEvent(prototype.ID)));
+        }
+
+        choices.Sort((a, b) => string.Compare(a.Text, b.Text, StringComparison.InvariantCultureIgnoreCase));
+        _dialog.OpenOptions(xeno.Owner,
+            Loc.GetString("rmc-xeno-transmute-title"),
+            choices,
+            Loc.GetString("rmc-xeno-transmute-prompt"));
+    }
+
+    private void OnXenoTransmuteChosen(Entity<XenoComponent> xeno, ref XenoTransmuteChosenEvent args)
+    {
+        Transmute(xeno, args.Choice);
     }
 
     private bool ContainedCheckPopup(EntityUid xeno, bool doPopup = true)
@@ -333,6 +381,98 @@ public sealed class XenoEvolutionSystem : EntitySystem
         return false;
     }
 
+    private bool CanTransmutePopup(Entity<XenoComponent> xeno, bool doPopup = true)
+    {
+        if (xeno.Comp.Tier is <= 0 or > 3)
+        {
+            if (doPopup)
+                _popup.PopupEntity(Loc.GetString("rmc-xeno-transmute-failed-tier"), xeno, xeno, PopupType.MediumCaution);
+
+            return false;
+        }
+
+        if (_mobState.IsDead(xeno.Owner))
+            return false;
+
+        if (!ContainedCheckPopup(xeno.Owner, doPopup))
+            return false;
+
+        if (!DamagedCheckPopup(xeno.Owner, false, doPopup))
+            return false;
+
+        if (TryComp(xeno.Owner, out TransformComponent? xform) &&
+            xform.MapID == MapId.Nullspace)
+        {
+            return false;
+        }
+
+        if (IsInTransmuteBlockingStance(xeno.Owner))
+        {
+            if (doPopup)
+                _popup.PopupEntity(Loc.GetString("rmc-xeno-transmute-failed-stance"), xeno, xeno, PopupType.MediumCaution);
+
+            return false;
+        }
+
+        return true;
+    }
+
+    private bool IsInTransmuteBlockingStance(EntityUid xeno)
+    {
+        return TryComp(xeno, out XenoFortifyComponent? fortify) && fortify.Fortified ||
+               TryComp(xeno, out XenoCrestComponent? crest) && crest.Lowered ||
+               TryComp(xeno, out XenoBurrowComponent? burrow) && (burrow.Active || burrow.Tunneling) ||
+               HasComp<XenoActiveInvisibleComponent>(xeno);
+    }
+
+    public EntityUid? Transmute(Entity<XenoComponent> xeno, EntProtoId to)
+    {
+        if (_net.IsClient ||
+            !CanTransmutePopup(xeno) ||
+            !TryComp(xeno.Owner, out XenoEvolutionComponent? evolution))
+        {
+            return null;
+        }
+
+        if (!_prototypes.TryIndex(to, out var prototype) ||
+            !IsBaseTransmuteCaste(prototype) ||
+            !prototype.TryGetComponent(out XenoComponent? newXenoComp, _compFactory) ||
+            newXenoComp.Tier != xeno.Comp.Tier ||
+            prototype.ID == Prototype(xeno.Owner)?.ID)
+        {
+            return null;
+        }
+
+        var newXeno = TransferXeno(xeno.Owner, to);
+        var ev = new NewXenoEvolvedEvent((xeno.Owner, evolution), newXeno, false);
+        RaiseLocalEvent(newXeno, ref ev, true);
+
+        _adminLog.Add(LogType.RMCEvolve, $"Xenonid {ToPrettyString(xeno)} transmuted into {ToPrettyString(newXeno)}");
+
+        Del(xeno.Owner);
+
+        _popup.PopupEntity(Loc.GetString("rmc-xeno-transmute-end"), newXeno, newXeno);
+
+        var afterEv = new AfterNewXenoEvolvedEvent();
+        RaiseLocalEvent(newXeno, ref afterEv);
+
+        return newXeno;
+    }
+
+    private bool IsBaseTransmuteCaste(EntityPrototype prototype)
+    {
+        if (prototype.Abstract ||
+            !prototype.TryGetComponent(out XenoBaseCasteComponent? baseCaste, _compFactory) ||
+            !baseCaste.Enabled ||
+            prototype.HasComponent<XenoStrainComponent>(_compFactory) ||
+            prototype.HasComponent<XenoHiddenComponent>(_compFactory))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
     private bool CanEvolvePopup(Entity<XenoEvolutionComponent> xeno, EntProtoId newXeno, bool doPopup = true)
     {
         if (!xeno.Comp.EvolvesTo.Contains(newXeno) && !xeno.Comp.EvolvesToWithoutPoints.Contains(newXeno))
@@ -355,7 +495,7 @@ public sealed class XenoEvolutionSystem : EntitySystem
         }
 
         // TODO RMC14 only allow evolving towards Queen if none is alive
-        if (!xeno.Comp.CanEvolveWithoutGranter && !HasLiving<XenoEvolutionGranterComponent>(1))
+        if (!xeno.Comp.CanEvolveWithoutGranter && !HasLivingGranterForEvolution(xeno.Owner))
         {
             if (doPopup)
             {
@@ -539,6 +679,36 @@ public sealed class XenoEvolutionSystem : EntitySystem
         return false;
     }
 
+    private bool HasLivingInHive<T>(EntityUid hiveMember, int count, Predicate<Entity<T>>? predicate = null) where T : IComponent
+    {
+        if (count <= 0)
+            return true;
+
+        var total = 0;
+        var query = EntityQueryEnumerator<T>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            if (!_xenoHive.FromSameHive(uid, hiveMember))
+                continue;
+
+            if (_mobStateQuery.TryComp(uid, out var mobState) &&
+                _mobState.IsDead(uid, mobState))
+            {
+                continue;
+            }
+
+            if (predicate != null && !predicate((uid, comp)))
+                continue;
+
+            total++;
+
+            if (total >= count)
+                return true;
+        }
+
+        return false;
+    }
+
     public FixedPoint2 AddPointsCapped(Entity<XenoEvolutionComponent?> evolution, FixedPoint2 points)
     {
         if (!Resolve(evolution, ref evolution.Comp, false))
@@ -567,9 +737,39 @@ public sealed class XenoEvolutionSystem : EntitySystem
         return HasLiving<XenoEvolutionGranterComponent>(1, e => HasComp<XenoAttachedOvipositorComponent>(e));
     }
 
+    public bool HasOvipositor(EntityUid hiveMember)
+    {
+        return HasLivingInHive<XenoEvolutionGranterComponent>(hiveMember,
+            1,
+            e => HasComp<XenoAttachedOvipositorComponent>(e));
+    }
+
     public bool LackingOvipositor()
     {
         return NeedsOvipositor() && !HasOvipositor();
+    }
+
+    public bool LackingOvipositor(EntityUid hiveMember)
+    {
+        return NeedsOvipositor() &&
+               !HasOvipositor(hiveMember) &&
+               !HasEvolutionBypass(hiveMember);
+    }
+
+    private bool HasLivingGranterForEvolution(EntityUid hiveMember)
+    {
+        if (HasEvolutionBypass(hiveMember))
+            return true;
+
+        return NeedsOvipositor()
+            ? HasOvipositor(hiveMember)
+            : HasLivingInHive<XenoEvolutionGranterComponent>(hiveMember, 1);
+    }
+
+    private bool HasEvolutionBypass(EntityUid hiveMember)
+    {
+        return _xenoBoon.TryGetActiveBoon<HiveBoonEvolutionComponent>(hiveMember, out var boon) &&
+               boon.Comp.BypassOvipositor;
     }
 
     private EntityUid TransferXeno(EntityUid xeno, EntProtoId proto)
@@ -692,9 +892,6 @@ public sealed class XenoEvolutionSystem : EntitySystem
         var time = _timing.CurTime;
         var roundDuration = _gameTicker.RoundDuration();
         var needsOvipositor = NeedsOvipositor();
-        var hasGranter = needsOvipositor
-            ? HasOvipositor()
-            : HasLiving<XenoEvolutionGranterComponent>(1);
         if (needsOvipositor)
         {
             var granters = EntityQueryEnumerator<XenoEvolutionGranterComponent>();
@@ -706,7 +903,7 @@ public sealed class XenoEvolutionSystem : EntitySystem
                 granter.GotOvipositorPopup = true;
                 Dirty(uid, granter);
 
-                _popup.PopupEntity("It is time to settle down and let your children grow.",
+                _popup.PopupEntity(Loc.GetString("rmc-xeno-evolution-ovipositor-needed"),
                     uid,
                     uid,
                     PopupType.LargeCaution
@@ -753,17 +950,38 @@ public sealed class XenoEvolutionSystem : EntitySystem
             }
             var points = (_earlyEvoBoostBefore > _gameTicker.RoundDuration()) ? comp.EarlyPointsPerSecond : comp.PointsPerSecond;
             var gain = evoOverride ?? points + evoBonus;
+            var hasEvolutionBoon = _xenoBoon.TryGetActiveBoon<HiveBoonEvolutionComponent>(uid, out var evolutionBoon);
+
             if (comp.Points < comp.Max || roundDuration < _evolutionAccumulatePointsBefore)
             {
-                if (needsOvipositor && comp.RequiresGranter && !hasGranter)
+                var hasGranter = needsOvipositor
+                    ? HasOvipositor(uid)
+                    : HasLivingInHive<XenoEvolutionGranterComponent>(uid, 1);
+
+                var bypassesGranter = hasEvolutionBoon && evolutionBoon.Comp.BypassOvipositor;
+                if (comp.RequiresGranter && !hasGranter && !bypassesGranter)
                     continue;
 
-                SetPoints((uid, comp), comp.Points + gain);
+                var gainToApply = hasEvolutionBoon
+                    ? GetFrozenEvolutionBoonGain((uid, comp), evolutionBoon) * evolutionBoon.Comp.Multiplier
+                    : gain;
+                SetPoints((uid, comp), comp.Points + gainToApply);
             }
             else if (comp.Points > comp.Max)
             {
                 SetPoints((uid, comp), FixedPoint2.Max(comp.Points - gain, comp.Max));
             }
         }
+    }
+
+    private FixedPoint2 GetFrozenEvolutionBoonGain(Entity<XenoEvolutionComponent> xeno, Entity<HiveBoonEvolutionComponent> boon)
+    {
+        var points = boon.Comp.FrozenEarlyEvolutionBoost
+            ? xeno.Comp.EarlyPointsPerSecond
+            : xeno.Comp.PointsPerSecond;
+
+        return boon.Comp.HasFrozenOverride
+            ? boon.Comp.FrozenOverride
+            : points + boon.Comp.FrozenBonus;
     }
 }

--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoTransmuteActionEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoTransmuteActionEvent.cs
@@ -1,0 +1,5 @@
+using Content.Shared.Actions;
+
+namespace Content.Shared._RMC14.Xenonids.Evolution;
+
+public sealed partial class XenoTransmuteActionEvent : InstantActionEvent;

--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoTransmuteChosenEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoTransmuteChosenEvent.cs
@@ -1,0 +1,8 @@
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Xenonids.Evolution;
+
+[ByRefEvent]
+[Serializable, NetSerializable]
+public sealed record XenoTransmuteChosenEvent(EntProtoId Choice);

--- a/Content.Shared/_RMC14/Xenonids/Fling/XenoFlingSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Fling/XenoFlingSystem.cs
@@ -70,7 +70,7 @@ public sealed class XenoFlingSystem : EntitySystem
         var targetId = args.Target;
         _rmcPulling.TryStopAllPullsFromAndOn(targetId);
 
-        var damage = _damageable.TryChangeDamage(targetId, _xeno.TryApplyXenoSlashDamageMultiplier(targetId, xeno.Comp.Damage), origin: xeno, tool: xeno);
+        var damage = _damageable.TryChangeDamage(targetId, _xeno.ApplyXenoMeleeDamageModifiers(xeno, targetId, xeno.Comp.Damage), origin: xeno, tool: xeno);
         if (damage?.GetTotal() > FixedPoint2.Zero)
         {
             var filter = Filter.Pvs(targetId, entityManager: EntityManager).RemoveWhereAttachedEntity(o => o == xeno.Owner);

--- a/Content.Shared/_RMC14/Xenonids/Flurry/XenoFlurrySystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Flurry/XenoFlurrySystem.cs
@@ -92,7 +92,7 @@ public sealed class XenoFlurrySystem : EntitySystem
 
             hits++;
 
-            var change = _damage.TryChangeDamage(victim, _xeno.TryApplyXenoSlashDamageMultiplier(victim, damage), origin: xeno, tool: xeno);
+            var change = _damage.TryChangeDamage(victim, _xeno.ApplyXenoMeleeDamageModifiers(xeno, victim, damage), origin: xeno, tool: xeno);
 
             if (change?.GetTotal() > FixedPoint2.Zero)
             {

--- a/Content.Shared/_RMC14/Xenonids/Headbite/XenoHeadbiteSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Headbite/XenoHeadbiteSystem.cs
@@ -35,6 +35,7 @@ public sealed class XenoHeadbiteSystem : EntitySystem
     [Dependency] private readonly SharedJitteringSystem _jitter = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly StatusEffectsSystem _status = default!;
+    [Dependency] private readonly XenoSystem _xeno = default!;
 
     private static readonly ProtoId<DamageTypePrototype> LethalDamageType = "Asphyxiation";
     private static readonly ProtoId<StatusEffectPrototype> Unconsciousness = "Unconscious";
@@ -94,7 +95,7 @@ public sealed class XenoHeadbiteSystem : EntitySystem
         _xenoHeal.CreateHealStacks(xeno, xeno.Comp.HealAmount, xeno.Comp.HealDelay, 1, xeno.Comp.HealDelay);
         _jitter.DoJitter(xeno, xeno.Comp.JitterTime, true, 80, 8, true);
 
-        var change = _damage.TryChangeDamage(target, xeno.Comp.Damage); // TODO target head
+        var change = _damage.TryChangeDamage(target, _xeno.ApplyXenoMeleeDamageModifiers(xeno, target, xeno.Comp.Damage), origin: xeno, tool: xeno); // TODO target head
         if (change?.GetTotal() > FixedPoint2.Zero)
         {
             var filter = Filter.Pvs(target, entityManager: EntityManager).RemoveWhereAttachedEntity(o => o == xeno.Owner);

--- a/Content.Shared/_RMC14/Xenonids/Headbutt/XenoHeadbuttSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Headbutt/XenoHeadbuttSystem.cs
@@ -112,14 +112,15 @@ public sealed class XenoHeadbuttSystem : EntitySystem
         if (_net.IsServer)
             _audio.PlayPvs(xeno.Comp.Sound, xeno);
 
-        var finalDamage = xeno.Comp.Damage;
+        // Copy because ExclusiveAdd mutates the damage specifier below.
+        var finalDamage = new DamageSpecifier(xeno.Comp.Damage);
 
         if (TryComp<XenoCrestComponent>(xeno, out var crest) && crest.Lowered)
         {
             finalDamage.ExclusiveAdd(xeno.Comp.CrestedDamageReduction);
         }
 
-        var damage = _damageable.TryChangeDamage(targetId, _xeno.TryApplyXenoSlashDamageMultiplier(targetId, finalDamage), armorPiercing: xeno.Comp.AP, origin: xeno, tool: xeno);
+        var damage = _damageable.TryChangeDamage(targetId, _xeno.ApplyXenoMeleeDamageModifiers(xeno, targetId, finalDamage), armorPiercing: xeno.Comp.AP, origin: xeno, tool: xeno);
         if (damage?.GetTotal() > FixedPoint2.Zero)
         {
             var filter = Filter.Pvs(targetId, entityManager: EntityManager).RemoveWhereAttachedEntity(o => o == xeno.Owner);

--- a/Content.Shared/_RMC14/Xenonids/Impale/XenoImpaleSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Impale/XenoImpaleSystem.cs
@@ -65,7 +65,7 @@ public sealed class XenoImpaleSystem : EntitySystem
     private void Impale(DamageSpecifier damage, int aP, EntProtoId animation, SoundSpecifier sound, EntityUid target, EntityUid xeno)
     {
         //TODO RMC14 targets chest
-        var damageTaken = _damage.TryChangeDamage(target, _xeno.TryApplyXenoSlashDamageMultiplier(target, damage), armorPiercing: aP, origin: xeno, tool: xeno);
+        var damageTaken = _damage.TryChangeDamage(target, _xeno.ApplyXenoMeleeDamageModifiers(xeno, target, damage), armorPiercing: aP, origin: xeno, tool: xeno);
         if (damageTaken?.GetTotal() > FixedPoint2.Zero)
         {
             var filter = Filter.Pvs(target, entityManager: EntityManager).RemoveWhereAttachedEntity(o => o == xeno);

--- a/Content.Shared/_RMC14/Xenonids/Leap/XenoLeapSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Leap/XenoLeapSystem.cs
@@ -576,7 +576,7 @@ public sealed class XenoLeapSystem : EntitySystem
                 SpawnAttachedTo(xeno.Comp.HitEffect, target.ToCoordinates());
         }
 
-        var damage = _damagable.TryChangeDamage(target, _xeno.TryApplyXenoSlashDamageMultiplier(target, xeno.Comp.Damage), origin: xeno, tool: xeno);
+        var damage = _damagable.TryChangeDamage(target, _xeno.ApplyXenoMeleeDamageModifiers(xeno, target, xeno.Comp.Damage), origin: xeno, tool: xeno);
         if (damage?.GetTotal() > FixedPoint2.Zero)
         {
             var filter = Filter.Pvs(target, entityManager: EntityManager).RemoveWhereAttachedEntity(o => o == xeno.Owner);

--- a/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonActivateAdaptabilityEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonActivateAdaptabilityEvent.cs
@@ -3,4 +3,4 @@ using Robust.Shared.Serialization;
 namespace Content.Shared._RMC14.Xenonids.ManageHive.Boons;
 
 [Serializable, NetSerializable]
-public sealed partial class HiveBoonActivateKingEvent : HiveBoonEvent;
+public sealed partial class HiveBoonActivateAdaptabilityEvent : HiveBoonEvent;

--- a/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonActivateAggressionEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonActivateAggressionEvent.cs
@@ -1,0 +1,11 @@
+using Content.Shared.FixedPoint;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Xenonids.ManageHive.Boons;
+
+[Serializable, NetSerializable]
+public sealed partial class HiveBoonActivateAggressionEvent : HiveBoonEvent
+{
+    [DataField]
+    public FixedPoint2 Damage = 5;
+}

--- a/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonActivateEvolutionEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonActivateEvolutionEvent.cs
@@ -1,0 +1,14 @@
+using Content.Shared.FixedPoint;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Xenonids.ManageHive.Boons;
+
+[Serializable, NetSerializable]
+public sealed partial class HiveBoonActivateEvolutionEvent : HiveBoonEvent
+{
+    [DataField]
+    public FixedPoint2 Multiplier = 2;
+
+    [DataField]
+    public bool BypassOvipositor;
+}

--- a/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonActivateFortificationEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonActivateFortificationEvent.cs
@@ -3,4 +3,4 @@ using Robust.Shared.Serialization;
 namespace Content.Shared._RMC14.Xenonids.ManageHive.Boons;
 
 [Serializable, NetSerializable]
-public sealed partial class HiveBoonActivateKingEvent : HiveBoonEvent;
+public sealed partial class HiveBoonActivateFortificationEvent : HiveBoonEvent;

--- a/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonAdaptabilityActionComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonAdaptabilityActionComponent.cs
@@ -1,0 +1,5 @@
+namespace Content.Shared._RMC14.Xenonids.ManageHive.Boons;
+
+[RegisterComponent]
+[Access(typeof(HiveBoonSystem))]
+public sealed partial class HiveBoonAdaptabilityActionComponent : Component;

--- a/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonAggressionComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonAggressionComponent.cs
@@ -1,0 +1,13 @@
+using Content.Shared._RMC14.Xenonids;
+using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.ManageHive.Boons;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(HiveBoonSystem), typeof(XenoSystem))]
+public sealed partial class HiveBoonAggressionComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 Damage = 5;
+}

--- a/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonDefinitionComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonDefinitionComponent.cs
@@ -5,9 +5,15 @@ using Robust.Shared.Prototypes;
 namespace Content.Shared._RMC14.Xenonids.ManageHive.Boons;
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-[Access(typeof(ManageHiveSystem))]
+[Access(typeof(HiveBoonSystem), typeof(ManageHiveSystem))]
 public sealed partial class HiveBoonDefinitionComponent : Component
 {
+    [DataField, AutoNetworkedField]
+    public LocId? ActivationAnnouncement;
+
+    [DataField, AutoNetworkedField]
+    public LocId? ExpirationAnnouncement;
+
     [DataField, AutoNetworkedField]
     public int Cost = 1;
 

--- a/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonEvolutionComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonEvolutionComponent.cs
@@ -1,0 +1,27 @@
+using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.ManageHive.Boons;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(HiveBoonSystem))]
+public sealed partial class HiveBoonEvolutionComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 Multiplier = 2;
+
+    [DataField, AutoNetworkedField]
+    public bool BypassOvipositor;
+
+    [DataField, AutoNetworkedField]
+    public bool FrozenEarlyEvolutionBoost;
+
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 FrozenBonus;
+
+    [DataField, AutoNetworkedField]
+    public bool HasFrozenOverride;
+
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 FrozenOverride;
+}

--- a/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonFortifiableWallComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonFortifiableWallComponent.cs
@@ -1,0 +1,18 @@
+using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.ManageHive.Boons;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
+[Access(typeof(HiveBoonSystem))]
+public sealed partial class HiveBoonFortifiableWallComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 Heal = 75;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan HealEvery = TimeSpan.FromSeconds(10);
+
+    [DataField, AutoNetworkedField, AutoPausedField]
+    public TimeSpan NextHealAt;
+}

--- a/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonFortificationComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonFortificationComponent.cs
@@ -1,0 +1,6 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.ManageHive.Boons;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class HiveBoonFortificationComponent : Component;

--- a/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonFortificationRepairingComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonFortificationRepairingComponent.cs
@@ -1,0 +1,5 @@
+namespace Content.Shared._RMC14.Xenonids.ManageHive.Boons;
+
+[RegisterComponent]
+[Access(typeof(HiveBoonSystem))]
+public sealed partial class HiveBoonFortificationRepairingComponent : Component;

--- a/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared._RMC14.Atmos;
 using Content.Shared._RMC14.Bioscan;
 using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Communications;
+using Content.Shared._RMC14.Damage;
 using Content.Shared._RMC14.Dialog;
 using Content.Shared._RMC14.GameTicking;
 using Content.Shared._RMC14.Map;
@@ -14,10 +15,15 @@ using Content.Shared._RMC14.Repairable;
 using Content.Shared._RMC14.Rules;
 using Content.Shared._RMC14.Xenonids.Announce;
 using Content.Shared._RMC14.Xenonids.Construction;
+using Content.Shared._RMC14.Xenonids.Construction.Events;
+using Content.Shared._RMC14.Xenonids.Evolution;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Weeds;
+using Content.Shared.Actions;
 using Content.Shared.Coordinates;
+using Content.Shared.Damage;
 using Content.Shared.Examine;
+using Content.Shared.FixedPoint;
 using Content.Shared.GameTicking;
 using Content.Shared.Mind;
 using Content.Shared.Mobs.Systems;
@@ -38,10 +44,12 @@ namespace Content.Shared._RMC14.Xenonids.ManageHive.Boons;
 
 public sealed class HiveBoonSystem : EntitySystem
 {
+    [Dependency] private readonly SharedActionsSystem _action = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly AreaSystem _area = default!;
     [Dependency] private readonly IComponentFactory _compFactory = default!;
     [Dependency] private readonly IConfigurationManager _config = default!;
+    [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly DialogSystem _dialog = default!;
     [Dependency] private readonly SharedGameTicker _gameTicker = default!;
     [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
@@ -53,6 +61,7 @@ public sealed class HiveBoonSystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly SharedRMCDamageableSystem _rmcDamageable = default!;
     [Dependency] private readonly SharedRMCGameTickerSystem _rmcGameTicker = default!;
     [Dependency] private readonly RMCMapSystem _rmcMap = default!;
     [Dependency] private readonly RMCPlanetSystem _rmcPlanet = default!;
@@ -62,6 +71,7 @@ public sealed class HiveBoonSystem : EntitySystem
 
     private static readonly EntProtoId<HiveBoonDefinitionComponent> KingBoonId = "RMCHiveBoonKing";
     private static readonly EntProtoId<HiveKingCocoonComponent> KingCocoonId = "RMCHiveCocoonKing";
+    private static readonly EntProtoId TransmuteActionId = "ActionXenoTransmute";
 
     public ImmutableArray<(EntityPrototype Prototype, HiveBoonDefinitionComponent Component)> Boons
     {
@@ -77,6 +87,7 @@ public sealed class HiveBoonSystem : EntitySystem
     private TimeSpan _kingVoteStartTime;
     private TimeSpan _kingVoteAskCandidatesTime;
     private TimeSpan _kingVoteStartHatchingTime;
+    private TimeSpan _earlyEvoBoostBefore;
 
     private EntityQuery<ExcludedFromKingVoteComponent> _excludedFromKingVoteQuery;
 
@@ -90,10 +101,15 @@ public sealed class HiveBoonSystem : EntitySystem
         SubscribeLocalEvent<HiveBoonActivateFireResistanceEvent>(OnActivateFireResistance);
         SubscribeLocalEvent<HiveBoonActivateLarvaSurgeEvent>(OnActivateLarvaSurge);
         SubscribeLocalEvent<HiveBoonActivateKingEvent>(OnActivateKing);
+        SubscribeLocalEvent<HiveBoonActivateEvolutionEvent>(OnActivateEvolution);
+        SubscribeLocalEvent<HiveBoonActivateAdaptabilityEvent>(OnActivateAdaptability);
+        SubscribeLocalEvent<HiveBoonActivateAggressionEvent>(OnActivateAggression);
+        SubscribeLocalEvent<HiveBoonActivateFortificationEvent>(OnActivateFortification);
 
         SubscribeLocalEvent<XenoComponent, RMCGetFireImmunityEvent>(OnGetTileFireImmunity);
         SubscribeLocalEvent<XenoComponent, GetIgnitionImmunityEvent>(OnGetTileFireIgnitionImmunity);
         SubscribeLocalEvent<XenoComponent, HiveKingVoteDialogEvent>(OnKingVote);
+        SubscribeLocalEvent<HiveBoonDefinitionComponent, EntityTerminatingEvent>(OnBoonTerminating);
 
         SubscribeLocalEvent<HiveClusterComponent, ExaminedEvent>(OnClusterExamined);
         SubscribeLocalEvent<HiveClusterComponent, AfterEntityWeedingEvent>(OnClusterAfterWeeding);
@@ -146,6 +162,11 @@ public sealed class HiveBoonSystem : EntitySystem
             v => _kingVoteStartHatchingTime = TimeSpan.FromSeconds(v),
             true);
 
+        Subs.CVar(_config,
+            RMCCVars.RMCXenoEarlyEvoPointBoostBeforeMinutes,
+            v => _earlyEvoBoostBefore = TimeSpan.FromMinutes(v),
+            true);
+
         ReloadPrototypes();
     }
 
@@ -158,32 +179,93 @@ public sealed class HiveBoonSystem : EntitySystem
     private void OnActivateFireResistance(HiveBoonActivateFireResistanceEvent ev)
     {
         EnsureComp<HiveBoonFireImmunityComponent>(ev.Boon);
-        _xenoAnnounce.AnnounceSameHiveDefaultSound(ev.Boon, "The Queen has imbued us with flame-resistant chitin for 5 minutes.");
+        AnnounceBoonActivation(ev.Boon);
     }
 
     private void OnActivateLarvaSurge(HiveBoonActivateLarvaSurgeEvent ev)
     {
         _hive.IncreaseBurrowedLarva(ev.Hive, 5);
-        _xenoAnnounce.AnnounceSameHiveDefaultSound(ev.Boon, "The Queen has awakened 5 extra burrowed larva to join the hive!");
+        AnnounceBoonActivation(ev.Boon);
+    }
+
+    private void OnActivateEvolution(HiveBoonActivateEvolutionEvent ev)
+    {
+        var evolution = EnsureComp<HiveBoonEvolutionComponent>(ev.Boon);
+        evolution.Multiplier = ev.Multiplier;
+        evolution.BypassOvipositor = ev.BypassOvipositor;
+        evolution.FrozenEarlyEvolutionBoost = _earlyEvoBoostBefore > _gameTicker.RoundDuration();
+
+        var bonus = FixedPoint2.Zero;
+        var bonuses = EntityQueryEnumerator<EvolutionBonusComponent>();
+        while (bonuses.MoveNext(out var comp))
+        {
+            bonus += comp.Amount;
+        }
+
+        evolution.FrozenBonus = bonus;
+        evolution.HasFrozenOverride = false;
+        evolution.FrozenOverride = FixedPoint2.Zero;
+
+        var overrides = EntityQueryEnumerator<EvolutionOverrideComponent>();
+        while (overrides.MoveNext(out var comp))
+        {
+            evolution.HasFrozenOverride = true;
+            evolution.FrozenOverride = comp.Amount;
+        }
+
+        Dirty(ev.Boon, evolution);
+
+        AnnounceBoonActivation(ev.Boon);
+    }
+
+    private void OnActivateAdaptability(HiveBoonActivateAdaptabilityEvent ev)
+    {
+        var xenos = EntityQueryEnumerator<XenoComponent>();
+        while (xenos.MoveNext(out var uid, out var xeno))
+        {
+            if (!_hive.FromSameHive(uid, ev.Boon) ||
+                !CanReceiveTransmuteAction((uid, xeno)))
+            {
+                continue;
+            }
+
+            if (_action.AddAction(uid, TransmuteActionId) == null)
+                continue;
+
+            EnsureComp<HiveBoonAdaptabilityActionComponent>(uid);
+        }
+
+        AnnounceBoonActivation(ev.Boon);
+    }
+
+    private void OnActivateAggression(HiveBoonActivateAggressionEvent ev)
+    {
+        var aggression = EnsureComp<HiveBoonAggressionComponent>(ev.Boon);
+        aggression.Damage = ev.Damage;
+        Dirty(ev.Boon, aggression);
+
+        AnnounceBoonActivation(ev.Boon);
+    }
+
+    private void OnActivateFortification(HiveBoonActivateFortificationEvent ev)
+    {
+        EnsureComp<HiveBoonFortificationComponent>(ev.Boon);
+        AnnounceBoonActivation(ev.Boon);
     }
 
     private void OnActivateKing(HiveBoonActivateKingEvent ev)
     {
-        var pylonQuery = EntityQueryEnumerator<HivePylonComponent>();
-        while (pylonQuery.MoveNext(out var uid, out _))
-        {
-            _area.TrySetCanOrbitalBombardRoofing(uid, false);
-        }
-
         if (ev.Core is not { } core)
             return;
 
         var cocoon = SpawnAtPosition(KingCocoonId, core.ToCoordinates());
         _hive.SetHive(cocoon, ev.Hive);
+        ApplyKingPylonObProtection(cocoon);
 
         var areaName = _area.GetAreaName(core);
         _marineAnnounce.AnnounceToMarines(Loc.GetString("rmc-boon-king-announcement-marine", ("area", areaName)));
         _xenoAnnounce.AnnounceSameHiveDefaultSound(core, Loc.GetString("rmc-boon-king-announcement-xenos", ("area", areaName)));
+        AnnounceBoonActivation(ev.Boon);
     }
 
     private void OnGetTileFireImmunity(Entity<XenoComponent> xeno, ref RMCGetFireImmunityEvent ev)
@@ -239,7 +321,7 @@ public sealed class HiveBoonSystem : EntitySystem
     {
         using (args.PushGroup(nameof(HivePylonComponent)))
         {
-            var msg = $"[color=cyan]This will grant the hive 1 royal resin every {(int)_royalResinEvery.TotalMinutes} minutes, allowing the Queen to obtain buffs![/color]";
+            var msg = Loc.GetString("rmc-boon-pylon-examine", ("minutes", (int)_royalResinEvery.TotalMinutes));
             args.PushMarkup(msg);
         }
     }
@@ -255,7 +337,7 @@ public sealed class HiveBoonSystem : EntitySystem
 
         var area = _area.GetAreaName(ent);
         _marineAnnounce.AnnounceToMarines(Loc.GetString("rmc-boon-pylon-destroyed-announcement-marine", ("area", area)));
-        _xenoAnnounce.AnnounceSameHiveDefaultSound(ent.Owner, $"We have lost our control of the tall's communication relay at {area}.");
+        _xenoAnnounce.AnnounceSameHiveDefaultSound(ent.Owner, Loc.GetString("rmc-boon-pylon-destroyed-announcement-xeno", ("area", area)));
 
         if (ent.Comp.Tower is { } tower)
         {
@@ -272,7 +354,7 @@ public sealed class HiveBoonSystem : EntitySystem
     {
         using (args.PushGroup(nameof(HivePylonComponent)))
         {
-            var msg = $"[color=cyan]If placed {(int) CommunicationTowerXenoTakeoverTime.TotalMinutes} minutes into the round, this can turn into a hive pylon when its weeds take over a telecommunications tower![/color]";
+            var msg = Loc.GetString("rmc-boon-cluster-examine", ("minutes", (int)CommunicationTowerXenoTakeoverTime.TotalMinutes));
             args.PushMarkup(msg);
         }
     }
@@ -310,7 +392,7 @@ public sealed class HiveBoonSystem : EntitySystem
             return;
 
         args.Cancelled = true;
-        args.Popup = $"The {Name(ent)} is entangled in resin. Impossible to interact with.";
+        args.Popup = Loc.GetString("rmc-boon-tower-repair-blocked", ("tower", Name(ent)));
     }
 
     private void OnCocoonTerminating(Entity<HiveKingCocoonComponent> ent, ref EntityTerminatingEvent args)
@@ -325,6 +407,101 @@ public sealed class HiveBoonSystem : EntitySystem
         var areaName = _area.GetAreaName(ent);
         _marineAnnounce.AnnounceToMarines(Loc.GetString("rmc-boon-king-announcement-stopped-marine", ("area", areaName)));
         _xenoAnnounce.AnnounceSameHiveDefaultSound(ent.Owner, Loc.GetString("rmc-boon-king-announcement-stopped-xeno"));
+    }
+
+    private void OnBoonTerminating(Entity<HiveBoonDefinitionComponent> ent, ref EntityTerminatingEvent args)
+    {
+        if (_hive.GetHive(ent.Owner) is not { } hive)
+            return;
+
+        var boons = EnsureBoons(hive);
+        foreach (var (id, active) in boons.Comp.Active.ToArray())
+        {
+            if (active == ent.Owner)
+                boons.Comp.Active.Remove(id);
+        }
+
+        Dirty(boons);
+
+        if (ent.Comp.Duration <= TimeSpan.Zero ||
+            ent.Comp.ExpirationAnnouncement is not { } announcement)
+        {
+            return;
+        }
+
+        _xenoAnnounce.AnnounceSameHiveDefaultSound(ent.Owner, Loc.GetString(announcement));
+    }
+
+    public string GetBoonName(EntityPrototype prototype)
+    {
+        return prototype.Name;
+    }
+
+    private string GetBoonName(EntityUid boon)
+    {
+        if (!TryComp(boon, out HiveBoonDefinitionComponent? comp) ||
+            Prototype(boon) is not { } prototype)
+        {
+            return Name(boon);
+        }
+
+        return GetBoonName(prototype);
+    }
+
+    private void AnnounceBoonActivation(EntityUid boon)
+    {
+        if (TryComp(boon, out HiveBoonDefinitionComponent? comp) &&
+            comp.ActivationAnnouncement is { } announcement)
+        {
+            _xenoAnnounce.AnnounceSameHiveDefaultSound(boon, Loc.GetString(announcement));
+        }
+    }
+
+    private bool CanReceiveTransmuteAction(Entity<XenoComponent> xeno)
+    {
+        if (xeno.Comp.Tier is <= 0 or > 3 ||
+            HasComp<HiveBoonAdaptabilityActionComponent>(xeno.Owner))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    public bool HasActiveBoon<T>(EntityUid hiveMember) where T : IComponent
+    {
+        return TryGetActiveBoon<T>(hiveMember, out _);
+    }
+
+    public bool TryGetActiveBoon<T>(EntityUid hiveMember, out Entity<T> boon) where T : IComponent
+    {
+        var query = EntityQueryEnumerator<T>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            if (TerminatingOrDeleted(uid) ||
+                !_hive.FromSameHive(uid, hiveMember))
+            {
+                continue;
+            }
+
+            boon = (uid, comp);
+            return true;
+        }
+
+        boon = default;
+        return false;
+    }
+
+    private void HealDamage(EntityUid uid, DamageableComponent damageable, FixedPoint2 amount)
+    {
+        if (amount <= FixedPoint2.Zero ||
+            damageable.TotalDamage <= FixedPoint2.Zero)
+        {
+            return;
+        }
+
+        var heal = -_rmcDamageable.DistributeTypesTotal((uid, damageable), amount);
+        _damageable.TryChangeDamage(uid, heal, true, damageable: damageable);
     }
 
     public bool HasEnoughAliveMarines()
@@ -376,7 +553,10 @@ public sealed class HiveBoonSystem : EntitySystem
 
         foreach (var uid in canVoteList)
         {
-            _dialog.OpenOptions(uid, "Choose a sister", options, "Vote for a sister you wish to become the King.");
+            _dialog.OpenOptions(uid,
+                Loc.GetString("rmc-boon-king-vote-title"),
+                options,
+                Loc.GetString("rmc-boon-king-vote-message"));
         }
 
         EnsureVote(cocoon);
@@ -469,7 +649,7 @@ public sealed class HiveBoonSystem : EntitySystem
 
             var areaName = _area.GetAreaName(tower);
             _marineAnnounce.AnnounceToMarines(Loc.GetString("rmc-boon-pylon-announcement-marine", ("area", areaName)));
-            _xenoAnnounce.AnnounceSameHiveDefaultSound(newWeedSource, $"We have harnessed the tall's communication relay at {areaName}.\n\nWe will now grow royal resin from this pylon. Hold it!");
+            _xenoAnnounce.AnnounceSameHiveDefaultSound(newWeedSource, Loc.GetString("rmc-boon-pylon-announcement-xeno", ("area", areaName)));
         }
 
         if (!TryComp(newWeedSource, out XenoWeedsComponent? newWeedSourceComp) ||
@@ -500,6 +680,8 @@ public sealed class HiveBoonSystem : EntitySystem
         {
             return;
         }
+
+        var boonName = GetBoonName(boonProto);
 
         if (_hive.GetHive(manage.Owner) is not { } hive)
             return;
@@ -550,6 +732,20 @@ public sealed class HiveBoonSystem : EntitySystem
 
         if (boonComp.NoLivingKing)
         {
+            var cocoonQuery = EntityQueryEnumerator<HiveKingCocoonComponent>();
+            while (cocoonQuery.MoveNext(out var uid, out _))
+            {
+                if (TerminatingOrDeleted(uid) ||
+                    !_hive.FromSameHive(manage.Owner, uid))
+                {
+                    continue;
+                }
+
+                var msg = Loc.GetString("rmc-boon-only-one-hatchery");
+                _popup.PopupCursor(msg, manage, PopupType.MediumCaution);
+                return;
+            }
+
             var kingQuery = EntityQueryEnumerator<HiveBoonKingComponent>();
             while (kingQuery.MoveNext(out var uid, out _))
             {
@@ -563,7 +759,8 @@ public sealed class HiveBoonSystem : EntitySystem
             }
         }
 
-        if (boonComp.RequiresCore && _hive.GetHiveCore(hive) == null)
+        var core = _hive.GetHiveCore(hive);
+        if (boonComp.RequiresCore && core == null)
         {
             var msg = Loc.GetString("rmc-boon-requires-core");
             _popup.PopupCursor(msg, manage, PopupType.MediumCaution);
@@ -577,7 +774,7 @@ public sealed class HiveBoonSystem : EntitySystem
             if (cooldownLeft > TimeSpan.Zero)
             {
                 var msg = Loc.GetString("rmc-boon-on-cooldown",
-                    ("boon", boonProto.Name),
+                    ("boon", boonName),
                     ("minutes", (int) cooldownLeft.TotalMinutes));
                 _popup.PopupCursor(msg, manage, PopupType.MediumCaution);
                 return;
@@ -588,14 +785,14 @@ public sealed class HiveBoonSystem : EntitySystem
             boons.Comp.Active.TryGetValue(duplicateId, out var activeBoonId) &&
             !TerminatingOrDeleted(activeBoonId))
         {
-            var msg = Loc.GetString("rmc-boon-duplicate-active", ("boon", Name(activeBoonId)));
+            var msg = Loc.GetString("rmc-boon-duplicate-active", ("boon", GetBoonName(activeBoonId)));
             _popup.PopupCursor(msg, manage, PopupType.MediumCaution);
             return;
         }
 
         if (!boonComp.Reusable && boons.Comp.UsedAt.ContainsKey(boonProto.ID))
         {
-            var msg = Loc.GetString("rmc-boon-not-reusable", ("boon", boonProto.Name));
+            var msg = Loc.GetString("rmc-boon-not-reusable", ("boon", boonName));
             _popup.PopupCursor(msg, manage, PopupType.MediumCaution);
             return;
         }
@@ -607,6 +804,9 @@ public sealed class HiveBoonSystem : EntitySystem
         if (ev == null)
             return;
 
+        ev.Hive = hive;
+        ev.Core = core;
+
         boons.Comp.UsedAt[boonProto.ID] = time;
         boons.Comp.RoyalResin = Math.Max(0, boons.Comp.RoyalResin - boonComp.Cost);
 
@@ -615,13 +815,24 @@ public sealed class HiveBoonSystem : EntitySystem
 
         EnsureComp<TimedDespawnComponent>(boonEnt).Lifetime = (float) boonComp.Duration.TotalSeconds;
 
-        boons.Comp.Active[boonProto.ID] = boonEnt;
+        var activeId = boonComp.DuplicateId ?? boonProto.ID;
+        boons.Comp.Active[activeId] = boonEnt;
         Dirty(boons, boons.Comp);
 
         ev.Boon = boonEnt;
-        ev.Hive = hive;
-        ev.Core = _hive.GetHiveCore(hive);
         RaiseLocalEvent((object) ev);
+    }
+
+    private void ApplyKingPylonObProtection(EntityUid hiveMember)
+    {
+        var pylonQuery = EntityQueryEnumerator<HivePylonComponent>();
+        while (pylonQuery.MoveNext(out var pylonId, out _))
+        {
+            if (!_hive.FromSameHive(hiveMember, pylonId))
+                continue;
+
+            _area.TrySetCanOrbitalBombardRoofing(pylonId, false);
+        }
     }
 
     private bool TryGetUnlockAt(Entity<HiveBoonsComponent> boons, EntProtoId<HiveBoonDefinitionComponent> boonId, out TimeSpan unlockAt)
@@ -662,7 +873,9 @@ public sealed class HiveBoonSystem : EntitySystem
             boons.Add((prototype, comp));
         }
 
-        boons.Sort((a, b) => string.Compare(a.Prototype.Name, b.Prototype.Name, StringComparison.InvariantCultureIgnoreCase));
+        boons.Sort((a, b) => string.Compare(GetBoonName(a.Prototype),
+            GetBoonName(b.Prototype),
+            StringComparison.InvariantCultureIgnoreCase));
         Boons = boons.ToImmutable();
     }
 
@@ -693,6 +906,42 @@ public sealed class HiveBoonSystem : EntitySystem
         }
     }
 
+    private void UpdateFortifiedStructures()
+    {
+        var time = _timing.CurTime;
+
+        var walls = EntityQueryEnumerator<HiveBoonFortifiableWallComponent, DamageableComponent>();
+        while (walls.MoveNext(out var uid, out var wall, out var damageable))
+        {
+            if (!HasActiveBoon<HiveBoonFortificationComponent>(uid))
+                continue;
+
+            if (time < wall.NextHealAt)
+                continue;
+
+            wall.NextHealAt = time + wall.HealEvery;
+            Dirty(uid, wall);
+            HealDamage(uid, damageable, wall.Heal);
+        }
+
+        var clusters = EntityQueryEnumerator<HiveClusterComponent, DamageableComponent>();
+        while (clusters.MoveNext(out var uid, out var cluster, out var damageable))
+        {
+            if (!HasActiveBoon<HiveBoonFortificationComponent>(uid))
+                continue;
+
+            if (time < cluster.NextFortificationRepairAt)
+                continue;
+
+            cluster.NextFortificationRepairAt = time + cluster.FortificationRepairEvery;
+            Dirty(uid, cluster);
+
+            HealDamage(uid, damageable, damageable.TotalDamage);
+            var ev = new XenoStructureRepairedEvent();
+            RaiseLocalEvent(uid, ev);
+        }
+    }
+
     public override void Update(float frameTime)
     {
         if (_net.IsClient)
@@ -700,6 +949,7 @@ public sealed class HiveBoonSystem : EntitySystem
 
         AnnounceKingUnlock();
         GainResin();
+        UpdateFortifiedStructures();
 
         var cocoonQuery = EntityQueryEnumerator<HiveKingCocoonComponent>();
         while (cocoonQuery.MoveNext(out var cocoonId, out var cocoonComp))
@@ -725,14 +975,7 @@ public sealed class HiveBoonSystem : EntitySystem
                 }
 
                 cocoonComp.LastPylons = pylons;
-                pylonQuery = EntityQueryEnumerator<HivePylonComponent>();
-                while (pylonQuery.MoveNext(out var pylonId, out _))
-                {
-                    if (!_hive.FromSameHive(cocoonId, pylonId))
-                        continue;
-
-                    _area.TrySetCanOrbitalBombardRoofing(pylonId, false);
-                }
+                ApplyKingPylonObProtection(cocoonId);
             }
             else
             {
@@ -855,7 +1098,7 @@ public sealed class HiveBoonSystem : EntitySystem
                 Dirty(boons);
 
                 var sound = new BioscanComponent().XenoSound;
-                _xenoAnnounce.AnnounceToHive(default, uid, "The hive is now ready to begin hatching His Grace, the King, if we gain control of both tall hivemind towers.", sound);
+                _xenoAnnounce.AnnounceToHive(default, uid, Loc.GetString("rmc-boon-king-unlock-announcement"), sound);
             }
         }
         catch (Exception e)

--- a/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonSystem.cs
@@ -72,6 +72,7 @@ public sealed class HiveBoonSystem : EntitySystem
     private static readonly EntProtoId<HiveBoonDefinitionComponent> KingBoonId = "RMCHiveBoonKing";
     private static readonly EntProtoId<HiveKingCocoonComponent> KingCocoonId = "RMCHiveCocoonKing";
     private static readonly EntProtoId TransmuteActionId = "ActionXenoTransmute";
+    private static readonly TimeSpan FortifiedStructuresUpdateEvery = TimeSpan.FromSeconds(1);
 
     public ImmutableArray<(EntityPrototype Prototype, HiveBoonDefinitionComponent Component)> Boons
     {
@@ -88,10 +89,12 @@ public sealed class HiveBoonSystem : EntitySystem
     private TimeSpan _kingVoteAskCandidatesTime;
     private TimeSpan _kingVoteStartHatchingTime;
     private TimeSpan _earlyEvoBoostBefore;
+    private TimeSpan _nextFortifiedStructuresUpdate;
 
     private EntityQuery<ExcludedFromKingVoteComponent> _excludedFromKingVoteQuery;
 
     private readonly HashSet<ProtoId<PlayTimeTrackerPrototype>> _xenoJobs = new();
+    private readonly HashSet<EntityUid> _fortifiedStructureHives = new();
 
     public override void Initialize()
     {
@@ -113,9 +116,12 @@ public sealed class HiveBoonSystem : EntitySystem
 
         SubscribeLocalEvent<HiveClusterComponent, ExaminedEvent>(OnClusterExamined);
         SubscribeLocalEvent<HiveClusterComponent, AfterEntityWeedingEvent>(OnClusterAfterWeeding);
+        SubscribeLocalEvent<HiveClusterComponent, DamageChangedEvent>(OnClusterDamageChanged);
 
         SubscribeLocalEvent<HivePylonComponent, ExaminedEvent>(OnPylonExamined);
         SubscribeLocalEvent<HivePylonComponent, EntityTerminatingEvent>(OnPylonTerminating);
+
+        SubscribeLocalEvent<HiveBoonFortifiableWallComponent, DamageChangedEvent>(OnFortifiableWallDamageChanged);
 
         SubscribeLocalEvent<CommunicationsTowerComponent, CommunicationsTowerStateChangedEvent>(OnTowerBreak);
         SubscribeLocalEvent<CommunicationsTowerComponent, RMCRepairableTargetAttemptEvent>(OnTowerRepairAttempt);
@@ -250,6 +256,8 @@ public sealed class HiveBoonSystem : EntitySystem
     private void OnActivateFortification(HiveBoonActivateFortificationEvent ev)
     {
         EnsureComp<HiveBoonFortificationComponent>(ev.Boon);
+        _nextFortifiedStructuresUpdate = TimeSpan.Zero;
+        QueueDamagedFortifiedStructures(ev.Boon);
         AnnounceBoonActivation(ev.Boon);
     }
 
@@ -370,6 +378,16 @@ public sealed class HiveBoonSystem : EntitySystem
         ReplaceCluster(ent, (args.CoveredEntity, tower));
     }
 
+    private void OnClusterDamageChanged(Entity<HiveClusterComponent> ent, ref DamageChangedEvent args)
+    {
+        QueueFortificationRepair(ent.Owner, args);
+    }
+
+    private void OnFortifiableWallDamageChanged(Entity<HiveBoonFortifiableWallComponent> ent, ref DamageChangedEvent args)
+    {
+        QueueFortificationRepair(ent.Owner, args);
+    }
+
     private void OnTowerBreak(Entity<CommunicationsTowerComponent> ent, ref CommunicationsTowerStateChangedEvent args)
     {
         if (ent.Comp.State != CommunicationsTowerState.Broken)
@@ -413,6 +431,12 @@ public sealed class HiveBoonSystem : EntitySystem
     {
         if (_hive.GetHive(ent.Owner) is not { } hive)
             return;
+
+        if (HasComp<HiveBoonFortificationComponent>(ent.Owner) &&
+            !HasOtherActiveFortificationBoon(hive, ent.Owner))
+        {
+            ClearFortificationRepairing(hive);
+        }
 
         var boons = EnsureBoons(hive);
         foreach (var (id, active) in boons.Comp.Active.ToArray())
@@ -909,12 +933,24 @@ public sealed class HiveBoonSystem : EntitySystem
     private void UpdateFortifiedStructures()
     {
         var time = _timing.CurTime;
+        if (time < _nextFortifiedStructuresUpdate)
+            return;
 
-        var walls = EntityQueryEnumerator<HiveBoonFortifiableWallComponent, DamageableComponent>();
-        while (walls.MoveNext(out var uid, out var wall, out var damageable))
+        _nextFortifiedStructuresUpdate = time + FortifiedStructuresUpdateEvery;
+
+        if (!TryGetFortifiedStructureHives(_fortifiedStructureHives))
+            return;
+
+        var walls = EntityQueryEnumerator<HiveBoonFortificationRepairingComponent, HiveBoonFortifiableWallComponent, DamageableComponent>();
+        while (walls.MoveNext(out var uid, out _, out var wall, out var damageable))
         {
-            if (!HasActiveBoon<HiveBoonFortificationComponent>(uid))
+            if (_hive.GetHive(uid) is not { } hive ||
+                !_fortifiedStructureHives.Contains(hive.Owner) ||
+                damageable.TotalDamage <= FixedPoint2.Zero)
+            {
+                RemCompDeferred<HiveBoonFortificationRepairingComponent>(uid);
                 continue;
+            }
 
             if (time < wall.NextHealAt)
                 continue;
@@ -922,13 +958,21 @@ public sealed class HiveBoonSystem : EntitySystem
             wall.NextHealAt = time + wall.HealEvery;
             Dirty(uid, wall);
             HealDamage(uid, damageable, wall.Heal);
+
+            if (damageable.TotalDamage <= FixedPoint2.Zero)
+                RemCompDeferred<HiveBoonFortificationRepairingComponent>(uid);
         }
 
-        var clusters = EntityQueryEnumerator<HiveClusterComponent, DamageableComponent>();
-        while (clusters.MoveNext(out var uid, out var cluster, out var damageable))
+        var clusters = EntityQueryEnumerator<HiveBoonFortificationRepairingComponent, HiveClusterComponent, DamageableComponent>();
+        while (clusters.MoveNext(out var uid, out _, out var cluster, out var damageable))
         {
-            if (!HasActiveBoon<HiveBoonFortificationComponent>(uid))
+            if (_hive.GetHive(uid) is not { } hive ||
+                !_fortifiedStructureHives.Contains(hive.Owner) ||
+                damageable.TotalDamage <= FixedPoint2.Zero)
+            {
+                RemCompDeferred<HiveBoonFortificationRepairingComponent>(uid);
                 continue;
+            }
 
             if (time < cluster.NextFortificationRepairAt)
                 continue;
@@ -939,7 +983,132 @@ public sealed class HiveBoonSystem : EntitySystem
             HealDamage(uid, damageable, damageable.TotalDamage);
             var ev = new XenoStructureRepairedEvent();
             RaiseLocalEvent(uid, ev);
+            RemCompDeferred<HiveBoonFortificationRepairingComponent>(uid);
         }
+    }
+
+    private bool TryGetFortifiedStructureHives(HashSet<EntityUid> hives)
+    {
+        hives.Clear();
+
+        var boons = EntityQueryEnumerator<HiveBoonFortificationComponent>();
+        while (boons.MoveNext(out var uid, out _))
+        {
+            if (TerminatingOrDeleted(uid) ||
+                _hive.GetHive(uid) is not { } hive)
+            {
+                continue;
+            }
+
+            hives.Add(hive.Owner);
+        }
+
+        return hives.Count > 0;
+    }
+
+    private void QueueFortificationRepair(EntityUid uid, DamageChangedEvent args)
+    {
+        if (_net.IsClient)
+            return;
+
+        if (args.Damageable.TotalDamage <= FixedPoint2.Zero)
+        {
+            RemCompDeferred<HiveBoonFortificationRepairingComponent>(uid);
+            return;
+        }
+
+        if (!args.DamageIncreased &&
+            args.DamageDelta != null)
+        {
+            return;
+        }
+
+        if (!HasActiveBoon<HiveBoonFortificationComponent>(uid))
+            return;
+
+        var wasQueued = HasComp<HiveBoonFortificationRepairingComponent>(uid);
+        EnsureComp<HiveBoonFortificationRepairingComponent>(uid);
+
+        if (!wasQueued)
+            StartFortificationRepairCooldown(uid);
+
+        _nextFortifiedStructuresUpdate = TimeSpan.Zero;
+    }
+
+    private void StartFortificationRepairCooldown(EntityUid uid)
+    {
+        var time = _timing.CurTime;
+
+        if (TryComp(uid, out HiveBoonFortifiableWallComponent? wall) &&
+            time >= wall.NextHealAt)
+        {
+            wall.NextHealAt = time + wall.HealEvery;
+            Dirty(uid, wall);
+        }
+
+        if (TryComp(uid, out HiveClusterComponent? cluster) &&
+            time >= cluster.NextFortificationRepairAt)
+        {
+            cluster.NextFortificationRepairAt = time + cluster.FortificationRepairEvery;
+            Dirty(uid, cluster);
+        }
+    }
+
+    private void QueueDamagedFortifiedStructures(EntityUid boon)
+    {
+        var walls = EntityQueryEnumerator<HiveBoonFortifiableWallComponent, DamageableComponent>();
+        while (walls.MoveNext(out var uid, out _, out var damageable))
+        {
+            if (damageable.TotalDamage <= FixedPoint2.Zero ||
+                !_hive.FromSameHive(uid, boon))
+            {
+                continue;
+            }
+
+            EnsureComp<HiveBoonFortificationRepairingComponent>(uid);
+        }
+
+        var clusters = EntityQueryEnumerator<HiveClusterComponent, DamageableComponent>();
+        while (clusters.MoveNext(out var uid, out _, out var damageable))
+        {
+            if (damageable.TotalDamage <= FixedPoint2.Zero ||
+                !_hive.FromSameHive(uid, boon))
+            {
+                continue;
+            }
+
+            EnsureComp<HiveBoonFortificationRepairingComponent>(uid);
+        }
+    }
+
+    private void ClearFortificationRepairing(Entity<HiveComponent> hive)
+    {
+        var repairing = EntityQueryEnumerator<HiveBoonFortificationRepairingComponent>();
+        while (repairing.MoveNext(out var uid, out _))
+        {
+            if (!_hive.IsMember(uid, hive.Owner))
+                continue;
+
+            RemCompDeferred<HiveBoonFortificationRepairingComponent>(uid);
+        }
+    }
+
+    private bool HasOtherActiveFortificationBoon(Entity<HiveComponent> hive, EntityUid terminating)
+    {
+        var boons = EntityQueryEnumerator<HiveBoonFortificationComponent>();
+        while (boons.MoveNext(out var uid, out _))
+        {
+            if (uid == terminating ||
+                TerminatingOrDeleted(uid) ||
+                !_hive.IsMember(uid, hive.Owner))
+            {
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
     }
 
     public override void Update(float frameTime)

--- a/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveClusterComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveClusterComponent.cs
@@ -1,12 +1,19 @@
-﻿using Robust.Shared.GameStates;
+using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared._RMC14.Xenonids.ManageHive.Boons;
 
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
 [Access(typeof(HiveBoonSystem))]
 public sealed partial class HiveClusterComponent : Component
 {
     [DataField, AutoNetworkedField]
     public EntProtoId TowerReplaceWith = "HivePylonXeno";
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan FortificationRepairEvery = TimeSpan.FromSeconds(20);
+
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
+    public TimeSpan NextFortificationRepairAt;
 }

--- a/Content.Shared/_RMC14/Xenonids/ManageHive/ManageHiveSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/ManageHive/ManageHiveSystem.cs
@@ -244,8 +244,9 @@ public sealed class ManageHiveSystem : EntitySystem
         var choices = new List<DialogOption>();
         foreach (var boon in _hiveBoon.Boons)
         {
+            var boonName = _hiveBoon.GetBoonName(boon.Prototype);
             var text = Loc.GetString("rmc-boon-name-cost",
-                ("boon", boon.Prototype.Name),
+                ("boon", boonName),
                 ("cost", boon.Component.Cost),
                 ("pylons", boon.Component.Pylons)
             );

--- a/Content.Shared/_RMC14/Xenonids/Pierce/XenoPierceSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Pierce/XenoPierceSystem.cs
@@ -107,7 +107,7 @@ public sealed class XenoPierceSystem : EntitySystem
 
                 hits++;
 
-                var change = _damage.TryChangeDamage(ent, _xeno.TryApplyXenoSlashDamageMultiplier(ent, xeno.Comp.Damage), origin: xeno, armorPiercing: xeno.Comp.AP, tool: xeno);
+                var change = _damage.TryChangeDamage(ent, _xeno.ApplyXenoMeleeDamageModifiers(xeno, ent, xeno.Comp.Damage), origin: xeno, armorPiercing: xeno.Comp.AP, tool: xeno);
 
                 if (change?.GetTotal() > FixedPoint2.Zero)
                 {

--- a/Content.Shared/_RMC14/Xenonids/Punch/XenoPunchSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Punch/XenoPunchSystem.cs
@@ -51,7 +51,7 @@ public sealed class XenoPunchSystem : EntitySystem
         var targetId = args.Target;
         _rmcPulling.TryStopAllPullsFromAndOn(targetId);
 
-        var damage = _damageable.TryChangeDamage(targetId, _xeno.TryApplyXenoSlashDamageMultiplier(targetId, xeno.Comp.Damage), origin: xeno, tool: xeno);
+        var damage = _damageable.TryChangeDamage(targetId, _xeno.ApplyXenoMeleeDamageModifiers(xeno, targetId, xeno.Comp.Damage), origin: xeno, tool: xeno);
         if (damage?.GetTotal() > FixedPoint2.Zero)
         {
             var filter = Filter.Pvs(targetId, entityManager: EntityManager).RemoveWhereAttachedEntity(o => o == xeno.Owner);

--- a/Content.Shared/_RMC14/Xenonids/Rend/XenoRendSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Rend/XenoRendSystem.cs
@@ -53,7 +53,7 @@ public sealed class XenoRendSystem : EntitySystem
             if (!_interact.InRangeUnobstructed(xeno.Owner, ent.Owner, xeno.Comp.Range))
                 continue;
 
-            var myDamage = _damage.TryChangeDamage(ent, xeno.Comp.Damage, origin: xeno, tool: xeno);
+            var myDamage = _damage.TryChangeDamage(ent, _xeno.ApplyXenoMeleeDamageModifiers(xeno, ent, xeno.Comp.Damage), origin: xeno, tool: xeno);
             if (myDamage?.GetTotal() > FixedPoint2.Zero)
             {
                 var filter = Filter.Pvs(ent, entityManager: EntityManager).RemoveWhereAttachedEntity(o => o == xeno.Owner);

--- a/Content.Shared/_RMC14/Xenonids/ScissorCut/XenoScissorCutSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/ScissorCut/XenoScissorCutSystem.cs
@@ -127,7 +127,7 @@ public sealed class XenoScissorCutSystem : EntitySystem
             if (hitEnt == null)
                 hitEnt = victim;
 
-            var change = _damage.TryChangeDamage(victim, xeno.Comp.Damage, origin: xeno, tool: xeno);
+            var change = _damage.TryChangeDamage(victim, _xeno.ApplyXenoMeleeDamageModifiers(xeno, victim, xeno.Comp.Damage), origin: xeno, tool: xeno);
 
             if (change?.GetTotal() > FixedPoint2.Zero)
             {

--- a/Content.Shared/_RMC14/Xenonids/Smackdown/XenoSmackdownSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Smackdown/XenoSmackdownSystem.cs
@@ -34,7 +34,7 @@ public sealed class XenoSmackdownSystem : EntitySystem
             _standing.IsDown(ent)))
                 continue;
 
-            var myDamage = _damageable.TryChangeDamage(ent, _xeno.TryApplyXenoSlashDamageMultiplier(ent, xeno.Comp.Damage), origin: xeno, tool: xeno);
+            var myDamage = _damageable.TryChangeDamage(ent, _xeno.ApplyXenoMeleeDamageModifiers(xeno, ent, xeno.Comp.Damage), origin: xeno, tool: xeno);
             if (myDamage?.GetTotal() > FixedPoint2.Zero)
             {
                 var filter = Filter.Pvs(ent, entityManager: EntityManager).RemoveWhereAttachedEntity(o => o == xeno.Owner);

--- a/Content.Shared/_RMC14/Xenonids/Stab/SharedXenoTailStabSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Stab/SharedXenoTailStabSystem.cs
@@ -152,7 +152,7 @@ public abstract class SharedXenoTailStabSystem : EntitySystem
                 RaiseLocalEvent(hit, attackedEv);
 
                 var modifiedDamage = DamageSpecifier.ApplyModifierSets(damage + hitEvent.BonusDamage + attackedEv.BonusDamage, hitEvent.ModifiersList);
-                var change = _damageable.TryChangeDamage(hit, _xeno.TryApplyXenoSlashDamageMultiplier(hit, modifiedDamage), origin: stab , tool: stab);
+                var change = _damageable.TryChangeDamage(hit, _xeno.ApplyXenoMeleeDamageModifiers(stab, hit, modifiedDamage), origin: stab , tool: stab);
 
                 if (change?.GetTotal() > FixedPoint2.Zero)
                 {

--- a/Content.Shared/_RMC14/Xenonids/Stomp/SharedXenoStompSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Stomp/SharedXenoStompSystem.cs
@@ -117,7 +117,7 @@ public sealed class XenoStompSystem : EntitySystem
                 if (!_standing.IsDown(receiver))
                     continue;
 
-                var damage = _damageable.TryChangeDamage(receiver, _xeno.TryApplyXenoSlashDamageMultiplier(receiver, xeno.Comp.Damage), origin: xeno, tool: xeno);
+                var damage = _damageable.TryChangeDamage(receiver, _xeno.ApplyXenoMeleeDamageModifiers(xeno, receiver, xeno.Comp.Damage), origin: xeno, tool: xeno);
                 if (damage?.GetTotal() > FixedPoint2.Zero)
                 {
                     var filter = Filter.Pvs(receiver, entityManager: EntityManager).RemoveWhereAttachedEntity(o => o == xeno.Owner);

--- a/Content.Shared/_RMC14/Xenonids/Sweep/XenoTailSweepSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Sweep/XenoTailSweepSystem.cs
@@ -78,7 +78,7 @@ public sealed class XenoTailSweepSystem : EntitySystem
             _rmcPulling.TryStopAllPullsFromAndOn(mob);
 
             if (xeno.Comp.Damage is { } damage)
-                _damageable.TryChangeDamage(mob, _xeno.TryApplyXenoSlashDamageMultiplier(mob, damage), origin: xeno, tool: xeno);
+                _damageable.TryChangeDamage(mob, _xeno.ApplyXenoMeleeDamageModifiers(xeno, mob, damage), origin: xeno, tool: xeno);
 
             var filter = Filter.Pvs(mob, entityManager: EntityManager);
             _colorFlash.RaiseEffect(Color.Red, new List<EntityUid> { mob }, filter);

--- a/Content.Shared/_RMC14/Xenonids/TailJab/XenoTailJabSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/TailJab/XenoTailJabSystem.cs
@@ -64,7 +64,7 @@ public sealed class XenoTailJabSystem : EntitySystem
         if (HasComp<DestroyOnXenoPierceScissorComponent>(target))
             damage.DamageDict.TryAdd(WindowBonusDamageType, WindowDamageBonus);
 
-        var damageTaken = _damage.TryChangeDamage(target, _xeno.TryApplyXenoSlashDamageMultiplier(target, damage), origin: xeno, tool: xeno);
+        var damageTaken = _damage.TryChangeDamage(target, _xeno.ApplyXenoMeleeDamageModifiers(xeno, target, damage), origin: xeno, tool: xeno);
         if (damageTaken?.GetTotal() > FixedPoint2.Zero)
         {
             var filter = Filter.Pvs(target, entityManager: EntityManager).RemoveWhereAttachedEntity(o => o == xeno.Owner);

--- a/Content.Shared/_RMC14/Xenonids/Tumble/XenoTumbleSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Tumble/XenoTumbleSystem.cs
@@ -124,7 +124,7 @@ public sealed class XenoTumbleSystem : EntitySystem
 
         _damageable.TryChangeDamage(
             args.Target,
-            _xeno.TryApplyXenoSlashDamageMultiplier(args.Target, xeno.Comp.Damage),
+            _xeno.ApplyXenoMeleeDamageModifiers(xeno, args.Target, xeno.Comp.Damage),
             origin: xeno,
             tool: xeno,
             armorPiercing: xeno.Comp.ArmorPiercing

--- a/Content.Shared/_RMC14/Xenonids/XenoSystem.HiveVsHive.cs
+++ b/Content.Shared/_RMC14/Xenonids/XenoSystem.HiveVsHive.cs
@@ -1,12 +1,19 @@
 using Content.Shared._RMC14.Stun;
+using Content.Shared._RMC14.Xenonids.ManageHive.Boons;
 using Content.Shared.Damage;
+using Content.Shared.Damage.Prototypes;
+using Content.Shared.FixedPoint;
 using Content.Shared.Weapons.Melee.Events;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared._RMC14.Xenonids;
 
 public sealed partial class XenoSystem : EntitySystem
 {
     [Dependency] private readonly RMCSizeStunSystem _size = default!;
+
+    private static readonly ProtoId<DamageTypePrototype>[] AggressionBruteDamageTypes = ["Blunt", "Slash", "Piercing"];
+    private static readonly ProtoId<DamageTypePrototype> AggressionStructuralDamageType = "Structural";
 
     public const float XENO_SLASH_DAMAGE_MULT = 1.5f;
     public const float XENO_DEBUFF_MULT = 1.25f;
@@ -19,6 +26,87 @@ public sealed partial class XenoSystem : EntitySystem
             return baseDamage;
 
         return baseDamage * XENO_SLASH_DAMAGE_MULT;
+    }
+
+    public DamageSpecifier ApplyXenoAggressionDamage(EntityUid attacker, DamageSpecifier baseDamage)
+    {
+        if (!_hiveBoon.TryGetActiveBoon<HiveBoonAggressionComponent>(attacker, out var boon))
+            return new DamageSpecifier(baseDamage);
+
+        return ApplyXenoAggressionDamageBonus(baseDamage, boon.Comp.Damage);
+    }
+
+    public DamageSpecifier ApplyXenoMeleeDamageModifiers(EntityUid attacker, EntityUid target, DamageSpecifier baseDamage)
+    {
+        return TryApplyXenoSlashDamageMultiplier(target, ApplyXenoAggressionDamage(attacker, baseDamage));
+    }
+
+    public static DamageSpecifier ApplyXenoAggressionDamageBonus(DamageSpecifier baseDamage, FixedPoint2 amount)
+    {
+        var damage = new DamageSpecifier(baseDamage);
+        AddPhysicalMeleeDamageBonus(damage, amount);
+        return damage;
+    }
+
+    private static void AddPhysicalMeleeDamageBonus(DamageSpecifier damage, FixedPoint2 amount)
+    {
+        if (amount <= FixedPoint2.Zero)
+            return;
+
+        var bruteTotal = FixedPoint2.Zero;
+        string? lastBruteType = null;
+        var bruteTypes = 0;
+
+        foreach (var type in AggressionBruteDamageTypes)
+        {
+            if (!damage.DamageDict.TryGetValue(type, out var value) ||
+                value <= FixedPoint2.Zero)
+            {
+                continue;
+            }
+
+            bruteTotal += value;
+            lastBruteType = type;
+            bruteTypes++;
+        }
+
+        if (bruteTotal > FixedPoint2.Zero &&
+            lastBruteType != null)
+        {
+            if (bruteTypes == 1)
+            {
+                damage.DamageDict[lastBruteType] += amount;
+                return;
+            }
+
+            var remaining = amount;
+            foreach (var type in AggressionBruteDamageTypes)
+            {
+                if (!damage.DamageDict.TryGetValue(type, out var value) ||
+                    value <= FixedPoint2.Zero)
+                {
+                    continue;
+                }
+
+                if (type == lastBruteType)
+                {
+                    damage.DamageDict[type] += remaining;
+                    return;
+                }
+
+                var added = amount * value / bruteTotal;
+                damage.DamageDict[type] += added;
+                remaining -= added;
+            }
+
+            return;
+        }
+
+        if (damage.DamageDict.TryGetValue(AggressionStructuralDamageType, out var structural) &&
+            structural > FixedPoint2.Zero)
+        {
+            damage.DamageDict[AggressionStructuralDamageType] = structural + amount;
+        }
     }
 
     public TimeSpan TryApplyXenoDebuffMultiplier(EntityUid target, TimeSpan baseDuration)

--- a/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
@@ -17,6 +17,7 @@ using Content.Shared._RMC14.Xenonids.Evolution;
 using Content.Shared._RMC14.Xenonids.Fortify;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.HiveLeader;
+using Content.Shared._RMC14.Xenonids.ManageHive.Boons;
 using Content.Shared._RMC14.Xenonids.Parasite;
 using Content.Shared._RMC14.Xenonids.Pheromones;
 using Content.Shared._RMC14.Xenonids.Plasma;
@@ -67,6 +68,7 @@ public sealed partial class XenoSystem : EntitySystem
     [Dependency] private readonly SharedEyeSystem _eye = default!;
     [Dependency] private readonly SharedHandsSystem _hands = default!;
     [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
+    [Dependency] private readonly HiveBoonSystem _hiveBoon = default!;
     [Dependency] private readonly HiveLeaderSystem _hiveLeader = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly MobThresholdSystem _mobThresholds = default!;
@@ -273,10 +275,10 @@ public sealed partial class XenoSystem : EntitySystem
 
     private void OnXenoGetMeleeDamage(Entity<XenoComponent> ent, ref GetMeleeDamageEvent args)
     {
-        if (MathHelper.CloseTo(_xenoDamageDealtMultiplier, 1))
-            return;
+        args.Damage = ApplyXenoAggressionDamage(ent.Owner, args.Damage);
 
-        args.Damage *= _xenoDamageDealtMultiplier;
+        if (!MathHelper.CloseTo(_xenoDamageDealtMultiplier, 1))
+            args.Damage *= _xenoDamageDealtMultiplier;
     }
 
     private void OnXenoDamageModify(Entity<XenoComponent> ent, ref DamageModifyEvent args)

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-boons.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-boons.ftl
@@ -5,11 +5,52 @@ rmc-boon-not-enough-royal-resin = We don't have enough royal resin! We need {$co
 rmc-boon-not-enough-pylons = We don't have enough hive pylons! We need {$cost} and have {$current}
 rmc-boon-not-enough-time = Our hive is not mature enough yet to purchase this!
 rmc-boon-not-enough-marines = There is not enough danger to warrant hive buffs.
+rmc-boon-only-one-hatchery = Only one hatchery may exist at a time!
 rmc-boon-only-one-king = Only one King may exist at a time!
 rmc-boon-requires-core = You must first construct a hive core.
 rmc-boon-on-cooldown = Our hive has already used {$boon} recently! Wait {$minutes} minutes.
 rmc-boon-duplicate-active = We already have a boon of {$boon} active!
 rmc-boon-not-reusable = Our hive has already used {$boon} and cannot use it again!
+
+rmc-boon-fire-resistance-activate = The Queen has imbued us with flame-resistant chitin.
+rmc-boon-fire-resistance-expire = The Boon of Fire Resistance has expired.
+
+rmc-boon-larva-surge-activate = The Queen has purchased 5 extra larva to join the hive!
+
+rmc-boon-evolution-activate = The Queen has blessed us with faster evolution.
+rmc-boon-evolution-expire = The Boon of Evolution has expired.
+rmc-boon-evolution-major-expire = The Major Boon of Evolution has expired.
+
+rmc-boon-adaptability-activate = The Queen has blessed us with adaptability.
+
+rmc-boon-aggression-activate = The Queen has imbued us with sharp claws.
+rmc-boon-aggression-major-activate = The Queen has imbued us with razor-sharp claws.
+rmc-boon-aggression-expire = The Boon of Aggression has expired.
+rmc-boon-aggression-major-expire = The Major Boon of Aggression has expired.
+
+rmc-boon-fortification-activate = The resin starts moving and shifting...
+rmc-boon-fortification-expire = The Boon of Fortification has expired.
+
+rmc-boon-king-activate = The Queen has purchased His Grace.
+
+rmc-boon-pylon-examine = [color=cyan]This will grant the hive 1 royal resin every {$minutes} minutes, allowing the Queen to obtain buffs![/color]
+rmc-boon-cluster-examine = [color=cyan]If placed {$minutes} minutes into the round, this can turn into a hive pylon when its weeds take over a telecommunications tower![/color]
+rmc-boon-pylon-announcement-xeno = We have harnessed the tall's communication relay at {$area}.
+
+    We will now grow royal resin from this pylon. Hold it!
+rmc-boon-pylon-destroyed-announcement-xeno = We have lost our control of the tall's communication relay at {$area}.
+rmc-boon-tower-repair-blocked = The {$tower} is entangled in resin. Impossible to interact with.
+
+rmc-boon-king-vote-title = Choose a sister
+rmc-boon-king-vote-message = Vote for a sister you wish to become the King.
+rmc-boon-king-unlock-announcement = The hive is now ready to begin hatching His Grace, the King, if we gain control of both tall hivemind towers.
+
+rmc-xeno-transmute-title = Choose a caste
+rmc-xeno-transmute-prompt = Choose a caste of the same tier to become.
+rmc-xeno-transmute-failed-tier = Your form cannot transmute.
+rmc-xeno-transmute-failed-stance = We can't transmute while in this stance.
+rmc-xeno-transmute-end = We have adapted into a new form.
+rmc-xeno-evolution-ovipositor-needed = It is time to settle down and let your children grow.
 
 rmc-boon-pylon-announcement-marine = [color=#CECECE][font size=16][bold]ARES v3.2 Biological Scanner[/bold][/font][/color][color=red][font size=16]
 

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-boons.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-boons.ftl
@@ -12,23 +12,24 @@ rmc-boon-on-cooldown = Our hive has already used {$boon} recently! Wait {$minute
 rmc-boon-duplicate-active = We already have a boon of {$boon} active!
 rmc-boon-not-reusable = Our hive has already used {$boon} and cannot use it again!
 
-rmc-boon-fire-resistance-activate = The Queen has imbued us with flame-resistant chitin.
+rmc-boon-fire-resistance-activate = The Queen has imbued us with flame-resistant chitin for 5 minutes.
 rmc-boon-fire-resistance-expire = The Boon of Fire Resistance has expired.
 
-rmc-boon-larva-surge-activate = The Queen has purchased 5 extra larva to join the hive!
+rmc-boon-larva-surge-activate = The Queen has awakened 5 extra burrowed larva to join the hive!
 
-rmc-boon-evolution-activate = The Queen has blessed us with faster evolution.
+rmc-boon-evolution-activate = The Queen has blessed us with faster evolution for 5 minutes.
+rmc-boon-evolution-major-activate = The Queen has blessed us with faster evolution for 10 minutes.
 rmc-boon-evolution-expire = The Boon of Evolution has expired.
 rmc-boon-evolution-major-expire = The Major Boon of Evolution has expired.
 
 rmc-boon-adaptability-activate = The Queen has blessed us with adaptability.
 
-rmc-boon-aggression-activate = The Queen has imbued us with sharp claws.
-rmc-boon-aggression-major-activate = The Queen has imbued us with razor-sharp claws.
+rmc-boon-aggression-activate = The Queen has imbued us with sharp claws for 5 minutes.
+rmc-boon-aggression-major-activate = The Queen has imbued us with razor-sharp claws for 10 minutes.
 rmc-boon-aggression-expire = The Boon of Aggression has expired.
 rmc-boon-aggression-major-expire = The Major Boon of Aggression has expired.
 
-rmc-boon-fortification-activate = The resin starts moving and shifting...
+rmc-boon-fortification-activate = The resin starts moving and shifting for 5 minutes...
 rmc-boon-fortification-expire = The Boon of Fortification has expired.
 
 rmc-boon-king-activate = The Queen has purchased His Grace.

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_self_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_self_actions.yml
@@ -233,6 +233,20 @@
       state: grow_ovipositor
 
 - type: entity
+  id: ActionXenoTransmute
+  parent: ActionXenoBase
+  name: Transmute
+  description: Change into another caste of the same tier.
+  components:
+  - type: Action
+    itemIconStyle: NoItem
+    icon:
+      sprite: _RMC14/Actions/xeno_actions.rsi
+      state: evolve
+  - type: InstantAction
+    event: !type:XenoTransmuteActionEvent
+
+- type: entity
   id: ActionXenoTurnInvisible
   parent: ActionXenoBase
   name: Turn Invisible (20) # TODO RMC14 proper plasma costs

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/boiler.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/boiler.yml
@@ -10,6 +10,7 @@
   name: Boiler
   description: A huge, grotesque xenonid covered in glowing, oozing acid slime.
   components:
+  - type: XenoBaseCaste
   - type: GuideHelp
     guides:
     - RMCGuideRoleBoiler

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/burrower.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/burrower.yml
@@ -11,6 +11,7 @@
   name: Burrower
   description: A beefy alien with sharp claws.
   components:
+  - type: XenoBaseCaste
   - type: CanBuildThickFromConstructNode
   - type: GuideHelp
     guides:

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/carrier.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/carrier.yml
@@ -111,6 +111,7 @@
   parent: RMCXenoCarrierBase
   id: CMXenoCarrier
   components:
+  - type: XenoBaseCaste
   - type: GuideHelp
     guides:
     - RMCGuideRoleCarrier

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/crusher.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/crusher.yml
@@ -117,6 +117,7 @@
   parent: CMXenoCrusherBase
   id: RMCXenoCrusher
   components:
+  - type: XenoBaseCaste
   - type: Xeno
     actionIds:
     - ActionXenoRest

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/defender.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/defender.yml
@@ -116,6 +116,7 @@
   parent: CMXenoDefenderBase
   id: CMXenoDefender
   components:
+  - type: XenoBaseCaste
   - type: GuideHelp
     guides:
     - RMCGuideRoleDefender

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/drone.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/drone.yml
@@ -111,6 +111,7 @@
   parent: CMXenoDroneBase
   id: CMXenoDrone
   components:
+  - type: XenoBaseCaste
   - type: GuideHelp
     guides:
     - RMCGuideRoleDrone

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/fun.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/fun.yml
@@ -12,6 +12,8 @@
   - type: XenoEvolution
     max: 200
     evolvesTo: [ ]
+  - type: XenoBaseCaste
+    enabled: false
   - type: XenoHidden
   - type: FixedIdentity
     name: rmc-rouny
@@ -29,6 +31,8 @@
   - type: XenoEvolution
     max: 200
     evolvesTo: [ ]
+  - type: XenoBaseCaste
+    enabled: false
   - type: XenoHidden
   - type: FixedIdentity
     name: rmc-wehny

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/hivelord.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/hivelord.yml
@@ -103,6 +103,7 @@
   parent: CMXenoHivelordBase
   id: CMXenoHivelord
   components:
+  - type: XenoBaseCaste
   - type: CanBuildThickFromConstructNode
   - type: GuideHelp
     guides:

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/king.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/king.yml
@@ -9,6 +9,7 @@
   name: King
   description: The end of the line.
   components:
+  - type: HiveBoonKing
   - type: GhostRole
     name: rmc-job-name-xeno-king
   - type: Sprite

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lurker.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lurker.yml
@@ -108,6 +108,7 @@
   id: CMXenoLurker
   suffix: Base
   components:
+  - type: XenoBaseCaste
   - type: GuideHelp
     guides:
     - RMCGuideRoleLurker

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/praetorian.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/praetorian.yml
@@ -125,6 +125,7 @@
   parent: CMXenoPraetorianBase
   id: CMXenoPraetorian
   components:
+  - type: XenoBaseCaste
   - type: GuideHelp
     guides:
     - RMCGuideRolePraetorian

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/ravager.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/ravager.yml
@@ -145,6 +145,7 @@
   parent: RMCXenoRavagerBase
   id: CMXenoRavager
   components:
+  - type: XenoBaseCaste
   - type: XenoShield
   - type: XenoLeap
     delay: 0

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/runner.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/runner.yml
@@ -130,6 +130,7 @@
   parent: CMXenoRunnerBase
   id: CMXenoRunner
   components:
+  - type: XenoBaseCaste
   - type: GuideHelp
     guides:
     - RMCGuideRoleRunner

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/sentinel.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/sentinel.yml
@@ -11,6 +11,7 @@
   name: Sentinel
   description: A slithery, spitting kind of alien.
   components:
+  - type: XenoBaseCaste
   - type: GuideHelp
     guides:
     - RMCGuideRoleSentinel

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/spitter.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/spitter.yml
@@ -11,6 +11,7 @@
   name: Spitter
   description: A gross, oozing alien of some kind.
   components:
+  - type: XenoBaseCaste
   - type: GuideHelp
     guides:
     - RMCGuideRoleSpitter

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/warrior.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/warrior.yml
@@ -10,6 +10,7 @@
   name: Warrior
   description: A beefy alien with an armored carapace.
   components:
+  - type: XenoBaseCaste
   - type: GuideHelp
     guides:
     - RMCGuideRoleWarrior

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_walls.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_walls.yml
@@ -28,6 +28,8 @@
   - type: XenoStructureUpgradeable
     to: WallXenoResinThick
     cost: 50
+  - type: HiveBoonFortifiableWall
+    heal: 75
   - type: MeleeReceivedMultiplier
     xenoDamage:
       types:
@@ -102,6 +104,8 @@
     scalingCost: true
   - type: XenoStructureUpgradeable
     to: null
+  - type: HiveBoonFortifiableWall
+    heal: 100
 
 - type: entity
   parent: CMBaseWallXeno

--- a/Resources/Prototypes/_RMC14/Entities/rmc_hive_boons.yml
+++ b/Resources/Prototypes/_RMC14/Entities/rmc_hive_boons.yml
@@ -13,6 +13,8 @@
   description: Makes all xenonids immune to fire for 5 minutes.
   components:
   - type: HiveBoonDefinition
+    activationAnnouncement: rmc-boon-fire-resistance-activate
+    expirationAnnouncement: rmc-boon-fire-resistance-expire
     duration: 5m
     duplicateId: RMCHiveBoonFireResistance
     event: !type:HiveBoonActivateFireResistanceEvent
@@ -24,10 +26,98 @@
   description: Provides 5 larva instantly to the hive.
   components:
   - type: HiveBoonDefinition
+    activationAnnouncement: rmc-boon-larva-surge-activate
     cost: 5
     reusable: false
     duplicateId: RMCHiveBoonLarvaSurge
     event: !type:HiveBoonActivateLarvaSurgeEvent
+
+- type: entity
+  parent: RMCHiveBoonBase
+  id: RMCHiveBoonEvolution
+  name: Boon of Evolution
+  description: Doubles same-hive xenonid evolution point gain for 5 minutes.
+  components:
+  - type: HiveBoonDefinition
+    activationAnnouncement: rmc-boon-evolution-activate
+    expirationAnnouncement: rmc-boon-evolution-expire
+    duration: 5m
+    duplicateId: RMCHiveBoonEvolution
+    event: !type:HiveBoonActivateEvolutionEvent
+      multiplier: 2
+
+- type: entity
+  parent: RMCHiveBoonBase
+  id: RMCHiveBoonEvolutionMajor
+  name: Major Boon of Evolution
+  description: Doubles same-hive xenonid evolution point gain for 10 minutes and bypasses the hive's ovipositor and evolution granter requirements.
+  components:
+  - type: HiveBoonDefinition
+    activationAnnouncement: rmc-boon-evolution-activate
+    expirationAnnouncement: rmc-boon-evolution-major-expire
+    cost: 2
+    pylons: 2
+    duration: 10m
+    duplicateId: RMCHiveBoonEvolution
+    event: !type:HiveBoonActivateEvolutionEvent
+      multiplier: 2
+      bypassOvipositor: true
+
+- type: entity
+  parent: RMCHiveBoonBase
+  id: RMCHiveBoonAdaptability
+  name: Boon of Adaptability
+  description: Grants same-hive xenonids a one-use transmute action into another base caste of the same tier.
+  components:
+  - type: HiveBoonDefinition
+    activationAnnouncement: rmc-boon-adaptability-activate
+    cost: 2
+    pylons: 2
+    duplicateId: RMCHiveBoonAdaptability
+    event: !type:HiveBoonActivateAdaptabilityEvent
+
+- type: entity
+  parent: RMCHiveBoonBase
+  id: RMCHiveBoonAggression
+  name: Boon of Aggression
+  description: Adds 5 damage to same-hive xenonid melee attacks and physical abilities for 5 minutes.
+  components:
+  - type: HiveBoonDefinition
+    activationAnnouncement: rmc-boon-aggression-activate
+    expirationAnnouncement: rmc-boon-aggression-expire
+    duration: 5m
+    duplicateId: RMCHiveBoonAggression
+    event: !type:HiveBoonActivateAggressionEvent
+      damage: 5
+
+- type: entity
+  parent: RMCHiveBoonBase
+  id: RMCHiveBoonAggressionMajor
+  name: Major Boon of Aggression
+  description: Adds 10 damage to same-hive xenonid melee attacks and physical abilities for 10 minutes.
+  components:
+  - type: HiveBoonDefinition
+    activationAnnouncement: rmc-boon-aggression-major-activate
+    expirationAnnouncement: rmc-boon-aggression-major-expire
+    cost: 2
+    pylons: 2
+    duration: 10m
+    duplicateId: RMCHiveBoonAggression
+    event: !type:HiveBoonActivateAggressionEvent
+      damage: 10
+
+- type: entity
+  parent: RMCHiveBoonBase
+  id: RMCHiveBoonFortification
+  name: Boon of Fortification
+  description: Repairs and empowers same-hive resin walls, hive clusters, recovery nodes, plasma trees, and egg morphers for 5 minutes.
+  components:
+  - type: HiveBoonDefinition
+    activationAnnouncement: rmc-boon-fortification-activate
+    expirationAnnouncement: rmc-boon-fortification-expire
+    duration: 5m
+    duplicateId: RMCHiveBoonFortification
+    event: !type:HiveBoonActivateFortificationEvent
 
 - type: entity
   parent: RMCHiveBoonBase
@@ -36,6 +126,7 @@
   description: A huge behemoth of a Xenonid which can tear its way through defences and flesh alike. Requires open space around the hive core to spawn.
   components:
   - type: HiveBoonDefinition
+    activationAnnouncement: rmc-boon-king-activate
     cost: 0
     pylons: 2
     cooldown: 15m

--- a/Resources/Prototypes/_RMC14/Entities/rmc_hive_boons.yml
+++ b/Resources/Prototypes/_RMC14/Entities/rmc_hive_boons.yml
@@ -53,7 +53,7 @@
   description: Doubles same-hive xenonid evolution point gain for 10 minutes and bypasses the hive's ovipositor and evolution granter requirements.
   components:
   - type: HiveBoonDefinition
-    activationAnnouncement: rmc-boon-evolution-activate
+    activationAnnouncement: rmc-boon-evolution-major-activate
     expirationAnnouncement: rmc-boon-evolution-major-expire
     cost: 2
     pylons: 2


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds the missing royal resin hive boons:

- Boon / Major Boon of Evolution: doubles same-hive xeno evolution point gain, with Major also bypassing the hive's ovipositor/evolution-granter requirement while active.
- Boon of Adaptability: grants eligible same-hive T1-T3 xenos a one-use Transmute action into another base caste of the same tier.
- Boon / Major Boon of Aggression: adds +5 / +10 physical melee damage for 5 / 10 minutes.
- Boon of Fortification: temporarily empowers hive defenses and support structures.

Also updates boon announcements/localization, cleans up several hardcoded boon strings, and fixes His Grace checks so a living same-hive King or active King cocoon blocks another purchase.

## Why / Balance
This ports the remaining royal-resin boon functionality toward parity without changing royal resin generation.

The new boons keep their SS13-style constraints: hive-scoped effects, duplicate IDs to prevent stacking minor/major versions, pylon requirements for major boons, and limited durations. Adaptability is limited to base same-tier castes so it cannot access hidden/strain/special variants. Aggression only boosts physical melee-style damage, not acid, projectile, poison, heat, or DoT damage.

Fortification improves hive sustain for a short window by repairing/boosting resin defenses and support structures, but does not expand weed range or create permanent global buffs.

## Technical details
- Extends `HiveBoonDefinition` with activation/expiration announcement loc IDs and cleans active boon tracking on despawn.
- Adds activation events and effect components for Evolution, Adaptability, Aggression, and Fortification boons.
- Adds `HiveBoonSystem.HasActiveBoon<T>` / `TryGetActiveBoon<T>` helpers for same-hive effect lookups.
- Adds transmute action/events, `XenoBaseCasteComponent`, base-caste prototype markers, and transmute validation in `XenoEvolutionSystem`.
- Adds frozen evolution gain snapshots for Evolution boons so active bonuses use the activation-time evolution boost state.
- Adds hive-scoped major Evolution bypass checks for ovipositor/evolution-granter locks.
- Adds Aggression damage helpers that apply the flat bonus to existing physical damage types, preserving damage type composition.
- Routes xeno physical ability/melee damage through the shared Aggression + xeno-size modifier helper.
- Adds Fortification behavior for resin walls, hive clusters, recovery nodes, plasma trees, and egg morphers.
- Fixes His Grace pylon OB protection to apply through a same-hive helper instead of a global pylon loop.
- Moves boon/pylon/cluster/King-vote/King-unlock/tower-repair text into `xeno-boons.ftl`.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: to4no_fix
- add: Added Boon of Evolution: costs 1 resin and requires 1 pylon. Doubles evolution point gain for xenos of the same hive for 5 minutes.
- add: Added Major Boon of Evolution: costs 2 resin and requires 2 pylons. Doubles evolution point gain for 10 minutes and allows the hive to bypass Queen/Ovipositor evolution requirements.
- add: Added Boon of Adaptability: costs 2 resin and requires 2 pylons. Grants T1-T3 xenos of the same hive a one-time Transmute action, allowing them to switch to another base caste of the same tier.
- add: Added Boon of Aggression: costs 1 resin and requires 1 pylon. Grants +5 damage to melee attacks and physical abilities for xenos of the same hive for 5 minutes.
- add: Added Major Boon of Aggression: costs 2 resin and requires 2 pylons. Grants +10 damage to melee attacks and physical abilities for xenos of the same hive for 10 minutes.
- add: Added Boon of Fortification: costs 1 resin and requires 1 pylon. Strengthens hive structures for 5 minutes: resin walls regenerate every 10 seconds, restoring 75 HP to regular resin walls and 100 HP to thick resin walls; the hive cluster is fully repaired every 20 seconds and restarts weed spreading 15 seconds after being auto-repaired; recovery nodes heal xenos for 100 instead of 25 and restore 25 HP to themselves per cycle; plasma trees restore 200 plasma instead of 75 and restore 25 HP to themselves per cycle; egg morphers grow parasites in 30 seconds instead of the usual 120 seconds.
- add: Added notifications for Boon expiration.
- fix: His Grace can no longer be purchased again while the same hive already has a living King or an active King cocoon.
- fix: His Grace OB protection now only applies to pylons belonging to the hive that evolved the King, instead of all pylons on the map.
