### PR TITLE
SMG mag inventory size fix

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/mac15.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/mac15.yml
@@ -116,6 +116,8 @@
     zeroVisible: false
     zeroOnlyOnEmpty: true
   - type: Appearance
+  - type: Item
+    size: Small
 
 - type: entity
   parent: RMCMagazineSMGMAC15

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/mp27.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/mp27.yml
@@ -132,6 +132,8 @@
     zeroVisible: false
     zeroOnlyOnEmpty: true
   - type: Appearance
+  - type: Item
+    size: Small
 
 - type: entity
   parent: RMCMagazineSMGMP27
@@ -157,6 +159,8 @@
       map: ["enum.GunVisualLayers.Base"]
     - state: mag-1
       map: ["enum.GunVisualLayers.Mag"]
+  - type: Item
+    size: Small
 
 - type: entity
   parent: CMCartridge10x20mm

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/mp5_smg.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/mp5_smg.yml
@@ -129,6 +129,8 @@
     zeroVisible: false
     zeroOnlyOnEmpty: true
   - type: Appearance
+  - type: Item
+    size: Small
 
 - type: entity
   parent: CMCartridge10x20mm

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/type19.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/type19.yml
@@ -125,6 +125,8 @@
     zeroVisible: false
     zeroOnlyOnEmpty: true
   - type: Appearance
+  - type: Item
+    size: Small
 
 - type: entity
   parent: CMMagazineRifleBase

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/type64.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/type64.yml
@@ -122,6 +122,8 @@
     zeroVisible: false
     zeroOnlyOnEmpty: true
   - type: Appearance
+  - type: Item
+    size: Small
 
 - type: entity
   parent: CMCartridgeSMGBase

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/uzi.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/uzi.yml
@@ -113,6 +113,8 @@
     zeroVisible: false
     zeroOnlyOnEmpty: true
   - type: Appearance
+  - type: Item
+    size: Small
 
 - type: entity
   parent: RMCMagazineSMGUZI
@@ -132,6 +134,8 @@
     tags:
     - CMMagazineSmg
     - RMCMagazineSMGUZIExt
+  - type: Item
+    size: Small
 
 - type: entity
   parent: CMCartridge9mmSMG


### PR DESCRIPTION
## About the PR
Changes Type 64, Mac15, MP27, type 19, mp5 and uzi mags to small size

## Why / Balance
Parity

They all parent from ammo_magazine which has the weight class set to small

<img width="1455" height="183" alt="obraz" src="https://github.com/user-attachments/assets/ef99b5c3-5cd7-4984-9150-0d3e81c0bfa4" />


## Technical details
Yaml

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed Type 64, UZI, Type 19, MP27, MAC15 and MP5 being the incorrect size, they are now small in inventories as intended
