### PR TITLE
Add queen psychic communication

### DIFF
--- a/Content.Server/_RMC14/Xenonids/Psychic/XenoPsychicCommunicationSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Psychic/XenoPsychicCommunicationSystem.cs
@@ -95,7 +95,7 @@ public sealed class XenoPsychicCommunicationSystem : EntitySystem
         SendQueenConfirmation(queen, Loc.GetString("rmc-xeno-psychic-whisper-sent", ("target", QueenTargetName(queen, target.Value))));
         var escaped = FormattedMessage.EscapeText(text);
         SendGhostCopy(queen, text, Loc.GetString("rmc-xeno-psychic-ghost-whisper", ("queen", queen.Owner), ("target", target.Value), ("message", escaped)));
-        _adminLog.Add(LogType.Chat, LogImpact.Low, $"Psychic whisper from {ToPrettyString(queen):user} to {ToPrettyString(target.Value):target}: {text}");
+        _adminLog.Add(LogType.RMCXenoPsychic, LogImpact.Low, $"Psychic whisper from {ToPrettyString(queen):user} to {ToPrettyString(target.Value):target}: {text}");
         _actions.StartUseDelay(action);
     }
 
@@ -147,7 +147,7 @@ public sealed class XenoPsychicCommunicationSystem : EntitySystem
         SendQueenConfirmation(queen, Loc.GetString("rmc-xeno-psychic-radiance-sent", ("count", recipients.Count)));
         var escaped = FormattedMessage.EscapeText(text);
         SendGhostCopy(queen, text, Loc.GetString("rmc-xeno-psychic-ghost-radiance", ("queen", queen.Owner), ("count", recipients.Count), ("message", escaped)));
-        _adminLog.Add(LogType.Chat, LogImpact.Low, $"Psychic radiance from {ToPrettyString(queen):user} to {recipients.Count} recipients: {text}");
+        LogPsychicRadiance(queen, recipients, text);
         _actions.StartUseDelay(action);
     }
 
@@ -197,7 +197,7 @@ public sealed class XenoPsychicCommunicationSystem : EntitySystem
         SendQueenConfirmation(queen, Loc.GetString("rmc-xeno-psychic-give-order-sent", ("target", target.Value)));
         var escaped = FormattedMessage.EscapeText(text);
         SendGhostCopy(queen, text, Loc.GetString("rmc-xeno-psychic-ghost-order", ("queen", queen.Owner), ("target", target.Value), ("message", escaped)));
-        _adminLog.Add(LogType.Chat, LogImpact.Low, $"Psychic order from {ToPrettyString(queen):user} to {ToPrettyString(target.Value):target}: {text}");
+        _adminLog.Add(LogType.RMCXenoPsychic, LogImpact.Low, $"Psychic order from {ToPrettyString(queen):user} to {ToPrettyString(target.Value):target}: {text}");
         _actions.StartUseDelay(action);
     }
 
@@ -363,6 +363,17 @@ public sealed class XenoPsychicCommunicationSystem : EntitySystem
             colorOverride: PsychicColor,
             recordReplay: true,
             author: author);
+    }
+
+    private void LogPsychicRadiance(Entity<XenoPsychicCommunicationComponent> queen, List<EntityUid> recipients, string message)
+    {
+        foreach (var recipient in recipients)
+        {
+            _adminLog.Add(
+                LogType.RMCXenoPsychic,
+                LogImpact.Low,
+                $"Psychic radiance from {ToPrettyString(queen):user} to {ToPrettyString(recipient):target} ({recipients.Count} recipients total): {message}");
+        }
     }
 
     private bool IsSameHiveXeno(Entity<XenoPsychicCommunicationComponent> queen, EntityUid target)

