### PR TITLE
Fixed three serious issues with xeno lag comp

### DIFF
--- a/Content.Shared/_RMC14/Movement/SharedRMCLagCompensationSystem.cs
+++ b/Content.Shared/_RMC14/Movement/SharedRMCLagCompensationSystem.cs
@@ -1,5 +1,6 @@
-﻿using Content.Shared._RMC14.CCVar;
+using Content.Shared._RMC14.CCVar;
 using Content.Shared.Coordinates;
+using Robust.Shared;
 using Robust.Shared.Configuration;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
@@ -22,8 +23,16 @@ public abstract class SharedRMCLagCompensationSystem : EntitySystem
     public float MarginTiles { get; private set; }
 
     private EntityQuery<ActorComponent> _actorQuery;
+    private int _substeps;
+    private float _substepTime;
+    // This contains _substeps + 1 items and is just an array of ratios
+    // representing how far into a frame each substep is. E.g. if there are four substeps
+    // the array would be [0.0f, 0.25f, 0.5f, 0.75f, 1.0f]
+    private float[] _substepMults = [];
+    private bool _logPrediction = false;
 
     private readonly Dictionary<NetUserId, GameTick> _lastRealTicks = new();
+
 
     public override void Initialize()
     {
@@ -34,11 +43,27 @@ public abstract class SharedRMCLagCompensationSystem : EntitySystem
         SubscribeNetworkEvent<RMCSetLastRealTickEvent>(OnSetLastRealTick);
 
         Subs.CVar(_config, RMCCVars.RMCLagCompensationMarginTiles, v => MarginTiles = v, true);
+        Subs.CVar(_config, CVars.NetTickrate, UpdateSubsteps, true);
+        Subs.CVar(_config, CVars.TargetMinimumTickrate, UpdateSubsteps, true);
     }
 
     private void OnSetLastRealTick(RMCSetLastRealTickEvent msg, EntitySessionEventArgs args)
     {
         SetLastRealTick(args.SenderSession.UserId, msg.Tick - 1);
+    }
+
+    private void UpdateSubsteps(int _)
+    {
+        // This is just ripped out from SharedPhysicsSystem
+        var targetMinTickrate = (float)_config.GetCVar(CVars.TargetMinimumTickrate);
+        var serverTickrate = (float)_config.GetCVar(CVars.NetTickrate);
+        _substeps = (int)Math.Ceiling(targetMinTickrate / serverTickrate);
+        _substepTime = 1.0f / serverTickrate / _substeps;
+
+        // Division is slow so we pre-calculate the multipliers we need here.
+        _substepMults = new float[_substeps + 1];
+        for (var i = 0; i <= _substeps; i++)
+            _substepMults[i] = (float)i / _substeps;
     }
 
     public virtual (EntityCoordinates Coordinates, Angle Angle) GetCoordinatesAngle(EntityUid uid,
@@ -110,7 +135,7 @@ public abstract class SharedRMCLagCompensationSystem : EntitySystem
         RaiseNetworkEvent(new RMCSetLastRealTickEvent(GetLastRealTick(null)));
     }
 
-    public bool Collides(Entity<FixturesComponent?> target, Entity<PhysicsComponent?> projectile, MapCoordinates targetCoordinates)
+    public bool Collides(Entity<FixturesComponent?> target, Entity<PhysicsComponent?> projectile, MapCoordinates targetCoordinates, int substep = 0)
     {
         if (!Resolve(target, ref target.Comp, false) ||
             !Resolve(projectile, ref projectile.Comp, false))
@@ -118,8 +143,12 @@ public abstract class SharedRMCLagCompensationSystem : EntitySystem
             return false;
         }
 
+        substep = Math.Clamp(substep, 0, _substeps);
+
         var projectileCoordinates = _transform.GetMapCoordinates(projectile);
-        var projectilePosition = projectileCoordinates.Position;
+        var projectileVelocity = _physics.GetLinearVelocity(projectile, projectile.Comp.LocalCenter);
+        var substeppedProjectilePos = projectileCoordinates.Position + (projectileVelocity / _timing.TickRate) * _substepMults[substep];
+
         var transform = new Transform(targetCoordinates.Position, 0);
         var bounds = new Box2(transform.Position, transform.Position);
 
@@ -135,24 +164,80 @@ public abstract class SharedRMCLagCompensationSystem : EntitySystem
             }
         }
 
-        if (bounds.Contains(projectilePosition))
-            return true;
+        if (_logPrediction)
+        {
+            Log.Debug($"""
+                Lag comp collide data:
+                  Pre-Substep Projectile Coords: {projectileCoordinates}
+                  Substep: {substep}
+                  Projectile Pos: {substeppedProjectilePos}
+                  Target Pos:     {targetCoordinates.Position}
+                  Target AABB:
+                    {bounds.BottomLeft}
+                    {bounds.TopRight}
+                  Contained in AABB? {bounds.Contains(substeppedProjectilePos)}
+                  Closest point diff: {(bounds.ClosestPoint(substeppedProjectilePos) - substeppedProjectilePos).Length()}
+                """);
+        }
 
-        var projectileVelocity = _physics.GetLinearVelocity(projectile, projectile.Comp.LocalCenter);
-        projectilePosition = projectileCoordinates.Position + projectileVelocity / _timing.TickRate / 1.5f;
-        if (bounds.Contains(projectilePosition))
+        if (bounds.Contains(substeppedProjectilePos))
+        {
             return true;
+        }
 
-        var closest = bounds.ClosestPoint(projectilePosition);
-        if ((closest - projectilePosition).LengthSquared() <= MarginTiles * MarginTiles)
+        var closest = bounds.ClosestPoint(substeppedProjectilePos);
+        if ((closest - substeppedProjectilePos).LengthSquared() <= MarginTiles * MarginTiles)
+        {
             return true;
+        }
+
+        if (_logPrediction)
+            Log.Warning("Predicted hit denied.");
 
         return false;
     }
 
-    public bool Collides(Entity<FixturesComponent?> target, Entity<PhysicsComponent?> projectile, ICommonSession session)
+    public bool Collides(Entity<FixturesComponent?> target, Entity<PhysicsComponent?> projectile, ICommonSession session, int substep = 0)
     {
         var coordinates = _transform.ToMapCoordinates(GetCoordinates(target, session));
-        return Collides(target, projectile, coordinates);
+        return Collides(target, projectile, coordinates, substep);
+    }
+
+    /// <summary>
+    /// Returns the current substep the physics system is in.
+    /// If physics isn't running, returns null.
+    /// </summary>
+    /// <returns></returns>
+    public int? GetCurrentSubstep()
+    {
+        if (_physics.EffectiveCurTime is not { } physicsTime)
+            return null;
+
+        var diff = physicsTime - _timing.CurTime;
+        return (int)Math.Round(diff.TotalSeconds / _substepTime);
+    }
+
+    public int GetSubsteps()
+    {
+        return _substeps;
+    }
+
+    /// <summary>
+    /// Gets the client's physics substep for purposes of telling the server how much work we've done.
+    /// </summary>
+    /// <returns>0 if physics isn't running. 1 to GetSubsteps() if physics is running.</returns>
+    public int GetClientSubstep()
+    {
+        var substep = GetCurrentSubstep();
+
+        // I know this is necessary from testing but I can't explain why. For some reason
+        // the server is a full physics step behind us but only for the very first substep.
+        // If we're not in a physics substep the server will be aligned with us.
+        if (!substep.HasValue)
+            substep = 0; // not in a physics substep
+        else if (substep == 0)
+            substep = _substeps; // first physics substep special case
+
+        return substep.Value;
     }
 }

--- a/Content.Shared/_RMC14/Movement/SharedRMCLagCompensationSystem.cs
+++ b/Content.Shared/_RMC14/Movement/SharedRMCLagCompensationSystem.cs
@@ -25,10 +25,6 @@ public abstract class SharedRMCLagCompensationSystem : EntitySystem
     private EntityQuery<ActorComponent> _actorQuery;
     private int _substeps;
     private float _substepTime;
-    // This contains _substeps + 1 items and is just an array of ratios
-    // representing how far into a frame each substep is. E.g. if there are four substeps
-    // the array would be [0.0f, 0.25f, 0.5f, 0.75f, 1.0f]
-    private float[] _substepMults = [];
     private bool _logPrediction = false;
 
     private readonly Dictionary<NetUserId, GameTick> _lastRealTicks = new();
@@ -59,11 +55,6 @@ public abstract class SharedRMCLagCompensationSystem : EntitySystem
         var serverTickrate = (float)_config.GetCVar(CVars.NetTickrate);
         _substeps = (int)Math.Ceiling(targetMinTickrate / serverTickrate);
         _substepTime = 1.0f / serverTickrate / _substeps;
