### PR TITLE
Hijack explosions

### DIFF
--- a/Content.Client/Atmos/EntitySystems/FireVisualizerSystem.cs
+++ b/Content.Client/Atmos/EntitySystems/FireVisualizerSystem.cs
@@ -1,5 +1,5 @@
 using Content.Client.Atmos.Components;
-using Content.Shared._RMC14.Atmos;
+using Content.Shared._RMC14.Atmos; // RMC14
 using Content.Shared.Atmos;
 using Robust.Client.GameObjects;
 using Robust.Shared.Map;
@@ -14,16 +14,22 @@ public sealed class FireVisualizerSystem : VisualizerSystem<FireVisualsComponent
 {
     [Dependency] private readonly PointLightSystem _lights = default!;
 
-    private EntityQuery<RMCFireColorComponent> _fireColorQuery; // RMC14
+    // RMC14 start
+    private EntityQuery<RMCFireColorComponent> _fireColorQuery;
+    // RMC14 end
 
     public override void Initialize()
     {
         base.Initialize();
 
-        _fireColorQuery = GetEntityQuery<RMCFireColorComponent>(); // RMC14
+        // RMC14 start
+        _fireColorQuery = GetEntityQuery<RMCFireColorComponent>();
+        // RMC14 end
 
         SubscribeLocalEvent<FireVisualsComponent, ComponentInit>(OnComponentInit);
+        // RMC14 start
         SubscribeLocalEvent<FireVisualsComponent, ComponentStartup>(OnComponentStartup);
+        // RMC14 end
         SubscribeLocalEvent<FireVisualsComponent, ComponentShutdown>(OnShutdown);
     }
 
@@ -56,6 +62,8 @@ public sealed class FireVisualizerSystem : VisualizerSystem<FireVisualsComponent
             SpriteSystem.LayerSetRsi((uid, sprite), FireVisualLayers.Fire, new ResPath(component.Sprite));
     }
 
+    // RMC14 start
+    // Delay the initial update until startup so client-side light children are not attached to an initializing parent.
     private void OnComponentStartup(EntityUid uid, FireVisualsComponent component, ComponentStartup args)
     {
         if (!TryComp<SpriteComponent>(uid, out var sprite) || !TryComp(uid, out AppearanceComponent? appearance))
@@ -63,6 +71,7 @@ public sealed class FireVisualizerSystem : VisualizerSystem<FireVisualsComponent
 
         UpdateAppearance(uid, component, sprite, appearance);
     }
+    // RMC14 end
 
     protected override void OnAppearanceChange(EntityUid uid, FireVisualsComponent component, ref AppearanceChangeEvent args)
     {
@@ -95,7 +104,7 @@ public sealed class FireVisualizerSystem : VisualizerSystem<FireVisualsComponent
         else
             SpriteSystem.LayerSetRsiState((uid, sprite), index, component.NormalState);
 
-        // RMC14
+        // RMC14 start
         var fireColor = component.LightColor;
         if (_fireColorQuery.TryComp(uid, out var fireColorComp))
         {
@@ -104,13 +113,17 @@ public sealed class FireVisualizerSystem : VisualizerSystem<FireVisualsComponent
         }
         // RMC14 end
 
+        // RMC14 start
         if (!MetaData(uid).EntityInitialized)
             return;
+        // RMC14 end
 
         component.LightEntity ??= Spawn(null, new EntityCoordinates(uid, default));
         var light = EnsureComp<PointLightComponent>(component.LightEntity.Value);
 
-        _lights.SetColor(component.LightEntity.Value, fireColor, light); // RMC14 fire color
+        // RMC14 start
+        _lights.SetColor(component.LightEntity.Value, fireColor, light);
+        // RMC14 end
 
         // light needs a minimum radius to be visible at all, hence the + 1.5f
         _lights.SetRadius(component.LightEntity.Value, Math.Clamp(1.5f + component.LightRadiusPerStack * fireStacks, 0f, component.MaxLightRadius), light);

--- a/Content.Client/Atmos/EntitySystems/FireVisualizerSystem.cs
+++ b/Content.Client/Atmos/EntitySystems/FireVisualizerSystem.cs
@@ -23,6 +23,7 @@ public sealed class FireVisualizerSystem : VisualizerSystem<FireVisualsComponent
         _fireColorQuery = GetEntityQuery<RMCFireColorComponent>(); // RMC14
 
         SubscribeLocalEvent<FireVisualsComponent, ComponentInit>(OnComponentInit);
+        SubscribeLocalEvent<FireVisualsComponent, ComponentStartup>(OnComponentStartup);
         SubscribeLocalEvent<FireVisualsComponent, ComponentShutdown>(OnShutdown);
     }
 
@@ -53,6 +54,12 @@ public sealed class FireVisualizerSystem : VisualizerSystem<FireVisualsComponent
         sprite.LayerSetShader(FireVisualLayers.Fire, "unshaded");
         if (component.Sprite != null)
             SpriteSystem.LayerSetRsi((uid, sprite), FireVisualLayers.Fire, new ResPath(component.Sprite));
+    }
+
+    private void OnComponentStartup(EntityUid uid, FireVisualsComponent component, ComponentStartup args)
+    {
+        if (!TryComp<SpriteComponent>(uid, out var sprite) || !TryComp(uid, out AppearanceComponent? appearance))
+            return;
 
         UpdateAppearance(uid, component, sprite, appearance);
     }
@@ -96,6 +103,9 @@ public sealed class FireVisualizerSystem : VisualizerSystem<FireVisualsComponent
             SpriteSystem.LayerSetColor((uid, sprite), index, fireColor);
         }
         // RMC14 end
+
+        if (!MetaData(uid).EntityInitialized)
+            return;
 
         component.LightEntity ??= Spawn(null, new EntityCoordinates(uid, default));
         var light = EnsureComp<PointLightComponent>(component.LightEntity.Value);

