### PR TITLE
Prevent sentires and weapons mounts from being damaged while undeployed

### DIFF
--- a/Content.Shared/_RMC14/Emplacements/SharedWeaponMountSystem.cs
+++ b/Content.Shared/_RMC14/Emplacements/SharedWeaponMountSystem.cs
@@ -113,7 +113,7 @@ public abstract class SharedWeaponMountSystem : EntitySystem
         SubscribeLocalEvent<WeaponMountComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<WeaponMountComponent, GetVerbsEvent<AlternativeVerb>>(OnAltVerb);
         SubscribeLocalEvent<WeaponMountComponent, BreakageEventArgs>(OnBreak);
-        SubscribeLocalEvent<WeaponMountComponent, DamageModifyEvent>(OnDamageModified);
+        SubscribeLocalEvent<WeaponMountComponent, BeforeDamageChangedEvent>(OnDamageModified);
         SubscribeLocalEvent<WeaponMountComponent, RMCCheckTileFreeEvent>(OnCheckTileFree);
         SubscribeLocalEvent<WeaponMountComponent, GetIFFGunUserEvent>(OnGetGunUser);
         SubscribeLocalEvent<WeaponMountComponent, InteractHandEvent>(OnInteractHand, before: new[] { typeof(SharedBuckleSystem) });
@@ -960,11 +960,11 @@ public abstract class SharedWeaponMountSystem : EntitySystem
         UpdateAppearance(ent);
     }
 
-    private void OnDamageModified(Entity<WeaponMountComponent> ent, ref DamageModifyEvent args)
+    private void OnDamageModified(Entity<WeaponMountComponent> ent, ref BeforeDamageChangedEvent args)
     {
-        // Set all damage received to 0 if the mount is folded.
+        // Receive no damage while folded.
         if (TryComp(ent, out FoldableComponent? foldable) && foldable.IsFolded)
-            args.Damage = new DamageSpecifier();
+            args.Cancelled = true;
     }
 
     private void OnCheckTileFree(Entity<WeaponMountComponent> ent, ref RMCCheckTileFreeEvent args)

--- a/Content.Shared/_RMC14/Emplacements/SharedWeaponMountSystem.cs
+++ b/Content.Shared/_RMC14/Emplacements/SharedWeaponMountSystem.cs
@@ -962,6 +962,9 @@ public abstract class SharedWeaponMountSystem : EntitySystem
 
     private void OnDamageModified(Entity<WeaponMountComponent> ent, ref BeforeDamageChangedEvent args)
     {
+        if (args.Damage.GetTotal() < 0)
+            return;
+
         // Receive no damage while folded.
         if (TryComp(ent, out FoldableComponent? foldable) && foldable.IsFolded)
             args.Cancelled = true;

--- a/Content.Shared/_RMC14/Sentry/SentrySystem.cs
+++ b/Content.Shared/_RMC14/Sentry/SentrySystem.cs
@@ -73,6 +73,7 @@ public sealed class SentrySystem : EntitySystem
         SubscribeLocalEvent<SentryComponent, SentryDisassembleDoAfterEvent>(OnSentryDisassembleDoAfter);
         SubscribeLocalEvent<SentryComponent, ExaminedEvent>(OnSentryExamined);
         SubscribeLocalEvent<SentryComponent, CombatModeShouldHandInteractEvent>(OnSentryShouldInteract);
+        SubscribeLocalEvent<SentryComponent, BeforeDamageChangedEvent>(OnBeforeDamageChanged);
         SubscribeLocalEvent<SentrySpikesComponent, AttackedEvent>(OnSentrySpikesAttacked);
 
         Subs.BuiEvents<SentryComponent>(SentryUiKey.Key,
@@ -358,6 +359,15 @@ public sealed class SentrySystem : EntitySystem
         var newSentry = Spawn(upgrade, coordinates, rotation: rotation);
         var ev = new SentryUpgradedEvent(oldSentry, newSentry, user);
         RaiseLocalEvent(newSentry, ref ev);
+    }
+
+    private void OnBeforeDamageChanged(Entity<SentryComponent> ent, ref BeforeDamageChangedEvent args)
+    {
+        if (args.Damage.GetTotal() < 0)
+            return;
+
+        if (ent.Comp.Mode == SentryMode.Item)
+            args.Cancelled = true;
     }
 
     private void UpdateState(Entity<SentryComponent> sentry)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Sentries and weapon mounts can no longer be damaged while undeployed.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug fix.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix: Fixed undeployed sentries and weapon mounts being damageable.
