### PR TITLE
Cleanup vehicle YML, add xenonid vision to all vehicles

### DIFF
--- a/Content.Shared/_RMC14/Vehicle/Core/VehicleSoundComponent.cs
+++ b/Content.Shared/_RMC14/Vehicle/Core/VehicleSoundComponent.cs
@@ -17,7 +17,7 @@ public sealed partial class VehicleSoundComponent : Component
     public SoundSpecifier? CollisionSound;
 
     [DataField]
-    public float CollisionSoundCooldown = 0.25f;
+    public float CollisionSoundCooldown = 0.5f;
 
     [DataField]
     public SoundSpecifier? MobCollisionSound;

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/vehicle_supply.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/vehicle_supply.yml
@@ -60,7 +60,7 @@
       - VehicleHumveeHatch
       - VehicleHumveeWheel
     - name: apc
-      vehicle: VehicleAPC
+      vehicle: VehicleAPCTracked
       hardpoints:
       - RMCAPCDualCannon
       - RMCAPCFrontCannon

--- a/Resources/Prototypes/_RMC14/Vehicles/APC/vehicles.yml
+++ b/Resources/Prototypes/_RMC14/Vehicles/APC/vehicles.yml
@@ -169,6 +169,12 @@
     - offset: -1.5,0
       radius: 0.7
       interiorCoords: 1.55,-1.2
+
+- type: entity
+  parent: VehicleAPC
+  id: VehicleAPCTracked
+  suffix: Drivable, APC, Base, Tracked
+  components:
   - type: MarineMapTracked
   - type: TacticalMapTracked
   - type: TacticalMapIcon
@@ -177,11 +183,11 @@
       state: apc
 
 - type: entity
-  parent: VehicleAPCBase
+  parent: VehicleAPCTracked
   id: VehicleAPCMed
   name: armored personnel carrier (medical)
   description: A medical-configured APC outfitted with triage markings.
-  suffix: Drivable, APC, Base, Medical
+  suffix: Drivable, APC, Base, Medical, Tracked
   components:
   - type: Sprite
     layers:
@@ -231,19 +237,13 @@
     - offset: 0,2
       radius: 0.85
       interiorCoords: 0.25,-1
-  - type: MarineMapTracked
-  - type: TacticalMapTracked
-  - type: TacticalMapIcon
-    icon:
-      sprite: /Textures/_RMC14/Interface/map_blips_large.rsi
-      state: apc
 
 - type: entity
-  parent: VehicleAPCBase
+  parent: VehicleAPCTracked
   id: VehicleAPCCommand
   name: armored personnel carrier (command)
   description: A command-configured APC bristling with sensors and comms gear.
-  suffix: Drivable, APC, Base, Command
+  suffix: Drivable, APC, Base, Command, Tracked
   components:
   - type: Sprite
     layers:
@@ -294,12 +294,8 @@
     - offset: 0,2
       radius: 0.85
       interiorCoords: 0.25,-1
-  - type: MarineMapTracked
-  - type: TacticalMapTracked
-  - type: TacticalMapIcon
-    icon:
-      sprite: /Textures/_RMC14/Interface/map_blips_large.rsi
-      state: apc
+
+## SPP
 
 - type: entity
   parent: VehicleAPCBase

--- a/Resources/Prototypes/_RMC14/Vehicles/APC/vehicles.yml
+++ b/Resources/Prototypes/_RMC14/Vehicles/APC/vehicles.yml
@@ -1,18 +1,13 @@
 - type: entity
+  parent: RMCVehicleBase
   id: VehicleAPCBase
   abstract: true
   name: armored personnel carrier
   description: A rugged armored personnel carrier outfitted for battlefield support.
   components:
-  - type: Vehicle
-    movementKind: Grid
-  - type: LagCompensation
-  - type: Clickable
   - type: WarpPoint
     follow: true
     location: APC
-  - type: RMCIgnoreGhostInteractionLimits
-  - type: RequireProjectileTarget
   - type: GridVehicleMover
     maxSpeed: 5
     acceleration: 4
@@ -25,19 +20,10 @@
     duration: 3
     cooldown: 15
     overchargeSound: /Audio/_RMC14/Vehicle/overdrive_activate.ogg
-  - type: VehicleSound
-    runningSound: /Audio/Effects/Vehicle/vehicleengineidle.ogg
-    runningSoundCooldown: 2
-    hornSound: /Audio/Effects/Vehicle/carhorn.ogg
-    hornCooldown: 1
-    collisionSoundCooldown: 0.5
-    mobCollisionSound: /Audio/_RMC14/Xeno/alien_claw_block.ogg
   - type: VehicleSpotlight
     radius: 7
     energy: 3
     softness: 2
-  - type: Physics
-    bodyType: Dynamic
   - type: Fixtures
     fixtures:
       world:
@@ -67,8 +53,7 @@
         - LargeMobLayer
   - type: Damageable
     damageContainer: StructuralMarine
