### PR TITLE
More Executive Bodyguard fixes

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Head/pmc.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Head/pmc.yml
@@ -359,7 +359,7 @@
 
 # PPO
 - type: entity
-  parent: CMHeadCapMP
+  parent: ArmorHelmetPMC
   id: RMCHeadCapExecutiveBodyguard
   name: executive bodyguard cap
   description: A protective cap made from flexible reinforced fiber. Standard issue for most security firms in the place of a helmet.

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/pmc.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/pmc.yml
@@ -283,6 +283,11 @@
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/PMC/ppo_armor.rsi
+  - type: CMArmor
+    melee: 15 # CLOTHING_ARMOR_MEDIUMLOW
+    bullet: 20 # CLOTHING_ARMOR_MEDIUM
+    bio: 10 # CLOTHING_ARMOR_LOW
+    explosionArmor: 25 # CLOTHING_ARMOR_MEDIUMHIGH
   - type: RemoveComponents
     components:
     - type: ClothingRequireEquipped
@@ -304,9 +309,13 @@
     melee: 15
     bullet: 20 # CLOTHING_ARMOR_MEDIUM
     explosionArmor: 15 # CLOTHING_ARMOR_MEDIUMLOW
+    bio: 0 # CLOTHING_ARMOR_NONE
   - type: ClothingSpeedModifier # SLOWDOWN_ARMOR_SUPER_LIGHT
     walkModifier: 0.949
     sprintModifier: 0.949
+  - type: Storage
+    grid:
+    - 0,0,1,1 # 1 slot
   - type: RemoveComponents
     components:
     - type: ClothingRequireEquipped

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/pmc.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/pmc.yml
@@ -47,7 +47,7 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/PMC/sniper.rsi
   - type: CMArmor
-    melee: 15
+    melee: 15 # CLOTHING_ARMOR_MEDIUMLOW
     bullet: 20 # CLOTHING_ARMOR_MEDIUM
     bio: 20 # CLOTHING_ARMOR_MEDIUM
     explosionArmor: 15 # CLOTHING_ARMOR_MEDIUMLOW
@@ -284,8 +284,8 @@
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/PMC/ppo_armor.rsi
   - type: CMArmor
-    melee: 15 # CLOTHING_ARMOR_MEDIUMLOW
-    bullet: 20 # CLOTHING_ARMOR_MEDIUM
+    melee: 20 # CLOTHING_ARMOR_MEDIUM
+    bullet: 25 # CLOTHING_ARMOR_MEDIUMHIGH
     bio: 10 # CLOTHING_ARMOR_LOW
     explosionArmor: 25 # CLOTHING_ARMOR_MEDIUMHIGH
   - type: RemoveComponents
@@ -305,11 +305,6 @@
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/PMC/ppo_light.rsi
-  - type: CMArmor
-    melee: 15
-    bullet: 20 # CLOTHING_ARMOR_MEDIUM
-    explosionArmor: 15 # CLOTHING_ARMOR_MEDIUMLOW
-    bio: 0 # CLOTHING_ARMOR_NONE
   - type: ClothingSpeedModifier # SLOWDOWN_ARMOR_SUPER_LIGHT
     walkModifier: 0.949
     sprintModifier: 0.949

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/executive_bodyguard.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/executive_bodyguard.yml
@@ -301,12 +301,12 @@
         ranks:
         - RMCRankWeYaBodyguardPPS
         - RMCRankWeYaBodyguardPPC
-        choices: { CMPrimary: 1 }
+        choices: { CMVendorBundleRiflemanApparel: 1 }
         entries:
         # RMC14 TODO: Shock Shotgun 15p
-        - id: RMCWeaponRifleM54CWhite
-        - id: RMCWeaponSMGM63WhiteNoLock
-        - id: RMCWeaponRifleSSG45Stripped
+        - id: RMCVendorBundleM54CWhiteNoLock
+        - id: RMCVendorBundleSMGM63WhiteNoLock
+        - id: RMCVendorBundleSMGSSG45NoLockStripped
       - name: Sidearm
         ranks:
         - RMCRankWeYaBodyguardPPS

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/bundles.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/bundles.yml
@@ -285,3 +285,51 @@
     - RMCMortarKit # RMC14 TODO: RCM Custom Light Mortar
     - RMCBeltRoyalMortarFilledMortarShells # RMC14 TODO: Check Parity Fill
     - RMCLaserDesignatorPVE
