### PR TITLE
Adds IMS and Laser Scalpel Functionality

### DIFF
--- a/Content.Client/_RMC14/Medical/Surgery/CMSurgeryBui.cs
+++ b/Content.Client/_RMC14/Medical/Surgery/CMSurgeryBui.cs
@@ -316,26 +316,20 @@ public sealed class CMSurgeryBui : BoundUserInterface
 
     private EntProtoId? GetVisibleSurgeryId(EntProtoId surgeryId)
     {
-        if (surgeryId == "RMCSurgeryOpenIncisionWithIMS")
+        var hasIMS = HasOpenIncisionToolInHand(OpenIncisionToolType.IMS);
+        var hasLaserScalpel = HasOpenIncisionToolInHand(OpenIncisionToolType.LaserScalpel);
+
+        return surgeryId switch
         {
-            if (HasIMSScalpelInHand())
-                return surgeryId;
-
-            return null;
-        }
-
-        if (surgeryId != "CMSurgeryOpenIncision")
-            return surgeryId;
-
-        if (HasIMSScalpelInHand())
-        {
-            return "RMCSurgeryOpenIncisionWithIMS";
-        }
-
-        return surgeryId;
+            var id when id == "RMCSurgeryOpenIncisionWithIMS" => hasIMS ? surgeryId : (EntProtoId?) null,
+            var id when id == "RMCSurgeryOpenIncisionWithLaserScapel" => !hasIMS && hasLaserScalpel ? surgeryId : (EntProtoId?) null,
+            var id when id == "CMSurgeryOpenIncision" && hasIMS => "RMCSurgeryOpenIncisionWithIMS",
+            var id when id == "CMSurgeryOpenIncision" && hasLaserScalpel => "RMCSurgeryOpenIncisionWithLaserScapel",
+            _ => surgeryId,
+        };
     }
 
-    private bool HasIMSScalpelInHand()
+    private bool HasOpenIncisionToolInHand(OpenIncisionToolType toolType)
     {
         if (_player.LocalEntity is not { } player ||
             !_entities.TryGetComponent(player, out HandsComponent? hands))
@@ -343,13 +337,13 @@ public sealed class CMSurgeryBui : BoundUserInterface
             return false;
         }
 
-        foreach (var held in _hands.EnumerateHeld((player, hands)))
+        var held = _hands.EnumerateHeld((player, hands));
+        return toolType switch
         {
-            if (_entities.HasComponent<RMCScalpelManagerComponent>(held))
-                return true;
-        }
-
-        return false;
+            OpenIncisionToolType.IMS => held.Any(uid => _entities.HasComponent<RMCScalpelManagerComponent>(uid)),
+            OpenIncisionToolType.LaserScalpel => held.Any(uid => _entities.HasComponent<RMCLaserScalpelComponent>(uid)),
+            _ => false,
+        };
     }
 
     private void RefreshSurgeryChoicesIfToolStateChanged()
@@ -541,5 +535,11 @@ public sealed class CMSurgeryBui : BoundUserInterface
         Next,
         Complete,
         Incomplete,
+    }
+
+    private enum OpenIncisionToolType
+    {
+        IMS,
+        LaserScalpel,
     }
 }

--- a/Content.Client/_RMC14/Medical/Surgery/CMSurgeryBui.cs
+++ b/Content.Client/_RMC14/Medical/Surgery/CMSurgeryBui.cs
@@ -1,7 +1,11 @@
-﻿using Content.Client._RMC14.Xenonids.UI;
+﻿using System.Linq;
+using Content.Client._RMC14.Xenonids.UI;
 using Content.Client.Administration.UI.CustomControls;
+using Content.Client.Hands.Systems;
 using Content.Shared._RMC14.Medical.Surgery;
+using Content.Shared._RMC14.Medical.Surgery.Tools;
 using Content.Shared.Body.Part;
+using Content.Shared.Hands.Components;
 using JetBrains.Annotations;
 using Robust.Client.GameObjects;
 using Robust.Client.Player;
