### PR TITLE
Fix planet side xenonids not turning into burrowed larva when hijack starts.

### DIFF
--- a/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.Hijack.cs
+++ b/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.Hijack.cs
@@ -100,7 +100,7 @@ public sealed partial class CMDistressSignalRuleSystem
                     _popup.PopupCoordinates(Loc.GetString("rmc-xeno-hibernation"), origin, Filter.SinglePlayer(session), true, PopupType.MediumXeno);
 
                     if (comp.CountedInSlots && _hive.GetHive(xeno) is { } hive)
-                        _larvaQueue.AddToLarvaQueueFront(hive, actor.PlayerSession.UserId);
+                        _larvaQueue.AddToLarvaQueueFront(hive, session.UserId);
                 }
 
                 QueueDel(xeno);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes planet side xenonids not being deleted on hijack.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug fix.
Resolves #10171

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix: Fix planet side xenonids not turning into burrowed larva when hijack starts.