-
-        // Division is slow so we pre-calculate the multipliers we need here.
-        _substepMults = new float[_substeps + 1];
-        for (var i = 0; i <= _substeps; i++)
-            _substepMults[i] = (float)i / _substeps;
     }
 
     public virtual (EntityCoordinates Coordinates, Angle Angle) GetCoordinatesAngle(EntityUid uid,
@@ -143,11 +134,11 @@ public abstract class SharedRMCLagCompensationSystem : EntitySystem
             return false;
         }
 
-        substep = Math.Clamp(substep, 0, _substeps);
+        substep = Math.Clamp(substep, -_substeps, _substeps);
 
         var projectileCoordinates = _transform.GetMapCoordinates(projectile);
         var projectileVelocity = _physics.GetLinearVelocity(projectile, projectile.Comp.LocalCenter);
-        var substeppedProjectilePos = projectileCoordinates.Position + (projectileVelocity / _timing.TickRate) * _substepMults[substep];
+        var substeppedProjectilePos = projectileCoordinates.Position + (projectileVelocity / _timing.TickRate) * (substep / (float)_substeps);
 
         var transform = new Transform(targetCoordinates.Position, 0);
         var bounds = new Box2(transform.Position, transform.Position);
@@ -226,18 +217,13 @@ public abstract class SharedRMCLagCompensationSystem : EntitySystem
     /// <summary>
     /// Gets the client's physics substep for purposes of telling the server how much work we've done.
     /// </summary>
-    /// <returns>0 if physics isn't running. 1 to GetSubsteps() if physics is running.</returns>
+    /// <returns>0 if physics isn't running. Current physics substep if it is.</returns>
     public int GetClientSubstep()
     {
         var substep = GetCurrentSubstep();
 
-        // I know this is necessary from testing but I can't explain why. For some reason
-        // the server is a full physics step behind us but only for the very first substep.
-        // If we're not in a physics substep the server will be aligned with us.
         if (!substep.HasValue)
             substep = 0; // not in a physics substep
-        else if (substep == 0)
-            substep = _substeps; // first physics substep special case
 
         return substep.Value;
     }

--- a/Content.Shared/_RMC14/Movement/SharedRMCLagCompensationSystem.cs
+++ b/Content.Shared/_RMC14/Movement/SharedRMCLagCompensationSystem.cs
@@ -139,7 +139,7 @@ public abstract class SharedRMCLagCompensationSystem : EntitySystem
         RaiseNetworkEvent(new RMCSetLastRealTickEvent(GetLastRealTick(null)));
     }
 
-    public bool Collides(Entity<FixturesComponent?> target, Entity<PhysicsComponent?> projectile, MapCoordinates targetCoordinates, int substep = 0)
+    public bool Collides(Entity<FixturesComponent?> target, Entity<PhysicsComponent?> projectile, ICommonSession? perspectiveSession, int substep = 0)
     {
         if (!Resolve(target, ref target.Comp, false) ||
             !Resolve(projectile, ref projectile.Comp, false))
@@ -153,6 +153,7 @@ public abstract class SharedRMCLagCompensationSystem : EntitySystem
         var projectileVelocity = _physics.GetLinearVelocity(projectile, projectile.Comp.LocalCenter);
         var substeppedProjectilePos = projectileCoordinates.Position + (projectileVelocity / _timing.TickRate) * (substep / (float)_substeps);
 
+        var targetCoordinates = _transform.ToMapCoordinates(GetCoordinates(target, perspectiveSession));
         var transform = new Transform(targetCoordinates.Position, 0);
         var targetBounds = new Box2(transform.Position, transform.Position);
 
@@ -189,6 +190,7 @@ public abstract class SharedRMCLagCompensationSystem : EntitySystem
         {
             Log.Debug($"""
                 Lag comp collide data:
+                  Session Name:   {perspectiveSession}
                   Pre-Substep
                     Proj Coords:  {projectileCoordinates}
                   CurTick:        {_timing.CurTick}
@@ -215,15 +217,9 @@ public abstract class SharedRMCLagCompensationSystem : EntitySystem
         }
 
         if (_logPrediction)
-            Log.Warning("Predicted hit denied.");
+            Log.Warning($"Predicted hit denied for session '{perspectiveSession}'");
 
         return false;
-    }
-
-    public bool Collides(Entity<FixturesComponent?> target, Entity<PhysicsComponent?> projectile, ICommonSession session, int substep = 0)
-    {
-        var coordinates = _transform.ToMapCoordinates(GetCoordinates(target, session));
-        return Collides(target, projectile, coordinates, substep);
     }
 
     /// <summary>

--- a/Content.Shared/_RMC14/Movement/SharedRMCLagCompensationSystem.cs
+++ b/Content.Shared/_RMC14/Movement/SharedRMCLagCompensationSystem.cs
@@ -168,15 +168,16 @@ public abstract class SharedRMCLagCompensationSystem : EntitySystem
         {
             Log.Debug($"""
                 Lag comp collide data:
-                  Pre-Substep Projectile Coords: {projectileCoordinates}
-                  Substep: {substep}
+                  Pre-Substep
+                    Proj Coords:  {projectileCoordinates}
+                  CurTick:        {_timing.CurTick}
+                  Substep:        {substep}
                   Projectile Pos: {substeppedProjectilePos}
                   Target Pos:     {targetCoordinates.Position}
-                  Target AABB:
-                    {bounds.BottomLeft}
-                    {bounds.TopRight}
-                  Contained in AABB? {bounds.Contains(substeppedProjectilePos)}
-                  Closest point diff: {(bounds.ClosestPoint(substeppedProjectilePos) - substeppedProjectilePos).Length()}
+                  Target AABB:    {bounds.BottomLeft}
+                                  {bounds.TopRight}
+                  Inside AABB?    {bounds.Contains(substeppedProjectilePos)}
+                  AABB closest:   {(bounds.ClosestPoint(substeppedProjectilePos) - substeppedProjectilePos).Length()}
                 """);
         }
 

--- a/Content.Shared/_RMC14/Movement/SharedRMCLagCompensationSystem.cs
+++ b/Content.Shared/_RMC14/Movement/SharedRMCLagCompensationSystem.cs
@@ -23,6 +23,7 @@ public abstract class SharedRMCLagCompensationSystem : EntitySystem
     public float MarginTiles { get; private set; }
 
     private EntityQuery<ActorComponent> _actorQuery;
+    private EntityQuery<FixturesComponent> _fixturesQuery;
     private int _substeps;
     private float _substepTime;
     private bool _logPrediction = false;
@@ -35,6 +36,7 @@ public abstract class SharedRMCLagCompensationSystem : EntitySystem
         base.Initialize();
 
         _actorQuery = GetEntityQuery<ActorComponent>();
+        _fixturesQuery = GetEntityQuery<FixturesComponent>();
 
         SubscribeNetworkEvent<RMCSetLastRealTickEvent>(OnSetLastRealTick);
 
@@ -55,6 +57,17 @@ public abstract class SharedRMCLagCompensationSystem : EntitySystem
         var serverTickrate = (float)_config.GetCVar(CVars.NetTickrate);
         _substeps = (int)Math.Ceiling(targetMinTickrate / serverTickrate);
         _substepTime = 1.0f / serverTickrate / _substeps;
+    }
+
+    private float AABBDistanceSquared(Box2 a, Box2 b)
+    {
+        var xDist = Math.Max(a.Left - b.Right, b.Left - a.Right);
+        var yDist = Math.Max(a.Bottom - b.Top, b.Bottom - a.Top);
+
+        xDist = Math.Max(0, xDist);
+        yDist = Math.Max(0, yDist);
+
+        return xDist * xDist + yDist * yDist;
     }
 
     public virtual (EntityCoordinates Coordinates, Angle Angle) GetCoordinatesAngle(EntityUid uid,
@@ -141,7 +154,7 @@ public abstract class SharedRMCLagCompensationSystem : EntitySystem
         var substeppedProjectilePos = projectileCoordinates.Position + (projectileVelocity / _timing.TickRate) * (substep / (float)_substeps);
 
         var transform = new Transform(targetCoordinates.Position, 0);
-        var bounds = new Box2(transform.Position, transform.Position);
+        var targetBounds = new Box2(transform.Position, transform.Position);
 
         foreach (var fixture in target.Comp.Fixtures.Values)
         {
@@ -151,7 +164,24 @@ public abstract class SharedRMCLagCompensationSystem : EntitySystem
             for (var i = 0; i < fixture.Shape.ChildCount; i++)
             {
                 var boundy = fixture.Shape.ComputeAABB(transform, i);
-                bounds = bounds.Union(boundy);
+                targetBounds = targetBounds.Union(boundy);
+            }
+        }
+
+        var projectileTransform = new Transform(substeppedProjectilePos, 0);
+        var projectileBounds = new Box2(projectileTransform.Position, projectileTransform.Position);
+
+        if (_fixturesQuery.TryComp(projectile, out var projFixtureComp))
+        {
+            foreach (var fixture in projFixtureComp.Fixtures.Values)
+            {
+                // TODO RMC14 maybe be more selective on which fixtures to include?
+                // Don't think it's a problem right now though.
+                for (var i = 0; i < fixture.Shape.ChildCount; i++)
+                {
+                    var boundy = fixture.Shape.ComputeAABB(projectileTransform, i);
+                    projectileBounds = projectileBounds.Union(boundy);
+                }
             }
         }
 
@@ -165,20 +195,21 @@ public abstract class SharedRMCLagCompensationSystem : EntitySystem
                   Substep:        {substep}
                   Projectile Pos: {substeppedProjectilePos}
                   Target Pos:     {targetCoordinates.Position}
-                  Target AABB:    {bounds.BottomLeft}
-                                  {bounds.TopRight}
-                  Inside AABB?    {bounds.Contains(substeppedProjectilePos)}
-                  AABB closest:   {(bounds.ClosestPoint(substeppedProjectilePos) - substeppedProjectilePos).Length()}
+                  Proj AABB:      {projectileBounds.BottomLeft}
+                                  {projectileBounds.TopRight}
+                  Target AABB:    {targetBounds.BottomLeft}
+                                  {targetBounds.TopRight}
+                  AABB Intersect? {targetBounds.Intersects(projectileBounds)}
+                  AABB Distance:  {Math.Sqrt(AABBDistanceSquared(targetBounds, projectileBounds))}
                 """);
         }
 
-        if (bounds.Contains(substeppedProjectilePos))
+        if (targetBounds.Intersects(projectileBounds))
         {
             return true;
         }
 
-        var closest = bounds.ClosestPoint(substeppedProjectilePos);
-        if ((closest - substeppedProjectilePos).LengthSquared() <= MarginTiles * MarginTiles)
+        if (AABBDistanceSquared(targetBounds, projectileBounds) <= MarginTiles * MarginTiles)
         {
             return true;
         }

--- a/Content.Shared/_RMC14/Xenonids/Leap/XenoLeapPredictedHitEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Leap/XenoLeapPredictedHitEvent.cs
@@ -1,11 +1,12 @@
-﻿using Robust.Shared.Serialization;
+using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 
 namespace Content.Shared._RMC14.Xenonids.Leap;
 
 [Serializable, NetSerializable]
-public sealed class XenoLeapPredictedHitEvent(NetEntity target, GameTick lastRealTick) : EntityEventArgs
+public sealed class XenoLeapPredictedHitEvent(NetEntity target, GameTick lastRealTick, int substep = 0) : EntityEventArgs
 {
     public readonly NetEntity Target = target;
     public readonly GameTick LastRealTick = lastRealTick;
+    public readonly int Substep = substep;
 }

--- a/Content.Shared/_RMC14/Xenonids/Leap/XenoLeapSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Leap/XenoLeapSystem.cs
@@ -126,7 +126,7 @@ public sealed class XenoLeapSystem : EntitySystem
                 return;
 
             _rmcLagCompensation.SetLastRealTick(args.SenderSession.UserId, msg.LastRealTick);
-            if (!_rmcLagCompensation.Collides(target, ent, args.SenderSession))
+            if (!_rmcLagCompensation.Collides(target, ent, args.SenderSession, msg.Substep))
                 return;
         }
 
