### PR TITLE
Fix area damage being able to hit entities inside containers

### DIFF
--- a/Content.Shared/_RMC14/Projectiles/RMCAreaDamageSystem.cs
+++ b/Content.Shared/_RMC14/Projectiles/RMCAreaDamageSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared._RMC14.Armor;
 using Content.Shared._RMC14.Stun;
+using Content.Shared._RMC14.Weapons.Ranged.Prediction;
 using Content.Shared.Damage;
 using Content.Shared.Effects;
 using Content.Shared.FixedPoint;
@@ -12,12 +13,13 @@ namespace Content.Shared._RMC14.Projectiles;
 
 public sealed class RMCAreaDamageSystem : EntitySystem
 {
-    [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
-    [Dependency] private readonly DamageableSystem _damage = default!;
-    [Dependency] private readonly SharedTransformSystem _transform = default!;
-    [Dependency] private readonly RMCSizeStunSystem _sizeStun = default!;
     [Dependency] private readonly SharedColorFlashEffectSystem _colorFlash = default!;
+    [Dependency] private readonly DamageableSystem _damage = default!;
+    [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
     [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly ISharedPlayerManager _player = default!;
+    [Dependency] private readonly RMCSizeStunSystem _sizeStun = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
 
     public override void Initialize()
     {
@@ -50,12 +52,12 @@ public sealed class RMCAreaDamageSystem : EntitySystem
         if (areaDamage.DamageArea == 0 || !TryComp(target, out MobStateComponent? mobState))
             return;
 
-        var nearbyEntities = _entityLookup.GetEntitiesInRange<MobStateComponent>(Transform(target).Coordinates, areaDamage.DamageArea);
+        var nearbyEntities = _entityLookup.GetEntitiesInRange<MobStateComponent>(Transform(target).Coordinates, areaDamage.DamageArea, LookupFlags.Uncontained);
 
         // Apply damage to all eligible entities in range.
         foreach (var entity in nearbyEntities)
         {
-            if(entity.Owner == target || entity == shooter)
+            if (entity.Owner == target || entity == shooter)
                 continue;
 
             var fromCoords = _transform.GetMapCoordinates(target);
@@ -78,11 +80,28 @@ public sealed class RMCAreaDamageSystem : EntitySystem
 
             var damageDealt = _damage.TryChangeDamage(entity, newDamage, armorPiercing: armorPiercing);
 
-            if (!(damageDealt?.GetTotal() > FixedPoint2.Zero) || !_net.IsClient)
+            if (!(damageDealt?.GetTotal() > FixedPoint2.Zero))
                 continue;
 
-            var filter = Filter.Pvs(entity, entityManager: EntityManager).RemoveWhereAttachedEntity(hit => hit == entity.Owner);
-            _colorFlash.RaiseEffect(Color.Red, new List<EntityUid> { entity }, filter);
+            if (HasComp<PredictedProjectileClientComponent>(uid))
+            {
+                if (_player.LocalEntity != shooter)
+                    continue;
+
+                _colorFlash.RaiseEffect(Color.Red, new List<EntityUid> { entity }, Filter.Local());
+                continue;
+            }
+
+            if (_net.IsServer)
+            {
+                var filter = Filter.Pvs(entity, entityManager: EntityManager)
+                    .RemoveWhereAttachedEntity(attached => attached == entity.Owner);
+
+                if (HasComp<PredictedProjectileServerComponent>(uid))
+                    filter = filter.RemoveWhereAttachedEntity(attached => attached == shooter);
+
+                _colorFlash.RaiseEffect(Color.Red, new List<EntityUid> { entity }, filter);
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

- Area damage no longer hits entities inside containers, like a larva inside a host.
- Area damage now always makes hit targets flicker red.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Resolves #10153 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix: Area damage now always applies the visual hit effect on damaged targets.
- fix: Area damage no longer hits entities inside containers.
