### PR TITLE
Rework Maintainer review labeler entirely

### DIFF
--- a/.github/workflows/labeler-maintainer-reviewed.yml
+++ b/.github/workflows/labeler-maintainer-reviewed.yml
@@ -22,7 +22,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }} # Authenticate gh CLI which is pre-installed, see docs above.
 
-      # These are our label names.
+      # These are our label names:
       LABEL_CHANGES_REQUESTED: "S: Awaiting Changes"
       LABEL_NEEDS_APPROVAL: "S: Needs Review"
       LABEL_PRE_APPROVED: "S: Partially Approved"
@@ -50,7 +50,7 @@ jobs:
           # Utility functions
           # ------------------------------------------------------------
           get_labels() {
-            gh pr view "$PR_NUMBER" \
+            gh pr -R "${{ github.repository }}" view "$PR_NUMBER" \
               --json labels \
               --jq '.labels[].name'
           }
@@ -75,7 +75,7 @@ jobs:
             for status in "${ALL_LABELS[@]}"; do
               for current in "${existing[@]}"; do
                 if [[ "$current" == "$status" ]]; then
-                  gh pr edit "$PR_NUMBER" --remove-label "$status"
+                  gh pr -R "${{ github.repository }}" edit "$PR_NUMBER" --remove-label "$status"
                 fi
               done
             done
@@ -86,7 +86,7 @@ jobs:
 
             remove_all_status_labels
 
-            gh pr edit "$PR_NUMBER" --add-label "$label"
+            gh pr -R "${{ github.repository }}" edit "$PR_NUMBER" --add-label "$label"
 
             echo "Set PR status: $label"
           }

--- a/.github/workflows/labeler-maintainer-reviewed.yml
+++ b/.github/workflows/labeler-maintainer-reviewed.yml
@@ -1,4 +1,4 @@
-name: PR Status Labeler
+name: "Labels: Reviewed By Maintainer"
 
 on:
   pull_request:

--- a/.github/workflows/labeler-maintainer-reviewed.yml
+++ b/.github/workflows/labeler-maintainer-reviewed.yml
@@ -82,6 +82,8 @@ jobs:
 
           set_status() {
             local label="$1"
+            echo $1
+            echo $label
 
             remove_all_status_labels
 
@@ -89,6 +91,12 @@ jobs:
 
             echo "Set PR status: $label"
           }
+
+          ##############################################################
+          # BUSINESS LOGIC STARTS HERE                                 #
+          ##############################################################
+          echo "Processing event type: ${EVENT_NAME}"
+          echo "Processing action: ${ACTION}"
 
           # ------------------------------------------------------------
           # If a new commit is pushed, set to needs approval.

--- a/.github/workflows/labeler-maintainer-reviewed.yml
+++ b/.github/workflows/labeler-maintainer-reviewed.yml
@@ -87,6 +87,8 @@ jobs:
 
             remove_all_status_labels
 
+            echo "Label is now: $label"
+
             gh pr -R "${{ github.repository }}" edit "$PR_NUMBER" --add-label "$label"
 
             echo "Set PR status: $label"

--- a/.github/workflows/labeler-maintainer-reviewed.yml
+++ b/.github/workflows/labeler-maintainer-reviewed.yml
@@ -68,7 +68,7 @@ jobs:
             local target_label="$1"
 
             for other_label in "${ALL_LABELS[@]}"; do
-              if [[ $target_label != $other_label && has_label "$other_label" ]]; then
+              if [[ "$target_label" != "$other_label" && has_label "$other_label" ]]; then
                 echo "Removing existing label: $other_label"
                 gh pr -R "${{ github.repository }}" edit "$PR_NUMBER" --remove-label "$other_label"
               fi

--- a/.github/workflows/labeler-maintainer-reviewed.yml
+++ b/.github/workflows/labeler-maintainer-reviewed.yml
@@ -3,8 +3,7 @@ name: "Labels: Reviewed By Maintainer"
 on:
   pull_request:
     types:
-      - opened      # Labeler runs when a PR is filed,
-      - reopened    # when the PR is reopened,
+      - opened      # Labeler runs when a PR is filed
       - synchronize # and when commits are added.
 
   pull_request_review:
@@ -97,19 +96,13 @@ jobs:
           fi
 
           # ------------------------------------------------------------
-          # PR opened/reopened, keep the old status if it has one,
+          # PR opened, keep the old status if it has one,
           # otherwise set S: Needs Review.
           # ------------------------------------------------------------
           if [[ "$EVENT_NAME" == "pull_request" ]]; then
