### PR TITLE
Sapper trap behavior adjustments

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Construction/DeployedTraps/SharedDeployedTrapsSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/DeployedTraps/SharedDeployedTrapsSystem.cs
@@ -1,10 +1,10 @@
-﻿using Content.Shared._RMC14.Marines;
+using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.Slow;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.StepTrigger.Systems;
 using Robust.Shared.Audio.Systems;
-using Robust.Shared.Network;
+using Robust.Shared.Physics.Systems;
 using Robust.Shared.Player;
 using Robust.Shared.Timing;
 
@@ -17,16 +17,24 @@ public sealed class SharedDeployedTrapsSystem : EntitySystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
-    [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
 
     public override void Initialize()
     {
-        SubscribeLocalEvent<XenoDeployedTrapsComponent, StepTriggeredOnEvent>(OnStepTriggered);
+        SubscribeLocalEvent<XenoDeployedTrapsComponent, StepTriggeredOnEvent>(OnStepOnTriggered);
+        SubscribeLocalEvent<XenoDeployedTrapsComponent, StepTriggeredOffEvent>(OnStepOffTriggered);
         SubscribeLocalEvent<XenoDeployedTrapsComponent, StepTriggerAttemptEvent>(OnStepTriggerAttempt);
+
+        UpdatesBefore.Add(typeof(StepTriggerSystem));
+        UpdatesAfter.Add(typeof(SharedPhysicsSystem));
     }
 
-    private void OnStepTriggered(Entity<XenoDeployedTrapsComponent> trap, ref StepTriggeredOnEvent args)
+    private void OnStepOnTriggered(Entity<XenoDeployedTrapsComponent> trap, ref StepTriggeredOnEvent args)
     {
+        // Don't trigger trap if it spawned under their feet. They have to specifically walk onto it.
+        if (HasComp<XenoNewlyDeployedTrapsComponent>(trap) || trap.Comp.ContactsAtStart.Contains(args.Tripper))
+            return;
+
         _slow.TryRoot(args.Tripper, trap.Comp.StunDuration, true);
 
         if (!trap.Comp.SoundPlayed)
@@ -42,6 +50,18 @@ public sealed class SharedDeployedTrapsSystem : EntitySystem
         PredictedQueueDel(trap.Owner);
     }
 
+    private void OnStepOffTriggered(Entity<XenoDeployedTrapsComponent> trap, ref StepTriggeredOffEvent args)
+    {
+        trap.Comp.ContactsAtStart.Remove(args.Tripper);
+    }
+
+    private void OnStepTriggerAttempt(Entity<XenoDeployedTrapsComponent> trap, ref StepTriggerAttemptEvent args)
+    {
+        args.Continue = !_hive.FromSameHive(args.Tripper, trap.Owner)
+                        && !_mobState.IsDead(args.Tripper)
+                        && (HasComp<XenoComponent>(args.Tripper) || HasComp<MarineComponent>(args.Tripper));
+    }
+
     public override void Update(float frameTime)
     {
         var query = EntityQueryEnumerator<XenoCaughtInTrapComponent>();
@@ -50,12 +70,15 @@ public sealed class SharedDeployedTrapsSystem : EntitySystem
             if (_timing.CurTime >= caught.ExpireTime)
                 RemCompDeferred<XenoCaughtInTrapComponent>(uid);
         }
-    }
 
-    private void OnStepTriggerAttempt(Entity<XenoDeployedTrapsComponent> trap, ref StepTriggerAttemptEvent args)
-    {
-        args.Continue = !_hive.FromSameHive(args.Tripper, trap.Owner)
-                        && !_mobState.IsDead(args.Tripper)
-                        && (HasComp<XenoComponent>(args.Tripper) || HasComp<MarineComponent>(args.Tripper));
+        var newTrapQuery = EntityQueryEnumerator<XenoNewlyDeployedTrapsComponent, XenoDeployedTrapsComponent>();
+        while (newTrapQuery.MoveNext(out var uid, out var newTrap, out var trap))
+        {
+            if (newTrap.Running)
+            {
+                trap.ContactsAtStart.UnionWith(_physics.GetContactingEntities(uid));
+                RemCompDeferred<XenoNewlyDeployedTrapsComponent>(uid);
+            }
+        }
     }
 }

--- a/Content.Shared/_RMC14/Xenonids/Construction/DeployedTraps/XenoDeployedTrapsComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/DeployedTraps/XenoDeployedTrapsComponent.cs
@@ -1,6 +1,5 @@
-﻿using Robust.Shared.Audio;
+using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
-using Robust.Shared.Serialization;
 
 namespace Content.Shared._RMC14.Xenonids.Construction.DeployedTraps;
 
