### PR TITLE
Dropship camera feeds remain active for a short while after the target disappears

### DIFF
--- a/Content.Shared/_RMC14/Dropship/Weapon/DropshipLingeringTargetComponent.cs
+++ b/Content.Shared/_RMC14/Dropship/Weapon/DropshipLingeringTargetComponent.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Dropship.Weapon;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class DropshipLingeringTargetComponent : Component
+{
+
+}

--- a/Content.Shared/_RMC14/Dropship/Weapon/DropshipTerminalWeaponsComponent.cs
+++ b/Content.Shared/_RMC14/Dropship/Weapon/DropshipTerminalWeaponsComponent.cs
@@ -43,6 +43,9 @@ public sealed partial class DropshipTerminalWeaponsComponent : Component
     [DataField, AutoNetworkedField]
     public bool NightVision;
 
+    [DataField, AutoNetworkedField]
+    public TimeSpan LingeringCameraDuration = TimeSpan.FromSeconds(5);
+
     [DataRecord]
     [Serializable, NetSerializable]
     public record struct Screen(

--- a/Content.Shared/_RMC14/Dropship/Weapon/SharedDropshipWeaponSystem.cs
+++ b/Content.Shared/_RMC14/Dropship/Weapon/SharedDropshipWeaponSystem.cs
@@ -363,7 +363,39 @@ public abstract class SharedDropshipWeaponSystem : EntitySystem
             if (terminal.Target == ent)
             {
                 RemovePvsActors((uid, terminal));
-                SetTarget((uid, terminal), null);
+
+                if (!HasComp<DropshipLingeringTargetComponent>(ent) &&
+                    _net.IsServer &&
+                    ent.Comp.Eyes.TryGetValue(uid, out var oldEye))
+                {
+                    var proxy = Spawn(null, Transform(ent).Coordinates);
+
+                    var proxyTarget = EnsureComp<DropshipTargetComponent>(proxy);
+                    proxyTarget.Abbreviation = ent.Comp.Abbreviation;
+                    proxyTarget.IsTargetableByWeapons = false;
+                    proxyTarget.Eyes[uid] = oldEye;
+
+                    EnsureComp<DropshipLingeringTargetComponent>(proxy);
+
+                    var proxyDespawn = EnsureComp<TimedDespawnComponent>(proxy);
+                    proxyDespawn.Lifetime = (float) terminal.LingeringCameraDuration.TotalSeconds;
+
+                    if (TryComp(oldEye, out DropshipTargetEyeComponent? eyeTarget))
+                    {
+                        eyeTarget.Target = proxy;
+                        Dirty(oldEye, eyeTarget);
+                    }
+
+                    ent.Comp.Eyes.Remove(uid);
+
+                    Dirty(proxy, proxyTarget);
+                    SetTarget((uid, terminal), proxy);
+                    AddPvsActors((uid, terminal));
+                }
+                else
+                {
+                    SetTarget((uid, terminal), null);
+                }
             }
 
             var targets = terminal.Targets;
@@ -627,9 +659,13 @@ public abstract class SharedDropshipWeaponSystem : EntitySystem
 
         if (!IsValidTarget(target))
         {
+            if (HasComp<DropshipLingeringTargetComponent>(target))
+                return;
+
             RemovePvsActors(ent);
             SetTarget(ent, null);
             Dirty(ent);
+
             return;
         }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The camera feed of a dropship target now cuts off 5 seconds after the target has disappeared.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This makes pilots able to see the result of their strike.

## Technical details
<!-- Summary of code changes for easier review. -->
A new dropship target is spawned at the old target location, it despawns after 5 seconds. This new target can't be used to shoot weapons and does not appear in the target list.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- tweak: Dropship camera feeds now remain active for 5 seconds after the selected target disappears, instead of cutting out instantly.
