### PR TITLE
Disabling flamer overlay accessibility option

### DIFF
--- a/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml
+++ b/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml
@@ -14,6 +14,7 @@
                 <CheckBox Name="EnableColorNameCheckBox" Text="{Loc 'ui-options-enable-color-name'}" />
                 <CheckBox Name="ColorblindFriendlyCheckBox" Text="{Loc 'ui-options-colorblind-friendly'}" />
                 <CheckBox Name="XenoAbilityPreviewsCheckBox" Text="{Loc 'rmc-ui-options-xeno-ability-previews'}" />
+                <CheckBox Name="MarineEquipmentPreviewsCheckBox" Text="{Loc 'rmc-ui-options-marine-equipment-previews'}" />
                 <ui:OptionSlider Name="ChatWindowOpacitySlider" Title="{Loc 'ui-options-chat-window-opacity'}" />
                 <ui:OptionSlider Name="SpeechBubbleTextOpacitySlider" Title="{Loc 'ui-options-speech-bubble-text-opacity'}" />
                 <ui:OptionSlider Name="SpeechBubbleSpeakerOpacitySlider" Title="{Loc 'ui-options-speech-bubble-speaker-opacity'}" />

--- a/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml.cs
@@ -27,6 +27,7 @@ public sealed partial class AccessibilityTab : Control
         Control.AddOptionCheckBox(RMCCVars.RMCUseAlternateSprites, RMCUseAlternateSpritesCheckBox); // RMC14
         Control.AddOptionCheckBox(RMCCVars.RMCChatSquadColorMode, RMCChatSquadColorModeCheckBox); // RMC14
         Control.AddOptionCheckBox(RMCCVars.RMCXenoAbilityPreviews, XenoAbilityPreviewsCheckBox); // RMC14
+        Control.AddOptionCheckBox(RMCCVars.RMCMarineEquipmentPreviews, MarineEquipmentPreviewsCheckBox); // RMC14
 
         Control.AddOptionCheckBox(CCVars.AccessibilityClientCensorNudity, CensorNudityCheckBox);
 

--- a/Content.Client/_RMC14/Weapons/Ranged/Flamer/RMCFlamerPreviewOverlay.cs
+++ b/Content.Client/_RMC14/Weapons/Ranged/Flamer/RMCFlamerPreviewOverlay.cs
@@ -3,6 +3,7 @@ using System.Numerics;
 using Content.Client.Weapons.Ranged.Systems;
 using Content.Shared._RMC14.Attachable.Systems;
 using Content.Shared._RMC14.Weapons.Ranged.Flamer;
+using Content.Shared._RMC14.CCVar;
 using Content.Shared.Wieldable.Components;
 using Robust.Client.Graphics;
 using Robust.Client.Input;
@@ -13,6 +14,7 @@ using Robust.Shared.IoC;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Maths;
+using Robust.Shared.Configuration;
 
 namespace Content.Client._RMC14.Weapons.Ranged.Flamer;
 
@@ -28,6 +30,7 @@ public sealed class RMCFlamerPreviewOverlay : Overlay
     private readonly IInputManager _input;
     private readonly IEyeManager _eye;
     private readonly IPlayerManager _player;
+    private readonly IConfigurationManager _config;
     private readonly GunSystem _guns;
     private readonly IMapManager _mapManager;
     private readonly SharedMapSystem _mapSystem;
@@ -44,6 +47,7 @@ public sealed class RMCFlamerPreviewOverlay : Overlay
         _input = IoCManager.Resolve<IInputManager>();
         _eye = IoCManager.Resolve<IEyeManager>();
         _player = IoCManager.Resolve<IPlayerManager>();
+        _config = IoCManager.Resolve<IConfigurationManager>();
         _mapManager = IoCManager.Resolve<IMapManager>();
         _guns = ents.System<GunSystem>();
         _mapSystem = ents.System<SharedMapSystem>();
@@ -57,6 +61,9 @@ public sealed class RMCFlamerPreviewOverlay : Overlay
 
     protected override void Draw(in OverlayDrawArgs args)
     {
+        if (!_config.GetCVar(RMCCVars.RMCMarineEquipmentPreviews))
+            return;
+
         var player = _player.LocalEntity;
         if (player == null)
             return;

--- a/Content.Shared/_RMC14/CCVar/RMCCVars.cs
+++ b/Content.Shared/_RMC14/CCVar/RMCCVars.cs
@@ -510,6 +510,8 @@ public sealed partial class RMCCVars : CVars
 
     public static readonly CVarDef<bool> RMCXenoAbilityPreviews =
         CVarDef.Create("rmc.xeno_ability_previews", true, CVar.CLIENTONLY | CVar.ARCHIVE);
+    public static readonly CVarDef<bool> RMCMarineEquipmentPreviews =
+        CVarDef.Create("rmc.marine_equipment_previews", true, CVar.CLIENTONLY | CVar.ARCHIVE);
 
     public static readonly CVarDef<int> RMCXenoDefaultNightVision =
         CVarDef.Create("rmc.xeno_default_night_vision", (int) NightVisionState.Half, CVar.CLIENT | CVar.ARCHIVE | CVar.REPLICATED);

--- a/Resources/Locale/en-US/_RMC14/ui.ftl
+++ b/Resources/Locale/en-US/_RMC14/ui.ftl
@@ -3,6 +3,7 @@
 rmc-ui-options-cassettes-volume = Cassette volume:
 rmc-ui-options-hijack-song-volume = Hijack song volume:
 rmc-ui-options-xeno-ability-previews = Show xeno ability previews
+rmc-ui-options-marine-equipment-previews = Show marine equipment previews
 
 rmc-ui-voicelines = Voicelines
 rmc-ui-options-tab-voicelines = Voicelines


### PR DESCRIPTION
## About the PR
Added an accessibility option to disable "marine equipment previews", named this way in case we add any more for marines in future.

## Why / Balance
Right now people cannot turn off flamer preview, this lets them.
<img width="1146" height="118" alt="image" src="https://github.com/user-attachments/assets/dc3c297e-7a30-4839-a824-2b2d27421de4" />

## Technical details
Same as the option to enable/disable the xeno ability previews. I made it a seperate option because some people will likely want to be able to have one faction's previews on but not the other.

## Media
option to disable marine equipment previews
<img width="792" height="435" alt="image" src="https://github.com/user-attachments/assets/32061b6f-ac03-4126-9060-3d915883992d" />

no more flamer preview
<img width="609" height="421" alt="Screenshot 2026-05-19 053448" src="https://github.com/user-attachments/assets/90d8e834-034b-43cc-add2-04ba2fcc791b" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: CatAndHats
- add: Added an option to disable "Marine Equipment Previews" (the flamer overlay) in the Accessibility options
