### PR TITLE
Rechargers No Longer Break Down Into Upstream Machine Frames

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -162,3 +162,12 @@
 #   id: RMCElectronicsAirlock
 #   name: airlock electronics
 #   description: A machine printed circuit board for an airlock # TODO RMC14 Airlock Building
+
+- type: entity
+  parent: CMBaseMachineCircuitboard
+  id: RMCRechargerCircuitboard
+  name: recharger machine board
+  description: A machine printed circuit board for a recharger
+  components:
+    - type: MachineBoard
+      prototype: RMCRecharger

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Power/recharger.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Power/recharger.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: BaseRecharger
+  parent: [ BaseRecharger, RMCConstructibleMachine ]
   id: RMCRecharger
   name: recharger
   components:
@@ -60,6 +60,14 @@
         whitelist:
           components:
             - Stunbaton
+  - type: Construction
+    graph: CMMachineFrame
+    node: machine
+    containers:
+    - machine_parts
+    - machine_board
+  - type: Machine
+    board: RMCRechargerCircuitboard
 
 - type: entity
   parent: RMCRecharger


### PR DESCRIPTION
## About the PR
Rechargers break down into upstreams machine frames right now, and dont give a circuitboard back - meaning they cant be replaced! I totally didnt do this my first time as a comtech and massively grief my team. Trust.
Fixes: https://github.com/RMC-14/RMC-14/issues/8204

## Why / Balance
- Feels bad to decon something you think should be fixable like any machine only to get back materials you cant even use.
- Less feels bad moments for new comstechs.
- Consistent with other machines.

## Technical details
-Adds a new CM circuitboard here Resources/Prototypes/_RMC14/Entities/Objects/Devices/Circuitboards/Machine/production.yml
- Multiple changes: Resources/Prototypes/_RMC14/Entities/Structures/Power/recharger.yml
1. Adds a new parent in the parent field, RMCConstructibleMachine.
2. Adds new construction graph code to overwrite the code from the parent (this is what causes the issue with the recharger deconstruction)
3. adds a new type field to define the circuitboard used in the machine.

## Media

https://github.com/user-attachments/assets/591c05f9-16c0-4564-971e-3fde76a5f632

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: The recharger no longer breaks down into an upstream machine frame.
