### PR TITLE
Add '(Fax Responder)' to all Fax Responder roles in admin spawn menu

### DIFF
--- a/Resources/Locale/en-US/_RMC14/job/responder.ftl
+++ b/Resources/Locale/en-US/_RMC14/job/responder.ftl
@@ -14,35 +14,35 @@ rmc-ghost-role-information-responder-rules = You are a [color=red][bold]Fax Resp
 
 
 #UNMC fax responder
-rmc-job-name-unmc-responder = UNMC Communications Officer
+rmc-job-name-unmc-responder = UNMC Communications Officer (Fax Responder)
 rmc-job-description-unmc-responder = "You are acting on behalf of UNMC Regional Command to respond to faxes sent to UNMC High Command."
 
 #We-Ya fax responder
-rmc-job-name-weya-responder = We-Ya Communications Executive
+rmc-job-name-weya-responder = We-Ya Communications Executive (Fax Responder)
 rmc-job-description-weya-responder = "You are acting on behalf of the Regional We-Ya special services department to respond to faxes."
 
 #Provost fax responder
-rmc-job-name-provost-responder = Provost Communications Officer
+rmc-job-name-provost-responder = Provost Communications Officer (Fax Responder)
 rmc-job-description-provost-responder = "You are acting on behalf of the regions Provost Marshal Office to respond to faxes sent to the Provost Marshal Office."
 
 #Free Press fax responder
-rmc-job-name-free-press-responder = Free Press
+rmc-job-name-free-press-responder = Free Press (Fax Responder)
 rmc-job-description-free-press-responder = "You are a promiment regional editor, a member of the Free Press."
 
 #CLF fax responder
-rmc-job-name-clf-responder = CLF Information Correspondent
+rmc-job-name-clf-responder = CLF Information Correspondent (Fax Responder)
 rmc-job-description-clf-responder = "You are a member of a regional CLF cell. Inform and receive information from local cells."
 rmc-job-prefix-clf-responder = INFO
 
 #SPP fax responder
-rmc-job-name-spp-responder = SPP Communications Officer
+rmc-job-name-spp-responder = SPP Communications Officer (Fax Responder)
 rmc-job-description-spp-responder = "You are acting on behalf of SPP Regional Command to respond to faxes sent to SPP Command."
 
 #TSE fax responder
-rmc-job-name-tse-responder = TSE Communications Officer
+rmc-job-name-tse-responder = TSE Communications Officer (Fax Responder)
 rmc-job-description-tse-responder = "You are acting on behalf of TSE Regional Command to respond to faxes sent to TSE Command."
 
 #CMB fax responder
-rmc-job-name-cmb-responder = CMB Communications Officer
+rmc-job-name-cmb-responder = CMB Communications Officer (Fax Responder)
 rmc-job-description-cmb-responder = "You are a dispatcher of the local branch of the CMB. Respond to faxes accordingly."
 

--- a/Resources/Locale/en-US/_RMC14/job/responder.ftl
+++ b/Resources/Locale/en-US/_RMC14/job/responder.ftl
@@ -14,35 +14,35 @@ rmc-ghost-role-information-responder-rules = You are a [color=red][bold]Fax Resp
 
 
 #UNMC fax responder
-rmc-job-name-unmc-responder = UNMC Communications Officer (Fax Responder)
+rmc-job-name-unmc-responder = UNMC Communications Officer
 rmc-job-description-unmc-responder = "You are acting on behalf of UNMC Regional Command to respond to faxes sent to UNMC High Command."
 
 #We-Ya fax responder
-rmc-job-name-weya-responder = We-Ya Communications Executive (Fax Responder)
+rmc-job-name-weya-responder = We-Ya Communications Executive
 rmc-job-description-weya-responder = "You are acting on behalf of the Regional We-Ya special services department to respond to faxes."
 
 #Provost fax responder
-rmc-job-name-provost-responder = Provost Communications Officer (Fax Responder)
+rmc-job-name-provost-responder = Provost Communications Officer
 rmc-job-description-provost-responder = "You are acting on behalf of the regions Provost Marshal Office to respond to faxes sent to the Provost Marshal Office."
 
 #Free Press fax responder
-rmc-job-name-free-press-responder = Free Press (Fax Responder)
+rmc-job-name-free-press-responder = Free Press
 rmc-job-description-free-press-responder = "You are a promiment regional editor, a member of the Free Press."
 
 #CLF fax responder
-rmc-job-name-clf-responder = CLF Information Correspondent (Fax Responder)
+rmc-job-name-clf-responder = CLF Information Correspondent
 rmc-job-description-clf-responder = "You are a member of a regional CLF cell. Inform and receive information from local cells."
 rmc-job-prefix-clf-responder = INFO
 
 #SPP fax responder
-rmc-job-name-spp-responder = SPP Communications Officer (Fax Responder)
+rmc-job-name-spp-responder = SPP Communications Officer
 rmc-job-description-spp-responder = "You are acting on behalf of SPP Regional Command to respond to faxes sent to SPP Command."
 
 #TSE fax responder
