### PR TITLE
Fix minor guidebook typo

### DIFF
--- a/Resources/Prototypes/_RMC14/Guidebook/rmc_guidebook.yml
+++ b/Resources/Prototypes/_RMC14/Guidebook/rmc_guidebook.yml
@@ -438,7 +438,7 @@
   parent: RMC
   id: RMCGuideRoleSapper
   priority: 4
-  name: "Trapper Guide"
+  name: "Sapper Guide"
   text: "/ServerInfo/Guidebook/_RMC14/Guides/Xenonid/RMCGuideRoleSapper.xml"
 
 - type: guideEntry


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed a minor typo in the guidebook header for the sapper that still referred to it as the trapper

## Why / Balance
Consistency

## Technical details
2 letter yaml change

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
no CL
