### PR TITLE
Changes the Division mentioned in the CL Guidebook page

### DIFF
--- a/Resources/ServerInfo/Guidebook/_RMC14/Guides/RMCGuideCorporateLiaison.xml
+++ b/Resources/ServerInfo/Guidebook/_RMC14/Guides/RMCGuideCorporateLiaison.xml
@@ -17,7 +17,7 @@
     <GuideEntityEmbed Entity="CMGuidebookRoleLiaisonYou"/>
   </Box>
 
-  Welcome to the [bold][color=#eb7a23]Weston[/color]-[color= #25b266]Yamada[/color] Corporation[/bold]! You have chosen to become a member of the Special Services Division as a Liaison; our representatives, sent afar to make sure that our interests are maintained and protected. However, that can feel vague and confusing, especially to Jr. Executives who aren’t yet acclimatized to the expectations and duties of the role. This guide is intended to fix that, by developing a set of Do’s and Don’ts, as well as establishing expectations and highlighting the resources you have access to.
+  Welcome to the [bold][color=#eb7a23]Weston[/color]-[color= #25b266]Yamada[/color] Corporation[/bold]! You have chosen to become a member of the Communications Division as a Liaison; our representatives, sent afar to make sure that our interests are maintained and protected. However, that can feel vague and confusing, especially to Jr. Executives who aren’t yet acclimatized to the expectations and duties of the role. This guide is intended to fix that, by developing a set of Do’s and Don’ts, as well as establishing expectations and highlighting the resources you have access to.
 
 
   ## Don’ts


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changes the Division mentioned that the Liaison belongs to from "Special Services" to "Communications"

## Why / Balance
Matches our lore better, Special Services isn't really present.

## Technical details
One XAML file

## Media
Very small fix.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: Changed the Liaison's Division from "Special Services" to "Communications"