### PR TITLE
[Fix] Missing light blue 'nurses' outfit from doc/cmo vendor

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/command.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/command.yml
@@ -1328,6 +1328,7 @@
         recommended: true
       - id: RMCJumpsuitDoctor
       - id: CMScrubsBlue
+      - id: RMCScrubsLightBlue
       - id: CMScrubsGreen
       - id: RMCScrubsPharm
       - id: CMScrubsPurple

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/medical.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/medical.yml
@@ -78,6 +78,7 @@
       - id: RMCScrubsBrown
       - id: RMCScrubsWhite
       - id: RMCScrubsBlack
+      - id: RMCScrubsLightBlue
     - name: Suit
       jobs:
       - CMNurse


### PR DESCRIPTION
## About the PR
The light blue medical outfit was made the 'nurses' outfit, but was removed from the CMO/Doc vendors, this just returns it, for the drip.

## Technical details
2 lines yaml

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Returned light blue outfit to CMO/Doc vendor
