### PR TITLE
Make water extinguish mobs when resisting fire

### DIFF
--- a/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
@@ -282,10 +282,9 @@ namespace Content.Server.Atmos.EntitySystems
                 return;
 
             // RMC14 use the normal stop-drop-roll resist before active water extinguishes.
-            var wasResisting = ent.Comp.Resisting;
             _rmcFlammable.DoStopDropRollAnimation(ent.Owner);
             Resist(ent, ent);
-            if (!wasResisting && ent.Comp.Resisting)
+            if (ent.Comp.Resisting)
                 TryExtinguishWithWater(ent.Owner, ent.Comp);
             // RMC14 end
 

--- a/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
@@ -4,6 +4,7 @@ using Content.Server.Damage.Components;
 using Content.Server.Stunnable;
 using Content.Server.Temperature.Systems;
 using Content.Shared._RMC14.Atmos;
+using Content.Shared._RMC14.Water;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared._RMC14.Xenonids.Projectile.Spit;
 using Content.Shared.ActionBlocker;
@@ -54,6 +55,7 @@ namespace Content.Server.Atmos.EntitySystems
         [Dependency] private readonly AudioSystem _audio = default!;
         [Dependency] private readonly IRobustRandom _random = default!;
         [Dependency] private readonly SharedRMCFlammableSystem _rmcFlammable = default!;
+        [Dependency] private readonly RMCWaterSystem _rmcWater = default!; // RMC14
         [Dependency] private readonly XenoSpitSystem _xenoSpit = default!;
         [Dependency] private readonly IPrototypeManager _prototype = default!;
 
@@ -279,11 +281,36 @@ namespace Content.Server.Atmos.EntitySystems
             if (args.Handled)
                 return;
 
+            // RMC14 use the normal stop-drop-roll resist before active water extinguishes.
+            var wasResisting = ent.Comp.Resisting;
             _rmcFlammable.DoStopDropRollAnimation(ent.Owner);
             Resist(ent, ent);
+            if (!wasResisting && ent.Comp.Resisting)
+                TryExtinguishWithWater(ent.Owner, ent.Comp);
+            // RMC14 end
+
             _xenoSpit.Resist(ent.Owner);
             args.Handled = true;
         }
+
+        // RMC14 water extinguishing helper. Active water reuses RMCWaterSystem.CanCollide so catwalk-covered
+        // water does not count.
+        private bool TryExtinguishWithWater(EntityUid uid, FlammableComponent flammable)
+        {
+            if (!CanWaterExtinguish(uid, flammable) || !_rmcWater.IsInWater(uid))
+                return false;
+
+            Extinguish(uid, flammable);
+            return true;
+        }
+
+        private bool CanWaterExtinguish(EntityUid uid, FlammableComponent flammable)
+        {
+            return !TerminatingOrDeleted(uid) &&
+                   flammable.OnFire &&
+                   flammable.CanExtinguish;
+        }
+        // RMC14 end
 
         public void UpdateAppearance(EntityUid uid, FlammableComponent? flammable = null, AppearanceComponent? appearance = null)
         {

--- a/Content.Shared/_RMC14/Water/RMCWaterSystem.cs
+++ b/Content.Shared/_RMC14/Water/RMCWaterSystem.cs
@@ -1,6 +1,8 @@
 ﻿using Content.Shared._RMC14.Map;
 using Content.Shared.NameModifier.EntitySystems;
 using Content.Shared.Whitelist;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Systems;
 using Robust.Shared.Timing;
 
 namespace Content.Shared._RMC14.Water;
@@ -10,6 +12,7 @@ public sealed class RMCWaterSystem : EntitySystem
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly EntityWhitelistSystem _entityWhitelist = default!;
     [Dependency] private readonly NameModifierSystem _nameModifier = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly RMCMapSystem _rmcMap = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
 
@@ -55,6 +58,43 @@ public sealed class RMCWaterSystem : EntitySystem
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Returns true for uncovered RMC water that should apply water contact effects.
+    /// </summary>
+    public bool IsActiveWater(EntityUid water, EntityUid user, RMCWaterComponent? component = null)
+    {
+        return IsActiveWater((water, component), user);
+    }
+
+    public bool IsActiveWater(Entity<RMCWaterComponent?> water, EntityUid user)
+    {
+        if (!Resolve(water, ref water.Comp, false))
+            return false;
+
+        return CanCollide(water, user);
+    }
+
+    /// <summary>
+    /// Checks current physics contacts for active RMC water.
+    /// </summary>
+    public bool IsInWater(EntityUid user, FixturesComponent? fixtures = null)
+    {
+        if (!Resolve(user, ref fixtures, false))
+            return false;
+
+        var contacts = _physics.GetContacts((user, fixtures));
+        while (contacts.MoveNext(out var contact))
+        {
+            if (!contact.IsTouching)
+                continue;
+
+            if (IsActiveWater(contact.OtherEnt(user), user))
+                return true;
+        }
+
+        return false;
     }
 
     public override void Update(float frameTime)


### PR DESCRIPTION
## About the PR

Makes fire resist interact with active RMC water.

Burning mobs that use the normal fire resist / stop-drop-roll action while standing in RMC water are extinguished immediately after the standard resist behavior starts. This matches the main CMSS13 behavior where humans and xenos roll/resist first, then `ExtinguishMob()` if they are on river water.

## Why / Balance

**PARITY**. Water now gives burning mobs a reliable way to extinguish themselves, but still requires the normal fire resist action. Simply walking into water does not passively extinguish fire.

Covered water is not treated as active water. The check reuses existing RMC water collision logic, so water covered by catwalks / water cover does not count.

This does not change tile fire behavior: fire can still exist on water, and mobs can still ignite from fire on a water tile until they resist.

## Technical details

Added RMC water helper methods in `RMCWaterSystem`:

- `IsActiveWater(...)`
- `IsInWater(...)`

These helpers reuse `RMCWaterSystem.CanCollide`, so existing RMC water cover behavior is respected.

`FlammableSystem.OnResistFireAlert` now keeps the normal RMC fire resist flow:

1. play stop-drop-roll visuals;
2. start normal `Resist`;
3. if the mob successfully started resisting and is in active RMC water, call `Extinguish`.

## Media

Minor change, no media required.

## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

- tweak: Burning mobs now extinguish immediately when using fire resist while standing in active RMC water.