### PR TITLE
Fixes: Missing Attributions for Phone Sounds

### DIFF
--- a/Resources/Audio/_RMC14/Phone/attributions.yml
+++ b/Resources/Audio/_RMC14/Phone/attributions.yml
@@ -1,0 +1,89 @@
+- files: ["dial.ogg"]
+  license: "CC-BY-SA-3.0"
+  copyright: "Taken from cmss13"
+  source: "https://github.com/cmss13-devs/cmss13/blob/master/sound/machines/telephone/dial.ogg"
+
+- files: ["phone_busy.ogg"]
+  license: "CC-BY-SA-3.0"
+  copyright: "Taken from cmss13"
+  source: "https://github.com/cmss13-devs/cmss13/blob/master/sound/machines/telephone/phone_busy.ogg"
+
+- files: ["remote_hangup.ogg"]
+  license: "CC-BY-SA-3.0"
+  copyright: "Taken from cmss13"
+  source: "https://github.com/cmss13-devs/cmss13/blob/master/sound/machines/telephone/remove_hangup.ogg"
+
+- files: ["remote_pickup.ogg"]
+  license: "CC-BY-SA-3.0"
+  copyright: "Taken from cmss13"
+  source: "https://github.com/cmss13-devs/cmss13/blob/master/sound/machines/telephone/remote_pickup.ogg"
+
+- files: ["ring_outgoing.ogg"]
+  license: "CC-BY-SA-3.0"
+  copyright: "Taken from cmss13"
+  source: "https://github.com/cmss13-devs/cmss13/blob/master/sound/machines/telephone/ring_outgoing.ogg"
+
+- files: ["rtb_handset_1.ogg"]
+  license: "CC-BY-SA-3.0"
+  copyright: "Taken from cmss13"
+  source: "https://github.com/cmss13-devs/cmss13/blob/master/sound/machines/telephone/rtb_handset_1.ogg"
+
+- files: ["rtb_handset_2.ogg"]
+  license: "CC-BY-SA-3.0"
+  copyright: "Taken from cmss13"
+  source: "https://github.com/cmss13-devs/cmss13/blob/master/sound/machines/telephone/rtb_handset_2.ogg"
+
+- files: ["rtb_handset_3.ogg"]
+  license: "CC-BY-SA-3.0"
+  copyright: "Taken from cmss13"
+  source: "https://github.com/cmss13-devs/cmss13/blob/master/sound/machines/telephone/rtb_handset_3.ogg"
+
+- files: ["rtb_handset_4.ogg"]
+  license: "CC-BY-SA-3.0"
+  copyright: "Taken from cmss13"
+  source: "https://github.com/cmss13-devs/cmss13/blob/master/sound/machines/telephone/rtb_handset_4.ogg"
+
+- files: ["rtb_handset_5.ogg"]
+  license: "CC-BY-SA-3.0"
+  copyright: "Taken from cmss13"
+  source: "https://github.com/cmss13-devs/cmss13/blob/master/sound/machines/telephone/rtb_handset_5.ogg"
+
+- files: ["talk_phone1.ogg"]
+  license: "CC-BY-SA-3.0"
+  copyright: "Taken from cmss13"
+  source: "https://github.com/cmss13-devs/cmss13/blob/master/sound/machines/telephone/talk_phone1.ogg"
+
+- files: ["talk_phone2.ogg"]
+  license: "CC-BY-SA-3.0"
+  copyright: "Taken from cmss13"
+  source: "https://github.com/cmss13-devs/cmss13/blob/master/sound/machines/telephone/talk_phone2.ogg"
+
+- files: ["talk_phone3.ogg"]
+  license: "CC-BY-SA-3.0"
+  copyright: "Taken from cmss13"
+  source: "https://github.com/cmss13-devs/cmss13/blob/master/sound/machines/telephone/talk_phone3.ogg"
+
+- files: ["talk_phone4.ogg"]
+  license: "CC-BY-SA-3.0"
+  copyright: "Taken from cmss13"
+  source: "https://github.com/cmss13-devs/cmss13/blob/master/sound/machines/telephone/talk_phone4.ogg"
+
+- files: ["talk_phone5.ogg"]
+  license: "CC-BY-SA-3.0"
+  copyright: "Taken from cmss13"
+  source: "https://github.com/cmss13-devs/cmss13/blob/master/sound/machines/telephone/talk_phone5.ogg"
+
+- files: ["talk_phone6.ogg"]
+  license: "CC-BY-SA-3.0"
+  copyright: "Taken from cmss13"
+  source: "https://github.com/cmss13-devs/cmss13/blob/master/sound/machines/telephone/talk_phone6.ogg"
+
+- files: ["talk_phone7.ogg"]
+  license: "CC-BY-SA-3.0"
+  copyright: "Taken from cmss13"
+  source: "https://github.com/cmss13-devs/cmss13/blob/master/sound/machines/telephone/talk_phone7.ogg"
+
+- files: ["telephone_ring.ogg"]
+  license: "CC-BY-SA-3.0"
+  copyright: "Taken from cmss13"
+  source: "https://github.com/cmss13-devs/cmss13/blob/master/sound/machines/telephone/telephone_ring.ogg"


### PR DESCRIPTION
## About the PR
adds missing attributions for the phone sounds. fixes: #10361 

## Why / Balance
no attribution bad

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
none player facing