### PR TITLE
Xeno grabing a pulled target starts devours

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Devour/XenoDevourSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Devour/XenoDevourSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared._RMC14.Actions;
 using Content.Shared._RMC14.Armor;
 using Content.Shared._RMC14.Attachable.Components;
 using Content.Shared._RMC14.CombatMode;
+using Content.Shared._RMC14.Fireman;
 using Content.Shared._RMC14.Inventory;
 using Content.Shared._RMC14.Pulling;
 using Content.Shared._RMC14.Synth;
@@ -106,6 +107,7 @@ public sealed class XenoDevourSystem : EntitySystem
         SubscribeLocalEvent<XenoDevourComponent, RMCCombatModeInteractOverrideUserEvent>(OnXenoCombatModeInteract);
         SubscribeLocalEvent<XenoDevourComponent, InteractUsingEvent>(OnXenoDevouredInteractWith);
         SubscribeLocalEvent<XenoDevourComponent, VentEnterAttemptEvent>(OnXenoDevouredVentAttempt);
+        SubscribeLocalEvent<XenoDevourComponent, RMCPullToggleEvent>(OnXenoDevourPullToggle);
 
         SubscribeLocalEvent<UsableWhileDevouredComponent, CMGetArmorPiercingEvent>(OnUsableWhileDevouredGetArmorPiercing);
     }
@@ -358,6 +360,12 @@ public sealed class XenoDevourSystem : EntitySystem
             return;
 
         if (StartDevourPulled(args.User))
+            args.Handled = true;
+    }
+
+    private void OnXenoDevourPullToggle(Entity<XenoDevourComponent> xeno, ref RMCPullToggleEvent args)
+    {
+        if (StartDevourPulled(xeno))
             args.Handled = true;
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title!

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity! I will note in parity I think it gets the normal delay from marine aggressive grabbing, but then it just becomes worst then click interacting, so I wasn't sure if I should add that (because you can still do the old method there).

## Technical details
<!-- Summary of code changes for easier review. -->
RMCPullToggle & StartDevourPulled.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->


https://github.com/user-attachments/assets/47ef3632-af12-476f-b58f-1932799db3b0


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Xenos grabbing a pulled target now starts devouring them.
