### PR TITLE
Tweak: Sanitises Planet Names in Intel Clues UI

### DIFF
--- a/Content.Shared/_RMC14/Intel/IntelSystem.cs
+++ b/Content.Shared/_RMC14/Intel/IntelSystem.cs
@@ -871,9 +871,17 @@ public sealed class IntelSystem : EntitySystem
     {
         if (_area.TryGetArea(ent, out var area, out _))
         {
-            ent.Comp.InitialArea = Name(area.Value);
+            ent.Comp.InitialArea = SanitizeAreaName(Name(area.Value));
             Dirty(ent);
         }
+    }
+
+    private static string SanitizeAreaName(string areaName)
+    {
+        var separatorIndex = areaName.IndexOf(" - ", System.StringComparison.Ordinal);
+        return separatorIndex == -1
+            ? areaName
+            : areaName[(separatorIndex + 3)..];
     }
 
     private void OnDataDiskMapInit(Entity<IntelDataDiskComponent> ent, ref MapInitEvent args)


### PR DESCRIPTION
## About the PR
The planet name no longer appears in the intel clues UI just the area on the planet.

## Why / Balance
clutters up the intel UI with useless info

## Technical details
added a sanitised area helper that trims the planet name and the - from the call. Only effects intel clues.

## Media
before <img width="847" height="197" alt="image" src="https://github.com/user-attachments/assets/b88a7f50-3b79-42d7-b954-34ffbde6f031" />


after 
<img width="625" height="581" alt="image" src="https://github.com/user-attachments/assets/673b5efa-3e1d-4f22-8760-d496fa7a4b32" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: Planet names now omitted from intel UI clue locations.