### PR TITLE
Keep lifeboat hatches open during hijack evac

### DIFF
--- a/Content.Server/_RMC14/Evacuation/EvacuationSystem.cs
+++ b/Content.Server/_RMC14/Evacuation/EvacuationSystem.cs
@@ -43,7 +43,7 @@ public sealed class EvacuationSystem : SharedEvacuationSystem
             {
                 door.Locked = true;
                 Dirty(child, door);
-                TryDisableHijackDockedOpen(child);
+                TryDisableEvacuationOpen(child);
 
                 _doors.Clear();
                 _entityLookup.GetEntitiesInRange(child.ToCoordinates(), 2.5f, _doors);
@@ -51,7 +51,7 @@ public sealed class EvacuationSystem : SharedEvacuationSystem
                 {
                     nearbyDoor.Comp.Locked = true;
                     Dirty(nearbyDoor);
-                    TryDisableHijackDockedOpen(nearbyDoor);
+                    TryDisableEvacuationOpen(nearbyDoor);
                 }
             }
         }

--- a/Content.Server/_RMC14/Evacuation/EvacuationSystem.cs
+++ b/Content.Server/_RMC14/Evacuation/EvacuationSystem.cs
@@ -43,6 +43,7 @@ public sealed class EvacuationSystem : SharedEvacuationSystem
             {
                 door.Locked = true;
                 Dirty(child, door);
+                TryDisableHijackDockedOpen(child);
 
                 _doors.Clear();
                 _entityLookup.GetEntitiesInRange(child.ToCoordinates(), 2.5f, _doors);
@@ -50,6 +51,7 @@ public sealed class EvacuationSystem : SharedEvacuationSystem
                 {
                     nearbyDoor.Comp.Locked = true;
                     Dirty(nearbyDoor);
+                    TryDisableHijackDockedOpen(nearbyDoor);
                 }
             }
         }

--- a/Content.Shared/_RMC14/Evacuation/RMCOpenOnEvacuationComponent.cs
+++ b/Content.Shared/_RMC14/Evacuation/RMCOpenOnEvacuationComponent.cs
@@ -4,7 +4,7 @@ namespace Content.Shared._RMC14.Evacuation;
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 [Access(typeof(SharedEvacuationSystem))]
-public sealed partial class RMCOpenOnHijackDockedComponent : Component
+public sealed partial class RMCOpenOnEvacuationComponent : Component
 {
     [DataField, AutoNetworkedField]
     public bool Enabled;

--- a/Content.Shared/_RMC14/Evacuation/RMCOpenOnHijackDockedComponent.cs
+++ b/Content.Shared/_RMC14/Evacuation/RMCOpenOnHijackDockedComponent.cs
@@ -1,0 +1,11 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Evacuation;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(SharedEvacuationSystem))]
+public sealed partial class RMCOpenOnHijackDockedComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public bool Enabled;
+}

--- a/Content.Shared/_RMC14/Evacuation/SharedEvacuationSystem.cs
+++ b/Content.Shared/_RMC14/Evacuation/SharedEvacuationSystem.cs
@@ -115,6 +115,12 @@ public abstract class SharedEvacuationSystem : EntitySystem
         {
             door.Locked = false;
             Dirty(uid, door);
+
+            if (TryEnableHijackDockedOpen(uid) &&
+                _doorQuery.TryComp(uid, out var doorComp))
+            {
+                _door.TryOpen(uid, doorComp);
+            }
         }
 
         _config.SetCVar(CCVars.GameDisallowLateJoins, true);
@@ -221,6 +227,13 @@ public abstract class SharedEvacuationSystem : EntitySystem
 
     private void OnEvacuationDoorBeforeClosed(Entity<EvacuationDoorComponent> ent, ref BeforeDoorClosedEvent args)
     {
+        if (TryComp(ent, out RMCOpenOnHijackDockedComponent? openOnHijack) &&
+            openOnHijack.Enabled)
+        {
+            args.Cancel();
+            return;
+        }
+
         if (ent.Comp.Locked)
             args.PerformCollisionCheck = false;
     }
@@ -382,6 +395,32 @@ public abstract class SharedEvacuationSystem : EntitySystem
 
     protected virtual void LaunchEvacuationFTL(EntityUid grid, float crashLandChance, SoundSpecifier? launchSound)
     {
+    }
+
+    protected bool TryDisableHijackDockedOpen(EntityUid uid)
+    {
+        if (!TryComp(uid, out RMCOpenOnHijackDockedComponent? openOnHijack) ||
+            !openOnHijack.Enabled)
+        {
+            return false;
+        }
+
+        openOnHijack.Enabled = false;
+        Dirty(uid, openOnHijack);
+        return true;
+    }
+
+    private bool TryEnableHijackDockedOpen(EntityUid uid)
+    {
+        if (!TryComp(uid, out RMCOpenOnHijackDockedComponent? openOnHijack))
+            return false;
+
+        if (openOnHijack.Enabled)
+            return true;
+
+        openOnHijack.Enabled = true;
+        Dirty(uid, openOnHijack);
+        return true;
     }
 
     private void SetPumpAppearance(EvacuationPumpVisuals visual)

--- a/Content.Shared/_RMC14/Evacuation/SharedEvacuationSystem.cs
+++ b/Content.Shared/_RMC14/Evacuation/SharedEvacuationSystem.cs
@@ -115,13 +115,10 @@ public abstract class SharedEvacuationSystem : EntitySystem
         {
             door.Locked = false;
             Dirty(uid, door);
-
-            if (TryEnableHijackDockedOpen(uid) &&
-                _doorQuery.TryComp(uid, out var doorComp))
-            {
-                _door.TryOpen(uid, doorComp);
-            }
         }
