### PR TITLE
[Fix] Fixed tallgrass blocking Resin.

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Misc/bushes.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Misc/bushes.yml
@@ -14,16 +14,9 @@
     bodyType: Static
     canCollide: false
   - type: Damageable
-    damageContainer: Inorganic
     damageModifierSet: Wood
   - type: Destructible
     thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 400
-      behaviors:
-        - !type:DoActsBehavior
-          acts: [ "Destruction" ]
     - trigger:
         !type:DamageTrigger
         damage: 50
@@ -861,7 +854,7 @@
   - type: PointLight
     castShadows: false
     radius: 2
-    
+
 # Stumps
 - type: entity
   parent: RMCBaseBush
@@ -874,7 +867,7 @@
     sprite: Objects/Decoration/Flora/flora_treessnow.rsi
     state: treestump
     offset: 0,0.7
-    
+
 - type: entity
   parent: RMCStump1
   id: RMCStump2

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Flora/tallgrass.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Flora/tallgrass.yml
@@ -1,24 +1,25 @@
 - type: entity
   abstract: true
-  parent: CMBaseStructure
   id: RMCGrassTallBase
   name: tallgrass
   suffix: Centre
+  placement:
+    mode: SnapgridCenter
   components:
   # make this slashable by only machete
+  - type: Clickable
   - type: Sprite
     sprite: _RMC14/Structures/Flora/tallgrass.rsi
     state: tallgrass
     drawdepth: Walls
   - type: Physics
     canCollide: false
-  - type: Fixtures
   - type: Damageable
-    damageContainer: Inorganic
+    damageModifierSet: Wood
   - type: MeleeSound
     soundGroups:
       Brute:
-        path: /Audio/Effects/chop.ogg
+        path: /Audio/Weapons/slash.ogg
         params:
           variation: 0.05
   - type: Destructible


### PR DESCRIPTION
## About the PR
Removed the _structure_ parenting and it works wonderfully.
Also fixed the RMCBasebush as it doubled up on destruction. 
Removed the strange inorganic damagecontainer.

## Why / Balance
Fix

## Technical details
yaml

## Media
<img width="255" height="423" alt="image" src="https://github.com/user-attachments/assets/898cad52-cbe2-47f6-b924-2929a358d864" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed Tallgrass blocking resin. 

