### PR TITLE
[Tweak] Hijack Explosion Throttle

### DIFF
--- a/Content.Server/_RMC14/Hijack/RMCHijackRandomDamageSystem.cs
+++ b/Content.Server/_RMC14/Hijack/RMCHijackRandomDamageSystem.cs
@@ -135,21 +135,14 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
 
     private void OnPipeRemove<T>(Entity<RMCHijackActivePipeComponent> ent, ref T args)
     {
+        QueueDel(ent.Comp.Warning);
+        ent.Comp.Warning = null;
+
         if (TerminatingOrDeleted(ent.Comp.Map))
             return;
 
         if (TryComp(ent.Comp.Map, out RMCHijackActiveMapComponent? map))
-        {
             map.Pipes.Remove(ent);
-            map.Explode.RemoveAll(pending =>
-            {
-                if (pending.Pipe != ent.Owner)
-                    return false;
-
-                QueueDel(pending.Warning);
-                return true;
-            });
-        }
     }
 
     private void OnPipeAnchorChanged(Entity<RMCHijackActivePipeComponent> ent, ref AnchorStateChangedEvent args)
@@ -269,16 +262,23 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
         var warning = Spawn(PipeExplosionWarning, _transform.GetMoverCoordinates(pipe, xform));
         _audio.PlayPvs(map.Comp.PipeHiss, pipe);
 
-        map.Comp.Explode.Add((pipe, warning));
+        if (TryComp(pipe, out RMCHijackActivePipeComponent? active))
+            active.Warning = warning;
+
+        map.Comp.Explode.Add(pipe);
         map.Comp.ExplodeAt = _timing.CurTime + map.Comp.ExplodeDelay;
     }
 
     /// <summary>
     ///     Explodes a warned pipe, starts local fire, and leaves a broken pipe visual in its place.
     /// </summary>
-    private void BurstPipe(EntityUid pipe, EntityUid warning)
+    private void BurstPipe(EntityUid pipe)
     {
-        QueueDel(warning);
+        if (TryComp(pipe, out RMCHijackActivePipeComponent? active))
+        {
+            QueueDel(active.Warning);
+            active.Warning = null;
+        }
 
         if (Deleted(pipe) ||
             !TryComp(pipe, out TransformComponent? xform) ||
@@ -326,8 +326,7 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
         var query = EntityQueryEnumerator<RMCHijackActiveMapComponent>();
         while (query.MoveNext(out var uid, out var active))
         {
-            if (active.ExplodeAt is { } explodeAt && time >= explodeAt)
-                BurstQueuedPipes(active);
+            TryBurstQueuedPipes(uid, active);
 
             if (time < active.Next)
                 continue;
@@ -343,15 +342,30 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
         }
     }
 
+    private void TryBurstQueuedPipes(EntityUid uid, RMCHijackActiveMapComponent active)
+    {
+        if (active.ExplodeAt is not { } explodeAt || _timing.CurTime < explodeAt)
+            return;
+
+        try
+        {
+            BurstQueuedPipes(active);
+        }
+        catch (Exception e)
+        {
+            Log.Error($"Error while bursting hijack pipes on {ToPrettyString(uid)}:\n{e}");
+        }
+    }
+
     private void BurstQueuedPipes(RMCHijackActiveMapComponent active)
     {
         var burst = 0;
         while (burst < MaxPipeBurstsPerTick && active.Explode.Count > 0)
         {
             var last = active.Explode.Count - 1;
-            var (pipe, warning) = active.Explode[last];
+            var pipe = active.Explode[last];
             active.Explode.RemoveAt(last);
-            BurstPipe(pipe, warning);
+            BurstPipe(pipe);
             burst++;
         }
 

--- a/Content.Server/_RMC14/Hijack/RMCHijackRandomDamageSystem.cs
+++ b/Content.Server/_RMC14/Hijack/RMCHijackRandomDamageSystem.cs
@@ -141,7 +141,14 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
         if (TryComp(ent.Comp.Map, out RMCHijackActiveMapComponent? map))
         {
             map.Pipes.Remove(ent);
-            map.Explode.Remove(ent);
+            map.Explode.RemoveAll(pending =>
+            {
+                if (pending.Pipe != ent.Owner)
+                    return false;
+
+                QueueDel(pending.Warning);
+                return true;
+            });
         }
     }
 
@@ -259,18 +266,20 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
             return;
         }
 
-        Spawn(PipeExplosionWarning, _transform.GetMoverCoordinates(pipe, xform));
+        var warning = Spawn(PipeExplosionWarning, _transform.GetMoverCoordinates(pipe, xform));
         _audio.PlayPvs(map.Comp.PipeHiss, pipe);
 
