### PR TITLE
spawn VC without squad

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/crewman.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/crewman.yml
@@ -59,7 +59,6 @@
     id: CMDogtagCrewman
     ears: RMCHeadsetCrewman
     outerClothing: RMCCoatTanker
-    back: CMSatchelMarine
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/crewman.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/crewman.yml
@@ -1,5 +1,5 @@
 ﻿- type: job
-  parent: CMJobSquadBase
+  parent: CMJobBase
   id: CMVehicleCrewman
   name: cm-job-name-vc
   description: cm-job-description-vc
@@ -50,7 +50,6 @@
       background:
         sprite: /Textures/_RMC14/Interface/map_blips.rsi
         state: background_intel
-  hidden: true #TODO RMC14 - Remove when vehicles are fully added.
 
 - type: startingGear
   id: CMGearVehicleCrewman


### PR DESCRIPTION
## About the PR

They currently spawn in a random or the players prefered squad.

## Why / Balance

Parity. Also removed the extra backpack that would spawn at their feet.

## Technical details

Different parent

## Media

<img width="422" height="145" alt="image" src="https://github.com/user-attachments/assets/7058ce53-e8c7-448e-ac9d-52a465b5e3b3" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- tweak: Vehicle crewman now wake up without being in a squad.