-    damageModifierSet: VehicleFrameAPC
-  - type: InteractionOutline
+    damageModifierSet: VehicleFrameAPC # APC damage modifier
   - type: Sprite
     drawdepth: Mobs
     sprite: _RMC14/Structures/Vehicles/apc.rsi
@@ -89,13 +74,6 @@
       visible: false
     - map: [ rmc-wheels ]
       state: wheels_1
-  - type: SpriteMovement
-    movementLayers:
-      rmc-wheels:
-        state: wheels_0
-    noMovementLayers:
-      rmc-wheels:
-        state: wheels_1
   - type: PointLight
     enabled: false
     radius: 12
@@ -103,18 +81,7 @@
     softness: 2
     autoRot: true
     offset: "0,0.9"
-  - type: Corrodible
-    isCorrodible: false
-  - type: DoAfter
-  - type: UserInterface
-    interfaces:
-      enum.HardpointUiKey.Key:
-        type: HardpointBoundUserInterface
-      enum.VehicleWeaponsUiKey.Key:
-        type: VehicleWeaponsBoundUserInterface
-  - type: VehicleWeapons
   - type: VehicleHardpointVisuals
-  - type: InputMover
   - type: ItemSlots
     slots:
       port-gun-north:
@@ -162,12 +129,6 @@
       hardpointType: HardpointTypeWheel
       slotType: HardpointSlotTypeWheel
       insertDelay: 1.5
-  - type: VehicleWheelSlots
-    slotCount: 1
-  - type: HardpointIntegrity
-    maxIntegrity: 1000
-    bypassEntryOnZero: true
-  - type: Appearance
   - type: VehicleEnter
     interiorPath: /Maps/_RMC14/Vehicles/apc_transport_interior.yml
     enterDoAfter: 1.0
@@ -185,6 +146,7 @@
 - type: entity
   parent: VehicleAPCBase
   id: VehicleAPC
+  suffix: Drivable, APC, Base
   components:
   - type: VehicleEnter
     interiorPath: /Maps/_RMC14/Vehicles/apc_transport_interior.yml
@@ -219,6 +181,7 @@
   id: VehicleAPCMed
   name: armored personnel carrier (medical)
   description: A medical-configured APC outfitted with triage markings.
+  suffix: Drivable, APC, Base, Medical
   components:
   - type: Sprite
     layers:
@@ -280,6 +243,7 @@
   id: VehicleAPCCommand
   name: armored personnel carrier (command)
   description: A command-configured APC bristling with sensors and comms gear.
+  suffix: Drivable, APC, Base, Command
   components:
   - type: Sprite
     layers:
@@ -342,6 +306,7 @@
   id: VehicleSPPAPC
   name: SPP armored personnel carrier
   description: An armored personnel carrier configured for SPP forces.
+  suffix: Drivable, APC, Base, SPP
   components:
   - type: GridVehicleMover
     maxSpeed: 5

--- a/Resources/Prototypes/_RMC14/Vehicles/Common/turret_visuals.yml
+++ b/Resources/Prototypes/_RMC14/Vehicles/Common/turret_visuals.yml
@@ -12,3 +12,5 @@
     - state: humveeturret
       visible: false
   - type: VehicleTurretVisual
+  - type: RMCNightVisionVisible
+    priority: -1

--- a/Resources/Prototypes/_RMC14/Vehicles/Humvee/vehicles.yml
+++ b/Resources/Prototypes/_RMC14/Vehicles/Humvee/vehicles.yml
@@ -151,7 +151,7 @@
 - type: entity
   parent: VehicleHumveeBase
   id: VehicleHumvee
-  suffix: Drivable, Humvee, Base
+  suffix: Drivable, Humvee, Base, Tracked
   components:
   - type: ItemSlots
     slots:
@@ -166,7 +166,7 @@
   id: VehicleHumveeMedical
   name: humvee (medical)
   description: A medical-configured humvee outfitted for field triage.
-  suffix: Drivable, Humvee, Base, Medical
+  suffix: Drivable, Humvee, Base, Medical, Tracked
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Vehicles/humvee_medical.rsi
@@ -228,7 +228,7 @@
   id: VehicleHumveeTransport
   name: humvee (transport)
   description: A transport humvee configured for passenger movement.
-  suffix: Drivable, Humvee, Base, Transport (More passengers)
+  suffix: Drivable, Humvee, Base, Transport, Tracked
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Vehicles/humvee_transport.rsi
@@ -290,7 +290,7 @@
   id: VehicleHumveeARC
   name: humvee (arc)
   description: A humvee configured for ARC interior layout.
-  suffix: Drivable, Humvee, Base, ARC
+  suffix: Drivable, Humvee, Base, ARC, Tracked
   components:
   - type: ItemSlots
     slots:
@@ -340,4 +340,3 @@
     - offset: 1,-0.1
       radius: 0.5
       interiorCoords: 3.56, -0.42
-

--- a/Resources/Prototypes/_RMC14/Vehicles/Humvee/vehicles.yml
+++ b/Resources/Prototypes/_RMC14/Vehicles/Humvee/vehicles.yml
@@ -1,18 +1,13 @@
 - type: entity
