### PR TITLE
fix: scuttle should now kill correctly

### DIFF
--- a/Content.Server/_RMC14/Nuke/RMCNukeSystem.cs
+++ b/Content.Server/_RMC14/Nuke/RMCNukeSystem.cs
@@ -19,7 +19,7 @@ public sealed class RMCNukeSystem : EntitySystem
     [Dependency] private readonly SensorTowerSystem _sensorTower = default!;
     [Dependency] private readonly RMCPowerSystem _power = default!;
 
-    private readonly DamageSpecifier _damage = new() { DamageDict = { { "Blunt", 1e10 }, { "Heat", 1e10 } } };
+    private readonly DamageSpecifier _damage = new() { DamageDict = { ["Blunt"] = 1e5, ["Heat"] = 1e5 } };
     private EntityQuery<RMCRepairableComponent> _repairable;
 
     public override void Initialize()


### PR DESCRIPTION
## About the PR

Just happened in round 12525 that the final explosion did not correctly kill some players.

## Why / Balance

Bugfix

## Technical details

Seems there was a overflow. Reduced damage from 1e10 to 1e5.

## Media

None

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- fix: The scuttle explosion should now correctly kill everything.