+
+- type: entity
+  parent: CMVendorBundleRiflemanApparel
+  id: RMCVendorBundleM54CWhiteNoLock
+  name: M54C assault rifle MK2
+  description: Contains the M54C assault rifle MK2 and 3 M54C magazines.
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Weapons/Guns/Rifles/m54c/snow.rsi
+    state: icon
+  - type: CMVendorBundle
+    bundle:
+    - RMCWeaponRifleM54CWhiteNoLock
+    - CMMagazineRifleM54C
+    - CMMagazineRifleM54C
+    - CMMagazineRifleM54C
+
+- type: entity
+  parent: CMVendorBundleRiflemanApparel
+  id: RMCVendorBundleSMGM63WhiteNoLock
+  name: M63 submachine gun
+  description: Contains the M63 submachine gun and 3 M63 magazines.
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Weapons/Guns/SMGs/m63/snow.rsi
+    state: icon
+  - type: CMVendorBundle
+    bundle:
+    - RMCWeaponSMGM63WhiteNoLock
+    - CMMagazineSMGM63
+    - CMMagazineSMGM63
+    - CMMagazineSMGM63
+
+- type: entity
+  parent: CMVendorBundleRiflemanApparel
+  id: RMCVendorBundleSMGSSG45NoLockStripped
+  name: SSG-45 Assault Rifle
+  description: Contains the SSG-45 Assault Rifle and 3 SSG-45 magazines.
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Weapons/Guns/Rifles/ssg45/ssg45_icon.rsi
+    state: base
+  - type: CMVendorBundle
+    bundle:
+    - RMCWeaponRifleSSG45NoLockStripped
+    - RMCMagazineRifleSSG45
+    - RMCMagazineRifleSSG45
+    - RMCMagazineRifleSSG45

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/executive_bodyguard.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/executive_bodyguard.yml
@@ -40,6 +40,7 @@
     - type: NpcFactionMember
       factions:
       - WeYa
+      - UNMC
     - type: JobPrefix
       prefix: rmc-job-prefix-executive-bodyguard
     - type: Skills

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/executive_bodyguard.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/executive_bodyguard.yml
@@ -32,8 +32,7 @@
   supervisors: cm-job-supervisors-we-ya
   roleWeight: 0.25
   accessGroups:
-  - Colony
-  - RMCWeYa
+  - RMCWeYaExecColony
   spawnMenuRoleName: Executive Bodyguard
   special:
   - !type:AddComponentSpecial
@@ -51,6 +50,7 @@
         RMCSkillEndurance: 2
         RMCSkillMeleeWeapons: 1
         RMCSkillFirearms: 1
+        RMCSkillMedical: 1
     - type: TacticalMapIcon
       icon:
         sprite: /Textures/_RMC14/Interface/map_blips.rsi

--- a/Resources/Prototypes/_RMC14/Roles/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Loadouts/role_loadouts.yml
@@ -758,7 +758,7 @@
   groups:
   - LiaisonBackpackRMC
   - LiaisonRoleSpecificRMC
-  - HeadwearRMCa
+  - HeadwearRMC
   - EyewearRMC
   - MasksRMC
   - HelmetGarbsRMC

--- a/Resources/Prototypes/_RMC14/Roles/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Loadouts/role_loadouts.yml
@@ -758,7 +758,7 @@
   groups:
   - LiaisonBackpackRMC
   - LiaisonRoleSpecificRMC
-  - HeadwearRMC
+  - HeadwearRMCa
   - EyewearRMC
   - MasksRMC
   - HelmetGarbsRMC

--- a/Resources/Prototypes/_RMC14/Roles/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Loadouts/role_loadouts.yml
@@ -787,7 +787,7 @@
   - MasksRMC
   - HelmetGarbsRMC
   - AccessoriesRMC
-  - WatchesBasicRMC
+  - WatchesLiaisonRMC
   - PaperworkRMC
   - RecreationalRMC
   - WeaponsRMC


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Gives EB access equivalent to that of the CL, gives them medical 1, and changes their watch category to match the Liaison

## Why / Balance
Access is parity, and makes sense; as a "partner" to the CL, they should have equivalent access, both to stay with the CL, as well as allowing them more mobility. Furthermore, it avoids reliance on others for access to where the CL might have moved to.

Medical 1 is parity, and allows for them to provide medical aid for the Liaison if they are suddenly injured

Having the EB have access to the Liaison Watch is logical, since the text implies it's oriented towards employees of the Weston-Yamada corporation, as well as style

UNMC Faction is present since it will allow for marines to see the icon, and match the CL.

Firearms being the unlocked varients and having 3 extra magazines spawn in is parity.

Armour values and storage have been brought to parity.

## Technical details
YML

## Media
<img width="406" height="299" alt="image" src="https://github.com/user-attachments/assets/4e5bc6c5-acaa-4d79-95e5-e87e12b44350" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed the Executive Bodyguard not having medical 1 skill
- tweak: Changed the Executive Bodyguard's watch category to that of the Liaisons
- fix: Fixed the Executive Bodyguard not having the same access as the CL
- fix: Fixed the Executive Bodyguard not being part of the UNMC faction like the Liaison
- fix: Fixed the Executive Bodyguard's firearms not being the unlocked variants and not spawning with 3 additional magazines
- fix: Fixed the Executive Bodyguard's armour and cap being incorrect