@@ -15,6 +14,9 @@ public sealed partial class XenoDeployedTrapsComponent : Component
 
     [DataField, AutoNetworkedField]
     public SoundSpecifier CatchSound = new SoundPathSpecifier("/Audio/_RMC14/Xeno/alien_claw_block.ogg");
-    
+
+    [DataField, AutoNetworkedField]
+    public HashSet<EntityUid> ContactsAtStart = new();
+
     public bool SoundPlayed = false;
 }

--- a/Content.Shared/_RMC14/Xenonids/Construction/DeployedTraps/XenoNewlyDeployedTrapsComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/DeployedTraps/XenoNewlyDeployedTrapsComponent.cs
@@ -1,0 +1,6 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.Construction.DeployedTraps;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class XenoNewlyDeployedTrapsComponent : Component;

--- a/Content.Shared/_RMC14/Xenonids/DeployTraps/XenoDeployTrapsSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/DeployTraps/XenoDeployTrapsSystem.cs
@@ -1,7 +1,5 @@
-﻿using System.Numerics;
-using Content.Shared._RMC14.Actions;
+using System.Numerics;
 using Content.Shared._RMC14.Emote;
-using Content.Shared._RMC14.Line;
 using Content.Shared._RMC14.Map;
 using Content.Shared._RMC14.Xenonids.AcidMine;
 using Content.Shared._RMC14.Xenonids.Construction.DeployedTraps;
@@ -11,10 +9,7 @@ using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared.Actions;
 using Content.Shared.Coordinates;
 using Content.Shared.Coordinates.Helpers;
-using Content.Shared.DoAfter;
 using Content.Shared.Examine;
-using Content.Shared.Interaction;
-using Content.Shared.Physics;
 using Content.Shared.Popups;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
@@ -35,7 +30,6 @@ public sealed class XenoDeployTrapsSystem : EntitySystem
     [Dependency] private readonly SharedMapSystem _mapSystem = default!;
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
-    [Dependency] private readonly SharedRMCActionsSystem _rmcActions = default!;
     [Dependency] private readonly RMCMapSystem _rmcMap = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly XenoPlasmaSystem _xenoPlasma = default!;
@@ -157,18 +151,13 @@ public sealed class XenoDeployTrapsSystem : EntitySystem
 
         if (_net.IsServer)
         {
-            if (empowered)
-            {
-                var traps = SpawnAtPosition(xeno.Comp.DeployEmpoweredTrapsId, target);
-                _hive.SetSameHive(xeno.Owner, traps);
-                EnsureComp<XenoDeployedTrapsComponent>(traps).PlacedBy = xeno.Owner;
-            }
-            else
-            {
-                var traps = SpawnAtPosition(xeno.Comp.DeployTrapsId, target);
-                _hive.SetSameHive(xeno.Owner, traps);
-                EnsureComp<XenoDeployedTrapsComponent>(traps).PlacedBy = xeno.Owner;
-            }
+            var deployId = empowered ? xeno.Comp.DeployEmpoweredTrapsId : xeno.Comp.DeployTrapsId;
+            var traps = SpawnAtPosition(deployId, target);
+            _hive.SetSameHive(xeno.Owner, traps);
+            EnsureComp<XenoNewlyDeployedTrapsComponent>(traps);
+            var comp = EnsureComp<XenoDeployedTrapsComponent>(traps);
+            comp.PlacedBy = xeno.Owner;
+            Dirty(traps, comp);
         }
     }
 

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_deployed_traps.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_deployed_traps.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   id: XenoTrapperTrap
   name: xeno trap
   description: A resin trap laid by a Sapper.
@@ -29,7 +29,7 @@
       trap_trigger:
         shape:
           !type:PhysShapeCircle
-          radius: 0.5
+          radius: 0.25
         hard: false
         layer:
         - Opaque


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Sapper traps no longer trigger if you are standing on them at the moment they spawn.

Sapper trap radius halved from 0.5 to 0.25.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Sapper traps not triggering if they spawn under you is parity behavior.

Regarding the radius reduction, there isn't really any "parity" behavior to match here because of the differences between pixel movement and tile movement. This radius change is _not_ necessarily a nerf. If the radius is too large, marines can too easily move around on the traps without triggering them when considering the above change. This reduced radius makes the traps work more like both the marine and the sapper would expect them to.

## Technical details
<!-- Summary of code changes for easier review. -->
Added XenoNewlyDeployedTrapsComponent for new traps.
New traps track their initial collisions and exclude them from triggering the trap.
Initial collisions fall off when they step off. ~~(I.e. they can trigger the trap once they step off of it)~~ (I.e. once they step off the trap, they will trigger it if they step on it again)
Slight refactors.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Sapper traps no longer trigger on marines that were standing on them when they were created.
- fix: Sapper trap radius reduced to prevent odd behavior with the above change.
