### PR TITLE
Freelancer armor fixes

### DIFF
--- a/Resources/Locale/en-US/_RMC14/armor/rmc-restricted.ftl
+++ b/Resources/Locale/en-US/_RMC14/armor/rmc-restricted.ftl
@@ -17,3 +17,5 @@ rmc-armor-not-spp-jumpsuit = You cannot wear this without wearing SPP fatigues.
 rmc-armor-not-cmb-jumpsuit = You cannot wear this without wearing a CMB uniform.
 
 rmc-armor-not-tse-jumpsuit = You cannot wear this without wearing a TSE uniform.
+
+rmc-armor-not-freelancer-jumpsuit = You cannot wear this without wearing a freelancer uniform.

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/armored_vest.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/armored_vest.yml
@@ -268,3 +268,137 @@
         - RMCBoxZipties
       whitelist: null
       count: 2
+
+# Plate carriers
+- type: entity
+  parent: RMCArmorVest
+  id: RMCArmorPlateCarrierBlack
+  name: black plate carrier vest
+  description: A standard plate carrier produced by virtually every armour manufacturer in the galaxy, and sold to both governments, mercenaries and civilians alike. As the name implies, it carries a series of armoured plates for protection, and has two pouches on the front.
+  suffix: no lamp
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Clothing/OuterClothing/Mercenary/platecarrier_black.rsi
+  - type: CMArmor
+    melee: 25 # CLOTHING_ARMOR_MEDIUMHIGH
+    bullet: 25
+    bio: 15
+    explosionArmor: 20
+  - type: RMCMagneticArmor
+  - type: Clothing
+    equipDelay: 2
+    unequipDelay: 2
+    equippedPrefix: off
+    clothingVisuals:
+      outerClothing:
+      - sprite: _RMC14/Objects/Clothing/OuterClothing/Mercenary/platecarrier_black.rsi
+        state: equipped-OUTERCLOTHING
+        
+- type: entity
+  parent: RMCArmorPlateCarrierBlack
+  id: RMCArmorPlateCarrierBeige
+  name: beige plate carrier vest
+  suffix: no lamp
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Clothing/OuterClothing/Mercenary/platecarrier_beige.rsi
+  - type: RMCMagneticArmor
+  - type: Clothing
+    clothingVisuals:
+      outerClothing:
+      - sprite: _RMC14/Objects/Clothing/OuterClothing/Mercenary/platecarrier_beige.rsi
+        state: equipped-OUTERCLOTHING
+
+- type: entity
+  parent: RMCArmorPlateCarrierBlack
+  id: RMCArmorPlateCarrierBlackLamp
+  description: A standard plate carrier produced by virtually every armour manufacturer in the galaxy, and sold to both governments, mercenaries and civilians alike. As the name implies, it carries a series of armoured plates for protection, two pouches on the front. This one has had a lamp attached to the back.
+  suffix: Lamp
+  components:
+    - type: ToggleableVisuals
+      spriteLayer: light
+      clothingVisuals:
+        outerClothing:
+        - sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/armor_overlays.rsi
+          state: lamp-on
+    - type: ItemTogglePointLight
+    - type: Sprite
+      layers:
+      - state: icon
+      - map: [ "enum.WebbingVisualLayers.Base" ]
+      - sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/armor_overlays.rsi
+        state: lamp-off
+      - sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/armor_overlays.rsi
+        state: lamp-on
+        visible: false
+        map: [ "light" ]
+    - type: Clothing
+      clothingVisuals:
+        outerClothing:
+        - state: equipped-OUTERCLOTHING
+        - sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/armor_overlays.rsi
+          state: lamp-off
+    - type: RMCSuitLight
+    - type: PointLight
+      enabled: false
+      radius: 5
+      offset: 0,-0.85
+      rotation: 90
+      softness: 5
+      autoRot: true
+      netsync: false
+      color: "#FFFFFF"
+      mask: /Textures/_RMC14/Effects/LightMasks/wide_ellipsis.png
+    - type: PointLightRotation
+      rotation: 90
+    - type: HandheldLight
+      addPrefix: true
+      blinkingBehaviourId: blinking
+      radiatingBehaviourId: radiating
+      turnOffSound:
+        path: /Audio/_RMC14/Handling/suitlight_crank.ogg
+      turnOnSound:
+        path: /Audio/_RMC14/Machines/suitlight_on.ogg
+    - type: NoHandsInteractionBlocked
+    - type: LightBehaviour
+      behaviours:
+      - !type:FadeBehaviour
+        id: radiating
+        interpolate: Linear
+        maxDuration: 2.0
+        startValue: 3.0
+        endValue: 2.0
+        isLooped: true
+        property: Radius
+        enabled: false
+        reverseWhenFinished: true
+      - !type:PulseBehaviour
+        id: blinking
+        interpolate: Nearest
+        maxDuration: 1.0
+        minValue: 0.1
+        maxValue: 2.0
+        isLooped: true
+        property: Radius
+        enabled: false
+    - type: Battery
+      maxCharge: 600
+      startingCharge: 600
+    - type: BatterySelfRecharger
+      autoRecharge: true
+      autoRechargeRate: 2
+
+- type: entity
+  parent: RMCArmorPlateCarrierBlackLamp
+  id: RMCArmorPlateCarrierBeigeLamp
+  name: beige plate carrier vest
+  suffix: Lamp
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Clothing/OuterClothing/Mercenary/platecarrier_beige.rsi
+  - type: Clothing
+    clothingVisuals:
+      outerClothing:
+      - state: equipped-OUTERCLOTHING
+      - sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/armor_overlays.rsi
+        state: lamp-off

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/armored_vest.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/armored_vest.yml
@@ -274,7 +274,7 @@
   parent: RMCArmorVest
   id: RMCArmorPlateCarrierBlack
   name: black plate carrier vest
