### PR TITLE
[Fix] High Command/Provost Marshal will have its proper accesses now.

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/IdCards/cm_id_other.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/IdCards/cm_id_other.yml
@@ -271,7 +271,7 @@
 - type: entity
   parent: RMCIDCardProvost
   id: RMCIDCardProvostAdvisor
-  name: provost advisor ID card
+  name: Provost Advisor ID card
   components:
   - type: PresetIdCard
     job: CMProvostAdvisor
@@ -279,7 +279,7 @@
 - type: entity
   parent: RMCIDCardProvost
   id: RMCIDCardProvostEnforcer
-  name: provost enforcer ID card
+  name: Provost Enforcer ID card
   components:
   - type: PresetIdCard
     job: CMProvostEnforcer
@@ -287,7 +287,7 @@
 - type: entity
   parent: RMCIDCardProvost
   id: RMCIDCardProvostTeamLeader
-  name: provost team leader ID card
+  name: Provost Team Leader ID card
   components:
   - type: PresetIdCard
     job: CMProvostTeamLeader
@@ -303,7 +303,8 @@
 - type: entity
   parent: RMCIDCardProvost
   id: RMCIDCardProvostDeputyMarshal
-  name: provost deputy marshal ID card
+  name: Provost Deputy Marshal ID card
+  suffix: Admin
   components:
   - type: PresetIdCard
     job: CMProvostDeputyMarshal
@@ -311,7 +312,7 @@
 - type: entity
   parent: RMCIDCardProvost
   id: RMCIDCardProvostInspector
-  name: provost inspector ID card
+  name: Provost Inspector ID card
   components:
   - type: PresetIdCard
     job: CMProvostInspector
@@ -319,7 +320,8 @@
 - type: entity
   parent: RMCIDCardProvost
   id: RMCIDCardProvostMarshal
-  name: provost marshal ID card
+  name: Provost Marshal ID card
+  suffix: Admin
   components:
   - type: PresetIdCard
     job: CMProvostMarshal

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/High_Command/high_command_adjutant.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/High_Command/high_command_adjutant.yml
@@ -12,6 +12,8 @@
   supervisors: cm-job-supervisors-staff
   accessGroups:
   - ShipMasterAccess
+  access:
+  - CMAccessHighCommand
   special:
   - !type:AddComponentSpecial
     components:
@@ -54,7 +56,7 @@
   parent: CMIDCardGold
   id: RMCIDCardUNMCAdjutant
   name: UNMC Adjutant ID card
-  description: A fancy ID card. Issued to the adjutants of high command.
+  description: Issued to members of UNMC High Command.
   components:
   - type: Sprite
     sprite: _RMC14/Objects/CMIDs/general.rsi
@@ -63,13 +65,10 @@
     slots:
     - idcard
     sprite: _RMC14/Objects/CMIDs/general.rsi
+  - type: PresetIdCard
+    job: CMUNMCAdjutant
   - type: Item
     heldPrefix: green
-  - type: Access
-    groups:
-    - ShipMasterAccess
-    tags:
-    - CMAccessHighCommand
 
 - type: playTimeTracker
   id: CMJobUNMCAdjutant

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/High_Command/high_command_brigadier_general.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/High_Command/high_command_brigadier_general.yml
@@ -11,6 +11,13 @@
   joinNotifyCrew: false
   accessGroups:
   - ShipMasterAccess
+  - Colony
+  - Corp
+  - RMCWeYa
+  access:
+  - CMAccessHighCommand
+  - CMAccessXenoQueen
+  - CMAccessXeno
   special:
   - !type:AddComponentSpecial
     components:
@@ -56,12 +63,14 @@
     - RMCHeadBeretGeneral
 
 - type: entity
-  parent: IDCardStandard # Deliberately parenting off of upstream ID card cause it needs to work with admin access configurator.
+  parent: CMIDCardGold
   id: RMCIDCardUNMCBrigadierGeneral
   name: brigadier general ID card
   suffix: Admin
-  description: Issued to the top brass of the UNMC. Premium, sleek, built to last.
+  description: Issued to members of UNMC High Command.
   components:
+  - type: PresetIdCard
+    job: CMUNMCBrigadierGeneral
   - type: Sprite
     sprite: _RMC14/Objects/CMIDs/general.rsi
     state: general
@@ -71,16 +80,6 @@
     sprite: _RMC14/Objects/CMIDs/general.rsi
   - type: Item
     heldPrefix: green
-  - type: Access
-    groups:
-    - ShipMasterAccess
-    - Colony
-    - Corp
-    - RMCWeYa
-    tags:
-    - CMAccessHighCommand
-    - CMAccessXenoQueen
-    - CMAccessXeno
 
 - type: playTimeTracker
   id: CMJobUNMCBrigadierGeneral

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Provost/provost_deputy_marshal.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Provost/provost_deputy_marshal.yml
@@ -11,6 +11,13 @@
   joinNotifyCrew: false
   accessGroups:
   - ShipMasterAccess
+  - Colony
+  - Corp
+  - RMCWeYa
+  access:
+  - CMAccessHighCommand
+  - CMAccessXenoQueen
+  - CMAccessXeno
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Provost/provost_marshal.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Provost/provost_marshal.yml
@@ -11,6 +11,13 @@
   joinNotifyCrew: false
   accessGroups:
   - ShipMasterAccess
+  - Colony
+  - Corp
+  - RMCWeYa
+  access:
+  - CMAccessHighCommand
+  - CMAccessXenoQueen
+  - CMAccessXeno
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Ranks/UNMC/provost.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Ranks/UNMC/provost.yml
@@ -5,35 +5,33 @@
   prefix: PvSM.
   paygrade: O9
 
-# Any admin with high law understanding
+# Admin
 - type: rank
   id: RMCRankProvostSeniorMarshal
   name: Senior Marshal
   prefix: PvSnM.
   paygrade: O8
 
-# Any admin with low law understanding, or wanting a lower rank
+# Admin
 - type: rank
   id: RMCRankProvostMarshal
   name: Marshal
   prefix: PvM.
   paygrade: O7
 
-# Any whitelisted CO
+# Admin
 - type: rank
   id: RMCRankProvostDeputyMarshal
   name: Deputy Marshal
   prefix: PvDM.
   paygrade: O6
 
-# Any player with high law understanding
 - type: rank
   id: RMCRankProvostChiefInspector
   name: Chief Inspector
   prefix: PvCI.
   paygrade: O5
 
-# Any player with medium-low law understanding
 - type: rank
   id: RMCRankProvostInspector
   name: Provost Inspector


### PR DESCRIPTION
## About the PR
Move the Accesses over to the job protoyml from the ID card
HiCom and ProvMarsh will have their HighCommand access now.
Capitalised the ID card entity spawn menu names; added admin suffix

## Why / Balance
Fix

## Technical details
Yml 

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- admin: Admin characters will have their proper High Command accesses.

