### PR TITLE
Localizes the remaining hardcoded text in the intel objectives window.

### DIFF
--- a/Content.Client/_RMC14/Intel/ViewIntelObjectivesBui.cs
+++ b/Content.Client/_RMC14/Intel/ViewIntelObjectivesBui.cs
@@ -87,7 +87,9 @@ public sealed class ViewIntelObjectivesBui(EntityUid owner, Enum uiKey) : BoundU
         if (_window?.HideAreasButton == null)
             return;
 
-        _window.HideAreasButton.Text = _hideAreas ? "Show Areas" : "Hide Areas";
+        _window.HideAreasButton.Text = Loc.GetString(_hideAreas
+            ? "rmc-ui-intel-show-areas"
+            : "rmc-ui-intel-hide-areas");
     }
 
     private void ApplyFilter(string query)
@@ -170,8 +172,8 @@ public sealed class ViewIntelObjectivesBui(EntityUid owner, Enum uiKey) : BoundU
             HorizontalExpand = true,
         };
 
-        const string separator = " in ";
-        var splitIndex = clue.LastIndexOf(separator, StringComparison.OrdinalIgnoreCase);
+        var separator = $" {Loc.GetString("rmc-ui-intel-clue-area-preposition")} ";
+        var splitIndex = clue.IndexOf(separator, StringComparison.OrdinalIgnoreCase);
 
         if (splitIndex < 0)
         {

--- a/Content.Client/_RMC14/Intel/ViewIntelObjectivesWindow.xaml
+++ b/Content.Client/_RMC14/Intel/ViewIntelObjectivesWindow.xaml
@@ -110,10 +110,10 @@
                     <ui:BlueHorizontalSeparator />
                     <BoxContainer Orientation="Horizontal" Margin="0 2 0 4" SeparationOverride="4">
                         <LineEdit Name="CluesSearchBar" Access="Public"
-                                  PlaceHolder="Search clues..."
+                                  PlaceHolder="{Loc rmc-ui-intel-search-placeholder}"
                                   HorizontalExpand="True" />
                         <Button Name="HideAreasButton" Access="Public"
-                                Text="Hide Areas"
+                                Text="{Loc rmc-ui-intel-hide-areas}"
                                 MinWidth="90" />
                     </BoxContainer>
                     <TabContainer Name="CluesContainer" Access="Public" VerticalExpand="True" />

--- a/Resources/Locale/en-US/_RMC14/intel.ftl
+++ b/Resources/Locale/en-US/_RMC14/intel.ftl
@@ -94,6 +94,10 @@ rmc-ui-intel-recover-corpses = [color=#5B88B0]Recover corpses:[/color]
 rmc-ui-intel-colony-comms = [color=#5B88B0]Colony communications:[/color]
 rmc-ui-intel-colony-power = [color=#5B88B0]Colony power:[/color]
 rmc-ui-intel-clues = [bold]Clues[/bold]
+rmc-ui-intel-search-placeholder = Search clues...
+rmc-ui-intel-hide-areas = Hide Areas
+rmc-ui-intel-show-areas = Show Areas
+rmc-ui-intel-clue-area-preposition = in
 rmc-ui-intel-points-value = { $value }
 rmc-ui-intel-tier-value = { $value }
 rmc-ui-intel-total-credits = Total earned credits: { $value }


### PR DESCRIPTION
## About the PR

Localizes the remaining hardcoded text in the intel objectives window.

## Why / Balance

No balance impact. This is a UI localization cleanup for the intel objectives menu.

## Technical details

- Replaced hardcoded "Search clues...", "Hide Areas", and "Show Areas" strings with locale keys.
- Added the corresponding English locale entries to `Resources/Locale/en-US/_RMC14/intel.ftl`.
- Uses a localized clue area preposition when splitting clue text for the hide areas toggle.

## Media

Not required, text-only UI localization fix.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:GrigoriyGalintano
- fix: Fixed hardcoded text in the intel objectives window.