--- a/Content.Server/_RMC14/Hijack/RMCHijackRandomDamageSystem.cs
+++ b/Content.Server/_RMC14/Hijack/RMCHijackRandomDamageSystem.cs
@@ -206,6 +206,7 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
             if (!comp.Enabled ||
                 comp.Category != RMCHijackRandomDamageCategory.Pipe ||
                 xform.MapUid != map ||
+                !xform.Anchored ||
                 _usedPipeTargets.Contains(uid) ||
                 _pendingPipeTargets.Contains(uid))
             {
@@ -235,8 +236,13 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
     /// </summary>
     private void StartPipeWarning(EntityUid pipe)
     {
-        if (Deleted(pipe) || !TryComp(pipe, out TransformComponent? xform) || !_usedPipeTargets.Add(pipe))
+        if (Deleted(pipe) ||
+            !TryComp(pipe, out TransformComponent? xform) ||
+            !xform.Anchored ||
+            !_usedPipeTargets.Add(pipe))
+        {
             return;
+        }
 
         _pendingPipeTargets.Add(pipe);
         Spawn(PipeExplosionWarning, _transform.GetMoverCoordinates(pipe, xform));
@@ -252,8 +258,13 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
     {
         _pendingPipeTargets.Remove(pipe);
 
-        if (Deleted(pipe) || !TryComp(pipe, out TransformComponent? xform) || xform.MapUid == null)
+        if (Deleted(pipe) ||
+            !TryComp(pipe, out TransformComponent? xform) ||
+            xform.MapUid == null ||
+            !xform.Anchored)
+        {
             return;
+        }
 
         var coordinates = _transform.GetMoverCoordinates(pipe, xform);
         var mapCoordinates = _transform.GetMapCoordinates(pipe, xform);

--- a/Content.Server/_RMC14/Hijack/RMCHijackRandomDamageSystem.cs
+++ b/Content.Server/_RMC14/Hijack/RMCHijackRandomDamageSystem.cs
@@ -1,0 +1,274 @@
+using Content.Shared._RMC14.Atmos;
+using Content.Shared._RMC14.Dropship;
+using Content.Shared._RMC14.Explosion;
+using Content.Shared._RMC14.Hijack;
+using Content.Shared.Damage;
+using Content.Shared.FixedPoint;
+using Robust.Shared.Audio;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+
+namespace Content.Server._RMC14.Hijack;
+
+public sealed class RMCHijackRandomDamageSystem : EntitySystem
+{
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly DamageableSystem _damageable = default!;
+    [Dependency] private readonly SharedRMCExplosionSystem _rmcExplosion = default!;
+    [Dependency] private readonly SharedRMCFlammableSystem _rmcFlammable = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    private static readonly EntProtoId BrokenPipe = "GasPipeBroken";
+    private static readonly EntProtoId PipeFire = "RMCHijackPipeFire";
+    private static readonly EntProtoId PipeExplosionWarning = "RMCHijackPipeExplosionWarning";
+    private static readonly SoundSpecifier PipeHiss = new SoundPathSpecifier("/Audio/Ambience/Objects/gas_hiss.ogg");
+
+    private static readonly TimeSpan PipeBarrageInterval = TimeSpan.FromSeconds(15);
+    private static readonly TimeSpan PipeWarningDelay = TimeSpan.FromSeconds(5);
+
+    private const float WallMinPercent = 0.03f;
+    private const float WallMaxPercent = 0.06f;
+    private const float WindowMinPercent = 0.30f;
+    private const float WindowMaxPercent = 0.50f;
+    private const float WindoorMinPercent = 0.50f;
+    private const float WindoorMaxPercent = 1.00f;
+    private const float PipeInitialPercent = 0.10f;
+    private const float PipeMinPercent = 0.007f;
+    private const float PipeMaxPercent = 0.012f;
+
+    private const float PipeExplosionTotal = 300f;
+    private const float PipeExplosionSlope = 25f;
+    private const float PipeExplosionMax = 20f;
+    private const int PipeFireRange = 2;
+
+    private readonly List<(EntityUid Uid, RMCHijackRandomDamageTargetComponent Comp)> _wallTargets = new();
+    private readonly List<(EntityUid Uid, RMCHijackRandomDamageTargetComponent Comp)> _windowTargets = new();
+    private readonly List<(EntityUid Uid, RMCHijackRandomDamageTargetComponent Comp)> _windoorTargets = new();
+    private readonly List<EntityUid> _pipeTargets = new();
+    private readonly List<EntityUid> _barrageMaps = new();
+    private readonly Dictionary<EntityUid, TimeSpan> _nextPipeBarrage = new();
+    private readonly HashSet<EntityUid> _applyingHijackDamage = new();
+    private readonly HashSet<EntityUid> _usedPipeTargets = new();
+    private readonly HashSet<EntityUid> _pendingPipeTargets = new();
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<DropshipHijackLandedEvent>(OnDropshipHijackLanded);
+        SubscribeLocalEvent<RMCHijackRandomDamageTargetComponent, BeforeDamageChangedEvent>(OnBeforeDamageChanged);
+    }
+
+    public override void Update(float frameTime)
+    {
+        if (_nextPipeBarrage.Count == 0)
+            return;
+
+        var now = _timing.CurTime;
+        _barrageMaps.Clear();
+
+        foreach (var (map, nextBarrage) in _nextPipeBarrage)
+        {
+            if (nextBarrage <= now)
+                _barrageMaps.Add(map);
+        }
+
+        foreach (var map in _barrageMaps)
+        {
+            if (Deleted(map))
+            {
+                _nextPipeBarrage.Remove(map);
+                continue;
+            }
+
+            DoPipeBarrage(map);
+        }
+    }
+
+    private void OnDropshipHijackLanded(ref DropshipHijackLandedEvent ev)
+    {
+        _wallTargets.Clear();
+        _windowTargets.Clear();
+        _windoorTargets.Clear();
+
+        var query = EntityQueryEnumerator<RMCHijackRandomDamageTargetComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out var comp, out var xform))
+        {
+            if (!comp.Enabled || xform.MapUid != ev.Map)
+                continue;
+
+            switch (comp.Category)
+            {
+                case RMCHijackRandomDamageCategory.Wall:
+                    _wallTargets.Add((uid, comp));
+                    break;
+                case RMCHijackRandomDamageCategory.Window:
+                    _windowTargets.Add((uid, comp));
+                    break;
+                case RMCHijackRandomDamageCategory.Windoor:
+                    _windoorTargets.Add((uid, comp));
+                    break;
+            }
+        }
+
+        ApplyRandomDamage(_wallTargets, WallMinPercent, WallMaxPercent);
+        ApplyRandomDamage(_windowTargets, WindowMinPercent, WindowMaxPercent);
+        ApplyRandomDamage(_windoorTargets, WindoorMinPercent, WindoorMaxPercent);
+
+        DoPipeBarrage(ev.Map, PipeInitialPercent, PipeInitialPercent);
+    }
+
+    private void ApplyRandomDamage(
+        List<(EntityUid Uid, RMCHijackRandomDamageTargetComponent Comp)> targets,
+        float minPercent,
+        float maxPercent)
+    {
+        var count = GetRandomCount(targets.Count, minPercent, maxPercent);
+        if (count == 0)
+            return;
+
+        _random.Shuffle(targets);
+
+        var breakCount = count / 2;
+        if (count % 2 != 0 && _random.Prob(0.5f))
+            breakCount++;
+
+        for (var i = 0; i < count; i++)
+        {
+            var (uid, comp) = targets[i];
+            ApplyOutcome(uid, comp, i < breakCount);
+        }
+    }
+
+    private void ApplyOutcome(EntityUid uid, RMCHijackRandomDamageTargetComponent comp, bool shouldBreak)
+    {
+        if (Deleted(uid))
+            return;
+
+        var damage = shouldBreak ? comp.BreakDamage : comp.Damage;
+        if (damage == null)
+            return;
+
+        ApplyDamageUpToTarget(uid, damage);
+    }
+
+    private void ApplyDamageUpToTarget(EntityUid uid, DamageSpecifier targetDamage)
+    {
+        if (!TryComp(uid, out DamageableComponent? damageable))
+            return;
+
+        var targetTotal = targetDamage.GetTotal();
+        if (targetTotal <= FixedPoint2.Zero || damageable.TotalDamage >= targetTotal)
+            return;
+
+        var remaining = targetTotal - damageable.TotalDamage;
+        var damage = targetDamage * (remaining / targetTotal);
+
+        _applyingHijackDamage.Add(uid);
+        try
+        {
+            _damageable.TryChangeDamage(uid, damage, true, damageable: damageable);
+        }
+        finally
+        {
+            _applyingHijackDamage.Remove(uid);
+        }
+    }
+
+    private void OnBeforeDamageChanged(Entity<RMCHijackRandomDamageTargetComponent> ent, ref BeforeDamageChangedEvent args)
+    {
+        if (!ent.Comp.HijackDamageOnly ||
+            _applyingHijackDamage.Contains(ent.Owner) ||
+            !args.Damage.AnyPositive())
+        {
+            return;
+        }
+
+        args.Cancelled = true;
+    }
+
+    private void DoPipeBarrage(EntityUid map, float minPercent = PipeMinPercent, float maxPercent = PipeMaxPercent)
+    {
+        _pipeTargets.Clear();
+
+        var query = EntityQueryEnumerator<RMCHijackRandomDamageTargetComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out var comp, out var xform))
+        {
+            if (!comp.Enabled ||
+                comp.Category != RMCHijackRandomDamageCategory.Pipe ||
+                xform.MapUid != map ||
+                _usedPipeTargets.Contains(uid) ||
+                _pendingPipeTargets.Contains(uid))
+            {
+                continue;
+            }
+
+            _pipeTargets.Add(uid);
+        }
+
+        var count = GetRandomCount(_pipeTargets.Count, minPercent, maxPercent);
+        if (count == 0)
+        {
+            _nextPipeBarrage.Remove(map);
+            return;
+        }
+
+        _random.Shuffle(_pipeTargets);
+
+        for (var i = 0; i < count; i++)
+            StartPipeWarning(_pipeTargets[i]);
+
+        _nextPipeBarrage[map] = _timing.CurTime + PipeBarrageInterval;
+    }
+
+    private void StartPipeWarning(EntityUid pipe)
+    {
+        if (Deleted(pipe) || !TryComp(pipe, out TransformComponent? xform) || !_usedPipeTargets.Add(pipe))
+            return;
+
+        _pendingPipeTargets.Add(pipe);
+        Spawn(PipeExplosionWarning, _transform.GetMoverCoordinates(pipe, xform));
+        _audio.PlayPvs(PipeHiss, pipe);
+
+        Timer.Spawn(PipeWarningDelay, () => BurstPipe(pipe));
+    }
+
+    private void BurstPipe(EntityUid pipe)
+    {
+        _pendingPipeTargets.Remove(pipe);
+
+        if (Deleted(pipe) || !TryComp(pipe, out TransformComponent? xform) || xform.MapUid == null)
+            return;
+
+        var coordinates = _transform.GetMoverCoordinates(pipe, xform);
+        var mapCoordinates = _transform.GetMapCoordinates(pipe, xform);
+        var rotation = xform.LocalRotation;
+
+        _rmcExplosion.QueueExplosion(
+            mapCoordinates,
+            "RMC",
+            PipeExplosionTotal,
+            PipeExplosionSlope,
+            PipeExplosionMax,
+            pipe,
+            canCreateVacuum: false);
+
+        _rmcFlammable.SpawnFireDiamond(PipeFire, coordinates, PipeFireRange);
+
+        Del(pipe);
+        var brokenPipe = Spawn(BrokenPipe, coordinates);
+        _transform.SetLocalRotation(brokenPipe, rotation);
+    }
+
+    private int GetRandomCount(int poolCount, float minPercent, float maxPercent)
+    {
+        if (poolCount == 0)
+            return 0;
+
+        var percent = _random.NextFloat(minPercent, maxPercent);
+        return Math.Clamp((int) MathF.Round(poolCount * percent), 1, poolCount);
+    }
+}