+  parent: RMCVehicleBase
   id: VehicleHumveeBase
   abstract: true
   name: humvee
   description: A fast armored utility vehicle outfitted for patrols and support.
   components:
-  - type: Vehicle
-    movementKind: Grid
-  - type: LagCompensation
-  - type: Clickable
   - type: WarpPoint
     follow: true
     location: Humvee
-  - type: RMCIgnoreGhostInteractionLimits
-  - type: RequireProjectileTarget
   - type: GridVehicleMover
     maxSpeed: 6
     acceleration: 5
@@ -29,17 +24,14 @@
   - type: VehicleSound
     runningSound: /Audio/Effects/Vehicle/vehicleengineidle.ogg
     runningSoundCooldown: 2
-    hornSound: /Audio/_RMC14/Vehicle/sound_vehicles_humvee_horn.ogg
+    hornSound: /Audio/_RMC14/Vehicle/sound_vehicles_humvee_horn.ogg # This uses a unique horn
     hornCooldown: 1
 #    collisionSound: /Audio/_RMC14/Structures/metalhit.ogg
-#    collisionSoundCooldown: 0.4
     mobCollisionSound: /Audio/_RMC14/Xeno/alien_claw_block.ogg
   - type: VehicleSpotlight
     radius: 6
     energy: 2.5
     softness: 2
-  - type: Physics
-    bodyType: Dynamic
   - type: Fixtures
     fixtures:
       world:
@@ -67,7 +59,6 @@
         - LargeMobLayer
         layer:
         - LargeMobLayer
-  - type: InteractionOutline
   - type: Sprite
     drawdepth: Mobs
     sprite: _RMC14/Structures/Vehicles/humvee.rsi
@@ -91,13 +82,6 @@
       visible: false
     - map: [ rmc-wheels ]
       state: wheels_1
-  - type: SpriteMovement
-    movementLayers:
-      rmc-wheels:
-        state: wheels_0
-    noMovementLayers:
-      rmc-wheels:
-        state: wheels_1
   - type: PointLight
     enabled: false
     radius: 12
@@ -105,18 +89,7 @@
     softness: 2
     autoRot: true
     offset: "0,0.9"
-  - type: Corrodible
-    isCorrodible: false
-  - type: DoAfter
-  - type: UserInterface
-    interfaces:
-      enum.HardpointUiKey.Key:
-        type: HardpointBoundUserInterface
-      enum.VehicleWeaponsUiKey.Key:
-        type: VehicleWeaponsBoundUserInterface
-  - type: VehicleWeapons
   - type: VehicleHardpointVisuals
-  - type: InputMover
   - type: ItemSlots
     slots:
       wheel-1:
@@ -149,9 +122,6 @@
       hardpointType: HardpointTypeWheel
       slotType: HardpointSlotTypeWheel
       insertDelay: 1.5
-  - type: VehicleWheelSlots
-    slotCount: 1
-  - type: Appearance
   - type: VehicleEnter
     interiorPath: /Maps/_RMC14/Vehicles/humvee_interior.yml
     enterDoAfter: 1.0
@@ -181,6 +151,7 @@
 - type: entity
   parent: VehicleHumveeBase
   id: VehicleHumvee
+  suffix: Drivable, Humvee, Base
   components:
   - type: ItemSlots
     slots:
@@ -189,25 +160,14 @@
         whitelist:
           components:
           - HardpointItem
-  - type: Damageable
-    damageContainer: StructuralMarine
-    damageModifierSet: StructuralMarine
-  - type: HardpointIntegrity
-    maxIntegrity: 1000
-    bypassEntryOnZero: true
 
 - type: entity
   parent: VehicleHumveeBase
   id: VehicleHumveeMedical
   name: humvee (medical)
   description: A medical-configured humvee outfitted for field triage.
+  suffix: Drivable, Humvee, Base, Medical
   components:
-  - type: Damageable
-    damageContainer: StructuralMarine
-    damageModifierSet: StructuralMarine
-  - type: HardpointIntegrity
-    maxIntegrity: 1000
-    bypassEntryOnZero: true
   - type: Sprite
     sprite: _RMC14/Structures/Vehicles/humvee_medical.rsi
     layers:
@@ -268,13 +228,8 @@
   id: VehicleHumveeTransport
   name: humvee (transport)
   description: A transport humvee configured for passenger movement.
+  suffix: Drivable, Humvee, Base, Transport (More passengers)
   components:
-  - type: Damageable
-    damageContainer: StructuralMarine
-    damageModifierSet: StructuralMarine
-  - type: HardpointIntegrity
-    maxIntegrity: 1000
-    bypassEntryOnZero: true
   - type: Sprite
     sprite: _RMC14/Structures/Vehicles/humvee_transport.rsi
     layers:
@@ -335,6 +290,7 @@
   id: VehicleHumveeARC
   name: humvee (arc)
   description: A humvee configured for ARC interior layout.
