### PR TITLE
Tweak: Standardised Special Survivor Naming Scheme

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Fiorina/RiotInProgress/riot_in_progress_CMB_RCO.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Fiorina/RiotInProgress/riot_in_progress_CMB_RCO.yml
@@ -7,7 +7,7 @@
   startingGear: RMCGearSurvivorFiorinaRiotInProgressCMBRiotControlOfficer
   accessGroups:
   - ColonistSec
-  spawnMenuRoleName: CMB Riot Control Officer (Special Survivor)
+  spawnMenuRoleName: CMB Riot Control Officer (Fiorina Special Survivor)
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Fiorina/RiotInProgress/riot_in_progress_CMB_RCTL.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Fiorina/RiotInProgress/riot_in_progress_CMB_RCTL.yml
@@ -67,12 +67,12 @@
   components:
   - type: EntityPreset
     primaryWeapons:
-    - [ RMCPouchShotgunFilledPolicing, RMCWeaponShotgunM12 ]
-    - [ RMCPouchShotgunFilledPolicing, RMCWeaponShotgunM12 ]
-    - [ RMCPouchShotgunFilledPolicing, RMCWeaponShotgunM12 ]
-    - [ RMCPouchShotgunFilledPolicing, RMCWeaponShotgunM12 ]
-    - [ RMCPouchShotgunFilledPolicing, RMCWeaponShotgunM12 ]
-    - [ RMCPouchShotgunFilledPolicing, RMCWeaponShotgunM12 ]
+    - [ RMCPouchShotgunFilledPolicing, RMCWeaponShotgunHG3712 ]
+    - [ RMCPouchShotgunFilledPolicing, RMCWeaponShotgunHG3712 ]
+    - [ RMCPouchShotgunFilledPolicing, RMCWeaponShotgunHG3712 ]
+    - [ RMCPouchShotgunFilledPolicing, RMCWeaponShotgunHG3712 ]
+    - [ RMCPouchShotgunFilledPolicing, RMCWeaponShotgunHG3712 ]
+    - [ RMCPouchShotgunFilledPolicing, RMCWeaponShotgunHG3712 ]
     - [ RMCPouchMagazineFilledM16, RMCWeaponRifleM16A5, RMCExplosiveBreachingCharge ]
     - [ RMCPouchMagazineFilledM16, RMCWeaponRifleM16A5, RMCExplosiveBreachingCharge ]
     - [ RMCPouchMagazineFilledMP5, RMCWeaponSMGMP5Alt, RMCMotionDetectorCompact ]

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Fiorina/RiotInProgress/riot_in_progress_CMB_RCTL.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Fiorina/RiotInProgress/riot_in_progress_CMB_RCTL.yml
@@ -7,7 +7,7 @@
   startingGear: RMCGearSurvivorFiorinaRiotInProgressCMBRiotControlTeamLeader
   accessGroups:
   - ColonistSec
-  spawnMenuRoleName: CMB Riot Control Team Leader (Special Survivor)
+  spawnMenuRoleName: CMB Riot Control Team Leader (Fiorina Special Survivor)
   icon: "RMCJobIconBureauDeputy"
   hasIcon: true
   special:
@@ -67,12 +67,12 @@
   components:
   - type: EntityPreset
     primaryWeapons:
-    - [ RMCPouchShotgunFilledPolicing, RMCWeaponShotgunHG3712 ]
-    - [ RMCPouchShotgunFilledPolicing, RMCWeaponShotgunHG3712 ]
-    - [ RMCPouchShotgunFilledPolicing, RMCWeaponShotgunHG3712 ]
-    - [ RMCPouchShotgunFilledPolicing, RMCWeaponShotgunHG3712 ]
-    - [ RMCPouchShotgunFilledPolicing, RMCWeaponShotgunHG3712 ]
-    - [ RMCPouchShotgunFilledPolicing, RMCWeaponShotgunHG3712 ]
+    - [ RMCPouchShotgunFilledPolicing, RMCWeaponShotgunM12 ]
+    - [ RMCPouchShotgunFilledPolicing, RMCWeaponShotgunM12 ]
+    - [ RMCPouchShotgunFilledPolicing, RMCWeaponShotgunM12 ]
+    - [ RMCPouchShotgunFilledPolicing, RMCWeaponShotgunM12 ]
+    - [ RMCPouchShotgunFilledPolicing, RMCWeaponShotgunM12 ]
+    - [ RMCPouchShotgunFilledPolicing, RMCWeaponShotgunM12 ]
     - [ RMCPouchMagazineFilledM16, RMCWeaponRifleM16A5, RMCExplosiveBreachingCharge ]
     - [ RMCPouchMagazineFilledM16, RMCWeaponRifleM16A5, RMCExplosiveBreachingCharge ]
     - [ RMCPouchMagazineFilledMP5, RMCWeaponSMGMP5Alt, RMCMotionDetectorCompact ]

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Hybrisa_Prospera/Paramarines/Para_Base.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Hybrisa_Prospera/Paramarines/Para_Base.yml
@@ -13,7 +13,7 @@
   hasIcon: true
   greeting: rmc-job-greeting-para
   playTimeTracker: RMCJobSurvivorMilitary
