### PR TITLE
Parity medical locker

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Storage/lockers.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Storage/lockers.yml
@@ -231,7 +231,7 @@
     access: [["CMAccessMedical"]]
   - type: StorageFill
     contents:
-     #- id: RMCJumpsuitDoctor RMC14 TODO nly when cold map
+     #- id: RMCJumpsuitDoctor RMC14 TODO only when cold map & a scarf
       - id: RMCLabcoat
       - id: RMCLabcoatShort
       - id: RMCLabcoatLong
@@ -243,6 +243,7 @@
       - id: RMCPouchSyringe
       - id: RMCPouchMedkit
       - id: RMCPouchChem
+      - id: CMSatchelMarine
 
 - type: entity
   parent: CMLockerBase

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Storage/lockers.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Storage/lockers.yml
@@ -226,9 +226,23 @@
   name: medical doctor's locker
   components:
   - type: Sprite
-    sprite: _RMC14/Structures/Storage/Lockers/medical.rsi
+    sprite: _RMC14/Structures/Storage/Lockers/medical_white.rsi
   - type: AccessReader
     access: [["CMAccessMedical"]]
+  - type: StorageFill
+    contents:
+     #- id: RMCJumpsuitDoctor RMC14 TODO nly when cold map
+      - id: RMCLabcoat
+      - id: RMCLabcoatShort
+      - id: RMCLabcoatLong
+      - id: RMCShoesWhite
+      - id: RMCMaskBreath
+      - id: CMMaskSterile
+      - id: RMCGlassesMedicalHUDGlasses
+      - id: RMCPouchMedical
+      - id: RMCPouchSyringe
+      - id: RMCPouchMedkit
+      - id: RMCPouchChem
 
 - type: entity
   parent: CMLockerBase


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds the missing items to the doctors medical locker, changes sprite to correct white variant. 
Parity is containing a medical headset on being on the almayer through a a zlevel check, but probably best to just make a separate locker for this
The cold weather could probably just be a separate locker as well (would be cleaner)
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
<img width="757" height="427" alt="image" src="https://github.com/user-attachments/assets/43d9eb6c-e91b-4b87-b94d-2bf213def54e" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Vixting
- add: Added missing items to the Doctor's medical locker.
