### PR TITLE
Fix the targeting overlay appearing offset while anyone nearby has pheromones

### DIFF
--- a/Content.Client/_RMC14/Xenonids/Pheromones/XenoPheromonesOverlay.cs
+++ b/Content.Client/_RMC14/Xenonids/Pheromones/XenoPheromonesOverlay.cs
@@ -139,5 +139,7 @@ public sealed class XenoPheromonesOverlay : Overlay
 
         var position = new Vector2(xOffset, yOffset);
         handle.DrawTexture(texture, position);
+
+        handle.SetTransform(Matrix3x2.Identity);
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The targeting overlay no longer appears offset while a nearby xeno has pheromones active.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Resolves #10216 

## Technical details
<!-- Summary of code changes for easier review. -->
The handle transform is now reset after the pheromone overlay is drawn.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix: Fixed the targeting overlay sometimes appearing at the wrong location.

