### PR TITLE
Leap and headbutt no longer affected by xeno's movement

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Headbutt/XenoHeadbuttSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Headbutt/XenoHeadbuttSystem.cs
@@ -86,7 +86,15 @@ public sealed class XenoHeadbuttSystem : EntitySystem
         Dirty(xeno);
 
         _rmcObstacleSlamming.MakeImmune(xeno);
-        _throwing.TryThrow(xeno, diff);
+
+        if (TryComp<PhysicsComponent>(xeno, out var physics))
+        {
+            // Prevent headbutt from having longer/shorter range or skewed direction
+            // based on the xeno's movement when using it.
+            _physics.ResetDynamics(xeno, physics);
+        }
+
+        _throwing.TryThrow(xeno, diff, doSpin: false);
     }
 
     private void OnXenoHeadbuttHit(Entity<XenoHeadbuttComponent> xeno, ref ThrowDoHitEvent args)

--- a/Content.Shared/_RMC14/Xenonids/Leap/XenoLeapSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Leap/XenoLeapSystem.cs
@@ -218,6 +218,11 @@ public sealed class XenoLeapSystem : EntitySystem
         leaping.LeapEndTime = _timing.CurTime + TimeSpan.FromSeconds(direction.Length() / xeno.Comp.Strength);
 
         _obstacleSlamming.MakeImmune(xeno, 0.5f);
+
+        // Prevent leap from having longer/shorter range or skewed direction
+        // based on the xeno's movement when using it.
+        _physics.ResetDynamics(xeno, physics);
+
         _physics.ApplyLinearImpulse(xeno, impulse, body: physics);
         _physics.SetBodyStatus(xeno, physics, BodyStatus.InAir);
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Leap-like abilities (Leap, Pounce, Rush, Dash, Assault) will now always land exactly where you click (or up to max distance towards it, or until you hit something). The landing point is no longer offset in the direction you were moving when you used the ability.

Headbutt will now always land exactly where the target was (or until you hit something). The landing point is no longer offset in the direction you were moving when you used the ability.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
All the above abilities were affected by your movement at the moment you used them. For example, if you are moving towards the target or position you clicked, you will overshoot by a tile or more. Likewise, if you are moving away from the target or position you clicked, you will undershoot by a tile or more.

Moving perpendicularly to the target also offset where you end up. If your target is to the right, for example, but you are moving up while using the ability, you will end up above where you clicked.

While some of this could be useful as techniques, overall I think it is counterintuitive to how the abilities should work. If you click on a spot or target, you should end up there. Their behavior will be consistent regardless of how you are moving when you use them.

Additionally, this behavior means that some abilities are able to go much farther than intended, past their "max range". In that sense, this is a bugfix as well.

## Technical details
<!-- Summary of code changes for easier review. -->
Immediately before applying the impulse to the xeno that's leaping or headbutting, make the xeno stop moving via ResetDynamics.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

**Unfixed headbutt:**

https://github.com/user-attachments/assets/08d36246-ebb6-4926-88df-9c425f02b281

**Fixed headbutt:**

https://github.com/user-attachments/assets/fedf8763-1ed3-4852-b561-82caa2916ef7

**Unfixed leap:**

https://github.com/user-attachments/assets/c0f9caa8-2000-4dca-95a4-0112e337a232

**Fixed leap:**

https://github.com/user-attachments/assets/1d3c5a70-000b-4933-b2b6-abbdfb37ee13


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Leap, Pounce, Dash, Rush, Assault, and Headbutt no longer overshoot, undershoot, or miss the target position due to your movement at the moment you used them.