+  suffix: Drivable, Humvee, Base, ARC
   components:
   - type: ItemSlots
     slots:
@@ -344,7 +300,7 @@
           - HardpointItem
   - type: Damageable
     damageContainer: StructuralMarine
-    damageModifierSet: VehicleFrameARC
+    damageModifierSet: VehicleFrameARC # ARC damage modifier
   - type: HardpointIntegrity
     maxIntegrity: 800
     bypassEntryOnZero: true

--- a/Resources/Prototypes/_RMC14/Vehicles/Tank/vehicles.yml
+++ b/Resources/Prototypes/_RMC14/Vehicles/Tank/vehicles.yml
@@ -174,6 +174,7 @@
   id: VehicleTankTest
   name: test tank (autodrive)
   description: A test tank that automatically drives east on spawn.
+  suffix: Debug
   components:
   - type: RMCVehicleAutopilot
     direction: 1,0
@@ -181,7 +182,7 @@
 - type: entity
   parent: VehicleTankBase
   id: VehicleTank
-  suffix: Drivable, Tank, Base
+  suffix: Drivable, Tank, Base, Tracked
   components:
   - type: VehicleEnter
     interiorPath: /Maps/_RMC14/Vehicles/tank_interior.yml
@@ -203,6 +204,8 @@
     icon:
       sprite: /Textures/_RMC14/Interface/map_blips_large.rsi
       state: tank
+
+## SPP
 
 - type: entity
   parent: VehicleTankBase

--- a/Resources/Prototypes/_RMC14/Vehicles/Tank/vehicles.yml
+++ b/Resources/Prototypes/_RMC14/Vehicles/Tank/vehicles.yml
@@ -1,18 +1,13 @@
 - type: entity
+  parent: RMCVehicleBase
   id: VehicleTankBase
   abstract: true
   name: tank
   description: A heavy armored tank built for battlefield dominance.
   components:
-  - type: Vehicle
-    movementKind: Grid
-  - type: LagCompensation
-  - type: Clickable
   - type: WarpPoint
     follow: true
     location: Tank
-  - type: RMCIgnoreGhostInteractionLimits
-  - type: RequireProjectileTarget
   - type: GridVehicleMover
     maxSpeed: 3
     acceleration: 1.154
@@ -40,16 +35,13 @@
   - type: VehicleSound
     runningSound: /Audio/Effects/Vehicle/vehicleengineidle.ogg
     runningSoundCooldown: 2
-    hornSound: /Audio/Effects/Vehicle/carhorn.ogg
+    hornSound: /Audio/Effects/Vehicle/carhorn.ogg # todo rmc14 add unique tank horn
     hornCooldown: 1
-    collisionSoundCooldown: 0.5
     mobCollisionSound: /Audio/_RMC14/Xeno/alien_claw_block.ogg
   - type: VehicleSpotlight
     radius: 8
     energy: 3
     softness: 2
-  - type: Physics
-    bodyType: Dynamic
   - type: Fixtures
     fixtures:
       world:
@@ -79,8 +71,7 @@
         - LargeMobLayer
   - type: Damageable
     damageContainer: StructuralMarine
-    damageModifierSet: VehicleFrameTank
-  - type: InteractionOutline
+    damageModifierSet: VehicleFrameTank # tank damage modifier
   - type: Sprite
     drawdepth: Mobs
     sprite: _RMC14/Structures/Vehicles/tank.rsi
@@ -101,13 +92,6 @@
       visible: false
     - map: [ rmc-wheels ]
       state: wheels_1
-  - type: SpriteMovement
-    movementLayers:
-      rmc-wheels:
-        state: wheels_0
-    noMovementLayers:
-      rmc-wheels:
-        state: wheels_1
   - type: PointLight
     enabled: false
     radius: 12
@@ -115,18 +99,7 @@
     softness: 2
     autoRot: true
     offset: "0,0.9"
-  - type: Corrodible
-    isCorrodible: false
-  - type: DoAfter
-  - type: UserInterface
-    interfaces:
-      enum.HardpointUiKey.Key:
-        type: HardpointBoundUserInterface
-      enum.VehicleWeaponsUiKey.Key:
-        type: VehicleWeaponsBoundUserInterface
-  - type: VehicleWeapons
   - type: VehicleHardpointVisuals
-  - type: InputMover
   - type: ItemSlots
     slots:
       armor:
@@ -185,12 +158,6 @@
       hardpointType: HardpointTypeWheel
       slotType: HardpointSlotTypeTreads
       insertDelay: 2.0
-  - type: VehicleWheelSlots
-    slotCount: 1
-  - type: HardpointIntegrity
-    maxIntegrity: 1000
-    bypassEntryOnZero: true
-  - type: Appearance
   - type: VehicleEnter
     interiorPath: /Maps/_RMC14/Vehicles/tank_interior.yml
     enterDoAfter: 1.0
@@ -214,6 +181,7 @@
 - type: entity
   parent: VehicleTankBase
   id: VehicleTank