@@ -19,6 +23,7 @@ public sealed class CMSurgeryBui : BoundUserInterface
     [Dependency] private readonly IPlayerManager _player = default!;
 
     private readonly CMSurgerySystem _system;
+    private readonly HandsSystem _hands;
 
     [ViewVariables]
     private CMSurgeryWindow? _window;
@@ -26,23 +31,28 @@ public sealed class CMSurgeryBui : BoundUserInterface
     private EntityUid? _part;
     private (EntityUid Ent, EntProtoId Proto)? _surgery;
     private readonly List<EntProtoId> _previousSurgeries = new();
+    private HashSet<EntityUid>? _lastHeldTools;
 
     public CMSurgeryBui(EntityUid owner, Enum uiKey) : base(owner, uiKey)
     {
         _system = _entities.System<CMSurgerySystem>();
+        _hands = _entities.System<HandsSystem>();
     }
 
     protected override void Open()
     {
         base.Open();
-        _system.OnRefresh += () =>
-        {
-            UpdateDisabledPanel();
-            RefreshUI();
-        };
+        _system.OnRefresh += OnSystemRefresh;
 
         if (State is CMSurgeryBuiState s)
             Update(s);
+    }
+
+    private void OnSystemRefresh()
+    {
+        RefreshSurgeryChoicesIfToolStateChanged();
+        UpdateDisabledPanel();
+        RefreshUI();
     }
 
     protected override void UpdateState(BoundUserInterfaceState state)