-  description: A standard plate carrier produced by virtually every armour manufacturer in the galaxy, and sold to both governments, mercenaries and civilians alike. As the name implies, it carries a series of armoured plates for protection, and has two pouches on the front.
+  description: A standard plate carrier produced by virtually every armour manufacturer in the galaxy, and sold to governments, mercenaries and civilians alike. As the name implies, it carries a series of armoured plates for protection, and has two pouches on the front.
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/Mercenary/platecarrier_black.rsi

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/armored_vest.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/armored_vest.yml
@@ -310,7 +310,7 @@
 - type: entity
   parent: RMCArmorPlateCarrierBlack
   id: RMCArmorPlateCarrierBlackLamp
-  description: A standard plate carrier produced by virtually every armour manufacturer in the galaxy, and sold to both governments, mercenaries and civilians alike. As the name implies, it carries a series of armoured plates for protection, two pouches on the front. This one has had a lamp attached to the back.
+  description: A standard plate carrier produced by virtually every armour manufacturer in the galaxy, and sold to governments, mercenaries and civilians alike. As the name implies, it carries a series of armoured plates for protection, two pouches on the front. This one has had a lamp attached to the back.
   suffix: Lamp
   components:
   - type: Item

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/armored_vest.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/armored_vest.yml
@@ -275,7 +275,6 @@
   id: RMCArmorPlateCarrierBlack
   name: black plate carrier vest
   description: A standard plate carrier produced by virtually every armour manufacturer in the galaxy, and sold to both governments, mercenaries and civilians alike. As the name implies, it carries a series of armoured plates for protection, and has two pouches on the front.
-  suffix: no lamp
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/Mercenary/platecarrier_black.rsi
@@ -298,7 +297,6 @@
   parent: RMCArmorPlateCarrierBlack
   id: RMCArmorPlateCarrierBeige
   name: beige plate carrier vest
-  suffix: no lamp
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/Mercenary/platecarrier_beige.rsi

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/armored_vest.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/armored_vest.yml
@@ -315,78 +315,82 @@
   description: A standard plate carrier produced by virtually every armour manufacturer in the galaxy, and sold to both governments, mercenaries and civilians alike. As the name implies, it carries a series of armoured plates for protection, two pouches on the front. This one has had a lamp attached to the back.
   suffix: Lamp
   components:
-    - type: ToggleableVisuals
-      spriteLayer: light
-      clothingVisuals:
-        outerClothing:
-        - sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/armor_overlays.rsi
-          state: lamp-on
-    - type: ItemTogglePointLight
-    - type: Sprite
-      layers:
-      - state: icon
-      - map: [ "enum.WebbingVisualLayers.Base" ]
+  - type: Item
+    heldPrefix: off
+  - type: Sprite
+    layers:
+    - state: icon
+    - map: [ "enum.WebbingVisualLayers.Base" ]
+    - sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/armor_overlays.rsi
+      state: lamp-off
+    - sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/armor_overlays.rsi
+      state: lamp-on
+      visible: false
+      map: [ "light" ]
+  - type: Clothing
+    equippedPrefix: off
+    clothingVisuals:
+      outerClothing:
+      - state: equipped-OUTERCLOTHING
       - sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/armor_overlays.rsi
         state: lamp-off
+  - type: Appearance
+  - type: ItemTogglePointLight
+  - type: ToggleableVisuals
+    spriteLayer: light
+    clothingVisuals:
+      outerClothing:
       - sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/armor_overlays.rsi
         state: lamp-on
-        visible: false
-        map: [ "light" ]
-    - type: Clothing
-      clothingVisuals:
-        outerClothing:
-        - state: equipped-OUTERCLOTHING
-        - sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/armor_overlays.rsi
-          state: lamp-off
-    - type: RMCSuitLight
-    - type: PointLight
+  - type: RMCSuitLight
+  - type: PointLight
+    enabled: false
+    radius: 5
+    offset: 0,-0.85
+    rotation: 90
+    softness: 5
+    autoRot: true
+    netsync: false
+    color: "#FFFFFF"
+    mask: /Textures/_RMC14/Effects/LightMasks/wide_ellipsis.png
+  - type: PointLightRotation
+    rotation: 90
+  - type: HandheldLight
+    addPrefix: true
+    blinkingBehaviourId: blinking
+    radiatingBehaviourId: radiating
+    turnOffSound:
+      path: /Audio/_RMC14/Handling/suitlight_crank.ogg
+    turnOnSound:
+      path: /Audio/_RMC14/Machines/suitlight_on.ogg
+  - type: NoHandsInteractionBlocked
+  - type: LightBehaviour
+    behaviours:
+    - !type:FadeBehaviour
+      id: radiating
+      interpolate: Linear
+      maxDuration: 2.0
+      startValue: 3.0
+      endValue: 2.0
+      isLooped: true
+      property: Radius
       enabled: false
-      radius: 5
-      offset: 0,-0.85
-      rotation: 90
-      softness: 5
-      autoRot: true
-      netsync: false
-      color: "#FFFFFF"
-      mask: /Textures/_RMC14/Effects/LightMasks/wide_ellipsis.png
-    - type: PointLightRotation
-      rotation: 90
-    - type: HandheldLight
-      addPrefix: true
-      blinkingBehaviourId: blinking
-      radiatingBehaviourId: radiating
-      turnOffSound:
-        path: /Audio/_RMC14/Handling/suitlight_crank.ogg
-      turnOnSound:
-        path: /Audio/_RMC14/Machines/suitlight_on.ogg
-    - type: NoHandsInteractionBlocked
-    - type: LightBehaviour
-      behaviours:
-      - !type:FadeBehaviour
-        id: radiating
-        interpolate: Linear
-        maxDuration: 2.0
-        startValue: 3.0
-        endValue: 2.0
-        isLooped: true
-        property: Radius
-        enabled: false
-        reverseWhenFinished: true
-      - !type:PulseBehaviour
-        id: blinking
-        interpolate: Nearest
-        maxDuration: 1.0
-        minValue: 0.1
-        maxValue: 2.0
-        isLooped: true
-        property: Radius
-        enabled: false
-    - type: Battery
-      maxCharge: 600
-      startingCharge: 600
-    - type: BatterySelfRecharger
-      autoRecharge: true
-      autoRechargeRate: 2
+      reverseWhenFinished: true
+    - !type:PulseBehaviour
+      id: blinking
+      interpolate: Nearest
+      maxDuration: 1.0
+      minValue: 0.1
+      maxValue: 2.0
+      isLooped: true
+      property: Radius
+      enabled: false
+  - type: Battery
+    maxCharge: 600
+    startingCharge: 600
+  - type: BatterySelfRecharger
+    autoRecharge: true
+    autoRechargeRate: 2
 
 - type: entity
   parent: RMCArmorPlateCarrierBlackLamp
