### PR TITLE
Two tiny xeno interaction/acid fixes

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Wallmounts/extinguisher_cabinet.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Wallmounts/extinguisher_cabinet.yml
@@ -16,6 +16,11 @@
         visible: true
       - state: closed
         map: ["enum.OpenableVisuals.Layer"]
+    - type: InteractedBlacklist
+      blacklist:
+        components:
+        - Xeno
+    - type: Corrodible
 
 - type: entity
   parent: RMCExtinguisherCabinet

--- a/Resources/Prototypes/_RMC14/Entities/Structures/rmc_atmos_props.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/rmc_atmos_props.yml
@@ -156,6 +156,7 @@
             collection: MetalBreak
         - !type:DoActsBehavior
           acts: ["Destruction"]
+  - type: Corrodible
 
 - type: entity
   id: RMCRadiatorRed


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Make radiators and fire extinguisher cabinets corrodible, and make fire extinguisher cabinets unable to be interacted with by xenos


## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity

## Technical details
<!-- Summary of code changes for easier review. -->
Yaml

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed Not being able to melt radiators and extinguisher cabinets, and make extinguisher cabinets uninteractable for xenos