+
+        if (IsEvacuationEnabled())
+            OpenEvacuationDoors();
 
         _config.SetCVar(CCVars.GameDisallowLateJoins, true);
     }
@@ -134,6 +131,8 @@ public abstract class SharedEvacuationSystem : EntitySystem
             computer.Enabled = true;
             Dirty(uid, computer);
         }
+
+        OpenEvacuationDoors();
 
         var evacuation = EntityQueryEnumerator<EvacuationComputerComponent>();
         while (evacuation.MoveNext(out var computerId, out var computer))
@@ -227,8 +226,8 @@ public abstract class SharedEvacuationSystem : EntitySystem
 
     private void OnEvacuationDoorBeforeClosed(Entity<EvacuationDoorComponent> ent, ref BeforeDoorClosedEvent args)
     {
-        if (TryComp(ent, out RMCOpenOnHijackDockedComponent? openOnHijack) &&
-            openOnHijack.Enabled)
+        if (TryComp(ent, out RMCOpenOnEvacuationComponent? openOnEvacuation) &&
+            openOnEvacuation.Enabled)
         {
             args.Cancel();
             return;
@@ -397,29 +396,44 @@ public abstract class SharedEvacuationSystem : EntitySystem
     {
     }
 
-    protected bool TryDisableHijackDockedOpen(EntityUid uid)
+    private void OpenEvacuationDoors()
     {
-        if (!TryComp(uid, out RMCOpenOnHijackDockedComponent? openOnHijack) ||
-            !openOnHijack.Enabled)
+        var doors = EntityQueryEnumerator<RMCOpenOnEvacuationComponent, DoorComponent>();
+        while (doors.MoveNext(out var uid, out _, out var door))
+        {
+            if (door.State is not DoorState.Open and not DoorState.Opening &&
+                !_door.TryOpen(uid, door))
+            {
+                continue;
+            }
+
+            TryEnableEvacuationOpen(uid);
+        }
+    }
+
+    protected bool TryDisableEvacuationOpen(EntityUid uid)
+    {
+        if (!TryComp(uid, out RMCOpenOnEvacuationComponent? openOnEvacuation) ||
+            !openOnEvacuation.Enabled)
         {
             return false;
         }
 
-        openOnHijack.Enabled = false;
-        Dirty(uid, openOnHijack);
+        openOnEvacuation.Enabled = false;
+        Dirty(uid, openOnEvacuation);
         return true;
     }
 
-    private bool TryEnableHijackDockedOpen(EntityUid uid)
+    private bool TryEnableEvacuationOpen(EntityUid uid)
     {
-        if (!TryComp(uid, out RMCOpenOnHijackDockedComponent? openOnHijack))
+        if (!TryComp(uid, out RMCOpenOnEvacuationComponent? openOnEvacuation))
             return false;
 
-        if (openOnHijack.Enabled)
+        if (openOnEvacuation.Enabled)
             return true;
 
-        openOnHijack.Enabled = true;
-        Dirty(uid, openOnHijack);
+        openOnEvacuation.Enabled = true;
+        Dirty(uid, openOnEvacuation);
         return true;
     }
 

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Doors/Airlocks/evacuation_airlocks.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Doors/Airlocks/evacuation_airlocks.yml
@@ -81,6 +81,7 @@
   - type: Sprite
     sprite: _RMC14/Structures/Lifeboat/lifeboat_doors.rsi
   - type: EvacuationDoor
+  - type: RMCOpenOnHijackDocked
   - type: Corrodible
     isCorrodible: true
   - type: ApcPowerReceiver

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Doors/Airlocks/evacuation_airlocks.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Doors/Airlocks/evacuation_airlocks.yml
@@ -81,7 +81,7 @@
   - type: Sprite
     sprite: _RMC14/Structures/Lifeboat/lifeboat_doors.rsi
   - type: EvacuationDoor
-  - type: RMCOpenOnHijackDocked
+  - type: RMCOpenOnEvacuation
   - type: Corrodible
     isCorrodible: true
   - type: ApcPowerReceiver


### PR DESCRIPTION
## About the PR
Makes large lifeboat docking hatches open when hijack evacuation is authorized, then stay open until the lifeboat launches.

## Why / Balance
During hijack evacuation, large lifeboat hatches could close again while the lifeboat was still docked, making boarding flow inconsistent. This now matches the intended evac flow more closely: the hatches are held open once evacuation is actually activated, not merely when the hijacked dropship lands.

## Technical details
Added `RMCOpenOnEvacuationComponent` for evacuation doors that should be held open during active evacuation. `RMCAirlockLifeboat` uses this component.

`DropshipHijackLandedEvent` still unlocks evacuation doors as before, but no longer opens lifeboat hatches by itself.

On `EvacuationEnabledEvent`, marked lifeboat hatches are opened and prevented from closing via `BeforeDoorClosedEvent`. If evacuation was already enabled before hijack landing, the hatches open after landing once the existing unlock logic runs.

When a lifeboat launches through `LaunchEvacuationFTL`, the hold-open state is cleared so existing launch/lock behavior continues normally.

## Media
No media required, logic-only door behavior fix.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
- fix: Fixed large lifeboat docking hatches closing during active hijack evacuation while the lifeboat is still docked.