### PR TITLE
Fixed a Minor Grammar Mistake in Stethoscope Inspect

### DIFF
--- a/Resources/Locale/en-US/_RMC14/medical/rmc-stethoscope.ftl
+++ b/Resources/Locale/en-US/_RMC14/medical/rmc-stethoscope.ftl
@@ -19,6 +19,6 @@ rmc-stethoscope-verb-message = Listen using the stethoscope.
 
 # Temporary until real organs are implemented. Delete when fully implemented.
 rmc-stethoscope-normal = You hear [color=green]normal heart beating patterns[/color] and [color=green]normal respiration sounds[/color] as well, {POSS-ADJ($target)} heart and lungs are [color=green]healthy[/color], probably.
-rmc-stethoscope-raggedy = You hear [color=yellow]small murmurs with each heart beat[/color] and [color=yellow]some crackles when {SUBJECT($target)} breath[/color].
+rmc-stethoscope-raggedy = You hear [color=yellow]small murmurs with each heart beat[/color] and [color=yellow]some crackles when {SUBJECT($target)} breathes[/color].
 rmc-stethoscope-hyper = You hear [color=orange]deviant heart beating patterns[/color] and [color=orange]unusual respiration sounds[/color].
 rmc-stethoscope-irregular = You hear [color=red]irregular and additional heart beating patterns[/color] and [color=red]barely hear any respiration sounds[/color], {SUBJECT($target)} is having a lot of difficulty breathing.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed "when (name) breath" to "when (name) breathes."

## Why / Balance
Once I saw it, I could not unsee it, and it bothered me.

## Technical details
One word replaced in text

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
<img width="295" height="63" alt="Screenshot 2026-06-14 155011" src="https://github.com/user-attachments/assets/3dde2d45-0dbe-4eed-922e-8e47760c6ed7" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [ X ] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Tuna224
- fix: Fixed a small grammar mistake in the stethoscopes inspect on wounded patients. 
