### PR TITLE
Adds: Small Tool Webbing (Filled) to Intel Vendor

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/intel.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/intel.yml
@@ -214,6 +214,7 @@
       - id: CMWebbingBlack
       - id: CMWebbingBrown
         recommended: true
+      - id: RMCToolWebbingSmallFilled
       - id: RMCWebbingLegPouch
       - id: RMCWebbingLegPouchBlack
       - id: CMWebbingHolster


### PR DESCRIPTION
## About the PR
Adds the small tool webbing filled to the intel vendor.

## Why / Balance
QoL. Most IOs I see carry these tools anyways in their regular webbing. It's a bit tedious to have to take the tools out of the belt and slot them into the webbing every round when we already have a dedicated webbing that could do that.

## Technical details
yml

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Small tool webbing (filled) to intel vendor.
