### PR TITLE
tweak: make small hosts visible though walls for xenos

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/NPCs/simplemob.yml
@@ -302,6 +302,7 @@
   - type: NpcFactionMember
     factions:
       - Passive
+  - type: RMCNightVisionVisible
 #  - type: HTN
 #    rootTask:
 #      task: SimpleHostileCompound


### PR DESCRIPTION
## About the PR

title

## Why / Balance

iirc the old monkey where visible thought walls

## Technical details

Added the RMCNightVisionVisible to the base.

## Media

<img width="950" height="838" alt="Screenshot From 2026-07-07 00-17-08" src="https://github.com/user-attachments/assets/62f84a9e-7d90-456c-9e7d-217287180b0b" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- tweak: Xenos can now see small hosts with their nightvision.
