### PR TITLE
Fixes #9841 Doafters not being visable over xenos 

### DIFF
--- a/Content.Client/DoAfter/DoAfterOverlay.cs
+++ b/Content.Client/DoAfter/DoAfterOverlay.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using Content.Client._RMC14.NightVision;
 using Content.Shared.DoAfter;
 using Content.Client.UserInterface.Systems;
 using Content.Shared._RMC14.Stealth;
@@ -20,6 +21,7 @@ public sealed class DoAfterOverlay : Overlay
     private readonly IEntityManager _entManager;
     private readonly IGameTiming _timing;
     private readonly IPlayerManager _player;
+    private readonly IOverlayManager _overlay;
     private readonly SharedTransformSystem _transform;
     private readonly MetaDataSystem _meta;
     private readonly ProgressColorSystem _progressColor;
@@ -38,13 +40,17 @@ public sealed class DoAfterOverlay : Overlay
     private const float StartX = 2;
     private const float EndX = 22f;
 
-    public override OverlaySpace Space => OverlaySpace.WorldSpaceBelowFOV;
+    public override OverlaySpace Space => _overlay.HasOverlay<NightVisionOverlay>()
+        ? OverlaySpace.WorldSpace
+        : OverlaySpace.WorldSpaceBelowFOV;
 
-    public DoAfterOverlay(IEntityManager entManager, IPrototypeManager protoManager, IGameTiming timing, IPlayerManager player)
+    public DoAfterOverlay(IEntityManager entManager, IPrototypeManager protoManager, IGameTiming timing, IPlayerManager player, IOverlayManager overlay)
     {
         _entManager = entManager;
         _timing = timing;
         _player = player;
+        _overlay = overlay;
+        ZIndex = 1;
         _transform = _entManager.EntitySysManager.GetEntitySystem<SharedTransformSystem>();
         _meta = _entManager.EntitySysManager.GetEntitySystem<MetaDataSystem>();
         _container = _entManager.EntitySysManager.GetEntitySystem<SharedContainerSystem>();
@@ -52,7 +58,6 @@ public sealed class DoAfterOverlay : Overlay
         _sprite = _entManager.System<SpriteSystem>();
         var sprite = new SpriteSpecifier.Rsi(new("/Textures/Interface/Misc/progress_bar.rsi"), "icon");
         _barTexture = _entManager.EntitySysManager.GetEntitySystem<SpriteSystem>().Frame0(sprite);
-
         _unshadedShader = protoManager.Index(UnshadedShader).Instance();
     }
 

--- a/Content.Client/DoAfter/DoAfterSystem.cs
+++ b/Content.Client/DoAfter/DoAfterSystem.cs
@@ -21,7 +21,7 @@ public sealed class DoAfterSystem : SharedDoAfterSystem
     public override void Initialize()
     {
         base.Initialize();
-        _overlay.AddOverlay(new DoAfterOverlay(EntityManager, _prototype, GameTiming, _player));
+        _overlay.AddOverlay(new DoAfterOverlay(EntityManager, _prototype, GameTiming, _player, _overlay));
     }
 
     public override void Shutdown()


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed #9841, where DoAfters would not show up on top of certain entities. 

## Why / Balance
It makes the xeno gameplay, especially playing boiler much easier when there are other big xenos near you

## Technical details
Due to how night vision of xenos work and how `NightVisionOverlay` renders that overlay, entities with `RMCNightVisionVisible`, so all the xenos and most resin structures would render above do afters due to `NightVisionOverlay` having `WorldSpace` OverlaySpace and `DoAfterOverlay` having `WorldSpaceBelowFOV` overlay. Therefore to fix it I have to check if the current overlay has `NightVisionOverlay` and if so, change the OverlaySpace of  `DoAfterOverlay` to `WorldSpace`. After that to make sure the DoAfter overlay draws after the night vision overlay, there is a `Zindex = 1` added.

The same mechanic used in `HiveLeaderOverlay`

## Media
<img width="793" height="442" alt="image" src="https://github.com/user-attachments/assets/1aa42dcc-ddac-40dc-998f-4d66e980c3f1" />

https://github.com/user-attachments/assets/1f793fd2-0ffa-4b80-823a-ddfd2e35e11c



## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed do-after bars not drawing over xeno and other sprites while using xeno night vision.