### PR TITLE
Players get added to the front of the larva queue when deleted on hijack start

### DIFF
--- a/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.Hijack.cs
+++ b/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.Hijack.cs
@@ -98,6 +98,9 @@ public sealed partial class CMDistressSignalRuleSystem
 
                     var origin = _transform.GetMoverCoordinates(xeno);
                     _popup.PopupCoordinates(Loc.GetString("rmc-xeno-hibernation"), origin, Filter.SinglePlayer(session), true, PopupType.MediumXeno);
+
+                    if (comp.CountedInSlots && _hive.GetHive(xeno) is { } hive)
+                        _larvaQueue.AddToLarvaQueueFront(hive, actor.PlayerSession.UserId);
                 }
 
                 QueueDel(xeno);

--- a/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.cs
@@ -52,6 +52,7 @@ using Content.Shared._RMC14.Xenonids.Construction.Nest;
 using Content.Shared._RMC14.Xenonids.Construction.Tunnel;
 using Content.Shared._RMC14.Xenonids.Evolution;
 using Content.Shared._RMC14.Xenonids.Hive;
+using Content.Shared._RMC14.Xenonids.JoinXeno;
 using Content.Shared._RMC14.Xenonids.Maturing;
 using Content.Shared._RMC14.Xenonids.Parasite;
 using Content.Shared.Actions;
@@ -152,6 +153,7 @@ public sealed partial class CMDistressSignalRuleSystem : GameRuleSystem<CMDistre
     [Dependency] private readonly ScalingSystem _scaling = default!;
     [Dependency] private readonly SharedXenoConstructionSystem _xenoConstruction = default!;
     [Dependency] private readonly SharedRoleSystem _roles = default!;
+    [Dependency] private readonly LarvaQueueSystem _larvaQueue = default!;
 
     private readonly HashSet<string> _operationNames = new();
     private readonly HashSet<string> _operationPrefixes = new();

--- a/Content.Shared/_RMC14/Xenonids/JoinXeno/LarvaQueueSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/JoinXeno/LarvaQueueSystem.cs
@@ -675,6 +675,25 @@ public sealed class LarvaQueueSystem : EntitySystem
         return -1;
     }
 
+    public void AddToLarvaQueueFront(Entity<HiveComponent> hive, NetUserId userId)
+    {
+        if (_net.IsClient)
+            return;
+
+        if (_pendingOffers.ContainsKey(userId))
+            return;
+
+        if (PreQueue.TryGetValue(hive.Owner, out var preQueue))
+            preQueue.Remove(userId);
+
+        if (Queue.TryGetValue(hive.Owner, out var queue))
+            queue.Remove(userId);
+
+        Queue.GetOrNew(hive.Owner).AddFirst(userId);
+
+        NotifyQueuePositions(hive);
+    }
+
     public override void Update(float frameTime)
     {
         if (_net.IsClient)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
When a xenonid player is not on the dropship when hijack starts they now automatically get added to the front of the larva queue.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity(I think?).

## Technical details
<!-- Summary of code changes for easier review. -->
I did not actually test it yet.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix: Xenonid players not on the dropship when a hijack is initiated now automatically get added to the front of the larva queue.