### PR TITLE
Fixed signal flare visuals not updating with roof changes

### DIFF
--- a/Content.Shared/_RMC14/Areas/AreaSystem.cs
+++ b/Content.Shared/_RMC14/Areas/AreaSystem.cs
@@ -1,25 +1,23 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Components;
 using Content.Shared._RMC14.Dropship.Weapon;
 using Content.Shared._RMC14.GameStates;
-using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.Warps;
 using Content.Shared._RMC14.Xenonids.Construction;
 using Content.Shared.Coordinates;
 using Content.Shared.Damage;
 using Content.Shared.GameTicking;
-using Content.Shared.Item.ItemToggle;
 using Content.Shared.Maps;
 using Content.Shared.Popups;
 using Content.Shared.Tag;
-using Lidgren.Network;
 using Robust.Shared.Configuration;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
+
 
 namespace Content.Shared._RMC14.Areas;
 
@@ -39,7 +37,6 @@ public sealed class AreaSystem : EntitySystem
     [Dependency] private readonly TurfSystem _turf = default!;
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
     [Dependency] private readonly SharedDropshipWeaponSystem _weapon = default!;
-    [Dependency] private readonly RMCComponentsSystem _toggle = default!;
 
     private static readonly ProtoId<TagPrototype> WallTag = "Wall";
 
@@ -52,7 +49,7 @@ public sealed class AreaSystem : EntitySystem
     private EntityQuery<XenoConstructComponent> _xenoConstruct;
 
     private readonly List<EntityUid> _toRender = new();
-    private readonly HashSet<Entity<FlareSignalComponent>> _roofEnts = new();
+    private readonly HashSet<Entity<FlareSignalComponent>> _flareEnts = new();
 
     private TimeSpan _earlySpreadHiveTime;
 
@@ -73,40 +70,32 @@ public sealed class AreaSystem : EntitySystem
         Subs.CVar(_config, RMCCVars.RMCHiveSpreadEarlyMinutes, v => _earlySpreadHiveTime = TimeSpan.FromMinutes(v), true);
     }
 
-
-    /// <summary>
-    ///     Raised when entity is destroyed and about to be deleted.
-    /// </summary>
-    public sealed class UpdateRoofEvent : EntityEventArgs
-    {
-        
-    }
     private void UpdateRoof(Entity<RoofingEntityComponent> ent)
     {
-        _roofEnts.Clear();
+        _flareEnts.Clear();
         var roofCoords = _transform.GetMoverCoordinates(ent);
-        //var update_roof_event = new UpdateRoofEvent();
-        //RaiseLocalEvent(update_roof_event);
-        _lookup.GetEntitiesInRange(roofCoords, ent.Comp.Range, _roofEnts);
-        //ent.Comp.Range = 0;
-        _roofEnts.ToString();
-        foreach (var foundEnt in _roofEnts)
+        _lookup.GetEntitiesInRange(roofCoords, ent.Comp.Range, _flareEnts);
+
+        foreach (var foundEnt in _flareEnts)
         {
             foundEnt.ToString();
-            if (HasComp<ActiveFlareSignalComponent>(foundEnt))
+            if (HasComp<ActiveFlareSignalComponent>(foundEnt)) //This Component indicates that the flare is arming, so we wait for that to update the visuals instead
                 continue;
             _weapon.UpdateSignalFlareVisuals(foundEnt);
         }
     }
+
     private void OnRoofMapInit(Entity<RoofingEntityComponent> ent, ref MapInitEvent args)
     {
         UpdateRoof(ent);
     }
+
     private void OnRoofRemoved(Entity<RoofingEntityComponent> ent, ref EntityTerminatingEvent args)
     {
         ent.Comp.CanCAS = true;
         UpdateRoof(ent);
     }
+
     private void OnAreaGridMapInit(Entity<AreaGridComponent> ent, ref MapInitEvent args)
     {
         _toRender.Add(ent);

--- a/Content.Shared/_RMC14/Areas/AreaSystem.cs
+++ b/Content.Shared/_RMC14/Areas/AreaSystem.cs
@@ -1,20 +1,25 @@
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Content.Shared._RMC14.CCVar;
+using Content.Shared._RMC14.Components;
+using Content.Shared._RMC14.Dropship.Weapon;
 using Content.Shared._RMC14.GameStates;
+using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.Warps;
 using Content.Shared._RMC14.Xenonids.Construction;
 using Content.Shared.Coordinates;
 using Content.Shared.Damage;
 using Content.Shared.GameTicking;
+using Content.Shared.Item.ItemToggle;
 using Content.Shared.Maps;
 using Content.Shared.Popups;
 using Content.Shared.Tag;
+using Lidgren.Network;
 using Robust.Shared.Configuration;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 
 namespace Content.Shared._RMC14.Areas;
 
@@ -32,6 +37,9 @@ public sealed class AreaSystem : EntitySystem
     [Dependency] private readonly ITileDefinitionManager _tile = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly TurfSystem _turf = default!;
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private readonly SharedDropshipWeaponSystem _weapon = default!;
+    [Dependency] private readonly RMCComponentsSystem _toggle = default!;
 
     private static readonly ProtoId<TagPrototype> WallTag = "Wall";
 
@@ -44,6 +52,7 @@ public sealed class AreaSystem : EntitySystem
     private EntityQuery<XenoConstructComponent> _xenoConstruct;
 
     private readonly List<EntityUid> _toRender = new();
+    private readonly HashSet<Entity<FlareSignalComponent>> _roofEnts = new();
 
     private TimeSpan _earlySpreadHiveTime;
 
@@ -58,10 +67,46 @@ public sealed class AreaSystem : EntitySystem
         _xenoConstruct = GetEntityQuery<XenoConstructComponent>();
 
         SubscribeLocalEvent<AreaGridComponent, MapInitEvent>(OnAreaGridMapInit);
+        SubscribeLocalEvent<RoofingEntityComponent, MapInitEvent>(OnRoofMapInit);
+        SubscribeLocalEvent<RoofingEntityComponent, EntityTerminatingEvent>(OnRoofRemoved);
 
         Subs.CVar(_config, RMCCVars.RMCHiveSpreadEarlyMinutes, v => _earlySpreadHiveTime = TimeSpan.FromMinutes(v), true);
     }
 