-            if [[ "$ACTION" == "opened" || "$ACTION" == "reopened" ]]; then
+            if [[ "$ACTION" == "opened" ]]; then
 
-              if ! has_label "$LABEL_CHANGES_REQUESTED" \
-                && ! has_label "$LABEL_NEEDS_APPROVAL" \
-                && ! has_label "$LABEL_PARTIAL_APPROVAL" \
-                && ! has_label "$LABEL_APPROVED"; then
-
-                set_status "$LABEL_NEEDS_APPROVAL"
-              fi
+              set_status "$LABEL_NEEDS_APPROVAL"
 
               exit 0
             fi

--- a/.github/workflows/labeler-maintainer-reviewed.yml
+++ b/.github/workflows/labeler-maintainer-reviewed.yml
@@ -68,7 +68,7 @@ jobs:
             local target_label="$1"
 
             for other_label in "${ALL_LABELS[@]}"; do
-              if [[ "$target_label" != "$other_label" && has_label "$other_label" ]]; then
+              if [[ "$target_label" != "$other_label" ]] && [[ has_label "$other_label" ]]; then
                 echo "Removing existing label: $other_label"
                 gh pr -R "${{ github.repository }}" edit "$PR_NUMBER" --remove-label "$other_label"
               fi

--- a/.github/workflows/labeler-maintainer-reviewed.yml
+++ b/.github/workflows/labeler-maintainer-reviewed.yml
@@ -68,7 +68,7 @@ jobs:
             local target_label="$1"
 
             for other_label in "${ALL_LABELS[@]}"; do
-              if [[ $target_label -neq $other_label && has_label "$other_label" ]]; then
+              if [[ $target_label != $other_label && has_label "$other_label" ]]; then
                 echo "Removing existing label: $other_label"
                 gh pr -R "${{ github.repository }}" edit "$PR_NUMBER" --remove-label "$other_label"
               fi

--- a/.github/workflows/labeler-maintainer-reviewed.yml
+++ b/.github/workflows/labeler-maintainer-reviewed.yml
@@ -68,12 +68,11 @@ jobs:
             local target_label="$1"
 
             for other_label in "${ALL_LABELS[@]}"; do
-              echo $other_label
-              echo [[ "$target_label" != "$other_label" ]]
-              echo [[ has_label "$other_label" ]]
-              if [[ "$target_label" != "$other_label" ]] && [[ has_label "$other_label" ]]; then
-                echo "Removing existing label: $other_label"
-                gh pr -R "${{ github.repository }}" edit "$PR_NUMBER" --remove-label "$other_label"
+              if [[ "$target_label" != "$other_label" ]]; then
+                if has_label "$other_label"; then
+                  echo "Removing existing label: $other_label"
+                  gh pr -R "${{ github.repository }}" edit "$PR_NUMBER" --remove-label "$other_label"
+                fi
               fi
             done
 

--- a/.github/workflows/labeler-maintainer-reviewed.yml
+++ b/.github/workflows/labeler-maintainer-reviewed.yml
@@ -68,6 +68,9 @@ jobs:
             local target_label="$1"
 
             for other_label in "${ALL_LABELS[@]}"; do
+              echo $other_label
+              echo [[ "$target_label" != "$other_label" ]]
+              echo [[ has_label "$other_label" ]]
               if [[ "$target_label" != "$other_label" ]] && [[ has_label "$other_label" ]]; then
                 echo "Removing existing label: $other_label"
                 gh pr -R "${{ github.repository }}" edit "$PR_NUMBER" --remove-label "$other_label"

--- a/.github/workflows/labeler-maintainer-reviewed.yml
+++ b/.github/workflows/labeler-maintainer-reviewed.yml
@@ -22,18 +22,17 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }} # Authenticate gh CLI which is pre-installed, see docs above.
 
-      # These are our label names:
-      LABEL_CHANGES_REQUESTED: "S: Awaiting Changes"
-      LABEL_NEEDS_APPROVAL: "S: Needs Review"
-      LABEL_PRE_APPROVED: "S: Partially Approved"
-      LABEL_APPROVED: "S: Approved"
-
     steps:
       - name: Update labels
         shell: bash
         run: |
           # Enable bash strict mode.
           set -euo pipefail
+
+          LABEL_CHANGES_REQUESTED="S: Awaiting Changes"
+          LABEL_NEEDS_APPROVAL="S: Needs Review"
+          LABEL_PARTIAL_APPROVAL="S: Partially Approved"
+          LABEL_APPROVED="S: Approved"
 
           PR_NUMBER="${{ github.event.pull_request.number }}"
           EVENT_NAME="${{ github.event_name }}"
