### PR TITLE
[Fix] Queen Eye Fix 2.0

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Eye/QueenEyeComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Eye/QueenEyeComponent.cs
@@ -14,4 +14,7 @@ public sealed partial class QueenEyeComponent : Component
 
     [DataField, AutoNetworkedField]
     public float SoftWeedDistance = 3f;
+
+    // Cache lives on comp for if ever multiple eyes. Do not set elsewhere.
+    public EntityUid? AnchorWeed;
 }

--- a/Content.Shared/_RMC14/Xenonids/Eye/QueenEyeComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Eye/QueenEyeComponent.cs
@@ -15,6 +15,7 @@ public sealed partial class QueenEyeComponent : Component
     [DataField, AutoNetworkedField]
     public float SoftWeedDistance = 3f;
 
-    // Cache lives on comp for if ever multiple eyes. Do not set elsewhere.
+    // Queen Eye only local cache for the range calc, lives on comp for if ever multiple eyes. Do not set elsewhere.
+    // Currently intentional to benot Datafield or AutoNetworkedField as there is no need.
     public EntityUid? AnchorWeed;
 }

--- a/Content.Shared/_RMC14/Xenonids/Eye/QueenEyeComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Eye/QueenEyeComponent.cs
@@ -16,6 +16,6 @@ public sealed partial class QueenEyeComponent : Component
     public float SoftWeedDistance = 3f;
 
     // Queen Eye only local cache for the range calc, lives on comp for if ever multiple eyes. Do not set elsewhere.
-    // Currently intentional to benot Datafield or AutoNetworkedField as there is no need.
+    // Currently intentional to not be Datafield or AutoNetworkedField as there is no need.
     public EntityUid? AnchorWeed;
 }

--- a/Content.Shared/_RMC14/Xenonids/Eye/QueenEyeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Eye/QueenEyeSystem.cs
@@ -319,16 +319,16 @@ public sealed class QueenEyeSystem : EntitySystem
 
     public override void Update(float frameTime)
     {
+        if (_timing.ApplyingState || _isRevertingMove)
+        {
+            _movedQueenEyes.Clear();
+            return;
+        }
+
         foreach (var (ent, oldCoords, newCoords) in _movedQueenEyes)
         {
-            if (_timing.ApplyingState)
-                return;
-
-            if (_isRevertingMove)
-                return;
-
             if (TerminatingOrDeleted(ent))
-                return;
+                continue;
 
             _nearbyWeeds.Clear();
             _entityLookup.GetEntitiesInRange(newCoords, ent.Comp.SoftWeedDistance, _nearbyWeeds);
@@ -382,6 +382,7 @@ public sealed class QueenEyeSystem : EntitySystem
                 _isRevertingMove = false;
             }
         }
+        _movedQueenEyes.Clear();
     }
 
     /// <summary>

--- a/Content.Shared/_RMC14/Xenonids/Eye/QueenEyeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Eye/QueenEyeSystem.cs
@@ -43,8 +43,6 @@ public sealed class QueenEyeSystem : EntitySystem
 
     private bool _isRevertingMove;
 
