### PR TITLE
fix barbed wire block message displaying when it shouldn't

### DIFF
--- a/Content.Shared/_RMC14/Barricade/SharedBarbedSystem.cs
+++ b/Content.Shared/_RMC14/Barricade/SharedBarbedSystem.cs
@@ -77,17 +77,17 @@ public abstract class SharedBarbedSystem : EntitySystem
 
     private void OnInteractUsing(Entity<BarbedComponent> ent, ref InteractUsingEvent args)
     {
-        if (_xenoAcid.IsMelted(ent))
-        {
-            var failPopup = Loc.GetString("rmc-construction-melted");
-            _popupSystem.PopupClient(failPopup, ent, args.User, PopupType.SmallCaution);
-
-            args.Handled = true;
-            return;
-        }
-
         if (!ent.Comp.IsBarbed && HasComp<BarbedWireComponent>(args.Used))
         {
+            if (_xenoAcid.IsMelted(ent))
+            {
+                var failPopup = Loc.GetString("rmc-construction-melted");
+                _popupSystem.PopupClient(failPopup, ent, args.User, PopupType.SmallCaution);
+
+                args.Handled = true;
+                return;
+            }
+
             var ev = new BarbedDoAfterEvent();
             var barbDoAfter = new DoAfterArgs(EntityManager, args.User, ent.Comp.WireTime, ev, ent, ent, used: args.Used)
             {
@@ -120,6 +120,15 @@ public abstract class SharedBarbedSystem : EntitySystem
 
         if (!_toolSystem.HasQuality(args.Used, ent.Comp.RemoveQuality, tool))
             return;
+
+        if (_xenoAcid.IsMelted(ent))
+        {
+            var failPopup = Loc.GetString("rmc-construction-melted");
+            _popupSystem.PopupClient(failPopup, ent, args.User, PopupType.SmallCaution);
+
+            args.Handled = true;
+            return;
+        }
 
         args.Handled = true;
         _popupSystem.PopupClient(Loc.GetString("barbed-wire-cutting-action-begin"), ent, args.User);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The message displayaed on any interaction with a cade even when that interaction wasn't blocked. Now only displays on a trying to barbed / unbarb a cade that has acid on it.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed the blocked cade acid popup displaying even when the interaction wasn't blocked