@@ -42,7 +41,7 @@ jobs:
           ALL_LABELS=(
             "$LABEL_CHANGES_REQUESTED"
             "$LABEL_NEEDS_APPROVAL"
-            "$LABEL_PRE_APPROVED"
+            "$LABEL_PARTIAL_APPROVAL"
             "$LABEL_APPROVED"
           )
 
@@ -109,7 +108,7 @@ jobs:
 
               if ! has_label "$LABEL_CHANGES_REQUESTED" \
                 && ! has_label "$LABEL_NEEDS_APPROVAL" \
-                && ! has_label "$LABEL_PRE_APPROVED" \
+                && ! has_label "$LABEL_PARTIAL_APPROVAL" \
                 && ! has_label "$LABEL_APPROVED"; then
 
                 set_status "$LABEL_NEEDS_APPROVAL"
@@ -156,12 +155,12 @@ jobs:
 
               # Needs approval -> Pre-approved
               if has_label "$LABEL_NEEDS_APPROVAL"; then
-                set_status "$LABEL_PRE_APPROVED"
+                set_status "$LABEL_PARTIAL_APPROVAL"
                 exit 0
               fi
 
               # Pre-approved -> Approved
-              if has_label "$LABEL_PRE_APPROVED"; then
+              if has_label "$LABEL_PARTIAL_APPROVAL"; then
                 set_status "$LABEL_APPROVED"
                 exit 0
               fi

--- a/.github/workflows/labeler-maintainer-reviewed.yml
+++ b/.github/workflows/labeler-maintainer-reviewed.yml
@@ -1,101 +1,169 @@
-name: "Labels: Reviewed By Maintainer"
+name: PR Status Labeler
 
 on:
+  pull_request:
+    types:
+      - opened      # Labeler runs when a PR is filed,
+      - reopened    # when the PR is reopened,
+      - synchronize # and when commits are added.
+
   pull_request_review:
-    types: [submitted, dismissed]
+    types:
+      - submitted   # Labeler also runs when a review is added.
+
+permissions:
+  pull-requests: write # Labeler must be able to read and write the pull request metadata.
 
 jobs:
   label:
-    runs-on: ubuntu-latest
+    # A single-core machine will do: https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+    runs-on: ubuntu-slim
+
+    env:
+      GH_TOKEN: ${{ github.token }} # Authenticate gh CLI which is pre-installed, see docs above.
+
+      # These are our label names.
+      LABEL_CHANGES_REQUESTED: "S: Awaiting Changes"
+      LABEL_NEEDS_APPROVAL: "S: Needs Review"
+      LABEL_PRE_APPROVED: "S: Partially Approved"
+      LABEL_APPROVED: "S: Approved"
 
     steps:
-    - name: Add Label Based On Review Type
-      uses: actions/github-script@v9
-      with:
-        script: |
-          const { owner, repo } = context.repo;
-          const review = context.payload.review;
-          const pr = context.payload.pull_request;
+      - name: Update labels
+        shell: bash
+        run: |
+          # Enable bash strict mode.
+          set -euo pipefail
 
-          const state = review.state;
-          const username = review.user.login;
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          EVENT_NAME="${{ github.event_name }}"
+          ACTION="${{ github.event.action }}"
 