-  spawnMenuRoleName: Royal Paramarine Survivor (Base)
+  spawnMenuRoleName: Royal Paramarine (Hybrisa Special Survivor)
   abstract: true
   hidden: true
 

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Hybrisa_Prospera/Paramarines/Para_Combat_Engineer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Hybrisa_Prospera/Paramarines/Para_Combat_Engineer.yml
@@ -7,7 +7,7 @@
   startingGear: RMCGearParaAssaultEngineer
   icon: RMCJobIconParaAssaultEngineer
   playTimeTracker: RMCJobSurvivorMilitary
-  spawnMenuRoleName: Royal Paramarine Assault Engineer (Survivor)
+  spawnMenuRoleName: Royal Paramarine Assault Engineer (Hybrisa Special Survivor)
   special:
     - !type:AddComponentSpecial
       components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Hybrisa_Prospera/Paramarines/Para_Commander.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Hybrisa_Prospera/Paramarines/Para_Commander.yml
@@ -9,7 +9,7 @@
   startingGear: RMCGearParaCommander
   icon: RMCJobIconParaCommander
   playTimeTracker: RMCJobSurvivorCO
-  spawnMenuRoleName: Royal Paramarine Commander (Survivor)
+  spawnMenuRoleName: Royal Paramarine Commander (Hybrisa Special Survivor)
   special:
     - !type:AddComponentSpecial
       components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Hybrisa_Prospera/Paramarines/Para_Medical_Technician.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Hybrisa_Prospera/Paramarines/Para_Medical_Technician.yml
@@ -7,7 +7,7 @@
   startingGear: RMCGearParaMedicalTechnician
   icon: RMCJobIconParaMedicalTechnican
   playTimeTracker: RMCJobSurvivorMilitary
-  spawnMenuRoleName: Royal Paramarine Medical Technician (Survivor)
+  spawnMenuRoleName: Royal Paramarine Medical Technician (Hybrisa Special Survivor)
   special:
     - !type:AddComponentSpecial
       components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Hybrisa_Prospera/Paramarines/Para_Pilot.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Hybrisa_Prospera/Paramarines/Para_Pilot.yml
@@ -7,7 +7,7 @@
   startingGear: RMCGearParaPilot
   icon: RMCJobIconParaPilot
   playTimeTracker: RMCJobSurvivorMilitary
-  spawnMenuRoleName: Royal Paramarine Fleet Air Arm Pilot (Survivor)
+  spawnMenuRoleName: Royal Paramarine Fleet Air Arm Pilot (Hybrisa Special Survivor)
   special:
     - !type:AddComponentSpecial
       components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Hybrisa_Prospera/Paramarines/Para_Rifleman.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Hybrisa_Prospera/Paramarines/Para_Rifleman.yml
@@ -4,7 +4,7 @@
   name: rmc-job-name-paramarine
   icon: RMCJobIconParamarine
   playTimeTracker: RMCJobSurvivorMilitary
-  spawnMenuRoleName: Royal Paramarine Rifleman (Survivor)
+  spawnMenuRoleName: Royal Paramarine Rifleman (Hybrisa Special Survivor)
   special:
     - !type:AddComponentSpecial
       components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Hybrisa_Prospera/Paramarines/Para_Synth.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Hybrisa_Prospera/Paramarines/Para_Synth.yml
