### PR TITLE
[Fix] Item pickup console Fix

### DIFF
--- a/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
+++ b/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
@@ -74,10 +74,12 @@ public abstract class SharedCMInventorySystem : EntitySystem
     ];
 
     private EntityQuery<RMCPickupDroppedItemsComponent> _pickupDroppedItemsQuery;
+    private EntityQuery<TransformComponent> _xformQuery;
 
     public override void Initialize()
     {
         _pickupDroppedItemsQuery = GetEntityQuery<RMCPickupDroppedItemsComponent>();
+        _xformQuery = GetEntityQuery<TransformComponent>();
 
         SubscribeLocalEvent<GunComponent, IsUnholsterableEvent>(AllowUnholster);
         SubscribeLocalEvent<MeleeWeaponComponent, IsUnholsterableEvent>(AllowUnholster);
@@ -369,6 +371,12 @@ public abstract class SharedCMInventorySystem : EntitySystem
 
         foreach (var item in sortedItems.Distinct())
         {
+            if (TerminatingOrDeleted(item) || !_xformQuery.HasComp(item))
+            {
+                pickupDroppedItems.DroppedItems.Remove(item);
+                continue;
+            }
+
             if (!_container.IsEntityInContainer(item) && _interaction.InRangeUnobstructed(user, item))
             {
                 if (_hands.TryPickupAnyHand(user, item))


### PR DESCRIPTION
## About the PR
More Console Spam Fix
Trying to pick up dropped items that are no longer valid spammed console.
Overall benefits should _maybe very minor_ improvements back end as the game should stop trying to process and subsequently spam these errors.

## Why / Balance
Fix is nice.

## Technical details
Prunes and guards the loop so game stops trying to process on something with no transformcomp. 
woe upon stale entries.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- fix: Fixed a console error resulting from trying to pick up invalid items.

