### PR TITLE
Tutorial Helpers (Work-In-Progress)

### DIFF
--- a/Content.Server/_RMC14/Tutorial/RMCTutorialAnnouncementComponent.cs
+++ b/Content.Server/_RMC14/Tutorial/RMCTutorialAnnouncementComponent.cs
@@ -14,5 +14,6 @@ public sealed partial class RMCTutorialAnnouncementComponent: Component
     [DataField]
     public string Sender = "Lt. Urist R. McHands";
 
+    [DataField]
     public bool HasTriggered = false;
 }

--- a/Content.Server/_RMC14/Tutorial/RMCTutorialAnnouncementComponent.cs
+++ b/Content.Server/_RMC14/Tutorial/RMCTutorialAnnouncementComponent.cs
@@ -6,14 +6,6 @@ namespace Content.Server._RMC14.Tutorial;
 [RegisterComponent]
 public sealed partial class RMCTutorialAnnouncementComponent: Component
 {
-    // List of components to strip from the owning Entity. (Used to make entity immortable/unaffectable)
-    [DataField]
-    public ComponentRegistry? RemoveComponents;
-
-    // Factions allowed to trigger Voicelines.
-    [DataField]
-    public HashSet<ProtoId<NpcFactionPrototype>> Factions = new();
-
     // Announcement Body Text
     [DataField]
     public string Text = "";

--- a/Content.Server/_RMC14/Tutorial/RMCTutorialAnnouncementComponent.cs
+++ b/Content.Server/_RMC14/Tutorial/RMCTutorialAnnouncementComponent.cs
@@ -1,0 +1,26 @@
+﻿using Content.Shared.NPC.Prototypes;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._RMC14.Tutorial;
+
+[RegisterComponent]
+public sealed partial class RMCTutorialAnnouncementComponent: Component
+{
+    // List of components to strip from the owning Entity. (Used to make entity immortable/unaffectable)
+    [DataField]
+    public ComponentRegistry? RemoveComponents;
+
+    // Factions allowed to trigger Voicelines.
+    [DataField]
+    public HashSet<ProtoId<NpcFactionPrototype>> Factions = new();
+
+    // Announcement Body Text
+    [DataField]
+    public string Text = "";
+
+    // Announcement Sender Text (For Marine announcements)
+    [DataField]
+    public string Sender = "Lt. Urist R. McHands";
+
+    public bool HasTriggered = false;
+}

--- a/Content.Server/_RMC14/Tutorial/RMCTutorialAnnouncementSystem.cs
+++ b/Content.Server/_RMC14/Tutorial/RMCTutorialAnnouncementSystem.cs
@@ -29,7 +29,7 @@ public sealed partial class RMCTutorialAnnouncementSystem : EntitySystem
             return;
         var subject = args.OtherEntity;
         // Ensure entity has a faction.
-        if (!TryComp<RMCTutorialDummyComponent>(subject, out var tutComp) || !TryComp<NpcFactionMemberComponent>(subject, out var factionComp))
+        if (!TryComp<RMCTutorialDummyComponent>(uid, out var tutComp) || !TryComp<NpcFactionMemberComponent>(subject, out var factionComp))
             return;
         // Ensures triggering entity is a member of the wanted faction
         if (!factionComp.Factions.Any(faction => tutComp.Factions.Contains(faction)))

--- a/Content.Server/_RMC14/Tutorial/RMCTutorialAnnouncementSystem.cs
+++ b/Content.Server/_RMC14/Tutorial/RMCTutorialAnnouncementSystem.cs
@@ -1,0 +1,81 @@
+﻿using System.Linq;
+using Content.Server._RMC14.Marines;
+using Content.Shared._RMC14.Bioscan;
+using Content.Shared._RMC14.Marines;
+using Content.Shared._RMC14.Xenonids;
+using Content.Shared._RMC14.Xenonids.Announce;
+using Content.Shared.NPC.Components;
+using Robust.Shared.Physics.Events;
+using Robust.Shared.Player;
+using Robust.Shared.Utility;
+
+namespace Content.Server._RMC14.Tutorial;
+
+public sealed partial class RMCTutorialAnnouncementSystem : EntitySystem
+{
+    [Dependency] private readonly SharedXenoAnnounceSystem _xenoAnnounceSystem = default!;
+    [Dependency] private readonly MarineAnnounceSystem _marineAnnounceSystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<RMCTutorialAnnouncementComponent, StartCollideEvent>(OnCollide);
+        SubscribeLocalEvent<RMCTutorialAnnouncementComponent, ComponentStartup>(OnStartup);
+    }
+
+    private void OnStartup(Entity<RMCTutorialAnnouncementComponent> ent, ref ComponentStartup args)
+    {
+        if (ent.Comp.RemoveComponents != null)
+            EntityManager.RemoveComponents(ent.Owner, ent.Comp.RemoveComponents);
+    }
+
+    private void OnCollide(EntityUid uid, RMCTutorialAnnouncementComponent component, ref StartCollideEvent args)
+    {
+        // Prevent repeat triggering.
+        if (component.HasTriggered)
+            return;
+        var subject = args.OtherEntity;
+        // Ensure entity has a faction.
+        if (!TryComp<NpcFactionMemberComponent>(subject, out var factionComp))
+            return;
+        // Ensures triggering entity is a member of the wanted faction
+        if (!factionComp.Factions.Any(faction => component.Factions.Contains(faction)))
+            return;
+
+        // Marine style signed announcement
+        if (TryComp<MarineComponent>(subject, out var marineComp))
+        {
+            // Format like a signed command announcement with signature and all that crap.
+            var formatted = Loc.GetString("rmc-announcement-message-signed", ("author", Loc.GetString("rmc-announcement-author")), ("message", component.Text), ("name", component.Sender));
+
+            // Actually trigger a private announcement to the user.
+            _marineAnnounceSystem.AnnounceToMarines(
+                message: formatted,
+                sound: null,
+                filter: Filter.Entities(subject)
+            );
+            component.HasTriggered = true;
+            return;
+        }
+        // Xeno style Queen announcement
+        if (TryComp<XenoComponent>(subject, out var xenoComp))
+        {
+            // Format like a Words of the Queen announcement (because for some reason that's not a preset)
+            var headerText = Loc.GetString("rmc-xeno-words-of-the-queen-header");
+            var formatted = FormattedMessage.EscapeText(component.Text);
+            var header = $"{_xenoAnnounceSystem.WrapHive(headerText)}";
+            var wrapped = $"{header}[color=red][font size=14][bold]{formatted}[/bold][/font][/color]";
+
+            // Actually trigger a private announcement to the user.
+            _xenoAnnounceSystem.Announce(
+                source: default,
+                filter: Filter.Entities(subject),
+                message: component.Text,
+                wrapped: wrapped,
+                sound: new BioscanComponent().XenoSound
+            );
+            component.HasTriggered = true;
+            return;
+        }
+    }
+}

