### PR TITLE
Plasma Trees give plasma to ovi Queen + change doafter visual

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Construction/PlasmaTree/PlasmaTreeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/PlasmaTree/PlasmaTreeSystem.cs
@@ -86,7 +86,7 @@ public sealed class PlasmaTreeSystem : EntitySystem
             BreakOnMove = true,
             MovementThreshold = 0.5f,
             DuplicateCondition = DuplicateConditions.SameEvent,
-            TargetEffect = "RMCEffectHealBusy",
+            TargetEffect = "RMCEffectHealPlasma",
         };
 
         if (_doafter.TryStartDoAfter(recover, out var id))

--- a/Content.Shared/_RMC14/Xenonids/Construction/PlasmaTree/PlasmaTreeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/PlasmaTree/PlasmaTreeSystem.cs
@@ -9,6 +9,7 @@ using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
+using Content.Shared._RMC14.Xenonids.Egg;
 
 namespace Content.Shared._RMC14.Xenonids.Construction.PlasmaTree;
 
@@ -57,7 +58,7 @@ public sealed class PlasmaTreeSystem : EntitySystem
         {
             if (!_hive.FromSameHive(ent, nearbyEntity) ||
                 !HasComp<XenoComponent>(nearbyEntity) ||
-                !HasComp<XenoRestingComponent>(nearbyEntity) ||
+                !(HasComp<XenoRestingComponent>(nearbyEntity) || HasComp<XenoAttachedOvipositorComponent>(nearbyEntity)) ||
                 !TryComp<XenoPlasmaComponent>(nearbyEntity, out var plasmaComp) ||
                 plasmaComp.Plasma == plasmaComp.MaxPlasma ||
                 !HasComp<MobStateComponent>(nearbyEntity) ||


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Request by Smug on #9471 and is currently blocking it (The ovi part). The plasma part is just nice and consistent.

## Technical details
<!-- Summary of code changes for easier review. -->
Plasma Tree checks for xenoResting or attachedOvipositor. Changed the effect to use the one used for plasma transfer.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

https://github.com/user-attachments/assets/35705cae-640a-42c3-92b2-4af5f86c5374

(effect not pictured)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Plasma Trees now check for if a xeno is resting or ovi for giving plasma.
- tweak: Plasma Tree doafter now uses the transfer plasma action's effects.
