### PR TITLE
Fix - Hive Core and Queen available announcements.

### DIFF
--- a/Content.Server/_RMC14/Xenonids/Hive/XenoHiveSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Hive/XenoHiveSystem.cs
@@ -209,7 +209,7 @@ public sealed class XenoHiveSystem : SharedXenoHiveSystem
                 EvoScreech(hive);
             }
 
-            if (!hive.AnnouncedQueenDeathCooldownOver && hive.CurrentQueen == null && hive.NewQueenAt.HasValue && roundTime >= hive.NewQueenAt.Value)
+            if (!hive.AnnouncedQueenDeathCooldownOver && hive.CurrentQueen == null && hive.NewQueenAt.HasValue && _timing.CurTime >= hive.NewQueenAt.Value)
             {
                 var queenPopup = Loc.GetString("rmc-queen-death-cooldown-over");
                 _xenoAnnounce.AnnounceToHive(EntityUid.Invalid, hiveId, queenPopup, hive.AnnounceSound);
@@ -218,7 +218,7 @@ public sealed class XenoHiveSystem : SharedXenoHiveSystem
             }
 
             //No queen has been picked they have 1 minutes to pick a queeen before hive goes feral
-            if (!hive.AnnouncedNoQueenCooldownOver && hive.CurrentQueen == null && hive.NewQueenAt.HasValue && roundTime >= hive.NewQueenAt.Value + hive.NoQueenAlertTime)
+            if (!hive.AnnouncedNoQueenCooldownOver && hive.CurrentQueen == null && hive.NewQueenAt.HasValue && _timing.CurTime >= hive.NewQueenAt.Value + hive.NoQueenAlertTime)
             {
                 var noQueenPopup = Loc.GetString("rmc-no-queen-warning");
                 _xenoAnnounce.AnnounceToHive(EntityUid.Invalid, hiveId, noQueenPopup, hive.AnnounceSound);
@@ -226,7 +226,7 @@ public sealed class XenoHiveSystem : SharedXenoHiveSystem
                 Dirty(hiveId, hive);
             }
 
-            if (!hive.AnnouncedHiveCoreCooldownOver && hive.NewCoreAt.HasValue && roundTime >= hive.NewCoreAt)
+            if (!hive.AnnouncedHiveCoreCooldownOver && hive.NewCoreAt.HasValue && _timing.CurTime >= hive.NewCoreAt)
             {
                 var corePopup = Loc.GetString("rmc-hive-core-cooldown-over");
                 _xenoAnnounce.AnnounceToHive(EntityUid.Invalid, hiveId, corePopup, hive.AnnounceSound);


### PR DESCRIPTION
## About the PR
Fixes the announcements so it fires properly.

## Why / Balance
Fixes.

## Technical details
Cur and roundtime not same, mismatch causing no running.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:

- fix: Hive Core or Queen being available will have an announcement now.
