### PR TITLE
Make critical mark spread predicted, spread to nearest first + tail trip fix

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Finesse/XenoFinesseSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Finesse/XenoFinesseSystem.cs
@@ -11,6 +11,7 @@ using Content.Shared.StatusEffect;
 using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.Network;
 using Robust.Shared.Timing;
+using System.Linq;
 
 namespace Content.Shared._RMC14.Xenonids.Finesse;
 
@@ -25,6 +26,7 @@ public sealed class XenoFinesseSystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedActionsSystem _actions = default!;
     [Dependency] private readonly ExamineSystemShared _examine = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
 
     private readonly HashSet<Entity<MarineComponent>> _marines = new();
     public override void Initialize()
@@ -94,11 +96,14 @@ public sealed class XenoFinesseSystem : EntitySystem
         EnsureComp<XenoCriticalMarkSpreadImmunityComponent>(hit).WearOffAt = currTime + xeno.Comp.CriticalMarkSpreadImmuneDuration;
 
         var spreadEffected = 0;
+        var selfCoords = xeno.Owner.ToCoordinates();
 
         _marines.Clear();
-        _entityLookup.GetEntitiesInRange(xeno.Owner.ToCoordinates(), xeno.Comp.SpreadCriticalMarkRange, _marines);
+        _entityLookup.GetEntitiesInRange(selfCoords, xeno.Comp.SpreadCriticalMarkRange, _marines);
 
-        foreach (var marine in _marines)
+        var nearestMarines = _marines.ToList().OrderBy(a => selfCoords.TryDistance(EntityManager, a.Owner.ToCoordinates(), out var distance) ? distance : 20).ToList();
+
+        foreach (var marine in nearestMarines)
         {
             if (!_examine.InRangeUnOccluded(xeno, marine, xeno.Comp.SpreadCriticalMarkRange))
                 continue;

--- a/Content.Shared/_RMC14/Xenonids/Finesse/XenoFinesseSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Finesse/XenoFinesseSystem.cs
@@ -2,6 +2,7 @@ using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.Xenonids.Impale;
 using Content.Shared._RMC14.Xenonids.TailTrip;
 using Content.Shared.Actions;
+using Content.Shared.Coordinates;
 using Content.Shared.Damage;
 using Content.Shared.Examine;
 using Content.Shared.Mobs.Systems;
@@ -69,9 +70,6 @@ public sealed class XenoFinesseSystem : EntitySystem
 
     private void OnXenoMarkedDamageChanged(Entity<XenoSpreadMarkAttemptComponent> marked, ref DamageChangedEvent args)
     {
-        if (_net.IsClient)
-            return;
-
         if (!TryComp<XenoFinesseComponent>(marked.Comp.Origin, out var finesse))
             return;
 
@@ -96,9 +94,9 @@ public sealed class XenoFinesseSystem : EntitySystem
         EnsureComp<XenoCriticalMarkSpreadImmunityComponent>(hit).WearOffAt = currTime + xeno.Comp.CriticalMarkSpreadImmuneDuration;
 
         var spreadEffected = 0;
-        _marines.Clear();
 
-        _entityLookup.GetEntitiesInRange(Transform(xeno).Coordinates, xeno.Comp.SpreadCriticalMarkRange, _marines);
+        _marines.Clear();
+        _entityLookup.GetEntitiesInRange(xeno.Owner.ToCoordinates(), xeno.Comp.SpreadCriticalMarkRange, _marines);
 
         foreach (var marine in _marines)
         {
@@ -125,7 +123,10 @@ public sealed class XenoFinesseSystem : EntitySystem
         }
 
         if (spreadEffected > 0)
+        {
             xeno.Comp.NextCriticalMarkSpreadTime = currTime + xeno.Comp.CritcalMarkSpreadCooldown;
+            Dirty(xeno);
+        }
     }
 
     public override void Update(float frameTime)

--- a/Content.Shared/_RMC14/Xenonids/TailTrip/XenoTailTripSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/TailTrip/XenoTailTripSystem.cs
@@ -65,6 +65,6 @@ public sealed class XenoTailTripSystem : EntitySystem
             _slow.TrySlowdown(args.Target, xeno.Comp.SlowTime, ignoreDurationModifier: true);
         }
 
-        args.Handled = criticalMark;
+        args.Handled = !criticalMark;
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Its good, its parity, thats a bug.

## Technical details
<!-- Summary of code changes for easier review. -->
Forgor to dirty the dancer's comp. Sometimes there's an issue of mispredicting the target but it's better.

Stole some bits from scissorcut code for ordering by nearest to dancer.

I forgot a !

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed Dancer Praetorian's critical mark spreading not being predicted and not prioritizing nearest targets to the dancer first.
- fix: Fixed Tail Trip having no cooldown when used off a normal mark or no mark.