@@ -7,7 +7,7 @@
   startingGear: RMCGearParaSupportSynthetic
   icon: RMCJobIconParaSupportSynthetic
   playTimeTracker: RMCJobSyntheticColony
-  spawnMenuRoleName: Royal Paramarine Support Synthetic (Survivor)
+  spawnMenuRoleName: Royal Paramarine Support Synthetic (Hybrisa Special Survivor)
   special:
     - !type:AddComponentSpecial
       components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Hybrisa_Prospera/Paramarines/Para_Team_Leader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Hybrisa_Prospera/Paramarines/Para_Team_Leader.yml
@@ -8,7 +8,7 @@
   startingGear: RMCGearParaTeamLeader
   icon: RMCJobIconParaTeamLeader
   playTimeTracker: RMCJobSurvivorMilitary
-  spawnMenuRoleName: Royal Paramarine Team Leader (Survivor)
+  spawnMenuRoleName: Royal Paramarine Team Leader (Hybrisa Special Survivor)
   special:
     - !type:AddComponentSpecial
       components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/LV624/corporate_dome_goon.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/LV624/corporate_dome_goon.yml
@@ -4,7 +4,7 @@
   name: rmc-job-name-pmc-corporate-goon
   description: cm-job-description-survivor
   playTimeTracker: CMJobSurvivor
-  spawnMenuRoleName: We-Ya Goon (Survivor Special)
+  spawnMenuRoleName: We-Ya Goon (LV624 Special Survivor)
   icon: "RMCJobIconPMCGoonStandard"
   ranks:
     RMCRankCivilianOfficer: []

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/LV624/corporate_dome_goon_engineer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/LV624/corporate_dome_goon_engineer.yml
@@ -4,7 +4,7 @@
   name: rmc-job-name-pmc-corporate-goon-engi
   description: cm-job-description-survivor
   playTimeTracker: CMJobSurvivorEngineer
-  spawnMenuRoleName: We-Ya Goon Engineer (Survivor Special)
+  spawnMenuRoleName: We-Ya Goon Engineer (LV624 Special Survivor)
   startingGear: RMCGearSurvivorGoon
   icon: "RMCJobIconPMCGoonEngi"
   hasIcon: true

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/LV624/corporate_dome_goon_lead.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/LV624/corporate_dome_goon_lead.yml
@@ -3,7 +3,7 @@
   id: CMSurvivorLV624CorporateDomeGoonLead
   name: rmc-job-name-pmc-corporate-goon-leader
   description: cm-job-description-survivor
-  spawnMenuRoleName: We-Ya Goon Lead (Survivor Special)
+  spawnMenuRoleName: We-Ya Goon Lead (LV624 Special Survivor)
   startingGear: RMCGearSurvivorGoonLead
   icon: "RMCJobIconPMCGoonLead"
   hasIcon: true

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/LV624/corporate_dome_goon_medic.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/LV624/corporate_dome_goon_medic.yml
@@ -3,7 +3,7 @@
   id: CMSurvivorLV624CorporateDomeGoonMedic
   name: rmc-job-name-pmc-corporate-goon-medic
   description: cm-job-description-survivor
-  spawnMenuRoleName: We-Ya Goon Medic (Survivor Special)
+  spawnMenuRoleName: We-Ya Goon Medic (LV624 Special Survivor)
   startingGear: RMCGearSurvivorGoon
   icon: "RMCJobIconPMCGoonMedic"
   hasIcon: true

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/LV624/corporate_security_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/LV624/corporate_security_survivor.yml
@@ -5,7 +5,7 @@
   startingGear: RMCGearSurvivorLV624SecurityGuard
   hasIcon: true
   icon: RMCJobIconWeYaSec
-  spawnMenuRoleName: WeYa Security Guard (LV624 Survivor)
+  spawnMenuRoleName: We-Ya Security Guard (LV624 Survivor)
   accessGroups:
   - ColonistSec
   - ColonistCorporate

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/New_Varadero/beachbum.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/New_Varadero/beachbum.yml
@@ -5,7 +5,7 @@
   description: cm-job-description-survivor
   playTimeTracker: CMJobSurvivor
   startingGear: RMCGearSurvivorBeachBum