--- a/Content.Server/_RMC14/Hijack/RMCHijackRandomDamageSystem.cs
+++ b/Content.Server/_RMC14/Hijack/RMCHijackRandomDamageSystem.cs
@@ -13,6 +13,10 @@ using Robust.Shared.Timing;
 
 namespace Content.Server._RMC14.Hijack;
 
+/// <summary>
+///     Applies shipwide randomized structural damage after a hijacked dropship lands.
+///     Percentages are calculated from the currently existing targets on the landing map.
+/// </summary>
 public sealed class RMCHijackRandomDamageSystem : EntitySystem
 {
     [Dependency] private readonly SharedAudioSystem _audio = default!;
@@ -31,6 +35,7 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
     private static readonly TimeSpan PipeBarrageInterval = TimeSpan.FromSeconds(15);
     private static readonly TimeSpan PipeWarningDelay = TimeSpan.FromSeconds(5);
 
+    // These ranges intentionally select a small random subset of existing map targets instead of wiping categories.
     private const float WallMinPercent = 0.03f;
     private const float WallMaxPercent = 0.06f;
     private const float WindowMinPercent = 0.30f;
@@ -95,6 +100,7 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
         _windowTargets.Clear();
         _windoorTargets.Clear();
 
+        // Build pools from the landing map only; hijack damage must never spill into other maps.
         var query = EntityQueryEnumerator<RMCHijackRandomDamageTargetComponent, TransformComponent>();
         while (query.MoveNext(out var uid, out var comp, out var xform))
         {
@@ -122,6 +128,10 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
         DoPipeBarrage(ev.Map, PipeInitialMinPercent, PipeInitialMaxPercent);
     }
 
+    /// <summary>
+    ///     Shuffles a target pool, selects a random percentage of it, and splits the selected targets
+    ///     between damage-only and break outcomes.
+    /// </summary>
     private void ApplyRandomDamage(
         List<(EntityUid Uid, RMCHijackRandomDamageTargetComponent Comp)> targets,
         float minPercent,
@@ -144,6 +154,9 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
         }
     }
 
+    /// <summary>
+    ///     Applies either the damage-only or breaking damage target for a selected entity.
+    /// </summary>
     private void ApplyOutcome(EntityUid uid, RMCHijackRandomDamageTargetComponent comp, bool shouldBreak)
     {
         if (Deleted(uid))
@@ -156,6 +169,9 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
         ApplyDamageUpToTarget(uid, damage);
     }
 
+    /// <summary>
+    ///     Applies enough damage to reach the requested target total without stacking repeated hijack damage.
+    /// </summary>
     private void ApplyDamageUpToTarget(EntityUid uid, DamageSpecifier targetDamage)
     {
         if (!TryComp(uid, out DamageableComponent? damageable))
@@ -179,6 +195,9 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
         }
     }
 
