### PR TITLE
Localize OB messages

### DIFF
--- a/Content.Client/_RMC14/Overwatch/OverwatchSquadView.xaml
+++ b/Content.Client/_RMC14/Overwatch/OverwatchSquadView.xaml
@@ -300,7 +300,7 @@
                                                 </BoxContainer>
                                                 <BoxContainer Orientation="Vertical">
                                                     <RichTextLabel Name="OrbitalStatus" Access="Public"
-                                                                   Text="[color=red][bold]No warhead loaded[/bold][/color]" />
+                                                                   Text="{Loc rmc-overwatch-console-no-warhead-loaded}" />
                                                     <Label Text="{Loc rmc-overwatch-console-status}" HorizontalAlignment="Center" />
                                                 </BoxContainer>
                                             </BoxContainer>

--- a/Content.Client/_RMC14/Rangefinder/RangefinderBui.cs
+++ b/Content.Client/_RMC14/Rangefinder/RangefinderBui.cs
@@ -55,7 +55,7 @@ public sealed class RangefinderBui : BoundUserInterface
             _window.BottomContainer.AddChild(AddRow("Supply Drop", _area.CanSupplyDrop(mapCoords)));
             _window.BottomContainer.AddChild(AddRow("Mortar", _area.CanMortarFire(coords)));
             _window.BottomContainer.AddChild(AddRow("Close Air Support", _area.CanCAS(coords)));
-            _window.BottomContainer.AddChild(AddRow("Orbital Bombardment", _area.CanOrbitalBombard(coords, out _)));
+            _window.BottomContainer.AddChild(AddRow(Loc.GetString("rmc-rangefinder-orbital-bombardment"), _area.CanOrbitalBombard(coords, out _)));
         }
     }
 

--- a/Content.Client/_RMC14/Roadmap/RoadmapWindow.xaml
+++ b/Content.Client/_RMC14/Roadmap/RoadmapWindow.xaml
@@ -48,7 +48,7 @@
                     <controls:RoadmapItem ItemState="Complete" HeaderText="Medical skill" Text="Allows more advanced medical procedures and increases their overall speed" />
                     <controls:RoadmapItem ItemState="Complete" HeaderText="Plasma and flamethrower sentries" />
                     <controls:RoadmapItem ItemState="Complete" HeaderText="Firearms skill" Text="Each marine role has a different firearms skill. This impacts how accurate they are with guns" />
-                    <controls:RoadmapItem ItemState="Complete" HeaderText="Orbital bombardment" />
+                    <controls:RoadmapItem ItemState="Complete" HeaderText="{Loc rmc-ui-roadmap-orbital-bombardment}" />
                     <controls:RoadmapItem ItemState="Complete" HeaderText="Squad Leader" Text="More equipment in the squad leader's equipment and gear racks" />
                     <controls:RoadmapItem ItemState="Complete" HeaderText="Fireteam Leader" Text="More equipment in the fireteam leader's equipment and gear racks" />
                     <controls:RoadmapItem ItemState="Complete" HeaderText="Specialist's Scout Kit" />