+  suffix: Drivable, Tank, Base
   components:
   - type: VehicleEnter
     interiorPath: /Maps/_RMC14/Vehicles/tank_interior.yml
@@ -241,6 +209,7 @@
   id: VehicleSPPTank
   name: SPP tank
   description: A heavy SPP battle tank.
+  suffix: Drivable, Tank, SPP
   components:
   - type: VehicleEnter
     interiorPath: /Maps/_RMC14/Vehicles/spp_tank_interior.yml
@@ -340,6 +309,7 @@
   id: VehicleSPPTankCommand
   name: SPP command tank
   description: A heavy SPP command tank.
+  suffix: Drivable, Tank, SPP, Command Interior
   components:
   - type: VehicleEnter
     interiorPath: /Maps/_RMC14/Vehicles/spp_tank_command_interior.yml

--- a/Resources/Prototypes/_RMC14/Vehicles/Van/vehicles.yml
+++ b/Resources/Prototypes/_RMC14/Vehicles/Van/vehicles.yml
@@ -109,6 +109,8 @@
   id: VehicleVan
   suffix: Drivable, Van, Base
 
+## CLF
+
 - type: entity
   parent: VehicleVanBase
   id: VehicleCLFVan

--- a/Resources/Prototypes/_RMC14/Vehicles/Van/vehicles.yml
+++ b/Resources/Prototypes/_RMC14/Vehicles/Van/vehicles.yml
@@ -1,18 +1,13 @@
 - type: entity
+  parent: RMCVehicleBase
   id: VehicleVanBase
   abstract: true
   name: van
   description: A rugged transport van.
   components:
-  - type: Vehicle
-    movementKind: Grid
-  - type: LagCompensation
-  - type: Clickable
   - type: WarpPoint
     follow: true
     location: Van
-  - type: RMCIgnoreGhostInteractionLimits
-  - type: RequireProjectileTarget
   - type: GridVehicleMover
     maxSpeed: 6
     acceleration: 5
@@ -26,20 +21,10 @@
     duration: 3
     cooldown: 15
     overchargeSound: /Audio/_RMC14/Vehicle/overdrive_activate.ogg
-  - type: VehicleSound
-    runningSound: /Audio/Effects/Vehicle/vehicleengineidle.ogg
-    runningSoundCooldown: 2
-    hornSound: /Audio/Effects/Vehicle/carhorn.ogg
-    hornCooldown: 1
-    #collisionSound: /Audio/_RMC14/Structures/metalhit.ogg
-    collisionSoundCooldown: 0.5
-    mobCollisionSound: /Audio/_RMC14/Xeno/alien_claw_block.ogg
   - type: VehicleSpotlight
     radius: 6
     energy: 2.5
     softness: 2
-  - type: Physics
-    bodyType: Dynamic
   - type: Fixtures
     fixtures:
       world:
@@ -67,10 +52,6 @@
         - LargeMobLayer
         layer:
         - LargeMobLayer
-  - type: Damageable
-    damageContainer: StructuralMarine
-    damageModifierSet: StructuralMarine
-  - type: InteractionOutline
   - type: Sprite
     drawdepth: Mobs
     sprite: _RMC14/Structures/Vehicles/van.rsi
@@ -82,13 +63,6 @@
       visible: false
     - map: [ rmc-wheels ]
       state: wheels_1
-  - type: SpriteMovement
-    movementLayers:
-      rmc-wheels:
-        state: wheels_0
-    noMovementLayers:
-      rmc-wheels:
-        state: wheels_1
   - type: PointLight
     enabled: false
     radius: 6
@@ -96,18 +70,6 @@
     softness: 2
     autoRot: true
     offset: "0,0.9"
-  - type: Corrodible
-    isCorrodible: false
-  - type: DoAfter
-  - type: UserInterface
-    interfaces:
-      enum.HardpointUiKey.Key:
-        type: HardpointBoundUserInterface
-      enum.VehicleWeaponsUiKey.Key:
-        type: VehicleWeaponsBoundUserInterface
-  - type: VehicleWeapons
-  - type: InputMover
-  - type: ItemSlots
   - type: ContainerContainer
     containers:
       wheel-1: !type:ContainerSlot
@@ -124,16 +86,7 @@
       whitelist:
         components:
         - VehicleWheelItem
-  - type: VehicleWheelSlots
-    slotCount: 1
-    slots:
-    - wheel-1
-  - type: HardpointIntegrity
-    maxIntegrity: 1000
-    integrity: 1000
-    bypassEntryOnZero: true
   - type: HardpointState
-  - type: Appearance
   - type: VehicleEnter
     interiorPath: /Maps/_RMC14/Vehicles/van_interior.yml
     enterDoAfter: 1.0
@@ -154,16 +107,18 @@
 - type: entity
   parent: VehicleVanBase
   id: VehicleVan
+  suffix: Drivable, Van, Base
 
 - type: entity
   parent: VehicleVanBase
   id: VehicleCLFVan
   name: CLF van
