### PR TITLE
vehicle fix: DRGN flame offset

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/vehicle_tank.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/vehicle_tank.yml
@@ -162,6 +162,7 @@
   - type: DeleteOnTrigger
   - type: SpawnOnTerminate
     spawn: VehicleDragonFlameImpact
+    spawnOffset: 0.5
   - type: IgnoreArc
   - type: IgnorePredictionHide
   - type: Fixtures


### PR DESCRIPTION
## About the PR

Move the spawned fire half a tile further.

## Why / Balance

## Technical details
<!-- Summary of code changes for easier review. -->

## Media

Before:

[Screencast From 2026-06-18 22-19-31.webm](https://github.com/user-attachments/assets/b97cd604-f117-4207-8147-fee6b187ffa0)


After:

[Screencast From 2026-06-18 22-26-56.webm](https://github.com/user-attachments/assets/88d8541a-80c5-4c68-a385-4d68949005be)


## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- fix: The tanks DRGN flamer now creates the fire centered on the target.
