### PR TITLE
Secsurv no longer rolls for Riot in Progress RCTL

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/rmc_planets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/rmc_planets.yml
@@ -237,13 +237,11 @@
       - CMSurvivorFiorinaResearcher: 2
     survivorJobScenarios:
       riot_in_progress: # Riot In Progress CMB Team. One as the main CMB RCTL, the rest as supporting officers.
-        - CMSurvivorSecurity: 1
         - CMSurvivor: -1
     survivorJobVariantScenarios:
       riot_in_progress: # Riot In Progress Riot Control team
-        CMSurvivorSecurity:
-        - RMCSurvivorFiorinaRiotInProgressCMBRiotControlTeamLeader: 1
         CMSurvivor:
+        - RMCSurvivorFiorinaRiotInProgressCMBRiotControlTeamLeader: 1
         - RMCSurvivorFiorinaRiotInProgressCMBRiotControlOfficer: -1
     survivorJobOverrideScenarios:
       riot_in_progress: # Riot In Progress job overrides.
@@ -251,6 +249,7 @@
         CMSurvivorEngineer: CMSurvivor
         CMSurvivorDoctor: CMSurvivor
         CMSurvivorScientist: CMSurvivor
+        CMSurvivorSecurity: CMSurvivor
 
 - type: entity
   id: RMCPlanetTrijent


### PR DESCRIPTION
## About the PR
Security colonist now rolls for all Riot in Progress roles instead of only rolling for Team Lead

## Why / Balance
Whoever rolled security colonist on Fiorina when the Riot in Progress insert rolled is fighting for the single team lead slot, and even with all other roles on medium, since everyone else would have their preference overridden to high for the regular riot team members, security colonists would lose their roll no matter what if they failed to win team lead. Now everyone has an equal chance to win and it just picks a team leader randomly

## Technical details
yaml

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Security colonist job preference no longer rolls for Riot in Progress Riot Control Team Lead on Fiorina, that role is now picked randomly