### PR TITLE
Fix - Recharger and other Powered required devices will now update their area properly.

### DIFF
--- a/Content.Server/_RMC14/Power/RMCPowerSystem.cs
+++ b/Content.Server/_RMC14/Power/RMCPowerSystem.cs
@@ -83,6 +83,8 @@ public sealed class RMCPowerSystem : SharedRMCPowerSystem
 
     protected override void OnReceiverMapInit(Entity<RMCPowerReceiverComponent> ent, ref MapInitEvent args)
     {
+        base.OnReceiverMapInit(ent, ref args);
+
         if (!TryComp(ent, out ApcPowerReceiverComponent? receiver))
             return;
 

--- a/Content.Shared/_RMC14/Power/SharedRMCPowerSystem.cs
+++ b/Content.Shared/_RMC14/Power/SharedRMCPowerSystem.cs
@@ -84,6 +84,7 @@ public abstract class SharedRMCPowerSystem : EntitySystem
 
         SubscribeLocalEvent<RMCPowerReceiverComponent, MapInitEvent>(OnReceiverMapInit);
         SubscribeLocalEvent<RMCPowerReceiverComponent, EntParentChangedMessage>(OnReceiverUpdate);
+        SubscribeLocalEvent<RMCPowerReceiverComponent, AnchorStateChangedEvent>(OnReceiverUpdate);
         SubscribeLocalEvent<RMCPowerReceiverComponent, ComponentRemove>(OnReceiverRemove);
         SubscribeLocalEvent<RMCPowerReceiverComponent, EntityTerminatingEvent>(OnReceiverRemove);
 


### PR DESCRIPTION
## About the PR
Fixes powered devices staying locked in to the initial power area.
Also fixes cases where power required items constructed mid round do not get  parent which causing them to be stuck unpowered

## Why / Balance
Power required devices were not powering even if placed in an area that was powered.

## Technical details
Subscribes to anchor state change as most powered devices don't get caught in the other loop that starts the receiver update


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:

- fix: Rechargers and other machines that require power will now be able to be re-anchored and powered at different APC areas.

