### PR TITLE
Fix access for fridges

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Storage/fridge.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Storage/fridge.yml
@@ -93,3 +93,12 @@
       amount: 14
     - id: RMCFoodMeatFish
       amount: 14
+
+- type: entity
+  parent: CMLockerFridge
+  id: CMLockerFridgeColony
+  name: fridge
+  suffix: colony
+  components:
+  - type: AccessReader
+    access: [["CMAccessColonyPublic"]]

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Storage/fridge.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Storage/fridge.yml
@@ -8,8 +8,6 @@
   - type: VehicleSmashable
   - type: Sprite
     sprite: _RMC14/Structures/Storage/Lockers/fridge.rsi
-  - type: AccessReader
-    access: [["CMAccessKitchen"], ["RMCAccessCommand"]]
   - type: AntiRottingContainer
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Storage/fridge.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Storage/fridge.yml
@@ -9,7 +9,7 @@
   - type: Sprite
     sprite: _RMC14/Structures/Storage/Lockers/fridge.rsi
   - type: AccessReader
-    access: [["CMAccessKitchen"]]
+    access: [["CMAccessKitchen"], ["RMCAccessCommand"]]
   - type: AntiRottingContainer
 
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Removed access requirements for fridges, this will allow more roles to use the fridges such as MPs, SOs, etc.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity, QoL
## Technical details
<!-- Summary of code changes for easier review. -->
yaml

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Fridges are now all-access
