### PR TITLE
Fix the dazed overlay not always being removed after the effect ends

### DIFF
--- a/Content.Client/_RMC14/Stun/DazedOverlay.cs
+++ b/Content.Client/_RMC14/Stun/DazedOverlay.cs
@@ -8,7 +8,7 @@ namespace Content.Client._RMC14.Stun;
 
 public sealed class DazedOverlay : Overlay
 {
-    private static readonly ProtoId<ShaderPrototype> DazedCircleMaskShader = "GradientCircleMask";
+    private static readonly ProtoId<ShaderPrototype> CircleMaskShader = "GradientCircleMask";
 
     public override OverlaySpace Space => OverlaySpace.WorldSpace;
 
@@ -25,7 +25,7 @@ public sealed class DazedOverlay : Overlay
         _entManager = entManager;
         _playerManager = playerManager;
 
-        _vignetteShader = prototypeManager.Index(DazedCircleMaskShader).InstanceUnique();
+        _vignetteShader = prototypeManager.Index(CircleMaskShader).InstanceUnique();
     }
 
     protected override void Draw(in OverlayDrawArgs args)

--- a/Content.Client/_RMC14/Stun/DazedOverlay.cs
+++ b/Content.Client/_RMC14/Stun/DazedOverlay.cs
@@ -1,4 +1,5 @@
 using Content.Shared._RMC14.Stun;
+using Content.Shared.StatusEffectNew;
 using Robust.Client.Graphics;
 using Robust.Client.Player;
 using Robust.Shared.Enums;
@@ -14,6 +15,7 @@ public sealed class DazedOverlay : Overlay
 
     private readonly IEntityManager _entManager;
     private readonly IPlayerManager _playerManager;
+    private readonly SharedStatusEffectsSystem _statusEffect;
 
     private readonly ShaderInstance _vignetteShader;
 
@@ -24,6 +26,7 @@ public sealed class DazedOverlay : Overlay
     {
         _entManager = entManager;
         _playerManager = playerManager;
+        _statusEffect = entManager.System<SharedStatusEffectsSystem>();
 
         _vignetteShader = prototypeManager.Index(CircleMaskShader).InstanceUnique();
     }