+    /// <summary>
+    ///     Allows mapped targets to be indestructible outside hijack while preserving normal damage flow for hijack.
+    /// </summary>
     private void OnBeforeDamageChanged(Entity<RMCHijackRandomDamageTargetComponent> ent, ref BeforeDamageChangedEvent args)
     {
         if (!ent.Comp.HijackDamageOnly ||
@@ -191,6 +210,9 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
         args.Cancelled = true;
     }
 
+    /// <summary>
+    ///     Selects a random percentage of remaining pipe targets and schedules their delayed explosions.
+    /// </summary>
     private void DoPipeBarrage(EntityUid map, float minPercent = PipeMinPercent, float maxPercent = PipeMaxPercent)
     {
         _pipeTargets.Clear();
@@ -225,6 +247,9 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
         _nextPipeBarrage[map] = _timing.CurTime + PipeBarrageInterval;
     }
 
+    /// <summary>
+    ///     Telegraphs a pipe explosion before bursting it, matching CM-SS13's delayed hijack barrage.
+    /// </summary>
     private void StartPipeWarning(EntityUid pipe)
     {
         if (Deleted(pipe) || !TryComp(pipe, out TransformComponent? xform) || !_usedPipeTargets.Add(pipe))
@@ -237,6 +262,9 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
         Timer.Spawn(PipeWarningDelay, () => BurstPipe(pipe));
     }
 
+    /// <summary>
+    ///     Explodes a warned pipe, starts local fire, and leaves a broken pipe visual in its place.
+    /// </summary>
     private void BurstPipe(EntityUid pipe)
     {
         _pendingPipeTargets.Remove(pipe);
@@ -264,6 +292,9 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
         _transform.SetLocalRotation(brokenPipe, rotation);
     }
 
+    /// <summary>
+    ///     Returns at least one selected target when a non-empty pool exists.
+    /// </summary>
     private int GetRandomCount(int poolCount, float minPercent, float maxPercent)
     {
         if (poolCount == 0)

--- a/Content.Server/_RMC14/Hijack/RMCHijackRandomDamageSystem.cs
+++ b/Content.Server/_RMC14/Hijack/RMCHijackRandomDamageSystem.cs
@@ -37,9 +37,10 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
     private const float WindowMaxPercent = 0.50f;
     private const float WindoorMinPercent = 0.50f;
     private const float WindoorMaxPercent = 1.00f;
-    private const float PipeInitialPercent = 0.10f;
-    private const float PipeMinPercent = 0.007f;
-    private const float PipeMaxPercent = 0.012f;
+    private const float PipeInitialMinPercent = 0.03f;
+    private const float PipeInitialMaxPercent = 0.05f;
+    private const float PipeMinPercent = 0.01f;
+    private const float PipeMaxPercent = 0.015f;
 
     private const float PipeExplosionTotal = 300f;
     private const float PipeExplosionSlope = 25f;
@@ -118,7 +119,7 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
         ApplyRandomDamage(_windowTargets, WindowMinPercent, WindowMaxPercent);
         ApplyRandomDamage(_windoorTargets, WindoorMinPercent, WindoorMaxPercent);
 
-        DoPipeBarrage(ev.Map, PipeInitialPercent, PipeInitialPercent);
+        DoPipeBarrage(ev.Map, PipeInitialMinPercent, PipeInitialMaxPercent);
     }
 
     private void ApplyRandomDamage(

--- a/Content.Server/_RMC14/Hijack/RMCHijackRandomDamageSystem.cs
+++ b/Content.Server/_RMC14/Hijack/RMCHijackRandomDamageSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server.Destructible;
 using Content.Shared._RMC14.Atmos;
 using Content.Shared._RMC14.Dropship;
 using Content.Shared._RMC14.Explosion;
@@ -58,14 +59,12 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
     private readonly List<EntityUid> _pipeTargets = new();
     private readonly List<EntityUid> _barrageMaps = new();
     private readonly Dictionary<EntityUid, TimeSpan> _nextPipeBarrage = new();
-    private readonly HashSet<EntityUid> _applyingHijackDamage = new();
     private readonly HashSet<EntityUid> _usedPipeTargets = new();
     private readonly HashSet<EntityUid> _pendingPipeTargets = new();
 
     public override void Initialize()
     {
         SubscribeLocalEvent<DropshipHijackLandedEvent>(OnDropshipHijackLanded);
-        SubscribeLocalEvent<RMCHijackRandomDamageTargetComponent, BeforeDamageChangedEvent>(OnBeforeDamageChanged);
     }
 
     public override void Update(float frameTime)
@@ -106,6 +105,13 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
         {
             if (!comp.Enabled || xform.MapUid != ev.Map)
                 continue;
+
+            // Structural hijack damage only uses prototypes with a normal damage/destructible flow.
+            if (comp.Category != RMCHijackRandomDamageCategory.Pipe &&
+                (!HasComp<DamageableComponent>(uid) || !HasComp<DestructibleComponent>(uid)))
+            {
+                continue;
+            }
 
             switch (comp.Category)
             {
@@ -184,30 +190,7 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
         var remaining = targetTotal - damageable.TotalDamage;
         var damage = targetDamage * (remaining / targetTotal);
 
-        _applyingHijackDamage.Add(uid);
-        try
-        {
-            _damageable.TryChangeDamage(uid, damage, true, damageable: damageable);
-        }
-        finally
-        {
-            _applyingHijackDamage.Remove(uid);
-        }
-    }
-
-    /// <summary>
-    ///     Allows mapped targets to be indestructible outside hijack while preserving normal damage flow for hijack.
-    /// </summary>
-    private void OnBeforeDamageChanged(Entity<RMCHijackRandomDamageTargetComponent> ent, ref BeforeDamageChangedEvent args)
-    {
-        if (!ent.Comp.HijackDamageOnly ||
-            _applyingHijackDamage.Contains(ent.Owner) ||
-            !args.Damage.AnyPositive())
-        {
-            return;
-        }
-
-        args.Cancelled = true;
+        _damageable.TryChangeDamage(uid, damage, true, damageable: damageable);
     }
 
     /// <summary>

--- a/Content.Shared/_RMC14/Construction/RMCConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Construction/RMCConstructionSystem.cs
@@ -84,15 +84,20 @@ public sealed class RMCConstructionSystem : EntitySystem
         var query = EntityQueryEnumerator<RMCReplaceOnHijackLandComponent>();
         while (query.MoveNext(out var uid, out var comp))
         {
+            if (!TryComp(uid, out TransformComponent? xform) || xform.MapUid != ev.Map)
+                continue;
+
             if (comp.Id is not { } id)
             {
                 Del(uid);
                 continue;
             }
 
-            var coordinates = _transform.GetMoverCoordinates(uid);
+            var coordinates = _transform.GetMoverCoordinates(uid, xform);
+            var rotation = xform.LocalRotation;
             Del(uid);
-            Spawn(id, coordinates);
+            var spawned = Spawn(id, coordinates);
+            _transform.SetLocalRotation(spawned, rotation);
         }
     }
 

--- a/Content.Shared/_RMC14/Hijack/RMCHijackRandomDamageTargetComponent.cs
+++ b/Content.Shared/_RMC14/Hijack/RMCHijackRandomDamageTargetComponent.cs
@@ -33,12 +33,6 @@ public sealed partial class RMCHijackRandomDamageTargetComponent : Component
     /// </summary>
     [DataField]
     public DamageSpecifier? BreakDamage;
-
-    /// <summary>
-    ///     Blocks ordinary damage while still allowing damage applied by the hijack system.
-    /// </summary>
-    [DataField]
-    public bool HijackDamageOnly;
 }
 
 /// <summary>

--- a/Content.Shared/_RMC14/Hijack/RMCHijackRandomDamageTargetComponent.cs
+++ b/Content.Shared/_RMC14/Hijack/RMCHijackRandomDamageTargetComponent.cs
@@ -2,25 +2,48 @@ using Content.Shared.Damage;
 
 namespace Content.Shared._RMC14.Hijack;
 
+/// <summary>
+///     Marks an entity as a possible random damage target when a hijacked dropship lands.
+/// </summary>
 [RegisterComponent]
 public sealed partial class RMCHijackRandomDamageTargetComponent : Component
 {
+    /// <summary>
+    ///     Whether this entity can currently be selected by the hijack damage system.
+    /// </summary>
     [DataField]
     public bool Enabled = true;
 
+    /// <summary>
+    ///     Target pool used for percentage selection and outcome handling.
+    /// </summary>
     [DataField(required: true)]
     public RMCHijackRandomDamageCategory Category;
 
+    /// <summary>
+    ///     Damage target for the non-breaking outcome.
+    ///     The system applies only the missing damage needed to reach this total.
+    /// </summary>
     [DataField]
     public DamageSpecifier? Damage;
 
+    /// <summary>
+    ///     Damage target for the breaking outcome.
+    ///     This should be high enough to trigger the prototype's existing destructible flow.
+    /// </summary>
     [DataField]
     public DamageSpecifier? BreakDamage;
 
+    /// <summary>
+    ///     Blocks ordinary damage while still allowing damage applied by the hijack system.
+    /// </summary>
     [DataField]
     public bool HijackDamageOnly;
 }
 
+/// <summary>
+///     Random hijack damage target pools.
+/// </summary>
 public enum RMCHijackRandomDamageCategory
 {
     Wall,

--- a/Content.Shared/_RMC14/Hijack/RMCHijackRandomDamageTargetComponent.cs
+++ b/Content.Shared/_RMC14/Hijack/RMCHijackRandomDamageTargetComponent.cs
@@ -1,0 +1,30 @@
+using Content.Shared.Damage;
+
+namespace Content.Shared._RMC14.Hijack;
+
+[RegisterComponent]
+public sealed partial class RMCHijackRandomDamageTargetComponent : Component
+{
+    [DataField]
+    public bool Enabled = true;
+
+    [DataField(required: true)]
+    public RMCHijackRandomDamageCategory Category;
+
+    [DataField]
+    public DamageSpecifier? Damage;
+
+    [DataField]
+    public DamageSpecifier? BreakDamage;
+
+    [DataField]
+    public bool HijackDamageOnly;
+}
+
+public enum RMCHijackRandomDamageCategory
+{
+    Wall,
+    Window,
+    Windoor,
+    Pipe,
+}

--- a/Resources/Prototypes/_RMC14/Effects/alert_effects.yml
+++ b/Resources/Prototypes/_RMC14/Effects/alert_effects.yml
@@ -13,6 +13,17 @@
     - HideContextMenu
 
 - type: entity
+  parent: RMCEffectAlert
+  id: RMCHijackPipeExplosionWarning
+  name: explosive warning
+  components:
+  - type: TimedDespawn
+    lifetime: 5
+  - type: Sprite
+    state: alert_greyscale
+    color: "#ff0000"
+
+- type: entity
   id: RMCActiveAlertEffect
   name: exclamation
   categories: [ HideSpawnMenu ]

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Doors/Windoors/windoor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Doors/Windoors/windoor.yml
@@ -147,6 +147,14 @@
         acts: [ "Destruction" ]
   - type: XenoCrusherChargable
   - type: RMCMesonsNonviewable
+  - type: RMCHijackRandomDamageTarget
+    category: Windoor
+    damage:
+      types:
+        Structural: 100
+    breakDamage:
+      types:
+        Structural: 150
 
 - type: entity
   parent: CMWindoor
@@ -192,3 +200,11 @@
               mix: 1
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
+  - type: RMCHijackRandomDamageTarget
+    category: Windoor
+    damage:
+      types:
+        Structural: 200
+    breakDamage:
+      types:
+        Structural: 300

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Piping/pipes.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Piping/pipes.yml
@@ -5,6 +5,8 @@
   - type: Item
     size: Small
     shape: null
+  - type: RMCHijackRandomDamageTarget
+    category: Pipe
   - type: VentExit
   - type: RMCContainerEmptyOnDestruction
   - type: ContainerContainer

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Walls/walls.yml
@@ -424,34 +424,6 @@
     - windows
     - doors
     base: wall
-  - type: Damageable
-    damageContainer: StructuralMarine
-    damageModifierSet: StructuralMarine
-  - type: ExaminableDamage
-    messages: RMCWallMessages
-  - type: RMCIntegrityExamine
-  - type: Construction
-    graph: CMGirder
-    node: reinforcedWall
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 9000
-      behaviors:
-      - !type:ChangeConstructionNodeBehavior
-        node: girder
-      - !type:DoActsBehavior
-        acts: [ "Breakage" ]
-  - type: RMCHijackRandomDamageTarget
-    category: Wall
-    hijackDamageOnly: true
-    damage:
-      types:
-        Structural: 6300
-    breakDamage:
-      types:
-        Structural: 9000
 
 - type: entity
   parent: CMWallReinforcedHeavyAlmayer
@@ -467,15 +439,6 @@
   - type: IconSmooth
     key: walls
     mode: NoSprite
-  - type: RMCHijackRandomDamageTarget
-    category: Wall
-    hijackDamageOnly: true
-    damage:
-      types:
-        Structural: 6300
-    breakDamage:
-      types:
-        Structural: 9000
 
 - type: entity
   parent: RMCWallAlmayerReinforcedHeavyDeco1
@@ -488,15 +451,6 @@
   - type: IconSmooth
     key: walls
     mode: NoSprite
-  - type: RMCHijackRandomDamageTarget
-    category: Wall
-    hijackDamageOnly: true
-    damage:
-      types:
-        Structural: 6300
-    breakDamage:
-      types:
-        Structural: 9000
 
 - type: entity
   parent: RMCWallAlmayerReinforcedHeavyDeco1
@@ -509,15 +463,6 @@
   - type: IconSmooth
     key: walls
     mode: NoSprite
-  - type: RMCHijackRandomDamageTarget
-    category: Wall
-    hijackDamageOnly: true
-    damage:
-      types:
-        Structural: 6300
-    breakDamage:
-      types:
-        Structural: 9000
 
 - type: entity
   parent: RMCWallAlmayerReinforcedHeavyDeco1
@@ -530,15 +475,6 @@
   - type: IconSmooth
     key: walls
     mode: NoSprite
-  - type: RMCHijackRandomDamageTarget
-    category: Wall
-    hijackDamageOnly: true
-    damage:
-      types:
-        Structural: 6300
-    breakDamage:
-      types:
-        Structural: 9000
 
 - type: entity
   parent: RMCWallAlmayerReinforcedHeavyDeco1
@@ -551,15 +487,6 @@
   - type: IconSmooth
     key: walls
     mode: NoSprite
-  - type: RMCHijackRandomDamageTarget
-    category: Wall
-    hijackDamageOnly: true
-    damage:
-      types:
-        Structural: 6300
-    breakDamage:
-      types:
-        Structural: 9000
 
 - type: entity
   parent: RMCWallAlmayerReinforcedHeavyDeco1
@@ -572,15 +499,6 @@
   - type: IconSmooth
     key: walls
     mode: NoSprite
-  - type: RMCHijackRandomDamageTarget
-    category: Wall
-    hijackDamageOnly: true
-    damage:
-      types:
-        Structural: 6300
-    breakDamage:
-      types:
-        Structural: 9000
 
 - type: entity
   parent: CMWallReinforcedHeavy
@@ -599,34 +517,6 @@
     - windows
     - doors
     base: wall
-  - type: Damageable
-    damageContainer: StructuralMarine
-    damageModifierSet: StructuralMarine
-  - type: ExaminableDamage
-    messages: RMCWallMessages
-  - type: RMCIntegrityExamine
-  - type: Construction
-    graph: CMGirder
-    node: reinforcedWall
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 9000
-      behaviors:
-      - !type:ChangeConstructionNodeBehavior
-        node: girder
-      - !type:DoActsBehavior
-        acts: [ "Breakage" ]
-  - type: RMCHijackRandomDamageTarget
-    category: Wall
-    hijackDamageOnly: true
-    damage:
-      types:
-        Structural: 6300
-    breakDamage:
-      types:
-        Structural: 9000
 
 - type: entity
   parent: CMWallReinforcedHeavy
@@ -645,34 +535,6 @@
     - windows
     - doors
     base: aiwall
-  - type: Damageable
-    damageContainer: StructuralMarine
-    damageModifierSet: StructuralMarine
-  - type: ExaminableDamage
-    messages: RMCWallMessages
-  - type: RMCIntegrityExamine
-  - type: Construction
-    graph: CMGirder
-    node: reinforcedWall
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 9000
-      behaviors:
-      - !type:ChangeConstructionNodeBehavior
-        node: girder
-      - !type:DoActsBehavior
-        acts: [ "Breakage" ]
-  - type: RMCHijackRandomDamageTarget
-    category: Wall
-    hijackDamageOnly: true
-    damage:
-      types:
-        Structural: 6300
-    breakDamage:
-      types:
-        Structural: 9000
 
 - type: entity
   parent: CMWallReinforcedHeavy
@@ -691,34 +553,6 @@
     - windows
     - doors
     base: aiwall
-  - type: Damageable
-    damageContainer: StructuralMarine
-    damageModifierSet: StructuralMarine
-  - type: ExaminableDamage
-    messages: RMCWallMessages
-  - type: RMCIntegrityExamine
-  - type: Construction
-    graph: CMGirder
-    node: reinforcedWall
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 9000
-      behaviors:
-      - !type:ChangeConstructionNodeBehavior
-        node: girder
-      - !type:DoActsBehavior
-        acts: [ "Breakage" ]
-  - type: RMCHijackRandomDamageTarget
-    category: Wall
-    hijackDamageOnly: true
-    damage:
-      types:
-        Structural: 6300
-    breakDamage:
-      types:
-        Structural: 9000
 
 # TODO RMC14 temp hull, breakable only after hijack
 

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Walls/walls.yml
@@ -60,6 +60,14 @@
     - windows
     - doors
     base: wall
+  - type: RMCHijackRandomDamageTarget
+    category: Wall
+    damage:
+      types:
+        Structural: 2100
+    breakDamage:
+      types:
+        Structural: 3000
 
 - type: entity
   parent: CMWallMetal
@@ -75,6 +83,14 @@
   - type: IconSmooth
     key: walls
     mode: NoSprite
+  - type: RMCHijackRandomDamageTarget
+    category: Wall
+    damage:
+      types:
+        Structural: 2100
+    breakDamage:
+      types:
+        Structural: 3000
 
 - type: entity
   parent: RMCWallAlmayerDeco1
@@ -153,6 +169,14 @@
     - windows
     - doors
     base: wall
+  - type: RMCHijackRandomDamageTarget
+    category: Wall
+    damage:
+      types:
+        Structural: 2100
+    breakDamage:
+      types:
+        Structural: 3000
 
 # Reinforced
 - type: entity
@@ -218,6 +242,14 @@
     - windows
     - doors
     base: wall
+  - type: RMCHijackRandomDamageTarget
+    category: Wall
+    damage:
+      types:
+        Structural: 6300
+    breakDamage:
+      types:
+        Structural: 9000
 
 - type: entity
   parent: RMCBaseWallReinforced
@@ -233,6 +265,14 @@
   - type: IconSmooth
     key: walls
     mode: NoSprite
+  - type: RMCHijackRandomDamageTarget
+    category: Wall
+    damage:
+      types:
+        Structural: 6300
+    breakDamage:
+      types:
+        Structural: 9000
 
 - type: entity
   parent: RMCWallAlmayerReinforcedDeco1
@@ -311,6 +351,14 @@
     - windows
     - doors
     base: wall
+  - type: RMCHijackRandomDamageTarget
+    category: Wall
+    damage:
+      types:
+        Structural: 6300
+    breakDamage:
+      types:
+        Structural: 9000
 
 - type: entity
   parent: RMCBaseWallReinforced
@@ -329,6 +377,14 @@
     - windows
     - doors
     base: aiwall
+  - type: RMCHijackRandomDamageTarget
+    category: Wall
+    damage:
+      types:
+        Structural: 6300
+    breakDamage:
+      types:
+        Structural: 9000
 
 # Indestructible
 - type: entity
@@ -368,6 +424,34 @@
     - windows
     - doors
     base: wall
+  - type: Damageable
+    damageContainer: StructuralMarine
+    damageModifierSet: StructuralMarine
+  - type: ExaminableDamage
+    messages: RMCWallMessages
+  - type: RMCIntegrityExamine
+  - type: Construction
+    graph: CMGirder
+    node: reinforcedWall
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 9000
+      behaviors:
+      - !type:ChangeConstructionNodeBehavior
+        node: girder
+      - !type:DoActsBehavior
+        acts: [ "Breakage" ]
+  - type: RMCHijackRandomDamageTarget
+    category: Wall
+    hijackDamageOnly: true
+    damage:
+      types:
+        Structural: 6300
+    breakDamage:
+      types:
+        Structural: 9000
 
 - type: entity
   parent: CMWallReinforcedHeavyAlmayer
@@ -383,6 +467,15 @@
   - type: IconSmooth
     key: walls
     mode: NoSprite
+  - type: RMCHijackRandomDamageTarget
+    category: Wall
+    hijackDamageOnly: true
+    damage:
+      types:
+        Structural: 6300
+    breakDamage:
+      types:
+        Structural: 9000
 
 - type: entity
   parent: RMCWallAlmayerReinforcedHeavyDeco1
@@ -395,6 +488,15 @@
   - type: IconSmooth
     key: walls
     mode: NoSprite
+  - type: RMCHijackRandomDamageTarget
+    category: Wall
+    hijackDamageOnly: true
+    damage:
+      types:
+        Structural: 6300
+    breakDamage:
+      types:
+        Structural: 9000
 
 - type: entity
   parent: RMCWallAlmayerReinforcedHeavyDeco1
@@ -407,6 +509,15 @@
   - type: IconSmooth
     key: walls
     mode: NoSprite
+  - type: RMCHijackRandomDamageTarget
+    category: Wall
+    hijackDamageOnly: true
+    damage:
+      types:
+        Structural: 6300
+    breakDamage:
+      types:
+        Structural: 9000
 
 - type: entity
   parent: RMCWallAlmayerReinforcedHeavyDeco1
@@ -419,6 +530,15 @@
   - type: IconSmooth
     key: walls
     mode: NoSprite
+  - type: RMCHijackRandomDamageTarget
+    category: Wall
+    hijackDamageOnly: true
+    damage:
+      types:
+        Structural: 6300
+    breakDamage:
+      types:
+        Structural: 9000
 
 - type: entity
   parent: RMCWallAlmayerReinforcedHeavyDeco1
@@ -431,6 +551,15 @@
   - type: IconSmooth
     key: walls
     mode: NoSprite
+  - type: RMCHijackRandomDamageTarget
+    category: Wall
+    hijackDamageOnly: true
+    damage:
+      types:
+        Structural: 6300
+    breakDamage:
+      types:
+        Structural: 9000
 
 - type: entity
   parent: RMCWallAlmayerReinforcedHeavyDeco1
@@ -443,6 +572,15 @@
   - type: IconSmooth
     key: walls
     mode: NoSprite
+  - type: RMCHijackRandomDamageTarget
+    category: Wall
+    hijackDamageOnly: true
+    damage:
+      types:
+        Structural: 6300
+    breakDamage:
+      types:
+        Structural: 9000
 
 - type: entity
   parent: CMWallReinforcedHeavy
@@ -461,6 +599,34 @@
     - windows
     - doors
     base: wall
+  - type: Damageable
+    damageContainer: StructuralMarine
+    damageModifierSet: StructuralMarine
+  - type: ExaminableDamage
+    messages: RMCWallMessages
+  - type: RMCIntegrityExamine
+  - type: Construction
+    graph: CMGirder
+    node: reinforcedWall
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 9000
+      behaviors:
+      - !type:ChangeConstructionNodeBehavior
+        node: girder
+      - !type:DoActsBehavior
+        acts: [ "Breakage" ]
+  - type: RMCHijackRandomDamageTarget
+    category: Wall
+    hijackDamageOnly: true
+    damage:
+      types:
+        Structural: 6300
+    breakDamage:
+      types:
+        Structural: 9000
 
 - type: entity
   parent: CMWallReinforcedHeavy
@@ -479,6 +645,34 @@
     - windows
     - doors
     base: aiwall
+  - type: Damageable
+    damageContainer: StructuralMarine
+    damageModifierSet: StructuralMarine
+  - type: ExaminableDamage
+    messages: RMCWallMessages
+  - type: RMCIntegrityExamine
+  - type: Construction
+    graph: CMGirder
+    node: reinforcedWall
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 9000
+      behaviors:
+      - !type:ChangeConstructionNodeBehavior
+        node: girder
+      - !type:DoActsBehavior
+        acts: [ "Breakage" ]
+  - type: RMCHijackRandomDamageTarget
+    category: Wall
+    hijackDamageOnly: true
+    damage:
+      types:
+        Structural: 6300
+    breakDamage:
+      types:
+        Structural: 9000
 
 - type: entity
   parent: CMWallReinforcedHeavy
@@ -497,6 +691,34 @@
     - windows
     - doors
     base: aiwall
+  - type: Damageable
+    damageContainer: StructuralMarine
+    damageModifierSet: StructuralMarine
+  - type: ExaminableDamage
+    messages: RMCWallMessages
+  - type: RMCIntegrityExamine
+  - type: Construction
+    graph: CMGirder
+    node: reinforcedWall
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 9000
+      behaviors:
+      - !type:ChangeConstructionNodeBehavior
+        node: girder
+      - !type:DoActsBehavior
+        acts: [ "Breakage" ]
+  - type: RMCHijackRandomDamageTarget
+    category: Wall
+    hijackDamageOnly: true
+    damage:
+      types:
+        Structural: 6300
+    breakDamage:
+      types:
+        Structural: 9000
 
 # TODO RMC14 temp hull, breakable only after hijack
 

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Windows/windows.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Windows/windows.yml
@@ -87,6 +87,50 @@
     - doors
     base: alm_rwindow
     mode: CardinalFlags
+  - type: Damageable
+    damageContainer: StructuralMarine
+    damageModifierSet: StructuralMarine
+  - type: Repairable
+  - type: Destructible
+    thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 600
+        behaviors:
+          - !type:PlaySoundBehavior
+            sound:
+              collection: WindowShatter
+          - !type:DoActsBehavior
+            acts: ["Destruction"]
+      - trigger:
+          !type:DamageTrigger
+          damage: 100
+        behaviors:
+          - !type:PlaySoundBehavior
+            sound:
+              collection: WindowShatter
+          - !type:SpawnEntitiesBehavior
+            spawn:
+              CMShardGlass:
+                min: 1
+                max: 1
+              CMRodMetal:
+                min: 1
+                max: 1
+          - !type:ChangeConstructionNodeBehavior
+            node: windowFrameAlmayer
+  - type: Construction
+    graph: RMCWindowAlmayer
+    node: windowAlmayerReinforced
+  - type: RMCHijackRandomDamageTarget
+    category: Window
+    hijackDamageOnly: true
+    damage:
+      types:
+        Structural: 60
+    breakDamage:
+      types:
+        Structural: 100
 
 - type: entity
   parent: CMBaseWindowIndestructible
@@ -106,6 +150,50 @@
     key: walls
     base: ai_rwindow
     mode: CardinalFlags
+  - type: Damageable
+    damageContainer: StructuralMarine
+    damageModifierSet: StructuralMarine
+  - type: Repairable
+  - type: Destructible
+    thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 600
+        behaviors:
+          - !type:PlaySoundBehavior
+            sound:
+              collection: WindowShatter
+          - !type:DoActsBehavior
+            acts: ["Destruction"]
+      - trigger:
+          !type:DamageTrigger
+          damage: 100
+        behaviors:
+          - !type:PlaySoundBehavior
+            sound:
+              collection: WindowShatter
+          - !type:SpawnEntitiesBehavior
+            spawn:
+              CMShardGlass:
+                min: 1
+                max: 1
+              CMRodMetal:
+                min: 1
+                max: 1
+          - !type:ChangeConstructionNodeBehavior
+            node: windowFrameAI
+  - type: Construction
+    graph: RMCWindowAI
+    node: windowAIReinforced
+  - type: RMCHijackRandomDamageTarget
+    category: Window
+    hijackDamageOnly: true
+    damage:
+      types:
+        Structural: 60
+    breakDamage:
+      types:
+        Structural: 100
 
 - type: entity
   parent: CMBaseWindowIndestructible
@@ -125,12 +213,59 @@
     key: walls
     base: alm_ai_rwindow
     mode: CardinalFlags
+  - type: Damageable
+    damageContainer: StructuralMarine
+    damageModifierSet: StructuralMarine
+  - type: Repairable
+  - type: Destructible
+    thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 600
+        behaviors:
+          - !type:PlaySoundBehavior
+            sound:
+              collection: WindowShatter
+          - !type:DoActsBehavior
+            acts: ["Destruction"]
+      - trigger:
+          !type:DamageTrigger
+          damage: 100
+        behaviors:
+          - !type:PlaySoundBehavior
+            sound:
+              collection: WindowShatter
+          - !type:SpawnEntitiesBehavior
+            spawn:
+              CMShardGlass:
+                min: 1
+                max: 1
+              CMRodMetal:
+                min: 1
+                max: 1
+          - !type:ChangeConstructionNodeBehavior
+            node: windowFrameAI
+  - type: Construction
+    graph: RMCWindowAI
+    node: windowAIReinforced
+  - type: RMCHijackRandomDamageTarget
+    category: Window
+    hijackDamageOnly: true
+    damage:
+      types:
+        Structural: 60
+    breakDamage:
+      types:
+        Structural: 100
 
 - type: entity
   parent: CMWindowReinforcedAlmayerHull
   id: RMCWindowReinforcedAlmayerHullHijackBustable
   suffix: Hijack Bustable
   components:
+  - type: RMCHijackRandomDamageTarget
+    enabled: false
+    hijackDamageOnly: true
   - type: RMCReplaceOnHijackLand # TODO RMC14 also spawn glass
     id: RMCWindowFrameAlmayer
 
@@ -191,6 +326,14 @@
     sound:
       collection: WindowShatter
   - type: ImmuneToUnarmed
+  - type: RMCHijackRandomDamageTarget
+    category: Window
+    damage:
+      types:
+        Structural: 60
+    breakDamage:
+      types:
+        Structural: 100
 
 - type: entity
   parent: CMBaseWindowIndestructible
@@ -212,6 +355,50 @@
     - doors
     base: white_rwindow
     mode: CardinalFlags
+  - type: Damageable
+    damageContainer: StructuralMarine
+    damageModifierSet: StructuralMarine
+  - type: Repairable
+  - type: Destructible
+    thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 600
+        behaviors:
+          - !type:PlaySoundBehavior
+            sound:
+              collection: WindowShatter
+          - !type:DoActsBehavior
+            acts: ["Destruction"]
+      - trigger:
+          !type:DamageTrigger
+          damage: 100
+        behaviors:
+          - !type:PlaySoundBehavior
+            sound:
+              collection: WindowShatter
+          - !type:SpawnEntitiesBehavior
+            spawn:
+              CMShardGlass:
+                min: 1
+                max: 1
+              CMRodMetal:
+                min: 1
+                max: 1
+          - !type:ChangeConstructionNodeBehavior
+            node: windowFrameWhite
+  - type: Construction
+    graph: RMCWindowWhite
+    node: windowWhiteReinforced
+  - type: RMCHijackRandomDamageTarget
+    category: Window
+    hijackDamageOnly: true
+    damage:
+      types:
+        Structural: 60
+    breakDamage:
+      types:
+        Structural: 100
 
 - type: entity
   parent: CMBaseWindow
@@ -269,6 +456,14 @@
     spawnPrototype: RMCWindowFrameWhite
     sound:
       collection: WindowShatter
+  - type: RMCHijackRandomDamageTarget
+    category: Window
+    damage:
+      types:
+        Structural: 60
+    breakDamage:
+      types:
+        Structural: 100
 
 - type: entity
   parent: CMBaseWindow
@@ -627,3 +822,11 @@
     spawnPrototype: RMCWindowFrameAI
     sound:
       collection: WindowShatter
+  - type: RMCHijackRandomDamageTarget
+    category: Window
+    damage:
+      types:
+        Structural: 60
+    breakDamage:
+      types:
+        Structural: 100

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Windows/windows.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Windows/windows.yml
@@ -87,50 +87,6 @@
     - doors
     base: alm_rwindow
     mode: CardinalFlags
-  - type: Damageable
-    damageContainer: StructuralMarine
-    damageModifierSet: StructuralMarine
-  - type: Repairable
-  - type: Destructible
-    thresholds:
-      - trigger:
-          !type:DamageTrigger
-          damage: 600
-        behaviors:
-          - !type:PlaySoundBehavior
-            sound:
-              collection: WindowShatter
-          - !type:DoActsBehavior
-            acts: ["Destruction"]
-      - trigger:
-          !type:DamageTrigger
-          damage: 100
-        behaviors:
-          - !type:PlaySoundBehavior
-            sound:
-              collection: WindowShatter
-          - !type:SpawnEntitiesBehavior
-            spawn:
-              CMShardGlass:
-                min: 1
-                max: 1
-              CMRodMetal:
-                min: 1
-                max: 1
-          - !type:ChangeConstructionNodeBehavior
-            node: windowFrameAlmayer
-  - type: Construction
-    graph: RMCWindowAlmayer
-    node: windowAlmayerReinforced
-  - type: RMCHijackRandomDamageTarget
-    category: Window
-    hijackDamageOnly: true
-    damage:
-      types:
-        Structural: 60
-    breakDamage:
-      types:
-        Structural: 100
 
 - type: entity
   parent: CMBaseWindowIndestructible
@@ -150,50 +106,6 @@
     key: walls
     base: ai_rwindow
     mode: CardinalFlags
-  - type: Damageable
-    damageContainer: StructuralMarine
-    damageModifierSet: StructuralMarine
-  - type: Repairable
-  - type: Destructible
-    thresholds:
-      - trigger:
-          !type:DamageTrigger
-          damage: 600
-        behaviors:
-          - !type:PlaySoundBehavior
-            sound:
-              collection: WindowShatter
-          - !type:DoActsBehavior
-            acts: ["Destruction"]
-      - trigger:
-          !type:DamageTrigger
-          damage: 100
-        behaviors:
-          - !type:PlaySoundBehavior
-            sound:
-              collection: WindowShatter
-          - !type:SpawnEntitiesBehavior
-            spawn:
-              CMShardGlass:
-                min: 1
-                max: 1
-              CMRodMetal:
-                min: 1
-                max: 1
-          - !type:ChangeConstructionNodeBehavior
-            node: windowFrameAI
-  - type: Construction
-    graph: RMCWindowAI
-    node: windowAIReinforced
-  - type: RMCHijackRandomDamageTarget
-    category: Window
-    hijackDamageOnly: true
-    damage:
-      types:
-        Structural: 60
-    breakDamage:
-      types:
-        Structural: 100
 
 - type: entity
   parent: CMBaseWindowIndestructible
@@ -213,61 +125,11 @@
     key: walls
     base: alm_ai_rwindow
     mode: CardinalFlags
-  - type: Damageable
-    damageContainer: StructuralMarine
-    damageModifierSet: StructuralMarine
-  - type: Repairable
-  - type: Destructible
-    thresholds:
-      - trigger:
-          !type:DamageTrigger
-          damage: 600
-        behaviors:
-          - !type:PlaySoundBehavior
-            sound:
-              collection: WindowShatter
-          - !type:DoActsBehavior
-            acts: ["Destruction"]
-      - trigger:
-          !type:DamageTrigger
-          damage: 100
-        behaviors:
-          - !type:PlaySoundBehavior
-            sound:
-              collection: WindowShatter
-          - !type:SpawnEntitiesBehavior
-            spawn:
-              CMShardGlass:
-                min: 1
-                max: 1
-              CMRodMetal:
-                min: 1
-                max: 1
-          - !type:ChangeConstructionNodeBehavior
-            node: windowFrameAI
-  - type: Construction
-    graph: RMCWindowAI
-    node: windowAIReinforced
-  - type: RMCHijackRandomDamageTarget
-    category: Window
-    hijackDamageOnly: true
-    damage:
-      types:
-        Structural: 60
-    breakDamage:
-      types:
-        Structural: 100
 
 - type: entity
   parent: CMWindowReinforcedAlmayerHull
   id: RMCWindowReinforcedAlmayerHullHijackBustable
   suffix: Hijack Bustable
-  components:
-  - type: RMCHijackRandomDamageTarget
-    enabled: false
-    hijackDamageOnly: true
-  - type: RMCReplaceOnHijackLand # TODO RMC14 also spawn glass
-    id: RMCWindowFrameAlmayer
 
 - type: entity
   parent: CMBaseWindow
@@ -355,50 +217,6 @@
     - doors
     base: white_rwindow
     mode: CardinalFlags
-  - type: Damageable
-    damageContainer: StructuralMarine
-    damageModifierSet: StructuralMarine
-  - type: Repairable
-  - type: Destructible
-    thresholds:
-      - trigger:
-          !type:DamageTrigger
-          damage: 600
-        behaviors:
-          - !type:PlaySoundBehavior
-            sound:
-              collection: WindowShatter
-          - !type:DoActsBehavior
-            acts: ["Destruction"]
-      - trigger:
-          !type:DamageTrigger
-          damage: 100
-        behaviors:
-          - !type:PlaySoundBehavior
-            sound:
-              collection: WindowShatter
-          - !type:SpawnEntitiesBehavior
-            spawn:
-              CMShardGlass:
-                min: 1
-                max: 1
-              CMRodMetal:
-                min: 1
-                max: 1
-          - !type:ChangeConstructionNodeBehavior
-            node: windowFrameWhite
-  - type: Construction
-    graph: RMCWindowWhite
-    node: windowWhiteReinforced
-  - type: RMCHijackRandomDamageTarget
-    category: Window
-    hijackDamageOnly: true
-    damage:
-      types:
-        Structural: 60
-    breakDamage:
-      types:
-        Structural: 100
 
 - type: entity
   parent: CMBaseWindow

--- a/Resources/Prototypes/_RMC14/Entities/Tiles/tile_fire.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Tiles/tile_fire.yml
@@ -237,6 +237,22 @@
     intensity: 30
 
 - type: entity
+  parent: RMCTileFire
+  id: RMCHijackPipeFire
+  suffix: Hijack pipe
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: TileFire
+    duration: 30
+  - type: RMCIgniteOnCollide
+    intensity: 20
+    duration: 30
+  - type: DamageOnCollide
+    damage:
+      types:
+        Heat: 60
+
+- type: entity
   parent: RMCTileFireLaser
   id: RMCTileFireBanshee
   components:


### PR DESCRIPTION
## About the PR

Adds randomized Almayer hijack crash destruction.

When a hijacked dropship lands, valid ship structures on the landing map can now be randomly damaged or broken, and RMC pipes start a delayed explosion barrage with warning alerts and local fire.

## Why / Balance

This makes hijack landings feel more destructive without wiping whole structure categories at once.

Damage is percentage-based and random per category, so the result varies between rounds. Indestructible hull structures remain protected: random structural hijack damage only affects entities with normal `Damageable` and `Destructible` behavior.

Pipe explosions are delayed and telegraphed, giving nearby players a short warning before the burst.

## Technical details

Added `RMCHijackRandomDamageSystem`, which listens to `DropshipHijackLandedEvent` and builds target pools only from entities on the landing map.

Added `RMCHijackRandomDamageTargetComponent` with category and damage configuration for:

- walls;
- windows;
- windoors;
- pipes.

Random structural damage uses these ranges:

- walls: 3-6%;
- windows: 30-50%;
- windoors: 50-100%.

Selected wall/window/windoor targets are shuffled and split between damage-only and break outcomes. Damage-only applies only enough damage to reach the configured target amount, while break damage uses the entity's existing destructible flow.

Structural targets are filtered at runtime to require both `DamageableComponent` and `DestructibleComponent`, so indestructible hull walls/windows are not made destructible by hijack damage.

Marked destructible Almayer wall, window, and windoor prototypes as hijack random damage targets. Marked `RMCBasePipe` as a pipe barrage target.

Added pipe barrage behavior:

1. initial barrage selects 3-5% of remaining pipes;
2. later barrages select 1-1.5% every 15 seconds;
3. each selected pipe shows `RMCHijackPipeExplosionWarning`;
4. the pipe plays a hiss warning for 5 seconds;
5. the pipe explodes using an RMC explosion;
6. local `RMCHijackPipeFire` is spawned;
7. the original pipe is replaced with `GasPipeBroken`;
8. used/pending pipes are not selected again.

Added `RMCHijackPipeExplosionWarning` and `RMCHijackPipeFire`.

Updated legacy `RMCReplaceOnHijackLand` handling to only affect the hijack landing map and preserve rotation when replacing entities.

Updated `FireVisualizerSystem` for RMC fire color support and delayed startup initialization, with RMC changes marked in the upstream file.

## Media


https://github.com/user-attachments/assets/0fd2f572-a9d9-4397-b965-15b4bf16df42



## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

- add: Added randomized Almayer damage after hijacked dropship crashes.
- add: Added delayed hijack pipe explosion barrages with warning alerts and local fire.