-  spawnMenuRoleName: Beach Bum (NV Survivor)
+  spawnMenuRoleName: Beach Bum (New Varadero Survivor)
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/New_Varadero/cargo_technician_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/New_Varadero/cargo_technician_survivor.yml
@@ -5,7 +5,7 @@
   description: cm-job-description-survivor
   playTimeTracker: CMJobSurvivorEngineer
   startingGear: RMCGearSurvivorCargoTechnician
-  spawnMenuRoleName: Cargo Technician (NV Survivor)
+  spawnMenuRoleName: Cargo Technician (New Varadero Survivor)
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/New_Varadero/commander_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/New_Varadero/commander_survivor.yml
@@ -11,7 +11,7 @@
   roleWeight: 0.25
   icon: "RMCJobIconSurvivorCommanderNewVaradero"
   hasIcon: true
-  spawnMenuRoleName: UNMC Commander (NV Survivor)
+  spawnMenuRoleName: UNMC Commander (New Varadero Survivor)
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/New_Varadero/icb_liaison_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/New_Varadero/icb_liaison_survivor.yml
@@ -3,7 +3,7 @@
   id: CMSurvivorVaraderoICB
   name: cm-job-name-survivor-icb
   description: cm-job-description-survivor
-  spawnMenuRoleName: Interstellar Commerce Bureau Liaison (NV Survivor)
+  spawnMenuRoleName: Interstellar Commerce Bureau Liaison (New Varadero Survivor)
   startingGear: RMCGearSurvivorVaraderoICB
 
 - type: startingGear

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/New_Varadero/medical_technician_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/New_Varadero/medical_technician_survivor.yml
@@ -5,7 +5,7 @@
   description: cm-job-description-survivor
   playTimeTracker: CMJobSurvivorDoctor
   startingGear: RMCGearSurvivorMedicalTechnician
-  spawnMenuRoleName: Medical Technician (NV Survivor)
+  spawnMenuRoleName: Medical Technician (New Varadero Survivor)
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/New_Varadero/new_varadero_researcher.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/New_Varadero/new_varadero_researcher.yml
@@ -5,7 +5,7 @@
   description: cm-job-description-survivor
   playTimeTracker: CMJobSurvivorScientist
   startingGear: RMCGearSurvivorNewVaraderoResearcher
-  spawnMenuRoleName: New Varadero Researcher (NV Survivor)
+  spawnMenuRoleName: Researcher (New Varadero Survivor)
   accessGroups:
   - ColonistMedical
   useLoadoutOfJob: CMSurvivorScientist # for inheritance

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/New_Varadero/technician_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/New_Varadero/technician_survivor.yml
@@ -5,7 +5,7 @@
   description: cm-job-description-survivor
   playTimeTracker: CMJobSurvivorEngineer
   startingGear: RMCGearSurvivorTechnician
-  spawnMenuRoleName: Engineering Technician (NV Survivor)
+  spawnMenuRoleName: Engineering Technician (New Varadero Survivor)
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/New_Varadero/varadero_peacekeeper.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/New_Varadero/varadero_peacekeeper.yml
@@ -5,7 +5,7 @@
   description: cm-job-description-survivor
   playTimeTracker: CMJobSurvivorSecurity
   startingGear: RMCGearSurvivorILRCPeacekeeper
-  spawnMenuRoleName: ILRC peacekeeper (NV Survivor)
+  spawnMenuRoleName: ILRC Peacekeeper (New Varadero Survivor)
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Shivas/Panic_Room/shivas_panic_room_assistant_manager.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Shivas/Panic_Room/shivas_panic_room_assistant_manager.yml
@@ -14,7 +14,7 @@
   joinNotifyCrew: false
   greeting: rmc-job-greeting-shivas-assistant-manager
   playTimeTracker: CMJobSurvivorCorporate
-  spawnMenuRoleName: Survivor — Assistant Operations Manager (Shivas)
+  spawnMenuRoleName: Assistant Operations Manager (Shivas Special Survivor)
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Shivas/Panic_Room/shivas_panic_room_civilian.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Shivas/Panic_Room/shivas_panic_room_civilian.yml
@@ -2,7 +2,7 @@
   parent: CMSurvivor
   id: RMCSurvivorShivasPanicRoomCivilian
   name: cm-job-name-survivor
