### PR TITLE
XenoZoom now increases PVS range

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Zoom/XenoZoomSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Zoom/XenoZoomSystem.cs
@@ -112,7 +112,7 @@ public sealed class XenoZoomSystem : EntitySystem
             const float pvsOverheadEstimate = 0.2f;
             var scale = (Math.Max(ent.Comp.Zoom.X, ent.Comp.Zoom.Y) + pvsOverheadEstimate) / (1 + pvsOverheadEstimate);
             // args.Scale is added to the scale, not multiplied, so we have to subtract 1 and make sure we don't scale down.
-            args.Scale = Math.Max(0, scale - 1);
+            args.Scale += Math.Max(0, scale - 1);
         }
     }
 

--- a/Content.Shared/_RMC14/Xenonids/Zoom/XenoZoomSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Zoom/XenoZoomSystem.cs
@@ -103,12 +103,13 @@ public sealed class XenoZoomSystem : EntitySystem
     {
         // We try to scale up the PVS radius while leaving the same amount of tiles as overhead.
         // pvsOverheadEstimate estimates what portion of the viewport is added on as "overhead" for PVS purposes.
-        // i.e. an estimate of 0.25 means the PVS radius is 25% larger than the actual viewport radius.
+        // i.e. an estimate of 0.2 means the PVS radius is 20% larger than the actual viewport radius.
         // A smaller estimate results in a LARGER pvs radius scale up, because there's less overhead proportionally.
-        // TODO RMC14 calculate the overhead from CVars instead of hardcoding it here.
+        // TODO RMC14 calculate the overhead from CVars instead of hardcoding it here. I calculated the default viewport
+        // as 21 tiles wide while the PVS bound appears to be 25 tiles wide. That's about 20% overhead.
         if (ent.Comp.Running)
         {
-            const float pvsOverheadEstimate = 0.25f;
+            const float pvsOverheadEstimate = 0.2f;
             var scale = (Math.Max(ent.Comp.Zoom.X, ent.Comp.Zoom.Y) + pvsOverheadEstimate) / (1 + pvsOverheadEstimate);
             // args.Scale is added to the scale, not multiplied, so we have to subtract 1 and make sure we don't scale down.
             args.Scale = Math.Max(0, scale - 1);

--- a/Content.Shared/_RMC14/Xenonids/Zoom/XenoZoomSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Zoom/XenoZoomSystem.cs
@@ -1,7 +1,6 @@
-﻿using System.Numerics;
+using System.Numerics;
 using Content.Shared._RMC14.Actions;
 using Content.Shared._RMC14.Xenonids.Leap;
-using Content.Shared._RMC14.Xenonids.Parasite;
 using Content.Shared._RMC14.Xenonids.Rest;
 using Content.Shared.Actions;
 using Content.Shared.Camera;
@@ -20,12 +19,25 @@ public sealed class XenoZoomSystem : EntitySystem
 
     public override void Initialize()
     {
+        SubscribeLocalEvent<XenoZoomComponent, ComponentStartup>(OnXenoZoomComponentStartup);
+        SubscribeLocalEvent<XenoZoomComponent, ComponentShutdown>(OnXenoZoomComponentShutdown);
         SubscribeLocalEvent<XenoZoomComponent, XenoZoomActionEvent>(OnXenoZoomAction);
         SubscribeLocalEvent<XenoZoomComponent, XenoZoomDoAfterEvent>(OnXenoZoomDoAfter);
         SubscribeLocalEvent<XenoZoomComponent, GetEyeOffsetEvent>(OnXenoZoomGetEyeOffset);
+        SubscribeLocalEvent<XenoZoomComponent, GetEyePvsScaleEvent>(OnXenoZoomGetEyePvsScale);
         SubscribeLocalEvent<XenoZoomComponent, RefreshMovementSpeedModifiersEvent>(OnXenoZoomRefreshSpeed);
         SubscribeLocalEvent<XenoZoomComponent, XenoLeapAttemptEvent>(OnLeapAttempt);
         SubscribeLocalEvent<XenoZoomComponent, XenoRestEvent>(OnRest);
+    }
+
+    private void OnXenoZoomComponentStartup(Entity<XenoZoomComponent> xeno, ref ComponentStartup args)
+    {
+        _contentEye.UpdatePvsScale(xeno);
+    }
+
+    private void OnXenoZoomComponentShutdown(Entity<XenoZoomComponent> xeno, ref ComponentShutdown args)
+    {
+        _contentEye.UpdatePvsScale(xeno);
     }
 
     private void OnXenoZoomAction(Entity<XenoZoomComponent> xeno, ref XenoZoomActionEvent args)
@@ -53,7 +65,7 @@ public sealed class XenoZoomSystem : EntitySystem
         }
         else
         {
-            _contentEye.ResetZoom(xeno);
+            _contentEye.SetZoom(xeno, SharedContentEyeSystem.DefaultZoom);
             xeno.Comp.Offset = Vector2.Zero;
         }
 
@@ -72,7 +84,18 @@ public sealed class XenoZoomSystem : EntitySystem
 
     private void OnXenoZoomGetEyeOffset(Entity<XenoZoomComponent> ent, ref GetEyeOffsetEvent args)
     {
-        args.Offset += ent.Comp.Offset;
+        if (ent.Comp.Running)
+            args.Offset += ent.Comp.Offset;
+    }
+
+    private void OnXenoZoomGetEyePvsScale(Entity<XenoZoomComponent> ent, ref GetEyePvsScaleEvent args)
+    {
+        // Scale is additive, i.e. adding .2 would increase PVS by 20%, so we subtract 1 from the zoom levels first.
+        // TODO RMC14 For now we divide by 2 in order to reduce how much "extra" overhead PVS we have outside of viewport range,
+        // because scale also scales up the default overhead amount, and we don't actually want the overhead scaled.
+        // Dividing by 2 only works for lower zoom levels (under 2). If we get higher zoom levels, come back to this and fix it.
+        if (ent.Comp.Running)
+            args.Scale += Math.Max(0, Math.Max(ent.Comp.Zoom.X - 1, ent.Comp.Zoom.Y - 1)) / 2;
     }
 
     private void OnXenoZoomRefreshSpeed(Entity<XenoZoomComponent> ent, ref RefreshMovementSpeedModifiersEvent args)

--- a/Content.Shared/_RMC14/Xenonids/Zoom/XenoZoomSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Zoom/XenoZoomSystem.cs
@@ -101,12 +101,18 @@ public sealed class XenoZoomSystem : EntitySystem
 
     private void OnXenoZoomGetEyePvsScale(Entity<XenoZoomComponent> ent, ref GetEyePvsScaleEvent args)
     {
-        // Scale is additive, i.e. adding .2 would increase PVS by 20%, so we subtract 1 from the zoom levels first.
-        // TODO RMC14 For now we divide by 2 in order to reduce how much "extra" overhead PVS we have outside of viewport range,
-        // because scale also scales up the default overhead amount, and we don't actually want the overhead scaled.
-        // Dividing by 2 only works for lower zoom levels (under 2). If we get higher zoom levels, come back to this and fix it.
+        // We try to scale up the PVS radius while leaving the same amount of tiles as overhead.
+        // pvsOverheadEstimate estimates what portion of the viewport is added on as "overhead" for PVS purposes.
+        // i.e. an estimate of 0.25 means the PVS radius is 25% larger than the actual viewport radius.
+        // A smaller estimate results in a LARGER pvs radius scale up, because there's less overhead proportionally.
+        // TODO RMC14 calculate the overhead from CVars instead of hardcoding it here.
         if (ent.Comp.Running)
-            args.Scale += Math.Max(0, Math.Max(ent.Comp.Zoom.X - 1, ent.Comp.Zoom.Y - 1)) / 2;
+        {
+            const float pvsOverheadEstimate = 0.25f;
+            var scale = (Math.Max(ent.Comp.Zoom.X, ent.Comp.Zoom.Y) + pvsOverheadEstimate) / (1 + pvsOverheadEstimate);
+            // args.Scale is added to the scale, not multiplied, so we have to subtract 1 and make sure we don't scale down.
+            args.Scale = Math.Max(0, scale - 1);
+        }
     }
 
     private void OnXenoZoomRefreshSpeed(Entity<XenoZoomComponent> ent, ref RefreshMovementSpeedModifiersEvent args)

--- a/Content.Shared/_RMC14/Xenonids/Zoom/XenoZoomSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Zoom/XenoZoomSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared._RMC14.Xenonids.Rest;
 using Content.Shared.Actions;
 using Content.Shared.Camera;
 using Content.Shared.DoAfter;
+using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Systems;
 
 namespace Content.Shared._RMC14.Xenonids.Zoom;
@@ -32,12 +33,22 @@ public sealed class XenoZoomSystem : EntitySystem
 
     private void OnXenoZoomComponentStartup(Entity<XenoZoomComponent> xeno, ref ComponentStartup args)
     {
-        _contentEye.UpdatePvsScale(xeno);
+        if (!TryComp<ContentEyeComponent>(xeno, out var contentEye))
+            return;
+        if (!TryComp<EyeComponent>(xeno, out var eye))
+            return;
+
+        _contentEye.UpdatePvsScale(xeno, contentEye, eye);
     }
 
     private void OnXenoZoomComponentShutdown(Entity<XenoZoomComponent> xeno, ref ComponentShutdown args)
     {
-        _contentEye.UpdatePvsScale(xeno);
+        if (!TryComp<ContentEyeComponent>(xeno, out var contentEye))
+            return;
+        if (!TryComp<EyeComponent>(xeno, out var eye))
+            return;
+
+        _contentEye.UpdatePvsScale(xeno, contentEye, eye);
     }
 
     private void OnXenoZoomAction(Entity<XenoZoomComponent> xeno, ref XenoZoomActionEvent args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
XenoZoomSystem adds some PVS range to the entity, depending on its max zoom.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Kind of needed for the Sapper strain's zoom to work (#9433). It has a zoom level of 1.75, which the default PVS range is not suitable for. The sapper encounters frequent pop-out and pop-in several tiles from the viewport's edge.

## Technical details
<!-- Summary of code changes for easier review. -->
XenoZoomSystem causes a PVS scale refresh when XenoZoomComponent starts up or shuts down.
XenoZoomSystem adjusts PVS scale depending on what the max zoom is.


## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
Ideally players will not notice any difference.