@@ -597,7 +597,10 @@ public sealed class XenoLeapSystem : EntitySystem
 
         if (_net.IsClient)
         {
-            var predictedEv = new XenoLeapPredictedHitEvent(GetNetEntity(target), _rmcLagCompensation.GetLastRealTick(null));
+            var predictedEv = new XenoLeapPredictedHitEvent(
+                GetNetEntity(target),
+                _rmcLagCompensation.GetLastRealTick(null),
+                _rmcLagCompensation.GetClientSubstep());
             RaiseNetworkEvent(predictedEv);
             if (_timing.InPrediction && _timing.IsFirstTimePredicted)
             {

--- a/Content.Shared/_RMC14/Xenonids/Leap/XenoLeapSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Leap/XenoLeapSystem.cs
@@ -83,6 +83,8 @@ public sealed class XenoLeapSystem : EntitySystem
     private EntityQuery<PhysicsComponent> _physicsQuery;
     private EntityQuery<FixturesComponent> _fixturesQuery;
 
+    private bool _logPrediction = false;
+
     public override void Initialize()
     {
         _physicsQuery = GetEntityQuery<PhysicsComponent>();
@@ -597,6 +599,25 @@ public sealed class XenoLeapSystem : EntitySystem
 
         if (_net.IsClient)
         {
+            if (_logPrediction)
+            {
+                // Leap code causes this to spam the console a bit
+                TryComp(xeno, out TransformComponent? leaperTransform);
+                TryComp(target, out TransformComponent? targetTransform);
+                Log.Debug($"""
+                    SENDING PREDICTED LEAP HIT!!
+                      CurTick:        {_timing.CurTick}
+                      LastRealTick:   {_rmcLagCompensation.GetLastRealTick(null)}
+                      Phys Substep:   {_rmcLagCompensation.GetCurrentSubstep()}
+                      In simulation?  {_timing.InSimulation}
+                      ApplyingState?  {_timing.ApplyingState}
+                      FirstTimePred?  {_timing.IsFirstTimePredicted}
+                      Substep:        {_rmcLagCompensation.GetClientSubstep()}
+                      Leaper Coords:  {leaperTransform?.Coordinates}
+                      Target Coords:  {targetTransform?.Coordinates}
+                    """);
+            }
+
             var predictedEv = new XenoLeapPredictedHitEvent(
                 GetNetEntity(target),
                 _rmcLagCompensation.GetLastRealTick(null),

--- a/Content.Shared/_RMC14/Xenonids/Projectile/XenoClientProjectileShotComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/XenoClientProjectileShotComponent.cs
@@ -1,4 +1,9 @@
-﻿namespace Content.Shared._RMC14.Xenonids.Projectile;
+using Robust.Shared.Timing;
+
+namespace Content.Shared._RMC14.Xenonids.Projectile;
 
 [RegisterComponent]
-public sealed partial class XenoClientProjectileShotComponent : Component;
+public sealed partial class XenoClientProjectileShotComponent : Component
+{
+    public GameTick LatestPredictedTick;
+}

--- a/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectilePredictedHitEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectilePredictedHitEvent.cs
@@ -4,11 +4,12 @@ using Robust.Shared.Timing;
 namespace Content.Shared._RMC14.Xenonids.Projectile;
 
 [Serializable, NetSerializable]
-public sealed class XenoProjectilePredictedHitEvent(int id, NetEntity target, GameTick lastRealTick, GameTick tick, int substep) : EntityEventArgs
+public sealed class XenoProjectilePredictedHitEvent(int id, NetEntity target, GameTick lastRealTick, GameTick tick, int substep, GameTick shotTick) : EntityEventArgs
 {
     public readonly int Id = id;
     public readonly NetEntity Target = target;
     public readonly GameTick LastRealTick = lastRealTick; // last update the client received from server
     public readonly GameTick Tick = tick; // tick the client predicted the collision
     public readonly int Substep = substep; // substep of tick the client predicted the collision
+    public readonly GameTick ShotAtTick = shotTick; // tick that the client predicted the shot started
 }

--- a/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectilePredictedHitEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectilePredictedHitEvent.cs
@@ -1,12 +1,13 @@
-﻿using Robust.Shared.Serialization;
+using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 
 namespace Content.Shared._RMC14.Xenonids.Projectile;
 
 [Serializable, NetSerializable]
-public sealed class XenoProjectilePredictedHitEvent(int id, NetEntity target, GameTick lastRealTick) : EntityEventArgs
+public sealed class XenoProjectilePredictedHitEvent(int id, NetEntity target, GameTick lastRealTick, int substep) : EntityEventArgs
 {
     public readonly int Id = id;
     public readonly NetEntity Target = target;
     public readonly GameTick LastRealTick = lastRealTick;
+    public readonly int Substep = substep;
 }

--- a/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectilePredictedHitEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectilePredictedHitEvent.cs
@@ -4,10 +4,11 @@ using Robust.Shared.Timing;
 namespace Content.Shared._RMC14.Xenonids.Projectile;
 
 [Serializable, NetSerializable]
-public sealed class XenoProjectilePredictedHitEvent(int id, NetEntity target, GameTick lastRealTick, int substep) : EntityEventArgs
+public sealed class XenoProjectilePredictedHitEvent(int id, NetEntity target, GameTick lastRealTick, GameTick tick, int substep) : EntityEventArgs
 {
     public readonly int Id = id;
     public readonly NetEntity Target = target;
-    public readonly GameTick LastRealTick = lastRealTick;
-    public readonly int Substep = substep;
+    public readonly GameTick LastRealTick = lastRealTick; // last update the client received from server
+    public readonly GameTick Tick = tick; // tick the client predicted the collision
+    public readonly int Substep = substep; // substep of tick the client predicted the collision
 }

--- a/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileShotComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileShotComponent.cs
@@ -1,6 +1,7 @@
-﻿using Robust.Shared.GameStates;
+using Robust.Shared.GameStates;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
+using Robust.Shared.Timing;
 
 namespace Content.Shared._RMC14.Xenonids.Projectile;
 
@@ -15,4 +16,6 @@ public sealed partial class XenoProjectileShotComponent : Component
 
     [DataField, AutoNetworkedField]
     public EntityUid? ShooterEnt;
+
+    public GameTick ShotAtTick;
 }

--- a/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
@@ -53,6 +53,7 @@ public sealed class XenoProjectileSystem : EntitySystem
     private EntityQuery<PreventAttackLightOffComponent> _preventAttackLightOffQuery;
 
     private int _limitHitsId;
+    private bool _logPrediction = false;
 
     public override void Initialize()
     {
@@ -68,7 +69,7 @@ public sealed class XenoProjectileSystem : EntitySystem
         SubscribeLocalEvent<XenoProjectileShotComponent, ComponentRemove>(OnShotRemove);
         SubscribeLocalEvent<XenoProjectileShotComponent, EntityTerminatingEvent>(OnShotRemove);
 
-        SubscribeLocalEvent<XenoClientProjectileShotComponent, StartCollideEvent>(OnShotCollide);
+        SubscribeLocalEvent<XenoClientProjectileShotComponent, ProjectileHitEvent>(OnShotHit);
 
         SubscribeLocalEvent<XenoProjectileComponent, PreventCollideEvent>(OnPreventCollide);
         SubscribeLocalEvent<XenoProjectileComponent, ProjectileHitEvent>(OnProjectileHit);
@@ -112,7 +113,7 @@ public sealed class XenoProjectileSystem : EntitySystem
             return;
         }
 
-        if (!_rmcLagCompensation.Collides(target, (shot.Value, physics), coordinates))
+        if (!_rmcLagCompensation.Collides(target, (shot.Value, physics), coordinates, msg.Substep))
             return;
 
         _projectile.ProjectileCollide((shot.Value, projectile, physics), target, true);
@@ -144,7 +145,10 @@ public sealed class XenoProjectileSystem : EntitySystem
         }
     }
 
-    private void OnShotCollide(Entity<XenoClientProjectileShotComponent> ent, ref StartCollideEvent args)
+    // TODO RMC14 There is a bug with clients trying to predict StartCollideEvent on our version of RT.
+    // This should be fixed in the newest versions of RT (2026 or later), and then we can change this back
+    // to react to StartCollideEvent.
+    private void OnShotHit(Entity<XenoClientProjectileShotComponent> ent, ref ProjectileHitEvent args)
     {
         if (_net.IsServer || !IsClientSide(ent))
             return;
@@ -152,10 +156,28 @@ public sealed class XenoProjectileSystem : EntitySystem
         if (!TryComp(ent, out XenoProjectileShotComponent? shot))
             return;
 
+        var substep = _rmcLagCompensation.GetClientSubstep();
+
+        if (_logPrediction)
+        {
+            TryComp(args.Target, out TransformComponent? targetTransform);
+            TryComp(ent, out TransformComponent? shotTransform);
+            Log.Debug($"""
+                SENDING PREDICTED PROJECTILE HIT!!
+                  CurTick: {_timing.CurTick}
+                  ClientLastRealTick: {_rmcLagCompensation.GetLastRealTick(null)}
+                  In physics? {_rmcLagCompensation.GetCurrentSubstep().HasValue}
+                  Substep: {substep}
+                  ShotCoords: {shotTransform?.Coordinates}
+                  Target Coords: {targetTransform?.Coordinates}
+                """);
+        }
+
         var ev = new XenoProjectilePredictedHitEvent(
             shot.Id,
-            GetNetEntity(args.OtherEntity),
-            _rmcLagCompensation.GetLastRealTick(null)
+            GetNetEntity(args.Target),
+            _rmcLagCompensation.GetLastRealTick(null),
+            substep
         );
         RaiseNetworkEvent(ev);
     }

--- a/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
@@ -106,9 +106,9 @@ public sealed class XenoProjectileSystem : EntitySystem
             Log.Debug($"""
                 Received predicted hit:
                   Session:  {args.SenderSession}
-                  CurTick:  {_timing.CurTick}
+                  Cur Tick: {_timing.CurTick}
                   Target:   {msg.Target}
-                  ShotID:   {msg.Id}
+                  Shot ID:  {msg.Id}
                   Shot At:  {msg.ShotAtTick}
                   Hit Tick: {msg.Tick}
                   Substep:  {msg.Substep}
@@ -306,17 +306,17 @@ public sealed class XenoProjectileSystem : EntitySystem
             TryComp(ent, out TransformComponent? shotTransform);
             Log.Debug($"""
                 SENDING PREDICTED PROJECTILE HIT!!
-                  ShotId:         {shot.Id}
-                  ShotAtTick:     {shot.ShotAtTick}
-                  CurTick:        {_timing.CurTick}
+                  Shot ID:        {shot.Id}
+                  Cur Tick:       {_timing.CurTick}
                   LastRealTick:   {_rmcLag.GetLastRealTick(null)}
                   Phys Substep:   {_rmcLag.GetCurrentSubstep()}
                   In simulation?  {_timing.InSimulation}
                   ApplyingState?  {_timing.ApplyingState}
                   FirstTimePred?  {_timing.IsFirstTimePredicted}
-                  PredictedTick:  {tick}
+                  Shot At Tick:   {shot.ShotAtTick}
+                  Pred Hit Tick:  {tick}
                   Substep:        {substep}
-                  ShotCoords:     {shotTransform?.Coordinates}
+                  Shot Coords:    {shotTransform?.Coordinates}
                   Target Coords:  {targetTransform?.Coordinates}
                 """);
         }

--- a/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
@@ -99,7 +99,11 @@ public sealed class XenoProjectileSystem : EntitySystem
         }
 
         if (!shooter.Shot.TryFirstOrNull(e => CompOrNull<XenoProjectileShotComponent>(e)?.Id == msg.Id, out var shot))
+        {
+            if (_logPrediction)
+                Log.Warning($"Predicted shot ID {msg.Id} not found!");
             return;
+        }
 
         if (TerminatingOrDeleted(shot))
             return;
@@ -164,11 +168,12 @@ public sealed class XenoProjectileSystem : EntitySystem
             TryComp(ent, out TransformComponent? shotTransform);
             Log.Debug($"""
                 SENDING PREDICTED PROJECTILE HIT!!
-                  CurTick: {_timing.CurTick}
-                  ClientLastRealTick: {_rmcLagCompensation.GetLastRealTick(null)}
-                  In physics? {_rmcLagCompensation.GetCurrentSubstep().HasValue}
-                  Substep: {substep}
-                  ShotCoords: {shotTransform?.Coordinates}
+                  CurTick:       {_timing.CurTick}
+                  LastRealTick:  {_rmcLagCompensation.GetLastRealTick(null)}
+                  In physics?    {_rmcLagCompensation.GetCurrentSubstep().HasValue}
+                  ShotId:        {shot.Id}
+                  Substep:       {substep}
+                  ShotCoords:    {shotTransform?.Coordinates}
                   Target Coords: {targetTransform?.Coordinates}
                 """);
         }

--- a/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
@@ -82,6 +82,7 @@ public sealed class XenoProjectileSystem : EntitySystem
     private void OnRoundRestartCleanup(RoundRestartCleanupEvent ev)
     {
         _limitHitsId = 0;
+        _earlyMessages.Clear();
     }
 
     private void OnPredictedHit(XenoProjectilePredictedHitEvent msg, EntitySessionEventArgs args) => OnPredictedHit(msg, args, true);

--- a/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
@@ -54,6 +54,7 @@ public sealed class XenoProjectileSystem : EntitySystem
 
     private int _limitHitsId;
     private bool _logPrediction = false;
+    private List<(EntityUid Shooter, GameTick ArrivalTick, XenoProjectilePredictedHitEvent Message, EntitySessionEventArgs Args)> _earlyMessages = [];
 
     public override void Initialize()
     {
@@ -81,7 +82,9 @@ public sealed class XenoProjectileSystem : EntitySystem
         _limitHitsId = 0;
     }
 
-    private void OnPredictedHit(XenoProjectilePredictedHitEvent msg, EntitySessionEventArgs args)
+    private void OnPredictedHit(XenoProjectilePredictedHitEvent msg, EntitySessionEventArgs args) => OnPredictedHit(msg, args, true);
+
+    private void OnPredictedHit(XenoProjectilePredictedHitEvent msg, EntitySessionEventArgs args, bool saveEarlyMessage)
     {
         if (_net.IsClient || !_gunPrediction.GunPrediction)
             return;
@@ -92,21 +95,23 @@ public sealed class XenoProjectileSystem : EntitySystem
         if (GetEntity(msg.Target) is not { Valid: true } target)
             return;
 
-        if (!TryComp(ent, out XenoProjectileShooterComponent? shooter) ||
-            shooter.Shot.Count == 0)
-        {
-            return;
-        }
-
-        if (!shooter.Shot.TryFirstOrNull(e => CompOrNull<XenoProjectileShotComponent>(e)?.Id == msg.Id, out var shot))
+        if (!TryComp(ent, out XenoProjectileShooterComponent? shooter)
+            || shooter.Shot.Count == 0
+            || !shooter.Shot.TryFirstOrNull(e => CompOrNull<XenoProjectileShotComponent>(e)?.Id == msg.Id, out var shot))
         {
             if (_logPrediction)
-                Log.Warning($"Predicted shot ID {msg.Id} not found!");
+                Log.Debug($"Predicted shot ID {msg.Id} not found! Saving it? {saveEarlyMessage} (Tick {_timing.CurTick})");
+            if (saveEarlyMessage)
+                _earlyMessages.Add((ent, _timing.CurTick, msg, args));
             return;
         }
 
         if (TerminatingOrDeleted(shot))
+        {
+            if (_logPrediction)
+                Log.Warning($"Predicted shot ID {msg.Id} already deleted! (Tick {_timing.CurTick})");
             return;
+        }
 
         _rmcLagCompensation.SetLastRealTick(args.SenderSession.UserId, msg.LastRealTick);
         var coordinates = _transform.ToMapCoordinates(_rmcLagCompensation.GetCoordinates(target, args.SenderSession));
@@ -356,6 +361,31 @@ public sealed class XenoProjectileSystem : EntitySystem
         }
 
         RaiseLocalEvent(xeno, ammoShotEvent);
+
+        // Client may have already predicted hits, check for them here.
+        if (_net.IsServer && predicted && _earlyMessages.Count > 0)
+        {
+            for (var i = 0; i < _earlyMessages.Count; ++i)
+            {
+                var item = _earlyMessages[i];
+                if (item.ArrivalTick < _timing.CurTick)
+                {
+                    if (_logPrediction)
+                        Log.Warning($"Removed expired prediction message: Shooter {item.Shooter}, Shot ID {item.Message.Id}");
+                    _earlyMessages[i] = _earlyMessages[_earlyMessages.Count - 1];
+                    _earlyMessages.RemoveAt(_earlyMessages.Count - 1);
+                    --i;
+                }
+                else if (item.Shooter == xeno)
+                {
+                    OnPredictedHit(item.Message, item.Args, false);
+                    _earlyMessages[i] = _earlyMessages[_earlyMessages.Count - 1];
+                    _earlyMessages.RemoveAt(_earlyMessages.Count - 1);
+                    --i;
+                }
+            }
+        }
+
         return true;
     }
 }

--- a/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
@@ -298,12 +298,14 @@ public sealed class XenoProjectileSystem : EntitySystem
         for (var i = _earlyMessages.Count - 1; i >= 0; --i)
         {
             var item = _earlyMessages[i];
+            var lastIndex = _earlyMessages.Count - 1;
             if (item.PredictedHitTick < _timing.CurTick)
             {
                 if (_logPrediction)
                     Log.Warning($"Removed expired prediction message: Shooter {item.Shooter}, Shot ID {item.Message.Id}");
-                _earlyMessages[i] = _earlyMessages[_earlyMessages.Count - 1];
-                _earlyMessages.RemoveAt(_earlyMessages.Count - 1);
+                if (i != lastIndex)
+                    _earlyMessages[i] = _earlyMessages[lastIndex];
+                _earlyMessages.RemoveAt(lastIndex);
             }
             else if (item.PredictedHitTick == _timing.CurTick)
             {
@@ -311,8 +313,9 @@ public sealed class XenoProjectileSystem : EntitySystem
                     continue;
 
                 OnPredictedHit(item.Message, item.Args, false);
-                _earlyMessages[i] = _earlyMessages[_earlyMessages.Count - 1];
-                _earlyMessages.RemoveAt(_earlyMessages.Count - 1);
+                if (i != lastIndex)
+                    _earlyMessages[i] = _earlyMessages[lastIndex];
+                _earlyMessages.RemoveAt(lastIndex);
             }
         }
     }

--- a/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
@@ -188,6 +188,13 @@ public sealed class XenoProjectileSystem : EntitySystem
             return true;
         }
 
+        if (projectile.ProjectileSpent)
+        {
+            if (_logPrediction)
+                Log.Debug($"Predicted hit from '{args.SenderSession}' shot {msg.Id} is spent and cannot hit anything anymore.");
+            return true;
+        }
+
         // server shot later than predicted, adjust the shot forward to try and hit
         if (xenoShot.ShotAtTick > msg.ShotAtTick)
         {

--- a/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
@@ -54,7 +54,7 @@ public sealed class XenoProjectileSystem : EntitySystem
 
     private int _limitHitsId;
     private bool _logPrediction = false;
-    private List<(EntityUid Shooter, GameTick ArrivalTick, XenoProjectilePredictedHitEvent Message, EntitySessionEventArgs Args)> _earlyMessages = [];
+    private List<(EntityUid Shooter, GameTick PredictedHitTick, XenoProjectilePredictedHitEvent Message, EntitySessionEventArgs Args)> _earlyMessages = [];
 
     public override void Initialize()
     {
@@ -75,6 +75,8 @@ public sealed class XenoProjectileSystem : EntitySystem
         SubscribeLocalEvent<XenoProjectileComponent, PreventCollideEvent>(OnPreventCollide);
         SubscribeLocalEvent<XenoProjectileComponent, ProjectileHitEvent>(OnProjectileHit);
         SubscribeLocalEvent<XenoProjectileComponent, CMClusterSpawnedEvent>(OnClusterSpawned);
+
+        UpdatesBefore.Add(typeof(SharedPhysicsSystem));
     }
 
     private void OnRoundRestartCleanup(RoundRestartCleanupEvent ev)
@@ -92,6 +94,23 @@ public sealed class XenoProjectileSystem : EntitySystem
         if (args.SenderSession.AttachedEntity is not { } ent)
             return;
 
+        var tick = msg.Tick;
+        var substep = msg.Substep;
+
+        if (tick < _timing.CurTick)
+        {
+            if (_logPrediction)
+                Log.Warning($"Predicted hit message arrived late (Message for {tick}, current tick {_timing.CurTick}).");
+            substep -= _rmcLagCompensation.GetSubsteps(); // adjust backwards by a full tick at most
+        }
+        else if (tick > _timing.CurTick)
+        {
+            if (_logPrediction)
+                Log.Debug($"Predicted hit message arrived early (Message for {tick}, current tick {_timing.CurTick}). Saving it.");
+            _earlyMessages.Add((ent, tick, msg, args));
+            return;
+        }
+
         if (GetEntity(msg.Target) is not { Valid: true } target)
             return;
 
@@ -99,10 +118,16 @@ public sealed class XenoProjectileSystem : EntitySystem
             || shooter.Shot.Count == 0
             || !shooter.Shot.TryFirstOrNull(e => CompOrNull<XenoProjectileShotComponent>(e)?.Id == msg.Id, out var shot))
         {
-            if (_logPrediction)
-                Log.Debug($"Predicted shot ID {msg.Id} not found! Saving it? {saveEarlyMessage} (Tick {_timing.CurTick})");
-            if (saveEarlyMessage)
-                _earlyMessages.Add((ent, _timing.CurTick, msg, args));
+            if (tick >= _timing.CurTick && saveEarlyMessage)
+            {
+                if (_logPrediction)
+                    Log.Debug($"Predicted non-late shot ID {msg.Id} not found! Saving as early. (Tick {_timing.CurTick})");
+                _earlyMessages.Add((ent, tick, msg, args));
+            }
+            else if (_logPrediction)
+            {
+                Log.Debug($"Predicted shot ID {msg.Id} not found! (Tick {_timing.CurTick})");
+            }
             return;
         }
 
@@ -122,7 +147,7 @@ public sealed class XenoProjectileSystem : EntitySystem
             return;
         }
 
-        if (!_rmcLagCompensation.Collides(target, (shot.Value, physics), coordinates, msg.Substep))
+        if (!_rmcLagCompensation.Collides(target, (shot.Value, physics), coordinates, substep))
             return;
 
         _projectile.ProjectileCollide((shot.Value, projectile, physics), target, true);
@@ -165,7 +190,15 @@ public sealed class XenoProjectileSystem : EntitySystem
         if (!TryComp(ent, out XenoProjectileShotComponent? shot))
             return;
 
+        // If a collision happens during a re-predicted frame, the projectile is actually at substep 0
+        // for the next frame. Not 100% sure why this is the case, but it's very accurate during testing.
+        var tick = ent.Comp.LatestPredictedTick;
         var substep = _rmcLagCompensation.GetClientSubstep();
+        if (!_timing.IsFirstTimePredicted)
+        {
+            tick += 1;
+            substep = 0;
+        }
 
         if (_logPrediction)
         {
@@ -173,13 +206,17 @@ public sealed class XenoProjectileSystem : EntitySystem
             TryComp(ent, out TransformComponent? shotTransform);
             Log.Debug($"""
                 SENDING PREDICTED PROJECTILE HIT!!
-                  CurTick:       {_timing.CurTick}
-                  LastRealTick:  {_rmcLagCompensation.GetLastRealTick(null)}
-                  In physics?    {_rmcLagCompensation.GetCurrentSubstep().HasValue}
-                  ShotId:        {shot.Id}
-                  Substep:       {substep}
-                  ShotCoords:    {shotTransform?.Coordinates}
-                  Target Coords: {targetTransform?.Coordinates}
+                  ShotId:         {shot.Id}
+                  CurTick:        {_timing.CurTick}
+                  LastRealTick:   {_rmcLagCompensation.GetLastRealTick(null)}
+                  Phys Substep:   {_rmcLagCompensation.GetCurrentSubstep()}
+                  In simulation?  {_timing.InSimulation}
+                  ApplyingState?  {_timing.ApplyingState}
+                  FirstTimePred?  {_timing.IsFirstTimePredicted}
+                  PredictedTick:  {tick}
+                  Substep:        {substep}
+                  ShotCoords:     {shotTransform?.Coordinates}
+                  Target Coords:  {targetTransform?.Coordinates}
                 """);
         }
 
@@ -187,6 +224,7 @@ public sealed class XenoProjectileSystem : EntitySystem
             shot.Id,
             GetNetEntity(args.Target),
             _rmcLagCompensation.GetLastRealTick(null),
+            tick,
             substep
         );
         RaiseNetworkEvent(ev);
@@ -243,6 +281,39 @@ public sealed class XenoProjectileSystem : EntitySystem
         foreach (var spawned in args.Spawned)
         {
             _hive.SetHive(spawned, hive);
+        }
+    }
+
+    /// <summary>
+    /// Processes predicted hits that arrived too early.
+    /// </summary>
+    /// <param name="forShooter">Only process hits for a specific shooter</param>
+    private void ProcessEarlyMessages(EntityUid? forShooter = null)
+    {
+        if (_net.IsClient)
+            return;
+
+        for (var i = 0; i < _earlyMessages.Count; ++i)
+        {
+            var item = _earlyMessages[i];
+            if (item.PredictedHitTick < _timing.CurTick)
+            {
+                if (_logPrediction)
+                    Log.Warning($"Removed expired prediction message: Shooter {item.Shooter}, Shot ID {item.Message.Id}");
+                _earlyMessages[i] = _earlyMessages[_earlyMessages.Count - 1];
+                _earlyMessages.RemoveAt(_earlyMessages.Count - 1);
+                --i;
+            }
+            else if (item.PredictedHitTick == _timing.CurTick)
+            {
+                if (forShooter != null && item.Shooter != forShooter)
+                    continue;
+
+                OnPredictedHit(item.Message, item.Args, false);
+                _earlyMessages[i] = _earlyMessages[_earlyMessages.Count - 1];
+                _earlyMessages.RemoveAt(_earlyMessages.Count - 1);
+                --i;
+            }
         }
     }
 
@@ -356,36 +427,38 @@ public sealed class XenoProjectileSystem : EntitySystem
             if (_net.IsServer)
                 continue;
 
-            EnsureComp<XenoClientProjectileShotComponent>(projectile);
+            var clientShot = EnsureComp<XenoClientProjectileShotComponent>(projectile);
+            clientShot.LatestPredictedTick = _timing.CurTick;
             _physics.UpdateIsPredicted(projectile);
         }
 
         RaiseLocalEvent(xeno, ammoShotEvent);
 
-        // Client may have already predicted hits, check for them here.
-        if (_net.IsServer && predicted && _earlyMessages.Count > 0)
+        // Client may have already predicted hits for this projectile, check before we test collisions.
+        if (_net.IsServer && predicted)
         {
-            for (var i = 0; i < _earlyMessages.Count; ++i)
-            {
-                var item = _earlyMessages[i];
-                if (item.ArrivalTick < _timing.CurTick)
-                {
-                    if (_logPrediction)
-                        Log.Warning($"Removed expired prediction message: Shooter {item.Shooter}, Shot ID {item.Message.Id}");
-                    _earlyMessages[i] = _earlyMessages[_earlyMessages.Count - 1];
-                    _earlyMessages.RemoveAt(_earlyMessages.Count - 1);
-                    --i;
-                }
-                else if (item.Shooter == xeno)
-                {
-                    OnPredictedHit(item.Message, item.Args, false);
-                    _earlyMessages[i] = _earlyMessages[_earlyMessages.Count - 1];
-                    _earlyMessages.RemoveAt(_earlyMessages.Count - 1);
-                    --i;
-                }
-            }
+            ProcessEarlyMessages(xeno);
         }
 
         return true;
+    }
+
+    public override void Update(float frameTime)
+    {
+        if (_net.IsClient)
+        {
+            if (!_timing.IsFirstTimePredicted)
+                return;
+
+            var shotQuery = EntityQueryEnumerator<XenoClientProjectileShotComponent>();
+            while (shotQuery.MoveNext(out var uid, out var comp))
+            {
+                comp.LatestPredictedTick = _timing.CurTick;
+            }
+        }
+        else // server
+        {
+            ProcessEarlyMessages();
+        }
     }
 }

--- a/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
@@ -26,6 +26,7 @@ using Robust.Shared.Physics.Systems;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
+using Robust.Shared.Serialization.Manager.Exceptions;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
@@ -41,7 +42,7 @@ public sealed class XenoProjectileSystem : EntitySystem
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly SharedProjectileSystem _projectile = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
-    [Dependency] private readonly SharedRMCLagCompensationSystem _rmcLagCompensation = default!;
+    [Dependency] private readonly SharedRMCLagCompensationSystem _rmcLag = default!;
     [Dependency] private readonly CMPoweredLightSystem _rmcPoweredLight = default!;
     [Dependency] private readonly RMCPseudoRandomSystem _rmcPseudoRandom = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
@@ -54,7 +55,8 @@ public sealed class XenoProjectileSystem : EntitySystem
 
     private int _limitHitsId;
     private bool _logPrediction = false;
-    private List<(EntityUid Shooter, GameTick PredictedHitTick, XenoProjectilePredictedHitEvent Message, EntitySessionEventArgs Args)> _earlyMessages = [];
+    private bool _predictingSpecificShooter = false;
+    private List<(EntityUid Shooter, GameTick PredictedHitTick, XenoProjectilePredictedHitEvent Message, EntitySessionEventArgs Args)> _predictedHitMessages = [];
 
     public override void Initialize()
     {
@@ -82,75 +84,171 @@ public sealed class XenoProjectileSystem : EntitySystem
     private void OnRoundRestartCleanup(RoundRestartCleanupEvent ev)
     {
         _limitHitsId = 0;
-        _earlyMessages.Clear();
+        _predictedHitMessages.Clear();
     }
 
-    private void OnPredictedHit(XenoProjectilePredictedHitEvent msg, EntitySessionEventArgs args) => OnPredictedHit(msg, args, true);
-
-    private void OnPredictedHit(XenoProjectilePredictedHitEvent msg, EntitySessionEventArgs args, bool saveEarlyMessage)
+    private void OnPredictedHit(XenoProjectilePredictedHitEvent msg, EntitySessionEventArgs args)
     {
         if (_net.IsClient || !_gunPrediction.GunPrediction)
             return;
 
+        if (msg.Tick > _timing.CurTick + 10)
+        {
+            // protection against naughty clients, or weird networking issues, or server is lagging bad.
+            Log.Warning($"Discarding extremely early predicted hit message from '{args.SenderSession} for tick {msg.Tick}. Current tick is {_timing.CurTick}.");
+            return;
+        }
+
         if (args.SenderSession.AttachedEntity is not { } ent)
             return;
 
+        if (_logPrediction)
+            Log.Debug($"""
+                Received predicted hit:
+                  Session:  {args.SenderSession}
+                  CurTick:  {_timing.CurTick}
+                  Target:   {msg.Target}
+                  ShotID:   {msg.Id}
+                  Shot At:  {msg.ShotAtTick}
+                  Hit Tick: {msg.Tick}
+                  Substep:  {msg.Substep}
+                """);
+
+        _predictedHitMessages.Add((ent, msg.Tick, msg, args));
+    }
+
+    /// <summary>
+    /// Handles a predicted hit message. Returns true if the message has been handled,
+    /// or false if the message should be handled again later.
+    /// </summary>
+    /// <param name="msg"></param>
+    /// <param name="args"></param>
+    /// <returns></returns>
+    private bool HandlePredictedHit(XenoProjectilePredictedHitEvent msg, EntitySessionEventArgs args)
+    {
+        if (args.SenderSession.AttachedEntity is not { } ent
+            || GetEntity(msg.Target) is not { Valid: true } target
+            || !TryComp<XenoProjectileShooterComponent>(ent, out var shooter))
+        {
+            if (_logPrediction)
+                Log.Warning($"Predicted hit from '{args.SenderSession}' discarded due to invalid data.");
+            return true;
+        }
+
         var tick = msg.Tick;
         var substep = msg.Substep;
+        var shotTick = msg.ShotAtTick;
 
-        if (tick < _timing.CurTick)
+        if (substep < 0 || substep > _rmcLag.GetSubsteps())
+        {
+            Log.Warning($"Predicted hit from '{args.SenderSession}' contained out-of-range substep {substep}. Sanitizing it.");
+            substep = Math.Clamp(substep, 0, _rmcLag.GetSubsteps());
+        }
+
+        if (tick > _timing.CurTick)
+        {
+            // This shouldn't happen, ProcessPredictedMessages should be delaying it.
+            DebugTools.Assert(!(tick > _timing.CurTick));
+            return false;
+        }
+        else if (tick <= _timing.CurTick - 2) // we allow processing a message up to one tick late
+        {
+            // This shouldn't happen, ProcessPredictedMessages should have discarded it.
+            DebugTools.Assert(!(tick <= _timing.CurTick - 2));
+            return true;
+        }
+
+        if (shooter.NextId <= msg.Id)
+        {
+            // The shooter hasn't shot our predicted shot yet.
+            // The message is either being processed too early, OR
+            // the server is shooting the shot later than expected, OR
+            // the server was unable to shoot the projectile as predicted.
+            if (_logPrediction)
+                Log.Debug($"Predicted hit from '{args.SenderSession}' for shot {msg.Id} at tick {tick}, but the latest shot was {shooter.NextId - 1} at tick {_timing.CurTick})");
+            return false;
+        }
+
+        if (shooter.Shot.Count == 0
+            || !shooter.Shot.TryFirstOrNull(e => CompOrNull<XenoProjectileShotComponent>(e)?.Id == msg.Id, out var shot)
+            || TerminatingOrDeleted(shot))
+        {
+            // The shooter shot our predicted shot, but we failed to find it. It has either hit something
+            // or its duration has expired.
+            if (_logPrediction)
+                Log.Debug($"Predicted hit from '{args.SenderSession}' could not find shot {msg.Id} after it was shot.");
+            return true;
+        }
+
+        if (!TryComp(shot, out XenoProjectileShotComponent? xenoShot)
+            || !TryComp(shot, out ProjectileComponent? projectile)
+            || !TryComp(shot, out PhysicsComponent? physics))
+        {
+            Log.Warning($"Predicted hit from '{args.SenderSession}' found a shot without a necessary component.");
+            return true;
+        }
+
+        // server shot later than predicted, adjust the shot forward to try and hit
+        if (xenoShot.ShotAtTick > msg.ShotAtTick)
         {
             if (_logPrediction)
-                Log.Warning($"Predicted hit message arrived late (Message for {tick}, current tick {_timing.CurTick}).");
-            substep -= _rmcLagCompensation.GetSubsteps(); // adjust backwards by a full tick at most
+                Log.Debug($"Predicted hit from '{args.SenderSession}' predicted shot at {msg.ShotAtTick} but it was shot at {xenoShot.ShotAtTick}. Adjusting forward.");
+            substep += _rmcLag.GetSubsteps();
         }
-        else if (tick > _timing.CurTick)
+
+        // predicted hit message processed late, adjust the shot backwards to try and hit
+        if (_timing.CurTick > msg.Tick)
         {
             if (_logPrediction)
-                Log.Debug($"Predicted hit message arrived early (Message for {tick}, current tick {_timing.CurTick}). Saving it.");
-            _earlyMessages.Add((ent, tick, msg, args));
-            return;
+                Log.Debug($"Predicted hit from '{args.SenderSession}' on tick {msg.Tick} but it's currently {_timing.CurTick}. Adjusting backwards.");
+            substep -= _rmcLag.GetSubsteps();
         }
 
-        if (GetEntity(msg.Target) is not { Valid: true } target)
-            return;
-
-        if (!TryComp(ent, out XenoProjectileShooterComponent? shooter)
-            || shooter.Shot.Count == 0
-            || !shooter.Shot.TryFirstOrNull(e => CompOrNull<XenoProjectileShotComponent>(e)?.Id == msg.Id, out var shot))
+        if (substep > _rmcLag.GetSubsteps())
         {
-            if (tick >= _timing.CurTick && saveEarlyMessage)
-            {
-                if (_logPrediction)
-                    Log.Debug($"Predicted non-late shot ID {msg.Id} not found! Saving as early. (Tick {_timing.CurTick})");
-                _earlyMessages.Add((ent, tick, msg, args));
-            }
-            else if (_logPrediction)
-            {
-                Log.Debug($"Predicted shot ID {msg.Id} not found! (Tick {_timing.CurTick})");
-            }
-            return;
+            // We're trying to predict over a tick ahead. Delay the message if we can,
+            // but it will be discarded if it's too late.
+            if (_logPrediction)
+                Log.Debug($"Predicted hit from '{args.SenderSession} needs to be pushed forward by {substep} substeps, " +
+                    $"above the limit of {_rmcLag.GetSubsteps()}. Delaying processing.");
+
+            return false;
         }
 
-        if (TerminatingOrDeleted(shot))
+        if (_logPrediction)
+            Log.Debug($"""
+                Predicted hit checks passed, will test collision. Details:
+                  Session Name:   {args.SenderSession}
+                  Last Real Tick: {msg.LastRealTick}
+                  Shot ID:        {msg.Id}
+                  During shoot?   {_predictingSpecificShooter}
+
+                  Cur Tick:       {_timing.CurTick}
+                  Pred Hit Tick:  {msg.Tick}
+
+                  Shot Tick:      {xenoShot.ShotAtTick}
+                  Pred Shot Tick: {msg.ShotAtTick}
+
+                  Pred Substep:   {msg.Substep}
+                  Adjust Substep: {substep}
+                """);
+
+        _rmcLag.SetLastRealTick(args.SenderSession.UserId, msg.LastRealTick);
+        var hitConfirmed = _rmcLag.Collides(target, (shot.Value, physics), args.SenderSession, substep);
+
+        if (hitConfirmed)
         {
             if (_logPrediction)
-                Log.Warning($"Predicted shot ID {msg.Id} already deleted! (Tick {_timing.CurTick})");
-            return;
+                Log.Debug($"Predicted hit from '{args.SenderSession}' ++ CONFIRMED!! ++");
+
+            _projectile.ProjectileCollide((shot.Value, projectile, physics), target, true);
         }
-
-        _rmcLagCompensation.SetLastRealTick(args.SenderSession.UserId, msg.LastRealTick);
-
-        if (!TryComp(shot, out ProjectileComponent? projectile) ||
-            !TryComp(shot, out PhysicsComponent? physics))
+        else if (_logPrediction)
         {
-            return;
+            Log.Warning($"Predicted hit from '{args.SenderSession}' -- denied --");
         }
 
-        if (!_rmcLagCompensation.Collides(target, (shot.Value, physics), args.SenderSession, substep))
-            return;
-
-        _projectile.ProjectileCollide((shot.Value, projectile, physics), target, true);
+        return true;
     }
 
     private void OnShooterRemove<T>(Entity<XenoProjectileShooterComponent> ent, ref T args)
@@ -195,7 +293,7 @@ public sealed class XenoProjectileSystem : EntitySystem
         // actually be at their starting positions for tick x + 1. This includes our projectile.
         // We don't have an up-to-date value for LatestPredictedTick because tick x + 1 hasn't run yet.
         var tick = ent.Comp.LatestPredictedTick;
-        var substep = _rmcLagCompensation.GetClientSubstep();
+        var substep = _rmcLag.GetClientSubstep();
         if (!_timing.IsFirstTimePredicted)
         {
             tick += 1;
@@ -209,9 +307,10 @@ public sealed class XenoProjectileSystem : EntitySystem
             Log.Debug($"""
                 SENDING PREDICTED PROJECTILE HIT!!
                   ShotId:         {shot.Id}
+                  ShotAtTick:     {shot.ShotAtTick}
                   CurTick:        {_timing.CurTick}
-                  LastRealTick:   {_rmcLagCompensation.GetLastRealTick(null)}
-                  Phys Substep:   {_rmcLagCompensation.GetCurrentSubstep()}
+                  LastRealTick:   {_rmcLag.GetLastRealTick(null)}
+                  Phys Substep:   {_rmcLag.GetCurrentSubstep()}
                   In simulation?  {_timing.InSimulation}
                   ApplyingState?  {_timing.ApplyingState}
                   FirstTimePred?  {_timing.IsFirstTimePredicted}
@@ -225,9 +324,10 @@ public sealed class XenoProjectileSystem : EntitySystem
         var ev = new XenoProjectilePredictedHitEvent(
             shot.Id,
             GetNetEntity(args.Target),
-            _rmcLagCompensation.GetLastRealTick(null),
+            _rmcLag.GetLastRealTick(null),
             tick,
-            substep
+            substep,
+            shot.ShotAtTick
         );
         RaiseNetworkEvent(ev);
     }
@@ -290,32 +390,34 @@ public sealed class XenoProjectileSystem : EntitySystem
     /// Processes predicted hits that arrived too early.
     /// </summary>
     /// <param name="forShooter">Only process hits for a specific shooter</param>
-    private void ProcessEarlyMessages(EntityUid? forShooter = null)
+    private void ProcessPredictedMessages(EntityUid? forShooter = null)
     {
         if (_net.IsClient)
             return;
 
-        for (var i = _earlyMessages.Count - 1; i >= 0; --i)
+        for (var i = _predictedHitMessages.Count - 1; i >= 0; --i)
         {
-            var item = _earlyMessages[i];
-            var lastIndex = _earlyMessages.Count - 1;
-            if (item.PredictedHitTick < _timing.CurTick)
+            var item = _predictedHitMessages[i];
+            var lastIndex = _predictedHitMessages.Count - 1;
+            if (item.PredictedHitTick <= _timing.CurTick - 2) // messages two ticks in the past are considered expired
             {
                 if (_logPrediction)
-                    Log.Warning($"Removed expired prediction message: Shooter {item.Shooter}, Shot ID {item.Message.Id}");
+                    Log.Warning("Removed expired prediction message: " +
+                        $"Shooter {item.Args.SenderSession}, Shot ID {item.Message.Id}, Tick {item.PredictedHitTick}, CurTick {_timing.CurTick}");
                 if (i != lastIndex)
-                    _earlyMessages[i] = _earlyMessages[lastIndex];
-                _earlyMessages.RemoveAt(lastIndex);
+                    _predictedHitMessages[i] = _predictedHitMessages[lastIndex];
+                _predictedHitMessages.RemoveAt(lastIndex);
             }
-            else if (item.PredictedHitTick == _timing.CurTick)
+            else if (item.PredictedHitTick <= _timing.CurTick) // process messages on their tick or up to one tick behind
             {
                 if (forShooter != null && item.Shooter != forShooter)
                     continue;
 
-                OnPredictedHit(item.Message, item.Args, false);
+                if (!HandlePredictedHit(item.Message, item.Args))
+                    continue; // wasn't handled yet, keep it around
                 if (i != lastIndex)
-                    _earlyMessages[i] = _earlyMessages[lastIndex];
-                _earlyMessages.RemoveAt(lastIndex);
+                    _predictedHitMessages[i] = _predictedHitMessages[lastIndex];
+                _predictedHitMessages.RemoveAt(lastIndex);
             }
         }
     }
@@ -424,6 +526,7 @@ public sealed class XenoProjectileSystem : EntitySystem
                 shot.Id = shooter.NextId++;
                 shot.Shooter = shooterPlayer;
                 shot.ShooterEnt = xeno;
+                shot.ShotAtTick = _timing.CurTick;
                 Dirty(projectile, shot);
             }
 
@@ -440,7 +543,9 @@ public sealed class XenoProjectileSystem : EntitySystem
         // Client may have already predicted hits for this projectile, check before we test collisions.
         if (_net.IsServer && predicted)
         {
-            ProcessEarlyMessages(xeno);
+            _predictingSpecificShooter = true;
+            ProcessPredictedMessages(xeno);
+            _predictingSpecificShooter = false;
         }
 
         return true;
@@ -461,7 +566,7 @@ public sealed class XenoProjectileSystem : EntitySystem
         }
         else // server
         {
-            ProcessEarlyMessages();
+            ProcessPredictedMessages();
         }
     }
 }

