### PR TITLE
Fix expendable lights burning out too soon.

### DIFF
--- a/Content.Client/Light/EntitySystems/ExpendableLightVisualizerSystem.cs
+++ b/Content.Client/Light/EntitySystems/ExpendableLightVisualizerSystem.cs
@@ -57,9 +57,11 @@ public sealed class ExpendableLightVisualizerSystem : VisualizerSystem<Expendabl
             case ExpendableLightState.PhaseFour:
             case ExpendableLightState.PhaseFive:
             case ExpendableLightState.Fading:
-                _audioSystem.Stop(comp.PlayingStream);
-                comp.PlayingStream = _audioSystem.PlayPvs(
-                    comp.LoopedSound, uid)?.Entity;
+                if (state != ExpendableLightState.PhaseOne)
+                    _audioSystem.Stop(comp.PlayingStream);
+
+                if (state == ExpendableLightState.Lit)
+                    comp.PlayingStream = _audioSystem.PlayPvs(comp.LoopedSound, uid)?.Entity;
 
                 if (SpriteSystem.LayerMapTryGet((uid, args.Sprite), ExpendableLightVisualLayers.Overlay, out var layerIdx, true))
                 {

--- a/Content.Server/Light/EntitySystems/ExpendableLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/ExpendableLightSystem.cs
@@ -108,6 +108,7 @@ namespace Content.Server.Light.EntitySystems
                     //RMC14
                     case ExpendableLightState.PhaseThree:
                         component.CurrentState = ExpendableLightState.PhaseFour;
+                        component.StateExpiryTime = (float)component.PhaseFourDuration.TotalSeconds;
 
                         if (component.PhaseFourDuration.TotalSeconds != 0f)
                             UpdateVisualizer(ent);
@@ -115,6 +116,7 @@ namespace Content.Server.Light.EntitySystems
                     //RMC14
                     case ExpendableLightState.PhaseFour:
                         component.CurrentState = ExpendableLightState.PhaseFive;
+                        component.StateExpiryTime = (float)component.PhaseFiveDuration.TotalSeconds;
 
                         if (component.PhaseFiveDuration.TotalSeconds != 0f)
                             UpdateVisualizer(ent);

--- a/Content.Shared/Light/Components/ExpendableLightComponent.cs
+++ b/Content.Shared/Light/Components/ExpendableLightComponent.cs
@@ -60,7 +60,7 @@ public sealed partial class ExpendableLightComponent : Component
     /// <summary>
     /// The sound that plays when the expendable light is lit.
     /// </summary>
-    [DataField, AutoNetworkedField]
+    [DataField]
     public EntityUid? PlayingStream;
 
     /// <summary>

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Tools/flares.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Tools/flares.yml
@@ -209,6 +209,8 @@
   - type: Sprite
     sprite: _RMC14/Objects/Misc/flares.rsi
     layers:
+    - map: [ "enum.ExpendableLightVisualLayers.Base" ]
+      state: starshell_ash
     - map: [ "enum.ExpendableLightVisualLayers.Glow" ]
       sprite: _RMC14/Objects/Misc/flares.rsi
       state: starshell_ash-on
@@ -216,7 +218,7 @@
       visible: false
     - map: [ "enum.ExpendableLightVisualLayers.Overlay" ]
       sprite: _RMC14/Objects/Misc/flares.rsi
-      state: starshell_ash
+      state: overlay
   - type: Icon
     sprite: _RMC14/Objects/Misc/flares.rsi
     state: starshell_ash


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

- Expendable lights no longer skip phase 4 and phase 5 of their light range curve, which made them extinguish too soon.
- Expendable lights no longer stack their sound multiple times when changing stage.
- Fixed an error related to starshell ash not having a base visualizer state.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes

<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix: Flares no longer play their "ignition" sound multiple times.
- fix: Fixed flares extinguishing too soon.
