### PR TITLE
tweak: Intel UI parity + QoL

### DIFF
--- a/Content.Client/_RMC14/Intel/ViewIntelObjectivesBui.cs
+++ b/Content.Client/_RMC14/Intel/ViewIntelObjectivesBui.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared._RMC14.Intel;
+using System.Linq;
+using Content.Shared._RMC14.Intel;
 using JetBrains.Annotations;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
@@ -9,6 +10,9 @@ namespace Content.Client._RMC14.Intel;
 public sealed class ViewIntelObjectivesBui(EntityUid owner, Enum uiKey) : BoundUserInterface(owner, uiKey)
 {
     private ViewIntelObjectivesWindow? _window;
+
+    private readonly List<(string PlainClue, Control Row, Control? AreaLabel)> _allClueRows = new();
+    private bool _hideAreas;
 
     protected override void Open()
     {
@@ -39,12 +43,91 @@ public sealed class ViewIntelObjectivesBui(EntityUid owner, Enum uiKey) : BoundU
         _window.ColonyCommunicationsLabel.Text = Loc.GetString("rmc-ui-intel-colony-status", ("online", tree.ColonyCommunications));
         _window.ColonyPowerLabel.Text = Loc.GetString("rmc-ui-intel-colony-status", ("online", tree.ColonyPower));
 
+        _allClueRows.Clear();
+        if (_window.CluesSearchBar != null)
+            _window.CluesSearchBar.Text = string.Empty;
+
         _window.CluesContainer.DisposeAllChildren();
         if (comp.PersonalClues.Count > 0)
             AddClueTab("rmc-intel-personal", comp.PersonalClues.Values);
 
         foreach (var (category, clues) in comp.Tree.Clues)
             AddClueTab(category, clues.Values);
+
+        if (_window.CluesSearchBar != null)
+        {
+            _window.CluesSearchBar.OnTextChanged -= OnSearchChanged;
+            _window.CluesSearchBar.OnTextChanged += OnSearchChanged;
+        }
+
+        if (_window.HideAreasButton != null)
+        {
+            _window.HideAreasButton.OnPressed -= OnHideAreasPressed;
+            _window.HideAreasButton.OnPressed += OnHideAreasPressed;
+            UpdateHideAreasButton();
+        }
+
+        ApplyAreaVisibility();
+    }
+
+    private void OnSearchChanged(LineEdit.LineEditEventArgs args)
+    {
+        ApplyFilter(args.Text.Trim());
+    }
+
+    private void OnHideAreasPressed(BaseButton.ButtonEventArgs _)
+    {
+        _hideAreas = !_hideAreas;
+        UpdateHideAreasButton();
+        ApplyAreaVisibility();
+    }
+
+    private void UpdateHideAreasButton()
+    {
+        if (_window?.HideAreasButton == null)
+            return;
+
+        _window.HideAreasButton.Text = _hideAreas ? "Show Areas" : "Hide Areas";
+    }
+
+    private void ApplyFilter(string query)
+    {
+        foreach ((string plainClue, Control row, Control? _) in _allClueRows)
+        {
+            var visible = string.IsNullOrEmpty(query) ||
+                          plainClue.IndexOf(query, StringComparison.OrdinalIgnoreCase) >= 0;
+            row.Visible = visible;
+        }
+    }
+
+    private void ApplyAreaVisibility()
+    {
+        foreach ((string _, Control _, Control? areaLabel) in _allClueRows)
+        {
+            if (areaLabel != null)
+                areaLabel.Visible = !_hideAreas;
+        }
+    }
+
+    private static string StripMarkup(string text)
+    {
+        var result = new System.Text.StringBuilder(text.Length);
+        var i = 0;
+        while (i < text.Length)
+        {
+            if (text[i] == '[')
+            {
+                var end = text.IndexOf(']', i);
+                if (end >= 0)
+                {
+                    i = end + 1;
+                    continue;
+                }
+            }
+            result.Append(text[i]);
+            i++;
+        }
+        return result.ToString();
     }
 
     private void AddClueTab(string category, IEnumerable<string> clues)
@@ -64,9 +147,13 @@ public sealed class ViewIntelObjectivesBui(EntityUid owner, Enum uiKey) : BoundU
             Margin = new Thickness(4),
         };
 
