### PR TITLE
Shivas invincible resin fixes

### DIFF
--- a/Resources/Maps/_RMC14/shiva.yml
+++ b/Resources/Maps/_RMC14/shiva.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 264.0.2
   forkId: ""
   forkVersion: ""
-  time: 05/14/2026 20:33:34
-  entityCount: 17722
+  time: 06/03/2026 07:11:22
+  entityCount: 17735
 maps:
 - 1
 grids:
@@ -45109,11 +45109,6 @@ entities:
     - type: Transform
       pos: 159.5,6.5
       parent: 1
-  - uid: 1582
-    components:
-    - type: Transform
-      pos: 163.5,19.5
-      parent: 1
   - uid: 1583
     components:
     - type: Transform
@@ -53524,6 +53519,11 @@ entities:
     - type: Transform
       pos: 207.5,124.5
       parent: 1
+  - uid: 1582
+    components:
+    - type: Transform
+      pos: 163.5,19.5
+      parent: 1
   - uid: 2200
     components:
     - type: Transform
@@ -53548,6 +53548,41 @@ entities:
     components:
     - type: Transform
       pos: 152.5,16.5
+      parent: 1
+  - uid: 3020
+    components:
+    - type: Transform
+      pos: 173.5,21.5
+      parent: 1
+  - uid: 3026
+    components:
+    - type: Transform
+      pos: 171.5,15.5
+      parent: 1
+  - uid: 3027
+    components:
+    - type: Transform
+      pos: 168.5,15.5
+      parent: 1
+  - uid: 3028
+    components:
+    - type: Transform
+      pos: 167.5,15.5
+      parent: 1
+  - uid: 3029
+    components:
+    - type: Transform
+      pos: 172.5,17.5
+      parent: 1
+  - uid: 3030
+    components:
+    - type: Transform
+      pos: 172.5,16.5
+      parent: 1
+  - uid: 3033
+    components:
+    - type: Transform
+      pos: 166.5,125.5
       parent: 1
   - uid: 3173
     components:
@@ -53584,6 +53619,16 @@ entities:
     - type: Transform
       pos: 148.5,46.5
       parent: 1
+  - uid: 3180
+    components:
+    - type: Transform
+      pos: 174.5,19.5
+      parent: 1
+  - uid: 15970
+    components:
+    - type: Transform
+      pos: 173.5,20.5
+      parent: 1
   - uid: 16686
     components:
     - type: Transform
@@ -53593,11 +53638,6 @@ entities:
     components:
     - type: Transform
       pos: 148.5,45.5
-      parent: 1
-  - uid: 17005
-    components:
-    - type: Transform
-      pos: 168.5,125.5
       parent: 1
   - uid: 17131
     components:
@@ -53609,20 +53649,10 @@ entities:
     - type: Transform
       pos: 151.5,46.5
       parent: 1
-  - uid: 17136
+  - uid: 17141
     components:
     - type: Transform
-      pos: 167.5,21.5
-      parent: 1
-  - uid: 17137
-    components:
-    - type: Transform
-      pos: 169.5,21.5
-      parent: 1
-  - uid: 17138
-    components:
-    - type: Transform
-      pos: 168.5,21.5
+      pos: 172.5,15.5
       parent: 1
   - uid: 17458
     components:
@@ -53998,18 +54028,6 @@ entities:
     components:
     - type: Transform
       pos: 204.5,142.5
-      parent: 1
-- proto: DrinkGlass
-  entities:
-  - uid: 3185
-    components:
-    - type: Transform
-      pos: 126.71324,53.50888
-      parent: 1
-  - uid: 3186
-    components:
-    - type: Transform
-      pos: 125.93546,54.53666
       parent: 1
 - proto: DrinkRamen
   entities:
@@ -109427,6 +109445,18 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
+- proto: RMCDrinkGlass
+  entities:
+  - uid: 3185
+    components:
+    - type: Transform
+      pos: 126.71324,53.50888
+      parent: 1
+  - uid: 3186
+    components:
+    - type: Transform
+      pos: 125.93546,54.53666
+      parent: 1
 - proto: RMCERTShuttleEngineLeft01
   entities:
   - uid: 13609
