### PR TITLE
M804 belt item whitelist parity pass

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
@@ -1490,6 +1490,7 @@
       - BarbedWire
       - EmptySandbag
       - WeaponMount # Not parity
+      - LightReplacer
   - type: IgnoreContentsSize
     items:
       components:

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml
@@ -1477,24 +1477,15 @@
       - CMFireExtinguisherPortable
       - RMCMagazineML66D
       - RMCMagazineM2C
-      - CableCoil
-      - Multitool
       - RMCExplosiveBreachingCharge
-      - RMCNailgunCompact
-      - RMCNailgunTactical
       - RMCExplosiveClaymoreMine
       - RMCSmartGunMounted # Not parity
       components:
       - Welder
-      - EntrenchingTool
-      - BarbedWire
-      - EmptySandbag
       - WeaponMount # Not parity
-      - LightReplacer
   - type: IgnoreContentsSize
     items:
       components:
-      - EntrenchingTool
       - MountableWeapon # Not parity
   - type: Tag
     tags:


### PR DESCRIPTION
## About the PR
Originally opened to add Light Replacers to the whitelist, it was pointed out this item isnt in parity right now and can take more than intended.

This PR updates the item whitelists of the M804 belt to be correct (outside of some QOL additions).

## Why / Balance
Parity.
Removal of unintended changes.

## Technical details
-Removes several entries from Resources/Prototypes/_RMC14/Entities/Clothing/Belt/belts.yml to update the whitelist of compatible tags/components.

## Media
<img width="464" height="291" alt="image" src="https://github.com/user-attachments/assets/0e4705bd-fbb4-4d0f-b59f-784b09dc8242" />
<img width="509" height="193" alt="image" src="https://github.com/user-attachments/assets/66d8690c-825b-4f79-93cc-af952279a4c2" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: The M804 Heavygunner Rig has had its whitelisted items adjusted to remove unintended additions.
