### PR TITLE
Ore box migration

### DIFF
--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -1494,3 +1494,6 @@ CMUpgradedTraumaKit: CMUpgradedTraumaKit10
 #2026-05-20
 RMCHeadCapFerret: RMCHeadCapGrey
 CMPosterRememberIo: CMRandomPosterAny
+
+#2026-05-21
+OreBox: RMCOreBox


### PR DESCRIPTION
## About the PR
Migrated the incorrect upstream ore boxes for our own

## Why / Balance
A bunch of our pvp and pve maps use the incorrect ore box, this fixes it.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
no CL