-    private readonly HashSet<(Entity<QueenEyeComponent> Eye, EntityCoordinates OldCoords, EntityCoordinates NewCoords)> _movedQueenEyes = new();
-
     public override void Initialize()
     {
         base.Initialize();
@@ -177,7 +175,79 @@ public sealed class QueenEyeSystem : EntitySystem
         if (!args.NewPosition.IsValid(EntityManager))
             return;
 
-        _movedQueenEyes.Add((ent, args.OldPosition, args.NewPosition));
+        var newCoords = args.NewPosition;
+        var newWorldPos = _transform.ToMapCoordinates(newCoords).Position;
+        var soft = ent.Comp.SoftWeedDistance;
+
+        if (ent.Comp.AnchorWeed is { } anchor &&
+            HasComp<XenoWeedsComponent>(anchor) &&
+            Vector2.DistanceSquared(newWorldPos, _transform.GetWorldPosition(anchor)) <= soft * soft)
+        {
+            return;
+        }
+
+        _nearbyWeeds.Clear();
+        _entityLookup.GetEntitiesInRange(newCoords, soft, _nearbyWeeds);
+
+        if (_nearbyWeeds.Count != 0)
+        {
+            ent.Comp.AnchorWeed = GetClosestWeed(newWorldPos, _nearbyWeeds, out _);
+            return;
+        }
+
+        ent.Comp.AnchorWeed = null;
+
+        _isRevertingMove = true;
+        try
+        {
+            _anchorWeeds.Clear();
+            _entityLookup.GetEntitiesInRange(args.OldPosition, ent.Comp.MaxWeedDistance, _anchorWeeds);
+            if (_anchorWeeds.Count > 0)
+            {
+                var oldWorldPos = _transform.ToMapCoordinates(args.OldPosition).Position;
+                GetClosestWeed(oldWorldPos, _anchorWeeds, out var closestWeedPos);
+
+                var offset = newWorldPos - closestWeedPos;
+                var dist = offset.Length();
+                var max = ent.Comp.MaxWeedDistance;
+                if (dist > soft)
+                {
+                    var t = Math.Clamp((dist - soft) / (max - soft), 0f, 1f);
+                    var dampedDist = soft + (max - soft) * t * t;
+                    _transform.SetWorldPosition(ent, closestWeedPos + offset / dist * dampedDist);
+                }
+            }
+            else if (ent.Comp.Queen is { } queen &&
+                     !TerminatingOrDeleted(queen) &&
+                     TryComp(queen, out QueenEyeActionComponent? queenAction))
+            {
+                RemoveQueenEye((queen, queenAction));
+            }
+        }
+        finally
+        {
+            _isRevertingMove = false;
+        }
+    }
+
+    private EntityUid? GetClosestWeed(Vector2 worldPos, HashSet<Entity<XenoWeedsComponent>> weeds, out Vector2 closestWeedPos)
+    {
+        EntityUid? closest = null;
+        closestWeedPos = worldPos;
+        var closestDistSq = float.MaxValue;
+        foreach (var weed in weeds)
+        {
+            var weedPos = _transform.GetWorldPosition(weed.Owner);
+            var distSq = Vector2.DistanceSquared(worldPos, weedPos);
+            if (distSq >= closestDistSq)
+                continue;
+
+            closestDistSq = distSq;
+            closestWeedPos = weedPos;
+            closest = weed.Owner;
+        }
+
+        return closest;
     }
 
     /// <param name="expansionSize">How much to expand the bounds before to find vision intersecting it. Makes this the largest vision size + 1 tile.</param>
@@ -315,74 +385,6 @@ public sealed class QueenEyeSystem : EntitySystem
 
         var targetTile = _map.CoordinatesToTile(gridId, grid, target);
         return IsAccessible((gridId, broadphase, grid), targetTile);