-rmc-job-name-tse-responder = TSE Communications Officer (Fax Responder)
+rmc-job-name-tse-responder = TSE Communications Officer
 rmc-job-description-tse-responder = "You are acting on behalf of TSE Regional Command to respond to faxes sent to TSE Command."
 
 #CMB fax responder
-rmc-job-name-cmb-responder = CMB Communications Officer (Fax Responder)
+rmc-job-name-cmb-responder = CMB Communications Officer
 rmc-job-description-cmb-responder = "You are a dispatcher of the local branch of the CMB. Respond to faxes accordingly."
 

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Fax_Responders/clf_responder.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Fax_Responders/clf_responder.yml
@@ -2,6 +2,7 @@
   parent: RMCJobRibbonBase
   id: CMCLFResponder
   name: rmc-job-name-clf-responder
+  spawnMenuRoleName: CLF Information Correspondent (Fax Responder)
   description: rmc-job-description-clf-responder
   playTimeTracker: CMJobCLFResponder
   ranks:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Fax_Responders/cmb_responder.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Fax_Responders/cmb_responder.yml
@@ -2,6 +2,7 @@
   parent: RMCJobRibbonBase
   id: CMCMBResponder
   name: rmc-job-name-cmb-responder
+  spawnMenuRoleName: CMB Communications Officer (Fax Responder)
   description: rmc-job-description-cmb-responder
   playTimeTracker: CMJobCMBResponder
   ranks:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Fax_Responders/free_press_responder.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Fax_Responders/free_press_responder.yml
@@ -2,6 +2,7 @@
   parent: RMCJobRibbonBase
   id: CMFreePressResponder
   name: rmc-job-name-free-press-responder
+  spawnMenuRoleName: Free Press (Fax Responder)
   description: rmc-job-description-free-press-responder
   playTimeTracker: CMJobFreePressResponder
   ranks:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Fax_Responders/provost_responder.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Fax_Responders/provost_responder.yml
@@ -2,6 +2,7 @@
   parent: CMJobBase
   id: CMProvostResponder
   name: rmc-job-name-provost-responder
+  spawnMenuRoleName: Provost Communications Officer (Fax Responder)
   description: rmc-job-description-provost-responder
   playTimeTracker: CMJobProvostResponder
   ranks:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Fax_Responders/spp_responder.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Fax_Responders/spp_responder.yml
@@ -2,6 +2,7 @@
   parent: CMJobBase
   id: CMSPPResponder
   name: rmc-job-name-spp-responder
+  spawnMenuRoleName: SPP Communications Officer (Fax Responder)
   description: rmc-job-description-spp-responder
   playTimeTracker: CMJobSPPResponder
   ranks:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Fax_Responders/tse_responder.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Fax_Responders/tse_responder.yml
@@ -2,6 +2,7 @@
   parent: CMJobBase
   id: CMTSEResponder
   name: rmc-job-name-tse-responder
+  spawnMenuRoleName: TSE Communications Officer (Fax Responder)
   description: rmc-job-description-tse-responder
   playTimeTracker: CMJobTSEResponder
   ranks:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Fax_Responders/unmc_responder.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Fax_Responders/unmc_responder.yml
@@ -2,6 +2,7 @@
   parent: CMJobBase
   id: RMCUNMCResponder
   name: rmc-job-name-unmc-responder
+  spawnMenuRoleName: UNMC Communications Officer (Fax Responder)
   description: rmc-job-description-unmc-responder
   playTimeTracker: CMJobUNMCResponder
   ranks:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Fax_Responders/we-ya_responder.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Fax_Responders/we-ya_responder.yml
@@ -2,6 +2,7 @@
   parent: RMCJobRibbonBase
   id: CMWeYaresponder
   name: rmc-job-name-weya-responder
+  spawnMenuRoleName: We-Ya Communications Executive (Fax Responder)
   description: rmc-job-description-weya-responder
   playTimeTracker: CMJobWeYaResponder
   ranks:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Fax_Responders/we-ya_responder.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Fax_Responders/we-ya_responder.yml
@@ -14,7 +14,6 @@
   accessGroups:
   - ShipMasterAccess
   - RMCWeYa
-  spawnMenuRoleName: WEYA Communications Executive
   special:
   - !type:AddComponentSpecial
     components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed the UNMC, WeYa, Provost, Free Press, CLF, SPP, TSE and CMB fax responder roles to have '(Fax Responder)' behind them in the admin menu for easy searching and locating.

## Why / Balance
Asked on Dev Chat in discord for Free Press, extended to all for consistency.

## Technical details
Add spawnMenuRoleName to all job titles with <original job name> + '(Fax Responder)' so UNMC Communications Officer -> "UNMC Communications Officer (Fax Responder)" and so on

## Media
<img width="308" height="425" alt="image" src="https://github.com/user-attachments/assets/95eefbb7-3ec0-48ab-9370-3751d3ad64f4" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Added '(Fax Responder)' to all Fax Responder roles in the spawn menu
