### PR TITLE
Fixed xeno construction announcements no longer appearing

### DIFF
--- a/Content.Server/_RMC14/Announce/XenoAnnounceSystem.cs
+++ b/Content.Server/_RMC14/Announce/XenoAnnounceSystem.cs
@@ -24,7 +24,7 @@ public sealed class XenoAnnounceSystem : SharedXenoAnnounceSystem
 
         if (needsQueen)
         {
-            if (Hive.GetHive(source) is { } sourceHive)
+            if (Hive.GetHiveOrSelf(source) is { } sourceHive)
             {
                 if (!Hive.HasHiveQueen(sourceHive))
                     return;

--- a/Content.Shared/_RMC14/Xenonids/Hive/SharedXenoHiveSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hive/SharedXenoHiveSystem.cs
@@ -170,6 +170,22 @@ public abstract class SharedXenoHiveSystem : EntitySystem
         return (uid, comp);
     }
 
+    /// <summary>
+    /// Gets the hive component either of the hive entity itself, or the hive of a hive member.
+    /// </summary>
+    /// <param name="uid">uid of the hive itself, or a member of a hive.</param>
+    public Entity<HiveComponent>? GetHiveOrSelf(EntityUid uid)
+    {
+        if (_query.TryComp(uid, out var comp))
+        {
+            return TerminatingOrDeleted(uid) ? null : (uid, comp);
+        }
+        else
+        {
+            return GetHive(uid);
+        }
+    }
+
     public Entity<HiveComponent>? GetHiveByName(string hiveName)
     {
         var query = EntityQueryEnumerator<HiveComponent>();


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Announcements when designating xeno constructions work again.

Got broken in #10309.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfix.

## Technical details
<!-- Summary of code changes for easier review. -->
`Announce` calls that needed a queen were trying to get the hive of the source. However, if the hive _was_ the source, it failed to find the hive because a hive isn't a hive member.

Added `GetHiveOrSelf` that works with either a hive entity, or a hive member entity. `Announce` uses that now so that it works in either scenario.

Only affected announcing designating a construction as other announcements that require a queen (such as xeno deaths) use a different check.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Xeno designated construction announcements work again.