-    }
-
-    public override void Update(float frameTime)
-    {
-        if (_timing.ApplyingState || _isRevertingMove)
-        {
-            _movedQueenEyes.Clear();
-            return;
-        }
-
-        foreach (var (ent, oldCoords, newCoords) in _movedQueenEyes)
-        {
-            if (TerminatingOrDeleted(ent))
-                continue;
-
-            _nearbyWeeds.Clear();
-            _entityLookup.GetEntitiesInRange(newCoords, ent.Comp.SoftWeedDistance, _nearbyWeeds);
-
-            if (_nearbyWeeds.Count != 0)
-                continue;
-
-            _isRevertingMove = true;
-            try
-            {
-                _anchorWeeds.Clear();
-                _entityLookup.GetEntitiesInRange(oldCoords, ent.Comp.MaxWeedDistance, _anchorWeeds);
-                if (_anchorWeeds.Count > 0)
-                {
-                    var newWorldPos = _transform.ToMapCoordinates(newCoords).Position;
-                    var oldWorldPos = _transform.ToMapCoordinates(oldCoords).Position;
-                    var closestDistSq = float.MaxValue;
-                    var closestWeedPos = oldWorldPos;
-
-                    foreach (var weed in _anchorWeeds)
-                    {
-                        var weedPos = _transform.GetWorldPosition(weed.Owner);
-                        var distSq = Vector2.DistanceSquared(oldWorldPos, weedPos);
-                        if (distSq < closestDistSq)
-                        {
-                            closestDistSq = distSq;
-                            closestWeedPos = weedPos;
-                        }
-                    }
-
-                    var offset = newWorldPos - closestWeedPos;
-                    var dist = offset.Length();
-                    var soft = ent.Comp.SoftWeedDistance;
-                    var max = ent.Comp.MaxWeedDistance;
-                    if (dist > soft)
-                    {
-                        var t = Math.Clamp((dist - soft) / (max - soft), 0f, 1f);
-                        var dampedDist = soft + (max - soft) * t * t;
-                        _transform.SetWorldPosition(ent, closestWeedPos + offset / dist * dampedDist);
-                    }
-                }
-                else if (ent.Comp.Queen is { } queen &&
-                         !TerminatingOrDeleted(queen) &&
-                         TryComp(queen, out QueenEyeActionComponent? queenAction))
-                {
-                    RemoveQueenEye((queen, queenAction));
-                }
-            }
-            finally
-            {
-                _isRevertingMove = false;
-            }
-        }
-        _movedQueenEyes.Clear();
     }
 
     /// <summary>

--- a/Content.Shared/_RMC14/Xenonids/Eye/QueenEyeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Eye/QueenEyeSystem.cs
@@ -176,18 +176,18 @@ public sealed class QueenEyeSystem : EntitySystem
             return;
 
         var newCoords = args.NewPosition;
-        var newWorldPos = _transform.ToMapCoordinates(newCoords).Position;
         var soft = ent.Comp.SoftWeedDistance;
         var max = ent.Comp.MaxWeedDistance;
 
-        var anchorPos = Vector2.Zero;
         var haveAnchor = ent.Comp.AnchorWeed is { } anchor && HasComp<XenoWeedsComponent>(anchor);
         if (haveAnchor)
         {
-            anchorPos = _transform.GetWorldPosition(ent.Comp.AnchorWeed!.Value);
-
-            if (Vector2.DistanceSquared(newWorldPos, anchorPos) <= soft * soft)
+            var anchorCoords = Transform(ent.Comp.AnchorWeed!.Value).Coordinates;
+            if (anchorCoords.TryDistance(EntityManager, _transform, newCoords, out var distance) &&
+            distance <= soft)
+            {
                 return;
+            }
         }
 
         _nearbyWeeds.Clear();
@@ -195,13 +195,18 @@ public sealed class QueenEyeSystem : EntitySystem
 
         if (_nearbyWeeds.Count != 0)
         {
-            ent.Comp.AnchorWeed = GetClosestWeed(newWorldPos, _nearbyWeeds, out _);
+            ent.Comp.AnchorWeed = GetClosestWeed(newCoords, _nearbyWeeds);
             return;
         }
 
+        var newWorldPos = _transform.ToMapCoordinates(newCoords).Position;
         var oldWorldPos = _transform.ToMapCoordinates(args.OldPosition).Position;
 
         Vector2 pivot;
+        var anchorPos = Vector2.Zero;
+        if (haveAnchor)
+            anchorPos = _transform.GetWorldPosition(ent.Comp.AnchorWeed!.Value);
+
         if (haveAnchor && Vector2.DistanceSquared(oldWorldPos, anchorPos) <= max * max + 0.01f)
         {
             pivot = anchorPos;
@@ -223,7 +228,8 @@ public sealed class QueenEyeSystem : EntitySystem
                 return;
             }
 
