### PR TITLE
Removes left click restocking on medical vendors.

### DIFF
--- a/Content.Shared/_RMC14/Vendors/SharedCMAutomatedVendorSystem.cs
+++ b/Content.Shared/_RMC14/Vendors/SharedCMAutomatedVendorSystem.cs
@@ -339,16 +339,6 @@ public abstract class SharedCMAutomatedVendorSystem : EntitySystem
             TryHackVendor(ent, args.User, args.Used);
             return;
         }
-
-        // Medical vendor restocking QoL - single items only
-        if (!HasComp<RMCMedLinkPortReceiverComponent>(ent) || !ent.Comp.CanManualRestock)
-            return;
-        if (args.Handled) // CMRefillableSolutionSystem. Only try to restock if the refill system didn't handle it (e.g., autoinjector already full).
-            return;
-        if (HasComp<StorageComponent>(args.Used)) // Use alt click for bulk restock
-            return;
-        if (TryRestockSingleItem(ent, args.Used, args.User))
-            args.Handled = true;
     }
 
     // Better than drag and drop to restock.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It's not popular because chem mains love their speed.

## Technical details
<!-- Summary of code changes for easier review. -->
Shrimple deletion and adjustments.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Left clicking no longer restocks medical vendors, use alt+left-click or right-click verb menu instead. For all my left-click spamming chemists out there. <3
