### PR TITLE
add ShootUseDelay to XM88

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/xm88_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/xm88_rifle.yml
@@ -105,6 +105,7 @@
       ballistic-ammo: !type:Container
   - type: RMCLoreExaminable
     content: rmc-lore-examinable-xm-88-heavy-rifle # Mention Favela Wars lore analogue here
+  - type: ShootUseDelay
 
 - type: entity
   parent: BulletRifle10x24mm


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds the ShootUseDelay component to the XM88, which shows the use delay timer gauge in your hands slot(s).

## Why / Balance
QOL, makes it easier to see the fire rate increase and when it can be fired again.

## Media
https://github.com/user-attachments/assets/1fa1278f-eef5-4e33-97ec-90f44b540892

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: The XM88 now has a visual indicator for when it can be refired, much like shotguns.
