### PR TITLE
Fix client mispredicting actions

### DIFF
--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -13,6 +13,7 @@ using Content.Client.UserInterface.Systems.Actions.Widgets;
 using Content.Client.UserInterface.Systems.Actions.Windows;
 using Content.Client.UserInterface.Systems.Gameplay;
 using Content.Shared._RMC14.Actions;
+using Content.Shared._RMC14.GameStates;
 using Content.Shared.Actions;
 using Content.Shared.Actions.Components;
 using Content.Shared.Charges.Systems;
@@ -52,6 +53,9 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
     [UISystemDependency] private readonly InteractionOutlineSystem? _interactionOutline = default;
     [UISystemDependency] private readonly TargetOutlineSystem? _targetOutline = default;
     [UISystemDependency] private readonly SpriteSystem _spriteSystem = default!;
+
+    // RMC14
+    [UISystemDependency] private readonly SharedRMCGameStateSystem _rmcGameState = default!;
 
     private ActionButtonContainer? _container;
     private readonly List<EntityUid?> _actions = new();
@@ -173,6 +177,10 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
         {
             return false;
         }
+
+        // RMC14
+        // Cursed workaround to put the client into "in simulation" state.
+        using var enforcedSim = _rmcGameState.EnforceSimulation();
 
         // Is the action currently valid?
         if (!_actionsSystem.ValidAction(action))

--- a/Content.Client/_RMC14/Xenonids/Rest/XenoRestKeybindSystem.cs
+++ b/Content.Client/_RMC14/Xenonids/Rest/XenoRestKeybindSystem.cs
@@ -1,5 +1,6 @@
 using Content.Client.Actions;
 using Content.Shared._RMC14.Actions;
+using Content.Shared._RMC14.GameStates;
 using Content.Shared._RMC14.Input;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared._RMC14.Xenonids.Rest;
@@ -14,6 +15,7 @@ public sealed class XenoRestKeybindSystem : EntitySystem
     [Dependency] private readonly ActionsSystem _actionsSystem = default!;
     [Dependency] private readonly IPlayerManager _playerManager = default!;
     [Dependency] private readonly SharedRMCActionsSystem _rmcActions = default!;
+    [Dependency] private readonly SharedRMCGameStateSystem _rmcGameState = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
 
     public override void Initialize()
@@ -26,6 +28,9 @@ public sealed class XenoRestKeybindSystem : EntitySystem
                     var ent = _playerManager.LocalEntity;
                     if (ent == null || !ent.Value.IsValid() || !HasComp<XenoComponent>(ent.Value))
                         return;