-        foreach (var clue in clues)
+        var sortedClues = clues.OrderBy(c => StripMarkup(c).ToLowerInvariant());
+
+        foreach (var clue in sortedClues)
         {
-            container.AddChild(BuildClueRow(clue));
+            var (row, areaLabel) = BuildClueRow(clue);
+            container.AddChild(row);
+            _allClueRows.Add((StripMarkup(clue), row, areaLabel));
         }
 
         scroll.AddChild(container);
@@ -74,7 +161,7 @@ public sealed class ViewIntelObjectivesBui(EntityUid owner, Enum uiKey) : BoundU
         TabContainer.SetTabTitle(scroll, Loc.GetString(category));
     }
 
-    private static Control BuildClueRow(string clue)
+    private static (Control Row, Control? AreaLabel) BuildClueRow(string clue)
     {
         var row = new BoxContainer
         {
@@ -94,7 +181,7 @@ public sealed class ViewIntelObjectivesBui(EntityUid owner, Enum uiKey) : BoundU
                 StyleClasses = { "Label" },
             });
 
-            return row;
+            return (row, null);
         }
 
         var itemPart = clue[..splitIndex].TrimEnd('.');
@@ -111,12 +198,14 @@ public sealed class ViewIntelObjectivesBui(EntityUid owner, Enum uiKey) : BoundU
             HorizontalExpand = true,
         });
 
-        row.AddChild(new RichTextLabel
+        var areaLabel = new RichTextLabel
         {
             Text = areaPart,
             StyleClasses = { "Label" },
-        });
+        };
 
-        return row;
+        row.AddChild(areaLabel);
+
+        return (row, areaLabel);
     }
 }

--- a/Content.Client/_RMC14/Intel/ViewIntelObjectivesBui.cs
+++ b/Content.Client/_RMC14/Intel/ViewIntelObjectivesBui.cs
@@ -66,16 +66,57 @@ public sealed class ViewIntelObjectivesBui(EntityUid owner, Enum uiKey) : BoundU
 
         foreach (var clue in clues)
         {
-            container.AddChild(new Label
-            {
-                Text = clue,
-                Margin = new Thickness(2, 1, 2, 1),
-                StyleClasses = { "Label" }
-            });
+            container.AddChild(BuildClueRow(clue));
         }
 
         scroll.AddChild(container);
         _window.CluesContainer.AddChild(scroll);
         TabContainer.SetTabTitle(scroll, Loc.GetString(category));
+    }
+
+    private static Control BuildClueRow(string clue)
+    {
+        var row = new BoxContainer
+        {
+            Orientation = BoxContainer.LayoutOrientation.Horizontal,
+            Margin = new Thickness(2, 1, 2, 1),
+            HorizontalExpand = true,
+        };
+
+        const string separator = " in ";
+        var splitIndex = clue.LastIndexOf(separator, StringComparison.OrdinalIgnoreCase);
+
+        if (splitIndex < 0)
+        {
+            row.AddChild(new RichTextLabel
+            {
+                Text = clue,
+                StyleClasses = { "Label" },
+            });
+
+            return row;
+        }
+
+        var itemPart = clue[..splitIndex].TrimEnd('.');
+        var areaPart = clue[(splitIndex + separator.Length)..].TrimEnd('.');
+
+        row.AddChild(new RichTextLabel
+        {
+            Text = itemPart,
+            StyleClasses = { "Label" },
+        });
+
+        row.AddChild(new Control
+        {
+            HorizontalExpand = true,
+        });
+
+        row.AddChild(new RichTextLabel
+        {
+            Text = areaPart,
+            StyleClasses = { "Label" },
+        });
+
+        return row;
     }
 }

--- a/Content.Client/_RMC14/Intel/ViewIntelObjectivesWindow.xaml
+++ b/Content.Client/_RMC14/Intel/ViewIntelObjectivesWindow.xaml
@@ -108,6 +108,14 @@
                 <BoxContainer Orientation="Vertical" Margin="8">
                     <RichTextLabel Text="{Loc rmc-ui-intel-clues}" />
                     <ui:BlueHorizontalSeparator />
+                    <BoxContainer Orientation="Horizontal" Margin="0 2 0 4" SeparationOverride="4">
+                        <LineEdit Name="CluesSearchBar" Access="Public"
+                                  PlaceHolder="Search clues..."
+                                  HorizontalExpand="True" />
+                        <Button Name="HideAreasButton" Access="Public"
+                                Text="Hide Areas"
+                                MinWidth="90" />
+                    </BoxContainer>
                     <TabContainer Name="CluesContainer" Access="Public" VerticalExpand="True" />
                 </BoxContainer>
             </PanelContainer>

