### PR TITLE
Fix the reflective wall not having a build animation

### DIFF
--- a/Resources/Prototypes/_RMC14/Effects/xeno_structures.yml
+++ b/Resources/Prototypes/_RMC14/Effects/xeno_structures.yml
@@ -89,7 +89,7 @@
     - sprite: /Textures/_RMC14/Effects/xeno_secrete.rsi
       state: secrete_base
     - map: ["enum.XenoConstructionVisualLayers.Animation"]
-      state: wall
+      state: wall # TODO RMC14 Make this have it's own build animation once the reflective wall stops using the skeletal resin sprite.
 
 - type: entity
   parent: RMCBaseEffectXenoStructure

--- a/Resources/Prototypes/_RMC14/Effects/xeno_structures.yml
+++ b/Resources/Prototypes/_RMC14/Effects/xeno_structures.yml
@@ -81,6 +81,18 @@
 
 - type: entity
   parent: RMCBaseEffectXenoStructure
+  id: RMCEffectWallXenoResinReflective
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    layers:
+    - sprite: /Textures/_RMC14/Effects/xeno_secrete.rsi
+      state: secrete_base
+    - map: ["enum.XenoConstructionVisualLayers.Animation"]
+      state: wall
+
+- type: entity
+  parent: RMCBaseEffectXenoStructure
   id: RMCEffectWallXenoMembrane
   categories: [ HideSpawnMenu ]
   components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added a build animation to the reflective wall, it's the same animation as the regular wall so it looks a bit weird, but that's parity.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fix.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix: Fixed the reflective wall not having a build animation.
