### PR TITLE
Large Chems Container adjustment

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Tools/bucket.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Tools/bucket.yml
@@ -110,7 +110,6 @@
       visible: false
   - type: Item
     sprite: _RMC14/Objects/Misc/Janitorial/bucket.rsi
-    size: Normal
   - type: SolutionContainerVisuals
     fillBaseName: janibucket-
   - type: SolutionContainerManager
@@ -179,3 +178,10 @@
         enum.OpenableVisuals.Layer:
           True: {visible: false}
           False: {visible: true}
+  - type: StorageNestedOpenSkillRequired
+    skills:
+      all:
+        RMCSkillMedical: 2
+  - type: Tag
+    tags:
+    - CMFirstAidKit


### PR DESCRIPTION
I've updated the Janitor bucket to not fit in any bags at all, and updated the Reagent Jug to only be storable with medical skill ( the same way the first-aid kits work currently). This is to allow Hypo-Jug based HM's and Shipside staff who use them for chemisty, to still function, but not allow Joe Rifleman to be lugging 2.5ku GC into the field.

## Technical details
YAML changes.

## Media
Ignore the Canister stuff in the video below, originally these were part of the same pr found [here](https://github.com/RMC-14/RMC-14/pull/9988)

https://github.com/user-attachments/assets/4f640c00-4da9-4641-b32b-81ea83bce79b




## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: Jani Bucket no longer store-able in bags, Reagent Jugs require med-skill to store in bags.