-  spawnMenuRoleName: Civilian (Shivas Panic Room Special Survivor)
+  spawnMenuRoleName: Civilian (Shivas Special Survivor)
   playTimeTracker: CMJobSurvivor
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Shivas/Panic_Room/shivas_panic_room_doctor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Shivas/Panic_Room/shivas_panic_room_doctor.yml
@@ -4,7 +4,7 @@
   name: rmc-job-name-survivor-shivas-doctor
   playTimeTracker: CMJobSurvivorDoctor
   startingGear: RMCGearSurvivorShivasDoctor
-  spawnMenuRoleName: Doctor (Shivas Panic Room Special Survivor)
+  spawnMenuRoleName: Doctor (Shivas Special Survivor)
   greeting: rmc-job-greeting-shivas-panic-room-doctor
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Shivas/Panic_Room/shivas_panic_room_engineer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Shivas/Panic_Room/shivas_panic_room_engineer.yml
@@ -4,7 +4,7 @@
   name: rmc-job-name-survivor-shivas-engineer
   playTimeTracker: CMJobSurvivorEngineer
   startingGear: RMCGearSurvivorShivasEngineer
-  spawnMenuRoleName: Engineer (Shivas Panic Room Special Survivor)
+  spawnMenuRoleName: Engineer (Shivas Special Survivor)
   greeting: rmc-job-greeting-shivas-panic-room-engineer
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Shivas/Panic_Room/shivas_panic_room_researcher.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Shivas/Panic_Room/shivas_panic_room_researcher.yml
@@ -4,7 +4,7 @@
   name: rmc-job-name-survivor-shivas-researcher
   playTimeTracker: CMJobSurvivorScientist
   startingGear: RMCGearSurvivorShivasResearcher
-  spawnMenuRoleName: Researcher (Shivas Panic Room Special Survivor)
+  spawnMenuRoleName: Researcher (Shivas Special Survivor)
   greeting: rmc-job-greeting-shivas-panic-room-researcher
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Shivas/Panic_Room/shivas_panic_room_weya_commando.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Shivas/Panic_Room/shivas_panic_room_weya_commando.yml
@@ -15,7 +15,7 @@
   camouflageStartingGear: null
   greeting: rmc-job-greeting-shivas-commando
   playTimeTracker: CMJobSurvivorSecurity
-  spawnMenuRoleName: Survivor - We-Ya Commando (Shivas)
+  spawnMenuRoleName: We-Ya Commando (Shivas Special Survivor)
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Solaris/Crashlanding_Offices/base.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Solaris/Crashlanding_Offices/base.yml
@@ -15,7 +15,7 @@
   joinNotifyCrew: false
   greeting: rmc-job-greeting-solaris-pmc
   playTimeTracker: RMCJobSurvivorMilitary
-  spawnMenuRoleName: Survivor — PMC (Base)
+  spawnMenuRoleName: PMC (Solaris Special Survivor - Base)
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Solaris/Crashlanding_Offices/corporate_supervisor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Solaris/Crashlanding_Offices/corporate_supervisor.yml
@@ -10,7 +10,7 @@
   - CMAccessIllegal
   icon: "CMJobIconExecAssMan"
   greeting: rmc-job-greeting-solaris-pmc-supervisor
-  spawnMenuRoleName: Survivor — Corporate Supervisor (Solaris Ridge special survivor)
+  spawnMenuRoleName: Corporate Supervisor (Solaris Special Survivor)
   startingGear: RMCGearSurvivorSolarisCorporateSupervisor
   special:
   - !type:AddComponentSpecial

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Solaris/Crashlanding_Offices/engineer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Solaris/Crashlanding_Offices/engineer.yml
@@ -11,7 +11,7 @@
   icon: RMCJobIconPMCEngineer
   greeting: rmc-job-greeting-solaris-pmc-engineer
   playTimeTracker: RMCJobSurvivorMilitary
-  spawnMenuRoleName: Survivor — PMC Engineer (Solaris Ridge special survivor)
+  spawnMenuRoleName: PMC Engineer (Solaris Special Survivor)
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Solaris/Crashlanding_Offices/field_operations_leader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Solaris/Crashlanding_Offices/field_operations_leader.yml
@@ -12,7 +12,7 @@
   icon: RMCJobIconPMCCommander
   greeting: rmc-job-greeting-solaris-pmc-commander
   playTimeTracker: RMCJobSurvivorCO