--- a/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
@@ -139,7 +139,6 @@ public sealed class XenoProjectileSystem : EntitySystem
         }
 
         _rmcLagCompensation.SetLastRealTick(args.SenderSession.UserId, msg.LastRealTick);
-        var coordinates = _transform.ToMapCoordinates(_rmcLagCompensation.GetCoordinates(target, args.SenderSession));
 
         if (!TryComp(shot, out ProjectileComponent? projectile) ||
             !TryComp(shot, out PhysicsComponent? physics))
@@ -147,7 +146,7 @@ public sealed class XenoProjectileSystem : EntitySystem
             return;
         }
 
-        if (!_rmcLagCompensation.Collides(target, (shot.Value, physics), coordinates, substep))
+        if (!_rmcLagCompensation.Collides(target, (shot.Value, physics), args.SenderSession, substep))
             return;
 
         _projectile.ProjectileCollide((shot.Value, projectile, physics), target, true);
@@ -191,7 +190,9 @@ public sealed class XenoProjectileSystem : EntitySystem
             return;
 
         // If a collision happens during a re-predicted frame, the projectile is actually at substep 0
-        // for the next frame. Not 100% sure why this is the case, but it's very accurate during testing.
+        // for the next frame. This is because on tick x, after the physics system runs, objects will
+        // actually be at their starting positions for tick x + 1. This includes our projectile.
+        // We don't have an up-to-date value for LatestPredictedTick because tick x + 1 hasn't run yet.
         var tick = ent.Comp.LatestPredictedTick;
         var substep = _rmcLagCompensation.GetClientSubstep();
         if (!_timing.IsFirstTimePredicted)
