### PR TITLE
[Fix] Sectioned Vendors will return true for Admin Ghosts to view.

### DIFF
--- a/Content.Client/_RMC14/Vendors/CMAutomatedVendorBui.cs
+++ b/Content.Client/_RMC14/Vendors/CMAutomatedVendorBui.cs
@@ -3,6 +3,7 @@ using Content.Shared._RMC14.Holiday;
 using Content.Shared._RMC14.Marines.Roles.Ranks;
 using Content.Shared._RMC14.Medical.Refill;
 using Content.Shared._RMC14.Vendors;
+using Content.Shared.Interaction.Components;
 using Content.Shared.Mind;
 using Content.Shared.Roles.Jobs;
 using Content.Shared.Stacks;
@@ -171,6 +172,9 @@ public sealed class CMAutomatedVendorBui : BoundUserInterface
 
     private bool IsSectionValid(CMVendorSection section)
     {
+        if (_player.LocalEntity is { } localEntity && EntMan.HasComponent<BypassInteractionChecksComponent>(localEntity))
+            return true;
+
         var validJob = true;
         var validRank = true;
         if (_player.LocalSession != null && _mind.TryGetMind(_player.LocalSession.UserId, out var mindId))


### PR DESCRIPTION
## About the PR
The vendors with sections based on jobs/ranks will now show their contents to Aghosts; the only entity with BypassInteractionChecks

## Why / Balance
Fix, code already has checks for the component.
This just unlocks viewing instead of showing empty

## Technical details
returns true if entity has the component. which shows the things inside

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- admin: Any vendor that sections its contents based on job or rank will now show its full contents to Admin Ghosts.

