### PR TITLE
[PVE] Type 71 Rack Fix

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/GunRacks/rifles.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/GunRacks/rifles.yml
@@ -604,7 +604,7 @@
           - RMCWeaponRifleType71PVE
 
 - type: entity
-  parent: RMCGunRackType71Empty
+  parent: RMCGunRackType71EmptyPVE
   id: RMCGunRackType71FilledPVE
   suffix: Type 71, Filled, PVE
   components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The filled PVE Type 71 rack now properly renders and can be refilled with PVE Type 71s.

## Why / Balance
Resolves #8762

## Technical details
yaml, the filled variant of the rack was incorrectly parented off the non-PVE rack

## Media


https://github.com/user-attachments/assets/72a1c8d0-be25-4be7-afca-eaeeacef79f5



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: [PVE] The PVE variant of the Type 71 gun rack now functions properly

