### PR TITLE
Fix imaginary friends being able to talk over the radio

### DIFF
--- a/Content.Server/_RMC14/Mentor/ImaginaryFriend/ImaginaryFriendSystem.cs
+++ b/Content.Server/_RMC14/Mentor/ImaginaryFriend/ImaginaryFriendSystem.cs
@@ -4,6 +4,7 @@ using Content.Server.EUI;
 using Content.Server.Humanoid;
 using Content.Server.Mind;
 using Content.Server.Preferences.Managers;
+using Content.Server.Radio;
 using Content.Server.Station.Systems;
 using Content.Shared._RMC14.Mentor.ImaginaryFriend;
 using Content.Shared._RMC14.Xenonids;
@@ -34,6 +35,8 @@ public sealed class ImaginaryFriendSystem : SharedImaginaryFriendSystem
     [Dependency] private readonly TransformSystem _transform = default!;
     [Dependency] private readonly VisibilitySystem _visibility = default!;
 
+    private EntityQuery<ImaginaryFriendComponent> _imaginaryFriendQuery;
+
     private static readonly EntProtoId ImaginaryFriendPrototype = "RMCImaginaryFriendHumanoid";
     private static readonly EntProtoId XenoImaginaryFriendPrototype = "RMCImaginaryFriendXeno";
 
@@ -44,12 +47,16 @@ public sealed class ImaginaryFriendSystem : SharedImaginaryFriendSystem
     {
         base.Initialize();
 
+        _imaginaryFriendQuery = GetEntityQuery<ImaginaryFriendComponent>();
+
         SubscribeLocalEvent<HasImaginaryFriendComponent, ComponentShutdown>(OnHasImaginaryFriendShutdown);
         SubscribeLocalEvent<HasImaginaryFriendComponent, GetVisMaskEvent>(OnHasImaginaryFriendVisMask);
 
         SubscribeLocalEvent<ImaginaryFriendComponent, ImaginaryFriendToggleVisibilityActionEvent>(OnFriendToggleVisibility);
         SubscribeLocalEvent<ImaginaryFriendComponent, ImaginaryFriendStopBeingFriendsActionEvent>(OnStopBeingFriends);
         SubscribeLocalEvent<ImaginaryFriendComponent, ComponentShutdown>(OnFriendShutdown);
+        SubscribeLocalEvent<RadioSendAttemptEvent>(OnRadioSendAttempt);
+        SubscribeLocalEvent<RadioReceiveAttemptEvent>(OnRadioReceiveAttempt);
     }
 
     private void OnHasImaginaryFriendShutdown(Entity<HasImaginaryFriendComponent> ent, ref ComponentShutdown args)
@@ -96,6 +103,18 @@ public sealed class ImaginaryFriendSystem : SharedImaginaryFriendSystem
     private void OnFriendShutdown(Entity<ImaginaryFriendComponent> ent, ref ComponentShutdown args)
     {
         RemoveImaginaryFriend(ent, ent.Comp);
+    }
+
+    private void OnRadioSendAttempt(ref RadioSendAttemptEvent args)
+    {
+        if (_imaginaryFriendQuery.HasComp(Transform(args.RadioSource).ParentUid))
+            args.Cancelled = true;
+    }
+
+    private void OnRadioReceiveAttempt(ref RadioReceiveAttemptEvent args)
+    {
+        if (_imaginaryFriendQuery.HasComp(Transform(args.RadioReceiver).ParentUid))
+            args.Cancelled = true;
     }
 
     public void OpenImaginaryFriendConfirmWindow(ICommonSession session, EntityUid target)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

- Imaginary friends can't talk over the radio anymore.
- Imaginary friends no longer hear all radio messages twice.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix: Imaginary friends can no longer talk through radio channels.
