### PR TITLE
fix: dropship navigation computers now work on all maps again

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/shuttle_console.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/shuttle_console.yml
@@ -11,12 +11,11 @@
   - type: InteractionOutline
   - type: ApcPowerReceiver
     powerLoad: 250
-    needsPower: true
+    needsPower: false
   - type: RMCPowerReceiver
     idleLoad: 300
     activeLoad: 300
     channel: Equipment
-  - type: ActivatableUIRequiresPower
 
 - type: entity
   parent: CMComputerDropship
@@ -41,9 +40,6 @@
         type: DropshipNavigationBui
       enum.DropshipHijackerUiKey.Key:
         type: DropshipHijackerBui
-  - type: ApcPowerReceiver
-    powerLoad: 0
-    needsPower: false
 
 - type: entity
   parent: CMComputerDropshipNavigation
@@ -134,8 +130,6 @@
     - RMCLaserDesignatorTarget
   - type: ActivatableUI
     key: enum.RMCCameraUiKey.Key
-  - type: ApcPowerReceiver
-    needsPower: false
 
 - type: entity
   parent: CMComputerDropshipCamerasAlamo
@@ -176,9 +170,6 @@
   - type: RequiresSkill
     skills:
       RMCSkillPilot: 1
-  - type: ApcPowerReceiver
-    powerLoad: 0
-    needsPower: false
 
 - type: entity
   parent: CMBaseStructure
@@ -205,7 +196,6 @@
     idleLoad: 300
     activeLoad: 300
     channel: Equipment
-  - type: ActivatableUIRequiresPower
   - type: Clickable
   - type: Corrodible
     isCorrodible: false

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/shuttle_console.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/shuttle_console.yml
@@ -9,14 +9,6 @@
   - type: Corrodible
     isCorrodible: false
   - type: InteractionOutline
-  - type: ApcPowerReceiver
-    powerLoad: 250
-    needsPower: true
-  - type: RMCPowerReceiver
-    idleLoad: 300
-    activeLoad: 300
-    channel: Equipment
-  - type: ActivatableUIRequiresPower
 
 - type: entity
   parent: CMComputerDropship
@@ -41,9 +33,6 @@
         type: DropshipNavigationBui
       enum.DropshipHijackerUiKey.Key:
         type: DropshipHijackerBui
-  - type: ApcPowerReceiver
-    powerLoad: 0
-    needsPower: false
 
 - type: entity
   parent: CMComputerDropshipNavigation
@@ -134,8 +123,6 @@
     - RMCLaserDesignatorTarget
   - type: ActivatableUI
     key: enum.RMCCameraUiKey.Key
-  - type: ApcPowerReceiver
-    needsPower: false
 
 - type: entity
   parent: CMComputerDropshipCamerasAlamo
@@ -176,9 +163,6 @@
   - type: RequiresSkill
     skills:
       RMCSkillPilot: 1
-  - type: ApcPowerReceiver
-    powerLoad: 0
-    needsPower: false
 
 - type: entity
   parent: CMBaseStructure
@@ -198,14 +182,6 @@
     - state: "security_cam0"
     - map: ["enum.PowerDeviceVisualLayers.Powered"]
       state: "security_cam"
-  - type: ApcPowerReceiver
-    powerLoad: 0
-    needsPower: false
-  - type: RMCPowerReceiver
-    idleLoad: 300
-    activeLoad: 300
-    channel: Equipment
-  - type: ActivatableUIRequiresPower
   - type: Clickable
   - type: Corrodible
     isCorrodible: false

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/shuttle_console.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/shuttle_console.yml
@@ -9,6 +9,14 @@
   - type: Corrodible
     isCorrodible: false
   - type: InteractionOutline
+  - type: ApcPowerReceiver
+    powerLoad: 250
+    needsPower: true
+  - type: RMCPowerReceiver
+    idleLoad: 300
+    activeLoad: 300
+    channel: Equipment
+  - type: ActivatableUIRequiresPower
 
 - type: entity
   parent: CMComputerDropship
@@ -33,6 +41,9 @@
         type: DropshipNavigationBui
       enum.DropshipHijackerUiKey.Key:
         type: DropshipHijackerBui
+  - type: ApcPowerReceiver
+    powerLoad: 0
+    needsPower: false
 
 - type: entity
   parent: CMComputerDropshipNavigation
@@ -123,6 +134,8 @@
     - RMCLaserDesignatorTarget
   - type: ActivatableUI
     key: enum.RMCCameraUiKey.Key
+  - type: ApcPowerReceiver
+    needsPower: false
 
 - type: entity
   parent: CMComputerDropshipCamerasAlamo
@@ -163,6 +176,9 @@
   - type: RequiresSkill
     skills:
       RMCSkillPilot: 1
+  - type: ApcPowerReceiver
+    powerLoad: 0
+    needsPower: false
 
 - type: entity
   parent: CMBaseStructure
@@ -182,6 +198,14 @@
     - state: "security_cam0"
     - map: ["enum.PowerDeviceVisualLayers.Powered"]
       state: "security_cam"
+  - type: ApcPowerReceiver
+    powerLoad: 0
+    needsPower: false
+  - type: RMCPowerReceiver
+    idleLoad: 300
+    activeLoad: 300
+    channel: Equipment
+  - type: ActivatableUIRequiresPower
   - type: Clickable
   - type: Corrodible
     isCorrodible: false


### PR DESCRIPTION
## About the PR

title

## Why / Balance

bugfix

## Technical details

on some maps the consoles are mapped to an area that doesn't have a APC, so I just removed the power requirement from it. Also cleaned up all the dropship related consoles as they all (for [some](https://github.com/RMC-14/RMC-14/issues/9975) [reason](https://github.com/RMC-14/RMC-14/commit/7b56f2fc9626fc13d6ee006bd5b9fba7c2f08af4#diff-05ce55fd518306f869be42a8a059921866a6aad0a6ab2b69ac75b40b8da28ce8)) inherited a power requirement and then removed it again.

## Media

<img width="640" height="360" alt="image" src="https://github.com/user-attachments/assets/88ae3d66-da33-4e28-b102-e0f423ec1c37" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- fix: The planetside dropship navigation computers should now work on all maps again.
