### PR TITLE
M59A can now load HEAP mags

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m59a_prototype_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m59a_prototype_rifle.yml
@@ -70,10 +70,12 @@
           tags:
           - CMMagazineRifleM54C
           - CMMagazineRifleM54CAP
+          - RMCMagazineRifleM54CHEAP
+          - RMCMagazineRifleM54CIncendiary
           - CMMagazineRifleM54CExt
           - CMMagazineRifleM54CMK1
           - CMMagazineRifleM54CMK1AP
-          - RMCMagazineRifleM54CIncendiary
+          - RMCMagazineRifleM54CMK1HEAP
           - RMCMagazineRifleM54CMK1Incendiary
         startingItem: CMMagazineRifleM54CMK1AP
   - type: GunDamageModifier


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
M59A can now load HEAP mags (M54 and MK1 mags)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity

## Technical details
<!-- Summary of code changes for easier review. -->
yaml

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: M59A can now load HEAP magazines