@@ -293,7 +294,7 @@ public sealed class XenoProjectileSystem : EntitySystem
         if (_net.IsClient)
             return;
 
-        for (var i = 0; i < _earlyMessages.Count; ++i)
+        for (var i = _earlyMessages.Count - 1; i >= 0; --i)
         {
             var item = _earlyMessages[i];
             if (item.PredictedHitTick < _timing.CurTick)
@@ -302,7 +303,6 @@ public sealed class XenoProjectileSystem : EntitySystem
                     Log.Warning($"Removed expired prediction message: Shooter {item.Shooter}, Shot ID {item.Message.Id}");
                 _earlyMessages[i] = _earlyMessages[_earlyMessages.Count - 1];
                 _earlyMessages.RemoveAt(_earlyMessages.Count - 1);
-                --i;
             }
             else if (item.PredictedHitTick == _timing.CurTick)
             {
@@ -312,7 +312,6 @@ public sealed class XenoProjectileSystem : EntitySystem
                 OnPredictedHit(item.Message, item.Args, false);
                 _earlyMessages[i] = _earlyMessages[_earlyMessages.Count - 1];
                 _earlyMessages.RemoveAt(_earlyMessages.Count - 1);
-                --i;
             }
         }
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Predicted/lag compensated xeno projectiles should hit their targets much more reliably.