+
+    /// <summary>
+    ///     Raised when entity is destroyed and about to be deleted.
+    /// </summary>
+    public sealed class UpdateRoofEvent : EntityEventArgs
+    {
+        
+    }
+    private void UpdateRoof(Entity<RoofingEntityComponent> ent)
+    {
+        _roofEnts.Clear();
+        var roofCoords = _transform.GetMoverCoordinates(ent);
+        //var update_roof_event = new UpdateRoofEvent();
+        //RaiseLocalEvent(update_roof_event);
+        _lookup.GetEntitiesInRange(roofCoords, ent.Comp.Range, _roofEnts);
+        //ent.Comp.Range = 0;
+        _roofEnts.ToString();
+        foreach (var foundEnt in _roofEnts)
+        {
+            foundEnt.ToString();
+            if (HasComp<ActiveFlareSignalComponent>(foundEnt))
+                continue;
+            _weapon.UpdateSignalFlareVisuals(foundEnt);
+        }
+    }
+    private void OnRoofMapInit(Entity<RoofingEntityComponent> ent, ref MapInitEvent args)
+    {
+        UpdateRoof(ent);
+    }
+    private void OnRoofRemoved(Entity<RoofingEntityComponent> ent, ref EntityTerminatingEvent args)
+    {
+        ent.Comp.CanCAS = true;
+        UpdateRoof(ent);
+    }
     private void OnAreaGridMapInit(Entity<AreaGridComponent> ent, ref MapInitEvent args)
     {
         _toRender.Add(ent);

--- a/Content.Shared/_RMC14/Areas/AreaSystem.cs
+++ b/Content.Shared/_RMC14/Areas/AreaSystem.cs
@@ -18,7 +18,6 @@ using Robust.Shared.Map.Components;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 
-
 namespace Content.Shared._RMC14.Areas;
 
 public sealed class AreaSystem : EntitySystem
@@ -78,8 +77,7 @@ public sealed class AreaSystem : EntitySystem
 
         foreach (var foundEnt in _flareEnts)
         {
-            foundEnt.ToString();
-            if (HasComp<ActiveFlareSignalComponent>(foundEnt)) //This Component indicates that the flare is arming, so we wait for that to update the visuals instead
+            if (HasComp<ActiveFlareSignalComponent>(foundEnt)) //This component indicates that the flare is arming, so we wait for that to update the visuals instead
                 continue;
             _weapon.UpdateSignalFlareVisuals(foundEnt);
         }

--- a/Content.Shared/_RMC14/Dropship/Weapon/SharedDropshipWeaponSystem.cs
+++ b/Content.Shared/_RMC14/Dropship/Weapon/SharedDropshipWeaponSystem.cs
@@ -1276,13 +1276,7 @@ public abstract class SharedDropshipWeaponSystem : EntitySystem
         _name.RefreshNameModifiers(ent.Owner);
         _physics.SetBodyType(ent, BodyType.Static);
 
-        var coordinates = _transform.GetMoverCoordinates(ent).SnapToGrid(EntityManager, _mapManager);
-
-        if (CasDebug || _area.CanCAS(coordinates))
-        {
-            if (TryComp<AppearanceComponent>(ent, out var appearance))
-                _appearance.SetData(ent, SignalFlareVisuals.BeaconState, true, appearance);
-        }
+        UpdateSignalFlareVisuals(ent);
 
         return true;
     }

--- a/Content.Shared/_RMC14/Dropship/Weapon/SharedDropshipWeaponSystem.cs
+++ b/Content.Shared/_RMC14/Dropship/Weapon/SharedDropshipWeaponSystem.cs
@@ -1287,6 +1287,26 @@ public abstract class SharedDropshipWeaponSystem : EntitySystem
         return true;
     }
 
+    public void UpdateSignalFlareVisuals(EntityUid ent)
+    {
+        var coordinates = _transform.GetMoverCoordinates(ent).SnapToGrid(EntityManager, _mapManager);
+
+        if (!IsFlareLit(ent))
+            return;
+
+        if (!TryComp<AppearanceComponent>(ent, out var appearance))
+            return;
+
+        if (CasDebug || _area.CanCAS(coordinates))
+        {
+            _appearance.SetData(ent, SignalFlareVisuals.BeaconState, true, appearance);
+        }
+        else
+        {
+            _appearance.SetData(ent, SignalFlareVisuals.BeaconState, false, appearance);
+        }
+    }
+
     public int ComputeNextId()
     {
         return _nextId++;


### PR DESCRIPTION
## About the PR
#8282 had a minor issue where the blinking light doesn't update when roofing changes due to pylons/hive cores being created/destroyed.
Now RoofingEntityComponent checks for signal flares in an area around it whenever the entity is created or destroyed

## Why / Balance
More accurately indicate when a flare can be fired on

## Technical details
RMC14 AreaSystem now watches RoofingEntityComponent MapInit and EntityTermination events and triggers a roof update around those entities when those events occur. If EntityTermination triggers it sets CanCas to true so that the flares being updated act as if the roof that is being terminated does not exist. 

Roof update scans for signal flares in the roof range and calls UpdateSignalFlareVisuals, which uses the CanCas method to set the appropriate visual

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [ X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
No need for changelog I think since it's a fix of my unreleased PR