### PR TITLE
add health indicators to mounted weapons and fix sentry health indicator

### DIFF
--- a/Content.Shared/_RMC14/HealthExaminable/RMCHealthExaminableComponent.cs
+++ b/Content.Shared/_RMC14/HealthExaminable/RMCHealthExaminableComponent.cs
@@ -12,5 +12,5 @@ public sealed partial class RMCHealthExaminableComponent : Component
     public List<ProtoId<DamageGroupPrototype>> Groups = new() { "Brute", "Burn", "Airloss" };
 
     [DataField, AutoNetworkedField]
-    public string SpeciesType = "";
+    public string? SpeciesType;
 }

--- a/Content.Shared/_RMC14/HealthExaminable/RMCHealthExaminableComponent.cs
+++ b/Content.Shared/_RMC14/HealthExaminable/RMCHealthExaminableComponent.cs
@@ -10,4 +10,7 @@ public sealed partial class RMCHealthExaminableComponent : Component
 {
     [DataField, AutoNetworkedField]
     public List<ProtoId<DamageGroupPrototype>> Groups = new() { "Brute", "Burn", "Airloss" };
+
+    [DataField, AutoNetworkedField]
+    public string SpeciesType = "";
 }

--- a/Content.Shared/_RMC14/HealthExaminable/RMCHealthExaminableSystem.cs
+++ b/Content.Shared/_RMC14/HealthExaminable/RMCHealthExaminableSystem.cs
@@ -17,6 +17,9 @@ public sealed class RMCHealthExaminableSystem : EntitySystem
 
     private void OnExamined(Entity<RMCHealthExaminableComponent> ent, ref ExaminedEvent args)
     {
+        if (ent.Comp.SpeciesType == null)
+            return;
+
         if (!TryComp(ent, out DamageableComponent? damageable))
             return;
 

--- a/Content.Shared/_RMC14/HealthExaminable/RMCHealthExaminableSystem.cs
+++ b/Content.Shared/_RMC14/HealthExaminable/RMCHealthExaminableSystem.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Immutable;
-using System.ComponentModel;
 using Content.Shared.Damage;
 using Content.Shared.Examine;
 using Content.Shared.FixedPoint;

--- a/Content.Shared/_RMC14/HealthExaminable/RMCHealthExaminableSystem.cs
+++ b/Content.Shared/_RMC14/HealthExaminable/RMCHealthExaminableSystem.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Immutable;
+using System.ComponentModel;
 using Content.Shared.Damage;
 using Content.Shared.Examine;
 using Content.Shared.FixedPoint;
@@ -8,7 +9,7 @@ namespace Content.Shared._RMC14.HealthExaminable;
 
 public sealed class RMCHealthExaminableSystem : EntitySystem
 {
-    private readonly ImmutableArray<FixedPoint2> _thresholds = ImmutableArray.Create<FixedPoint2>(25, 50, 75);
+    private readonly ImmutableArray<FixedPoint2> _thresholds = ImmutableArray.Create<FixedPoint2>(25, 50, 75, 100, 200, 300);
 
     public override void Initialize()
     {
@@ -33,7 +34,7 @@ public sealed class RMCHealthExaminableSystem : EntitySystem
                     if (groupDamage < threshold)
                         continue;
 
-                    var id = $"rmc-health-examinable-{group}-{threshold.Int()}";
+                    var id = $"rmc-health-examinable-{ent.Comp.SpeciesType}-{group}-{threshold.Int()}";
                     if (!Loc.TryGetString(id, out var msg, ("target", Identity.Entity(ent, EntityManager, args.Examiner))))
                         continue;
 

--- a/Resources/Locale/en-US/_RMC14/health-examinable.ftl
+++ b/Resources/Locale/en-US/_RMC14/health-examinable.ftl
@@ -1,10 +1,30 @@
-﻿rmc-health-examinable-Brute-25 = [color=red]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } minor contusions across { POSS-ADJ($target) } body.[/color]
-rmc-health-examinable-Brute-50 = [color=crimson]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } major bruises all over { POSS-ADJ($target) } body![/color]
-rmc-health-examinable-Brute-75 = [color=crimson]{ CAPITALIZE(POSS-ADJ($target)) } body is completely covered in lesions![/color]
+﻿rmc-health-examinable-Humanoid-Brute-25 = [color=red]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } minor contusions across { POSS-ADJ($target) } body.[/color]
+rmc-health-examinable-Humanoid-Brute-50 = [color=crimson]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } major bruises all over { POSS-ADJ($target) } body![/color]
+rmc-health-examinable-Humanoid-Brute-75 = [color=crimson]{ CAPITALIZE(POSS-ADJ($target)) } body is completely covered in lesions![/color]
 
