### PR TITLE
qol: prevent zoom on rest

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Zoom/XenoZoomComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Zoom/XenoZoomComponent.cs
@@ -27,4 +27,7 @@ public sealed partial class XenoZoomComponent : Component
 
     [DataField, AutoNetworkedField]
     public bool BlockLeaps;
+
+    [DataField, AutoNetworkedField]
+    public bool WasZoomedBeforeRest;
 }

--- a/Content.Shared/_RMC14/Xenonids/Zoom/XenoZoomSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Zoom/XenoZoomSystem.cs
@@ -42,14 +42,18 @@ public sealed class XenoZoomSystem : EntitySystem
             return;
 
         args.Handled = true;
+        SetZoomEnabled(xeno, !xeno.Comp.Enabled);
+    }
 
-        xeno.Comp.Enabled = !xeno.Comp.Enabled;
+    private void SetZoomEnabled(Entity<XenoZoomComponent> xeno, bool enabled)
+    {
+        xeno.Comp.Enabled = enabled;
 
-        if (xeno.Comp.Enabled)
+        if (enabled)
         {
             _contentEye.SetMaxZoom(xeno, xeno.Comp.Zoom);
             _contentEye.SetZoom(xeno, xeno.Comp.Zoom);
-            xeno.Comp.Offset = Transform(args.User).LocalRotation.GetCardinalDir().ToVec() * xeno.Comp.OffsetLength;
+            xeno.Comp.Offset = Transform(xeno.Owner).LocalRotation.GetCardinalDir().ToVec() * xeno.Comp.OffsetLength;
         }
         else
         {
@@ -61,7 +65,7 @@ public sealed class XenoZoomSystem : EntitySystem
 
         foreach (var action in _rmcActions.GetActionsWithEvent<XenoZoomActionEvent>(xeno))
         {
-            _actions.SetToggled((action, action), xeno.Comp.Enabled);
+            _actions.SetToggled((action, action), enabled);
         }
 
         _movementSpeed.RefreshMovementSpeedModifiers(xeno);
@@ -89,21 +93,21 @@ public sealed class XenoZoomSystem : EntitySystem
 
     private void OnRest(Entity<XenoZoomComponent> ent, ref XenoRestEvent args)
     {
-        if (!ent.Comp.Enabled)
+        if (args.Resting)
+        {
+            ent.Comp.WasZoomedBeforeRest = ent.Comp.Enabled;
+
+            if (!ent.Comp.Enabled)
+                return;
+
+            SetZoomEnabled(ent, false);
+            return;
+        }
+
+        if (!ent.Comp.WasZoomedBeforeRest)
             return;
 
-        ent.Comp.Enabled = false;
-        _contentEye.ResetZoom(ent);
-        ent.Comp.Offset = Vector2.Zero;
-        Dirty(ent);
-        _movementSpeed.RefreshMovementSpeedModifiers(ent);
-
-        if (TryComp(ent, out EyeComponent? eye))
-            _contentEye.UpdateEyeOffset((ent.Owner, eye));
-
-        foreach (var action in _rmcActions.GetActionsWithEvent<XenoZoomActionEvent>(ent))
-        {
-            _actions.SetToggled((action, action), ent.Comp.Enabled);
-        }
+        ent.Comp.WasZoomedBeforeRest = false;
+        SetZoomEnabled(ent, true);
     }
 }

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_self_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_self_actions.yml
@@ -181,6 +181,7 @@
     useDelay: 0.2
   - type: InstantAction
     event: !type:XenoZoomActionEvent
+  - type: ActionBlockIfResting
 
 - type: entity
   parent: CMGuidebookActionXenoBase


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR prevents xeno from using Zoom while resting and also adds a QoL that reactivates Zoom if it was active before player went into resting state

## Why / Balance
It's too much unnecessary micromanagement to keep the Zoom active

## Technical details
Added new field `WasZoomedBeforeRest` to the `XenoZoomComponent` that remembers zoomed state when player goes resting. Expanded `XenoZoomSystem` to restore zoom state when player stops resting.

## Media
https://drive.google.com/file/d/1bAjuaILdV0H3DO0uNCemT6MC6iyFVKu_/view?usp=sharing

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: zoom state restored when stop resting
- tweak: zoom feature is disabled while resting