-            ent.Comp.AnchorWeed = GetClosestWeed(oldWorldPos, _anchorWeeds, out pivot);
+            ent.Comp.AnchorWeed = GetClosestWeed(args.OldPosition, _anchorWeeds);
+            pivot = _transform.GetWorldPosition(ent.Comp.AnchorWeed!.Value);
         }
 
         var offset = newWorldPos - pivot;
@@ -246,20 +252,20 @@ public sealed class QueenEyeSystem : EntitySystem
         }
     }
 
-    private EntityUid? GetClosestWeed(Vector2 worldPos, HashSet<Entity<XenoWeedsComponent>> weeds, out Vector2 closestWeedPos)
+    private EntityUid? GetClosestWeed(EntityCoordinates origin, HashSet<Entity<XenoWeedsComponent>> weeds)
     {
         EntityUid? closest = null;
-        closestWeedPos = worldPos;
-        var closestDistSq = float.MaxValue;
+        var closestDist = float.MaxValue;
         foreach (var weed in weeds)
         {
-            var weedPos = _transform.GetWorldPosition(weed.Owner);
-            var distSq = Vector2.DistanceSquared(worldPos, weedPos);
-            if (distSq >= closestDistSq)
+            var weedCoords = Transform(weed).Coordinates;
+            if (!origin.TryDistance(EntityManager, _transform, weedCoords, out var distance))
                 continue;
 
-            closestDistSq = distSq;
-            closestWeedPos = weedPos;
+            if (distance >= closestDist)
+                continue;
+
+            closestDist = distance;
             closest = weed.Owner;
         }
 

--- a/Content.Shared/_RMC14/Xenonids/Eye/QueenEyeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Eye/QueenEyeSystem.cs
@@ -178,12 +178,16 @@ public sealed class QueenEyeSystem : EntitySystem
         var newCoords = args.NewPosition;
         var newWorldPos = _transform.ToMapCoordinates(newCoords).Position;
         var soft = ent.Comp.SoftWeedDistance;
+        var max = ent.Comp.MaxWeedDistance;
 
-        if (ent.Comp.AnchorWeed is { } anchor &&
-            HasComp<XenoWeedsComponent>(anchor) &&
-            Vector2.DistanceSquared(newWorldPos, _transform.GetWorldPosition(anchor)) <= soft * soft)
+        var anchorPos = Vector2.Zero;
+        var haveAnchor = ent.Comp.AnchorWeed is { } anchor && HasComp<XenoWeedsComponent>(anchor);
+        if (haveAnchor)
         {
-            return;
+            anchorPos = _transform.GetWorldPosition(ent.Comp.AnchorWeed!.Value);
+
+            if (Vector2.DistanceSquared(newWorldPos, anchorPos) <= soft * soft)
+                return;
         }
 
         _nearbyWeeds.Clear();
@@ -195,38 +199,50 @@ public sealed class QueenEyeSystem : EntitySystem
             return;
         }
 
-        ent.Comp.AnchorWeed = null;
+        var oldWorldPos = _transform.ToMapCoordinates(args.OldPosition).Position;
 
