### PR TITLE
Remove Fiorina LZ2 Engi Ring comms and LZ1 Comms Relay comms

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Areas/areas_fiorina.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Areas/areas_fiorina.yml
@@ -443,7 +443,7 @@
 - type: entity
   parent: RMCAreaFiorinaStationTelecomm
   id: RMCAreaFiorinaStationTelecommLz1Tram
-  name: Fiorina - LZ1 Aux Port Communications Relay
+  name: Fiorina - LZ1 Aux Port Engineering Passage
   components:
   - type: Area
     landingZone: true


### PR DESCRIPTION
## About the PR
Removed two comms arrays from fiorina, pictured below.
Renames the area LZ1 Aux Port Communications Relay to LZ1 Aux Port Engineering Passage

## Why / Balance
Double-engi ring comms is terrible for the gameplay that it can cause where two comms towers are powered from a single APC and can be easily defended by the marines to nuke, and the south LZ1 comms relay is far too easy to defend for marines in general. Agreed by Shromply, engi rings comms removal agreed by Smug.

## Media
removes the two comms relays pictured.
<img width="1062" height="848" alt="image" src="https://github.com/user-attachments/assets/c384f3c3-2d03-45c4-8e4b-6822b3a33779" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: CatAndHats
- remove: Removed two Communications Relay spawns on Fiorina: LZ2 Engi Rings Comms and LZ1 Comms Relay Comms