### PR TITLE
Tweak: Added Plushies as a Loadout Option for Missing Roles Them

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Loadouts/role_loadouts.yml
@@ -717,6 +717,7 @@
   - WatchesLiaisonRMC
   - PaperworkRMC
   - RecreationalRMC
+  - PlushiesRMC
   - WeaponsRMC
   - CannedDrinksRMC
   - FlasksRMC
@@ -741,6 +742,7 @@
   - WatchesBasicRMC
   - PaperworkRMC
   - RecreationalRMC
+  - PlushiesRMC
   - WeaponsRMC
   - CannedDrinksRMC
   - FlasksRMC
@@ -766,6 +768,7 @@
   - WatchesLiaisonRMC
   - PaperworkRMC
   - RecreationalRMC
+  - PlushiesRMC
   - WeaponsRMC
   - CannedDrinksRMC
   - FlasksRMC
@@ -789,6 +792,7 @@
   - AccessoriesRMC
   - PaperworkRMC
   - RecreationalRMC
+  - PlushiesRMC
   - WeaponsRMC
   - CannedDrinksRMC
   - FlasksRMC


### PR DESCRIPTION
## About the PR
Added plushies as a loadout option for, correspondent, combat corespondent, liason and liason bodyguard.

## Technical details
yml

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: Correspondent, combat correspondent, liason and liason bodyguard now have plushies in their loadout options.
