### PR TITLE
Security colonists on Fiorina can no longer roll for prisoner

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/rmc_planets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/rmc_planets.yml
@@ -233,6 +233,7 @@
       - CMSurvivor: -1
       - CMSurvivorISR: -1
       - CMSurvivorGangLeader: -1
+      - CMSurvivorPrisoner: -1
       CMSurvivorCorporate:
       - CMSurvivorFiorinaCorporateLiaison: 2
       CMSurvivorDoctor:
@@ -240,7 +241,6 @@
       CMSurvivorEngineer:
       - CMSurvivorFiorinaEngineer: 2
       CMSurvivorSecurity:
-      - CMSurvivorPrisoner: 2
       - CMSurvivorFiorinaPrisonGuard: 2
       - CMSurvivorFiorinaRiotOfficer: 2
       CMSurvivorScientist:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Misc/prisoner_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Misc/prisoner_survivor.yml
@@ -4,7 +4,7 @@
   id: CMSurvivorPrisoner
   name: cm-job-name-survivor-prisoner
   description: cm-job-description-survivor
-  playTimeTracker: CMJobSurvivorSecurity
+  playTimeTracker: CMJobSurvivor
   startingGear: RMCGearSurvivorPrisoner
   spawnMenuRoleName: Prisoner (Survivor)
   special:
@@ -21,7 +21,7 @@
       - Civilian
     - type: IntelRescueSurvivorObjective
     - type: RMCAllowSuitStorage
-  useLoadoutOfJob: CMSurvivorSecurity # for inheritance
+  useLoadoutOfJob: CMSurvivor # for inheritance
 
 - type: startingGear
   parent: RMCGearSurvivorBaseNoBackpack


### PR DESCRIPTION
## About the PR
Security survivor on Fiorina can no longer roll prisoner, now civilian survivor rolls for it instead

## Why / Balance
Prisoner has abysmal skills, all of which the other secsurv roles have (Medical 0, Engineering 0, Firearms 1) so they have no reason to take up limited slots like RCO's and weya goons do

Gang leader spawns with identical if not better equipment AND better skills and yet they are a civilian role so I see no reason why it shouldn't apply to both

## Technical details
Two lines of yaml

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Security Colonists can no longer become Prisoners, you must now roll Civilian Colonist to become one