### PR TITLE
Defender crest toggle popup text

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Crest/XenoCrestSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Crest/XenoCrestSystem.cs
@@ -67,6 +67,7 @@ public sealed class XenoCrestSystem : EntitySystem
 
         _movementSpeed.RefreshMovementSpeedModifiers(xeno);
         _appearance.SetData(xeno, XenoVisualLayers.Crest, xeno.Comp.Lowered);
+        _popup.PopupClient(Loc.GetString("cm-xeno-toggle-crest-" + (xeno.Comp.Lowered ? "lower" : "raise")), xeno, xeno);
 
         foreach (var action in _rmcActions.GetActionsWithEvent<XenoToggleCrestActionEvent>(xeno))
         {

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
@@ -179,6 +179,8 @@ rmc-xeno-rest-cant-secrete = You can't secrete while resting!
 rmc-xeno-rest-cant = You can't do that while resting!
 
 # Toggle Crest Defense
+cm-xeno-toggle-crest-lower = You lower your crest.
+cm-xeno-toggle-crest-raise = You raise your crest.
 cm-xeno-toggle-crest-cant-fortify = You can't fortify while your crest is lowered!
 cm-xeno-toggle-crest-cant-rest = You can't rest while your crest is lowered!
 cm-xeno-toggle-crest-cant-tail-sweep = You can't tail sweep while your crest is lowered!


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds a little popup message when you toggle your crest defense as a defender, to let you know what it's changed to.
I PR'd this for CM13 a few years ago so I figured I'd port it.

## Why / Balance
It can be difficult to tell what crest state you're currently in without moving around to check your movement speed, especially when facing northwards. There is a sprite change and the ability button gets a highlight, but they're both pretty subtle.

An *ideal* solution to this (imo anyway) would be some sort of HUD alert if your crest is lowered, but the popup text at least helps at little.

## Media
<img width="251" height="230" alt="fendy" src="https://github.com/user-attachments/assets/209ff2a9-f3bc-43a1-b97a-d68d881ec389" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added a text popup when toggling Crest Defense as a Defender.