@@ -110599,6 +110629,21 @@ entities:
       parent: 1
 - proto: RMCFogWallWeed30
   entities:
+  - uid: 17137
+    components:
+    - type: Transform
+      pos: 163.5,18.5
+      parent: 1
+  - uid: 17138
+    components:
+    - type: Transform
+      pos: 163.5,17.5
+      parent: 1
+  - uid: 17140
+    components:
+    - type: Transform
+      pos: 163.5,20.5
+      parent: 1
   - uid: 17144
     components:
     - type: Transform
@@ -125055,6 +125100,11 @@ entities:
     - type: InsideEntityStorage
 - proto: RMCSpaceHeater
   entities:
+  - uid: 3019
+    components:
+    - type: Transform
+      pos: 174.5,22.5
+      parent: 1
   - uid: 15957
     components:
     - type: Transform
@@ -125119,11 +125169,6 @@ entities:
     components:
     - type: Transform
       pos: 102.5,17.5
-      parent: 1
-  - uid: 15970
-    components:
-    - type: Transform
-      pos: 174.5,21.5
       parent: 1
   - uid: 15971
     components:
@@ -131555,10 +131600,40 @@ entities:
       parent: 1
 - proto: WallXenoResinImpenetrable
   entities:
-  - uid: 3180
+  - uid: 3021
     components:
     - type: Transform
-      pos: 164.5,21.5
+      pos: 166.5,15.5
+      parent: 1
+  - uid: 3022
+    components:
+    - type: Transform
+      pos: 169.5,15.5
+      parent: 1
+  - uid: 3023
+    components:
+    - type: Transform
+      pos: 169.5,14.5
+      parent: 1
+  - uid: 3024
+    components:
+    - type: Transform
+      pos: 170.5,15.5
+      parent: 1
+  - uid: 3025
+    components:
+    - type: Transform
+      pos: 170.5,14.5
+      parent: 1
+  - uid: 3031
+    components:
+    - type: Transform
+      pos: 166.5,126.5
+      parent: 1
+  - uid: 3032
+    components:
+    - type: Transform
+      pos: 166.5,124.5
       parent: 1
   - uid: 3181
     components:
@@ -131605,35 +131680,25 @@ entities:
     - type: Transform
       pos: 152.5,15.5
       parent: 1
+  - uid: 17005
+    components:
+    - type: Transform
+      pos: 172.5,18.5
+      parent: 1
   - uid: 17133
     components:
     - type: Transform
-      pos: 165.5,21.5
+      pos: 173.5,18.5
       parent: 1
   - uid: 17135
     components:
     - type: Transform
-      pos: 166.5,21.5
+      pos: 173.5,19.5
       parent: 1
-  - uid: 17140
+  - uid: 17136
     components:
     - type: Transform
-      pos: 170.5,21.5
-      parent: 1
-  - uid: 17141
-    components:
-    - type: Transform
-      pos: 171.5,21.5
-      parent: 1
-  - uid: 17142
-    components:
-    - type: Transform
-      pos: 172.5,21.5
-      parent: 1
-  - uid: 17143
-    components:
-    - type: Transform
-      pos: 173.5,21.5
+      pos: 172.5,19.5
       parent: 1
   - uid: 17462
     components:


### PR DESCRIPTION
## About the PR
Fixed two spots where people could paradrop into the invincible resin

## Why / Balance
polish, bugfixing

## Media

Red circle is the where the old invincible resin was, blue shaded area is where people can paradrop in, the new resin now surrounds this and prevents this access
<img width="593" height="480" alt="image" src="https://github.com/user-attachments/assets/714f9ed8-cdd3-47f3-858a-d0725eda8500" />

removed invincible door at red circle, new resin placed at purple circle, this is because that one blue ticked tile could be paradropped into.
<img width="441" height="387" alt="image" src="https://github.com/user-attachments/assets/35967e82-55a3-4cd7-b2e9-d7f9cdf4c17f" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
no CL