### PR TITLE
Fixed observers being unable to hear xenos with 'Ghost Hearing' disabled

### DIFF
--- a/Content.Server/_RMC14/Chat/Chat/CMChatSystem.cs
+++ b/Content.Server/_RMC14/Chat/Chat/CMChatSystem.cs
@@ -9,6 +9,7 @@ using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.Mentor.ImaginaryFriend;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared.Chat;
+using Content.Shared.Ghost;
 using Content.Shared.Inventory;
 using Content.Shared.Popups;
 using Content.Shared.Radio;
@@ -72,7 +73,9 @@ public sealed class CMChatSystem : SharedCMChatSystem
             if (data.Observer)
                 continue;
 
-            if (!HasComp<XenoComponent>(session.AttachedEntity))
+            // `data.Observer` only indicates whether the recipient has `GhostHearingComponent`.
+            // Disabling ghost hearing removes this component, so the `GhostComponent` check is needed to keep ghosts included.
+            if (!HasComp<XenoComponent>(session.AttachedEntity) && !HasComp<GhostComponent>(session.AttachedEntity))
                 _toRemove.Add(session);
         }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed ghosts being unable to hear xenos talking if they disabled 'Ghost Hearing'. (Fixes #6469, Fixes #3131)

The reason they're currently unable to hear it is due to them not having `XenoComponent`, and therefore failing the check in `OnXenoAfterGetRecipients()`. If ghost hearing is enabled then that sets `data.Observer` to `true` and skips the check.
https://github.com/RMC-14/RMC-14/blob/179c7cdd4d1287747610221c3378d69d658d0ee3/Content.Server/_RMC14/Chat/Chat/CMChatSystem.cs#L70-L77

## Why / Balance
Bugfix!

## Technical details
It feels a bit hacky just directly adding a `HasComp` check instead of reworking how `data.Observer` works, but that would involve a bunch of upstream edits and ends up using `HasComp` anyway, so I think this is fine?

## Media
### Before:

https://github.com/user-attachments/assets/ccd8e9d4-22cf-4b13-bb8e-6fc4b375db55


### After:

https://github.com/user-attachments/assets/31be2fa2-9ff9-45a1-9758-9bfa3934e193

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed observers being unable to hear xenos talking if 'Ghost Hearing' was disabled.