### PR TITLE
Add dropship fabricator print queue

### DIFF
--- a/Content.Client/_RMC14/Dropship/Fabricator/DropshipFabricatorBui.cs
+++ b/Content.Client/_RMC14/Dropship/Fabricator/DropshipFabricatorBui.cs
@@ -83,10 +83,82 @@ public sealed class DropshipFabricatorBui : BoundUserInterface
         if (_window is not { Disposed: false })
             return;
 
-        if (EntMan.TryGetComponent(Owner, out DropshipFabricatorComponent? fabricator))
+        if (!EntMan.TryGetComponent(Owner, out DropshipFabricatorComponent? fabricator))
+            return;
+
+        _window.PointsLabel.Text = Loc.GetString("rmc-dropship-fabricator-points",
+            ("points", fabricator.Points));
+
+        if (fabricator.Printing is { } printing)
         {
-            _window.PointsLabel.Text = Loc.GetString("rmc-dropship-fabricator-points", 
-                ("points", fabricator.Points));
+            _window.CurrentLabel.SetMarkupPermissive(Loc.GetString("rmc-dropship-fabricator-current",
+                ("item", GetPrintableName(printing))));
         }
+        else
+        {
+            _window.CurrentLabel.SetMarkupPermissive(Loc.GetString("rmc-dropship-fabricator-idle"));
+        }
+
+        _window.QueueLabel.SetMarkupPermissive(Loc.GetString("rmc-dropship-fabricator-queue",
+            ("count", fabricator.Queue.Count),
+            ("max", fabricator.MaxQueue)));
+
+        _window.QueueContainer.DisposeAllChildren();
+        if (fabricator.Queue.Count == 0)
+        {
+            var empty = new Label
+            {
+                Text = Loc.GetString("rmc-dropship-fabricator-queue-empty"),
+                Margin = new Thickness(4, 2),
+                HorizontalExpand = true,
+            };
+            _window.QueueContainer.AddChild(empty);
+            return;
+        }
+
+        for (var i = 0; i < fabricator.Queue.Count; i++)
+        {
+            var entry = fabricator.Queue[i];
+            var index = i;
+
+            var label = new Label
+            {
+                Text = Loc.GetString("rmc-dropship-fabricator-queue-entry",
+                    ("position", i + 1),
+                    ("item", GetPrintableName(entry.Id)),
+                    ("cost", entry.Cost)),
+                Margin = new Thickness(4, 2),
+                HorizontalExpand = false,
+            };
+
+            var cancel = new Button
+            {
+                Text = Loc.GetString("rmc-dropship-fabricator-cancel"),
+                StyleClasses = { "OpenBoth" },
+                MinWidth = 90,
+            };
+            cancel.OnPressed += _ => SendPredictedMessage(new DropshipFabricatorCancelQueueMsg(index));
+
+            var container = new BoxContainer
+            {
+                Orientation = LayoutOrientation.Horizontal,
+                Margin = new Thickness(0, 2),
+                Children =
+                {
+                    label,
+                    new Control { HorizontalExpand = true },
+                    cancel
+                },
+                HorizontalExpand = true,
+            };
+            _window.QueueContainer.AddChild(container);
+        }
+    }
+
+    private string GetPrintableName(EntProtoId<DropshipFabricatorPrintableComponent> id)
+    {
+        return _prototypes.TryIndex(id, out var proto)
+            ? proto.Name
+            : id.ToString();
     }
 }

--- a/Content.Client/_RMC14/Dropship/Fabricator/DropshipFabricatorBui.cs
+++ b/Content.Client/_RMC14/Dropship/Fabricator/DropshipFabricatorBui.cs
@@ -12,6 +12,8 @@ namespace Content.Client._RMC14.Dropship.Fabricator;
 [UsedImplicitly]
 public sealed class DropshipFabricatorBui : BoundUserInterface
 {
+    private const int QueueRowHeight = 28;
+
     [Dependency] private readonly IComponentFactory _compFactory = default!;
     [Dependency] private readonly IPrototypeManager _prototypes = default!;
 
@@ -111,6 +113,7 @@ public sealed class DropshipFabricatorBui : BoundUserInterface
                 Text = Loc.GetString("rmc-dropship-fabricator-queue-empty"),
                 Margin = new Thickness(4, 2),
                 HorizontalExpand = true,
+                SetHeight = QueueRowHeight,
             };
             _window.QueueContainer.AddChild(empty);
             return;