-        map.Comp.Explode.Add(pipe);
+        map.Comp.Explode.Add((pipe, warning));
         map.Comp.ExplodeAt = _timing.CurTime + map.Comp.ExplodeDelay;
     }
 
     /// <summary>
     ///     Explodes a warned pipe, starts local fire, and leaves a broken pipe visual in its place.
     /// </summary>
-    private void BurstPipe(EntityUid pipe)
+    private void BurstPipe(EntityUid pipe, EntityUid warning)
     {
+        QueueDel(warning);
+
         if (Deleted(pipe) ||
             !TryComp(pipe, out TransformComponent? xform) ||
             xform.MapUid == null ||
@@ -323,9 +332,9 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
                 while (active.Explode.Count > 0 && burst < MaxPipeBurstsPerTick)
                 {
                     var index = active.Explode.Count - 1;
-                    var pipe = active.Explode[index];
+                    var entry = active.Explode[index];
                     active.Explode.RemoveAt(index);
-                    BurstPipe(pipe);
+                    BurstPipe(entry.Pipe, entry.Warning);
                     burst++;
                 }
 

--- a/Content.Server/_RMC14/Hijack/RMCHijackRandomDamageSystem.cs
+++ b/Content.Server/_RMC14/Hijack/RMCHijackRandomDamageSystem.cs
@@ -53,6 +53,8 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
     private const float PipeExplosionMax = 20f;
     private const int PipeFireRange = 2;
 
+    private const int MaxPipeBurstsPerTick = 1;
+
     private TimeSpan _hijackCrashStunTime;
 
     private readonly List<(EntityUid Uid, RMCHijackRandomDamageTargetComponent Comp)> _wallTargets = new();
@@ -137,7 +139,10 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
             return;
 
         if (TryComp(ent.Comp.Map, out RMCHijackActiveMapComponent? map))
+        {
             map.Pipes.Remove(ent);
+            map.Explode.Remove(ent);
+        }
     }
 
     private void OnPipeAnchorChanged(Entity<RMCHijackActivePipeComponent> ent, ref AnchorStateChangedEvent args)
@@ -225,7 +230,9 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
         var count = GetRandomCount(map.Comp.Pipes.Count, minPercent, maxPercent);
         if (count == 0)
         {
-            RemCompDeferred<RMCHijackActiveMapComponent>(map);
+            if (map.Comp.Explode.Count == 0 && map.Comp.ExplodeAt == null)
+                RemCompDeferred<RMCHijackActiveMapComponent>(map);
+
             return;
         }
 
@@ -312,19 +319,18 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
         {
             if (active.ExplodeAt != null && time >= active.ExplodeAt.Value)
             {
-                active.ExplodeAt = null;
+                var burst = 0;
+                while (active.Explode.Count > 0 && burst < MaxPipeBurstsPerTick)
+                {
+                    var index = active.Explode.Count - 1;
+                    var pipe = active.Explode[index];
+                    active.Explode.RemoveAt(index);
+                    BurstPipe(pipe);
+                    burst++;
+                }
 
-                try
-                {
-                    foreach (var explode in active.Explode)
-                    {
-                        BurstPipe(explode);
-                    }
-                }
-                finally
-                {
-                    active.Explode.Clear();
-                }
+                if (active.Explode.Count == 0)
+                    active.ExplodeAt = null;
             }
 
             if (time < active.Next)

--- a/Content.Server/_RMC14/Hijack/RMCHijackRandomDamageSystem.cs
+++ b/Content.Server/_RMC14/Hijack/RMCHijackRandomDamageSystem.cs
@@ -326,21 +326,8 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
         var query = EntityQueryEnumerator<RMCHijackActiveMapComponent>();
         while (query.MoveNext(out var uid, out var active))
         {
-            if (active.ExplodeAt != null && time >= active.ExplodeAt.Value)
-            {
-                var burst = 0;
-                while (active.Explode.Count > 0 && burst < MaxPipeBurstsPerTick)
-                {
-                    var index = active.Explode.Count - 1;
-                    var entry = active.Explode[index];
-                    active.Explode.RemoveAt(index);
-                    BurstPipe(entry.Pipe, entry.Warning);
-                    burst++;
-                }
-
-                if (active.Explode.Count == 0)
-                    active.ExplodeAt = null;
-            }
+            if (active.ExplodeAt is { } explodeAt && time >= explodeAt)
+                BurstQueuedPipes(active);
 
             if (time < active.Next)
                 continue;
@@ -354,5 +341,21 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
 
             DoPipeBarrage((uid, active));
         }
+    }
+
+    private void BurstQueuedPipes(RMCHijackActiveMapComponent active)
+    {
+        var burst = 0;
+        while (burst < MaxPipeBurstsPerTick && active.Explode.Count > 0)
+        {
+            var last = active.Explode.Count - 1;
+            var (pipe, warning) = active.Explode[last];
+            active.Explode.RemoveAt(last);
+            BurstPipe(pipe, warning);
+            burst++;
+        }
+
+        if (active.Explode.Count == 0)
+            active.ExplodeAt = null;
     }
 }

