### PR TITLE
Imaginary friend fixes

### DIFF
--- a/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
@@ -7,6 +7,7 @@ using Content.Server.Power.EntitySystems;
 using Content.Server.Radio.Components;
 using Content.Server.Speech;
 using Content.Server.Speech.Components;
+using Content.Shared._RMC14.Mentor.ImaginaryFriend;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared.Examine;
 using Content.Shared.Interaction;
@@ -193,6 +194,9 @@ public sealed class RadioDeviceSystem : EntitySystem
             return; // no feedback loops please.
 
         if (component.IgnoreXenos && HasComp<XenoComponent>(args.Source))
+            return;
+
+        if (HasComp<ImaginaryFriendComponent>(args.Source))
             return;
 
         var channel = _protoMan.Index<RadioChannelPrototype>(component.BroadcastChannel)!;

--- a/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
@@ -196,9 +196,6 @@ public sealed class RadioDeviceSystem : EntitySystem
         if (component.IgnoreXenos && HasComp<XenoComponent>(args.Source))
             return;
 
-        if (HasComp<ImaginaryFriendComponent>(args.Source))
-            return;
-
         var channel = _protoMan.Index<RadioChannelPrototype>(component.BroadcastChannel)!;
         if (_recentlySent.Add((args.Message, args.Source, channel)))
             _radio.SendRadioMessage(args.Source, args.Message, channel, uid);

--- a/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
@@ -7,7 +7,6 @@ using Content.Server.Power.EntitySystems;
 using Content.Server.Radio.Components;
 using Content.Server.Speech;
 using Content.Server.Speech.Components;
-using Content.Shared._RMC14.Mentor.ImaginaryFriend;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared.Examine;
 using Content.Shared.Interaction;

--- a/Content.Server/Speech/EntitySystems/ListeningSystem.cs
+++ b/Content.Server/Speech/EntitySystems/ListeningSystem.cs
@@ -1,5 +1,6 @@
 using Content.Server.Chat.Systems;
 using Content.Server.Speech.Components;
+using Content.Shared._RMC14.Mentor.ImaginaryFriend;
 using Content.Shared._RMC14.Xenonids;
 
 namespace Content.Server.Speech.EntitySystems;
@@ -24,8 +25,10 @@ public sealed class ListeningSystem : EntitySystem
 
     public void PingListeners(EntityUid source, string message, string? obfuscatedMessage)
     {
-        if (HasComp<XenoComponent>(source))
+        // RMC14
+        if (HasComp<XenoComponent>(source) || HasComp<ImaginaryFriendComponent>(source))
             return;
+        // RMC14
 
         // TODO whispering / audio volume? Microphone sensitivity?
         // for now, whispering just arbitrarily reduces the listener's max range.

--- a/Content.Server/_RMC14/LinkAccount/LinkAccountSystem.cs
+++ b/Content.Server/_RMC14/LinkAccount/LinkAccountSystem.cs
@@ -5,6 +5,7 @@ using Content.Server.GameTicking;
 using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.GhostColor;
 using Content.Shared._RMC14.LinkAccount;
+using Content.Shared._RMC14.Mentor.ImaginaryFriend;
 using Content.Shared.Database;
 using Content.Shared.Ghost;
 using Robust.Server.Player;
@@ -97,7 +98,8 @@ public sealed class LinkAccountSystem : EntitySystem
         if (!TryComp(ent, out ActorComponent? actor) ||
             _linkAccount.GetConnectedPatron(actor.PlayerSession.UserId) is not { } patron ||
             patron.Tier is not { GhostColor: true } ||
-            patron.GhostColor is not { } color)
+            patron.GhostColor is not { } color ||
+            HasComp<ImaginaryFriendComponent>(ent))
         {
             RemCompDeferred<GhostColorComponent>(ent);
             return;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

- Shortwave radios and universal recorders no longer hear chat messages from nearby imaginary friends.
- Imaginary friends no longer get the patreon ghost color applied to them.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix: Shortwave radios and universal recorders no longer hear speech from nearby imaginary friends.
- fix: The patreon ghost color no longer gets applied to imaginary friends.