@@ -56,7 +66,11 @@ public sealed class CMSurgeryBui : BoundUserInterface
         if (_window == null)
         {
             _window = this.CreateWindow<CMSurgeryWindow>();
-            _window.OnClose += () => _system.OnRefresh -= RefreshUI;
+            _window.OnClose += () =>
+            {
+                _system.OnRefresh -= OnSystemRefresh;
+                _window = null;
+            };
             _window.Title = "Surgery";
 
             _window.PartsButton.OnPressed += _ =>
@@ -159,14 +173,19 @@ public sealed class CMSurgeryBui : BoundUserInterface
 
             foreach (var surgeryId in surgeries)
             {
-                if (_system.GetSingleton(surgeryId) is not { } surgery ||
+                var effectiveSurgeryId = GetVisibleSurgeryId(surgeryId);
+
+                if (effectiveSurgeryId == null)
+                    continue;
+
+                if (_system.GetSingleton(effectiveSurgeryId.Value) is not { } surgery ||
                     !_entities.TryGetComponent(surgery, out CMSurgeryComponent? surgeryComp))
                 {
                     continue;
                 }
 
-                if (oldPart == part && oldSurgery?.Proto == surgeryId)
-                    OnSurgeryPressed((surgery, surgeryComp), netPart, surgeryId);
+                if (oldPart == part && oldSurgery?.Proto == effectiveSurgeryId.Value)
+                    OnSurgeryPressed((surgery, surgeryComp), netPart, effectiveSurgeryId.Value);
             }
 
             if (oldPart == part && oldSurgery == null)
@@ -175,6 +194,8 @@ public sealed class CMSurgeryBui : BoundUserInterface
 
         RefreshUI();
         UpdateDisabledPanel();
+
+        _lastHeldTools = GetHeldToolsSnapshot();
 
         if (!_window.IsOpen)
             _window.OpenCentered();
@@ -207,24 +228,28 @@ public sealed class CMSurgeryBui : BoundUserInterface
 
         _window.Steps.DisposeAllChildren();
 
-        if (surgery.Comp.Requirement is { } requirementId && _system.GetSingleton(requirementId) is { } requirement)
+        if (surgery.Comp.Requirement is { } requirementId)
         {
-            var label = new XenoChoiceControl();
-            label.Button.OnPressed += _ =>
+            var effectiveRequirementId = GetVisibleSurgeryId(requirementId) ?? requirementId;
+            if (_system.GetSingleton(effectiveRequirementId) is { } requirement)
             {
-                _previousSurgeries.Add(surgeryId);
+                var label = new XenoChoiceControl();
+                label.Button.OnPressed += _ =>
+                {
+                    _previousSurgeries.Add(surgeryId);
 
-                if (_entities.TryGetComponent(requirement, out CMSurgeryComponent? requirementComp))
-                    OnSurgeryPressed((requirement, requirementComp), netPart, requirementId);
-            };
+                    if (_entities.TryGetComponent(requirement, out CMSurgeryComponent? requirementComp))
+                        OnSurgeryPressed((requirement, requirementComp), netPart, effectiveRequirementId);
+                };
 
-            var msg = new FormattedMessage();
-            var surgeryName = _entities.GetComponent<MetaDataComponent>(requirement).EntityName;
-            msg.AddMarkupOrThrow($"[bold]Requires: {surgeryName}[/bold]");
-            label.Set(msg, null);
+                var msg = new FormattedMessage();
+                var surgeryName = _entities.GetComponent<MetaDataComponent>(requirement).EntityName;
+                msg.AddMarkupOrThrow($"[bold]Requires: {surgeryName}[/bold]");
+                label.Set(msg, null);
 
-            _window.Steps.AddChild(label);
-            _window.Steps.AddChild(new HSeparator { Color = Color.FromHex("#4972A1"), Margin = new Thickness(0, 0, 0, 1) });
+                _window.Steps.AddChild(label);
+                _window.Steps.AddChild(new HSeparator { Color = Color.FromHex("#4972A1"), Margin = new Thickness(0, 0, 0, 1) });
+            }
         }
 
         foreach (var stepId in surgery.Comp.Steps)
@@ -238,7 +263,7 @@ public sealed class CMSurgeryBui : BoundUserInterface
 
     private void OnPartPressed(NetEntity netPart, List<EntProtoId> surgeryIds)
     {
-        if (_window == null)
+        if (_window is not { Disposed: false })
             return;
 
         _part = _entities.GetEntity(netPart);
@@ -246,16 +271,25 @@ public sealed class CMSurgeryBui : BoundUserInterface
         _window.Surgeries.DisposeAllChildren();
 
         var surgeries = new List<(Entity<CMSurgeryComponent> Ent, EntProtoId Id, string Name)>();
+        var seenSurgeries = new HashSet<EntProtoId>();
         foreach (var surgeryId in surgeryIds)
         {
-            if (_system.GetSingleton(surgeryId) is not { } surgery ||
+            var effectiveSurgeryId = GetVisibleSurgeryId(surgeryId);
+
+            if (effectiveSurgeryId == null)
+                continue;
+
+            if (!seenSurgeries.Add(effectiveSurgeryId.Value))
+                continue;
+
+            if (_system.GetSingleton(effectiveSurgeryId.Value) is not { } surgery ||
                 !_entities.TryGetComponent(surgery, out CMSurgeryComponent? surgeryComp))
             {
                 continue;
             }
 
             var name = _entities.GetComponent<MetaDataComponent>(surgery).EntityName;
-            surgeries.Add(((surgery, surgeryComp), surgeryId, name));
+            surgeries.Add(((surgery, surgeryComp), effectiveSurgeryId.Value, name));
         }
 
         surgeries.Sort((a, b ) =>
@@ -278,6 +312,92 @@ public sealed class CMSurgeryBui : BoundUserInterface
 
         RefreshUI();
         View(ViewType.Surgeries);
+    }
+
+    private EntProtoId? GetVisibleSurgeryId(EntProtoId surgeryId)
+    {
+        if (surgeryId == "RMCSurgeryOpenIncisionWithIMS")
+        {
+            if (HasIMSScalpelInHand())
+                return surgeryId;
+
+            return null;
+        }
+
+        if (surgeryId != "CMSurgeryOpenIncision")
+            return surgeryId;
+
+        if (HasIMSScalpelInHand())
+        {
+            return "RMCSurgeryOpenIncisionWithIMS";
+        }
+
+        return surgeryId;
+    }
+
+    private bool HasIMSScalpelInHand()
+    {
+        if (_player.LocalEntity is not { } player ||
+            !_entities.TryGetComponent(player, out HandsComponent? hands))
+        {
+            return false;
+        }
+
+        foreach (var held in _hands.EnumerateHeld((player, hands)))
+        {
+            if (_entities.HasComponent<RMCScalpelManagerComponent>(held))
+                return true;
+        }
+
+        return false;
+    }
+
+    private void RefreshSurgeryChoicesIfToolStateChanged()
+    {
+        if (_window is not { Disposed: false, IsOpen: true })
+            return;
+
+        var heldTools = GetHeldToolsSnapshot();
+        if (_lastHeldTools != null && _lastHeldTools.SetEquals(heldTools))
+            return;
+
+        _lastHeldTools = heldTools;
+
+        if (_part == null)
+            return;
+
+        if (!_entities.TryGetNetEntity(_part, out var netPart))
+            return;
+
+        if (_window.Surgeries.Visible)
+        {
+            if (State is not CMSurgeryBuiState state ||
+                !state.Choices.TryGetValue(netPart.Value, out var surgeries))
+            {
+                return;
+            }
+
+            OnPartPressed(netPart.Value, surgeries);
+            return;
+        }
+
+        if (_window.Steps.Visible &&
+            _surgery is { } selected &&
+            _entities.TryGetComponent(selected.Ent, out CMSurgeryComponent? selectedComp))
+        {
+            OnSurgeryPressed((selected.Ent, selectedComp), netPart.Value, selected.Proto);
+        }
+    }
+
+    private HashSet<EntityUid> GetHeldToolsSnapshot()
+    {
+        if (_player.LocalEntity is not { } player ||
+            !_entities.TryGetComponent(player, out HandsComponent? hands))
+        {
+            return new HashSet<EntityUid>();
+        }
+
+        return _hands.EnumerateHeld((player, hands)).ToHashSet();
     }
 
     private void RefreshUI()

--- a/Content.Client/_RMC14/Medical/Surgery/CMSurgeryBui.cs
+++ b/Content.Client/_RMC14/Medical/Surgery/CMSurgeryBui.cs
@@ -185,13 +185,15 @@ public sealed class CMSurgeryBui : BoundUserInterface
                 }
 
                 if (oldPart == part && oldSurgery?.Proto == effectiveSurgeryId.Value)
+                {
                     OnSurgeryPressed((surgery, surgeryComp), netPart, effectiveSurgeryId.Value);
+                    break;
+                }
             }
 
             if (oldPart == part && oldSurgery == null)
                 OnPartPressed(netPart, surgeries);
         }