+
+                    // Cursed workaround to put the client into "in simulation" state.
+                    using var enforcedSim = _rmcGameState.EnforceSimulation();
 
                     foreach (var (actionId, actionComp) in _rmcActions.GetActionsWithEvent<XenoRestActionEvent>(ent.Value))
                     {

--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -1,7 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Content.Shared._RMC14.Actions;
-using Content.Shared._RMC14.Chat;
+using Content.Shared._RMC14.GameStates;
 using Content.Shared._RMC14.Movement;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Actions.Components;
@@ -38,6 +38,7 @@ public abstract class SharedActionsSystem : EntitySystem
 
     // RMC14
     [Dependency] private readonly SharedRMCActionsSystem _rmcActions = default!;
+    [Dependency] private readonly SharedRMCGameStateSystem _rmcGameState = default!;
     [Dependency] private readonly SharedRMCLagCompensationSystem _rmcLagCompensation = default!;
 
     private EntityQuery<ActionComponent> _actionQuery;
@@ -269,6 +270,10 @@ public abstract class SharedActionsSystem : EntitySystem
     /// </summary>
     private void OnActionRequest(RequestPerformActionEvent ev, EntitySessionEventArgs args)
     {
+        // RMC14
+        // Cursed workaround to put the client into "in simulation" state.
+        using var enforcedSim = _rmcGameState.EnforceSimulation();
+
         _rmcLagCompensation.SetLastRealTick(args.SenderSession.UserId, ev.LastRealTick);
         if (args.SenderSession.AttachedEntity is not { } user)
             return;

--- a/Content.Shared/_RMC14/GameStates/SharedRMCGameStateSystem.cs
+++ b/Content.Shared/_RMC14/GameStates/SharedRMCGameStateSystem.cs
@@ -1,8 +1,7 @@
-﻿using Content.Shared.Administration;
 using Robust.Shared;
 using Robust.Shared.Configuration;
-using Robust.Shared.Console;
 using Robust.Shared.Network;
+using Robust.Shared.Timing;
 
 namespace Content.Shared._RMC14.GameStates;
 
@@ -10,6 +9,7 @@ public sealed class SharedRMCGameStateSystem : EntitySystem
 {
     [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
 
     public override void Initialize()
     {
@@ -22,5 +22,54 @@ public sealed class SharedRMCGameStateSystem : EntitySystem
             return;
 
         _config.SetCVar(CVars.NetPredict, ev.Enable);
+    }
+
+    /// <summary>
+    /// Puts the game into "InSimulation" state. For whenever that's necessary.
+    /// Remember to call Unenforce() or dispose this object. Or use `using var` to do so automatically.
+    /// </summary>
+    /// <remarks>
+    /// Welcome to one of the most cursed workarounds I've written yet.
+    /// It turns out that on the client, we do a lot of game actions "out of simulation". That's kind of bad.
+    /// If we need to force the game into "in simulation" mode, do `using var enforcedSim = _rmcGameState.EnforceSimulation()`.
+    /// The game will be put into simulation state, and when the var goes out of scope the simulation will return to its previous state.
+    /// It only does anything on the client.
+    /// </remarks>
+    /// <returns>An EnforcedInSimulation object. Use with a `using var` so that it disposes automatically.</returns>
+    public EnforcedInSimulation EnforceSimulation()
+    {
+        var result = new EnforcedInSimulation(_timing.InSimulation, _timing, _net);
+
+        if (_net.IsClient)
+            _timing.InSimulation = true;
+
+        return result;
+    }
+
+    public readonly struct EnforcedInSimulation : IDisposable
+    {
+        public bool OldInSimulation { get; }
+        private IGameTiming Timing { get; }
+        private INetManager Net { get; }
+
+        public EnforcedInSimulation(bool oldInSimulation, IGameTiming timing, INetManager net)
+        {
+            OldInSimulation = oldInSimulation;
+            Timing = timing;
+            Net = net;
+        }
+
+        public void Unenforce()
+        {
+            if (Net.IsClient)
+                Timing.InSimulation = OldInSimulation;
+        }
+
+        // Yes we're disposing a struct so that we can make use of that
+        // sweet `using var` syntactic sugar.
+        public void Dispose()
+        {
+            Unenforce();
+        }
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Client no longer allows you to use actions before their cooldown is actually up. Actions are now run "in simulation" rather than "out of simulation".

Fixes #8702.

Might require changes in #9963. That PR has a small bit of jank regarding how many substeps the server has to run compared to the client, and I fear that this out-of-simulation action behavior could be the cause of that jank.

~~Edit: I tested these two PRs merged together, and yep, I will need to fix #9963 if this PR is merged. The jank was being caused exactly by this issue, where client actions were predicted out-of-simulation.~~
Edit2: Actually probably not. Testing it is a bit difficult, I now believe this PR doesn't cause issues with it.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfix.

## Technical details
<!-- Summary of code changes for easier review. -->
Actions are UI. UI is considered out of simulation. Out of simulation timing does not use the same "CurTime" as in simulation timing. Basically every action we have does in-simulation things. The end result is, the client tries to predict a lot of "in simulation" things while the engine says it's "out of simulation". It goes poorly.

The root cause of the ghost action issue is that when the client tries to use an action, it compares CurTime to the action's cooldown EndTime. But because we're "out of simulation", CurTime can actually be a value in the middle of a tick. That means if you use the action late enough in the final tick of the cooldown, the client will let you, because CurTime advanced past the EndTime _during the tick_ that EndTime is in. In simulation that is not possible, you would have to wait for the next tick for CurTime to advance past EndTime.

I am honestly not sure how best to deal with this. This feels like a big oversight by basically all actions in content (both ours and upstream). It seems every action has this problem.

The fix I decided on is very forceful but seems effective. I set `InSimulation` to be true during all the action code, and reset it to its old value when done. This only needs to be done on the client.

This seems to work quite well. A lot of the timing code actually adjusts itself based on the value of `InSimulation`. `CurTick` is calculated based on the value of `InSimulation`. So all the cooldown checks end up working just fine after doing this. All the client code that runs off of an action will also end up having the correct `CurTick` so abilities might actually be predicted much better as a result.

I tested several abilities and they seem to work fine. The root cause is completely dealt with so there are no more ghost actions. However, the effects of this fix could be extensive. This whole time, the client has been predicting actions out-of-simulation. I cannot predict for certain how every action will behave due to this change, but I expect most of the effects should actually be positive.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Clients will no longer let you use actions before their cooldown is actually over, which resulted in "ghost actions".
