### PR TITLE
White Phosphorous to specialist vendor, grenade belt content parity

### DIFF
--- a/Resources/Prototypes/_RMC14/Catalog/Fills/Clothing/belt.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Fills/Clothing/belt.yml
@@ -152,12 +152,13 @@
   - type: StorageFill
     contents:
     - id: CMGrenadeHighExplosive
-      amount: 5
-    - id: CMGrenadeFrag
-      amount: 1
+      amount: 3
+    - id: RMC40MMGrenadeM74AGMF
+      amount: 2
     - id: RMCGrenadeIncendiary
       amount: 2
-    # TODO Original is 3 HEDP, 2 HIDP incen, 2 airburst frag, 1 airburst incen
+    - id: RMC40MMGrenadeM74AGMI
+      amount: 1
 
 - type: entity
   parent: RMCBeltGrenadeLarge
@@ -167,12 +168,13 @@
   - type: StorageFill
     contents:
     - id: CMGrenadeHighExplosive
-      amount: 12
-    - id: CMGrenadeFrag
-      amount: 3
+      amount: 6
+    - id: RMC40MMGrenadeM74AGMF
+      amount: 6
     - id: RMCGrenadeIncendiary
       amount: 3
-    # TODO Original is 6 HEDP, 3 HIDP incen, 6 airburst frag, 3 airburst incen
+    - id: RMC40MMGrenadeM74AGMI
+      amount: 3
 
 - type: entity
   parent: RMCBeltGrenadeLarge

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/specialist.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/specialist.yml
@@ -113,8 +113,10 @@
         name: 30mm HIDP Incendiary Grenades (x6)
         points: 40
         spawn: 6
-      #- id: M40HPDPWhitePhosphorusGrenadesx6
-      #  points: 40
+      - id: RMCGrenadeWhitePhosphorusCompound
+        name: M40 CCDP Chemical Compound Grenades (x6)
+        points: 40
+        spawn: 6
       - id: RMC40MMGrenadeM74AGMF
         points: 40
         spawn: 6


### PR DESCRIPTION
## About the PR
Added white phosphorous grenades to the weapon specialist vendor
Completed the TODO on the grenade belt contents to be parity
Replaced the large grenade belt on sorokyne to the regular one

## Why / Balance
Parity

## Media
cm13 regular grenade belt
<img width="531" height="192" alt="Screenshot 2026-05-29 033900" src="https://github.com/user-attachments/assets/4f4c47f1-5cd3-4cc7-8826-30ea5fff6ea6" />
our regular grenade belt now with parity contents
<img width="451" height="156" alt="Screenshot 2026-05-29 033949" src="https://github.com/user-attachments/assets/588ab275-aed8-4387-adee-f660a417e3f2" />

cm13 gren specialist grenade belt
<img width="813" height="511" alt="Screenshot 2026-05-29 034014" src="https://github.com/user-attachments/assets/88640f6e-c9e6-4f35-8bf5-8432b5877598" />
our gren specialist grenade belt now with parity contents
<img width="449" height="215" alt="Screenshot 2026-05-29 033958" src="https://github.com/user-attachments/assets/15e5889d-5dc0-4084-bab5-9d42da4d814d" />

grenade belt on sorokyne is now parity as a regular not specialist belt
<img width="977" height="301" alt="image" src="https://github.com/user-attachments/assets/50841c4d-88d8-435d-aa58-660568a819f1" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: CatAndHats
- add: Added CCDP Chemical Compound grenades to the weapon specialist vendor
- tweak: Changed the contents of the weapon specialist and regular grenade belts. They no longer feature HEFA grenades, and have lost some of their HEDP in exchange for fragmentation and incendiary airburst grenades.
- fix: Fixed the filled grenade belt on Sorokyne Strata to now be a regular grenade belt not a weapon specialist grenade belt.
