### PR TITLE
Fix: trijent dam prop bugs

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/rmc_filtration_props.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/rmc_filtration_props.yml
@@ -127,6 +127,8 @@
     state: flacculation_arm
     offset: "-0.5, 0.0"
 
+# Main filtration machines
+
 - type: entity
   parent: RMCFiltration
   id: RMCFiltrationMachine
@@ -139,7 +141,7 @@
       fix1:
         shape:
           !type:PhysShapeAabb
-          bounds: "-0.49,-1.49,0.49,1.49"
+          bounds: "-0.5,-2.5,1.5,1.5"
         density: 60
         layer:
         - MobMask
@@ -147,8 +149,6 @@
     sprite: _RMC14/Structures/Filtration/64x128.rsi
     state: filtration
     offset: "0.5, -0.5"
-
-# Main filtration machines
 
 - type: entity
   parent: RMCFiltrationMachine
@@ -340,6 +340,8 @@
   - type: Sprite
     sprite: _RMC14/Structures/Filtration/32x32.rsi
     state: ne1
+  - type: Destructible
+    thresholds: []
 
 - type: entity
   parent: RMCCoagulationCatwalkNE1
@@ -350,14 +352,11 @@
     state: ne2
 
 - type: entity
-  parent: CMCatwalk
+  parent: RMCCoagulationCatwalkNE1
   id: RMCCoagulationCatwalkNE3
-  name: coagulation catwalk
-  description: ""
   suffix: NE, lower
   components:
   - type: Sprite
-    sprite: _RMC14/Structures/Filtration/32x32.rsi
     state: ne3
 
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The catwalks around the Coagulation pits are made unbreakable to not reveal the NON toxic water below it 
Fixed the hitbox on a filtration prop as it was mapped wrong
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
bug fix

## Technical details
<!-- Summary of code changes for easier review. -->
.yml changes

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
The edges of this pit are made unbreakable as the water below is NON toxic water. Because their are breakable right now the player comes in contact with the NON toxic water which is mapped below it

<img width="566" height="555" alt="grafik" src="https://github.com/user-attachments/assets/e832d494-9c30-4ad4-a598-e5d185280315" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: The edges of the coagulation pits on trijent dam are now unbreakable!