+  suffix: Drivable, Van, CLF
   description: A rugged transport van painted in CLF colors.
   components:
   - type: Damageable
     damageContainer: StructuralMarine
-    damageModifierSet: VehicleFrameCLFVan
+    damageModifierSet: VehicleFrameCLFVan # CLF van modifiers
   - type: Sprite
     sprite: _RMC14/Structures/Vehicles/CLF_van.rsi
     layers:
@@ -175,7 +130,6 @@
     - map: [ rmc-wheels ]
       state: wheels_1
   - type: VehicleSound
-    collisionSoundCooldown: 0.4
   - type: VehicleEnter
     interiorPath: /Maps/_RMC14/Vehicles/van_interior.yml #TODO RMC14 add a dedicated CLF interior
     enterDoAfter: 1.0
@@ -194,43 +148,15 @@
       interiorCoords: 0.25,-1
 
 - type: entity
+  parent: VehicleVanBase
   id: VehicleBoxVanBase
   abstract: true
   name: box van
   description: A rugged transport van fitted with a box body.
   components:
-  - type: Vehicle
-    movementKind: Grid
-  - type: Clickable
   - type: WarpPoint
     follow: true
     location: Box Van
-  - type: GridVehicleMover
-    maxSpeed: 6
-    acceleration: 5
-    deceleration: 12
-    turnDelay: 0.25
-    pushCooldown: 2
-    xenoBlockMinimumSize: Immobile
-    xenoPushMinimumSize: Immobile
-  - type: VehicleOvercharge
-    speedMultiplier: 1.6
-    duration: 3
-    cooldown: 15
-    overchargeSound: /Audio/_RMC14/Vehicle/overdrive_activate.ogg
-  - type: VehicleSound
-    runningSound: /Audio/Effects/Vehicle/vehicleengineidle.ogg
-    runningSoundCooldown: 2
-    hornSound: /Audio/Effects/Vehicle/carhorn.ogg
-    hornCooldown: 1
-    collisionSoundCooldown: 0.4
-    mobCollisionSound: /Audio/_RMC14/Xeno/alien_claw_block.ogg
-  - type: VehicleSpotlight
-    radius: 6
-    energy: 2.5
-    softness: 2
-  - type: Physics
-    bodyType: Dynamic
   - type: Fixtures
     fixtures:
       world:
@@ -258,10 +184,6 @@
         - LargeMobLayer
         layer:
         - LargeMobLayer
-  - type: Damageable
-    damageContainer: StructuralMarine
-    damageModifierSet: StructuralMarine
-  - type: InteractionOutline
   - type: Sprite
     offset: "0,0.5"
     drawdepth: Mobs
@@ -274,58 +196,6 @@
       visible: false
     - map: [ rmc-wheels ]
       state: wheels_1
-  - type: SpriteMovement
-    movementLayers:
-      rmc-wheels:
-        state: wheels_0
-    noMovementLayers:
-      rmc-wheels:
-        state: wheels_1
-  - type: PointLight
-    enabled: false
-    radius: 6
-    energy: 2.5
-    softness: 2
-    autoRot: true
-    offset: "0,0.9"
-  - type: Corrodible
-    isCorrodible: false
-  - type: DoAfter
-  - type: UserInterface
-    interfaces:
-      enum.HardpointUiKey.Key:
-        type: HardpointBoundUserInterface
-      enum.VehicleWeaponsUiKey.Key:
-        type: VehicleWeaponsBoundUserInterface
-  - type: VehicleWeapons
-  - type: InputMover
-  - type: ItemSlots
-  - type: ContainerContainer
-    containers:
-      wheel-1: !type:ContainerSlot
-        showEnts: false
-        occludes: true
-        ent: null
-  - type: HardpointSlots
-    vehicleFamily: HardpointVehicleFamilyVan
-    slots:
-    - id: wheel-1
-      hardpointType: HardpointTypeWheel
-      slotType: HardpointSlotTypeWheel
-      insertDelay: 1.5
-      whitelist:
-        components:
-        - VehicleWheelItem
-  - type: VehicleWheelSlots
-    slotCount: 1
-    slots:
-    - wheel-1
-  - type: HardpointIntegrity
-    maxIntegrity: 1000
-    integrity: 1000
-    bypassEntryOnZero: true
-  - type: HardpointState
-  - type: Appearance
   - type: VehicleEnter
     interiorPath: /Maps/_RMC14/Vehicles/box_van_interior.yml
     enterDoAfter: 1.0
@@ -346,6 +216,7 @@
 - type: entity
   parent: VehicleBoxVanBase
   id: VehicleBoxVan
+  suffix: Vehicle, Unaffiliated
 
 - type: entity
   parent: VehicleBoxVanBase
@@ -410,7 +281,6 @@
     - offset: 1.2,-0.3
       radius: 0.7
       interiorCoords: 2.5,0.9
-
     - offset: -1.2,-0.3
       radius: 0.7
       interiorCoords: 2.5,-0.2
@@ -546,7 +416,7 @@
       interiorCoords: 2.5,-0.2
 
 - type: entity
