### PR TITLE
Fixes welding not blinding you when repairing cades/weapons

### DIFF
--- a/Content.Shared/_RMC14/Repairable/RMCRepairableSystem.cs
+++ b/Content.Shared/_RMC14/Repairable/RMCRepairableSystem.cs
@@ -93,6 +93,9 @@ public sealed class RMCRepairableSystem : EntitySystem
             return;
         }
 
+        var toolUseAttempt = new ToolUseAttemptEvent(user, (float) repairable.Comp.FuelUsed);
+        RaiseLocalEvent(used, toolUseAttempt);
+
         var hasReplace = TryComp(repairable, out RMCRepairableReplaceComponent? replace);
 
         if (!TryComp(repairable, out DamageableComponent? damageable))

--- a/Content.Shared/_RMC14/Repairable/RMCRepairableSystem.cs
+++ b/Content.Shared/_RMC14/Repairable/RMCRepairableSystem.cs
@@ -93,8 +93,6 @@ public sealed class RMCRepairableSystem : EntitySystem
             return;
         }
 
-        var toolUseAttempt = new ToolUseAttemptEvent(user, (float) repairable.Comp.FuelUsed);
-        RaiseLocalEvent(used, toolUseAttempt);
 
         var hasReplace = TryComp(repairable, out RMCRepairableReplaceComponent? replace);
 
@@ -137,6 +135,9 @@ public sealed class RMCRepairableSystem : EntitySystem
 
         if (!UseFuel(args.Used, args.User, repairable.Comp.FuelUsed, true))
             return;
+
+        var toolUseAttempt = new ToolUseAttemptEvent(user, (float) repairable.Comp.FuelUsed);
+        RaiseLocalEvent(used, toolUseAttempt);
 
         var delay = hasReplace
             ? (float) repairable.Comp.Delay.TotalSeconds


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Makes welding barricades and mounted weapons without eye protection blind you

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity, you are using a welder, which should blind you

## Technical details
<!-- Summary of code changes for easier review. -->
Repairing is now considered a tool use event

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed barricades and mounted weapons not blinding you when welding them