-  spawnMenuRoleName: Survivor — PMC Field Operations Leader (Solaris Ridge special survivor)
+  spawnMenuRoleName: PMC Field Operations Leader (Solaris Special Survivor)
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Solaris/Crashlanding_Offices/gunner.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Solaris/Crashlanding_Offices/gunner.yml
@@ -13,7 +13,7 @@
   hasIcon: true
   greeting: rmc-job-greeting-solaris-pmc
   playTimeTracker: RMCJobSurvivorMilitary
-  spawnMenuRoleName: Survivor — PMC Standard (Solaris Ridge special survivor)
+  spawnMenuRoleName: PMC Standard (Solaris Special Survivor)
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Solaris/Crashlanding_Offices/leader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Solaris/Crashlanding_Offices/leader.yml
@@ -11,7 +11,7 @@
   icon: RMCJobIconPMCLeader
   greeting: rmc-job-greeting-solaris-pmc-leader
   playTimeTracker: RMCJobSurvivorMilitary
-  spawnMenuRoleName: Survivor — PMC Leader (Solaris Ridge special survivor)
+  spawnMenuRoleName: PMC Leader (Solaris Special Survivor)
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Solaris/Crashlanding_Offices/medic.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Solaris/Crashlanding_Offices/medic.yml
@@ -11,7 +11,7 @@
   icon: RMCJobIconPMCMedic
   greeting: rmc-job-greeting-solaris-pmc-medic
   playTimeTracker: RMCJobSurvivorMilitary
-  spawnMenuRoleName: Survivor — PMC Medic (Solaris Ridge special survivor)
+  spawnMenuRoleName: PMC Medic (Solaris Special Survivor)
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Solaris/solaris_peacekeeper.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Solaris/solaris_peacekeeper.yml
@@ -5,7 +5,7 @@
   description: cm-job-description-survivor
   playTimeTracker: CMJobSurvivorSecurity
   startingGear: RMCGearSurvivorSolarisILRCPeacekeeper
-  spawnMenuRoleName: ILRC peacekeeper (Solaris Survivor)
+  spawnMenuRoleName: ILRC Peacekeeper (Solaris Survivor)
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/SPP_SOF/spp_sof_base.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/SPP_SOF/spp_sof_base.yml
@@ -13,7 +13,7 @@
   hasIcon: true
   greeting: rmc-job-greeting-soro-sof
   playTimeTracker: RMCJobSurvivorMilitary
-  spawnMenuRoleName: SPP SOF Survivor (Base)
+  spawnMenuRoleName: SPP SOF (Sorokyne Special Survivor - Base)
   useLoadoutOfJob: CMSurvivor
   basePlaytimeTracker: true
   abstract: true

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/SPP_SOF/spp_sof_medic.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/SPP_SOF/spp_sof_medic.yml
@@ -6,7 +6,7 @@
   ranks:
     RMCRankSPPMladshiySerzhant: []
   icon: "RMCJobIconSPPMedic"
-  spawnMenuRoleName: SPP SOF Medic (Survivor)
+  spawnMenuRoleName: SPP SOF Medic (Sorokyne Special Survivor)
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/SPP_SOF/spp_sof_sapper.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/SPP_SOF/spp_sof_sapper.yml
@@ -6,7 +6,7 @@
   ranks:
     RMCRankSPPMladshiySerzhant: []
   icon: "RMCJobIconSPPEngineer"
-  spawnMenuRoleName: SPP SOF Sapper (Survivor)
+  spawnMenuRoleName: SPP SOF Sapper (Sorokyne Special Survivor)
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/SPP_SOF/spp_sof_sl.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/SPP_SOF/spp_sof_sl.yml
@@ -6,7 +6,7 @@
   ranks:
     RMCRankSPPStarshiySerzhant: []
   icon: "RMCJobIconSPPLeader"
-  spawnMenuRoleName: SPP SOF Squad Leader (Survivor)
+  spawnMenuRoleName: SPP SOF Squad Leader (Sorokyne Special Survivor)
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/SPP_SOF/spp_sof_soldier.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/SPP_SOF/spp_sof_soldier.yml
@@ -3,7 +3,7 @@
   id: RMCSurvivorSPPSOFSoldier
   name: rmc-job-name-soro-sof-soldier
   icon: "RMCJobIconSPPRifleman"