--- a/Content.Client/_RMC14/Intel/ViewIntelObjectivesWindow.xaml
+++ b/Content.Client/_RMC14/Intel/ViewIntelObjectivesWindow.xaml
@@ -4,7 +4,7 @@
     xmlns:ui="clr-namespace:Content.Client._RMC14.UserInterface"
     xmlns:graphics="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
     Title="{Loc rmc-ui-intel-title}"
-    MinSize="620 570">
+    MinSize="700 650">
     <PanelContainer>
         <PanelContainer.PanelOverride>
             <graphics:StyleBoxFlat 

--- a/Content.Shared/_RMC14/Intel/IntelSystem.cs
+++ b/Content.Shared/_RMC14/Intel/IntelSystem.cs
@@ -1923,6 +1923,7 @@ public sealed class IntelSystem : EntitySystem
             terminal.Completed = true;
             Dirty(uid, terminal);
             CompleteUpload(uid, terminal.Value);
+            _audio.PlayPvs(new SoundPathSpecifier("/Audio/_RMC14/Machines/screen_output1.ogg"), uid);
             _popup.PopupEntity(Loc.GetString("rmc-intel-data-terminal-finished"), uid, terminalUser);
         }
 

--- a/Content.Shared/_RMC14/Intel/IntelSystem.cs
+++ b/Content.Shared/_RMC14/Intel/IntelSystem.cs
@@ -32,6 +32,7 @@ using Content.Shared.Random.Helpers;
 using Content.Shared.Sprite;
 using Content.Shared.Storage;
 using Content.Shared.Storage.EntitySystems;
+using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Configuration;
 using Robust.Shared.Containers;
@@ -1956,6 +1957,7 @@ public sealed class IntelSystem : EntitySystem
             Dirty(disk.Value);
             _nameModifier.RefreshNameModifiers(disk.Value.Owner);
             CompleteUpload(disk.Value.Owner, disk.Value.Comp.UploadValue);
+            _audio.PlayPvs(new SoundPathSpecifier("/Audio/_RMC14/Machines/screen_output1.ogg"), uid);
 
             if (TryComp(disk.Value.Owner, out IntelRetrieveItemObjectiveComponent? retrieve) &&
                 retrieve.State == IntelObjectiveState.Inactive)

--- a/Resources/Locale/en-US/_RMC14/intel.ftl
+++ b/Resources/Locale/en-US/_RMC14/intel.ftl
@@ -15,29 +15,29 @@ rmc-intel-misc = Miscellaneous
 rmc-intel-personal = Personal Clues
 
 rmc-intel-data-disk-uploaded = {$baseName} (uploaded)