@@ -129,6 +132,7 @@ public sealed class DropshipFabricatorBui : BoundUserInterface
                     ("cost", entry.Cost)),
                 Margin = new Thickness(4, 2),
                 HorizontalExpand = false,
+                VerticalAlignment = Control.VAlignment.Center,
             };
 
             var cancel = new Button
@@ -136,6 +140,7 @@ public sealed class DropshipFabricatorBui : BoundUserInterface
                 Text = Loc.GetString("rmc-dropship-fabricator-cancel"),
                 StyleClasses = { "OpenBoth" },
                 MinWidth = 90,
+                SetHeight = 24,
             };
             cancel.OnPressed += _ => SendPredictedMessage(new DropshipFabricatorCancelQueueMsg(index));
 
@@ -150,6 +155,7 @@ public sealed class DropshipFabricatorBui : BoundUserInterface
                     cancel
                 },
                 HorizontalExpand = true,
+                SetHeight = QueueRowHeight,
             };
             _window.QueueContainer.AddChild(container);
         }

--- a/Content.Client/_RMC14/Dropship/Fabricator/DropshipFabricatorWindow.xaml
+++ b/Content.Client/_RMC14/Dropship/Fabricator/DropshipFabricatorWindow.xaml
@@ -23,6 +23,11 @@
                 <BoxContainer Orientation="Vertical" Margin="4">
                     <RichTextLabel Text="{Loc 'rmc-dropship-fabricator-title'}" HorizontalAlignment="Center" />
                     <Label Name="PointsLabel" Access="Public" Margin="4 2" HorizontalAlignment="Center" />
+                    <ui:BlueHorizontalSeparator />
+                    <RichTextLabel Name="CurrentLabel" Access="Public" Margin="4 2" />
+                    <RichTextLabel Name="QueueLabel" Access="Public" Margin="4 2 4 0" />
+                    <BoxContainer Name="QueueContainer" Access="Public" Orientation="Vertical"
+                                  HorizontalExpand="True" />
                 </BoxContainer>
             </PanelContainer>
             <BoxContainer Orientation="Horizontal" HorizontalExpand="True" VerticalExpand="True">

--- a/Content.Client/_RMC14/Dropship/Fabricator/DropshipFabricatorWindow.xaml
+++ b/Content.Client/_RMC14/Dropship/Fabricator/DropshipFabricatorWindow.xaml
@@ -4,7 +4,8 @@
     xmlns:ui="clr-namespace:Content.Client._RMC14.UserInterface"
     xmlns:graphics="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
     Title="{Loc 'rmc-dropship-fabricator-title'}"
-    MinSize="950 450">
+    MinSize="950 570"
+    SetSize="950 570">
     <PanelContainer>
         <PanelContainer.PanelOverride>
             <graphics:StyleBoxFlat 
@@ -26,8 +27,11 @@
                     <ui:BlueHorizontalSeparator />
                     <RichTextLabel Name="CurrentLabel" Access="Public" Margin="4 2" />
                     <RichTextLabel Name="QueueLabel" Access="Public" Margin="4 2 4 0" />
-                    <BoxContainer Name="QueueContainer" Access="Public" Orientation="Vertical"
-                                  HorizontalExpand="True" />
+                    <ScrollContainer HScrollEnabled="False" VScrollEnabled="True"
+                                     HorizontalExpand="True" MinHeight="84" MaxHeight="84" SetHeight="84">
+                        <BoxContainer Name="QueueContainer" Access="Public" Orientation="Vertical"
+                                      HorizontalExpand="True" />
+                    </ScrollContainer>
                 </BoxContainer>
             </PanelContainer>
             <BoxContainer Orientation="Horizontal" HorizontalExpand="True" VerticalExpand="True">

