### PR TITLE
[Fix] Xenos can no longer collapse the MB-6 folding barricade.

### DIFF
--- a/Content.Shared/_RMC14/Barricade/RMCFoldingBarricadeSystem.cs
+++ b/Content.Shared/_RMC14/Barricade/RMCFoldingBarricadeSystem.cs
@@ -2,6 +2,7 @@ using Content.Shared._RMC14.Construction;
 using Content.Shared._RMC14.Damage;
 using Content.Shared._RMC14.Marines.Skills;
 using Content.Shared._RMC14.Repairable;
+using Content.Shared._RMC14.Xenonids;
 using Content.Shared._RMC14.Xenonids.Acid;
 using Content.Shared._RMC14.Xenonids.Spray;
 using Content.Shared.ActionBlocker;
@@ -284,6 +285,9 @@ public sealed class RMCFoldingBarricadeSystem : EntitySystem
         if (!args.CanAccess || !args.CanInteract)
             return;
 
+        if (HasComp<XenoComponent>(args.User))
+            return;
+
         var user = args.User;
         args.Verbs.Add(new AlternativeVerb
         {
@@ -303,6 +307,9 @@ public sealed class RMCFoldingBarricadeSystem : EntitySystem
         if (args.User != args.Target)
             return;
 
+        if (HasComp<XenoComponent>(args.User))
+            return;
+
         args.CanDrop = true;
         args.Handled = true;
     }
@@ -310,6 +317,9 @@ public sealed class RMCFoldingBarricadeSystem : EntitySystem
     private void OnBarricadeDragDropDragged(Entity<RMCFoldingBarricadeComponent> ent, ref DragDropDraggedEvent args)
     {
         if (args.User != args.Target)
+            return;
+
+        if (HasComp<XenoComponent>(args.User))
             return;
 
         args.Handled = true;
@@ -344,6 +354,9 @@ public sealed class RMCFoldingBarricadeSystem : EntitySystem
 
     private void OnBarricadeExamined(Entity<RMCFoldingBarricadeComponent> ent, ref ExaminedEvent args)
     {
+        if (HasComp<XenoComponent>(args.Examiner))
+            return;
+
         using (args.PushGroup(nameof(RMCFoldingBarricadeComponent)))
         {
             args.PushMarkup(Loc.GetString("rmc-folding-barricade-deployed-examine"));


### PR DESCRIPTION
## About the PR
Xenos can no longer ALT+Leftclick or drag onto sprite to unpack the MB-6 folding barricades.
Fixes the examine text to no longer show "drag to collapse" portion for xenos.
## Why / Balance
Bugfix for unintended interactions.

## Technical details
Compcheck returns

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- fix: Fixed Xenos being able to collapse the MB-6 folding barricade.

