### PR TITLE
Scale Fish Based on Length

### DIFF
--- a/Content.Server/_RMC14/Fishing/RMCFishingSystem.cs
+++ b/Content.Server/_RMC14/Fishing/RMCFishingSystem.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using Content.Shared._RMC14.Areas;
 using Content.Shared._RMC14.Fishing;
 using Content.Shared._RMC14.Map;
@@ -595,6 +596,13 @@ public sealed class RMCFishingSystem : EntitySystem
     private void UpdateFishAppearance(Entity<RMCFishComponent> ent)
     {
         _appearance.SetData(ent.Owner, RMCFishVisuals.Gutted, ent.Comp.Gutted);
+
+        if (ent.Comp.MaxLength == ent.Comp.MinLength)
+            return;
+
+        var t = (float)(ent.Comp.Length - ent.Comp.MinLength) / (ent.Comp.MaxLength - ent.Comp.MinLength);
+        var scaleVal = ent.Comp.MinScale + t * (ent.Comp.MaxScale - ent.Comp.MinScale);
+        _appearance.SetData(ent.Owner, ScaleVisuals.Scale,  Vector2.One * scaleVal);
     }
 
     private void OnSpearAfterInteract(Entity<RMCFishingSpearComponent> ent, ref AfterInteractEvent args)

--- a/Content.Shared/_RMC14/Fishing/RMCFishingComponents.cs
+++ b/Content.Shared/_RMC14/Fishing/RMCFishingComponents.cs
@@ -108,6 +108,12 @@ public sealed partial class RMCFishComponent : Component
     public int Length;
 
     [DataField]
+    public float MinScale = 0.5f;
+
+    [DataField]
+    public float MaxScale = 1.5f;
+
+    [DataField]
     public bool Guttable = true;
 
     [DataField, AutoNetworkedField]

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Fishing/fishing.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Fishing/fishing.yml
@@ -161,6 +161,7 @@
   - type: Sprite
     sprite: _RMC14/Objects/Fishing/Fish/fish.rsi
   - type: Appearance
+  - type: ScaleVisuals
   - type: Food
     transferAmount: 3
   - type: FlavorProfile


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Scales fish sprites based on the length displayed in description. The scale goes from 0.5 for smallest fish (so it's easy to see and click on) to 1.5 for largest fish (so none of them are larger than a xeno sprite for example).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Just fun, it doesn't affect gameplay and adds some more RP opportunities.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
<img width="893" height="510" alt="image" src="https://github.com/user-attachments/assets/76675e5e-9eff-4eae-bc7c-651ae46e632a" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Fish are scaled based on length.
