### PR TITLE
Delay hijack pipe barrage until crash stun ends

### DIFF
--- a/Content.Server/_RMC14/Hijack/RMCHijackRandomDamageSystem.cs
+++ b/Content.Server/_RMC14/Hijack/RMCHijackRandomDamageSystem.cs
@@ -1,4 +1,5 @@
 using Content.Server.Destructible;
+using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Atmos;
 using Content.Shared._RMC14.Dropship;
 using Content.Shared._RMC14.Explosion;
@@ -8,6 +9,7 @@ using Content.Shared.Explosion;
 using Content.Shared.FixedPoint;
 using Content.Shared.GameTicking;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
@@ -21,6 +23,7 @@ namespace Content.Server._RMC14.Hijack;
 public sealed class RMCHijackRandomDamageSystem : EntitySystem
 {
     [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly SharedRMCExplosionSystem _rmcExplosion = default!;
     [Dependency] private readonly SharedRMCFlammableSystem _rmcFlammable = default!;
@@ -50,6 +53,8 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
     private const float PipeExplosionMax = 20f;
     private const int PipeFireRange = 2;
 
+    private TimeSpan _hijackCrashStunTime;
+
     private readonly List<(EntityUid Uid, RMCHijackRandomDamageTargetComponent Comp)> _wallTargets = new();
     private readonly List<(EntityUid Uid, RMCHijackRandomDamageTargetComponent Comp)> _windowTargets = new();
     private readonly List<(EntityUid Uid, RMCHijackRandomDamageTargetComponent Comp)> _windoorTargets = new();
@@ -62,6 +67,8 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
         SubscribeLocalEvent<RMCHijackActivePipeComponent, ComponentRemove>(OnPipeRemove);
         SubscribeLocalEvent<RMCHijackActivePipeComponent, EntityTerminatingEvent>(OnPipeRemove);
         SubscribeLocalEvent<RMCHijackActivePipeComponent, AnchorStateChangedEvent>(OnPipeAnchorChanged);
+
+        Subs.CVar(_config, RMCCVars.RMCHijackCrashStunTimeSeconds, v => _hijackCrashStunTime = TimeSpan.FromSeconds(v), true);
     }
 
     private void OnRoundRestart(RoundRestartCleanupEvent ev)
@@ -120,7 +127,8 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
         ApplyRandomDamage(_windowTargets, WindowMinPercent, WindowMaxPercent);
         ApplyRandomDamage(_windoorTargets, WindoorMinPercent, WindoorMaxPercent);
 
-        DoPipeBarrage(ev.Map, PipeInitialMinPercent, PipeInitialMaxPercent);
+        map.InitialPipeBarragePending = true;
+        map.Next = _timing.CurTime + _hijackCrashStunTime;
     }
 
     private void OnPipeRemove<T>(Entity<RMCHijackActivePipeComponent> ent, ref T args)
@@ -321,6 +329,13 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
 
             if (time < active.Next)
                 continue;
+
+            if (active.InitialPipeBarragePending)
+            {
+                active.InitialPipeBarragePending = false;
+                DoPipeBarrage((uid, active), PipeInitialMinPercent, PipeInitialMaxPercent);
+                continue;
+            }
 
             DoPipeBarrage((uid, active));
         }

--- a/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.cs
@@ -165,7 +165,7 @@ public sealed partial class CMDistressSignalRuleSystem : GameRuleSystem<CMDistre
     private float _minimumSurvivors;
     private int _mapVoteExcludeLast;
     private bool _useCarryoverVoting;
-    private readonly TimeSpan _hijackStunTime = TimeSpan.FromSeconds(5);
+    private TimeSpan _hijackStunTime;
     private bool _landingZoneMiasmaEnabled;
     private TimeSpan _sunsetDuration;
     private TimeSpan _sunriseDuration;
@@ -283,6 +283,7 @@ public sealed partial class CMDistressSignalRuleSystem : GameRuleSystem<CMDistre
         Subs.CVar(_config, RMCCVars.RMCSunsetDuration, v => _sunsetDuration = TimeSpan.FromSeconds(v), true);
         Subs.CVar(_config, RMCCVars.RMCSunriseDuration, v => _sunriseDuration = TimeSpan.FromSeconds(v), true);
         Subs.CVar(_config, RMCCVars.RMCForceEndHijackTimeMinutes, v => _forceEndHijackTime = TimeSpan.FromMinutes(v), true);
+        Subs.CVar(_config, RMCCVars.RMCHijackCrashStunTimeSeconds, v => _hijackStunTime = TimeSpan.FromSeconds(v), true);
         Subs.CVar(_config, RMCCVars.RMCHijackShipWeight, v => _hijackShipWeight = v, true);
         Subs.CVar(_config, RMCCVars.RMCMinimumHijackBurrowed, v => _hijackMinBurrowed = v, true);
         Subs.CVar(_config, RMCCVars.RMCDistressXenosMinimum, v => _xenosMinimum = v, true);

--- a/Content.Shared/_RMC14/CCVar/RMCCVars.cs
+++ b/Content.Shared/_RMC14/CCVar/RMCCVars.cs
@@ -454,6 +454,9 @@ public sealed partial class RMCCVars : CVars
     public static readonly CVarDef<int> RMCForceEndHijackTimeMinutes =
         CVarDef.Create("rmc.force_hijack_end_time_minutes", 25, CVar.REPLICATED | CVar.SERVER);
 
+    public static readonly CVarDef<int> RMCHijackCrashStunTimeSeconds =
+        CVarDef.Create("rmc.hijack_crash_stun_time_seconds", 5, CVar.REPLICATED | CVar.SERVER);
+
     public static readonly CVarDef<float> RMCMovementPenCapSubtract =
         CVarDef.Create("rmc.movement_pen_cap_subtract", 0.8f, CVar.REPLICATED | CVar.SERVER);
 

--- a/Content.Shared/_RMC14/Hijack/RMCHijackActiveMapComponent.cs
+++ b/Content.Shared/_RMC14/Hijack/RMCHijackActiveMapComponent.cs
@@ -16,6 +16,9 @@ public sealed partial class RMCHijackActiveMapComponent : Component
     public TimeSpan NextDelay = TimeSpan.FromSeconds(15);
 
     [DataField]
+    public bool InitialPipeBarragePending;
+
+    [DataField]
     public List<EntityUid> Explode = new();
 
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField]


### PR DESCRIPTION
## About the PR
Delays the first hijack pipe explosion barrage until after the crash stun from the hijacked dropship landing has ended.

## Why / Balance
Players are currently stunned immediately when the hijacked dropship crashes into the ship, while the pipe explosion cycle also starts immediately. This can cause pipe warnings/explosions to begin while players are still unable to react.

This keeps the crash impact and structural hijack damage intact, but gives players control back before the pipe barrage begins.

## Technical details
Added `rmc.hijack_crash_stun_time_seconds` as the shared timing source for the hijack crash stun duration.

`CMDistressSignalRuleSystem` now uses that CVar for the crash paralyze duration. `RMCHijackRandomDamageSystem` also uses the same CVar to delay the initial pipe barrage by the same amount, instead of starting it immediately on `DropshipHijackLandedEvent`.

Added `InitialPipeBarragePending` to `RMCHijackActiveMapComponent` so the first barrage can still use the initial pipe percentages after the delay. Later pipe barrages continue using the existing `NextDelay`.

## Media
Not required, timing-only gameplay fix.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:GrigoriyGalintano
- fix: Delayed hijack pipe explosions until after the dropship crash stun ends.