-
         RefreshUI();
         UpdateDisabledPanel();
 
@@ -322,9 +324,9 @@ public sealed class CMSurgeryBui : BoundUserInterface
         return surgeryId switch
         {
             var id when id == "RMCSurgeryOpenIncisionWithIMS" => hasIMS ? surgeryId : (EntProtoId?) null,
-            var id when id == "RMCSurgeryOpenIncisionWithLaserScapel" => !hasIMS && hasLaserScalpel ? surgeryId : (EntProtoId?) null,
+            var id when id == "RMCSurgeryOpenIncisionWithLaserScalpel" => !hasIMS && hasLaserScalpel ? surgeryId : (EntProtoId?) null,
             var id when id == "CMSurgeryOpenIncision" && hasIMS => "RMCSurgeryOpenIncisionWithIMS",
-            var id when id == "CMSurgeryOpenIncision" && hasLaserScalpel => "RMCSurgeryOpenIncisionWithLaserScapel",
+            var id when id == "CMSurgeryOpenIncision" && hasLaserScalpel => "RMCSurgeryOpenIncisionWithLaserScalpel",
             _ => surgeryId,
         };
     }
@@ -351,14 +353,15 @@ public sealed class CMSurgeryBui : BoundUserInterface
         if (_window is not { Disposed: false, IsOpen: true })
             return;
 
+        if (_part == null)
+            return;
+
         var heldTools = GetHeldToolsSnapshot();
+
         if (_lastHeldTools != null && _lastHeldTools.SetEquals(heldTools))
             return;
 
         _lastHeldTools = heldTools;
-
-        if (_part == null)
-            return;
 
         if (!_entities.TryGetNetEntity(_part, out var netPart))
             return;