--- a/Content.Shared/_RMC14/OrbitalCannon/OrbitalCannonSystem.cs
+++ b/Content.Shared/_RMC14/OrbitalCannon/OrbitalCannonSystem.cs
@@ -219,7 +219,7 @@ public sealed class OrbitalCannonSystem : EntitySystem
         {
             foreach (var buckled in args.Buckled)
             {
-                _popup.PopupClient("The tray is already loaded into the cannon!", args.Target, buckled, PopupType.MediumCaution);
+                _popup.PopupClient(Loc.GetString("rmc-ob-tray-already-loaded"), args.Target, buckled, PopupType.MediumCaution);
             }
 
             return;
@@ -230,7 +230,7 @@ public sealed class OrbitalCannonSystem : EntitySystem
         {
             foreach (var buckled in args.Buckled)
             {
-                _popup.PopupClient("There is already a warhead loaded!", args.Target, buckled, PopupType.MediumCaution);
+                _popup.PopupClient(Loc.GetString("rmc-ob-warhead-already-loaded"), args.Target, buckled, PopupType.MediumCaution);
             }
 
             return;
@@ -240,11 +240,15 @@ public sealed class OrbitalCannonSystem : EntitySystem
         {
             foreach (var buckled in args.Buckled)
             {
-                _popup.PopupClient($"You can't insert {Name(args.Used)} into the {Name(args.Target)}!", args.Target, buckled, PopupType.MediumCaution);
+                _popup.PopupClient(Loc.GetString("rmc-ob-cant-insert",
+                    ("used", Name(args.Used)),
+                    ("target", Name(args.Target))), args.Target, buckled, PopupType.MediumCaution);
             }
         }
 
-        _popup.PopupClient($"You load {Name(args.Used)} into the {Name(args.Target)}!", args.Target, args.Target, PopupType.Medium);
+        _popup.PopupClient(Loc.GetString("rmc-ob-load-into-tray",
+            ("used", Name(args.Used)),
+            ("target", Name(args.Target))), args.Target, args.Target, PopupType.Medium);
         _powerLoader.TrySyncHands(args.PowerLoader);
 
         if (_net.IsServer)
@@ -317,7 +321,7 @@ public sealed class OrbitalCannonSystem : EntitySystem
         {
             foreach (var buckled in args.Buckled)
             {
-                _popup.PopupClient("The tray is already loaded into the cannon!", buckled, PopupType.MediumCaution);
+                _popup.PopupClient(Loc.GetString("rmc-ob-tray-already-loaded"), buckled, PopupType.MediumCaution);
             }
 
             return;
@@ -328,7 +332,8 @@ public sealed class OrbitalCannonSystem : EntitySystem
         {
             foreach (var buckled in args.Buckled)
             {
-                _popup.PopupClient($"A warhead must be placed in the {Name(args.Target)} first.", args.Target, buckled, PopupType.MediumCaution);
+                _popup.PopupClient(Loc.GetString("rmc-ob-warhead-needed-before-fuel",
+                    ("target", Name(args.Target))), args.Target, buckled, PopupType.MediumCaution);
             }
 
             return;
@@ -339,7 +344,8 @@ public sealed class OrbitalCannonSystem : EntitySystem
         {
             foreach (var buckled in args.Buckled)
             {
-                _popup.PopupClient($"The {Name(args.Target)} can't accept more solid fuel!", args.Target, buckled, PopupType.MediumCaution);
+                _popup.PopupClient(Loc.GetString("rmc-ob-too-much-fuel",
+                    ("target", Name(args.Target))), args.Target, buckled, PopupType.MediumCaution);
             }
 
             return;
@@ -349,13 +355,17 @@ public sealed class OrbitalCannonSystem : EntitySystem
         {
             foreach (var buckled in args.Buckled)
             {
-                _popup.PopupClient($"You can't insert {Name(args.Used)} into the {Name(args.Target)}!", args.Target, buckled, PopupType.MediumCaution);
+                _popup.PopupClient(Loc.GetString("rmc-ob-cant-insert",
+                    ("used", Name(args.Used)),
+                    ("target", Name(args.Target))), args.Target, buckled, PopupType.MediumCaution);
             }
 
             return;
         }
 
-        _popup.PopupClient($"You load {Name(args.Used)} into the {Name(args.Target)}!", args.Target, args.Target, PopupType.Medium);
+        _popup.PopupClient(Loc.GetString("rmc-ob-load-into-tray",
+            ("used", Name(args.Used)),
+            ("target", Name(args.Target))), args.Target, args.Target, PopupType.Medium);
         _powerLoader.TrySyncHands(args.PowerLoader);
 
         if (_net.IsServer)
@@ -617,27 +627,33 @@ public sealed class OrbitalCannonSystem : EntitySystem
 
         if (cannon.Comp.LinkedTray is not { } trayId || !TryComp(trayId, out OrbitalCannonTrayComponent? tray))
         {
-            _popup.PopupCursor("The orbital cannon has no linked tray.", user, PopupType.LargeCaution);
+            _popup.PopupCursor(Loc.GetString("rmc-ob-no-linked-tray"), user, PopupType.LargeCaution);
             return false;
         }
 
         if (!_container.TryGetContainer(trayId, tray.WarheadContainer, out var warheadContainer) ||
             warheadContainer.ContainedEntities.Count == 0)
         {
-            _popup.PopupCursor("The orbital cannon has no ammo chambered.", user, PopupType.LargeCaution);
+            _popup.PopupCursor(Loc.GetString("rmc-ob-no-ammo-chambered"), user, PopupType.LargeCaution);
             return false;
         }
 
         if (!_rmcPlanet.TryPlanetToCoordinates(fireCoordinates, out var planetCoordinates))
         {
-            _popup.PopupCursor("The target zone appears to be out of bounds. Please check coordinates.", user, PopupType.LargeCaution);
+            _popup.PopupCursor(
+                Loc.GetString("rmc-ob-target-out-of-bounds"),
+                user,
+                PopupType.LargeCaution);
             return false;
         }
 
         if (!_rmcMap.TryGetTileDef(planetCoordinates, out var tile) ||
             tile.ID == ContentTileDefinition.SpaceID)
         {
-            _popup.PopupCursor("The target zone appears to be out of bounds. Please check coordinates.", user, PopupType.LargeCaution);
+            _popup.PopupCursor(
+                Loc.GetString("rmc-ob-target-out-of-bounds"),
+                user,
+                PopupType.LargeCaution);
             return false;
         }
 
@@ -645,15 +661,21 @@ public sealed class OrbitalCannonSystem : EntitySystem
         {
             if (roofed)
             {
-                _popup.PopupCursor("The target zone has strong biological protection. The orbital strike cannot reach here.", user, PopupType.LargeCaution);
+                _popup.PopupCursor(
+                    Loc.GetString("rmc-ob-target-protected"),
+                    user,
+                    PopupType.LargeCaution);
                 return false;
             }
 
-            _popup.PopupCursor("The target zone is deep underground. The orbital strike cannot reach here.", user, PopupType.LargeCaution);
+            _popup.PopupCursor(
+                Loc.GetString("rmc-ob-target-underground"),
+                user,
+                PopupType.LargeCaution);
             return false;
         }
 
-        _popup.PopupCursor("Orbital bombardment request accepted. Orbital cannons are now calibrating.", PopupType.Large);
+        _popup.PopupCursor(Loc.GetString("rmc-ob-request-accepted"), PopupType.Large);
 
         var warhead = warheadContainer.ContainedEntities[0];
         var misfuel = 0;
@@ -691,7 +713,7 @@ public sealed class OrbitalCannonSystem : EntitySystem
 
         Dirty(cannon, firing);
 
-        _popup.PopupCursor("Orbital bombardment launched!", user);
+        _popup.PopupCursor(Loc.GetString("rmc-ob-launched"), user);
 
         var logMessage = $"{ToPrettyString(user)} launched orbital bombardment at {fireCoordinates} for squad {ToPrettyString(squad)}, misfuel: {misfuel}, final coords: {adjustedCoords}";
         _adminLog.Add(LogType.RMCOrbitalBombardment, $"{logMessage}");
@@ -754,12 +776,14 @@ public sealed class OrbitalCannonSystem : EntitySystem
 
                 _audio.PlayGlobal(cannon.GroundAlertSound, groundFilter, true);
 
-                var msg = "[font size=16][color=red]Orbital bombardment launch command detected![/color][/font]";
+                var msg = Loc.GetString("rmc-ob-launch-detected");
                 _rmcChat.ChatMessageToMany(msg, msg, groundFilter, ChatChannel.Radio);
 
                 if (_area.TryGetArea(planetCoordinates, out _, out var areaProto))
                 {
-                    msg = $"[color=red]Launch command informs {firing.WarheadName}. Estimated impact area: {areaProto.Name}[/color]";
+                    msg = Loc.GetString("rmc-ob-launch-area",
+                        ("warhead", firing.WarheadName),
+                        ("area", areaProto.Name));
                     _rmcChat.ChatMessageToMany(msg, msg, groundFilter, ChatChannel.Radio);
                 }
             }
@@ -775,10 +799,10 @@ public sealed class OrbitalCannonSystem : EntitySystem
                 _audio.PlayPvs(cannon.FireSound, uid);
                 _animation.TryFlick(uid, cannon.FiringAnimation, cannon.ChamberedState, cannon.BaseLayerKey);
 
-                var msg = "[color=red]The deck of the UNS Almayer shudders as the orbital cannons open fire on the colony.[/color]";
+                var msg = Loc.GetString("rmc-ob-ship-shudder");
                 _rmcChat.ChatMessageToMany(msg, msg, sameMap, ChatChannel.Radio);
 
-                _marineAnnounce.AnnounceSquad("WARNING! Ballistic trans-atmospheric launch detected! Get outside of Danger Close!", firing.Squad);
+                _marineAnnounce.AnnounceSquad(Loc.GetString("rmc-ob-squad-warning"), firing.Squad);
             }
 
             if (!firing.Fired && time > firing.StartedAt + firing.FireDelay)

--- a/Content.Shared/_RMC14/Xenonids/Neurotoxin/SharedNeurotoxinSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Neurotoxin/SharedNeurotoxinSystem.cs
@@ -389,10 +389,9 @@ public abstract class SharedNeurotoxinSystem : EntitySystem
                 break;
             case NeuroHallucinations.OB:
                 //Little extra to confuse the player
-                //TODO RMC14 replace if it gets a locId
                 if (_player.TryGetSessionByEntity(victim, out var session))
                 {
-                    var msg = "[font size=16][color=red]Orbital bombardment launch command detected![/color][/font]";
+                    var msg = Loc.GetString("rmc-ob-launch-detected");
                     msg = $"[bold][font size=24][color=red]\n{msg}\n[/color][/font][/bold]";
                     _rmcChat.ChatMessageToOne(ChatChannel.Radio, msg, msg, default, false, session.Channel, recordReplay: true);
 
@@ -402,7 +401,9 @@ public abstract class SharedNeurotoxinSystem : EntitySystem
 
                         if (_proto.TryIndex(warhead, out var warHeadProto))
                         {
-                            msg = $"[color=red]Launch command informs {warHeadProto.Name}. Estimated impact area: {areaProto.Name}[/color]";
+                            msg = Loc.GetString("rmc-ob-launch-area",
+                                ("warhead", warHeadProto.Name),
+                                ("area", areaProto.Name));
                             _rmcChat.ChatMessageToOne(ChatChannel.Radio, msg, msg, default, false, session.Channel, recordReplay: true);
                         }
                     }

--- a/Resources/Locale/en-US/_RMC14/ob.ftl
+++ b/Resources/Locale/en-US/_RMC14/ob.ftl
@@ -6,6 +6,27 @@ rmc-ob-warning-above-two = The sky roars louder right above you!
 rmc-ob-warning-three = OH GOD THE SKY WILL EXPLODE!!!
 rmc-ob-warning-above-three = YOU SHOULDN'T BE HERE!
 
+### Orbital Cannon Popups
+rmc-ob-tray-already-loaded = The tray is already loaded into the cannon!
+rmc-ob-warhead-already-loaded = There is already a warhead loaded!
+rmc-ob-cant-insert = You can't insert {$used} into the {$target}!
+rmc-ob-load-into-tray = You load {$used} into the {$target}!
+rmc-ob-warhead-needed-before-fuel = A warhead must be placed in the {$target} first.
+rmc-ob-too-much-fuel = The {$target} can't accept more solid fuel!
+rmc-ob-no-linked-tray = The orbital cannon has no linked tray.
+rmc-ob-no-ammo-chambered = The orbital cannon has no ammo chambered.
+rmc-ob-target-out-of-bounds = The target zone appears to be out of bounds. Please check coordinates.
+rmc-ob-target-protected = The target zone has strong biological protection. The orbital strike cannot reach here.
+rmc-ob-target-underground = The target zone is deep underground. The orbital strike cannot reach here.
+rmc-ob-request-accepted = Orbital bombardment request accepted. Orbital cannons are now calibrating.
+rmc-ob-launched = Orbital bombardment launched!
+
+### Orbital Cannon Announcements
+rmc-ob-launch-detected = [font size=16][color=red]Orbital bombardment launch command detected![/color][/font]
+rmc-ob-launch-area = [color=red]Launch command informs {$warhead}. Estimated impact area: {$area}[/color]
+rmc-ob-ship-shudder = [color=red]The deck of the UNS Almayer shudders as the orbital cannons open fire on the colony.[/color]
+rmc-ob-squad-warning = WARNING! Ballistic trans-atmospheric launch detected! Get outside of Danger Close!
+
 ### Orbital Cannon Console
 rmc-ui-ob-console-name = Orbital Cannon Console
 rmc-ui-ob-console-title = ORBITAL CANNON CONTROL

--- a/Resources/Locale/en-US/_RMC14/rangefinder/rmc-rangefinder.ftl
+++ b/Resources/Locale/en-US/_RMC14/rangefinder/rmc-rangefinder.ftl
@@ -3,6 +3,7 @@ rmc-rangefinder-header = [bold]SIMPLIFIED COORDINATES OF TARGET[/bold]
 rmc-rangefinder-longitude = [font size=28]LONGITUDE : {$x},[/font]
 rmc-rangefinder-latitude = [font size=28]LATITUDE : {$y}[/font]
 rmc-rangefinder-examine = {CAPITALIZE(THE($item))} reads: LONGITUDE {$x}, LATITUDE {$y}
+rmc-rangefinder-orbital-bombardment = Orbital Bombardment
 
 rmc-laser-designator-out-of-range = You can't see that far!
 rmc-laser-designator-already-targeting = You're already targeting something!

--- a/Resources/Locale/en-US/_RMC14/ui.ftl
+++ b/Resources/Locale/en-US/_RMC14/ui.ftl
@@ -38,6 +38,7 @@ rmc-ui-audio-emotes-feroxi = Play emotes for feroxis
 rmc-ui-audio-emotes-skrell = Play emotes for skrells
 
 cm-ui-roadmap = Roadmap
+rmc-ui-roadmap-orbital-bombardment = Orbital bombardment
 
 rmc-ui-link-discord-account = Link Discord
 rmc-ui-link-discord-account-text = Click the button below to copy your code.


### PR DESCRIPTION
## About the PR
Localized orbital bombardment-related player-facing strings into FTL.

## Why / Balance
No balance changes. This only moves existing OB text into localization files so it can be translated and maintained consistently.

## Technical details
Replaced hardcoded OB popups, radio announcements, squad warnings, rangefinder OB label, overwatch OB status text, and roadmap OB text with `Loc.GetString(...)`.

## Media
Not required, localization-only/code cleanup change.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

- tweak: Localized orbital bombardment messages into FTL.