### PR TITLE
[Fix] Orbitaldrop Command fix

### DIFF
--- a/Content.Server/_RMC14/Admin/Utility/OrbitalDropCommand.cs
+++ b/Content.Server/_RMC14/Admin/Utility/OrbitalDropCommand.cs
@@ -1,5 +1,4 @@
 using System.Globalization;
-using System.Linq;
 using Content.Server.Administration;
 using Content.Shared._RMC14.Dropship.Utility.Systems;
 using Content.Shared.Administration;
@@ -69,7 +68,7 @@ internal sealed class OrbitalDropCommand : LocalizedEntityCommands
     {
         return args.Length switch
         {
-            1 => CompletionResult.FromHintOptions(_entities.GetEntities().Select(e => e.ToString()), "<EntityUid>"),
+            1 => CompletionResult.FromHintOptions(CompletionHelper.NetEntities(args[0], _entities), "<EntityUid>"),
             2 => CompletionResult.FromHint("<x>"),
             3 => CompletionResult.FromHint("<y>"),
             4 => CompletionResult.FromHintOptions(CompletionHelper.MapIds(_entities), "[MapId]"),


### PR DESCRIPTION
## About the PR
Change the command to use existing helper that caps results to max 20 entities and filters based on whats typed (like all other commands)

## Why / Balance
because it was freezing and crashing client locally trying to enumerate every single entity the moment you typed the command.

## Technical details
Changed so the command uses the CompletionHelper from RobustToolbox. 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

No player facing change.