--- a/Content.Shared/_RMC14/Medical/Surgery/Tools/RMCLaserScalpelComponent.cs
+++ b/Content.Shared/_RMC14/Medical/Surgery/Tools/RMCLaserScalpelComponent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Medical.Surgery.Tools;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(SharedCMSurgerySystem))]
+public sealed partial class RMCLaserScalpelComponent : Component, ICMSurgeryToolComponent
+{
+    public string ToolName => "a laser scalpel";
+}

--- a/Content.Shared/_RMC14/Medical/Surgery/Tools/RMCScalpelManagerComponent.cs
+++ b/Content.Shared/_RMC14/Medical/Surgery/Tools/RMCScalpelManagerComponent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Medical.Surgery.Tools;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(SharedCMSurgerySystem))]
+public sealed partial class RMCScalpelManagerComponent : Component, ICMSurgeryToolComponent
+{
+    public string ToolName => "an incision management system";
+}

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Medical/surgery.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Medical/surgery.yml
@@ -296,7 +296,8 @@
   components:
   - type: Sprite
     state: pict_system
-    # as a note for future developers, the pict system doesnt actually do any cauterisation, despite the description. according to the cm13 code, its just a shit scalpel.
+  - type: CMCautery
+
 
 # - Manager
 - type: entity

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Medical/surgery.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Medical/surgery.yml
@@ -220,6 +220,11 @@
   name: prototype laser scalpel
   description: A scalpel augmented with a directed laser, for controlling bleeding as the incision is made. Also functions as a cautery. This one looks like an unreliable early model.
   components:
+  - type: CMSurgeryTool
+    startSound:
+      path: /Audio/_RMC14/Medical/Surgery/cautery1.ogg
+    endSound:
+      path: /Audio/_RMC14/Medical/Surgery/cautery2.ogg
   - type: RMCLaserScalpel
   - type: CMCautery
   - type: Sprite

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Medical/surgery.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Medical/surgery.yml
@@ -220,6 +220,8 @@
   name: prototype laser scalpel
   description: A scalpel augmented with a directed laser, for controlling bleeding as the incision is made. Also functions as a cautery. This one looks like an unreliable early model.
   components:
+  - type: RMCLaserScalpel
+  - type: CMCautery
   - type: Sprite
     layers:
     - state: scalpel_laser
@@ -289,19 +291,18 @@
   components:
   - type: Sprite
     state: pict_system
+    # as a note for future developers, the pict system doesnt actually do any cauterisation, despite the description. according to the cm13 code, its just a shit scalpel.
 
 # - Manager
 - type: entity
   parent: CMScalpel
   id: CMScalpelManager
   name: incision management system
-  description: A true extension of the surgeon's body, this marvel instantly and completely prepares an incision allowing for the immediate commencement of therapeutic steps.
+  description: A true extension of the surgeon's body, this marvel completely prepares an incision allowing for the efficient commencement of therapeutic steps.
   components:
   - type: RMCScalpelManager
   - type: Sprite
     state: scalpel_manager
-
-
 
 # Circular saw
 - type: entity

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Medical/surgery.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Medical/surgery.yml
@@ -297,6 +297,7 @@
   name: incision management system
   description: A true extension of the surgeon's body, this marvel instantly and completely prepares an incision allowing for the immediate commencement of therapeutic steps.
   components:
+  - type: RMCScalpelManager
   - type: Sprite
     state: scalpel_manager
 

--- a/Resources/Prototypes/_RMC14/Entities/Surgery/cm_surgeries.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Surgery/cm_surgeries.yml
@@ -71,3 +71,13 @@
   - type: RMCSurgeryXenoHeartCondition
   - type: CMSurgeryPartCondition
     part: Head
+
+- type: entity
+  parent: CMSurgeryBase
+  id: RMCSurgeryOpenIncisionWithIMS
+  name: Open Incision with IMS
+  components:
+  - type: CMSurgery
+    priority: -1
+    steps:
+    - RMCSurgeryStepOpenIncisionWithIMS