-rmc-health-examinable-Burn-25 = [color=yellow]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } minor burns across { POSS-ADJ($target) } body.[/color]
-rmc-health-examinable-Burn-50 = [color=orange]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } major burns across { POSS-ADJ($target) } body.[/color]
-rmc-health-examinable-Burn-75 = [color=orange]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } severe third-degree burns across { POSS-ADJ($target) } body![/color]
+rmc-health-examinable-Humanoid-Burn-25 = [color=yellow]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } minor burns across { POSS-ADJ($target) } body.[/color]
+rmc-health-examinable-Humanoid-Burn-50 = [color=orange]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } major burns across { POSS-ADJ($target) } body.[/color]
+rmc-health-examinable-Humanoid-Burn-75 = [color=orange]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } severe third-degree burns across { POSS-ADJ($target) } body![/color]
 
-rmc-health-examinable-Airloss-25 = [color=lightblue]{ CAPITALIZE(POSS-ADJ($target)) } lips are turning blue.[/color]
-rmc-health-examinable-Airloss-75 = [color=lightblue]{ CAPITALIZE(POSS-ADJ($target)) } face is turning blue.[/color]
+rmc-health-examinable-Humanoid-Airloss-25 = [color=lightblue]{ CAPITALIZE(POSS-ADJ($target)) } lips are turning blue.[/color]
+rmc-health-examinable-Humanoid-Airloss-75 = [color=lightblue]{ CAPITALIZE(POSS-ADJ($target)) } face is turning blue.[/color]
+
+
+rmc-health-examinable-Mechanical-Brute-25 = [color=yellow]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-HAVE($target)} a few dents.[/color]
+rmc-health-examinable-Mechanical-Brute-50 = [color=orange]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} a bit beat up.[/color]
+rmc-health-examinable-Mechanical-Brute-75 = [color=red]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} very caved in![/color]
+rmc-health-examinable-Mechanical-Brute-100 = [color=crimson]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} barely holding together![/color]
+
+rmc-health-examinable-Mechanical-Burn-25 = [color=yellow]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-HAVE($target)} spots of corrosion.[/color]
+rmc-health-examinable-Mechanical-Burn-50 = [color=orange]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} starting to corrode.[/color]
+rmc-health-examinable-Mechanical-Burn-75 = [color=red]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-HAVE($target)} almost melted![/color]
+rmc-health-examinable-Mechanical-Burn-100 = [color=crimson]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} barely recognizable![/color]
+
+
+rmc-health-examinable-Xeno-Brute-100 = [color=red]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } minor contusions across { POSS-ADJ($target) } body.[/color]
+rmc-health-examinable-Xeno-Brute-200 = [color=crimson]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } major bruises all over { POSS-ADJ($target) } body![/color]
+rmc-health-examinable-Xeno-Brute-300 = [color=crimson]{ CAPITALIZE(POSS-ADJ($target)) } body is completely covered in lesions![/color]
+
+rmc-health-examinable-Xeno-Burn-100 = [color=yellow]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } minor burns across { POSS-ADJ($target) } body.[/color]
+rmc-health-examinable-Xeno-Burn-200 = [color=orange]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } major burns across { POSS-ADJ($target) } body.[/color]
+rmc-health-examinable-Xeno-Burn-300 = [color=orange]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } severe third-degree burns across { POSS-ADJ($target) } body![/color]

--- a/Resources/Locale/en-US/_RMC14/health-examinable.ftl
+++ b/Resources/Locale/en-US/_RMC14/health-examinable.ftl
@@ -9,7 +9,6 @@ rmc-health-examinable-Humanoid-Burn-75 = [color=orange]{ CAPITALIZE(SUBJECT($tar
 rmc-health-examinable-Humanoid-Airloss-25 = [color=lightblue]{ CAPITALIZE(POSS-ADJ($target)) } lips are turning blue.[/color]
 rmc-health-examinable-Humanoid-Airloss-75 = [color=lightblue]{ CAPITALIZE(POSS-ADJ($target)) } face is turning blue.[/color]
 
-
 rmc-health-examinable-Mechanical-Brute-25 = [color=yellow]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-HAVE($target)} a few dents.[/color]
 rmc-health-examinable-Mechanical-Brute-50 = [color=orange]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} a bit beat up.[/color]
 rmc-health-examinable-Mechanical-Brute-75 = [color=red]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} very caved in![/color]