--- a/Content.Server/_RMC14/Xenonids/Psychic/XenoPsychicCommunicationSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Psychic/XenoPsychicCommunicationSystem.cs
@@ -1,0 +1,387 @@
+using System.Text.RegularExpressions;
+using Content.Server.Administration.Logs;
+using Content.Shared._RMC14.Chat;
+using Content.Shared._RMC14.Dialog;
+using Content.Shared._RMC14.Xenonids;
+using Content.Shared._RMC14.Xenonids.Hive;
+using Content.Shared._RMC14.Xenonids.Plasma;
+using Content.Shared._RMC14.Xenonids.Psychic;
+using Content.Shared._RMC14.Xenonids.Watch;
+using Content.Shared.Actions;
+using Content.Shared.Actions.Components;
+using Content.Shared.Chat;
+using Content.Shared.Database;
+using Content.Shared.Ghost;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.Popups;
+using Robust.Shared.Player;
+using Robust.Shared.Timing;
+using Robust.Shared.Utility;
+
+namespace Content.Server._RMC14.Xenonids.Psychic;
+
+public sealed class XenoPsychicCommunicationSystem : EntitySystem
+{
+    [Dependency] private readonly IAdminLogManager _adminLog = default!;
+    [Dependency] private readonly SharedActionsSystem _actions = default!;
+    [Dependency] private readonly SharedCMChatSystem _chat = default!;
+    [Dependency] private readonly DialogSystem _dialog = default!;
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
+    [Dependency] private readonly XenoPlasmaSystem _plasma = default!;
+    [Dependency] private readonly SharedXenoWatchSystem _watch = default!;
+
+    private static readonly Color PsychicColor = Color.FromHex("#921992");
+    private static readonly Regex NewLineRegex = new("\n{3,}", RegexOptions.Compiled);
+
+    private readonly HashSet<Entity<MobStateComponent>> _nearbyMobs = new();
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<XenoPsychicCommunicationComponent, XenoPsychicWhisperActionEvent>(OnWhisperAction);
+        SubscribeLocalEvent<XenoPsychicCommunicationComponent, XenoPsychicWhisperInputEvent>(OnWhisperInput);
+        SubscribeLocalEvent<XenoPsychicCommunicationComponent, XenoPsychicRadianceActionEvent>(OnRadianceAction);
+        SubscribeLocalEvent<XenoPsychicCommunicationComponent, XenoPsychicRadianceInputEvent>(OnRadianceInput);
+        SubscribeLocalEvent<XenoPsychicCommunicationComponent, XenoGiveOrderActionEvent>(OnGiveOrderAction);
+        SubscribeLocalEvent<XenoPsychicCommunicationComponent, XenoGiveOrderInputEvent>(OnGiveOrderInput);
+    }
+
+    private void OnWhisperAction(Entity<XenoPsychicCommunicationComponent> queen, ref XenoPsychicWhisperActionEvent args)
+    {
+        if (args.Handled || !CanUseQueen(queen))
+            return;
+
+        if (!CanUseQueen(queen) ||
+            !TryGetAction(queen, GetNetEntity(args.Action), out _) ||
+            !CanWhisperTo(queen, args.Target))
+        {
+            _popup.PopupEntity(Loc.GetString("rmc-xeno-psychic-target-invalid"), queen, queen, PopupType.MediumCaution);
+            return;
+        }
+
+        _dialog.OpenInput(
+            queen,
+            Loc.GetString("rmc-xeno-psychic-whisper-message", ("target", QueenTargetName(queen, args.Target))),
+            new XenoPsychicWhisperInputEvent(GetNetEntity(args.Action), GetNetEntity(args.Target)),
+            largeInput: true,
+            characterLimit: queen.Comp.CharacterLimit,
+            minCharacterLimit: 1,
+            smartCheck: true);
+    }
+
+    private void OnWhisperInput(Entity<XenoPsychicCommunicationComponent> queen, ref XenoPsychicWhisperInputEvent args)
+    {
+        if (!CanUseQueen(queen))
+            return;
+
+        var text = CleanMessage(queen, args.Message);
+        if (text == null)
+            return;
+
+        if (!TryGetEntity(args.Target, out var target) ||
+            !TryGetAction(queen, args.Action, out var action) ||
+            !CanWhisperTo(queen, target.Value))
+        {
+            _popup.PopupEntity(Loc.GetString("rmc-xeno-psychic-target-invalid"), queen, queen, PopupType.MediumCaution);
+            return;
+        }
+
+        SendPsychicMessage(queen, target.Value, text, PsychicMessageKind.Whisper);
+        SendQueenConfirmation(queen, Loc.GetString("rmc-xeno-psychic-whisper-sent", ("target", QueenTargetName(queen, target.Value))));
+        var escaped = FormattedMessage.EscapeText(text);
+        SendGhostCopy(queen, text, Loc.GetString("rmc-xeno-psychic-ghost-whisper", ("queen", queen.Owner), ("target", target.Value), ("message", escaped)));
+        _adminLog.Add(LogType.Chat, LogImpact.Low, $"Psychic whisper from {ToPrettyString(queen):user} to {ToPrettyString(target.Value):target}: {text}");
+        _actions.StartUseDelay(action);
+    }
+
+    private void OnRadianceAction(Entity<XenoPsychicCommunicationComponent> queen, ref XenoPsychicRadianceActionEvent args)
+    {
+        if (args.Handled || !CanUseQueen(queen))
+            return;
+
+        if (!_plasma.HasPlasmaPopup(queen.Owner, queen.Comp.RadiancePlasmaCost))
+            return;
+
+        _dialog.OpenInput(
+            queen,
+            Loc.GetString("rmc-xeno-psychic-radiance-message"),
+            new XenoPsychicRadianceInputEvent(GetNetEntity(args.Action)),
+            largeInput: true,
+            characterLimit: queen.Comp.CharacterLimit,
+            minCharacterLimit: 1,
+            smartCheck: true);
+    }
+
+    private void OnRadianceInput(Entity<XenoPsychicCommunicationComponent> queen, ref XenoPsychicRadianceInputEvent args)
+    {
+        if (!CanUseQueen(queen))
+            return;
+
+        var text = CleanMessage(queen, args.Message);
+        if (text == null)
+            return;
+
+        if (!TryGetAction(queen, args.Action, out var action))
+            return;
+
+        var recipients = GetRecipients(queen, queen.Comp.RadianceRange);
+        if (recipients.Count == 0)
+        {
+            _popup.PopupEntity(Loc.GetString("rmc-xeno-psychic-radiance-no-targets"), queen, queen, PopupType.MediumCaution);
+            return;
+        }
+
+        if (!_plasma.TryRemovePlasmaPopup(queen.Owner, queen.Comp.RadiancePlasmaCost, predicted: false))
+            return;
+
+        foreach (var recipient in recipients)
+        {
+            SendPsychicMessage(queen, recipient, text, PsychicMessageKind.Radiance);
+        }
+
+        SendQueenConfirmation(queen, Loc.GetString("rmc-xeno-psychic-radiance-sent", ("count", recipients.Count)));
+        var escaped = FormattedMessage.EscapeText(text);
+        SendGhostCopy(queen, text, Loc.GetString("rmc-xeno-psychic-ghost-radiance", ("queen", queen.Owner), ("count", recipients.Count), ("message", escaped)));
+        _adminLog.Add(LogType.Chat, LogImpact.Low, $"Psychic radiance from {ToPrettyString(queen):user} to {recipients.Count} recipients: {text}");
+        _actions.StartUseDelay(action);
+    }
+
+    private void OnGiveOrderAction(Entity<XenoPsychicCommunicationComponent> queen, ref XenoGiveOrderActionEvent args)
+    {
+        if (args.Handled || !CanUseQueen(queen))
+            return;
+
+        if (!_plasma.HasPlasmaPopup(queen.Owner, queen.Comp.GiveOrderPlasmaCost))
+            return;
+
+        if (!TryGetWatchedXeno(queen, out var watched))
+            return;
+
+        _dialog.OpenInput(
+            queen,
+            Loc.GetString("rmc-xeno-psychic-give-order-message", ("target", watched)),
+            new XenoGiveOrderInputEvent(GetNetEntity(args.Action), GetNetEntity(watched)),
+            largeInput: true,
+            characterLimit: queen.Comp.CharacterLimit,
+            minCharacterLimit: 1,
+            smartCheck: true);
+    }
+
+    private void OnGiveOrderInput(Entity<XenoPsychicCommunicationComponent> queen, ref XenoGiveOrderInputEvent args)
+    {
+        if (!CanUseQueen(queen))
+            return;
+
+        var text = CleanMessage(queen, args.Message);
+        if (text == null)
+            return;
+
+        if (!TryGetEntity(args.Target, out var target) ||
+            !TryGetAction(queen, args.Action, out var action) ||
+            !TryGetWatchedXeno(queen, out var watched) ||
+            watched != target.Value)
+        {
+            _popup.PopupEntity(Loc.GetString("rmc-xeno-psychic-target-invalid"), queen, queen, PopupType.MediumCaution);
+            return;
+        }
+
+        if (!_plasma.TryRemovePlasmaPopup(queen.Owner, queen.Comp.GiveOrderPlasmaCost, predicted: false))
+            return;
+
+        SendPsychicMessage(queen, target.Value, text, PsychicMessageKind.Order);
+        SendQueenConfirmation(queen, Loc.GetString("rmc-xeno-psychic-give-order-sent", ("target", target.Value)));
+        var escaped = FormattedMessage.EscapeText(text);
+        SendGhostCopy(queen, text, Loc.GetString("rmc-xeno-psychic-ghost-order", ("queen", queen.Owner), ("target", target.Value), ("message", escaped)));
+        _adminLog.Add(LogType.Chat, LogImpact.Low, $"Psychic order from {ToPrettyString(queen):user} to {ToPrettyString(target.Value):target}: {text}");
+        _actions.StartUseDelay(action);
+    }
+
+    private List<EntityUid> GetRecipients(Entity<XenoPsychicCommunicationComponent> queen, float range)
+    {
+        var recipients = new List<EntityUid>();
+        _nearbyMobs.Clear();
+        _lookup.GetEntitiesInRange(Transform(queen).Coordinates, range, _nearbyMobs);
+
+        foreach (var recipient in _nearbyMobs)
+        {
+            if (!IsValidRecipient(queen, recipient, range))
+                continue;
+
+            recipients.Add(recipient);
+        }
+
+        recipients.Sort((a, b) => string.CompareOrdinal(Name(a), Name(b)));
+        return recipients;
+    }
+
+    private bool CanUseQueen(Entity<XenoPsychicCommunicationComponent> queen)
+    {
+        if (!HasComp<ActorComponent>(queen))
+            return false;
+
+        if (_mobState.IsDead(queen))
+            return false;
+
+        return true;
+    }
+
+    private bool CanWhisperTo(Entity<XenoPsychicCommunicationComponent> queen, EntityUid target)
+    {
+        return IsValidRecipient(queen, target, queen.Comp.WhisperRange);
+    }
+
+    private bool IsValidRecipient(Entity<XenoPsychicCommunicationComponent> queen, EntityUid target, float range)
+    {
+        if (queen.Owner == target || TerminatingOrDeleted(target))
+            return false;
+
+        if (!HasComp<ActorComponent>(target) ||
+            !HasComp<MobStateComponent>(target) ||
+            _mobState.IsDead(target))
+        {
+            return false;
+        }
+
+        return _transform.InRange(queen.Owner, target, range);
+    }
+
+    private bool TryGetWatchedXeno(Entity<XenoPsychicCommunicationComponent> queen, out EntityUid watched)
+    {
+        watched = default;
+        if (!_watch.TryGetWatched(queen.Owner, out watched) ||
+            watched == queen.Owner)
+        {
+            _popup.PopupEntity(Loc.GetString("rmc-xeno-psychic-give-order-must-watch"), queen, queen, PopupType.MediumCaution);
+            return false;
+        }
+
+        if (!HasComp<XenoComponent>(watched) ||
+            !HasComp<ActorComponent>(watched) ||
+            _mobState.IsDead(watched) ||
+            !_hive.FromSameHive(queen.Owner, watched))
+        {
+            _popup.PopupEntity(Loc.GetString("rmc-xeno-psychic-target-invalid"), queen, queen, PopupType.MediumCaution);
+            return false;
+        }
+
+        return true;
+    }
+
+    private bool TryGetAction(Entity<XenoPsychicCommunicationComponent> queen, NetEntity netAction, out EntityUid action)
+    {
+        action = default;
+        if (!TryGetEntity(netAction, out var actionId) ||
+            !TryComp(actionId, out ActionComponent? actionComp) ||
+            actionComp.AttachedEntity != queen.Owner ||
+            !actionComp.Enabled ||
+            _actions.IsCooldownActive(actionComp, _timing.CurTime))
+        {
+            return false;
+        }
+
+        action = actionId.Value;
+        return true;
+    }
+
+    private string? CleanMessage(Entity<XenoPsychicCommunicationComponent> queen, string message)
+    {
+        message = FormattedMessage.RemoveMarkupPermissive(message).Trim();
+        if (string.IsNullOrWhiteSpace(message))
+            return null;
+
+        if (message.Length > queen.Comp.CharacterLimit)
+            message = message[..queen.Comp.CharacterLimit].Trim();
+
+        message = NewLineRegex.Replace(message, "\n\n");
+        return _chat.SanitizeMessageReplaceWords(queen, message);
+    }
+
+    private void SendPsychicMessage(Entity<XenoPsychicCommunicationComponent> queen, EntityUid target, string message, PsychicMessageKind kind)
+    {
+        if (!TryComp(target, out ActorComponent? actor))
+            return;
+
+        var escapedMessage = FormattedMessage.EscapeText(message);
+        var queenName = FormattedMessage.EscapeText(Name(queen));
+        var wrapped = kind switch
+        {
+            PsychicMessageKind.Order => Loc.GetString("rmc-xeno-psychic-message-order", ("queen", queenName), ("message", escapedMessage)),
+            _ when IsSameHiveXeno(queen, target) => Loc.GetString("rmc-xeno-psychic-message-xeno", ("queen", queenName), ("message", escapedMessage)),
+            _ => Loc.GetString("rmc-xeno-psychic-message-alien", ("message", escapedMessage)),
+        };
+
+        var author = CompOrNull<ActorComponent>(queen)?.PlayerSession.UserId;
+        _chat.ChatMessageToOne(
+            ChatChannel.Local,
+            message,
+            wrapped,
+            queen,
+            false,
+            actor.PlayerSession.Channel,
+            PsychicColor,
+            recordReplay: true,
+            author: author);
+    }
+
+    private void SendQueenConfirmation(Entity<XenoPsychicCommunicationComponent> queen, string message)
+    {
+        _popup.PopupEntity(message, queen, queen, PopupType.Medium);
+
+        if (!TryComp(queen, out ActorComponent? actor))
+            return;
+
+        _chat.ChatMessageToOne(
+            ChatChannel.Local,
+            message,
+            message,
+            default,
+            false,
+            actor.PlayerSession.Channel,
+            PsychicColor,
+            recordReplay: true,
+            author: actor.PlayerSession.UserId);
+    }
+
+    private void SendGhostCopy(Entity<XenoPsychicCommunicationComponent> queen, string message, string wrapped)
+    {
+        var ghosts = Filter.Empty().AddWhereAttachedEntity(HasComp<GhostComponent>);
+        if (ghosts.Count == 0)
+            return;
+
+        var author = CompOrNull<ActorComponent>(queen)?.PlayerSession.UserId;
+        _chat.ChatMessageToMany(
+            message,
+            wrapped,
+            ghosts,
+            ChatChannel.Local,
+            queen,
+            colorOverride: PsychicColor,
+            recordReplay: true,
+            author: author);
+    }
+
+    private bool IsSameHiveXeno(Entity<XenoPsychicCommunicationComponent> queen, EntityUid target)
+    {
+        return HasComp<XenoComponent>(target) && _hive.FromSameHive(queen.Owner, target);
+    }
+
+    private object QueenTargetName(Entity<XenoPsychicCommunicationComponent> queen, EntityUid target)
+    {
+        if (IsSameHiveXeno(queen, target))
+            return target;
+
+        return Loc.GetString("rmc-xeno-psychic-target-unknown");
+    }
+
+    private enum PsychicMessageKind
+    {
+        Whisper,
+        Radiance,
+        Order,
+    }
+}