--- a/Content.Shared/_RMC14/Dropship/Fabricator/DropshipFabricatorComponent.cs
+++ b/Content.Shared/_RMC14/Dropship/Fabricator/DropshipFabricatorComponent.cs
@@ -1,6 +1,7 @@
 ﻿using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared._RMC14.Dropship.Fabricator;
@@ -18,6 +19,12 @@ public sealed partial class DropshipFabricatorComponent : Component
     [DataField, AutoNetworkedField]
     public EntProtoId<DropshipFabricatorPrintableComponent>? Printing;
 
+    [DataField, AutoNetworkedField]
+    public List<DropshipFabricatorQueueEntry> Queue = new();
+
+    [DataField, AutoNetworkedField]
+    public int MaxQueue = 6;
+
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
     public TimeSpan PrintAt;
 
@@ -26,4 +33,24 @@ public sealed partial class DropshipFabricatorComponent : Component
 
     [DataField, AutoNetworkedField]
     public SoundSpecifier RecycleSound = new SoundPathSpecifier("/Audio/_RMC14/Machines/fax.ogg");
+}
+
+[DataDefinition, Serializable, NetSerializable]
+public sealed partial class DropshipFabricatorQueueEntry
+{
+    [DataField]
+    public EntProtoId<DropshipFabricatorPrintableComponent> Id;
+
+    [DataField]
+    public int Cost;
+
+    public DropshipFabricatorQueueEntry()
+    {
+    }
+
+    public DropshipFabricatorQueueEntry(EntProtoId<DropshipFabricatorPrintableComponent> id, int cost)
+    {
+        Id = id;
+        Cost = cost;
+    }
 }

--- a/Content.Shared/_RMC14/Dropship/Fabricator/DropshipFabricatorSystem.cs
+++ b/Content.Shared/_RMC14/Dropship/Fabricator/DropshipFabricatorSystem.cs
@@ -46,6 +46,7 @@ public sealed class DropshipFabricatorSystem : EntitySystem
             subs =>
             {
                 subs.Event<DropshipFabricatorPrintMsg>(OnPrintMsg);
+                subs.Event<DropshipFabricatorCancelQueueMsg>(OnCancelQueueMsg);
             });
 
         Subs.CVar(_config, RMCCVars.RMCDropshipFabricatorStartingPoints, v => _startingPoints = v, true);
@@ -85,6 +86,7 @@ public sealed class DropshipFabricatorSystem : EntitySystem
 
         points.Points += (int) (refund * printable.RecycleMultiplier);
         Dirty(ent.Comp.Account.Value, points);
+        SendUIStateAll(points.Points);
         Del(args.Used);
 
         _audio.PlayPvs(ent.Comp.RecycleSound, ent);
@@ -100,27 +102,89 @@ public sealed class DropshipFabricatorSystem : EntitySystem
             return;
 
         var actor = args.Actor;
-        if (ent.Comp.Printing != null)
-        {
-            _popup.PopupClient(Loc.GetString("rmc-dropship-fabricator-busy"), actor, actor, PopupType.SmallCaution);
-            return;
-        }
-
         if (!TryComp(ent.Comp.Account, out DropshipFabricatorPointsComponent? points))
             return;
 
-        if (printable.Cost > points.Points)
+        if (ent.Comp.Queue.Count >= ent.Comp.MaxQueue)
+        {
+            _popup.PopupClient(Loc.GetString("rmc-dropship-fabricator-queue-full"), actor, actor, PopupType.SmallCaution);
             return;
+        }
+
+        if (printable.Cost > points.Points)
+        {
+            _popup.PopupClient(Loc.GetString("rmc-dropship-fabricator-insufficient-points"), actor, actor, PopupType.SmallCaution);
+            return;
+        }
 
         points.Points -= printable.Cost;
         Dirty(ent.Comp.Account.Value, points);
+        SendUIStateAll(points.Points);
 
