### PR TITLE
Fix non-guns being acid clearable

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Acid/SharedXenoAcidSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Acid/SharedXenoAcidSystem.cs
@@ -264,13 +264,15 @@ public abstract class SharedXenoAcidSystem : EntitySystem
             if (!solution.Comp.Solution.ContainsReagent(AcidRemovedBy, null))
                 continue;
 
-            if (HasComp<GunComponent>(ent.Owner) &&
-                (!TryComp(ent.Owner, out GunSecondWindComponent? secondWind) || !secondWind.HasSecondWind))
+            if (!TryComp(ent.Owner, out GunSecondWindComponent? secondWind) || !secondWind.HasSecondWind)
             {
-                _popup.PopupEntity(
-                    Loc.GetString("rmc-acid-gun-second-wind-spent", ("target", ent.Owner)),
-                    ent.Owner,
-                    PopupType.SmallCaution);
+                if (secondWind != null)
+                {
+                    _popup.PopupEntity(
+                        Loc.GetString("rmc-acid-gun-second-wind-spent", ("target", ent.Owner)),
+                        ent.Owner,
+                        PopupType.SmallCaution);
+                }
                 return;
             }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug. In parity you can't extinguish anything without second wind.

## Technical details
<!-- Summary of code changes for easier review. -->
Moved the gun comp check to check if the message should be displayed only when second wind is a comp instead, main part now checks if second wind isn't present or is used.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed acid being extinguishable off of non-guns