-  parent: VehicleBoxVanBase
+  parent: VehicleSPPVan
   id: VehicleSPPVanLogistics
   name: SPP van (logistics)
   description: An SPP logistics van fitted with an enlarged cargo body.

--- a/Resources/Prototypes/_RMC14/Vehicles/Van/vehicles.yml
+++ b/Resources/Prototypes/_RMC14/Vehicles/Van/vehicles.yml
@@ -129,7 +129,6 @@
       visible: false
     - map: [ rmc-wheels ]
       state: wheels_1
-  - type: VehicleSound
   - type: VehicleEnter
     interiorPath: /Maps/_RMC14/Vehicles/van_interior.yml #TODO RMC14 add a dedicated CLF interior
     enterDoAfter: 1.0
@@ -146,6 +145,8 @@
     - offset: 0,2
       radius: 0.75
       interiorCoords: 0.25,-1
+
+## Box Vans
 
 - type: entity
   parent: VehicleVanBase
@@ -216,13 +217,14 @@
 - type: entity
   parent: VehicleBoxVanBase
   id: VehicleBoxVan
-  suffix: Vehicle, Unaffiliated
+  suffix: Drivable, Box Van, Base
 
 - type: entity
   parent: VehicleBoxVanBase
   id: VehiclePizzaVan
   name: pizza van
   description: A van repurposed for pizza delivery, still sturdy enough for transport.
+  suffix: Drivable, Box Van, Pizza
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Vehicles/pizza_van.rsi
@@ -252,11 +254,14 @@
       radius: 0.75
       interiorCoords: -0.75,1.2
 
+## SPP Vans
+
 - type: entity
   parent: VehicleVanBase
   id: VehicleSPPVan
   name: SPP van
   description: A rugged transport van painted in SPP colors.
+  suffix: Drivable, Van, SPP, Transport
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Vehicles/sppvan.rsi
@@ -298,6 +303,7 @@
   id: VehicleSPPVanArmed
   name: SPP van (armed)
   description: An SPP van fitted with a roof-mounted weapon.
+  suffix: Drivable, Van, SPP, Armed
   components:
   - type: Sprite
     layers:
@@ -356,6 +362,7 @@
   id: VehicleSPPVanMedical
   name: SPP van (medical)
   description: An SPP van marked for casualty evacuation and field treatment.
+  suffix: Drivable, Van, SPP, Medical
   components:
   - type: Sprite
     layers:
@@ -388,6 +395,7 @@
   id: VehicleSPPVanPrisoner
   name: SPP van (prisoner)
   description: An SPP van refitted for prisoner transport.
+  suffix: Drivable, Van, SPP, Prisoner
   components:
   - type: Sprite
     layers:
@@ -420,6 +428,7 @@
   id: VehicleSPPVanLogistics
   name: SPP van (logistics)
   description: An SPP logistics van fitted with an enlarged cargo body.
+  suffix: Drivable, Van, SPP, Logistics
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Vehicles/sppvan_logistics.rsi
@@ -447,11 +456,3 @@
     - offset: -1.2,-0.3
       radius: 0.7
       interiorCoords: 2.5,-0.2
-  - type: HardpointSlots
-    vehicleFamily: HardpointVehicleFamilyVan
-    slots:
-    - id: wheel-1
-      hardpointType: HardpointTypeWheel
-      slotType: HardpointSlotTypeWheel
-      compatibilityId: HardpointCompatibilitySPPVan
-      insertDelay: 1.5

--- a/Resources/Prototypes/_RMC14/Vehicles/base_vehicle.yml
+++ b/Resources/Prototypes/_RMC14/Vehicles/base_vehicle.yml
@@ -5,6 +5,7 @@
   description: An abstract vehicle. Make sure to replace this!
   components:
   - type: RMCNightVisionVisible
+    priority: -2
   - type: Vehicle
     movementKind: Grid
   - type: LagCompensation