@@ -32,7 +35,13 @@ public sealed class DazedOverlay : Overlay
     {
         var localEntity = _playerManager.LocalEntity;
 
-        if (localEntity == null || !_entManager.TryGetComponent(localEntity, out RMCDazedComponent? dazed))
+        if (localEntity == null)
+            return;
+
+        if (!_statusEffect.TryGetStatusEffect(localEntity.Value, RMCDazedSystem.StatusEffectDazed, out var statusEffect))
+            return;
+
+        if (!_entManager.TryGetComponent(statusEffect, out RMCDazedComponent? dazed))
             return;
 
         var handle = args.WorldHandle;

--- a/Content.Client/_RMC14/Stun/DazedOverlay.cs
+++ b/Content.Client/_RMC14/Stun/DazedOverlay.cs
@@ -1,49 +1,53 @@
+using Content.Shared._RMC14.Stun;
 using Robust.Client.Graphics;
+using Robust.Client.Player;
 using Robust.Shared.Enums;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Timing;
 
 namespace Content.Client._RMC14.Stun;
 
 public sealed class DazedOverlay : Overlay
 {
-    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
-    [Dependency] private readonly IGameTiming _timing = default!;
+    private static readonly ProtoId<ShaderPrototype> DazedCircleMaskShader = "GradientCircleMask";
 
     public override OverlaySpace Space => OverlaySpace.WorldSpace;
 
+    private readonly IEntityManager _entManager;
+    private readonly IPlayerManager _playerManager;
+
     private readonly ShaderInstance _vignetteShader;
 
-    public bool IsEnabled { get; set; }
+    private const float MinVisionScale = 0.1f;
+    private const float MaxVisionScale = 1f;
 
-    private float _outerFadeStart = 0.0f;
-    private float _outerFadeEnd = 0.8f;
-    private float _alpha = 1.0f;
-
-    public DazedOverlay()
+    public DazedOverlay(IEntityManager entManager, IPlayerManager playerManager, IPrototypeManager prototypeManager)
     {
-        IoCManager.InjectDependencies(this);
-        _vignetteShader = _prototypeManager.Index<ShaderPrototype>("GradientCircleMask").InstanceUnique();
+        _entManager = entManager;
+        _playerManager = playerManager;
+
+        _vignetteShader = prototypeManager.Index(DazedCircleMaskShader).InstanceUnique();
     }
 
     protected override void Draw(in OverlayDrawArgs args)
     {
-        if (!IsEnabled)
+        var localEntity = _playerManager.LocalEntity;
+
+        if (localEntity == null || !_entManager.TryGetComponent(localEntity, out RMCDazedComponent? dazed))
             return;
 
         var handle = args.WorldHandle;
         var viewport = args.WorldAABB;
-        var distance = args.ViewportBounds.Width;
+        var visionRadius = args.ViewportBounds.Width * Math.Clamp(1f - dazed.VisionReduction, MinVisionScale, MaxVisionScale);
 
-        _vignetteShader.SetParameter("color", new Vector3(0f, 0f, 0f));
-        _vignetteShader.SetParameter("darknessAlphaOuter", _alpha);
-        _vignetteShader.SetParameter("darknessAlphaInner", 0f);
+        _vignetteShader.SetParameter("color", new Vector3(dazed.Color.R, dazed.Color.G, dazed.Color.B));
+        _vignetteShader.SetParameter("darknessAlphaOuter", dazed.Alpha);
+        _vignetteShader.SetParameter("darknessAlphaInner", dazed.InnerAlpha);
 
-        _vignetteShader.SetParameter("innerCircleRadius", _outerFadeStart * distance * 0.5f);
-        _vignetteShader.SetParameter("innerCircleMaxRadius", _outerFadeStart * distance * 0.5f);
+        _vignetteShader.SetParameter("innerCircleRadius", dazed.OuterFadeStart * visionRadius);
+        _vignetteShader.SetParameter("innerCircleMaxRadius", dazed.OuterFadeStart * visionRadius);
 
-        _vignetteShader.SetParameter("outerCircleRadius", _outerFadeEnd * distance * 0.5f);
-        _vignetteShader.SetParameter("outerCircleMaxRadius", _outerFadeEnd * distance * 0.5f);
+        _vignetteShader.SetParameter("outerCircleRadius", dazed.OuterFadeEnd * visionRadius);
+        _vignetteShader.SetParameter("outerCircleMaxRadius", dazed.OuterFadeEnd * visionRadius);
 
         handle.UseShader(_vignetteShader);
         handle.DrawRect(viewport, Color.White);

--- a/Content.Client/_RMC14/Stun/DazedUiController.cs
+++ b/Content.Client/_RMC14/Stun/DazedUiController.cs
@@ -2,14 +2,16 @@ using Content.Shared._RMC14.Stun;
 using Robust.Client.Graphics;
 using Robust.Client.Player;
 using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
 
 namespace Content.Client._RMC14.Stun;
 
 public sealed class DazedUiController : EntitySystem
 {
+    [Dependency] private readonly IEntityManager _entityManager = default!;
     [Dependency] private readonly IOverlayManager _overlayManager = default!;
     [Dependency] private readonly IPlayerManager _playerManager = default!;
-    [Dependency] private readonly IEntityManager _entityManager = default!;
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
 
     private DazedOverlay _overlay = default!;
 
@@ -17,18 +19,16 @@ public sealed class DazedUiController : EntitySystem
     {
         base.Initialize();
 
-        _overlay = new DazedOverlay();
+        _overlay = new DazedOverlay(_entityManager, _playerManager, _prototypeManager);
 
         SubscribeLocalEvent<LocalPlayerAttachedEvent>(OnPlayerAttach);
         SubscribeLocalEvent<LocalPlayerDetachedEvent>(OnPlayerDetached);
 
         SubscribeLocalEvent<RMCDazedComponent, ComponentStartup>(OnStartup);
-        SubscribeNetworkEvent<DazedComponentShutdownEvent>(OnLocalPlayerDazedShutdown);
     }
 
     private void OnPlayerAttach(LocalPlayerAttachedEvent args)
     {
-        _overlay.IsEnabled = _entityManager.HasComponent<RMCDazedComponent>(args.Entity);
         if (!_overlayManager.HasOverlay<DazedOverlay>())
             _overlayManager.AddOverlay(_overlay);
     }
@@ -37,21 +37,14 @@ public sealed class DazedUiController : EntitySystem
     {
         if (_overlayManager.HasOverlay<DazedOverlay>())
              _overlayManager.RemoveOverlay(_overlay);
-        _overlay.IsEnabled = false;
     }
 
     private void OnStartup(Entity<RMCDazedComponent> ent, ref ComponentStartup args)
     {
         if (ent == _playerManager.LocalEntity)
         {
-            _overlay.IsEnabled = true;
             if (!_overlayManager.HasOverlay<DazedOverlay>())
                 _overlayManager.AddOverlay(_overlay);
         }
-    }
-
-    private void OnLocalPlayerDazedShutdown(DazedComponentShutdownEvent args)
-    {
-         _overlay.IsEnabled = false;
     }
 }

--- a/Content.Shared/_RMC14/StatusEffect/RMCStatusEffectSystem.cs
+++ b/Content.Shared/_RMC14/StatusEffect/RMCStatusEffectSystem.cs
@@ -13,7 +13,6 @@ public sealed class RMCStatusEffectSystem : EntitySystem
     private static readonly ProtoId<StatusEffectPrototype> Knockdown = "KnockedDown";
     private static readonly ProtoId<StatusEffectPrototype> Stun = "Stun";
     private static readonly ProtoId<StatusEffectPrototype> Unconscious = "Unconscious";
-    private static readonly ProtoId<StatusEffectPrototype> Dazed = "Dazed";
 
     public override void Initialize()
     {
@@ -26,7 +25,7 @@ public sealed class RMCStatusEffectSystem : EntitySystem
 
     private void OnSkillsStatusEffectTime(Entity<SkillsComponent> ent, ref RMCStatusEffectTimeEvent args)
     {
-        if (args.Key != Knockdown && args.Key != Stun && args.Key != Unconscious && args.Key != Dazed)
+        if (args.Key != Knockdown && args.Key != Stun && args.Key != Unconscious)
             return;
 
         var endurance = _skills.GetSkill((ent, ent), EnduranceSkill);
@@ -40,7 +39,7 @@ public sealed class RMCStatusEffectSystem : EntitySystem
 
     private void OnXenoStatusEffectTime(Entity<XenoComponent> ent, ref RMCStatusEffectTimeEvent args)
     {
-        if (args.Key != Knockdown && args.Key != Stun && args.Key != Unconscious && args.Key != Dazed)
+        if (args.Key != Knockdown && args.Key != Stun && args.Key != Unconscious)
             return;
 
         args.Duration *= 0.667;
@@ -48,7 +47,7 @@ public sealed class RMCStatusEffectSystem : EntitySystem
 
     private void OnStunResistanceStatusEffectTime(Entity<RMCStunResistanceComponent> ent, ref RMCStatusEffectTimeEvent args)
     {
-        if (args.Key != Knockdown && args.Key != Stun && args.Key != Unconscious && args.Key != Dazed)
+        if (args.Key != Knockdown && args.Key != Stun && args.Key != Unconscious)
             return;
 
         args.Duration /= ent.Comp.Resistance;

--- a/Content.Shared/_RMC14/Stun/RMCDazedComponent.cs
+++ b/Content.Shared/_RMC14/Stun/RMCDazedComponent.cs
@@ -5,6 +5,26 @@ namespace Content.Shared._RMC14.Stun;
 /// <summary>
 ///     Having this component prevents being dazed again.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 [Access(typeof(RMCDazedSystem))]
-public sealed partial class RMCDazedComponent : Component;
+public sealed partial class RMCDazedComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public float VisionReduction = 0.5f;
+
+    [DataField, AutoNetworkedField]
+    public float OuterFadeStart;
+
+    [DataField, AutoNetworkedField]
+    public float OuterFadeEnd = 0.8f;
+
+    [DataField, AutoNetworkedField]
+    public float Alpha = 1;
+
+    [DataField, AutoNetworkedField]
+    public float InnerAlpha;
+
+    [DataField, AutoNetworkedField]
+    public Color Color = Color.Black;
+
+}

--- a/Content.Shared/_RMC14/Stun/RMCDazedComponent.cs
+++ b/Content.Shared/_RMC14/Stun/RMCDazedComponent.cs
@@ -26,5 +26,4 @@ public sealed partial class RMCDazedComponent : Component
 
     [DataField, AutoNetworkedField]
     public Color Color = Color.Black;
-
 }

--- a/Content.Shared/_RMC14/Stun/RMCDazedSystem.cs
+++ b/Content.Shared/_RMC14/Stun/RMCDazedSystem.cs
@@ -4,19 +4,14 @@ using Content.Shared.Charges.Components;
 using Content.Shared.Charges.Systems;
 using Content.Shared.Speech.EntitySystems;
 using Content.Shared.StatusEffect;
-using Robust.Shared.Network;
-using Robust.Shared.Player;
-using Robust.Shared.Serialization;
 
 namespace Content.Shared._RMC14.Stun;
 
 public sealed class RMCDazedSystem : EntitySystem
 {
     [Dependency] private readonly SharedChargesSystem _charges = default!;
-    [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly StatusEffectsSystem _statusEffect = default!;
     [Dependency] private readonly SharedActionsSystem _actions = default!;
-    [Dependency] private readonly ISharedPlayerManager _playerManager = default!;
     [Dependency] private readonly SharedStutteringSystem _stutter = default!;
 
     public override void Initialize()

--- a/Content.Shared/_RMC14/Stun/RMCDazedSystem.cs
+++ b/Content.Shared/_RMC14/Stun/RMCDazedSystem.cs
@@ -56,12 +56,6 @@ public sealed class RMCDazedSystem : EntitySystem
                 _charges.ResetCharges(actionId);
             }
         }
-
-        if (_net.IsServer && _playerManager.TryGetSessionByEntity(ent.Owner, out var session))
-        {
-            var ev = new DazedComponentShutdownEvent();
-            RaiseNetworkEvent(ev, session.Channel);
-        }
     }
 
     public bool TryDaze(EntityUid uid, TimeSpan time, bool refresh = false, StatusEffectsComponent? status = null, bool stutter = false)
@@ -91,6 +85,3 @@ public sealed class RMCDazedSystem : EntitySystem
 /// </summary>
 [ByRefEvent]
 public record struct DazedEvent(TimeSpan Duration);
-
-[NetSerializable, Serializable]
-public sealed class DazedComponentShutdownEvent: EntityEventArgs;

--- a/Content.Shared/_RMC14/Stun/RMCDazedSystem.cs
+++ b/Content.Shared/_RMC14/Stun/RMCDazedSystem.cs
@@ -4,22 +4,26 @@ using Content.Shared.Charges.Components;
 using Content.Shared.Charges.Systems;
 using Content.Shared.Speech.EntitySystems;
 using Content.Shared.StatusEffect;
+using Content.Shared.StatusEffectNew;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared._RMC14.Stun;
 
 public sealed class RMCDazedSystem : EntitySystem
 {
     [Dependency] private readonly SharedChargesSystem _charges = default!;
-    [Dependency] private readonly StatusEffectsSystem _statusEffect = default!;
+    [Dependency] private readonly SharedStatusEffectsSystem _statusEffect = default!;
     [Dependency] private readonly SharedActionsSystem _actions = default!;
     [Dependency] private readonly SharedStutteringSystem _stutter = default!;
+
+    public static readonly EntProtoId StatusEffectDazed = "Dazed";
 
     public override void Initialize()
     {
         base.Initialize();
 
-        SubscribeLocalEvent<RMCDazedComponent, DazedEvent>(OnDazed);
-        SubscribeLocalEvent<RMCDazedComponent, ComponentShutdown>(OnDazedEnd);
+        SubscribeLocalEvent<RMCDazedComponent, StatusEffectAppliedEvent>(OnDazed);
+        SubscribeLocalEvent<RMCDazedComponent, StatusEffectRemovedEvent>(OnDazedEnd);
     }
 
     /// <summary>
@@ -27,7 +31,7 @@ public sealed class RMCDazedSystem : EntitySystem
     ///     cooldown isn't higher already.
     /// </summary>
     /// <seealso cref="RMCDazeableActionComponent"/>
-    private void OnDazed(Entity<RMCDazedComponent> ent, ref DazedEvent args)
+    private void OnDazed(Entity<RMCDazedComponent> ent, ref StatusEffectAppliedEvent args)
     {
         foreach (var (actionId, _) in _actions.GetActions(ent))
         {
@@ -41,7 +45,7 @@ public sealed class RMCDazedSystem : EntitySystem
         }
     }
 
-    private void OnDazedEnd(Entity<RMCDazedComponent> ent, ref ComponentShutdown args)
+    private void OnDazedEnd(Entity<RMCDazedComponent> ent, ref StatusEffectRemovedEvent args)
     {
         foreach (var (actionId, _) in _actions.GetActions(ent))
         {
@@ -61,22 +65,18 @@ public sealed class RMCDazedSystem : EntitySystem
         if (time <= TimeSpan.Zero)
             return false;
 
-        if (_statusEffect.TryAddStatusEffect<RMCDazedComponent>(uid, "Dazed", time, refresh, status))
+        var appliedEffect = false;
+        if (refresh)
         {
-            if (stutter)
-                _stutter.DoStutter(uid, time, true);
-
-            var ev = new DazedEvent(time);
-            RaiseLocalEvent(uid, ref ev);
-            return true;
+            _statusEffect.TryUpdateStatusEffectDuration(uid, StatusEffectDazed, time);
+            appliedEffect = true;
         }
+        else if (_statusEffect.TryAddStatusEffectDuration(uid, StatusEffectDazed, time))
+            appliedEffect = true;
+
+        if (appliedEffect && stutter)
+            _stutter.DoStutter(uid, time, true, status);
 
         return false;
     }
 }
-
-/// <summary>
-///     Raised directed on an entity when it is dazed.
-/// </summary>
-[ByRefEvent]
-public record struct DazedEvent(TimeSpan Duration);

--- a/Content.Shared/_RMC14/Xenonids/FightOrFlight/XenoFightOrFlightComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/FightOrFlight/XenoFightOrFlightComponent.cs
@@ -32,8 +32,12 @@ public sealed partial class XenoFightOrFlightComponent : Component
     [DataField, AutoNetworkedField]
     public TimeSpan Jitter = TimeSpan.FromSeconds(1);
 
+    //TODO RMC14 move these effects over to the new status effect system
     [DataField, AutoNetworkedField]
-    public ProtoId<StatusEffectPrototype>[] AilmentsRemove = ["KnockedDown", "Stun", "Dazed", "Unconscious"];
+    public ProtoId<StatusEffectPrototype>[] AilmentsRemove = ["KnockedDown", "Stun", "Unconscious"];
+
+    [DataField, AutoNetworkedField]
+    public EntProtoId[] AilmentsRemoveNew = ["Dazed"];
 
     [DataField]
     public ComponentRegistry ComponentsRemove;

--- a/Content.Shared/_RMC14/Xenonids/FightOrFlight/XenoFightOrFlightSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/FightOrFlight/XenoFightOrFlightSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared.Coordinates;
 using Content.Shared.Jittering;
 using Content.Shared.Popups;
 using Content.Shared.StatusEffect;
+using Content.Shared.StatusEffectNew;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Network;
 
@@ -17,6 +18,7 @@ public sealed class XenoFightOrFlightSystem : EntitySystem
     [Dependency] private readonly XenoEnergySystem _energy = default!;
     [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
     [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
+    [Dependency] private readonly SharedStatusEffectsSystem _statusEffect = default!;
     [Dependency] private readonly StatusEffectsSystem _status = default!;
     [Dependency] private readonly SharedJitteringSystem _jitter = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
@@ -59,6 +61,11 @@ public sealed class XenoFightOrFlightSystem : EntitySystem
             foreach (var status in xeno.Comp.AilmentsRemove)
             {
                 _status.TryRemoveStatusEffect(otherXeno, status);
+            }
+
+            foreach (var status in xeno.Comp.AilmentsRemoveNew)
+            {
+                _statusEffect.TryRemoveStatusEffect(otherXeno, status);
             }
 
             EntityManager.RemoveComponents(otherXeno, xeno.Comp.ComponentsRemove);

--- a/Content.Shared/_RMC14/Xenonids/Heal/SharedXenoHealSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Heal/SharedXenoHealSystem.cs
@@ -1,10 +1,8 @@
 using Content.Shared._RMC14.Actions;
 using Content.Shared._RMC14.Atmos;
 using Content.Shared._RMC14.Damage;
-using Content.Shared._RMC14.Slow;
 using Content.Shared._RMC14.Stun;
 using Content.Shared._RMC14.Xenonids.Announce;
-using Content.Shared._RMC14.Xenonids.Construction;
 using Content.Shared._RMC14.Xenonids.Energy;
 using Content.Shared._RMC14.Xenonids.Eye;
 using Content.Shared._RMC14.Xenonids.Hive;
@@ -23,6 +21,7 @@ using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Popups;
 using Content.Shared.StatusEffect;
+using Content.Shared.StatusEffectNew;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
@@ -47,6 +46,7 @@ public abstract class SharedXenoHealSystem : EntitySystem
     [Dependency] private readonly QueenEyeSystem _queenEye = default!;
     [Dependency] private readonly SharedRMCActionsSystem _rmcActions = default!;
     [Dependency] private readonly SharedRMCDamageableSystem _rmcDamageable = default!;
+    [Dependency] private readonly SharedStatusEffectsSystem _statusEffect = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedBodySystem _body = default!;
@@ -327,6 +327,10 @@ public abstract class SharedXenoHealSystem : EntitySystem
             _status.TryRemoveStatusEffect(target, status);
         }
 
+        foreach (var status in args.AilmentsRemoveNew)
+        {
+            _statusEffect.TryRemoveStatusEffect(target, status);
+        }
 
         EntityManager.RemoveComponents(target, args.ComponentsRemove);
 

--- a/Content.Shared/_RMC14/Xenonids/Heal/XenoSacrificeHealActionEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Heal/XenoSacrificeHealActionEvent.cs
@@ -1,4 +1,3 @@
-using Content.Shared._RMC14.Slow;
 using Content.Shared.Actions;
 using Content.Shared.FixedPoint;
 using Content.Shared.StatusEffect;
@@ -26,8 +25,12 @@ public sealed partial class XenoSacrificeHealActionEvent : EntityTargetActionEve
     [DataField]
     public EntProtoId HealEffect = "RMCEffectHealSacrifice";
 
+    //TODO RMC14 move these effects over to the new status effect system
     [DataField]
-    public ProtoId<StatusEffectPrototype>[] AilmentsRemove = ["KnockedDown", "Stun", "Dazed", "Unconscious"];
+    public ProtoId<StatusEffectPrototype>[] AilmentsRemove = ["KnockedDown", "Stun", "Unconscious"];
+
+    [DataField]
+    public EntProtoId[] AilmentsRemoveNew = ["Dazed"];
 
     [DataField]
     public ComponentRegistry ComponentsRemove;

--- a/Resources/Prototypes/_RMC14/StatusEffects/status_effects.yml
+++ b/Resources/Prototypes/_RMC14/StatusEffects/status_effects.yml
@@ -1,8 +1,12 @@
 - type: statusEffect
   id: Deaf
 
-- type: statusEffect
+- type: entity
+  parent: MobStatusEffectBase
   id: Dazed
+  name: Dazed
+  components:
+  - type: RMCDazed
 
 - type: statusEffect
   id: Blinded


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

- Fixed the dazed overlay effect sometimes not being removed after the effect ended.
- Cleaned the dazed code a bit.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Resolves #10198 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix: Fixed the dazed overlay effect sometimes not being removed after the effect ended.