@@ -396,9 +400,3 @@
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/OuterClothing/Mercenary/platecarrier_beige.rsi
-  - type: Clothing
-    clothingVisuals:
-      outerClothing:
-      - state: equipped-OUTERCLOTHING
-      - sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/armor_overlays.rsi
-        state: lamp-off

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/freelancer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/freelancer.yml
@@ -17,11 +17,11 @@
       tags:
       - RMCUniformFreelancer
 
-- entity:
+- type: entity
   parent: RMCArmorPlateCarrierBlack
   id: RMCArmorFreelancerPlateCarrierBlack
-  name: black plate carrier vest
-  prefix: no lamp, freelancer
+  name: freelancer's black plate carrier vest
+  prefix: no lamp
   components:
   - type: ClothingRequireEquipped
     autoUnequip: true
@@ -30,11 +30,11 @@
       tags:
       - RMCUniformFreelancer
 
-- entity:
+- type: entity
   parent: RMCArmorPlateCarrierBeige
   id: RMCArmorFreelancerPlateCarrierBeige
-  name: beige plate carrier vest
-  prefix: no lamp, freelancer
+  name: freelancer's beige plate carrier vest
+  prefix: no lamp
   components:
   - type: ClothingRequireEquipped
     autoUnequip: true
@@ -43,11 +43,11 @@
       tags:
       - RMCUniformFreelancer
 
-- entity:
+- type: entity
   parent: RMCArmorPlateCarrierBlackLamp
   id: RMCArmorFreelancerPlateCarrierBlackLamp
-  name: black plate carrier vest
-  prefix: lamp, freelancer
+  name: freelancer's black plate carrier vest
+  prefix: lamp
   components:
   - type: ClothingRequireEquipped
     autoUnequip: true
@@ -56,11 +56,11 @@
       tags:
       - RMCUniformFreelancer
 
-- entity:
+- type: entity
   parent: RMCArmorPlateCarrierBeigeLamp
   id: RMCArmorFreelancerPlateCarrierBeigeLamp
-  name: beige plate carrier vest
-  prefix: lamp, freelancer
+  name: freelancer's beige plate carrier vest
+  prefix: lamp
   components:
   - type: ClothingRequireEquipped
     autoUnequip: true

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/freelancer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/freelancer.yml
@@ -23,6 +23,12 @@
     grid:
     - 0,0,3,1 # 2 slots
     maxItemSize: Small
+  - type: ClothingRequireEquipped
+    autoUnequip: true
+    denyReason: rmc-armor-not-freelancer-jumpsuit
+    whitelist:
+      tags:
+      - RMCUniformFreelancer
 
 - type: entity
   parent: RMCArmorVestXLBase
@@ -50,6 +56,12 @@
       outerClothing:
       - sprite: _RMC14/Objects/Clothing/OuterClothing/Mercenary/platecarrier_black.rsi
         state: equipped-OUTERCLOTHING
+  - type: ClothingRequireEquipped
+    autoUnequip: true
+    denyReason: rmc-armor-not-freelancer-jumpsuit
+    whitelist:
+      tags:
+      - RMCUniformFreelancer
 
 - type: entity
   parent: RMCArmorFreelancerVestBlack

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/freelancer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/freelancer.yml
@@ -17,32 +17,12 @@
       tags:
       - RMCUniformFreelancer
 
-- type: entity
-  parent: RMCArmorVestXLBase
-  id: RMCArmorFreelancerVestBlack
+- entity:
+  parent: RMCArmorPlateCarrierBlack
+  id: RMCArmorFreelancerPlateCarrierBlack
   name: black plate carrier vest
-  description: A standard plate carrier produced by virtually every armour manufacturer in the galaxy, and sold to both governments, mercenaries and civilians alike. As the name implies, it carries a series of armoured plates for protection, and has two pouches on the front.
-  suffix: No lamp
+  prefix: no lamp, freelancer
   components:
-  - type: Sprite
-    sprite: _RMC14/Objects/Clothing/OuterClothing/Mercenary/platecarrier_black.rsi
-  - type: CMArmor
-    melee: 25 # CLOTHING_ARMOR_MEDIUMHIGH
-    bullet: 25
-    bio: 15
-    explosionArmor: 20
-  - type: ClothingSpeedModifier # SLOWDOWN_ARMOR_LIGHT
-    walkModifier: 0.725
-    sprintModifier: 0.725
-  - type: RMCMagneticArmor
-  - type: Clothing
-    equipDelay: 2
-    unequipDelay: 2
-    equippedPrefix: off
-    clothingVisuals:
-      outerClothing:
-      - sprite: _RMC14/Objects/Clothing/OuterClothing/Mercenary/platecarrier_black.rsi
-        state: equipped-OUTERCLOTHING
   - type: ClothingRequireEquipped
     autoUnequip: true
     denyReason: rmc-armor-not-freelancer-jumpsuit
@@ -50,120 +30,41 @@
       tags:
       - RMCUniformFreelancer
 
-- type: entity
-  parent: RMCArmorFreelancerVestBlack
-  id: RMCArmorFreelancerVestBlackLamp
-  suffix: Lamp
-  description: A standard plate carrier produced by virtually every armour manufacturer in the galaxy, and sold to both governments, mercenaries and civilians alike. As the name implies, it carries a series of armoured plates for protection, two pouches on the front. This one has had a lamp attached to the back.
-  components:
-  - type: ToggleableVisuals
-    spriteLayer: light
-    clothingVisuals:
-      outerClothing:
-      - sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/armor_overlays.rsi
-        state: lamp-on
-  - type: ItemTogglePointLight
-  - type: Sprite
-    layers:
-    - state: icon
-    - map: [ "enum.WebbingVisualLayers.Base" ]
-    - sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/armor_overlays.rsi
-      state: lamp-off
-    - sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/armor_overlays.rsi
-      state: lamp-on
-      visible: false
-      map: [ "light" ]
-  - type: Clothing
-    clothingVisuals:
-      outerClothing:
-      - state: equipped-OUTERCLOTHING
-      - sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/armor_overlays.rsi
-        state: lamp-off
-  - type: RMCSuitLight
-  - type: PointLight
-    enabled: false
-    radius: 5
-    offset: 0,-0.85
-    rotation: 90
-    softness: 5
-    autoRot: true
-    netsync: false
-    color: "#FFFFFF"
-    mask: /Textures/_RMC14/Effects/LightMasks/wide_ellipsis.png
-  - type: PointLightRotation
-    rotation: 90
-  - type: HandheldLight
-    addPrefix: true
-    blinkingBehaviourId: blinking
-    radiatingBehaviourId: radiating
-    turnOffSound:
-      path: /Audio/_RMC14/Handling/suitlight_crank.ogg
-    turnOnSound:
-      path: /Audio/_RMC14/Machines/suitlight_on.ogg
-  - type: NoHandsInteractionBlocked
-  - type: LightBehaviour
-    behaviours:
-    - !type:FadeBehaviour
-      id: radiating
-      interpolate: Linear
-      maxDuration: 2.0
-      startValue: 3.0
-      endValue: 2.0
-      isLooped: true
-      property: Radius
-      enabled: false
-      reverseWhenFinished: true
-    - !type:PulseBehaviour
-      id: blinking
-      interpolate: Nearest
-      maxDuration: 1.0
-      minValue: 0.1
-      maxValue: 2.0
-      isLooped: true
-      property: Radius
-      enabled: false
-  - type: Battery
-    maxCharge: 600
-    startingCharge: 600
-  - type: BatterySelfRecharger
-    autoRecharge: true
-    autoRechargeRate: 2
-
-- type: entity
-  parent: RMCArmorFreelancerVestBlack
-  id: RMCArmorFreelancerVestBeige
+- entity:
+  parent: RMCArmorPlateCarrierBeige
+  id: RMCArmorFreelancerPlateCarrierBeige
   name: beige plate carrier vest
