### PR TITLE
Add universal recorder + tapes to sec belt whitelist

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/police.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/police.yml
@@ -23,8 +23,7 @@
       - Donut
       - RMCGrenadeFlashBang
       - Radio
-      - UniversalRecorder
-      - UniversalRecorderTape
+      - Recorder
       components:
       - Handcuff
       - Flash

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/police.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/police.yml
@@ -23,6 +23,8 @@
       - Donut
       - RMCGrenadeFlashBang
       - Radio
+      - RMCUniversalRecorder
+      - RMCUniversalRecorderTape
       components:
       - Handcuff
       - Flash

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/police.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Belt/police.yml
@@ -23,8 +23,8 @@
       - Donut
       - RMCGrenadeFlashBang
       - Radio
-      - RMCUniversalRecorder
-      - RMCUniversalRecorderTape
+      - UniversalRecorder
+      - UniversalRecorderTape
       components:
       - Handcuff
       - Flash

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Devices/universal_recorder.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Devices/universal_recorder.yml
@@ -5,7 +5,7 @@
   components:
   - type: Tag
    tags: 
-   - recorder
+   - Recorder
   - type: Sprite
     sprite: _RMC14/Objects/Devices/cassette_player.rsi
     layers:
@@ -78,7 +78,7 @@
   components:
   - type: Tag
    tags: 
-    - recorder
+    - Recorder
   - type: Sprite
     sprite: _RMC14/Objects/Devices/cassette_player.rsi
     layers:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Devices/universal_recorder.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Devices/universal_recorder.yml
@@ -3,6 +3,9 @@
   parent: BaseItem
   id: RMCUniversalRecorderBase
   components:
+  - type: Tag
+   tags: 
+   - recorder
   - type: Sprite
     sprite: _RMC14/Objects/Devices/cassette_player.rsi
     layers:
@@ -73,6 +76,9 @@
   parent: BaseItem
   id: RMCUniversalRecorderTapeBase
   components:
+  - type: Tag
+   tags: 
+    - recorder
   - type: Sprite
     sprite: _RMC14/Objects/Devices/cassette_player.rsi
     layers:


### PR DESCRIPTION
## About the PR
Title

## Why / Balance
QOL, it should fit, have not checked if this is parity but even if it isn't it doesn't have any impact, can add the #rmc tags if requested

## Technical details
2 lines of YAML

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: The security belt is now able to hold the universal recorder and individual tapes