-        ent.Comp.Points = points.Points;
-        ent.Comp.Printing = proto.ID;
-        ent.Comp.PrintAt = _timing.CurTime + printable.Delay;
+        ent.Comp.Queue.Add(new DropshipFabricatorQueueEntry(proto.ID, printable.Cost));
         Dirty(ent);
+        TryStartNextPrint(ent);
+    }
 
-        _appearance.SetData(ent, DropshipFabricatorVisuals.State, DropshipFabricatorState.Fabricating);
+    private void OnCancelQueueMsg(Entity<DropshipFabricatorComponent> ent, ref DropshipFabricatorCancelQueueMsg args)
+    {
+        if (args.Index < 0 || args.Index >= ent.Comp.Queue.Count)
+            return;
+
+        var entry = ent.Comp.Queue[args.Index];
+        ent.Comp.Queue.RemoveAt(args.Index);
+
+        if (TryComp(ent.Comp.Account, out DropshipFabricatorPointsComponent? points))
+        {
+            points.Points += entry.Cost;
+            Dirty(ent.Comp.Account.Value, points);
+            SendUIStateAll(points.Points);
+        }
+
+        Dirty(ent);
+    }
+
+    private bool TryStartNextPrint(Entity<DropshipFabricatorComponent> ent)
+    {
+        if (ent.Comp.Printing != null)
+            return false;
+
+        var changed = false;
+        while (ent.Comp.Queue.Count > 0)
+        {
+            changed = true;
+            var entry = ent.Comp.Queue[0];
+            ent.Comp.Queue.RemoveAt(0);
+
+            if (!_prototypes.TryIndex(entry.Id, out var proto) ||
+                !proto.TryGetComponent(out DropshipFabricatorPrintableComponent? printable, _compFactory))
+            {
+                RefundQueuedCost(ent, entry.Cost);
+                continue;
+            }
+
+            ent.Comp.Printing = entry.Id;
+            ent.Comp.PrintAt = _timing.CurTime + printable.Delay;
+            Dirty(ent);
+
+            _appearance.SetData(ent, DropshipFabricatorVisuals.State, DropshipFabricatorState.Fabricating);
+            return true;
+        }
+
+        if (changed)
+            Dirty(ent);
+
+        return false;
+    }
+
+    private void RefundQueuedCost(Entity<DropshipFabricatorComponent> ent, int cost)
+    {
+        if (!TryComp(ent.Comp.Account, out DropshipFabricatorPointsComponent? points))
+            return;
+
+        points.Points += cost;
+        Dirty(ent.Comp.Account.Value, points);
+        SendUIStateAll(points.Points);
     }
 
     private Entity<DropshipFabricatorPointsComponent> EnsurePoints()
@@ -181,10 +245,13 @@ public sealed class DropshipFabricatorSystem : EntitySystem
         var allFabricatorQuery = EntityQueryEnumerator<DropshipFabricatorComponent, TransformComponent>();
         while (allFabricatorQuery.MoveNext(out var uid, out var comp, out var xform))
         {
-            if (time < comp.PrintAt)
-                continue;
-
             if (comp.Printing == null)
+            {
+                TryStartNextPrint((uid, comp));
+                continue;
+            }
+
+            if (time < comp.PrintAt)
                 continue;
 
             var rotation = _transform.GetWorldRotation(xform);
@@ -194,7 +261,8 @@ public sealed class DropshipFabricatorSystem : EntitySystem
             comp.Printing = null;
             Dirty(uid, comp);
 
-            _appearance.SetData(uid, DropshipFabricatorVisuals.State, DropshipFabricatorState.Idle);
+            if (!TryStartNextPrint((uid, comp)))
+                _appearance.SetData(uid, DropshipFabricatorVisuals.State, DropshipFabricatorState.Idle);
         }
 
         var pointsQuery = EntityQueryEnumerator<DropshipFabricatorPointsComponent>();

--- a/Content.Shared/_RMC14/Dropship/Fabricator/DropshipFabricatorUi.cs
+++ b/Content.Shared/_RMC14/Dropship/Fabricator/DropshipFabricatorUi.cs
@@ -14,3 +14,9 @@ public sealed class DropshipFabricatorPrintMsg(EntProtoId id) : BoundUserInterfa
 {
     public readonly EntProtoId Id = id;
 }
