### PR TITLE
[PVE] Add language commands

### DIFF
--- a/Content.Server/_RMC14/Language/Commands/LanguageCommand.cs
+++ b/Content.Server/_RMC14/Language/Commands/LanguageCommand.cs
@@ -14,8 +14,6 @@ public sealed class LanguageCommand : ToolshedCommand
 {
     private LanguageSystem? _language;
 
-    private readonly ProtoId<LanguagePrototype> BACKUP_LANGUAGE = "English";
-
     [CommandImplementation("add")]
     public EntityUid Add(
         [CommandInvocationContext] IInvocationContext ctx,
@@ -61,7 +59,8 @@ public sealed class LanguageCommand : ToolshedCommand
     [CommandImplementation("reset")]
     public EntityUid Reset(
         [CommandInvocationContext] IInvocationContext ctx,
-        [PipedArgument] EntityUid ent)
+        [PipedArgument] EntityUid ent,
+        [CommandArgument] ProtoId<LanguagePrototype> language)
     {
         if (!TryComp<LanguageComponent>(ent, out var languages))
         {
@@ -76,9 +75,9 @@ public sealed class LanguageCommand : ToolshedCommand
         langs.UnionWith(languages.UnderstoodLanguages);
         langs.UnionWith(languages.SpokenLanguages);
 
-        langs.Remove(BACKUP_LANGUAGE);
+        langs.Remove(language);
 
-        _language.AddLanguage(ent, BACKUP_LANGUAGE);
+        _language.AddLanguage(ent, language);
 
         foreach (var known in langs)
         {
@@ -112,8 +111,9 @@ public sealed class LanguageCommand : ToolshedCommand
 
     public IEnumerable<EntityUid> Reset(
     [CommandInvocationContext] IInvocationContext ctx,
-    [PipedArgument] IEnumerable<EntityUid> ents)
+    [PipedArgument] IEnumerable<EntityUid> ents,
+    [CommandArgument] ProtoId<LanguagePrototype> language)
     {
-        return ents.Select(ent => Reset(ctx, ent));
+        return ents.Select(ent => Reset(ctx, ent, language));
     }
 }

--- a/Content.Server/_RMC14/Language/Commands/LanguageCommand.cs
+++ b/Content.Server/_RMC14/Language/Commands/LanguageCommand.cs
@@ -1,0 +1,119 @@
+using Content.Server._RMC14.Language.Systems;
+using Content.Server.Administration;
+using Content.Shared._RMC14.Language.Components;
+using Content.Shared._RMC14.Language.Prototypes;
+using Content.Shared.Administration;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Toolshed;
+using System.Linq;
+
+namespace Content.Server._RMC14.Language.Commands;
+
+[ToolshedCommand, AdminCommand(AdminFlags.VarEdit)]
+public sealed class LanguageCommand : ToolshedCommand
+{
+    private LanguageSystem? _language;
+
+    private readonly ProtoId<LanguagePrototype> BACKUP_LANGUAGE = "English";
+
+    [CommandImplementation("add")]
+    public EntityUid Add(
+        [CommandInvocationContext] IInvocationContext ctx,
+        [PipedArgument] EntityUid ent,
+        [CommandArgument] ProtoId<LanguagePrototype> language,
+        [CommandArgument] bool canSpeak,
+        [CommandArgument] bool canUnderstand)
+    {
+        if (!HasComp<LanguageComponent>(ent))
+        {
+            ctx.WriteLine("Cannot add language to entity without a language comp!");
+            return ent;
+        }
+
+        _language ??= GetSys<LanguageSystem>();
+
+        _language.AddLanguage(ent, language, canSpeak, canUnderstand);
+
+        return ent;
+    }
+
+    [CommandImplementation("remove")]
+    public EntityUid Remove(
+        [CommandInvocationContext] IInvocationContext ctx,
+        [PipedArgument] EntityUid ent,
+        [CommandArgument] ProtoId<LanguagePrototype> language,
+        [CommandArgument] bool removeSpeaking,
+        [CommandArgument] bool removeUnderstanding)
+    {
+        if (!HasComp<LanguageComponent>(ent))
+        {
+            ctx.WriteLine("Cannot remove language from entity without a language comp!");
+            return ent;
+        }
+
+        _language ??= GetSys<LanguageSystem>();
+
+        _language.RemoveLanguage(ent, language, removeSpeaking, removeUnderstanding);
+
+        return ent;
+    }
+
+    [CommandImplementation("reset")]
+    public EntityUid Reset(
+        [CommandInvocationContext] IInvocationContext ctx,
+        [PipedArgument] EntityUid ent)
+    {
+        if (!TryComp<LanguageComponent>(ent, out var languages))
+        {
+            ctx.WriteLine("Cannot reset languages from entity without a language comp!");
+            return ent;
+        }
+
+        _language ??= GetSys<LanguageSystem>();
+
+        HashSet<ProtoId<LanguagePrototype>> langs = new();
+
+        langs.UnionWith(languages.UnderstoodLanguages);
+        langs.UnionWith(languages.SpokenLanguages);
+
+        langs.Remove(BACKUP_LANGUAGE);
+
+        _language.AddLanguage(ent, BACKUP_LANGUAGE);
+
+        foreach (var known in langs)
+        {
+            _language.RemoveLanguage(ent, known);
+        }
+
+        return ent;
+    }
+
+    [CommandImplementation("add")]
+    public IEnumerable<EntityUid> Add(
+    [CommandInvocationContext] IInvocationContext ctx,
+    [PipedArgument] IEnumerable<EntityUid> ents,
+    [CommandArgument] ProtoId<LanguagePrototype> language,
+    [CommandArgument] bool canSpeak,
+    [CommandArgument] bool canUnderstand)
+    {
+        return ents.Select(ent => Add(ctx, ent, language, canSpeak, canUnderstand));
+    }
+
+    [CommandImplementation("remove")]
+    public IEnumerable<EntityUid> Remove(
+    [CommandInvocationContext] IInvocationContext ctx,
+    [PipedArgument] IEnumerable<EntityUid> ents,
+    [CommandArgument] ProtoId<LanguagePrototype> language,
+    [CommandArgument] bool removeSpeaking,
+    [CommandArgument] bool removeUnderstanding)
+    {
+        return ents.Select(ent => Remove(ctx, ent, language, removeSpeaking, removeUnderstanding));
+    }
+
+    public IEnumerable<EntityUid> Reset(
+    [CommandInvocationContext] IInvocationContext ctx,
+    [PipedArgument] IEnumerable<EntityUid> ents)
+    {
+        return ents.Select(ent => Reset(ctx, ent));
+    }
+}

--- a/Resources/Locale/en-US/_RMC14/administration/commands/languages-command.ftl
+++ b/Resources/Locale/en-US/_RMC14/administration/commands/languages-command.ftl
@@ -1,0 +1,3 @@
+command-description-language-add = Adds a language to a given entity(ies).
+command-description-language-remove = Removes a language from a given entity(ies).
+command-description-language-reset = Resets an entity(ies) to only knowing and speaking English.

--- a/Resources/Locale/en-US/_RMC14/administration/commands/languages-command.ftl
+++ b/Resources/Locale/en-US/_RMC14/administration/commands/languages-command.ftl
@@ -1,3 +1,3 @@
 command-description-language-add = Adds a language to a given entity(ies).
 command-description-language-remove = Removes a language from a given entity(ies).
-command-description-language-reset = Resets an entity(ies) to only knowing and speaking English.
+command-description-language-reset = Resets an entity(ies) to only knowing and speaking the specified language.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
language:add, language:remove, and language:reset to modify languages via commands.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Easier to modify one or many ents languages, like with skills.

## Technical details
<!-- Summary of code changes for easier review. -->
New commands, passing in an ent or ents and adding/removing languages. Reset does both.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

https://github.com/user-attachments/assets/7cbfc452-ce3c-4b1a-b110-03b7a50eb2ab



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: [PVE] Added language:add, language:remove, and language:reset for modifying an entities' known languages.