--- a/Content.Shared.Database/LogType.cs
+++ b/Content.Shared.Database/LogType.cs
@@ -525,4 +525,5 @@ public enum LogType
     RMCIconLabel = RMCMarineAnnounce + 43,
     RMCMedalRecommendation = RMCMarineAnnounce + 44,
     RMCAutodocSurgeryAbort = RMCMarineAnnounce + 45,
+    RMCXenoPsychic = RMCMarineAnnounce + 46,
 }

--- a/Content.Shared/_RMC14/Xenonids/Psychic/XenoPsychicCommunicationComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Psychic/XenoPsychicCommunicationComponent.cs
@@ -1,0 +1,22 @@
+using Content.Shared.FixedPoint;
+
+namespace Content.Shared._RMC14.Xenonids.Psychic;
+
+[RegisterComponent]
+public sealed partial class XenoPsychicCommunicationComponent : Component
+{
+    [DataField]
+    public float WhisperRange = 7;
+
+    [DataField]
+    public float RadianceRange = 12;
+
+    [DataField]
+    public FixedPoint2 RadiancePlasmaCost = 100;
+
+    [DataField]
+    public FixedPoint2 GiveOrderPlasmaCost = 100;
+
+    [DataField]
+    public int CharacterLimit = 200;
+}

