### PR TITLE
Fixed the underbarrel offset for the PK7

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/pk7.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/pk7.yml
@@ -50,7 +50,7 @@
   - type: AttachableHolderVisuals
     offsets:
       rmc-aslot-rail: -0.1, 0.22
-      rmc-aslot-underbarrel: 0.3, -0.2
+      rmc-aslot-underbarrel: 0.58, -0.2
 
 - type: entity
   parent: CMBaseMagazinePistol


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed the offset of the pk-7 underbarrel

## Why / Balance
Looks better and more realistic

## Technical details
YML

## Media
**BEFORE AND AFTER**

<img width="218" height="63" alt="image" src="https://github.com/user-attachments/assets/4dfac443-4fdd-486b-9d5a-147fccad3a49" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed the PK7's Underbarrel Offset