### PR TITLE
Made spammable xeno announcements use repeated chat system

### DIFF
--- a/Content.Shared/_RMC14/CCVar/RMCCVars.cs
+++ b/Content.Shared/_RMC14/CCVar/RMCCVars.cs
@@ -515,7 +515,7 @@ public sealed partial class RMCCVars : CVars
         CVarDef.Create("rmc.lobby_start_paused", false, CVar.REPLICATED | CVar.SERVER);
 
     public static readonly CVarDef<int> RMCChatRepeatHistory =
-        CVarDef.Create("rmc.chat_repeat_history", 4, CVar.REPLICATED | CVar.SERVER);
+        CVarDef.Create("rmc.chat_repeat_history", 5, CVar.REPLICATED | CVar.SERVER);
 
     public static readonly CVarDef<bool> RMCChatSquadColorMode =
         CVarDef.Create("rmc.chat_squad_color_mode", true, CVar.CLIENTONLY | CVar.ARCHIVE);

--- a/Content.Shared/_RMC14/Xenonids/Announce/SharedXenoAnnounceSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Announce/SharedXenoAnnounceSystem.cs
@@ -35,7 +35,7 @@ public abstract class SharedXenoAnnounceSystem : EntitySystem
         else
         {
             if (HasComp<XenoEvolutionGranterComponent>(ent) || _xenoEvolution.HasLiving<XenoEvolutionGranterComponent>(1))
-                AnnounceSameHive(ent.Owner, Loc.GetString(ent.Comp.Message, ("xeno", ent.Owner), ("location", locationName)), color: ent.Comp.Color);
+                AnnounceSameHive(ent.Owner, Loc.GetString(ent.Comp.Message, ("xeno", ent.Owner), ("location", locationName)), color: ent.Comp.Color, useHiveAsSource: true);
         }
     }
 

--- a/Content.Shared/_RMC14/Xenonids/Announce/SharedXenoAnnounceSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Announce/SharedXenoAnnounceSystem.cs
@@ -31,7 +31,7 @@ public abstract class SharedXenoAnnounceSystem : EntitySystem
             locationName = areaProto.Name;
 
         if (HasComp<ParasiteSpentComponent>(ent))
-            AnnounceSameHive(ent.Owner, Loc.GetString("rmc-xeno-parasite-announce-infect", ("xeno", ent.Owner), ("location", locationName)), color: ent.Comp.Color);
+            AnnounceSameHive(ent.Owner, Loc.GetString("rmc-xeno-parasite-announce-infect", ("xeno", ent.Owner), ("location", locationName)), color: ent.Comp.Color, useHiveAsSource: true);
         else
         {
             if (HasComp<XenoEvolutionGranterComponent>(ent) || _xenoEvolution.HasLiving<XenoEvolutionGranterComponent>(1))
@@ -82,12 +82,13 @@ public abstract class SharedXenoAnnounceSystem : EntitySystem
         SoundSpecifier? sound = null,
         PopupType? popup = null,
         Color? color = null,
-        bool needsQueen = false)
+        bool needsQueen = false,
+        bool useHiveAsSource = false)
     {
-        if (Hive.GetHive(xeno) is not {} hive)
+        if (Hive.GetHive(xeno) is not { } hive)
             return;
 
-        AnnounceToHive(xeno, hive, message, sound, popup, color, needsQueen);
+        AnnounceToHive(useHiveAsSource ? hive : xeno, hive, message, sound, popup, color, needsQueen);
     }
 
     public void AnnounceSameHiveDefaultSound(Entity<HiveMemberComponent?> xeno,

--- a/Content.Shared/_RMC14/Xenonids/Construction/ResinHole/SharedXenoResinHoleSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/ResinHole/SharedXenoResinHoleSystem.cs
@@ -120,16 +120,13 @@ public abstract class SharedXenoResinHoleSystem : EntitySystem
 
     private void OnResinHoleActivation(Entity<XenoResinHoleComponent> ent, ref XenoResinHoleActivationEvent args)
     {
-        if (_hive.GetHive(ent.Owner) is not { } hive)
-            return;
-
         var locationName = "Unknown";
 
         if (_areas.TryGetArea(ent, out _, out var areaProto))
             locationName = areaProto.Name;
 
         var msg = Loc.GetString(args.message, ("location", locationName), ("type", GetTrapTypeName(ent)));
-        _announce.AnnounceToHive(ent.Owner, hive, msg, color: ent.Comp.MessageColor);
+        _announce.AnnounceSameHive(ent.Owner, msg, color: ent.Comp.MessageColor, useHiveAsSource: true);
     }
 
     protected void SetTrapType(Entity<XenoResinHoleComponent> resinHole, string? newTrapPrototype)

--- a/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
@@ -261,9 +261,6 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
         if (HasComp<HiveConstructionSuppressAnnouncementsComponent>(ent))
             return;
 
-        if (_hive.GetHive(ent.Owner) is not { } hive)
-            return;
-
         var locationName = "Unknown";
         var structureName = "Unknown";
 
@@ -281,7 +278,7 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
         }
 
         var msg = Loc.GetString(ent.Comp.MessageID, ("location", locationName), ("structureName", structureName), ("destructionVerb", ent.Comp.DestructionVerb));
-        _announce.AnnounceToHive(ent.Owner, hive, msg, color: ent.Comp.MessageColor);
+        _announce.AnnounceSameHive(ent.Owner, msg, color: ent.Comp.MessageColor, useHiveAsSource: true);
     }
 
     private void OnXenoPlantWeedsAction(Entity<XenoConstructionComponent> xeno, ref XenoPlantWeedsActionEvent args)
@@ -827,7 +824,7 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
             areaName = areaProto.Name;
 
         msg = Loc.GetString("rmc-xeno-order-construction-structure-designated", ("construct", structureProto.Name), ("area", areaName));
-        _announce.AnnounceSameHive(xeno.Owner, msg, needsQueen: true);
+        _announce.AnnounceSameHive(xeno.Owner, msg, needsQueen: true, useHiveAsSource: true);
     }
 
     private void OnHiveConstructionNodeAddPlasmaDoAfter(Entity<XenoCanAddPlasmaToConstructComponent> xeno, ref XenoConstructionAddPlasmaDoAfterEvent args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Xeno announcements that can be spammed now make use of the repeated chat message system to reduce chat spam.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Reduce chat spam when many announcements of the same kind appear in succession.

## Technical details
<!-- Summary of code changes for easier review. -->
The reason the spammed announcements didn't use the repeated chat system is because each announcement came from a different source entity. Since they came from different sources, they were not eligible to be "repeated". This PR changes the spammable announcements to come from the hive of the source entity instead, making them eligible since they all come from the same source.

I also increased the repeated message history to 5 to increase the reliability of the system working during the announcement spam that happens during an OB, because if too many announcements with different text appear between repeats the repeats will not be detected. It will not be 100% reliable but I hope it is Good Enough™️.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

https://github.com/user-attachments/assets/3dfa8798-e8df-4730-8995-856a75813c60


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Spammable xeno announcements (such as traps being destroyed) will use the repeated message system when possible to reduce how much the chat window gets flooded with messages, such as during an orbital bombardment.
