### PR TITLE
Fixed APC lights staying on after being broken.

### DIFF
--- a/Content.Server/_RMC14/Power/RMCPowerSystem.cs
+++ b/Content.Server/_RMC14/Power/RMCPowerSystem.cs
@@ -233,6 +233,7 @@ public sealed class RMCPowerSystem : SharedRMCPowerSystem
                     UpdateApcChannel(apc, area, RMCPowerChannel.Equipment, false);
                     UpdateApcChannel(apc, area, RMCPowerChannel.Lighting, false);
                     UpdateApcChannel(apc, area, RMCPowerChannel.Environment, false);
+                    _light.SetEnabled(apc, false);
                     continue;
                 }
 
@@ -296,6 +297,7 @@ public sealed class RMCPowerSystem : SharedRMCPowerSystem
                 }
 
                 _appearance.SetData(apc, RMCApcVisualsLayers.Power, apcComp.ChargeStatus);
+                _light.SetEnabled(apc, true);
                 _light.SetColor(apc,
                     apcComp.ChargeStatus switch
                     {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed APC lights staying on after being broken.

## Why / Balance
This makes it easier to tell which APCs are intact and which aren't. The APC's screen is also turned off visually so it makes sense.

## Media

https://github.com/user-attachments/assets/d8a51427-1f82-4012-83ef-fb9a00c2e0a0

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed APC lights staying on after being broken.