@@ -19,7 +18,6 @@ rmc-health-examinable-Mechanical-Burn-25 = [color=yellow]{CAPITALIZE(SUBJECT($ta
 rmc-health-examinable-Mechanical-Burn-50 = [color=orange]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} starting to corrode.[/color]
 rmc-health-examinable-Mechanical-Burn-75 = [color=red]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-HAVE($target)} almost melted![/color]
 rmc-health-examinable-Mechanical-Burn-100 = [color=crimson]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} barely recognizable![/color]
-
 
 rmc-health-examinable-Xeno-Brute-100 = [color=red]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } minor contusions across { POSS-ADJ($target) } body.[/color]
 rmc-health-examinable-Xeno-Brute-200 = [color=crimson]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } major bruises all over { POSS-ADJ($target) } body![/color]

--- a/Resources/Locale/en-US/_RMC14/rmc-sentry.ftl
+++ b/Resources/Locale/en-US/_RMC14/rmc-sentry.ftl
@@ -32,32 +32,5 @@ rmc-sentry-disassemble-finish-others = {$user} disassembles {THE($sentry)}.
 
 rmc-sentry-unanchor-is-on = {CAPITALIZE(THE($sentry))} is currently active. The motors will prevent you from unanchoring it safely.
 
-health-examinable-sentry-none = It is in pristine condition.
-
-health-examinable-sentry-Blunt-10 = [color=yellow]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-HAVE($target)} a few dents.[/color]
-health-examinable-sentry-Blunt-25 = [color=orange]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} a bit beat up.[/color]
-health-examinable-sentry-Blunt-50 = [color=red]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} very caved in![/color]
-health-examinable-sentry-Blunt-75 = [color=crimson]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} barely holding together![/color]
-
-health-examinable-sentry-Slash-10 = [color=yellow]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-HAVE($target)} a few scratches.[/color]
-health-examinable-sentry-Slash-25 = [color=orange]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} scratched up.[/color]
-health-examinable-sentry-Slash-50 = [color=red]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} covered in slash marks![/color]
-health-examinable-sentry-Slash-75 = [color=crimson]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} falling apart![/color]
-
-health-examinable-sentry-Piercing-10 = [color=yellow]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-HAVE($target)} a few holes.[/color]
-health-examinable-sentry-Piercing-25 = [color=orange]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-HAVE($target)} quite a few holes.[/color]
-health-examinable-sentry-Piercing-50 = [color=red]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} littered with holes![/color]
-health-examinable-sentry-Piercing-75 = [color=crimson]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} about to collapse![/color]
-
-health-examinable-sentry-Heat-10 = [color=yellow]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-HAVE($target)} spots of corrosion.[/color]
-health-examinable-sentry-Heat-25 = [color=orange]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} starting to corrode.[/color]
-health-examinable-sentry-Heat-50 = [color=red]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-HAVE($target)} almost melted![/color]
-health-examinable-sentry-Heat-75 = [color=crimson]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} barely recognizable![/color]
-
-health-examinable-sentry-Shock-10 = [color=yellow]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-HAVE($target)} a few scorch marks.[/color]
-health-examinable-sentry-Shock-25 = [color=orange]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} lightly charred.[/color]
-health-examinable-sentry-Shock-50 = [color=red]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} letting off sparks![/color]
-health-examinable-sentry-Shock-75 = [color=crimson]{CAPITALIZE(SUBJECT($target))} can barely function![/color]
-
 rmc-sentry-not-emergency = {CAPITALIZE(THE($deployer))} can only be activated in emergencies.
 rmc-sentry-deploy = You deploy {THE($spawned)}

--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -109,7 +109,7 @@
 #    - Caustic
 #    - Asphyxiation
 #    - Radiation
-  - type: RMCHealthExaminable
+  - type: RMCHealthExaminable # RMC14
     speciesType: Humanoid
   - type: DamageOnHighSpeedImpact
     damage:

--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -109,7 +109,8 @@
 #    - Caustic
 #    - Asphyxiation
 #    - Radiation
-  - type: RMCHealthExaminable # RMC14
+  - type: RMCHealthExaminable
+    speciesType: Humanoid
   - type: DamageOnHighSpeedImpact
     damage:
       types:

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
@@ -75,6 +75,7 @@
       params:
         volume: -4
   - type: RMCHealthExaminable
+    speciesType: Xeno
   - type: AcidBloodSplash
     closeSplashRadius: 0.5
     standardSplashRadius: 1.5

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/HMGs/weapon_mounts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/HMGs/weapon_mounts.yml
@@ -37,7 +37,7 @@
         - ItemMask
         restitution: 0.3
         friction: 0.2
-  - type: RMCRepairable #Damages eyes
+  - type: RMCRepairable #ToDo: Make this actually damage your eyes
     heal: 40
     skill: RMCSkillConstruction
     delay: 8

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/HMGs/weapon_mounts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/HMGs/weapon_mounts.yml
@@ -37,7 +37,7 @@
         - ItemMask
         restitution: 0.3
         friction: 0.2
-  - type: RMCRepairable
+  - type: RMCRepairable #Damages eyes
     heal: 40
     skill: RMCSkillConstruction
     delay: 8
@@ -75,6 +75,8 @@
   - type: XenoCrusherChargable
   - type: Physics
     bodyType: Dynamic
+  - type: RMCHealthExaminable
+    speciesType: Mechanical
 
 - type: entity
   parent: RMCBaseWeaponMount

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/HMGs/weapon_mounts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/HMGs/weapon_mounts.yml
@@ -37,7 +37,7 @@
         - ItemMask
         restitution: 0.3
         friction: 0.2
-  - type: RMCRepairable #ToDo: Make this actually damage your eyes
+  - type: RMCRepairable
     heal: 40
     skill: RMCSkillConstruction
     delay: 8

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Sentries/almayer_sentries.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Sentries/almayer_sentries.yml
@@ -49,6 +49,8 @@
   - type: UserIFF
     factions:
     - FactionMarine
+  - type: RMCHealthExaminable
+    speciesType: Mechanical
 
 - type: entity
   parent: BaseStructure

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Sentries/premade_sentries.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Sentries/premade_sentries.yml
@@ -110,14 +110,8 @@
     interfaces:
       enum.SentryUiKey.Key:
         type: SentryUpgradeBui
-  - type: HealthExaminable
-    locPrefix: sentry
-    examinableTypes:
-    - Blunt
-    - Slash
-    - Piercing
-    - Heat
-    - Shock
+  - type: RMCHealthExaminable
+    speciesType: Mechanical
   - type: ShortExamine
   - type: InteractedBlacklist
     blacklist:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Sentries/tesla.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Sentries/tesla.yml
@@ -84,14 +84,8 @@
   - type: DeviceNetwork
   - type: DeviceLinkSink
     ports: [ SentryControl ]
-  - type: HealthExaminable
-    locPrefix: sentry
-    examinableTypes:
-    - Blunt
-    - Slash
-    - Piercing
-    - Heat
-    - Shock
+  - type: RMCHealthExaminable
+    speciesType: Mechanical
   - type: ShortExamine
   - type: SentryTargeting
     targetedFactions:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Added health examination to the M2C and ML66D, no longer will you have to guess your weapons health, damage values at 25, 50, 75 and 100.

Fixed the health examination of sentries, sentries once again give you a rough idea of how they are doing damage wise, with damage values at 25, 50, 75 and 100.

Changed the numbers on xeno health examination to be slightly more accurate to their health pools, displaying at 100, 200 and 300 instead of 25, 50 and 75.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Viewing the health state of your weapon/sentry is a good QoL and partially parity

Xenos have much more health than humanoids and should have their health messages higher to compensate

## Technical details
<!-- Summary of code changes for easier review. -->
Yaml, slight bit of edits to the "RMCHealthExaminableSystem" and component

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added a health indicator to the m2c and ml66d, you will now have a rough idea of how damaged they are.
- fix: Fixed sentries missing most of their damage indicator text, you can once again determine how much damage your sentry has.
- tweak: Changed xeno damage examines from 25, 50, and 75 damage to 100, 200, and 300 damage.