--- a/Content.Shared/_RMC14/Xenonids/Psychic/XenoPsychicCommunicationEvents.cs
+++ b/Content.Shared/_RMC14/Xenonids/Psychic/XenoPsychicCommunicationEvents.cs
@@ -1,0 +1,23 @@
+using Content.Shared._RMC14.Dialog;
+using Content.Shared.Actions;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Xenonids.Psychic;
+
+public sealed partial class XenoPsychicWhisperActionEvent : EntityTargetActionEvent;
+
+public sealed partial class XenoPsychicRadianceActionEvent : InstantActionEvent;
+
+public sealed partial class XenoGiveOrderActionEvent : InstantActionEvent;
+
+[Serializable, NetSerializable]
+public sealed record XenoPsychicWhisperInputEvent(NetEntity Action, NetEntity Target, string Message = "")
+    : DialogInputEvent(Message);
+
+[Serializable, NetSerializable]
+public sealed record XenoPsychicRadianceInputEvent(NetEntity Action, string Message = "")
+    : DialogInputEvent(Message);
+
+[Serializable, NetSerializable]
+public sealed record XenoGiveOrderInputEvent(NetEntity Action, NetEntity Target, string Message = "")
+    : DialogInputEvent(Message);

--- a/Content.Shared/_RMC14/Xenonids/Word/XenoWordQueenSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Word/XenoWordQueenSystem.cs
@@ -4,11 +4,13 @@ using Content.Shared._RMC14.Xenonids.Announce;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared.Actions;
+using Content.Shared.Actions.Components;
 using Content.Shared.CCVar;
 using Content.Shared.Popups;
 using Robust.Shared.Configuration;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