Leap-like abilities should hit their targets more reliably.

Fixes #9957.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfix.

## Technical details
<!-- Summary of code changes for easier review. -->
~~There were two issues I found.~~ Edit: Three now.

**Issue 1: Server was rejecting fair hits**

Clients tell the server that they got a hit on their end at a certain time. The server confirms that by rewinding the position of the target to where the client would have seen them, and then checking if the collision would be valid. However, the server was struggling to confirm the projectile's actual position due to physics substepping. The client was hitting their target at some physics substep, but the server had no knowledge of which substep the hit was on. Although the server tested some substeps, it didn't test all of them, and thus many hits were being rejected.

This is fixed by the client telling the server which substep the hit was on. The server then moves the projectile as if it was substepped that many times and THEN tests for a collision. From my testing, this is significantly more reliable.

**Issue 2: Engine bug regarding StartCollideEvent on clients**

Our version of RT has a bug where StartCollideEvent doesn't trigger on the client if the collision happens while the client is applying server state. This ended up happening VERY reliably, but only in a small band of distances from the target that varies based on your ping. The reason this is a problem is that the client simply DID NOT SEND a predicted hit event. At all. There was no lag comp because the server was never made aware the client hit something by the client itself.

This engine bug is fixed in newer versions of RT (any version released in 2026 or later should work), but in the mean time we have to use a workaround. I decided to use ProjectileHitEvent. This event does fire on StartCollideEvent, but its system ALSO fires it in an update loop which checks for collisions too.

**EDIT**
**Issue 3: Server processes predicted hit message before projectile is spawned**

Fairly simple compared to the above issues. Server processes the `XenoProjectilePredictedHitEvent` it receives before the processing that spawns the projectile occurs. This happens if you are near the target and hit them on the same tick that you made the projectile. For fast projectiles, this range is quite large. The result is that the predicted event is discarded because the projectile wasn't found.

Fixed this by storing the messages and processing them when the shooting actually happens.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

I did not record a video of the fix, it just looks like the abilities working like they should. Instead here is a video of the issue in action, which from my testing no longer occurs:

https://github.com/user-attachments/assets/da0ee49c-0a68-4492-b023-80aeb5a6d856


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Xeno projectile abilities should hit their targets much more reliably. (Spike Shed, Bone Spurs, Tail Seize, and all spit abilities.)
- fix: Leap-like abilities should hit their targets more reliably. (Leap, Pounce, Dash, Rush, Assault)
