### PR TITLE
Energy-based castes no longer gain acid from hitting infected hosts

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/AciderGeneration/XenoAciderGenerationSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/AciderGeneration/XenoAciderGenerationSystem.cs
@@ -35,7 +35,7 @@ public sealed class XenoAciderGenerationSystem : EntitySystem
                 return;
 
             if (HasComp<VictimInfectedComponent>(hit))
-                return;
+                continue;
 
             startGenerating = true;
             break;

--- a/Content.Shared/_RMC14/Xenonids/AciderGeneration/XenoAciderGenerationSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/AciderGeneration/XenoAciderGenerationSystem.cs
@@ -1,6 +1,7 @@
 using Content.Shared._RMC14.Xenonids.Energy;
 using Content.Shared._RMC14.Xenonids.Rest;
 using Content.Shared._RMC14.TrainingDummy;
+using Content.Shared._RMC14.Xenonids.Parasite;
 using Content.Shared.Mobs;
 using Content.Shared.StatusEffect;
 using Content.Shared.Stunnable;

--- a/Content.Shared/_RMC14/Xenonids/AciderGeneration/XenoAciderGenerationSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/AciderGeneration/XenoAciderGenerationSystem.cs
@@ -33,6 +33,9 @@ public sealed class XenoAciderGenerationSystem : EntitySystem
             if (HasComp<RMCTrainingDummyComponent>(hit))
                 return;
 
+            if (HasComp<VictimInfectedComponent>(hit))
+                return;
+
             startGenerating = true;
             break;
         }

--- a/Content.Shared/_RMC14/Xenonids/Energy/XenoEnergyComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Energy/XenoEnergyComponent.cs
@@ -31,9 +31,6 @@ public sealed partial class XenoEnergyComponent : Component
     public int GainAttackDowned = 50;
 
     [DataField, AutoNetworkedField]
-    public bool IgnoreLateInfected = false;
-
-    [DataField, AutoNetworkedField]
     public bool GainOnProjectiles = true;
 
     [DataField, AutoNetworkedField]

--- a/Content.Shared/_RMC14/Xenonids/Energy/XenoEnergySystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Energy/XenoEnergySystem.cs
@@ -61,7 +61,7 @@ public sealed class XenoEnergySystem : EntitySystem
             if (!_xeno.CanAbilityAttackTarget(xeno.Owner, hit))
                 continue;
 
-            if (xeno.Comp.IgnoreLateInfected && TryComp<VictimInfectedComponent>(hit, out var infect) && infect.CurrentStage >= infect.FinalSymptomsStart)
+            if (HasComp<VictimInfectedComponent>(hit))
                 continue;
 
             if (HasComp<RMCTrainingDummyComponent>(hit))

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/runner.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/runner.yml
@@ -211,7 +211,6 @@
     gain: 1
     gainAttack: 14
     gainAttackDowned: 8
-    ignoreLateInfected: true
     popupGain: rmc-xeno-acid-increase-user
     popupNotEnough: rmc-xeno-not-enough-acid
     alert: XenoEnergyAcider


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title
Closes #7385
Removes the `IgnoreInfectedComponent` member from `XenoEnergyComponent`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Per #7385:
> As per the title, It would be better for both xenos and marines if acid runner did not get acid off of hugged marines, forcing the acid runner to actually hit people on the front and not hang around the hive hitting caps until they either die or have been damaged enough for that runners standards. This kind of behavior should not be encouraged and should receive no benefit

> Wanna note if someone is infected (past stage 4) they get no acid from it. It could, to be fair, probably should check earlier (around when they become dead draggable) instead. (Current value at 4 is due to parity atm).

This PR also prevents _all_ castes with a special resource that uses XenoEnergySystem from gaining their resource upon hitting an infected host.

This change is nonparity. It may not be desired or may need to wait until postparity.

## Technical details
<!-- Summary of code changes for easier review. -->
Minor C#. Check if a hit entity has VictimInfectedComponent and if so, continue. Additionally removed `IgnoreInfectedComponent` from `XenoEnergyComponent.cs` since its only use was with acid runners.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
Small fix.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Acid runners and valkyrie praetorians no longer gain acid or fury when hitting an infected host
