### PR TITLE
Fix flamer direct hits still hitting multiple times

### DIFF
--- a/Content.Shared/_RMC14/Atmos/SharedRMCFlammableSystem.cs
+++ b/Content.Shared/_RMC14/Atmos/SharedRMCFlammableSystem.cs
@@ -1009,7 +1009,7 @@ public abstract class SharedRMCFlammableSystem : EntitySystem
                     TryIgnite((uid, apply), contact, true);
                 }
 
-                RemCompDeferred<DamageOnCollideComponent>(uid);
+                _onCollide.DisableDamageOnCollide(uid);
             }
         }
         catch (Exception e)

--- a/Content.Shared/_RMC14/OnCollide/DamageOnCollideComponent.cs
+++ b/Content.Shared/_RMC14/OnCollide/DamageOnCollideComponent.cs
@@ -76,6 +76,6 @@ public sealed partial class DamageOnCollideComponent : Component
     [DataField]
     public bool CanRehit;
 
-    [DataField]
+    [DataField, AutoNetworkedField]
     public bool Disabled = false;
 }

--- a/Content.Shared/_RMC14/OnCollide/DamageOnCollideComponent.cs
+++ b/Content.Shared/_RMC14/OnCollide/DamageOnCollideComponent.cs
@@ -75,4 +75,7 @@ public sealed partial class DamageOnCollideComponent : Component
 
     [DataField]
     public bool CanRehit;
+
+    [DataField]
+    public bool Disabled = false;
 }

--- a/Content.Shared/_RMC14/OnCollide/SharedOnCollideSystem.cs
+++ b/Content.Shared/_RMC14/OnCollide/SharedOnCollideSystem.cs
@@ -69,6 +69,9 @@ public abstract class SharedOnCollideSystem : EntitySystem
 
     private void OnCollide(Entity<DamageOnCollideComponent> ent, EntityUid other)
     {
+        if (ent.Comp.Disabled)
+            return;
+
         if (ent.Comp.Damaged.Contains(other))
             return;
 
@@ -187,6 +190,15 @@ public abstract class SharedOnCollideSystem : EntitySystem
         }
 
         return refs;
+    }
+
+    public void DisableDamageOnCollide(Entity<DamageOnCollideComponent?> ent)
+    {
+        if (!_damageOnCollideQuery.Resolve(ent, ref ent.Comp, false))
+            return;
+
+        ent.Comp.Disabled = true;
+        Dirty(ent);
     }
 
     public override void Update(float frameTime)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug. The DamageOnCollide comp got deleted early by `RunIgniteOnCollide`, which caused the chain to also, get deleted because its in there, which caused the entire chain system to just ignore it so you still got hit multiple times.

Instead of doing that theres now a disabled field on DamageOnCollide, that just skips the OnCollide part if true. `RunIgniteOnCollide` just disables it now.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed direct hit of the incinerator's stream dealing damage multiple times, for real this time. This may have also fixed some instances of other fires dealing damage multiple times on spawn.
