### PR TITLE
Fix: Toxic water damage

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Tiles/toxic_water.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Tiles/toxic_water.yml
@@ -32,11 +32,11 @@
     sound:
       collection: ToxicWaterSizzle
     multipliers:
-    - multiplier: 0.069  # 0.98 
+    - multiplier: 0.050  # 0.98
       whitelist:
         tags:
         - RMCXenoLarva
-    - multiplier: 0.87  # 17.12
+    - multiplier: 0.866  # 17.04
       whitelist:
         components:
         - Xeno

--- a/Resources/Prototypes/_RMC14/Entities/Tiles/toxic_water.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Tiles/toxic_water.yml
@@ -32,11 +32,11 @@
     sound:
       collection: ToxicWaterSizzle
     multipliers:
-    - multiplier: 0.133
+    - multiplier: 0.069  # 0.98 
       whitelist:
         tags:
         - RMCXenoLarva
-    - multiplier: 2.266
+    - multiplier: 0.87  # 17.12
       whitelist:
         components:
         - Xeno

--- a/Resources/Prototypes/_RMC14/Entities/Tiles/toxic_water.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Tiles/toxic_water.yml
@@ -23,8 +23,8 @@
       tags:
       - Catwalk
     armorPiercingDamage:
-      groups:
-        Burn: 15
+      types:
+        Heat: 15
     emotes:
     - Cough
     - Gasp
@@ -32,11 +32,11 @@
     sound:
       collection: ToxicWaterSizzle
     multipliers:
-    - multiplier: 0.13333
+    - multiplier: 0.0543
       whitelist:
         tags:
         - RMCXenoLarva
-    - multiplier: 2.26666
+    - multiplier: 0.8700
       whitelist:
         components:
         - Xeno

--- a/Resources/Prototypes/_RMC14/Entities/Tiles/toxic_water.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Tiles/toxic_water.yml
@@ -24,7 +24,7 @@
       - Catwalk
     armorPiercingDamage:
       types:
-        Heat: 15
+        Heat: 7.5
     emotes:
     - Cough
     - Gasp
@@ -32,11 +32,11 @@
     sound:
       collection: ToxicWaterSizzle
     multipliers:
-    - multiplier: 0.0543
+    - multiplier: 0.133
       whitelist:
         tags:
         - RMCXenoLarva
-    - multiplier: 0.8700
+    - multiplier: 2.266
       whitelist:
         components:
         - Xeno


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Toxic water damage has been reduced 
| Xeno| Larva| Marine|
|--------|--------|--------|
| 88 Burn| 4.91 Burn | 15 Burn|
| 17.12 Heat| 0.98 Heat| 7.5Heat|

cmss13 stats are 34, 2 and 15 heat

> This brings all values to parity no nerfs or buffs.
RMC systems damage ticks every 1second, CMs damage values are calculated on ticks of 2 seconds.
So the values you have are per 2 seconds.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity

## Technical details
<!-- Summary of code changes for easier review. -->
Changed the damage type to heat instead of group: burn which caused to player to take cold damage also, changed the 2 multipliers 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: The damage per second of the toxic water has been greatly reduced to only be 7.5 for marines, 17 for xenonids and 1 for larvae!