-          if (!["approved", "changes_requested", "dismissed"].includes(state)) {
-            console.log(`Skipping review type: ${state}.`);
-            return;
+          ALL_LABELS=(
+            "$LABEL_CHANGES_REQUESTED"
+            "$LABEL_NEEDS_APPROVAL"
+            "$LABEL_PRE_APPROVED"
+            "$LABEL_APPROVED"
+          )
+
+          # ------------------------------------------------------------
+          # Utility functions
+          # ------------------------------------------------------------
+          get_labels() {
+            gh pr view "$PR_NUMBER" \
+              --json labels \
+              --jq '.labels[].name'
           }
 
-          console.log(`Processing review type: ${state}.`);
+          has_label() {
+            local target="$1"
 
-          const approvedLabel = "S: Approved";
-          const partiallyApprovedLabel = "S: Partially Approved";
-          const changesRequestedLabel = "S: Awaiting Changes";
+            while IFS= read -r label; do
+              [[ "$label" == "$target" ]] && return 0
+            done < <(get_labels)
 
-          async function removeLabel(name) {
-            try {
-              console.log(`Removing label: ${name}.`)
-              await github.rest.issues.removeLabel({
-                owner,
-                repo,
-                issue_number: pr.number,
-                name,
-              });
-            } catch (e) {
-              console.log(`removeLabel failed for ${name}: ${e.message}`);
-            }
+            return 1
           }
 
-          async function addLabel(name) {
-            console.log(`Adding label: ${name}.`)
-            await github.rest.issues.addLabels({
-              owner,
-              repo,
-              issue_number: pr.number,
-              labels: [name],
-            });
+          remove_all_status_labels() {
+            local existing=()
+
+            while IFS= read -r label; do
+              existing+=("$label")
+            done < <(get_labels)
+
+            for status in "${ALL_LABELS[@]}"; do
+              for current in "${existing[@]}"; do
+                if [[ "$current" == "$status" ]]; then
+                  gh pr edit "$PR_NUMBER" --remove-label "$status"
+                fi
+              done
+            done
           }
 
-          if (state === "dismissed") {
-            await removeLabel(approvedLabel);
-            await removeLabel(partiallyApprovedLabel);
-            return;
+          set_status() {
+            local label="$1"
+
+            remove_all_status_labels
+
+            gh pr edit "$PR_NUMBER" --add-label "$label"
+
+            echo "Set PR status: $label"
           }
 
-          const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
-            owner,
-            repo,
-            username,
-          });
+          # ------------------------------------------------------------
+          # If a new commit is pushed, set to needs approval.
+          # (GitHub dismisses all reviews on the HEAD commit anyways.)
+          # ------------------------------------------------------------
+          if [[ "$EVENT_NAME" == "pull_request" && "$ACTION" == "synchronize" ]]; then
+            set_status "$LABEL_NEEDS_APPROVAL"
+            exit 0
+          fi
 
-          const permission = data.permission;
-          if (!["write", "maintain", "admin"].includes(permission)) {
-            console.log(`Skipping ${username}, permission: ${permission}`);
-            return;
-          }
+          # ------------------------------------------------------------
+          # PR opened/reopened, keep the old status if it has one,
+          # otherwise set S: Needs Review.
+          # ------------------------------------------------------------
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            if [[ "$ACTION" == "opened" || "$ACTION" == "reopened" ]]; then
 
-          if (state === "changes_requested") {
-            await removeLabel(approvedLabel);
-            await addLabel(changesRequestedLabel);
-            return;
-          }
+              if ! has_label "$LABEL_CHANGES_REQUESTED" \
+                && ! has_label "$LABEL_NEEDS_APPROVAL" \
+                && ! has_label "$LABEL_PRE_APPROVED" \
+                && ! has_label "$LABEL_APPROVED"; then
 
-          if (state === "approved") {
-            const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
-              owner,
-              repo,
-              issue_number: pr.number,
-            });
+                set_status "$LABEL_NEEDS_APPROVAL"
+              fi
 
-            const labels = new Set(currentLabels.map(l => l.name));
+              exit 0
+            fi
+          fi
 
-            if (!labels.has(partiallyApprovedLabel) && !labels.has(approvedLabel)) {
-              await addLabel(partiallyApprovedLabel);
-              return;
-            }
+          # ------------------------------------------------------------
+          # Review submitted
+          # ------------------------------------------------------------
+          if [[ "$EVENT_NAME" == "pull_request_review" ]]; then
+            REVIEW_AUTHOR_ASSOCIATION="${{ github.event.review.author_association }}"
 
-            if (labels.has(partiallyApprovedLabel) && !labels.has(approvedLabel)) {
-              await removeLabel(changesRequestedLabel);
-              await removeLabel(partiallyApprovedLabel);
-              await addLabel(approvedLabel);
-            }
-          }
+            # Filter for write access
+            case "$REVIEW_AUTHOR_ASSOCIATION" in
+              OWNER|MEMBER|COLLABORATOR)
+                echo "Trusted reviewer (Association: $REVIEW_AUTHOR_ASSOCIATION )"
+                ;;
+              *)
+                echo "Ignoring review from non-writer (Association: $REVIEW_AUTHOR_ASSOCIATION )"
+                exit 0
+                ;;
+            esac
+
+            REVIEW_STATE="${{ github.event.review.state }}"
+
+            # changes_requested
+            if [[ "$REVIEW_STATE" == "changes_requested" ]]; then
+              set_status "$LABEL_CHANGES_REQUESTED"
+              exit 0
+            fi
+
+            # approved
+            if [[ "$REVIEW_STATE" == "approved" ]]; then
+
+              # Never move away from changes requested on a review,
+              # the label is there for a reason
+              if has_label "$LABEL_CHANGES_REQUESTED"; then
+                echo "PR is in Changes requested; ignoring approval"
+                exit 0
+              fi
+
+              # Needs approval -> Pre-approved
+              if has_label "$LABEL_NEEDS_APPROVAL"; then
+                set_status "$LABEL_PRE_APPROVED"
+                exit 0
+              fi
+
+              # Pre-approved -> Approved
+              if has_label "$LABEL_PRE_APPROVED"; then
+                set_status "$LABEL_APPROVED"
+                exit 0
+              fi
+            fi
+          fi

