### PR TITLE
Minor poster fix

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Markers/Spawners/Random/posters.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Markers/Spawners/Random/posters.yml
@@ -11,7 +11,6 @@
   - type: RandomSpawner
     offset: 0
     prototypes:
-    - CMPosterBroken
     - CMPosterTheFuture
     - CMPosterUnicorn
     - CMPosterRocker1
@@ -114,7 +113,7 @@
     - CMPosterSPP13
     chance: 0.95
     rarePrototypes:
-    - PosterBroken
+    - CMPosterBroken
     rareChance: 0.05
 
 - type: entity
@@ -130,7 +129,6 @@
   - type: RandomSpawner
     offset: 0
     prototypes:
-    - CMPosterBroken
     - CMPosterTheFuture
     - CMPosterUnicorn
     - CMPosterRocker1
@@ -220,7 +218,7 @@
     - RMCPosterTSEPA3
     chance: 0.95
     rarePrototypes:
-    - PosterBroken
+    - CMPosterBroken
     rareChance: 0.05
 
 - type: entity
@@ -237,7 +235,6 @@
     offset: 0
     prototypes:
     - CMPosterSuspicious
-    - CMPosterBroken
     - CMPosterSafetyWaste
     - CMPosterSafetySilence
     - CMPosterSafetySwitch
@@ -264,5 +261,58 @@
     - CMPosterSPP13
     chance: 0.95
     rarePrototypes:
-    - PosterBroken
+    - CMPosterBroken
+    rareChance: 0.05
+
+- type: entity
+  parent: CMRandomPosterAny
+  id: RMCRandomPosterWeYa
+  name: random poster spawner
+  suffix: RMC14, WeYa
+  components:
+  - type: Sprite
+    layers:
+    - sprite: _RMC14/Structures/Wallmounts/posters.rsi
+      state: random_anything
+  - type: RandomSpawner
+    offset: 0
+    prototypes:
+    - RMCPosterWEYA1
+    - RMCPosterWEYA2
+    - RMCPosterWEYA3
+    - RMCPosterWEYA4
+    - RMCPosterWEYA5
+    - CMPosterDaniel1
+    - CMPosterDaniel2
+    - CMPosterDaniel3
+    - CMPosterDaniel4
+    - CMPosterDaniel5
+    - CMPosterDaniel6
+    - CMPosterDaniel7
+    - CMPosterSilicon
+    - CMPosterSilicon2
+    chance: 0.95
+    rarePrototypes:
+    - CMPosterBroken
+    rareChance: 0.05
+
+- type: entity
+  parent: CMRandomPosterAny
+  id: RMCRandomPosterTSEPA
+  name: random poster spawner
+  suffix: RMC14, TSEPA
+  components:
+  - type: Sprite
+    layers:
+    - sprite: _RMC14/Structures/Wallmounts/posters.rsi
+      state: random_anything
+  - type: RandomSpawner
+    offset: 0
+    prototypes:
+    - RMCPosterTSEPA1
+    - RMCPosterTSEPA2
+    - RMCPosterTSEPA3
+    chance: 0.95
+    rarePrototypes:
+    - CMPosterBroken
     rareChance: 0.05

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Wallmounts/Signs/posters.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Wallmounts/Signs/posters.yml
@@ -6,7 +6,7 @@
   - type: WallMount
     arc: 360
   - type: Sprite
-    drawdepth: WallTops
+    drawdepth: WallMountedItems    
     sprite: _RMC14/Structures/Wallmounts/posters.rsi
     snapCardinals: true
   - type: Destructible
@@ -22,7 +22,7 @@
         acts: [ "Destruction" ]
       - !type:SpawnEntitiesBehavior
         spawn:
-          PosterBroken:
+          CMPosterBroken:
             min: 1
             max: 1
         offset: 0
@@ -34,7 +34,7 @@
   description: "You can't make out anything from the poster's original print. It's ruined."
   components:
   - type: Sprite
-    drawdepth: WallTops
+    drawdepth: WallMountedItems
     sprite: _RMC14/Structures/Wallmounts/posters.rsi
     state: poster_ripped
   - type: Destructible
@@ -153,7 +153,7 @@
   parent: CMPosterBase
   id: CMPosterMissJanuary
   name: "'Miss January' pinup"
-  description: "This poster features Roxanne Straski. She was the January 2180 centerfold in House Bunny Gentleman's Magazine. Don't ask how you know that."
+  description: "This poster features Roxanne Straski. She was the January 2120 centerfold in House Bunny Gentleman's Magazine. Don't ask how you know that."
   components:
   - type: Sprite
     state: miss_january
@@ -189,7 +189,7 @@
   parent: CMPosterBase
   id: CMPosterMissJuly
   name: "'Miss July' pinup"
-  description: "This poster features Audrey Rainwater standing in a jacuzzi. She was the July 2180 centerfold in House Bunny Gentleman's Magazine. Don't ask how you know that."
+  description: "This poster features Audrey Rainwater standing in a jacuzzi. She was the July 2124 centerfold in House Bunny Gentleman's Magazine. Don't ask how you know that."
   components:
   - type: Sprite
     state: miss_july
