### PR TITLE
Fix - Hijack Lava Surge and groundside Xeno deletion.

### DIFF
--- a/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.Hijack.cs
+++ b/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.Hijack.cs
@@ -62,10 +62,10 @@ public sealed partial class CMDistressSignalRuleSystem
         }
 
         //TODO RMC14 only do main hive
-        var xenos = EntityQueryEnumerator<XenoComponent, MobStateComponent, InfectableComponent, TransformComponent>();
+        var xenos = EntityQueryEnumerator<XenoComponent, MobStateComponent, TransformComponent>();
         var xenoAmount = 0;
         var larva = 0;
-        while (xenos.MoveNext(out var xeno, out var comp, out _, out _, out var transformComp))
+        while (xenos.MoveNext(out var xeno, out var comp, out _, out var transformComp))
         {
             if (_mobState.IsDead(xeno))
                 continue;
@@ -149,7 +149,7 @@ public sealed partial class CMDistressSignalRuleSystem
             return;
 
         var hiveComp = EnsureComp<HiveComponent>(rule.Hive);
-        _hive.ChangeBurrowedLarva(larva);
+        _hive.ChangeBurrowedLarva((rule.Hive, hiveComp), larva);
         _hive.ResetHiveCoreCooldown((rule.Hive, hiveComp));
         var surge = EnsureComp<HijackBurrowedSurgeComponent>(rule.Hive);
         surge.PooledLarva = surgeAmount;

--- a/Content.Server/_RMC14/Xenonids/Hive/XenoHiveSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Hive/XenoHiveSystem.cs
@@ -253,7 +253,7 @@ public sealed class XenoHiveSystem : SharedXenoHiveSystem
                 continue;
             }
 
-            ChangeBurrowedLarva(1);
+            ChangeBurrowedLarva((id, hive), 1);
             burrowed.PooledLarva--;
             if (burrowed.PooledLarva < 1)
                 RemCompDeferred<HijackBurrowedSurgeComponent>(id);


### PR DESCRIPTION
## About the PR
The refactored code had an erroneous component pasted on its query (potentially from the marine query) which resulted in the Xeno query returning 0 all the time as Xenos don't have infectable component.
Which resulted in no Xenos groundside detected for deletion nor adding to the burrowed "refund".

## Why / Balance
Fixes title. No more abandoned xenos groundside.  
Lava Surge works as intended

## Technical details
removed the InfectableComponent from the Xeno Query Loop. 
Tested in a localdev hijack .

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- fix: Hijack once again deletes any Xeno outside the dropship and adds them to the burrowed count for the hive.