### PR TITLE
Adds Samosas to the WEYA MRE

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Food/MRE/mre.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Food/MRE/mre.yml
@@ -155,6 +155,9 @@
       orGroup: side
     # snack
     - id: RMCFoodSnackHotdogPackaged
+      orGroup: snack
+    - id: RMCFoodSnackSamosaPackaged
+      orGroup: snack
     # dessert
     - id: RMCFoodSnackEATBar
       orGroup: dessert


### PR DESCRIPTION
## About the PR
Added samosas to the WEYA MRE snack section

## Why / Balance
More possible combos and options (Hot-dogs were the only options previously)

## Technical details
One yaml addition

## Media
<img width="374" height="72" alt="image" src="https://github.com/user-attachments/assets/17cc6673-980c-4a67-8b15-2af77e75e674" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Added the samosa for the WEYA colony ration pack
