### PR TITLE
Container Transfer Amount Tweaks

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Medical/beaker.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Medical/beaker.yml
@@ -355,6 +355,23 @@
     fillBaseName: can
   - type: SolutionTransfer
     transferAmount: 100
+    maxTransferAmount: 480
+    canChangeTransferAmount: true
+    transferAmounts:
+    - 5
+    - 10
+    - 15
+    - 20
+    - 25
+    - 30
+    - 40
+    - 60
+    - 80
+    - 95
+    - 100
+    - 120
+    - 240
+    - 480
   - type: StaticPrice
     price: 40
   - type: Tag

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Medical/beaker.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Medical/beaker.yml
@@ -571,6 +571,25 @@
     solutions:
       beaker:
         maxVol: 500
+  - type: SolutionTransfer
+    transferAmount: 100
+    maxTransferAmount: 500
+    canChangeTransferAmount: true
+    transferAmounts:
+    - 5
+    - 10
+    - 15
+    - 20
+    - 25
+    - 30
+    - 40
+    - 60
+    - 80
+    - 100
+    - 120
+    - 240
+    - 300
+    - 500
   - type: SolutionContainerVisuals
     fillBaseName: reagentjug-
     inHandsMaxFillLevels: 5

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Tools/bucket.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Tools/bucket.yml
@@ -122,7 +122,7 @@
   - type: SolutionTransfer
     transferAmount: 100
     minTransferAmount: 5
-    maxTransferAmount: 500
+    maxTransferAmount: 300
     transferAmounts:
     - 5
     - 10
@@ -137,7 +137,6 @@
     - 120
     - 240
     - 300
-    - 500
   - type: PhysicalComposition
     materialComposition:
       CMSteel: 8000


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Tweaks the selectable transfer amounts on janitorial buckets, reagent jugs, and pressurised reagent canisters. Jugs can now transfer up to 500u, janitorial buckets can no longer go above 300u, and pressurised canisters now have options for 95u, 120u, 240u, and 480u, with custom amounts up to 480u.

## Why / Balance
QOL, plus janitorial buckets can no longer use the 500u option after the nerf.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Jugs and pressurized canisters can now transfer up to their full volume
- fix: Janitorial buckets no longer have a useless 500u transfer option
