### PR TITLE
Remove Trijent SPP Type 71 HEAP

### DIFF
--- a/Resources/Maps/_RMC14/Inserts/Trijent/crashlanding-spp-bar.yml
+++ b/Resources/Maps/_RMC14/Inserts/Trijent/crashlanding-spp-bar.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 264.0.2
   forkId: ""
   forkVersion: ""
-  time: 04/08/2026 16:27:33
+  time: 06/27/2026 21:30:17
   entityCount: 671
 maps: []
 grids:
@@ -960,12 +960,16 @@ entities:
       rot: 3.141592653589793 rad
       pos: 8.5,-3.5
       parent: 1
+    missingComponents:
+    - Damageable
   - uid: 288
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-1.5
       parent: 1
+    missingComponents:
+    - Damageable
 - proto: CMShardGlass
   entities:
   - uid: 647
@@ -1794,13 +1798,6 @@ entities:
     - type: Transform
       pos: 14.437447,-1.3396895
       parent: 1
-- proto: DrinkWineBottleFull
-  entities:
-  - uid: 636
-    components:
-    - type: Transform
-      pos: 15.267014,1.8017164
-      parent: 1
 - proto: RMCAshtrayGlass
   entities:
   - uid: 651
@@ -2434,6 +2431,13 @@ entities:
     components:
     - type: Transform
       pos: 11.55493,-22.658415
+      parent: 1
+- proto: RMCDrinkAlcoholPurpleWine
+  entities:
+  - uid: 636
+    components:
+    - type: Transform
+      pos: 15.267014,1.8017164
       parent: 1
 - proto: RMCDrinkAlcoholRum
   entities:
@@ -3810,7 +3814,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: 17.5,-13.5
       parent: 1
-- proto: RMCMagazineRifleType71HEAP
+- proto: RMCMagazineRifleType71HEAPEmpty
   entities:
   - uid: 300
     components:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/type71.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/type71.yml
@@ -239,6 +239,13 @@
     bulletType: null
 
 - type: entity
+  parent: RMCMagazineRifleType71HEAP
+  id: RMCMagazineRifleType71HEAPEmpty
+  suffix: HEAP, Empty
+  components:
+  - type: RMCEmptyMag
+
+- type: entity
   parent: RMCMagazineRifleType71
   id: RMCMagazineRifleType71Rubber
   name: "Type 71 rubber magazine (5.45x39mm)"


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Replaced the HEAP magainzes on the SPP insert with empty ones

## Why / Balance
Parity
<img width="1471" height="791" alt="image" src="https://github.com/user-attachments/assets/46dfa63a-ed6f-4833-b517-b5f2d5d6fdcc" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: CatAndHats
- remove: Removed the incorrectly mapped Type-71 HEAP magazines from the Trijent SPP survivor insert and replaced them with empty versions