+using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
 namespace Content.Shared._RMC14.Xenonids.Word;
@@ -18,6 +20,7 @@ public sealed class XenoWordQueenSystem : EntitySystem
     [Dependency] private readonly SharedActionsSystem _actions = default!;
     [Dependency] private readonly SharedCMChatSystem _cmChat = default!;
     [Dependency] private readonly IConfigurationManager _config = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
@@ -45,7 +48,6 @@ public sealed class XenoWordQueenSystem : EntitySystem
         if (args.Handled)
             return;
 
-        args.Handled = true;
         _ui.TryOpenUi(queen.Owner, XenoWordQueenUI.Key, queen);
     }
 
@@ -55,6 +57,9 @@ public sealed class XenoWordQueenSystem : EntitySystem
 
         var text = args.Text.Trim();
         if (string.IsNullOrWhiteSpace(text))
+            return;
+
+        if (!CanSend(queen))
             return;
 
         if (!_xenoPlasma.HasPlasmaPopup(queen.Owner, queen.Comp.PlasmaCost))
@@ -98,5 +103,21 @@ public sealed class XenoWordQueenSystem : EntitySystem
             if (HasComp<XenoWordQueenActionComponent>(actionId))
                 _actions.StartUseDelay(actionId);
         }
+    }
+
+    private bool CanSend(EntityUid queen)
+    {
+        foreach (var (actionId, action) in _actions.GetActions(queen))
+        {
+            if (!HasComp<XenoWordQueenActionComponent>(actionId))
+                continue;
+
+            if (!action.Enabled || _actions.IsCooldownActive(action, _timing.CurTime))
+                return false;
+
+            return true;
+        }
+
+        return false;
     }
 }

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
@@ -13,6 +13,24 @@ rmc-xeno-internal-health-increase-user = We feel our internal health reserves in
 rmc-xeno-not-enough-fury = We're not angry enough for this!
 rmc-xeno-fury-increase-user = We are overcome with rage!
 
