### PR TITLE
Disabled Hold-To-Fire on Su-6

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/su6_pistol.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/su6_pistol.yml
@@ -27,6 +27,7 @@
     - Burst
     soundGunshot:
       path: /Audio/_RMC14/Weapons/Guns/Gunshots/su6_shoot.ogg
+  - type: GunClickToFire
   - type: RMCSelectiveFire
     baseFireModes:
     - SemiAuto


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added GunClickToFire component to the su-6 yaml.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The SU-6 is my (and others') replacement for the M13 now that the M13 has been parity nerfed. Currently, the SU-6 has 300 DPS 20 AP @ 0 tiles and 250 DPS 20 AP @ 5 tiles, which makes it better than marine primaries at close range with the only downside being the small magazine size and somewhat nasty falloff. Ammo is plentiful in squad ammo vendors and in requisitions.
In lieu of deviating from parity and changing its stats, and with the spirit of the M13 parity nerf in mind, I've disabled the hold-to-fire accessibility feature on the SU-6. We can adjust its stats and re-add hold-to-fire post-parity.

## Technical details
<!-- Summary of code changes for easier review. -->
Oneline yamlmaxxing

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
Small fix, not adding media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The SU-6 Smart Pistol can no longer be used with hold-to-fire.
