### PR TITLE
Fill All Organs with GreyMatter

### DIFF
--- a/Resources/Prototypes/Body/Organs/human.yml
+++ b/Resources/Prototypes/Body/Organs/human.yml
@@ -16,12 +16,12 @@
         - ReagentId: Nutriment
           Quantity: 10
       food:
-        maxVol: 35 # RMC14 - Increase Max Vol for CarpoToxin
+        maxVol: 80 # RMC14 - Increase Max Vol for GreyMatter
         reagents:
         - ReagentId: UncookedAnimalProteins
           Quantity: 5
-        - ReagentId: CarpoToxin # RMC14 - Add Carpotoxin to mechanically discourage eating organs.
-          Quantity: 30 # This is enough to deal 150 damage, after vomiting this will be slightly lower.
+        - ReagentId: GreyMatter # RMC14 - Add Grey Matter to all organs to mechanically discourage eating organs.
+          Quantity: 75 # This is enough to deal 150 clone damage, along vomiting/tox this will either place them just barely into crit or just below it.
   - type: FlavorProfile
     flavors:
       - people
@@ -62,10 +62,10 @@
         - ReagentId: Nutriment
           Quantity: 10
       food:
-        maxVol: 5
+        maxVol: 75 # RMC14 Increase to match parent and prevent overwrite.
         reagents:
         - ReagentId: GreyMatter
-          Quantity: 5
+          Quantity: 75 # RMC14 Increase to match parent and prevent overwrite.
   - type: FlavorProfile
     flavors:
       - people
@@ -153,10 +153,12 @@
         maxVol: 100.0
         canReact: false
       food:
-        maxVol: 5
+        maxVol: 80 # RMC14 Increase to match parent and prevent overwrite.
         reagents:
         - ReagentId: UncookedAnimalProteins
           Quantity: 5
+        - ReagentId: GreyMatter
+          Quantity: 75 # RMC14 Increase to match parent and prevent overwrite.
 
 - type: entity
   id: OrganHumanHeart
@@ -196,10 +198,12 @@
       stomach:
         maxVol: 80
       food:
-        maxVol: 5
+        maxVol: 80 # RMC14 Increase to match parent and prevent overwrite.
         reagents:
         - ReagentId: UncookedAnimalProteins
           Quantity: 5
+        - ReagentId: GreyMatter
+          Quantity: 75 # RMC14 Increase to match parent and prevent overwrite.
   - type: Stomach
   # The stomach metabolizes stuff like foods and drinks.
   # TODO: Have it work off of the ent's solution container, and move this

--- a/Resources/Prototypes/Body/Organs/human.yml
+++ b/Resources/Prototypes/Body/Organs/human.yml
@@ -16,10 +16,12 @@
         - ReagentId: Nutriment
           Quantity: 10
       food:
-        maxVol: 5
+        maxVol: 35 # RMC14 - Increase Max Vol for CarpoToxin
         reagents:
         - ReagentId: UncookedAnimalProteins
           Quantity: 5
+        - ReagentId: CarpoToxin # RMC14 - Add Carpotoxin to mechanically discourage eating organs.
+          Quantity: 30 # This is enough to deal 150 damage, after vomiting this will be slightly lower.
   - type: FlavorProfile
     flavors:
       - people


### PR DESCRIPTION
## About the PR
Replaces #8823 . We'll leave it open to try this first and then only outright disable it if this still fails.
Gives the organ base 75 units of "Grey Matter" which will do 150 damage (Slightly less, like to 147, because the proteins will make them vomit or more depending on tox from proteins.) which will just barely crit someone or get them close. Grey matter processes faster and because of the quantity it means you have to take around 15~ bites of it to eat it entirely, so there is no "I didn't mean to eat it!" anymore, and if someone force feeds you, you have ample time to walk away.

The organs all get grinded into nutriment by default, so as long as nobody overwrites it later we're not giving out the ability to get "GreyMatter".

The only concern I have is the fact we don't reallyyy have a way to heal cellular damage, but its so small from one bite I am unsure if its a big issue for accidentally and it will stop people from eating them "for funny", probably needs discussed though.

## Why / Balance
Meant to discourage people from doing something that can become an RP issue really quickly.

## Technical details
Increased max vol and then filled it with grey matter, did the same to entities that would have overwritten it.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl: PursuitinAshes
- tweak: Organs will now cause 75 units of grey matter to appear in your system, best to avoid eating them now.