@@ -198,7 +198,7 @@
   parent: CMPosterBase
   id: CMPosterMissApril
   name: "'Miss April' pinup"
-  description: "This poster features Juliette Simmons. She was the April 2179 centerfold in House Bunny Gentleman's Magazine. Don't ask how you know that."
+  description: "This poster features Juliette Simmons. She was the April 2123 centerfold in House Bunny Gentleman's Magazine. Don't ask how you know that."
   components:
   - type: Sprite
     state: miss_april
@@ -279,7 +279,7 @@
   parent: CMPosterBase
   id: CMPosterMissFebruary
   name: "'Miss February' pinup"
-  description: "This poster features Miranda Noel. She was the February 2180 centerfold in House Bunny Gentleman's Magazine. Don't ask how you know that."
+  description: "This poster features Miranda Noel. She was the February 2124 centerfold in House Bunny Gentleman's Magazine. Don't ask how you know that."
   components:
   - type: Sprite
     state: miss_february
@@ -296,8 +296,8 @@
 - type: entity
   parent: CMPosterBase
   id: CMPosterMrUniverse1
-  name: "Mr. Universe 2170-74"
-  description: "This poster depicts Lance McDonell, the winner of Mr. Universe 2170-74. Don't ask how you know that. He bears a striking resemblance to the 42nd President of the United States, Arnold Schwarzenegger."
+  name: "Mr. Universe 2114-18"
+  description: "This poster depicts Lance McDonell, the winner of Mr. Universe 2114-18. Don't ask how you know that. He bears a striking resemblance to the 42nd President of the United States, Arnold Schwarzenegger."
   components:
   - type: Sprite
     state: mr_universe_1
@@ -305,8 +305,8 @@
 - type: entity
   parent: CMPosterBase
   id: CMPosterMrUniverse2
-  name: "Mr. Universe 2174-76"
-  description: "This poster depicts Rockwell Jordan, the winner of Mr. Universe 2174-76. Don't ask how you know that."
+  name: "Mr. Universe 2118-20"
+  description: "This poster depicts Rockwell Jordan, the winner of Mr. Universe 2118-20. Don't ask how you know that."
   components:
   - type: Sprite
     state: mr_universe_2
@@ -314,7 +314,7 @@
 - type: entity
   parent: CMPosterBase
   id: CMPosterMrUniverse3
-  name: "Mr. Universe 2176-present"
+  name: "Mr. Universe 2120-present"
   description: "This poster depicts Wilson Winslow, the current Mr. Universe reigning champion. Don't ask how you know that."
   components:
   - type: Sprite
@@ -351,7 +351,7 @@
   parent: CMPosterBase
   id: CMPosterMTV
   name: "MTV"
-  description: "MTV: Broadcasting nothing but music videos for over 200 years. Bootleg tapes of current music fetch a premium in the Outer Rim barter market."
+  description: "MTV: Broadcasting nothing but music videos for over 140 years. Bootleg tapes of current music fetch a premium in the Outer Rim barter market."
   components:
   - type: Sprite
     state: mtv
@@ -369,7 +369,7 @@
   parent: CMPosterBase
   id: CMPosterVoteNo
   name: "Vote 'NO' to Proposition 339 and Vote 'NO!' to the Colony Protection Act"
-  description: "This poster demands that you vote 'NO!' to that new piece of legislation that would give the military carte blanche permission to stick its nose in corporate affairs. Many view the bill as government overreach, but many others view it as the lesser of two evils compared to letting the megacorps do whatever they want. Because space is friggin' huge, it's going to take a while to gather all of the votes and even if it's passed, it likely won't go into effect until 2186 at the earliest."
+  description: "This poster demands that you vote 'NO!' to that new piece of legislation that would give the military carte blanche permission to stick its nose in corporate affairs. Many view the bill as government overreach, but many others view it as the lesser of two evils compared to letting the megacorps do whatever they want. Because space is friggin' huge, it's going to take a while to gather all of the votes and even if it's passed, it likely won't go into effect until 2130 at the earliest."
   components:
   - type: Sprite
     state: vote_no


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Changed the dates that are mentioned in the posters to our dates as cmss13 takes place in 2182 and we are stuck in the past (2126), it wouldnt make sense for Mr Universe 2172 to already be elected.

CMPosters now layer above entities like shipping containers, vending machine and tables. On many maps posters are already mapped "above" the containers but get shown behind it.

Breaking a CMPoster now spawns the CMBrokenPoster like intended. (Right now it just spawns the Upstream version)

Random Poster Spawners now longer spawn upstream broken posters and the CMbrokenposter has been moved to the Rare spawn rate lootpool
adds TSEPA and WeYa random poster spawner
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity + Lore

## Technical details
<!-- Summary of code changes for easier review. -->
minor .yml changes

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
<img width="740" height="694" alt="Screenshot 2026-05-18 231816" src="https://github.com/user-attachments/assets/b0d1dee3-b2c6-4031-b34c-5ad4a31c9cf6" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed posters not layering above cargo containers or tables!
