### PR TITLE
Changes SOF radio color

### DIFF
--- a/Resources/Prototypes/_RMC14/radio_channels.yml
+++ b/Resources/Prototypes/_RMC14/radio_channels.yml
@@ -143,7 +143,7 @@
   name: chat-radio-marine-sof
   keycode: "k"
   frequency: 1724
-  color: "#851524"
+  color: "#a53e4c"
   longRange: true
   tower: true
 

--- a/Resources/Prototypes/_RMC14/radio_channels.yml
+++ b/Resources/Prototypes/_RMC14/radio_channels.yml
@@ -143,7 +143,7 @@
   name: chat-radio-marine-sof
   keycode: "k"
   frequency: 1724
-  color: "#9afff8"
+  color: "#b7faf5"
   longRange: true
   tower: true
 

--- a/Resources/Prototypes/_RMC14/radio_channels.yml
+++ b/Resources/Prototypes/_RMC14/radio_channels.yml
@@ -143,7 +143,7 @@
   name: chat-radio-marine-sof
   keycode: "k"
   frequency: 1724
-  color: "#a53e4c"
+  color: "#9afff8"
   longRange: true
   tower: true
 


### PR DESCRIPTION
## About the PR
Changes SOF radio color to a lighter shade

## Why / Balance
Current one is genuinely unreadable on a darker monitor because it doesn't contrast against the chatbox background whatsoever

## Technical details
yaml

## Media
Before
<img width="468" height="43" alt="obraz" src="https://github.com/user-attachments/assets/d731d774-74ca-408a-a4b4-8f744427d1f4" />

After
<img width="395" height="82" alt="obraz" src="https://github.com/user-attachments/assets/a8d840f4-1134-402b-be3b-b5346ca9f3b0" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Changed SOF radio channel color to make it distinguishable
