### PR TITLE
Forecon loadout fixes

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/base_forecon.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/base_forecon.yml
@@ -44,12 +44,12 @@
     randomGearOther:
     -
       - [ RMCCigarettePackLuckySloths ]
-    # todo walkman and casette
-    # todo deck of cards
+      - [ RMCPlayingCardDeck ]
+      - [ RMCCassettePlayer, RMCCassetteTapeCustom ] # It's supposed to be the indie cassette but I don't think we can use the sounds
     randomWeapon:
     - [ RMCM1911BeltFilledForecon ]
     - [ RMCM1911BeltFilledForecon ]
-    - [ RMCM1911BeltFilledForecon ]
+    - [ RMCHolsterSMGPouchFilledExtended ]
     - [ RMCHolsterSMGPouchFilledExtended ]
     - [ RMCMotionDetector ]
     tryEquipRandomWeapon: true
@@ -61,8 +61,10 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: EntityPreset
-    primaryWeapons:
+    primaryWeapons: # 1/3 M4SPR, 2/3 M54C
     - [ CMMagazineRifleM4SPR, CMMagazineRifleM4SPR, WeaponRifleM4SPRFilled ]
+    - [ RMCWeaponRifleM54CFilled, CMMagazineRifleM54C, CMMagazineRifleM54C ]
+    - [ RMCWeaponRifleM54CFilled, CMMagazineRifleM54C, CMMagazineRifleM54C ]
     primaryWeaponChance: 1
 
 - type: entity


### PR DESCRIPTION
## About the PR
Forecon now has a chance to spawn with an M54C and some additional fluff items

Sidearm RNG was adjusted, it's now 2/5 for M1911, 2/5 for M63 and 1/5 for MD

## Why / Balance
Parity

## Technical details
Yaml

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Forecon can now spawn with an M54C and additional fluff items
