### PR TITLE
Planet Medical Lockers + Mapped on Kutjevo

### DIFF
--- a/Resources/Prototypes/_RMC14/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Fills/Lockers/medical.yml
@@ -1,0 +1,68 @@
+- type: entity
+  parent: CMLockerBase
+  id: RMCClosetMedical
+  name: medical closet
+  description: Filled with medical items.
+  components:
+  - type: Sprite
+    sprite: _RMC14/Structures/Storage/Lockers/medical_white.rsi
+
+- type: entity
+  parent: RMCClosetMedical
+  id: RMCClosetMedicalMedicine
+  name: medicine closet
+  suffix: Filled, Medical, Medicine
+  components:
+  - type: StorageFill
+    contents:
+      - id: RMCBoxSyringe
+      - id: RMCDropper
+      - id: RMCDropper
+      - id: CMBeaker
+      - id: CMBeaker
+      - id: CMBottleInaprovaline
+      - id: CMBottleDylovene
+      - id: RMCBoxPillCanister
+      - id: RMCBoxPillCanister
+
+- type: entity
+  parent: RMCClosetMedical
+  id: RMCClosetMedicalAnesthetic
+  name: anesthetic closet
+  description: Used to knock people out.
+  suffix: Filled, Medical, Anesthetic
+  components:
+  - type: AccessReader
+    access: [["CMAccessMedical"]]
+  - type: StorageFill
+    contents:
+      - id: CMAnestheticTank
+      - id: CMAnestheticTank
+      - id: CMAnestheticTank
+      - id: CMMaskGasMedical
+      - id: CMMaskGasMedical
+      - id: CMMaskGasMedical
+
+- type: entity
+  parent: RMCClosetMedical
+  id: RMCClosetMedicalDoctors
+  name: medical doctor's locker
+  suffix: Filled, Medical, Doctor's
+  components:
+  - type: StorageFill
+    contents:
+      - id: CMBeltMedicalFilled
+      - id: CMBeltMedicalFilled
+      - id: CMSatchelMarine
+      - id: CMScrubsGreen
+      - id: RMCPouchMedical
+      - id: RMCPouchMedical
+      - id: RMCPouchSyringe
+      - id: RMCPouchMedkit
+      - id: RMCPouchMedkit
+      - id: RMCPouchChem
+      - id: RMCPouchChem
+      - id: RMCPouchVialFill
+      - id: RMCPouchVialFill
+      - id: RMCPouchReagentCanister
+      - id: RMCPouchReagentCanister


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added the 3 colony medical lockers and mapped them on kutjevo, they will need to be mapped on the other maps too.
Fixes https://github.com/RMC-14/RMC-14/issues/10151

## Why / Balance
Parity

## Media
correct skill-less pill bottle there, along with the 3 mapped closets on kutjevo
<img width="582" height="760" alt="image" src="https://github.com/user-attachments/assets/06a0cdf1-896e-465a-b01d-00534866c488" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: CatAndHats
- add: Added colony medical lockers with their parity contents