### PR TITLE
Predicted removal of slow and root effects

### DIFF
--- a/Content.Shared/_RMC14/Slow/RMCSlowSystem.cs
+++ b/Content.Shared/_RMC14/Slow/RMCSlowSystem.cs
@@ -234,16 +234,13 @@ public sealed class RMCSlowSystem : EntitySystem
 
     public override void Update(float frameTime)
     {
-        if (_net.IsClient)
-            return;
-
         var time = _timing.CurTime;
 
         var slowQuery = EntityQueryEnumerator<RMCSlowdownComponent>();
 
         while (slowQuery.MoveNext(out var uid, out var slow))
         {
-            if (time < slow.ExpiresAt)
+            if (!slow.Running || time < slow.ExpiresAt)
                 continue;
 
             RemCompDeferred<RMCSlowdownComponent>(uid);
@@ -254,7 +251,7 @@ public sealed class RMCSlowSystem : EntitySystem
 
         while (superSlowQuery.MoveNext(out var uid, out var slow))
         {
-            if (time < slow.ExpiresAt)
+            if (!slow.Running || time < slow.ExpiresAt)
                 continue;
 
             RemCompDeferred<RMCSuperSlowdownComponent>(uid);
@@ -265,7 +262,7 @@ public sealed class RMCSlowSystem : EntitySystem
 
         while (rootQuery.MoveNext(out var uid, out var root))
         {
-            if (time < root.ExpiresAt)
+            if (!root.Running || time < root.ExpiresAt)
                 continue;
 
             RemCompDeferred<RMCRootedComponent>(uid);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Client should now properly predicts when a slow, superslow, or root effect expires. This should reduce rubberbanding that occurs when those effects expire.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfix.

## Technical details
<!-- Summary of code changes for easier review. -->
The code that handled those effects expiring only ran on the server, so the client simply did not predict them. I changed the update loop to run both on the client and server.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed some rubberbanding that occurred when slow or root effects expired.