+# Queen psychic communication
+rmc-xeno-psychic-whisper-message = Whisper to {$target}.
+rmc-xeno-psychic-whisper-sent = We whisper to {$target}.
+rmc-xeno-psychic-target-unknown = that mind
+rmc-xeno-psychic-radiance-message = Radiate a psychic message.
+rmc-xeno-psychic-radiance-no-targets = There are no nearby minds to radiate to.
+rmc-xeno-psychic-radiance-sent = We radiate our thoughts to {$count} nearby minds.
+rmc-xeno-psychic-give-order-message = Give an order to {$target}.
+rmc-xeno-psychic-give-order-must-watch = We must be watching a sister to give an order.
+rmc-xeno-psychic-give-order-sent = We give an order to {$target}.
+rmc-xeno-psychic-target-invalid = That mind is no longer within our reach.
+rmc-xeno-psychic-message-xeno = [color=#921992][font size=14][bold]The voice of {$queen} resonates in your head:[/bold] "{$message}"[/font][/color]
+rmc-xeno-psychic-message-alien = [color=#921992][font size=14][bold]You hear a strange, alien voice in your head:[/bold] "{$message}"[/font][/color]
+rmc-xeno-psychic-message-order = [color=#921992][font size=14][bold]{$queen} commands you:[/bold] "{$message}"[/font][/color]
+rmc-xeno-psychic-ghost-whisper = [color=#921992][font size=14][bold]Psychic Whisper ({$queen} -> {$target}):[/bold] "{$message}"[/font][/color]
+rmc-xeno-psychic-ghost-radiance = [color=#921992][font size=14][bold]Psychic Radiance ({$queen}, {$count} recipients):[/bold] "{$message}"[/font][/color]
+rmc-xeno-psychic-ghost-order = [color=#921992][font size=14][bold]Psychic Order ({$queen} -> {$target}):[/bold] "{$message}"[/font][/color]
+
 # Acid reserves
 rmc-xeno-not-enough-acid = We don't have enough acid built up!
 rmc-xeno-acid-increase-user = We feel your acid reserves increase!

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_self_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_self_actions.yml
@@ -208,6 +208,61 @@
   - type: RMCDazeableAction
 
 - type: entity
+  id: ActionXenoPsychicWhisper
+  parent: ActionXenoBase
+  name: Psychic Whisper
+  description: Whisper a psychic message to a nearby mind.
+  components:
+  - type: Action
+    itemIconStyle: NoItem
+    icon:
+      sprite: _RMC14/Actions/xeno_actions.rsi
+      state: psychic_whisper
+    useDelay: 10
+  - type: TargetAction
+    range: 7
+  - type: EntityTargetAction
+    event: !type:XenoPsychicWhisperActionEvent
+    canTargetSelf: false
+    toggleOutline: false
+    whitelist:
+      components:
+      - MobState
+  - type: RMCDazeableAction
+
+- type: entity
+  id: ActionXenoPsychicRadiance
+  parent: ActionXenoBase
+  name: Psychic Radiance (100)
+  description: Radiate a psychic message to nearby minds.
+  components:
+  - type: Action
+    itemIconStyle: NoItem
+    icon:
+      sprite: _RMC14/Actions/xeno_actions.rsi
+      state: psychic_radiance
+    useDelay: 10
+  - type: InstantAction
+    event: !type:XenoPsychicRadianceActionEvent
+  - type: RMCDazeableAction
+
+- type: entity
+  id: ActionXenoGiveOrder
+  parent: ActionXenoBase
+  name: Give Order (100)
+  description: Send a psychic order to the xenonid you are watching.
+  components:
+  - type: Action
+    itemIconStyle: NoItem
+    icon:
+      sprite: _RMC14/Actions/xeno_actions.rsi
+      state: queen_order
+    useDelay: 10
+  - type: InstantAction
+    event: !type:XenoGiveOrderActionEvent
+  - type: RMCDazeableAction
+
+- type: entity
   id: ActionXenoGrowOvipositor
   parent: ActionXenoBase
   name: Grow Ovipositor (700) # TODO RMC14 proper plasma costs

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
@@ -58,8 +58,9 @@
     - ActionXenoAcidNormal
     - ActionXenoPheromones
     - ActionXenoWordQueen
-#    - ActionXenoPsychicWhisper
-#    - ActionXenoPsychicRadiance
+    - ActionXenoPsychicWhisper
+    - ActionXenoPsychicRadiance
+    - ActionXenoGiveOrder
     - ActionXenoGut
     - ActionXenoPlantWeeds
     - ActionXenoChooseStructure
@@ -104,6 +105,7 @@
     xenoArmor: 25
     explosionArmor: 100
   - type: XenoWordQueen
+  - type: XenoPsychicCommunication
   - type: InnateCommandSpeech
   - type: RMCInnateRadioTextIncrease
     radioTextIncrease: 3


### PR DESCRIPTION
## About the PR

Adds Queen psychic communication abilities:

- `Psychic Whisper`
- `Psychic Radiance`
- `Give Order`

Psychic Whisper is a targeted click ability: the Queen selects the action, clicks a mob, then enters the message. It does not show a list of nearby target names.

## Why / Balance

**PARITY**, with an RMC14-specific anti-metagame adjustment.

CM13 lets the Queen send personal psychic messages, radiance messages, and orders, but its target list exposes nearby mob names. This PR avoids that name leak by making Psychic Whisper target a clicked mob instead of listing all nearby valid targets. Non-xeno targets are shown to the Queen only as `that mind`, so the ability cannot be used as a free name scanner.

Costs:

- Psychic Whisper: `0` plasma
- Psychic Radiance: `100` plasma
- Give Order: `100` plasma

Plasma and cooldown are only consumed after a message is actually delivered.

## Technical details

Added shared psychic communication component and events:

- `XenoPsychicCommunicationComponent`
- `XenoPsychicWhisperActionEvent`
- `XenoPsychicRadianceActionEvent`
- `XenoGiveOrderActionEvent`
- dialog input events for submitted messages

Added server-side `XenoPsychicCommunicationSystem`.

Psychic Whisper:

- is an `EntityTargetAction`;
- requires clicking a valid mob in range 7;
- does not open a target list;
- disables target outline to avoid extra scanning;
- revalidates target, range, actor, mob state, action availability, and cooldown after text input;
- sends Queen identity only to same-hive xenos;
- sends humans/non-hive targets a generic strange alien voice message.

Psychic Radiance:

- opens text input directly;
- collects valid player-controlled living mobs in range 12 after submit;
- costs 100 plasma only if there is at least one valid recipient;
- does not spend plasma on empty text or no recipients.

Give Order:

- uses the currently watched xeno from `SharedXenoWatchSystem`;
- requires a living same-hive xeno with a player actor;
- revalidates the watched target after text input;
- costs 100 plasma only after successful delivery.

Also fixed `Word of the Queen` so opening its message window no longer starts cooldown. The cooldown now starts only after the word is actually sent.

Reused existing systems:

- `DialogSystem`
- `XenoPlasmaSystem`
- `SharedXenoWatchSystem`
- `SharedCMChatSystem`
- existing xeno action/cooldown pipeline

Added prototype coverage for the new Queen actions and component wiring.
## Media

<img width="132" height="268" alt="image" src="https://github.com/user-attachments/assets/14ad114c-5410-4ec9-8632-3a45c4a5c048" />
<img width="1485" height="550" alt="image" src="https://github.com/user-attachments/assets/3bc7563b-8fde-4ce2-bfee-09ca583855a9" />
<img width="1564" height="387" alt="image" src="https://github.com/user-attachments/assets/2f3e3785-4f71-4ea0-8463-63de88ea1264" />


## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
- add: Added Queen Psychic Whisper, Psychic Radiance, and Give Order abilities.