--- a/Content.Server/_RMC14/Tutorial/RMCTutorialAnnouncementSystem.cs
+++ b/Content.Server/_RMC14/Tutorial/RMCTutorialAnnouncementSystem.cs
@@ -20,13 +20,6 @@ public sealed partial class RMCTutorialAnnouncementSystem : EntitySystem
     {
         base.Initialize();
         SubscribeLocalEvent<RMCTutorialAnnouncementComponent, StartCollideEvent>(OnCollide);
-        SubscribeLocalEvent<RMCTutorialAnnouncementComponent, ComponentStartup>(OnStartup);
-    }
-
-    private void OnStartup(Entity<RMCTutorialAnnouncementComponent> ent, ref ComponentStartup args)
-    {
-        if (ent.Comp.RemoveComponents != null)
-            EntityManager.RemoveComponents(ent.Owner, ent.Comp.RemoveComponents);
     }
 
     private void OnCollide(EntityUid uid, RMCTutorialAnnouncementComponent component, ref StartCollideEvent args)
@@ -36,10 +29,10 @@ public sealed partial class RMCTutorialAnnouncementSystem : EntitySystem
             return;
         var subject = args.OtherEntity;
         // Ensure entity has a faction.
-        if (!TryComp<NpcFactionMemberComponent>(subject, out var factionComp))
+        if (!TryComp<RMCTutorialDummyComponent>(subject, out var tutComp) || !TryComp<NpcFactionMemberComponent>(subject, out var factionComp))
             return;
         // Ensures triggering entity is a member of the wanted faction
-        if (!factionComp.Factions.Any(faction => component.Factions.Contains(faction)))
+        if (!factionComp.Factions.Any(faction => tutComp.Factions.Contains(faction)))
             return;
 
         // Marine style signed announcement