--- a/Content.Server/_RMC14/Hijack/RMCHijackRandomDamageSystem.cs
+++ b/Content.Server/_RMC14/Hijack/RMCHijackRandomDamageSystem.cs
@@ -317,7 +317,7 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
             return 0;
 
         var percent = _random.NextFloat(minPercent, maxPercent);
-        return Math.Clamp((int) MathF.Round(poolCount * percent), 1, poolCount);
+        return Math.Clamp((int)MathF.Round(poolCount * percent), 1, poolCount);
     }
 
     public override void Update(float frameTime)
@@ -326,7 +326,7 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
         var query = EntityQueryEnumerator<RMCHijackActiveMapComponent>();
         while (query.MoveNext(out var uid, out var active))
         {
-            TryBurstQueuedPipes(uid, active);
+            TryBurstQueuedPipes(uid, active, time);
 
             if (time < active.Next)
                 continue;
@@ -342,9 +342,9 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
         }
     }
 
-    private void TryBurstQueuedPipes(EntityUid uid, RMCHijackActiveMapComponent active)
+    private void TryBurstQueuedPipes(EntityUid uid, RMCHijackActiveMapComponent active, TimeSpan time)
     {
-        if (active.ExplodeAt is not { } explodeAt || _timing.CurTime < explodeAt)
+        if (active.ExplodeAt is not { } explodeAt || time < explodeAt)
             return;
 
         try

--- a/Content.Shared/_RMC14/Hijack/RMCHijackActiveMapComponent.cs
+++ b/Content.Shared/_RMC14/Hijack/RMCHijackActiveMapComponent.cs
@@ -19,7 +19,7 @@ public sealed partial class RMCHijackActiveMapComponent : Component
     public bool InitialPipeBarragePending;
 
     [DataField]
-    public List<(EntityUid Pipe, EntityUid Warning)> Explode = new();
+    public List<EntityUid> Explode = new();
 
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField]
     public TimeSpan? ExplodeAt;

--- a/Content.Shared/_RMC14/Hijack/RMCHijackActiveMapComponent.cs
+++ b/Content.Shared/_RMC14/Hijack/RMCHijackActiveMapComponent.cs
@@ -19,7 +19,7 @@ public sealed partial class RMCHijackActiveMapComponent : Component
     public bool InitialPipeBarragePending;
 
     [DataField]
-    public List<EntityUid> Explode = new();
+    public List<(EntityUid Pipe, EntityUid Warning)> Explode = new();
 
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField]
     public TimeSpan? ExplodeAt;

--- a/Content.Shared/_RMC14/Hijack/RMCHijackActivePipeComponent.cs
+++ b/Content.Shared/_RMC14/Hijack/RMCHijackActivePipeComponent.cs
@@ -5,4 +5,7 @@ public sealed partial class RMCHijackActivePipeComponent : Component
 {
     [DataField]
     public EntityUid? Map;
+
+    [DataField]
+    public EntityUid? Warning;
 }

--- a/Resources/Prototypes/_RMC14/Effects/alert_effects.yml
+++ b/Resources/Prototypes/_RMC14/Effects/alert_effects.yml
@@ -18,7 +18,7 @@
   name: explosive warning
   components:
   - type: TimedDespawn
-    lifetime: 5
+    lifetime: 6
   - type: Sprite
     state: alert_greyscale
     color: "#ff0000"


### PR DESCRIPTION
## About the PR
I think the explosions are soul, but as a lot of players have found; they can get quite taxing.
This just limits how many explosions can go off at once.

## Why / Balance
Spreads out the pipe explosions per tick and turns it into staggered rolling explosions.
Should smooth things out slightly more at the start of hijack.

## Technical details
Pain.
Throttles the amount of pipes that can explode per tick,  can be tweaked alongside the % of pipes queued for exploding.
_e.g. if maxpipesburst is 2 and the % of pipe it selects was 5.  Tick 1 would have 2 bursts, tick 2 have 2 ,and tick 3 have1._

Currently its set to 1 to smooth out the whole hijack instead of the current behaviour where the initial crash and subsequent few minutes are a mixture of simultaneous explosions that are unavoidable and teleporting into said explosions because of other explosions.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: Throttled the explosions on Hijack; behaviour should be a staggered but rolling explosion one at a time now.
