### PR TITLE
[Fix] Empty Magazines spawned/mapped are no longer Proto Null

### DIFF
--- a/Content.Shared/_RMC14/Weapons/Ranged/Ammo/RMCEmptyMagComponent.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/Ammo/RMCEmptyMagComponent.cs
@@ -1,0 +1,4 @@
+namespace Content.Shared._RMC14.Weapons.Ranged.Ammo;
+
+[RegisterComponent]
+public sealed partial class RMCEmptyMagComponent : Component;

--- a/Content.Shared/_RMC14/Weapons/Ranged/Ammo/RMCEmptyMagSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/Ammo/RMCEmptyMagSystem.cs
@@ -9,6 +9,7 @@ public sealed class RMCEmptyMagSystem : EntitySystem
 
     public override void Initialize()
     {
+        base.Initialize();
         SubscribeLocalEvent<RMCEmptyMagComponent, MapInitEvent>(OnMapInit,
             after: new[] { typeof(SharedGunSystem) });
     }

--- a/Content.Shared/_RMC14/Weapons/Ranged/Ammo/RMCEmptyMagSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/Ammo/RMCEmptyMagSystem.cs
@@ -1,0 +1,21 @@
+using Content.Shared.Weapons.Ranged.Components;
+using Content.Shared.Weapons.Ranged.Systems;
+
+namespace Content.Shared._RMC14.Weapons.Ranged.Ammo;
+
+public sealed class RMCEmptyMagSystem : EntitySystem
+{
+    [Dependency] private readonly SharedGunSystem _gun = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<RMCEmptyMagComponent, MapInitEvent>(OnMapInit,
+            after: new[] { typeof(SharedGunSystem) });
+    }
+
+    private void OnMapInit(Entity<RMCEmptyMagComponent> ent, ref MapInitEvent args)
+    {
+        if (TryComp(ent, out BallisticAmmoProviderComponent? ballistic))
+            _gun.SetBallisticUnspawned((ent, ballistic), 0);
+    }
+}

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/mk80_pistol.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/mk80_pistol.yml
@@ -133,8 +133,7 @@
   id: RMCMagazinePistolMK80Empty
   suffix: Empty
   components:
-  - type: BallisticAmmoProvider
-    proto: null
+  - type: RMCEmptyMag
 
 - type: entity
   id: RMCCartridgePistol9mmSquashHead

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/Type77_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/Type77_rifle.yml
@@ -201,8 +201,7 @@
   id: RMCMagazineRifleType77Empty
   suffix: Empty
   components:
-  - type: BallisticAmmoProvider
-    proto: null
+  - type: RMCEmptyMag
 
 - type: entity
   parent: RMCMagazineRifleType77

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/l42a.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/l42a.yml
@@ -119,8 +119,7 @@
   id: RMCMagazineRifleL42AEmpty
   suffix: Empty
   components:
-  - type: BallisticAmmoProvider
-    proto: null
+  - type: RMCEmptyMag
 
 - type: entity
   parent: RMCMagazineRifleL42A
@@ -152,8 +151,7 @@
   id: RMCMagazineRifleL42AExtendedEmpty
   suffix: Empty
   components:
-  - type: BallisticAmmoProvider
-    proto: null
+  - type: RMCEmptyMag
 
 
 - type: entity
@@ -251,8 +249,7 @@
   id: RMCMagazineRifleL42AAPEmpty
   suffix: Empty
   components:
-  - type: BallisticAmmoProvider
-    proto: null
+  - type: RMCEmptyMag
 
 - type: Tag
   id: RMCWeaponRifleL42A

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m4spr_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m4spr_rifle.yml
@@ -403,8 +403,7 @@
   id: RMCMagazineRifleM4SPRAPEmpty
   suffix: AP, Empty
   components:
-  - type: BallisticAmmoProvider
-    proto: null
+  - type: RMCEmptyMag
 
 - type: entity
   parent: CMMagazineRifleM4SPR

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m54c_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m54c_rifle.yml
@@ -487,8 +487,7 @@
   id: RMCMagazineRifleM54CHEAPEmpty
   suffix: HEAP, Empty
   components:
-  - type: BallisticAmmoProvider
-    proto: null
+  - type: RMCEmptyMag
 
 - type: entity
   parent: CMMagazineRifleM54C

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/ssg45.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/ssg45.yml
@@ -295,8 +295,7 @@
   id: RMCMagazineRifleSSG45HEAPEmpty
   suffix: HEAP, Empty
   components:
-  - type: BallisticAmmoProvider
-    proto: null
+  - type: RMCEmptyMag
 
 - type: entity
   parent: RMCMagazineRifleSSG45

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/m63_smg.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/m63_smg.yml
@@ -266,8 +266,7 @@
   id: RMCMagazineSMGM63HEAPEmpty
   suffix: HEAP, Empty
   components:
-  - type: BallisticAmmoProvider
-    proto: null
+  - type: RMCEmptyMag
 
 - type: entity
   parent: CMMagazineSMGM63


### PR DESCRIPTION
## About the PR
Fixes #9991 
Empty magazines spawned on the map can be reliably used, even with spam cans (if avail)

## Why / Balance
Bugfix.  Most straightforward way I could think to do empty mags without the nulls or touching upstream.

## Technical details
EmptyMagComp marker and System 


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:

- fix: Fixed mapped empty magazines from firing non-existent bullets if reloaded from a spam can.