--- a/Content.Server/_RMC14/Tutorial/RMCTutorialDummyComponent.cs
+++ b/Content.Server/_RMC14/Tutorial/RMCTutorialDummyComponent.cs
@@ -1,0 +1,16 @@
+﻿using Content.Shared.NPC.Prototypes;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._RMC14.Tutorial;
+
+[RegisterComponent]
+public sealed partial class RMCTutorialDummyComponent: Component
+{
+    // List of components to strip from the owning Entity. (Used to make entity immortable/unaffectable)
+    [DataField]
+    public ComponentRegistry? RemoveComponents;
+
+    // Factions allowed to trigger Voicelines.
+    [DataField]
+    public HashSet<ProtoId<NpcFactionPrototype>> Factions = new();
+}

--- a/Content.Server/_RMC14/Tutorial/RMCTutorialDummySystem.cs
+++ b/Content.Server/_RMC14/Tutorial/RMCTutorialDummySystem.cs
@@ -1,0 +1,16 @@
+﻿namespace Content.Server._RMC14.Tutorial;
+
+public sealed partial class RMCTutorialDummySystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<RMCTutorialDummyComponent, ComponentStartup>(OnStartup);
+    }
+
+    private void OnStartup(Entity<RMCTutorialDummyComponent> ent, ref ComponentStartup args)
+    {
+        if (ent.Comp.RemoveComponents != null)
+            EntityManager.RemoveComponents(ent.Owner, ent.Comp.RemoveComponents);
+    }
+}

--- a/Content.Server/_RMC14/Tutorial/RMCTutorialNPCComponent.cs
+++ b/Content.Server/_RMC14/Tutorial/RMCTutorialNPCComponent.cs
@@ -1,0 +1,39 @@
+﻿using Content.Shared.NPC.Prototypes;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._RMC14.Tutorial;
+
+[RegisterComponent]
+public sealed partial class RMCTutorialNPCComponent: Component
+{
+    // List of components to strip from the owning Entity. (Used to make entity immortable/unaffectable)
+    [DataField]
+    public ComponentRegistry? RemoveComponents;
+
+    // Factions allowed to trigger Voicelines.
+    [DataField]
+    public HashSet<ProtoId<NpcFactionPrototype>> Factions = new();
+
+    // List of messages for the NPC to state
+    [DataField]
+    public List<string> Voicelines = [];
+
+    // Current voiceline index from Voicelines
+    public int LineIndex = -1;
+
+    // Set the seconds delay between the next voiceline, set to 0 to require manually retriggering.
+    [DataField]
+    public int LineDelay = 3;
+
+    // Should the NPC automatically move onto the next voiceline as long as the player is near.
+    [DataField]
+    public bool AutoLine = true;
+
+    public TimeSpan TimeSinceLastLine = TimeSpan.Zero;
+
+    // Set the seconds delay before allowing the voicelines to be repeated, set to 0 to disable repeats.
+    [DataField]
+    public int ResetDelay = 10;
+
+    public TimeSpan TimeSinceEnd = TimeSpan.Zero;
+}