--- a/Resources/Prototypes/_RMC14/Entities/Surgery/cm_surgeries.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Surgery/cm_surgeries.yml
@@ -78,6 +78,15 @@
   name: Open Incision with IMS
   components:
   - type: CMSurgery
-    priority: -1
     steps:
     - RMCSurgeryStepOpenIncisionWithIMS
+
+- type: entity
+  parent: CMSurgeryBase
+  id: RMCSurgeryOpenIncisionWithLaserScapel
+  name: Open Incision with Laser Scalpel
+  components:
+  - type: CMSurgery
+    steps:
+    - RMCSurgeryStepOpenIncisionWithLaserScalpel
+    - CMSurgeryStepRetractSkin

--- a/Resources/Prototypes/_RMC14/Entities/Surgery/cm_surgeries.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Surgery/cm_surgeries.yml
@@ -83,7 +83,7 @@
 
 - type: entity
   parent: CMSurgeryBase
-  id: RMCSurgeryOpenIncisionWithLaserScapel
+  id: RMCSurgeryOpenIncisionWithLaserScalpel
   name: Open Incision with Laser Scalpel
   components:
   - type: CMSurgery

--- a/Resources/Prototypes/_RMC14/Entities/Surgery/cm_surgery_steps.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Surgery/cm_surgery_steps.yml
@@ -216,3 +216,23 @@
     sprite: _RMC14/Objects/Medical/Surgery/hemostat.rsi
     state: hemostat
   - type: RMCSurgeryStepXenoHeartEffect
+
+- type: entity
+  parent: CMSurgeryStepBase
+  id: RMCSurgeryStepOpenIncisionWithIMS
+  name: Open incision with an Incision Management System
+  components:
+  - type: CMSurgeryStep
+    skill: 2
+    tool:
+    - type: RMCScalpelManager
+    add:
+    - type: CMIncisionOpen
+    - type: CMBleedersClamped
+    - type: CMSkinRetracted
+  - type: Sprite
+    sprite: _RMC14/Objects/Medical/Surgery/scalpel.rsi
+    state: scalpel_manager
+  - type: CMSurgeryStepBleedEffect
+    damage: 10
+  - type: CMSurgeryStepEmoteEffect

--- a/Resources/Prototypes/_RMC14/Entities/Surgery/cm_surgery_steps.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Surgery/cm_surgery_steps.yml
@@ -233,6 +233,21 @@
   - type: Sprite
     sprite: _RMC14/Objects/Medical/Surgery/scalpel.rsi
     state: scalpel_manager
-  - type: CMSurgeryStepBleedEffect
-    damage: 10
+  - type: CMSurgeryStepEmoteEffect
+
+- type: entity
+  parent: CMSurgeryStepBase
+  id: RMCSurgeryStepOpenIncisionWithLaserScalpel
+  name: Open incision with a Laser Scalpel
+  components:
+  - type: CMSurgeryStep
+    skill: 2
+    tool:
+    - type: RMCLaserScalpel
+    add:
+    - type: CMIncisionOpen
+    - type: CMBleedersClamped
+  - type: Sprite
+    sprite: _RMC14/Objects/Medical/Surgery/scalpel.rsi
+    state: scalpel_laser
   - type: CMSurgeryStepEmoteEffect


### PR DESCRIPTION
## About the PR
Adds the functionality to the Incision management system(IMS) and Laser scalpel to skip various steps of the surgery process.
The IMS does all 3 steps of the incision management system at once.
The Laser scalpel does the first two steps, but also acts as a cautery.

## Why / Balance
Gives these items some use and reason to be gathered. Also Parity. 

## Technical details
New surgery steps and variants of the open incision task.
Logic handles which tool you have to update the open incision task with which tool you have available.
Updates the requirement links to use the new tool based tasks.
Updates laser scalpel to also be a cautery.
Made the laser scapel sound like a cautery. ( cm13 ties sounds to surgery steps, rmc ties it to the tool, might need a rework in the future, but laser sounding like a knife felt weird )

## Media
https://github.com/user-attachments/assets/9bad520e-5881-4348-8765-6a4128b9cb23


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Functionality to the Incision management system and Laser scalpel