--- a/.github/workflows/labeler-maintainer-reviewed.yml
+++ b/.github/workflows/labeler-maintainer-reviewed.yml
@@ -34,16 +34,16 @@ jobs:
           LABEL_PARTIAL_APPROVAL="S: Partially Approved"
           LABEL_APPROVED="S: Approved"
 
-          PR_NUMBER="${{ github.event.pull_request.number }}"
-          EVENT_NAME="${{ github.event_name }}"
-          ACTION="${{ github.event.action }}"
-
           ALL_LABELS=(
             "$LABEL_CHANGES_REQUESTED"
             "$LABEL_NEEDS_APPROVAL"
             "$LABEL_PARTIAL_APPROVAL"
             "$LABEL_APPROVED"
           )
+
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          EVENT_NAME="${{ github.event_name }}"
+          ACTION="${{ github.event.action }}"
 
           # ------------------------------------------------------------
           # Utility functions
@@ -64,34 +64,19 @@ jobs:
             return 1
           }
 
-          remove_all_status_labels() {
-            local existing=()
-
-            while IFS= read -r label; do
-              existing+=("$label")
-            done < <(get_labels)
-
-            for status in "${ALL_LABELS[@]}"; do
-              for current in "${existing[@]}"; do
-                if [[ "$current" == "$status" ]]; then
-                  gh pr -R "${{ github.repository }}" edit "$PR_NUMBER" --remove-label "$status"
-                fi
-              done
-            done
-          }
-
           set_status() {
-            local label="$1"
-            echo $1
-            echo $label
+            local target_label="$1"
 
-            remove_all_status_labels
+            for other_label in "${ALL_LABELS[@]}"; do
+              if [[ $target_label -neq $other_label && has_label "$other_label" ]]; then
+                echo "Removing existing label: $other_label"
+                gh pr -R "${{ github.repository }}" edit "$PR_NUMBER" --remove-label "$other_label"
+              fi
+            done
 
-            echo "Label is now: $label"
+            gh pr -R "${{ github.repository }}" edit "$PR_NUMBER" --add-label "$target_label"
 
-            gh pr -R "${{ github.repository }}" edit "$PR_NUMBER" --add-label "$label"
-
-            echo "Set PR status: $label"
+            echo "Set PR status: $target_label"
           }
 
           ##############################################################


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Changes the "Labels: Reviewed By Maintainer" entirely to be more concise, and purpose built for RMC.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Current system is broken. Also uh... labels are balanced in-game. Please just trust me on that.

## Technical details
<!-- Summary of code changes for easier review. -->

The workflow file **should be reviewed irrespective of what it was before**, as it was entirely built from the ground up. The workflow implements the following finite state machine:

<img width="971" height="630" alt="image" src="https://github.com/user-attachments/assets/8faf2a22-6ef2-45cc-95b9-9bb52537c0fa" />

Technical details:
- GitHub offers slim runners for simple tasks like this, which can be targeted with `ubuntu-slim`: https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories
- The GitHub-hosted runners come packed with the GitHub CLI.
- For `gh pr ...` commands, we must pass the `-R` option with the repository context filled in, otherwise GitHub CLI will try to read this information from the local checked-out repository state, which means we'd need to add an `actions/checkout` to the workflow, which we can do without. ( https://cli.github.com/manual/gh_pr )
- For `gh pr edit ...` commands, first-class support for label handling is provided with the flags `--add-label` and `--remove-label` which both take the label name as input to the parameter. ( https://cli.github.com/manual/gh_pr_edit )
- The event payloads for `pull_request_review` is documented here: https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=submitted#pull_request_review - Pay specific `attention to event.review.author_association` which according to [this stackoverflow answer](https://stackoverflow.com/a/76852343) can be read such that we need either `OWNER` (owner of the organisation), `MEMBER` (member of the owner organisation) or `COLLABORATOR` (external collaborator invited on the repo directly).

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

GitHub screenshots are not interesting.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

Absolutely not.