--- a/Content.Server/_RMC14/Tutorial/RMCTutorialNPCComponent.cs
+++ b/Content.Server/_RMC14/Tutorial/RMCTutorialNPCComponent.cs
@@ -1,19 +1,8 @@
-﻿using Content.Shared.NPC.Prototypes;
-using Robust.Shared.Prototypes;
-
-namespace Content.Server._RMC14.Tutorial;
+﻿namespace Content.Server._RMC14.Tutorial;
 
 [RegisterComponent]
 public sealed partial class RMCTutorialNPCComponent: Component
 {
-    // List of components to strip from the owning Entity. (Used to make entity immortable/unaffectable)
-    [DataField]
-    public ComponentRegistry? RemoveComponents;
-
-    // Factions allowed to trigger Voicelines.
-    [DataField]
-    public HashSet<ProtoId<NpcFactionPrototype>> Factions = new();
-
     // List of messages for the NPC to state
     [DataField]
     public List<string> Voicelines = [];

--- a/Content.Server/_RMC14/Tutorial/RMCTutorialNPCSystem.cs
+++ b/Content.Server/_RMC14/Tutorial/RMCTutorialNPCSystem.cs
@@ -24,9 +24,6 @@ public sealed partial class RMCTutorialNPCSystem : EntitySystem
 
     private void OnStartup(Entity<RMCTutorialNPCComponent> ent, ref ComponentStartup args)
     {
-        if (ent.Comp.RemoveComponents != null)
-            EntityManager.RemoveComponents(ent.Owner, ent.Comp.RemoveComponents);
-
         // Can't set gender via component as it gets overwritten on spawn.
         if (TryComp<GrammarComponent>(ent.Owner, out var grammar))
         {
@@ -38,9 +35,9 @@ public sealed partial class RMCTutorialNPCSystem : EntitySystem
     {
         // Ensures triggering entity is a member of a given faction.
         var subject = args.OtherEntity;
-        if (!TryComp<NpcFactionMemberComponent>(subject, out var factionComp))
+        if (!TryComp<RMCTutorialDummyComponent>(subject, out var tutComp) || !TryComp<NpcFactionMemberComponent>(subject, out var factionComp))
             return;
-        if (!EntityManager.System<NpcFactionSystem>().IsMemberOfAny(uid, component.Factions))
+        if (!EntityManager.System<NpcFactionSystem>().IsMemberOfAny(uid, tutComp.Factions))
             return;
 
         // If it hasn't yet started, set initial Index

--- a/Content.Server/_RMC14/Tutorial/RMCTutorialNPCSystem.cs
+++ b/Content.Server/_RMC14/Tutorial/RMCTutorialNPCSystem.cs
@@ -1,0 +1,96 @@
+﻿using System.Linq;
+using System.Timers;
+using Content.Server.Chat.Systems;
+using Content.Shared._RMC14.Marines;
+using Content.Shared.NPC.Components;
+using Content.Shared.NPC.Systems;
+using Robust.Shared.Enums;
+using Robust.Shared.GameObjects.Components.Localization;
+using Robust.Shared.Physics.Events;
+using Robust.Shared.Timing;
+using SQLitePCL;
+
+namespace Content.Server._RMC14.Tutorial;
+
+public sealed partial class RMCTutorialNPCSystem : EntitySystem
+{
+    [Dependency] private readonly GrammarSystem _grammarSystem = default!;
+    [Dependency] private readonly ChatSystem _chat = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<RMCTutorialNPCComponent, ComponentStartup>(OnStartup);
+        SubscribeLocalEvent<RMCTutorialNPCComponent, StartCollideEvent>(OnCollide);
+    }
+
+    private void OnStartup(Entity<RMCTutorialNPCComponent> ent, ref ComponentStartup args)
+    {
+        if (ent.Comp.RemoveComponents != null)
+            EntityManager.RemoveComponents(ent.Owner, ent.Comp.RemoveComponents);
+
+        // Can't set gender via component as it gets overwritten on spawn.
+        if (TryComp<GrammarComponent>(ent.Owner, out var grammar))
+        {
+            _grammarSystem.SetGender((ent.Owner, grammar), Gender.Epicene);
+        }
+    }
+
+    private void OnCollide(EntityUid uid, RMCTutorialNPCComponent component, ref StartCollideEvent args)
+    {
+        // Ensures triggering entity is a member of a given faction.
+        var subject = args.OtherEntity;
+        if (!TryComp<NpcFactionMemberComponent>(subject, out var factionComp))
+            return;
+        if (!EntityManager.System<NpcFactionSystem>().IsMemberOfAny(uid, component.Factions))
+            return;
+
+        // If it hasn't yet started, set initial Index
+        if (component.LineIndex < 0)
+            component.LineIndex = 0;
+
+        if (!component.AutoLine)
+            SayNextVoiceline(uid, component);
+    }
+
+    public override void Update(float frameTime)
+    {
+        var tutorialNPCQuery = EntityQueryEnumerator<RMCTutorialNPCComponent>();
+
+        while (tutorialNPCQuery.MoveNext(out var uid, out var component))
+        {
+            if (component.AutoLine)
+                SayNextVoiceline(uid, component);
+        }
+        base.Update(frameTime);
+    }
+
+    private void SayNextVoiceline(EntityUid uid, RMCTutorialNPCComponent component)
+    {
+        // Prevent line if index is out of range
+        if ((component.LineIndex >= component.Voicelines.Count) || (component.LineIndex < 0))
+            return;
+
+        // Limits triggering to the delay times set in component
+        if (_timing.CurTime < (component.TimeSinceLastLine + TimeSpan.FromSeconds(component.LineDelay)) ||
+            _timing.CurTime < (component.TimeSinceEnd +  TimeSpan.FromSeconds(component.ResetDelay)) )
+            return;
+
+        // Send next voiceline and update state.
+        _chat.TrySendInGameICMessage(uid, component.Voicelines[component.LineIndex], InGameICChatType.Speak, ChatTransmitRange.Normal);
+        component.LineIndex += 1;
+        component.TimeSinceLastLine = _timing.CurTime;
+
+        // If at end of the dialogue, note the end time
+        if (component.LineIndex == component.Voicelines.Count)
+        {
+            component.TimeSinceEnd = _timing.CurTime;
+            Log.Info($"{component.ResetDelay}, {component.LineIndex}");
+            // Reset index to start if looping is enabled, else leave out of index to prevent looping
+            if (component.ResetDelay > 0)
+                component.LineIndex = -1;
+        }
+    }
+}

--- a/Content.Server/_RMC14/Tutorial/RMCTutorialNPCSystem.cs
+++ b/Content.Server/_RMC14/Tutorial/RMCTutorialNPCSystem.cs
@@ -1,14 +1,10 @@
-﻿using System.Linq;
-using System.Timers;
-using Content.Server.Chat.Systems;
-using Content.Shared._RMC14.Marines;
+﻿using Content.Server.Chat.Systems;
 using Content.Shared.NPC.Components;
 using Content.Shared.NPC.Systems;
 using Robust.Shared.Enums;
 using Robust.Shared.GameObjects.Components.Localization;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Timing;
-using SQLitePCL;
 
 namespace Content.Server._RMC14.Tutorial;
 

--- a/Content.Server/_RMC14/Tutorial/RMCTutorialSpawnerComponent.cs
+++ b/Content.Server/_RMC14/Tutorial/RMCTutorialSpawnerComponent.cs
@@ -1,0 +1,25 @@
+﻿using Content.Shared.NPC.Prototypes;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._RMC14.Tutorial;
+
+[RegisterComponent]
+public sealed partial class RMCTutorialSpawnerComponent: Component
+{
+    // The entity proto you want to spawn when triggered
+    [DataField]
+    public EntProtoId SpawnPrototype;
+
+    // Amount of the entity to spawn when triggered
+    [DataField]
+    public int SpawnCount = 1;
+
+    // Offset to apply from spawner position
+    [DataField]
+    public int SpawnOffsetX = 0;
+    [DataField]
+    public int SpawnOffsetY = 0;
+
+    [DataField]
+    public bool HasTriggered = false;
+}

--- a/Content.Server/_RMC14/Tutorial/RMCTutorialSpawnerSystem.cs
+++ b/Content.Server/_RMC14/Tutorial/RMCTutorialSpawnerSystem.cs
@@ -1,0 +1,45 @@
+﻿using System.Linq;
+using Content.Shared.NPC.Components;
+using Robust.Shared.Map;
+using Robust.Shared.Physics.Events;
+
+namespace Content.Server._RMC14.Tutorial;
+
+public sealed partial class RMCTutorialSpawnerSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<RMCTutorialSpawnerComponent, StartCollideEvent>(OnCollide);
+    }
+
+    private void OnCollide(EntityUid uid, RMCTutorialSpawnerComponent component, ref StartCollideEvent args)
+    {
+        // Prevent repeat triggering.
+        if (component.HasTriggered)
+            return;
+
+        var subject = args.OtherEntity;
+        // Ensure entity has a faction.
+        if (!TryComp<RMCTutorialDummyComponent>(uid, out var tutComp) ||
+            !TryComp<NpcFactionMemberComponent>(subject, out var factionComp))
+            return;
+
+        // Ensures triggering entity is a member of the wanted faction
+        if (!factionComp.Factions.Any(faction => tutComp.Factions.Contains(faction)))
+            return;
+
+        var currentPos = Transform(uid).Coordinates;
+        var newPos = new EntityCoordinates(currentPos.EntityId,
+            currentPos.X + component.SpawnOffsetX,
+            currentPos.Y + component.SpawnOffsetY);
+
+        for (int i = 0; i < component.SpawnCount; i++)
+        {
+            SpawnAtPosition(component.SpawnPrototype, newPos);
+        }
+
+        component.HasTriggered = true;
+        Log.Info($"Done");
+    }
+}

--- a/Resources/Prototypes/_RMC14/Tutorial/scenarios/new_xeno.yml
+++ b/Resources/Prototypes/_RMC14/Tutorial/scenarios/new_xeno.yml
@@ -18,10 +18,11 @@
   components:
   - type: DropshipAmmo
     travelTime: 0
+
     explosion:
-      total: 400
+      total: 200
       slope: 10
-      max: 55
+      max: 4
 
 - type: entity
   parent: RMCDropshipMissileExplosionNapalm
@@ -39,7 +40,7 @@
       range: 1
       cardinalRange: 2
 
-# Visual CAS flare, does not work
+# Scripted CAS flare, fires "fake" missile when entered
 - type: entity
   id: RMCTutorialCASFlare
   name: signal flare
@@ -71,13 +72,29 @@
     bodyType: Static
   - type: AmbientSound
     enabled: true
-    volume: 1
-    range: 5
+    volume: 0.5
+    range: 4
     sound:
       path: /Audio/Items/Flare/flare_burn.ogg
       params:
         loop: true
-
+  - type: RMCTutorialSpawner
+    spawnPrototype: RMCTutorialWidowmakerExplosion
+    spawnOffsetY: 0
+  - type: RMCTutorialDummy
+    factions:
+    - RMCXeno
+  - type: Fixtures
+    fixtures:
+      tutorialTrigger:
+        shape:
+          !type:PhysShapeCircle
+          radius: 2
+        mask:
+        - MobMask
+        layer:
+        - MobLayer
+        hard: false
 
 # Dummy Hivelord that should be really easy to kill
 - type: entity

--- a/Resources/Prototypes/_RMC14/Tutorial/scenarios/new_xeno.yml
+++ b/Resources/Prototypes/_RMC14/Tutorial/scenarios/new_xeno.yml
@@ -1,0 +1,97 @@
+﻿# Sentry that does very little damage
+- type: entity
+  parent: RMCSentry
+  id: RMCTutorialSentry
+  suffix: Tutorial
+  components:
+  - type: RMCTutorialDummy
+    removeComponents:
+    - type: Destructible
+  - type: GunDamageModifier
+    multiplier: 0.1
+
+# Fake Missiles that does very little damage to show off CAS
+- type: entity
+  parent: RMCDropshipMissileExplosionWidowmaker
+  id: RMCTutorialWidowmakerExplosion
+  suffix: Tutorial
+  components:
+  - type: DropshipAmmo
+    travelTime: 0
+    explosion:
+      total: 400
+      slope: 10
+      max: 55
+
+- type: entity
+  parent: RMCDropshipMissileExplosionNapalm
+  id: RMCTutorialNapalmExplosion
+  suffix: Tutorial
+  components:
+  - type: DropshipAmmo
+    travelTime: 0
+    explosion:
+      total: 30
+      slope: 3
+      max: 30
+    fire:
+      type: RMCTileFireNapalm
+      range: 1
+      cardinalRange: 2
+
+# Visual CAS flare, does not work
+- type: entity
+  id: RMCTutorialCASFlare
+  name: signal flare
+  suffix: Tutorial
+  description: A green UNMC issued signal flare. The telemetry computer works on chemical reaction that releases smoke and light and thus works only while the flare is burning.
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Misc/cas_flares.rsi
+    layers:
+    - map: [ "enum.ExpendableLightVisualLayers.Base" ]
+      state: flare
+    - map: [ "enum.ExpendableLightVisualLayers.Glow" ]
+      sprite: _RMC14/Objects/Misc/cas_flares.rsi
+      state: flare_flame
+      color: "#A7FFA7"
+    - map: [ "enum.ExpendableLightVisualLayers.Overlay" ]
+      sprite: _RMC14/Objects/Misc/cas_flares.rsi
+      state: overlay
+  - type: Icon
+    sprite: _RMC14/Objects/Misc/cas_flares.rsi
+    state: flare
+  - type: PointLight
+    enabled: true
+    radius: 1
+    energy: 5.0
+    netsync: false
+    color: "#AACCAA"
+  - type: Physics
+    bodyType: Static
+  - type: AmbientSound
+    enabled: true
+    volume: 1
+    range: 5
+    sound:
+      path: /Audio/Items/Flare/flare_burn.ogg
+      params:
+        loop: true
+
+
+# Dummy Hivelord that should be really easy to kill
+- type: entity
+  parent: CMXenoHivelord
+  id: RMCTutorialHivelordDeathProp
+  suffix: Tutorial
+  components:
+  - type: RMCTutorialDummy
+    removeComponents:
+    - type: GhostRole
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      40: Critical
+      80: Dead
+  - type: CMArmor
+    explosionArmor: 0

--- a/Resources/Prototypes/_RMC14/Tutorial/tutorial_announcer.yml
+++ b/Resources/Prototypes/_RMC14/Tutorial/tutorial_announcer.yml
@@ -17,17 +17,19 @@
         layer:
         - MobLayer
         hard: false
-  - type: RMCTutorialAnnouncement
-    text: "This is a test announcement"
+  - type: RMCTutorialDummy
     factions:
     - UNMC
+  - type: RMCTutorialAnnouncement
+    text: "This is a test announcement"
 
 - type: entity
   parent: RMCBaseTutorialAnnouncer
   id: RMCBaseTutorialAnnouncer2
   suffix: RMC14 2
   components:
-  - type: RMCTutorialAnnouncement
-    text: "Xibidi"
+  - type: RMCTutorialDummy
     factions:
     - RMCXeno
+  - type: RMCTutorialAnnouncement
+    text: "Xibidi"

--- a/Resources/Prototypes/_RMC14/Tutorial/tutorial_announcer.yml
+++ b/Resources/Prototypes/_RMC14/Tutorial/tutorial_announcer.yml
@@ -1,0 +1,33 @@
+﻿- type: entity
+  id: RMCBaseTutorialAnnouncer
+  name: RMC Tutorial Announcer Zone
+  description: A trigger zone that plays an announcement to the player that enters it. (One time use)
+  suffix: RMC14
+  components:
+  - type: Physics
+    bodyType: Static
+  - type: Fixtures
+    fixtures:
+      tutorialTrigger:
+        shape:
+          !type:PhysShapeCircle
+          radius: 2
+        mask:
+        - MobMask
+        layer:
+        - MobLayer
+        hard: false
+  - type: RMCTutorialAnnouncement
+    text: "This is a test announcement"
+    factions:
+    - UNMC
+
+- type: entity
+  parent: RMCBaseTutorialAnnouncer
+  id: RMCBaseTutorialAnnouncer2
+  suffix: RMC14 2
+  components:
+  - type: RMCTutorialAnnouncement
+    text: "Xibidi"
+    factions:
+    - RMCXeno

--- a/Resources/Prototypes/_RMC14/Tutorial/tutorial_npc.yml
+++ b/Resources/Prototypes/_RMC14/Tutorial/tutorial_npc.yml
@@ -24,7 +24,7 @@
         layer:
         - MobLayer
         hard: false
-  - type: RMCTutorialNPC
+  - type: RMCTutorialDummy
     removeComponents:
     - type: CanEnterCryostorage
     - type: CommendationReceiver
@@ -50,6 +50,8 @@
     - type: Strippable
     factions:
     - UNMC
+
+  - type: RMCTutorialNPC
     voicelines:
     - "Rise and shine, soldier! Get up and get tactical!"
     - "You've just woken up, so you're hungry. Head to the food vendor, dispense two meals from the machine and get them down your neck. If you have complaints about the food, you can address them to someone who gives a damn!"

--- a/Resources/Prototypes/_RMC14/Tutorial/tutorial_npc.yml
+++ b/Resources/Prototypes/_RMC14/Tutorial/tutorial_npc.yml
@@ -1,0 +1,98 @@
+﻿- type: entity
+  parent: RMCBaseMobSpeciesOrganic
+  id: RMCTutorialNPC
+  name: SgtMaj. Urist R. McMarine
+  description: A Senior Enlisted Advisor tasked with training new recruits to the United Nations Marine Corps.
+  suffix: RMC14
+  components:
+  - type: Loadout
+    prototypes: [ RMCGearTutorialNPC ]
+  - type: FixedIdentity
+    name: cm-chatsan-replacement-synthetic
+  - type: Physics
+    bodyType: Static
+  - type: StatusEffects
+    allowed: []
+  - type: Fixtures
+    fixtures:
+      tutorialTrigger:
+        shape:
+          !type:PhysShapeCircle
+          radius: 3
+        mask:
+        - MobMask
+        layer:
+        - MobLayer
+        hard: false
+  - type: RMCTutorialNPC
+    removeComponents:
+    - type: CanEnterCryostorage
+    - type: CommendationReceiver
+    - type: Hunger
+    - type: Infectable
+    - type: Marine
+    - type: MarineMapTracked
+    - type: MindContainer
+    - type: NewPlayerLabel
+    - type: Perishable
+    - type: RMCRevivable
+    - type: SSDIndicator
+    - type: TacticalMapTracked
+    - type: Thirst
+    - type: Damageable
+    - type: CMSurgeryTarget
+    - type: RMCDisarmable
+    - type: Infectable
+    - type: Tackleable
+    - type: XenoNestable
+    - type: Devourable
+    - type: EmoteCooldown
+    - type: Strippable
+    factions:
+    - UNMC
+    voicelines:
+    - "Rise and shine, soldier! Get up and get tactical!"
+    - "You've just woken up, so you're hungry. Head to the food vendor, dispense two meals from the machine and get them down your neck. If you have complaints about the food, you can address them to someone who gives a damn!"
+    - "You can't bring those trays with you, so leave them on a nearby table or throw them into the disposals. God help you if I catch you throwing them anywhere else!"
+    lineDelay: 3
+    resetDelay: 8
+
+
+- type: startingGear
+  id: RMCGearTutorialNPC
+  equipment:
+    jumpsuit: CMJumpsuitBO
+    shoes: CMBootsBrownFilled
+    head: CMHeadCapDrill
+    id: CMIDCardSeniorEnlistedAdvisor
+    ears: RMCHeadsetSEA
+
+
+- type: entity
+  parent: RMCTutorialNPC
+  id: RMCTutorialNPC2
+  suffix: RMC14 2
+  components:
+  - type: RMCTutorialNPC
+    voicelines:
+    - "MARINE! You cannot fight in your shorts! Get dressed! DOUBLE TIME!!"
+    - "Haul your ass to the automated equipment vendor and get your uniform on. Click on the vending machine, and then click the 'Standard Marine Apparel'."
+    - "This will give you your uniform, including undersuit, boots, gloves, helmet, and headset - and you will wear them at ALL TIMES."
+    - "Take note of the colors on your helmet, they denote your squad."
+    lineDelay: 5
+    resetDelay: 0
+
+- type: entity
+  parent: RMCTutorialNPC
+  id: RMCTutorialNPC3
+  suffix: RMC14 3
+  components:
+  - type: RMCTutorialNPC
+    voicelines:
+    - "You now have your choice of equipment. You will only be dispensed one item per category (two for pouches) so choose carefully. Anything marked in Green is recommended for your role."
+    - "Grab yourself some light or medium armor, an M276 Ammo Load Rig, some first aid pouches, and a gas mask or coif if you so desire."
+    - "You have 45 points to spend on extra equipment, such as grenades, tools, or special ammo! Each item has its own point cost and some items are better value than others."
+    - "For now, grab some extended or armor-piercing magazines for the M54C and store them in your belt."
+    autoLine: false
+    lineDelay: 1
+    resetDelay: 0

--- a/Resources/Prototypes/_RMC14/Tutorial/tutorial_npc.yml
+++ b/Resources/Prototypes/_RMC14/Tutorial/tutorial_npc.yml
@@ -1,6 +1,6 @@
 ﻿- type: entity
   parent: RMCBaseMobSpeciesOrganic
-  id: RMCTutorialNPC
+  id: RMCBaseTutorialNPC
   name: SgtMaj. Urist R. McMarine
   description: A Senior Enlisted Advisor tasked with training new recruits to the United Nations Marine Corps.
   suffix: RMC14
@@ -69,7 +69,7 @@
 
 
 - type: entity
-  parent: RMCTutorialNPC
+  parent: RMCBaseTutorialNPC
   id: RMCTutorialNPC2
   suffix: RMC14 2
   components:
@@ -79,11 +79,9 @@
     - "Haul your ass to the automated equipment vendor and get your uniform on. Click on the vending machine, and then click the 'Standard Marine Apparel'."
     - "This will give you your uniform, including undersuit, boots, gloves, helmet, and headset - and you will wear them at ALL TIMES."
     - "Take note of the colors on your helmet, they denote your squad."
-    lineDelay: 5
-    resetDelay: 0
 
 - type: entity
-  parent: RMCTutorialNPC
+  parent: RMCBaseTutorialNPC
   id: RMCTutorialNPC3
   suffix: RMC14 3
   components:


### PR DESCRIPTION
# THIS IS A WIP, I WILL BE AWAY FOR A WHILE BUT HERE IT IS.

## About the PR
Adds Tutorial Helper Components & Prototypes for mapping use only.
(Does not include mapping itself)


## Why / Balance
Should enable mappers to start building up tutorial maps.

## Technical details
Everything mappers need should be accessible via Components such as:

```cs
- type: RMCTutorialNPC
    voicelines:
    - "MARINE! You cannot fight in your shorts! Get dressed! DOUBLE TIME!!"
    - "Haul your ass to the automated equipment vendor and get your uniform on. Click on the vending machine, and then click the 'Standard Marine Apparel'."
    - "This will give you your uniform, including undersuit, boots, gloves, helmet, and headset - and you will wear them at ALL TIMES."
    - "Take note of the colors on your helmet, they denote your squad."
```

```cs
- type: RMCTutorialAnnouncement
    text: "Xibidi"
```

## Media
<img width="442" height="295" alt="image" src="https://github.com/user-attachments/assets/d6932f75-fcd8-4512-9a84-b5c4bdcada46" />
<img width="2560" height="1400" alt="image" src="https://github.com/user-attachments/assets/14c744b8-bddb-46a0-be84-1b9ca868e65e" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- add: Added Components & Entities for Tutorial Mapping