+
+[Serializable, NetSerializable]
+public sealed class DropshipFabricatorCancelQueueMsg(int index) : BoundUserInterfaceMessage
+{
+    public readonly int Index = index;
+}

--- a/Resources/Locale/en-US/_RMC14/dropship/rmc-dropship.ftl
+++ b/Resources/Locale/en-US/_RMC14/dropship/rmc-dropship.ftl
@@ -88,6 +88,14 @@ rmc-dropship-fabricator-equipment = [bold]Equipment[/bold]
 rmc-dropship-fabricator-ammo = [bold]Ammo[/bold]
 rmc-dropship-fabricator-fabricate = Fabricate ({$cost})
 rmc-dropship-fabricator-busy = The dropship part fabricator is busy. Please wait for completion of previous operation.
+rmc-dropship-fabricator-current = [bold]Current:[/bold] {$item}
+rmc-dropship-fabricator-idle = [bold]Current:[/bold] Idle
+rmc-dropship-fabricator-queue = [bold]Queue:[/bold] {$count}/{$max}
+rmc-dropship-fabricator-queue-empty = No pending orders.
+rmc-dropship-fabricator-queue-entry = {$position}. {$item} ({$cost})
+rmc-dropship-fabricator-cancel = Cancel
+rmc-dropship-fabricator-queue-full = The dropship part fabricator queue is full.
+rmc-dropship-fabricator-insufficient-points = You don't have enough points to fabricate that.
 
 rmc-dropship-firemission-warning = A DROPSHIP FIRES TOWARDS THE {$direction}
 rmc-dropship-firemission-warning-above = A DROPSHIP FIRES RIGHT ONTOP OF YOU!


### PR DESCRIPTION
## About the PR
Adds a pending print queue to the dropship part fabricator. Players can now order multiple CAS weapons, rockets, ammo, and other dropship fabricator items while another item is already printing.

## Why / Balance
This brings the fabricator closer to the CMSS13 behavior and removes the need to wait at the console for every single print. Points are still spent when an item is queued, so this does not allow free over-ordering. Pending orders can be cancelled for a refund, while the currently printing item cannot be cancelled.

## Technical details
Added `DropshipFabricatorQueueEntry` and a networked `Queue` list to `DropshipFabricatorComponent`, plus `MaxQueue = 6` to match the existing lathe/autolathe queue limit.

`DropshipFabricatorSystem` now validates printable prototypes, checks queue capacity, checks the shared dropship fabricator points account, reserves the cost immediately, and appends the item to the pending queue. If the fabricator is idle, `TryStartNextPrint` removes the first pending entry, sets the existing `Printing` field, updates `PrintAt`, and switches the fabricator appearance to fabricating.

When `Update` finishes the active `Printing` item, it spawns the prototype at the existing fabricator offset, clears `Printing`, and immediately attempts to start the next queued entry. If no entry remains, the fabricator returns to idle. Invalid queued prototypes are skipped and their reserved cost is refunded.

Added `DropshipFabricatorCancelQueueMsg` for cancelling pending entries by index. Cancelling removes the pending entry, refunds its stored cost to the shared points account, and dirties all fabricators so open UIs update. The active `Printing` item is still not cancellable.

The client BUI still uses the existing auto-networked component update path through `DropshipFabricatorUISystem`. `DropshipFabricatorBui.Refresh()` now reads `Printing`, `Queue`, `Points`, and `MaxQueue` directly from `DropshipFabricatorComponent`, then redraws the current job label and pending queue rows with cancel buttons. The existing Equipment and Ammo print buttons are unchanged.

Added locale strings for current job, idle state, queue count, empty queue, queue entries, cancel, queue full, and insufficient points.

## Media
<img width="1197" height="395" alt="image" src="https://github.com/user-attachments/assets/44a82e52-4130-49d3-9bd1-40398b652776" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
- add: Added a queue to the dropship part fabricator.