### PR TITLE
Add brief invulnerability to larva spawning on the hivecore, queen, and respawns

### DIFF
--- a/Content.Server/_RMC14/Xenonids/Respawn/XenoRespawnSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Respawn/XenoRespawnSystem.cs
@@ -1,4 +1,5 @@
 using Content.Server._RMC14.Xenonids.Hive;
+using Content.Shared._RMC14.Damage;
 using Content.Server.Ghost;
 using Content.Server.Ghost.Roles.Components;
 using Content.Server.Mind;
@@ -25,6 +26,7 @@ public sealed partial class XenoRespawnSystem : EntitySystem
     [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly AudioSystem _audio = default!;
     [Dependency] private readonly TransformSystem _transform = default!;
+    [Dependency] private readonly RMCTemporaryInvincibilitySystem _invincibility = default!;
     public void RespawnXeno(EntityUid xeno, TimeSpan time, bool atLocation = false, EntityCoordinates? location = null)
     {
         if (!TryComp(xeno, out ActorComponent? actor))
@@ -78,6 +80,7 @@ public sealed partial class XenoRespawnSystem : EntitySystem
 
                 var spawn = SpawnAtPosition(respawn.Larva, respawn.Location.Value);
                 _hive.SetHive(spawn, respawn.Hive);
+                _invincibility.GiveInvincibility(spawn, respawn.CorpseInvincibilityTime);
 
                 if (!TryComp(ghost, out actor))
                     continue;

--- a/Content.Shared/_RMC14/Damage/RMCTemporaryInvincibilitySystem.cs
+++ b/Content.Shared/_RMC14/Damage/RMCTemporaryInvincibilitySystem.cs
@@ -40,6 +40,22 @@ public sealed class RMCTemporaryInvincibilitySystem : EntitySystem
     {
         args.Evasion += 1000; // Bullets need to always miss
     }
+
+    /// <summary>
+    ///     Grants an entity temporary invincibility (blocks damage and ignition, and makes projectiles miss) for the
+    ///     given duration. This is the single entry point all larva spawn/respawn paths use so the behavior stays
+    ///     consistent. Calling again refreshes the expiry; a duration of zero or less does nothing.
+    /// </summary>
+    public void GiveInvincibility(EntityUid uid, TimeSpan duration)
+    {
+        if (duration <= TimeSpan.Zero)
+            return;
+
+        var invincibility = EnsureComp<RMCTemporaryInvincibilityComponent>(uid);
+        invincibility.ExpiresAt = _timing.CurTime + duration;
+        Dirty(uid, invincibility);
+    }
+
     public override void Update(float frameTime)
     {
         base.Update(frameTime);

--- a/Content.Shared/_RMC14/Xenonids/Hive/HiveComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hive/HiveComponent.cs
@@ -102,4 +102,27 @@ public sealed partial class HiveComponent : Component
 
     [DataField, AutoNetworkedField]
     public HashSet<GibbedXenoInfo> GibbedXenos = new();
+
+    /// <summary>
+    ///     How long a burrowed larva is invincible for after spawning on the hive core.
+    ///     Mirrors the invincibility a larva gets after bursting out of a host.
+    ///     Set to zero or less to disable.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public TimeSpan BurrowedLarvaHiveCoreInvincibilityTime = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    ///     How long a burrowed larva is invincible for after spawning on the queen.
+    ///     Set to zero or less to disable.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public TimeSpan BurrowedLarvaQueenInvincibilityTime = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    ///     How long a burrowed larva is invincible for after spawning on a fallback hive member
+    ///     (when no hive core or queen is available).
+    ///     Set to zero or less to disable.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public TimeSpan BurrowedLarvaFallbackInvincibilityTime = TimeSpan.FromSeconds(5);
 }

--- a/Content.Shared/_RMC14/Xenonids/Hive/SharedXenoHiveSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hive/SharedXenoHiveSystem.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using Content.Shared._RMC14.Damage;
 using Content.Shared._RMC14.Dropship;
 using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.NightVision;
@@ -43,6 +44,7 @@ public abstract class SharedXenoHiveSystem : EntitySystem
     [Dependency] private readonly PullingSystem _pulling = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly RMCTemporaryInvincibilitySystem _invincibility = default!;
     [Dependency] private readonly SharedXenoAnnounceSystem _xenoAnnounce = default!;
     [Dependency] private readonly XenoSystem _xeno = default!;
 
@@ -472,12 +474,17 @@ public abstract class SharedXenoHiveSystem : EntitySystem
             return false;
         }
 
-        if (!TrySpawnAt<HiveCoreComponent>() &&
-            !TrySpawnAt<XenoEvolutionGranterComponent>() &&
-            !TrySpawnAt<XenoComponent>())
-        {
+        // Spawning grants temporary invincibility, the same mechanic a freshly burst larva gets.
+        // The duration depends on where the larva spawns, in priority order: hive core, then the queen, then a fallback hive member.
+        TimeSpan invincibilityTime;
+        if (TrySpawnAt<HiveCoreComponent>())
+            invincibilityTime = hive.Comp.BurrowedLarvaHiveCoreInvincibilityTime;
+        else if (TrySpawnAt<XenoEvolutionGranterComponent>())
+            invincibilityTime = hive.Comp.BurrowedLarvaQueenInvincibilityTime;
+        else if (TrySpawnAt<XenoComponent>())
+            invincibilityTime = hive.Comp.BurrowedLarvaFallbackInvincibilityTime;
+        else
             return false;
-        }
 
         if (larva == null)
             return false;
@@ -486,6 +493,8 @@ public abstract class SharedXenoHiveSystem : EntitySystem
 
         _xeno.MakeXeno(larva.Value);
         SetHive(larva.Value, hive);
+
+        _invincibility.GiveInvincibility(larva.Value, invincibilityTime);
 
         var newMind = _mind.CreateMind(session.UserId,
             EntityManager.GetComponent<MetaDataComponent>(larva.Value).EntityName);

--- a/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
@@ -84,6 +84,7 @@ public abstract partial class SharedXenoParasiteSystem : EntitySystem
     [Dependency] private readonly RMCSizeStunSystem _size = default!;
     [Dependency] private readonly RMCUnrevivableSystem _unrevivable = default!;
     [Dependency] private readonly SharedRMCActionsSystem _rmcActions = default!;
+    [Dependency] private readonly RMCTemporaryInvincibilitySystem _invincibility = default!;
 
     private const CollisionGroup LeapCollisionGroup = CollisionGroup.InteractImpassable;
     private const CollisionGroup ThrownCollisionGroup = CollisionGroup.InteractImpassable | CollisionGroup.BarricadeImpassable;
@@ -958,9 +959,7 @@ public abstract partial class SharedXenoParasiteSystem : EntitySystem
             foreach (var larva in container.ContainedEntities)
             {
                 RemCompDeferred<BursterComponent>(larva);
-                var invc = EnsureComp<RMCTemporaryInvincibilityComponent>(larva);
-                invc.ExpiresAt = _timing.CurTime + ent.Comp.LarvaInvincibilityTime;
-                Dirty(larva, invc);
+                _invincibility.GiveInvincibility(larva, ent.Comp.LarvaInvincibilityTime);
             }
 
             _container.EmptyContainer(container, destination: coords);

--- a/Content.Shared/_RMC14/Xenonids/Respawn/XenoRespawnComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Respawn/XenoRespawnComponent.cs
@@ -23,6 +23,14 @@ public sealed partial class XenoRespawnComponent : Component
     [DataField]
     public EntProtoId Larva = "CMXenoLarva";
 
+    /// <summary>
+    ///     How long the respawned larva is invincible for when it spawns at the corpse (the fallback when no hive core
+    ///     is available). Respawns that go through the hive instead use the per-location handles on <see cref="HiveComponent"/>.
+    ///     Set to zero or less to disable.
+    /// </summary>
+    [DataField]
+    public TimeSpan CorpseInvincibilityTime = TimeSpan.FromSeconds(5);
+
     [DataField]
     public SoundSpecifier CorpseSound = new SoundPathSpecifier("/Audio/_RMC14/Xeno/xeno_newlarva.ogg");
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Bursts already give larva a brief 1s invulnerability window. With the addition of larva queue, the problem of spawning on the queen and immediately dying has only been more noticeable. This PR adds a 1s invulnerability to when the larva spawns on the hivecore, and an extended 5s invulnerability to unsafe spawns, such as on the queen.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Larva currently appear with zero protection and can be instakilled before the player reacts, this feels very bad.

I have given unsafe spawns 5s of invulnerability for now, but this can be tuned down at maintainer discretion easily.

## Technical details
<!-- Summary of code changes for easier review. -->
New `RMCTemporaryInvincibilitySystem.GiveInvincibility(uid, duration)` helper called for all spawn paths.

Invulnerability durations are configurable in: 
- `HiveComponent` (hive core 1s, queen 5s, member 5s)
- `XenoRespawnComponent.CorpseInvincibilityTime` (5s)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
https://github.com/user-attachments/assets/c0d7685d-b47f-4e5e-b532-bda2dc3aab99

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Larva spawning on the hive core or queen, or respawning from a healer drone's sacrifice or an acid runner's detonation, now get a brief window of invulnerability.