### PR TITLE
Increase the range of all grenade launchers and increase the M83 fire rate

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/base_grenade_launcher.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/base_grenade_launcher.yml
@@ -21,7 +21,7 @@
     recoilWielded: 2
   - type: ShootAtFixedPoint
     shootArcProj: true
-    maxFixedRange: 7
+    maxFixedRange: 8.463 # The result of CircleAreaFromSquareAbilityRange(7)
   - type: OnShootTriggerAmmoTimer
     delay: 1
     beepInterval: 2

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m74_airburst_grenades.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m74_airburst_grenades.yml
@@ -138,7 +138,7 @@
   - type: Projectile
     deleteOnCollide: false
     impactEffect: BulletImpactEffect
-    maxFixedRange: 8.463
+    maxFixedRange: 8.463 #The result of CircleAreaFromSquareAbilityRange(7)
     damage:
       types:
         Piercing: 100

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m74_airburst_grenades.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m74_airburst_grenades.yml
@@ -138,7 +138,7 @@
   - type: Projectile
     deleteOnCollide: false
     impactEffect: BulletImpactEffect
-    maxFixedRange: 7
+    maxFixedRange: 8.463
     damage:
       types:
         Piercing: 100

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m83_grenade_launcher.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m83_grenade_launcher.yml
@@ -26,7 +26,7 @@
   #- type: Clothing
   #  sprite: _RMC14/Objects/Weapons/Guns/GrenadeLaunchers/m83inhands.rsi
   - type: RMCSelectiveFire
-    baseFireRate: 0.3125
+    baseFireRate: 0.833
   - type: GunUserWhitelist
     whitelist:
       components:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m83_grenade_launcher.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m83_grenade_launcher.yml
@@ -26,7 +26,7 @@
   #- type: Clothing
   #  sprite: _RMC14/Objects/Weapons/Guns/GrenadeLaunchers/m83inhands.rsi
   - type: RMCSelectiveFire
-    baseFireRate: 0.833
+    baseFireRate: 0.675
   - type: GunUserWhitelist
     whitelist:
       components:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m85a1_grenade_launcher.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m85a1_grenade_launcher.yml
@@ -19,7 +19,7 @@
     soundGunshot:
       path: /Audio/_RMC14/Weapons/Guns/Gunshots/m79_shoot.ogg
   - type: RMCSelectiveFire
-    baseFireRate: 0.833
+    baseFireRate: 0.3125
   - type: BallisticAmmoProvider
     whitelist:
       tags:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m85a1_grenade_launcher.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m85a1_grenade_launcher.yml
@@ -19,7 +19,7 @@
     soundGunshot:
       path: /Audio/_RMC14/Weapons/Guns/Gunshots/m79_shoot.ogg
   - type: RMCSelectiveFire
-    baseFireRate: 0.3125
+    baseFireRate: 0.833
   - type: BallisticAmmoProvider
     whitelist:
       tags:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

- Increased the M83 firerate from 0.3125 to 0.675
- Increased the grenade launcher max range from 7 to 8.463

Should be merged with https://github.com/RMC-14/RMC-14/pull/9632
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Balance change and a fix.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix: Fixed grenade launchers not having enough range, increased from 7 to 8.463.
- tweak: Increased the firerate of the Grenadier's M83 grenade launcher from 0.3125 to 0.675