-        _isRevertingMove = true;
-        try
+        Vector2 pivot;
+        if (haveAnchor && Vector2.DistanceSquared(oldWorldPos, anchorPos) <= max * max + 0.01f)
+        {
+            pivot = anchorPos;
+        }
+        else
         {
             _anchorWeeds.Clear();
-            _entityLookup.GetEntitiesInRange(args.OldPosition, ent.Comp.MaxWeedDistance, _anchorWeeds);
-            if (_anchorWeeds.Count > 0)
+            _entityLookup.GetEntitiesInRange(args.OldPosition, max, _anchorWeeds);
+            if (_anchorWeeds.Count == 0)
             {
-                var oldWorldPos = _transform.ToMapCoordinates(args.OldPosition).Position;
-                GetClosestWeed(oldWorldPos, _anchorWeeds, out var closestWeedPos);
-
-                var offset = newWorldPos - closestWeedPos;
-                var dist = offset.Length();
-                var max = ent.Comp.MaxWeedDistance;
-                if (dist > soft)
+                ent.Comp.AnchorWeed = null;
+                if (ent.Comp.Queen is { } queen &&
+                    !TerminatingOrDeleted(queen) &&
+                    TryComp(queen, out QueenEyeActionComponent? queenAction))
                 {
-                    var t = Math.Clamp((dist - soft) / (max - soft), 0f, 1f);
-                    var dampedDist = soft + (max - soft) * t * t;
-                    _transform.SetWorldPosition(ent, closestWeedPos + offset / dist * dampedDist);
+                    RemoveQueenEye((queen, queenAction));
                 }
+
+                return;
             }
-            else if (ent.Comp.Queen is { } queen &&
-                     !TerminatingOrDeleted(queen) &&
-                     TryComp(queen, out QueenEyeActionComponent? queenAction))
-            {
-                RemoveQueenEye((queen, queenAction));
-            }
+
+            ent.Comp.AnchorWeed = GetClosestWeed(oldWorldPos, _anchorWeeds, out pivot);
         }
-        finally
+
+        var offset = newWorldPos - pivot;
+        var dist = offset.Length();
+        if (dist > soft)
         {
-            _isRevertingMove = false;
+            var denom = max - soft;
+            var t = denom > 0f ? Math.Clamp((dist - soft) / denom, 0f, 1f) : 1f;
+            var dampedDist = soft + denom * t * t;
+
+            _isRevertingMove = true;
+            try
+            {
+                _transform.SetWorldPosition(ent, pivot + offset / dist * dampedDist);
+            }
+            finally
+            {
+                _isRevertingMove = false;
+            }
         }
     }
 

--- a/Content.Shared/_RMC14/Xenonids/Eye/QueenEyeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Eye/QueenEyeSystem.cs
@@ -184,7 +184,7 @@ public sealed class QueenEyeSystem : EntitySystem
         {
             var anchorCoords = Transform(ent.Comp.AnchorWeed!.Value).Coordinates;
             if (anchorCoords.TryDistance(EntityManager, _transform, newCoords, out var distance) &&
-            distance <= soft)
+                distance <= soft)
             {
                 return;
             }


### PR DESCRIPTION
## About the PR
**Edit: The math wasn't mathing properly but post fix it now absolutely uses the cached anchor which means its practically free within weeds and when at the "edge" it only does a cheap vector calc instead of the expensive lookup. 
HALF THE COST DOUBLE THE VALUE.tm**

- Reverts the logic change to Queen Eye. 
- Fixes Queen Eye's leash breaking after the lag/crash which was caused by the below.
- Fixes the leak from stale entries not being cleared, it just grows exponentially while in eye as the round goes on.

Added an early out to the expensive look up so should equal out to the same as the perf fixes commit.

## Why / Balance
Fixes the new bugs and keeps the performance saving ideal.

## Technical details
**Edit: Fixed the eye trying to continuously use the GetEntitiesInRange at the edge of the +3 range off weeds it now only does a cheap vector calc from its cached anchorweeds which ends up being near or at 0 cost when on weeds and within anchor** 

_Due to prediction the leash calculations needing to live inline with the onQueenEyeMove or we get a jittery mess at the edges just due to timings._

_Adds a AnchorWeed cache on QueenEyeComp as an early out and cheap vector check instead of the expensive GetEntitiesInRange._

_Essentially throttles the expensive check to only run when its needed._ 

_Ive tried everything from tweaking the anchors, coords but nothing resolves the jitters and stutters.
Only way was to keep it inline so the timings line up._

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:

- fix: Fixed Queen Eye's leash breaking.
- fix: Fixed various Queen Eye performance issues.