-rmc-intel-color-red = red
-rmc-intel-color-black = black
-rmc-intel-color-blue = blue
-rmc-intel-color-yellow = yellow
-rmc-intel-color-white = white
-rmc-intel-color-grey = grey
-rmc-intel-color-green = green
-rmc-intel-color-cracked-blue = cracked blue
-rmc-intel-color-bloodied-blue = bloodied blue
+rmc-intel-color-red = [color=#eb4034]red[/color]
+rmc-intel-color-black = [color=#000000]black[/color]
+rmc-intel-color-blue = [color=#3449eb]blue[/color]
+rmc-intel-color-yellow = [color=#ebe534]yellow[/color]
+rmc-intel-color-white = [color=#ffffff]white[/color]
+rmc-intel-color-grey = [color=#949494]grey[/color]
+rmc-intel-color-green = [color=#5dbf36]green[/color]
+rmc-intel-color-cracked-blue = [color=#3449eb]cracked blue[/color]
+rmc-intel-color-bloodied-blue = [color=#3449eb]bloodied blue[/color]
 rmc-intel-color-unknown = unmarked
 rmc-intel-clue-found = You make out something about {$clue}.
 rmc-intel-personal-clues-added = New clues have been added to your personal clues.
 rmc-intel-clue-label-number = #{$number}
 rmc-intel-clue-label-serial = #{$serial}
 rmc-intel-clue-label-unmarked = no visible label
-rmc-intel-clue-paper-scrap = A paper scrap {$label} in {$area}.
-rmc-intel-clue-progress-report = A progress report {$label} in {$area}.
-rmc-intel-clue-folder = A {$color} folder {$label} in {$area}.
-rmc-intel-clue-technical-manual = A technical manual {$label} in {$area}.
-rmc-intel-clue-experimental-device = Retrieve {$name} {$label} in {$area}.
-rmc-intel-clue-data-disk = Retrieve {$color} computer disk {$label} in {$area}, decryption password is {$key}.
-rmc-intel-clue-data-terminal = Upload data from data terminal {$label} in {$area}, the password is {$password}.
-rmc-intel-clue-safe = Crack open a safe {$label} in {$area}, the combination lock is {$code}.
+rmc-intel-clue-paper-scrap = paper scrap {$label} in {$area}.
+rmc-intel-clue-progress-report = progress report {$label} in {$area}.
+rmc-intel-clue-folder = {$color} folder {$label} in {$area}.
+rmc-intel-clue-technical-manual = technical manual {$label} in {$area}.
+rmc-intel-clue-experimental-device = {$name} {$label} in {$area}.
+rmc-intel-clue-data-disk = {$color} disk [bold]{$label}[/bold], decryption key is [bold]{$key}[/bold] in {$area}.
+rmc-intel-clue-data-terminal = Upload data from terminal [bold]{$label}[/bold], password is [bold]{$password}[/bold] in {$area}.
+rmc-intel-clue-safe = Crack open the safe {$label}, combination lock is [bold]{$code}[/bold] in {$area}.
 rmc-intel-data-terminal-password-prompt = Enter the password
 rmc-intel-data-terminal-no-power = This terminal has no power!
 rmc-intel-data-terminal-no-comms = The terminal flashes a network connection error.

--- a/Resources/Prototypes/_RMC14/Entities/Objects/rmc_intel.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/rmc_intel.yml
@@ -249,8 +249,11 @@
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Machines/computer.rsi
-    state: medlaptop
-    layers: []
+    layers:
+    - map: ["base"]
+      state: "medlaptop0"
+    - map: ["enum.PowerDeviceVisualLayers.Powered"]
+      state: "medlaptop"
   - type: InteractionOutline
   - type: ApcPowerReceiver
     powerLoad: 250


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Removed a lot of the clutter in the UI and made in more like the cmss13 UI.
Made the UI a bit bigger so that now 5 clues can be instantly seen instead of the normal 3 
The UI now only shows the name, code and location without a lot of the filler text.
Added color and bold text for the UI
Added a searchbar at the top, the search bar only works in the current tab and is not able to smart find anything between tabs
Added a button which hides the areas/locations, very useful for ASOs as their do not need this information and it removes a bit of the clutter in the UI for them.
The location is now right side aligned this might lead to problems with overlapping for terminal/disk/safe codes, if the location has a really long name but that can be easily solved by extending the UI as a player and the hide areas button should resolve this as field deployed intel only needs to know the location of the terminal/safes of which there are maybe a total of 5 on a map. The ASO uses the most codes and they do not need the location names.
The clues are also now sorted in alphabetical order
The disk reader now also plays a sound when the task got completed as in parity.
The data terminal now has a off sprite and plays the same audio as the disk reader when its done uploading as in parity.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The UI right now is not very player friendly and it got worse after the intel update. The clue text was just to long for the small box which forces you to expand the window to read anything.

## Technical details
<!-- Summary of code changes for easier review. -->
Added .cs code which allows [color, bold] to be used for the UI
If it in the .ftl it says "In" the next following word will be right side aligned, this is used for "in {$area}."
Added code for the searchbar to ignore the [bold,etc].
resolves #10193 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
Before:
<img width="730" height="672" alt="Screenshot 2026-06-22 111357" src="https://github.com/user-attachments/assets/c2cee0fa-caf7-4227-85b9-3803ba2375b3" />
This is how much you need to extend the window to even see the codes 
<img width="1908" height="1046" alt="grafik" src="https://github.com/user-attachments/assets/663267bb-407c-433e-b54f-3d0ba2e41a95" />

After:

https://github.com/user-attachments/assets/756df8ab-23fd-4962-8113-e4bf32183966


cmss13:
<img width="799" height="348" alt="grafik" src="https://github.com/user-attachments/assets/f675fbc1-5792-456e-aaed-255b6c08ea74" />
<img width="998" height="367" alt="grafik" src="https://github.com/user-attachments/assets/0b56f3fa-0182-4b07-8405-cc7b0a5d022f" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:

- add: Added a search bar to the Intel UI, which allows you to search for any word in the clues tab. Clues are now sorted alphabetically and received a visual overhaul by shortening the text, making the IDs and codes bigger, and adding color. Also added a button to hide the location information!
- tweak: Data terminal now has a unpowered sprite and plays a small tune when its done uploading. The SIGINT disk reader also now plays a tune when its done uploading data!