-  description: A standard plate carrier produced by virtually every armour manufacturer in the galaxy, and sold to both governments, mercenaries and civilians alike. As the name implies, it carries a series of armoured plates for protection, and has two pouches on the front.
-  suffix: No lamp
+  prefix: no lamp, freelancer
   components:
-  - type: Sprite
-    sprite: _RMC14/Objects/Clothing/OuterClothing/Mercenary/platecarrier_beige.rsi
-  - type: CMArmor
-    melee: 25 # CLOTHING_ARMOR_MEDIUMHIGH
-    bullet: 25
-    bio: 15
-    explosionArmor: 20
-  - type: ClothingSpeedModifier # SLOWDOWN_ARMOR_LIGHT
-    walkModifier: 0.725
-    sprintModifier: 0.725
-  - type: RMCMagneticArmor
-  - type: Clothing
-    clothingVisuals:
-      outerClothing:
-      - sprite: _RMC14/Objects/Clothing/OuterClothing/Mercenary/platecarrier_beige.rsi
-        state: equipped-OUTERCLOTHING
+  - type: ClothingRequireEquipped
+    autoUnequip: true
+    denyReason: rmc-armor-not-freelancer-jumpsuit
+    whitelist:
+      tags:
+      - RMCUniformFreelancer
 
-- type: entity
-  parent: RMCArmorFreelancerVestBlackLamp
-  id: RMCArmorFreelancerVestBeigeLamp
-  name: beige plate carrier vest
-  suffix: Lamp
+- entity:
+  parent: RMCArmorPlateCarrierBlackLamp
+  id: RMCArmorFreelancerPlateCarrierBlackLamp
+  name: black plate carrier vest
+  prefix: lamp, freelancer
   components:
-  - type: Sprite
-    sprite: _RMC14/Objects/Clothing/OuterClothing/Mercenary/platecarrier_beige.rsi
-  - type: Clothing
-    clothingVisuals:
-      outerClothing:
-      - state: equipped-OUTERCLOTHING
-      - sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/armor_overlays.rsi
-        state: lamp-off
+  - type: ClothingRequireEquipped
+    autoUnequip: true
+    denyReason: rmc-armor-not-freelancer-jumpsuit
+    whitelist:
+      tags:
+      - RMCUniformFreelancer
+
+- entity:
+  parent: RMCArmorPlateCarrierBeigeLamp
+  id: RMCArmorFreelancerPlateCarrierBeigeLamp
+  name: beige plate carrier vest
+  prefix: lamp, freelancer
+  components:
+  - type: ClothingRequireEquipped
+    autoUnequip: true
+    denyReason: rmc-armor-not-freelancer-jumpsuit
+    whitelist:
+      tags:
+      - RMCUniformFreelancer

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/freelancer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/freelancer.yml
@@ -1,5 +1,5 @@
 ﻿- type: entity
-  parent: RMCArmorSPP
+  parent: CMArmorM3Light
   id: CMArmorFreelancer
   name: freelancer cuirass
   description: An armored protective chestplate scrapped together from various plates. It keeps up remarkably well, as the craftsmanship is solid, and the design mirrors such armors in the SPP and the UNMC. The many skilled craftsmen in the freelancers ranks produce these vests at a rate about one a month.
@@ -9,20 +9,7 @@
   - type: CMArmor
     melee: 25 # CLOTHING_ARMOR_MEDIUMHIGH
     bullet: 25
-    bio: 15
     explosionArmor: 20
-  - type: RMCArmorSpeedTier
-    speedTier: light
-  - type: ClothingSpeedModifier # SLOWDOWN_ARMOR_LIGHT
-    walkModifier: 0.725
-    sprintModifier: 0.725
-  - type: ExplosionResistance
-    damageCoefficient: 0
-    worn: false
-  - type: Storage
-    grid:
-    - 0,0,3,1 # 2 slots
-    maxItemSize: Small
   - type: ClothingRequireEquipped
     autoUnequip: true
     denyReason: rmc-armor-not-freelancer-jumpsuit

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/freelancer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/freelancer.yml
@@ -21,7 +21,6 @@
   parent: RMCArmorPlateCarrierBlack
   id: RMCArmorFreelancerPlateCarrierBlack
   name: freelancer's black plate carrier vest
