### PR TITLE
fix: CCDP grenade scaling

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
@@ -96,7 +96,7 @@
         amount: 25
       - id: RMCGrenadeIncendiary
         amount: 4
-      - id: RMCPacketGrenadeWhitePhosphorusCompoundFilled
+      - id: RMCGrenadeWhitePhosphorusCompound
         amount: 4
       - id: CMGrenadeSmoke
         amount: 5
@@ -321,6 +321,11 @@
       - id: RMCPacketGrenadeIncendiaryFilled
         name: 30mm HIDP grenade packet
         box: RMCGrenadeIncendiary
+        boxAmount: 3
+        boxSlots: 3
+      - id: RMCPacketGrenadeWhitePhosphorusCompoundFilled
+        name: 30mm CCDP grenade packet
+        box: RMCGrenadeWhitePhosphorusCompound
         boxAmount: 3
         boxSlots: 3
       - id: RMCPacketGrenadeSmokeFilled


### PR DESCRIPTION
## About the PR

title

## Why / Balance

its supposed to be 4 grenades per, not 4 grenade boxes

## Technical details

yaml warrior

## Media

Before:
<img width="491" height="272" alt="image" src="https://github.com/user-attachments/assets/05f09ea1-08ee-4c61-9e4e-b0cbda79b62e" />

After:
<img width="491" height="272" alt="Screenshot From 2026-06-21 19-10-34" src="https://github.com/user-attachments/assets/1ca37f3b-3b52-45ee-af7e-8bc6aeb7bd14" />

Reference:
https://github.com/cmss13-devs/cmss13/blob/master/code/game/machinery/vending/vendor_types/requisitions.dm#L52

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- fix: Requisitions was incorrectly provided with too many CCDP grenades.