--- a/Resources/Prototypes/_RMC14/Vehicles/base_vehicle.yml
+++ b/Resources/Prototypes/_RMC14/Vehicles/base_vehicle.yml
@@ -1,0 +1,141 @@
+- type: entity
+  id: RMCVehicleBase
+  abstract: true
+  name: abstract vehicle
+  description: An abstract vehicle. Make sure to replace this!
+  components:
+  - type: RMCNightVisionVisible
+  - type: Vehicle
+    movementKind: Grid
+  - type: LagCompensation
+  - type: Clickable
+  - type: WarpPoint
+    follow: true
+  - type: RMCIgnoreGhostInteractionLimits
+  - type: RequireProjectileTarget
+  - type: GridVehicleMover
+    maxSpeed: 6
+    acceleration: 5
+    deceleration: 12
+    turnDelay: 0.25
+    pushCooldown: 2
+    xenoBlockMinimumSize: Immobile
+    xenoPushMinimumSize: Immobile
+  - type: VehicleOvercharge
+    speedMultiplier: 1.6
+    duration: 3
+    cooldown: 15
+    overchargeSound: /Audio/_RMC14/Vehicle/overdrive_activate.ogg
+  - type: VehicleSound
+    runningSound: /Audio/Effects/Vehicle/vehicleengineidle.ogg
+    runningSoundCooldown: 2
+    hornSound: /Audio/Effects/Vehicle/carhorn.ogg
+    hornCooldown: 1
+    #collisionSound: /Audio/_RMC14/Structures/metalhit.ogg
+    mobCollisionSound: /Audio/_RMC14/Xeno/alien_claw_block.ogg
+  - type: VehicleSpotlight
+    radius: 6
+    energy: 2.5
+    softness: 2
+  - type: Physics
+    bodyType: Dynamic
+  - type: Fixtures
+    fixtures:
+      world:
+        shape:
+          !type:PhysShapeAabb
+          bounds: -0.425,-1.2,0.425,1.2
+        density: 1000
+        mask:
+        - Impassable
+        - HighImpassable
+        - LowImpassable
+        - LargeMobLayer
+        - Vehicle
+        layer:
+        - LargeMobLayer
+        - Vehicle
+      mob:
+        shape:
+          !type:PhysShapeAabb
+          bounds: -0.425,-1.2,0.425,1.2
+        density: 1000
+        mask:
+        - MidImpassable
+        - BarricadeImpassable
+        - LargeMobLayer
+        layer:
+        - LargeMobLayer
+  - type: Damageable
+    damageContainer: StructuralMarine
+    damageModifierSet: StructuralMarine
+  - type: InteractionOutline
+  - type: Sprite
+    drawdepth: Mobs
+    sprite: _RMC14/Structures/Vehicles/van.rsi
+    layers:
+    - map: [ base ]
+      state: van_base
+    - map: [ damaged_frame ]
+      state: damaged_frame
+      visible: false
+    - map: [ rmc-wheels ]
+      state: wheels_1
+  - type: SpriteMovement
+    movementLayers:
+      rmc-wheels:
+        state: wheels_0
+    noMovementLayers:
+      rmc-wheels:
+        state: wheels_1
+  - type: PointLight
+    enabled: false
+    radius: 6
+    energy: 2.5
+    softness: 2
+    autoRot: true
+    offset: "0,0.9"
+  - type: Corrodible
+    isCorrodible: false
+  - type: DoAfter
+  - type: UserInterface
+    interfaces:
+      enum.HardpointUiKey.Key:
+        type: HardpointBoundUserInterface
+      enum.VehicleWeaponsUiKey.Key:
+        type: VehicleWeaponsBoundUserInterface
+  - type: VehicleWeapons
+  - type: InputMover
+  - type: ItemSlots
+  - type: HardpointSlots
+    vehicleFamily: HardpointVehicleFamilyVan
+    slots:
+    - id: wheel-1
+      hardpointType: HardpointTypeWheel
+      slotType: HardpointSlotTypeWheel
+      insertDelay: 1.5
+      whitelist:
+        components:
+        - VehicleWheelItem
+  - type: VehicleWheelSlots
+    slotCount: 1
+  - type: HardpointIntegrity
+    maxIntegrity: 1000
+    bypassEntryOnZero: true
+  - type: Appearance
+  - type: VehicleEnter
+    interiorPath: /Maps/_RMC14/Vehicles/van_interior.yml
+    enterDoAfter: 1.0
+    exitDoAfter: 1.0
+    maxPassengers: 8
+    maxXenos: 2
+    entryPoints:
+    - offset: 1,-1
+      radius: 0.6
+      interiorCoords: 3.5,-0.34
+    - offset: -1,-1
+      radius: 0.6
+      interiorCoords: 3.25,-1
+    - offset: 0,2
+      radius: 0.75
+      interiorCoords: 0.25,-1

--- a/Resources/Prototypes/_RMC14/Vehicles/base_vehicle.yml
+++ b/Resources/Prototypes/_RMC14/Vehicles/base_vehicle.yml
@@ -120,8 +120,11 @@
         - VehicleWheelItem
   - type: VehicleWheelSlots
     slotCount: 1
+    slots:
+    - wheel-1
   - type: HardpointIntegrity
     maxIntegrity: 1000
+    integrity: 1000
     bypassEntryOnZero: true
   - type: Appearance
   - type: VehicleEnter


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- General code maintenance
- Adds xenonid vision to all vehicles, as implemented in #10370 
- Suffixes all vehicles, they will be easier to find in spawn menus if you search by suffix.

## Media
<img width="833" height="415" alt="image" src="https://github.com/user-attachments/assets/b6a26bd4-5789-47ac-8892-64e49145848a" />
<img width="647" height="205" alt="image" src="https://github.com/user-attachments/assets/cb178aa1-ac7c-4f69-b857-9e41b51e6874" />
<img width="985" height="604" alt="image" src="https://github.com/user-attachments/assets/083745d1-f788-4e32-a21a-f5a9f0724b79" />



**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Vixting, Whisper
- add: Added xenonid vision to all vehicles.
