### PR TITLE
Fixes directional tinted windows

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Windows/directional_windows.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Windows/directional_windows.yml
@@ -18,9 +18,9 @@
         layer:
         - GlassLayer
   - type: RotationDrawDepth
+    defaultDrawDepth: SmallObjects
     southDrawDepth: OverMobs
   - type: Sprite
-    drawdepth: Mobs
     sprite: _RMC14/Structures/Windows/directional.rsi
     state: window
   - type: Icon


### PR DESCRIPTION
## About the PR
Fixes #9881 where tinted windows wouldn't render above the tables. It is such a simple change (one line) but I have no idea if it broke something so if it is somehow wrong do tell what I am NOT well versed

## Why / Balance
Polish + looks better

## Technical details
Added a `defaultDrawDepth` and made it render above the table.

## Media
<img width="602" height="548" alt="image" src="https://github.com/user-attachments/assets/145917b4-5e63-42f7-bb33-c512430f52a4" />
<img width="257" height="286" alt="image" src="https://github.com/user-attachments/assets/993ff7e0-7958-450f-ad88-d2dc490787b9" />
Best I could do with rotating viewport

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed #9881 