-  spawnMenuRoleName: SPP SOF Rifleman (Survivor)
+  spawnMenuRoleName: SPP SOF Rifleman (Sorokyne Special Survivor)
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/SPP_SOF/spp_sof_spec.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Sorokyne_Strata/SPP_SOF/spp_sof_spec.yml
@@ -6,7 +6,7 @@
   ranks:
     RMCRankSPPSerzhant: []
   icon: "RMCJobIconSPPSpecialist"
-  spawnMenuRoleName: SPP SOF Specialist (Survivor)
+  spawnMenuRoleName: SPP SOF Specialist (Sorokyne Special Survivor)
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Trijent_Dam/SPPCrashlanding/spp_crashland_base.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Trijent_Dam/SPPCrashlanding/spp_crashland_base.yml
@@ -12,7 +12,7 @@
   startingGear: RMCGearSPPCrashlandBase
   hasIcon: true
   greeting: rmc-job-greeting-crashland
-  spawnMenuRoleName: SPP Airborne Survivor (Base)
+  spawnMenuRoleName: SPP Airborne (Trijent Special Survivor - Base)
   abstract: true
   hidden: true
 

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Trijent_Dam/SPPCrashlanding/spp_crashland_medic.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Trijent_Dam/SPPCrashlanding/spp_crashland_medic.yml
@@ -6,7 +6,7 @@
   ranks:
     RMCRankSPPMladshiySerzhant: []
   icon: "RMCJobIconSPPMedic"
-  spawnMenuRoleName: SPP Airborne Medic (Survivor)
+  spawnMenuRoleName: SPP Airborne Medic (Trijent Special Survivor)
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Trijent_Dam/SPPCrashlanding/spp_crashland_sapper.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Trijent_Dam/SPPCrashlanding/spp_crashland_sapper.yml
@@ -6,7 +6,7 @@
   ranks:
     RMCRankSPPMladshiySerzhant: []
   icon: "RMCJobIconSPPEngineer"
-  spawnMenuRoleName: SPP Airborne Sapper (Survivor)
+  spawnMenuRoleName: SPP Airborne Sapper (Trijent Special Survivor)
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Trijent_Dam/SPPCrashlanding/spp_crashland_soldier.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Trijent_Dam/SPPCrashlanding/spp_crashland_soldier.yml
@@ -3,7 +3,7 @@
   id: RMCSurvivorSPPCrashlandSoldier
   name: rmc-job-name-crashland-soldier
   icon: "RMCJobIconSPPRifleman"
-  spawnMenuRoleName: SPP Airborne Rifleman (Survivor)
+  spawnMenuRoleName: SPP Airborne Rifleman (Trijent Special Survivor)
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Trijent_Dam/SPPCrashlanding/spp_crashland_specialist.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Trijent_Dam/SPPCrashlanding/spp_crashland_specialist.yml
@@ -6,7 +6,7 @@
   ranks:
     RMCRankSPPSerzhant: []
   icon: "RMCJobIconSPPSpecialist"
-  spawnMenuRoleName: SPP Airborne Specialist (Survivor)
+  spawnMenuRoleName: SPP Airborne Specialist (Trijent Special Survivor)
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Trijent_Dam/SPPCrashlanding/spp_crashland_squadleader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Trijent_Dam/SPPCrashlanding/spp_crashland_squadleader.yml
@@ -6,7 +6,7 @@
   ranks:
     RMCRankSPPStarshiySerzhant: []
   icon: "RMCJobIconSPPLeader"
-  spawnMenuRoleName: SPP Airborne Squad Leader (Survivor)
+  spawnMenuRoleName: SPP Airborne Squad Leader (Trijent Special Survivor)
   special:
   - !type:AddComponentSpecial
     components:


### PR DESCRIPTION
## About the PR
Standardised special survivor naming scheme, fixes: #10348 

Naming scheme is as follows: Name (Map Special Survivor)

for base survs the addition of - Base: Name (Map Special Survivor - Base)

## Why / Balance
different names bad

## Technical details
yml

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
None player facing