-  prefix: no lamp
   components:
   - type: ClothingRequireEquipped
     autoUnequip: true
@@ -34,7 +33,6 @@
   parent: RMCArmorPlateCarrierBeige
   id: RMCArmorFreelancerPlateCarrierBeige
   name: freelancer's beige plate carrier vest
-  prefix: no lamp
   components:
   - type: ClothingRequireEquipped
     autoUnequip: true
@@ -47,7 +45,7 @@
   parent: RMCArmorPlateCarrierBlackLamp
   id: RMCArmorFreelancerPlateCarrierBlackLamp
   name: freelancer's black plate carrier vest
-  prefix: lamp
+  suffix: Lamp
   components:
   - type: ClothingRequireEquipped
     autoUnequip: true
@@ -60,7 +58,7 @@
   parent: RMCArmorPlateCarrierBeigeLamp
   id: RMCArmorFreelancerPlateCarrierBeigeLamp
   name: freelancer's beige plate carrier vest
-  prefix: lamp
+  suffix: Lamp
   components:
   - type: ClothingRequireEquipped
     autoUnequip: true

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/freelancers.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Uniforms/freelancers.yml
@@ -8,6 +8,9 @@
     sprite: _RMC14/Objects/Clothing/Uniforms/freelancer.rsi
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/Uniforms/freelancer.rsi
+  - type: Tag
+    tags:
+    - RMCUniformFreelancer
 
 - type: entity
   parent: [RMCMarineUniformBase, RMCAlternateFoldableUniformBase]
@@ -19,6 +22,9 @@
     sprite: _RMC14/Objects/Clothing/Uniforms/Freelancer/blueshirt_tanpants.rsi
   - type: Clothing
     sprite: _RMC14/Objects/Clothing/Uniforms/Freelancer/blueshirt_tanpants.rsi
+  - type: Tag
+    tags:
+    - RMCUniformFreelancer
 
 - type: entity
   parent: RMCJumpsuitFreelancerBluePants

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/PVE/freelancer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/PVE/freelancer.yml
@@ -87,17 +87,17 @@
         amount: 5
     - name: Armor
       entries:
-      - id: RMCArmorFreelancerVestBlackLamp
-        name: Black Plate Carrier (Lamp)
+      - id: RMCArmorFreelancerPlateCarrierBlackLamp
+        name: Black Plate Carrier Vest (Lamp)
         amount: 15
-      - id: RMCArmorFreelancerVestBlack
-        name: Black Plate Carrier
+      - id: RMCArmorFreelancerPlateCarrierBlack
+        name: Black Plate Carrier Vest
         amount: 15
-      - id: RMCArmorFreelancerVestBeigeLamp
-        name: Beige Plate Carrier (Lamp)
+      - id: RMCArmorFreelancerPlateCarrierBeige
+        name: Beige Plate Carrier Vest (Lamp)
         amount: 15
-      - id: RMCArmorFreelancerVestBeige
-        name: Beige Plate Carrier
+      - id: RMCArmorFreelancerPlateCarrierBeigeLamp
+        name: Beige Plate Carrier Vest
         amount: 15
     - name: Backpack
       entries:

--- a/Resources/Prototypes/_RMC14/rmc_tags.yml
+++ b/Resources/Prototypes/_RMC14/rmc_tags.yml
@@ -187,6 +187,9 @@
   id: RMCUniformTSE
 
 - type: Tag
+  id: RMCUniformFreelancer
+
+- type: Tag
   id: RMCXenoParasitePreparingLeap
 
 - type: Tag


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Freelancer armor pieces now have a check for uniforms tagged as freelancer.
Freelancer armor pieces have been reparented to a generic plate carrier, which is parented to `RMCArmorVest`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Faction armor should be restricted to faction uniforms.
Maintainability, make the parenting and inheritance slightly less evil.

## Technical details
<!-- Summary of code changes for easier review. -->
Added locale for armor requirement.
Added a requirement for RMCUniformFreelancer tag to the freelancer armor pieces.
Added the RMCUniformFreelancer tag to the freelancer uniform and variants.
Replaced all mentions of the old freelancer armor with the new freelancer armor.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
Small fix
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Freelancer armor now requires a freelancer uniform to wear
