### PR TITLE
Makes souto vending machine bag unmeltable and unstrippable

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Back/backpacks.yml
@@ -631,3 +631,5 @@
         volume: -7
   - type: Corrodible
     isCorrodible: false
+  - type: RMCUnstrippable
+    policeCanStrip: false

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Back/backpacks.yml
@@ -629,3 +629,5 @@
       path:  /Audio/Machines/machine_vend.ogg
       params:
         volume: -7
+  - type: Corrodible
+    isCorrodible: false


### PR DESCRIPTION
## About the PR
Makes souto vending machine bag unmeltable

## Why / Balance
Parity

## Technical details
Two lines of yaml

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed the Bobda vending machine bag being meltable and strippable
