### PR TITLE
Acid mine doesn't damage sentry guns and weapon mounts

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/AcidMine/XenoAcidBlastSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/AcidMine/XenoAcidBlastSystem.cs
@@ -149,9 +149,7 @@ public sealed class XenoAcidBlastSystem : EntitySystem
         return !HasComp<MobStateComponent>(target) &&
                !_hive.FromSameHive(ent.Owner, target) &&
                HasComp<DamageableComponent>(target) &&
-               (HasComp<WeaponMountComponent>(target) ||
-                HasComp<SentryComponent>(target) ||
-                HasComp<BarricadeComponent>(target));
+               HasComp<BarricadeComponent>(target);
     }
 
     private void ApplyStructureDamage(Entity<XenoAcidBlastComponent> ent, EntityUid target)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The Sapper's "Acid Mine" ability no longer damages sentry guns and weapon mounts.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix: Fixed the Boiler Sapper's "Acid Mine" ability damaging sentry guns and weapon mounts.
