### PR TITLE
CO Spawns with Secure Satchel

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Loadouts/Backpack/backpacks.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Loadouts/Backpack/backpacks.yml
@@ -10,6 +10,11 @@
     back: CMSatchel
 
 - type: loadout
+  id: MarineSecureSatchel
+  equipment:
+    back: CMSatchelCommandSecure
+
+- type: loadout
   id: LiaisonSecureSatchel
   equipment:
     back: CMSatchelLiaisonSecure

--- a/Resources/Prototypes/_RMC14/Roles/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Loadouts/loadout_groups.yml
@@ -18,6 +18,14 @@
   - MarineLeatherSatchel
 
 - type: loadoutGroup
+  id: MarineSecureBackpack
+  name: rmc-loadout-group-backpack
+  minLimit: 1
+  hidden: true
+  loadouts:
+  - MarineSecureSatchel
+
+- type: loadoutGroup
   id: LiaisonBackpackRMC
   name: rmc-loadout-group-backpack
   minLimit: 1

--- a/Resources/Prototypes/_RMC14/Roles/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Loadouts/role_loadouts.yml
@@ -151,7 +151,7 @@
   id: JobCMCommandingOfficer
   points: 7
   groups:
-  - MarineLeatherBackpack
+  - MarineSecureBackpack
   - CommandingOfficerIDRMC
   - CommandingOfficerWeaponRMC
   - CommandingOfficerRoleSpecificRMC


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Made it to the CO now spawns with a secure satchel, while a second remains available in their vendor as before (as is parity)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity + Now it's not contesting with the RTO.

## Technical details
<!-- Summary of code changes for easier review. -->
Added loadout option for the secure satchel
Added loadout group for the secure satchel
Replaced CO standard satchel spawn with secure satchel spawn

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
No applicable changes to showcase

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: CO now spawns with their secure satchel instead of a standard leather satchel
