### PR TITLE
tweak: disallow squad unassignment of rifleman

### DIFF
--- a/Content.Shared/_RMC14/Marines/Access/IdModificationConsoleComponent.cs
+++ b/Content.Shared/_RMC14/Marines/Access/IdModificationConsoleComponent.cs
@@ -1,6 +1,7 @@
 using Content.Shared._RMC14.Marines.Skills;
 using Content.Shared._RMC14.Weapons.Ranged.IFF;
 using Content.Shared.Access;
+using Content.Shared.Roles;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
@@ -53,6 +54,9 @@ public sealed partial class IdModificationConsoleComponent : Component
 
     [DataField] [AutoNetworkedField]
     public List<IdModificationConsoleSquads>? Squads;
+
+    [DataField] [AutoNetworkedField]
+    public HashSet<ProtoId<JobPrototype>> DisallowSquadUnassignment = ["CMRifleman"];
 }
 
 [Serializable] [NetSerializable]

--- a/Content.Shared/_RMC14/Marines/Access/IdModificationConsoleSystem.cs
+++ b/Content.Shared/_RMC14/Marines/Access/IdModificationConsoleSystem.cs
@@ -508,6 +508,12 @@ public sealed class IdModificationConsoleSystem : EntitySystem
 
         if (args.Squad is not { } squadNetEnt)
         {
+            if (ent.Comp.DisallowSquadUnassignment.Contains(job.Id))
+            {
+                _popup.PopupCursor($"You cannot unassign a {jobName}!", actor, PopupType.LargeCaution);
+                return;
+            }
+
             _squad.RemoveSquad(marineId, null);
             _metaData.SetEntityName(uid.Value,
                 $"{MetaData(idCard.OriginalOwner.Value).EntityName} ({jobName})");

--- a/Content.Shared/_RMC14/Marines/Access/IdModificationConsoleSystem.cs
+++ b/Content.Shared/_RMC14/Marines/Access/IdModificationConsoleSystem.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Content.Shared._RMC14.Marines.Announce;
 using Content.Shared._RMC14.Marines.Roles.Ranks;
 using Content.Shared._RMC14.Marines.Skills;
+using Content.Shared._RMC14.Marines.Skills.Pamphlets;
 using Content.Shared._RMC14.Marines.Squads;
 using Content.Shared._RMC14.Roles;
 using Content.Shared._RMC14.Weapons.Ranged.IFF;
@@ -503,7 +504,9 @@ public sealed class IdModificationConsoleSystem : EntitySystem
             return;
 
         var jobName = job.Id;
-        if (_prototype.TryIndex(job, out var jobProto))
+        if (TryComp<UsedSkillPamphletComponent>(marineId, out var usedSkillPamphlet) && usedSkillPamphlet.JobTitle is { } title)
+            jobName = Loc.GetString(title);
+        else if (_prototype.TryIndex(job, out var jobProto))
             jobName = Loc.GetString(jobProto.Name);
 
         if (args.Squad is not { } squadNetEnt)


### PR DESCRIPTION
## About the PR

There is no real reason to ever unassign a rifleman from a squad. Other squad roles could be added later if the issue comes up again.

## Why / Balance

Fixes #9972

## Technical details

- HashSet of jobs that are not allowed to be unassigned.
- Check before attempting to unassign.

## Media

<img width="726" height="657" alt="Screenshot_2026-06-02_11-34-14_zoom" src="https://github.com/user-attachments/assets/2955c41e-db1a-4344-88b6-c37d59475e28" />

https://github.com/user-attachments/assets/c80fb0de-f6b4-4a0c-ab92-4488807d5433


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- tweak: Rifleman can no longer be squadless.
- fix: The id console now respects titles granted by pamphlets.
