### PR TITLE
Add xeno last stand system

### DIFF
--- a/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.RoundEnd.cs
+++ b/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.RoundEnd.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Content.Server.GameTicking;
 using Content.Server.Ghost.Roles.Components;
 using Content.Shared._RMC14.Armor.Ghillie;
@@ -11,6 +11,7 @@ using Content.Shared._RMC14.Rules;
 using Content.Shared._RMC14.Thunderdome;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared._RMC14.Xenonids.Evolution;
+using Content.Shared._RMC14.Xenonids.LastStand;
 using Content.Shared._RMC14.Xenonids.Parasite;
 using Content.Shared.CCVar;
 using Content.Shared.GameTicking;
@@ -26,6 +27,8 @@ namespace Content.Server._RMC14.Rules.DistressSignal;
 public sealed partial class CMDistressSignalRuleSystem
 {
     private const int LastMarineEquipmentCooldownHours = 2;
+
+    private const int XenoLastStandMinNumber = 1;
 
     /// <summary>
     /// Performs all round end condition checks including hijack status, faction live counts,
@@ -60,6 +63,7 @@ public sealed partial class CMDistressSignalRuleSystem
 
         ApplyLastMarineEffects(time);
         CheckQueenDeath(distress);
+        CheckLastXenoAlive();
     }
 
     private void UpdateHijackState(CMDistressSignalRuleComponent distress)
@@ -424,6 +428,27 @@ public sealed partial class CMDistressSignalRuleSystem
             _chatManager.SendAdminAnnouncement(msg);
             _chatManager.DispatchServerAnnouncement(msg);
             ev.Cancel();
+        }
+    }
+
+    private void CheckLastXenoAlive()
+    {
+        //TODO RMC14 check main hive only
+        var xenoCount = _xenoEvolution.GetLiving<XenoComponent>(x => x.Comp.CountedInSlots);
+
+        if (xenoCount > XenoLastStandMinNumber)
+            return;
+
+        var xenos = EntityQueryEnumerator<ActorComponent, XenoLastStandableComponent, MobStateComponent, TransformComponent>();
+        while (xenos.MoveNext(out var xenoId, out _, out var xeno, out var mobState, out var xform))
+        {
+            if (HasComp<ThunderdomeMapComponent>(xform.MapUid))
+                continue;
+
+            if (_mobState.IsDead(xenoId))
+                continue;
+
+            EnsureComp<XenoLastStandComponent>(xenoId);
         }
     }
 }

--- a/Content.Shared/_RMC14/Xenonids/Flurry/XenoFlurrySystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Flurry/XenoFlurrySystem.cs
@@ -103,8 +103,11 @@ public sealed class XenoFlurrySystem : EntitySystem
             SpawnAttachedTo(xeno.Comp.AttackEffect, victim.ToCoordinates());
             _audio.PlayEntity(xeno.Comp.SlashSound, xeno, victim);
 
-            SpawnAttachedTo(xeno.Comp.HealEffect, xeno.Owner.ToCoordinates());
-            _xenoHeal.CreateHealStacks(xeno, xeno.Comp.HealAmount, xeno.Comp.HealDelay, xeno.Comp.HealCharges, xeno.Comp.HealDelay);
+            if (_xeno.CanHeal(xeno))
+            {
+                SpawnAttachedTo(xeno.Comp.HealEffect, xeno.Owner.ToCoordinates());
+                _xenoHeal.CreateHealStacks(xeno, xeno.Comp.HealAmount, xeno.Comp.HealDelay, xeno.Comp.HealCharges, xeno.Comp.HealDelay);
+            }
 
             if (xeno.Comp.MaxTargets != null && hits >= xeno.Comp.MaxTargets)
                 break;

--- a/Content.Shared/_RMC14/Xenonids/Fury/XenoFurySystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Fury/XenoFurySystem.cs
@@ -61,8 +61,7 @@ public sealed partial class XenoFurySystem : EntitySystem
             if (!_hive.FromSameHive(xeno.Owner, otherXeno.Owner))
                 continue;
 
-            var toHeal = -_rmcDamageable.DistributeTypesTotal(otherXeno.Owner, healAmount);
-            _damageable.TryChangeDamage(otherXeno.Owner, toHeal, origin: xeno, tool: xeno);
+            _xeno.HealDamage(otherXeno.Owner, healAmount);
 
             if (_net.IsServer)
                 SpawnAttachedTo(xeno.Comp.Effect, otherXeno.Owner.ToCoordinates());

--- a/Content.Shared/_RMC14/Xenonids/Headbite/XenoHeadbiteSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Headbite/XenoHeadbiteSystem.cs
@@ -34,6 +34,7 @@ public sealed class XenoHeadbiteSystem : EntitySystem
     [Dependency] private readonly SharedJitteringSystem _jitter = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly StatusEffectsSystem _status = default!;
+    [Dependency] private readonly XenoSystem _xeno = default!;
 
     private static readonly ProtoId<StatusEffectPrototype> Unconsciousness = "Unconscious";
 
@@ -83,7 +84,8 @@ public sealed class XenoHeadbiteSystem : EntitySystem
 
         if (_net.IsServer)
         {
-            SpawnAttachedTo(xeno.Comp.HealEffect, xeno.Owner.ToCoordinates());
+            if (_xeno.CanHeal(xeno))
+                SpawnAttachedTo(xeno.Comp.HealEffect, xeno.Owner.ToCoordinates());
             SpawnAttachedTo(xeno.Comp.HeadbiteEffect, target.ToCoordinates());
             _emote.TryEmoteWithChat(xeno, xeno.Comp.Emote, cooldown: xeno.Comp.EmoteCooldown);
             _audio.PlayPvs(xeno.Comp.HitSound, xeno);

--- a/Content.Shared/_RMC14/Xenonids/Heal/SharedXenoHealSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Heal/SharedXenoHealSystem.cs
@@ -55,6 +55,7 @@ public abstract class SharedXenoHealSystem : EntitySystem
     [Dependency] private readonly SharedXenoAnnounceSystem _xenoAnnounce = default!;
     [Dependency] private readonly XenoStrainSystem _xenoStrain = default!;
     [Dependency] private readonly StatusEffectsSystem _status = default!;
+    [Dependency] private readonly XenoSystem _xeno = default!;
 
     private static readonly ProtoId<DamageGroupPrototype> BruteGroup = "Brute";
     private static readonly ProtoId<DamageGroupPrototype> BurnGroup = "Burn";
@@ -360,6 +361,9 @@ public abstract class SharedXenoHealSystem : EntitySystem
 
     public void Heal(EntityUid target, FixedPoint2 amount)
     {
+        if (!_xeno.CanHeal(target))
+            return;
+
         var damage = _rmcDamageable.DistributeDamageCached(target, BruteGroup, amount);
         var totalHeal = damage.GetTotal();
         var leftover = amount - totalHeal;

--- a/Content.Shared/_RMC14/Xenonids/LastStand/XenoLastStandComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/LastStand/XenoLastStandComponent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.LastStand;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class XenoLastStandComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public bool CallToArmsDone = false;
+}

--- a/Content.Shared/_RMC14/Xenonids/LastStand/XenoLastStandSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/LastStand/XenoLastStandSystem.cs
@@ -1,0 +1,54 @@
+using Content.Shared._RMC14.Xenonids.Egg;
+using Content.Shared._RMC14.Xenonids.Evolution;
+using Content.Shared.Popups;
+using Content.Shared.Rejuvenate;
+using Robust.Shared.Network;
+
+namespace Content.Shared._RMC14.Xenonids.LastStand;
+
+public sealed partial class XenoLastStandSystem : EntitySystem
+{
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly INetManager _net = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<XenoLastStandableComponent, NewXenoEvolvedEvent>(OnXenoEvolved);
+        SubscribeLocalEvent<XenoLastStandableComponent, XenoDevolvedEvent>(OnXenoDevolved);
+
+        SubscribeLocalEvent<XenoLastStandComponent, ComponentStartup>(OnXenoLastStandAdded);
+        SubscribeLocalEvent<XenoLastStandComponent, XenoHealAttemptEvent>(OnXenoHealAttempt);
+    }
+
+    private void OnXenoHealAttempt(Entity<XenoLastStandComponent> xeno, ref XenoHealAttemptEvent args)
+    {
+        if (!HasComp<XenoEvolutionGranterComponent>(xeno))
+            args.Cancelled = true;
+    }
+
+    private void OnXenoEvolved(Entity<XenoLastStandableComponent> xeno, ref NewXenoEvolvedEvent args)
+    {
+        if (TryComp<XenoLastStandComponent>(args.OldXeno, out var comp))
+            CopyComp(xeno, args.NewXeno, comp);
+    }
+
+    private void OnXenoDevolved(Entity<XenoLastStandableComponent> xeno, ref XenoDevolvedEvent args)
+    {
+        if (TryComp<XenoLastStandComponent>(args.OldXeno, out var comp))
+            CopyComp(args.OldXeno, args.NewXeno, comp);
+    }
+
+    private void OnXenoLastStandAdded(Entity<XenoLastStandComponent> xeno, ref ComponentStartup args)
+    {
+        if (!xeno.Comp.CallToArmsDone && _net.IsServer)
+        {
+            _popup.PopupEntity(Loc.GetString("rmc-xeno-last-stand"), xeno, xeno, PopupType.MediumXeno);
+            xeno.Comp.CallToArmsDone = true;
+            Dirty(xeno);
+        }
+
+        RaiseLocalEvent(xeno, new RejuvenateEvent());
+    }
+}

--- a/Content.Shared/_RMC14/Xenonids/LastStand/XenoLastStandableComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/LastStand/XenoLastStandableComponent.cs
@@ -1,0 +1,6 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.LastStand;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class XenoLastStandableComponent : Component;

--- a/Content.Shared/_RMC14/Xenonids/Soak/XenoSoakSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Soak/XenoSoakSystem.cs
@@ -1,6 +1,7 @@
 using Content.Shared._RMC14.Actions;
 using Content.Shared._RMC14.Aura;
 using Content.Shared._RMC14.Damage;
+using Content.Shared._RMC14.Xenonids.Heal;
 using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared._RMC14.Xenonids.Stab;
 using Content.Shared.Actions;
@@ -23,6 +24,7 @@ public sealed class XenoSoakSystem : EntitySystem
     [Dependency] private readonly DamageableSystem _damage = default!;
     [Dependency] private readonly SharedRMCActionsSystem _rmcActions = default!;
     [Dependency] private readonly SharedRMCDamageableSystem _rmcDamageable = default!;
+    [Dependency] private readonly SharedXenoHealSystem _heal = default!;
 
     public override void Initialize()
     {
@@ -60,8 +62,7 @@ public sealed class XenoSoakSystem : EntitySystem
         if (xeno.Comp.DamageAccumulated < xeno.Comp.DamageGoal)
             return;
 
-        var amount = -_rmcDamageable.DistributeTypesTotal(xeno.Owner, xeno.Comp.Heal);
-        _damage.TryChangeDamage(xeno, amount, origin: xeno, tool: xeno);
+        _heal.Heal(xeno, xeno.Comp.Heal);
 
         foreach (var action in _rmcActions.GetActionsWithEvent<XenoTailStabEvent>(xeno))
         {

--- a/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
@@ -462,7 +462,7 @@ public sealed partial class XenoSystem : EntitySystem
 
     public void HealDamage(Entity<DamageableComponent?> xeno, FixedPoint2 amount)
     {
-        if (_rmcFlammable.IsOnFire(xeno.Owner))
+        if (!CanHeal(xeno))
             return;
 
         if (!_damageableQuery.Resolve(xeno, ref xeno.Comp, false) ||

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-last-stand.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-last-stand.ftl
@@ -1,0 +1,1 @@
+rmc-xeno-last-stand = Our carapace rattles with RAGE. We are all that remains of the hive! Go out fighting, KILL THEM ALL!

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
@@ -374,6 +374,7 @@
   - type: RMCMesonsNonviewable
     xenoVisible: true
   - type: CanBeLarvaQueued
+  - type: XenoLastStandable
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/parasite.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/parasite.yml
@@ -153,6 +153,7 @@
     components:
     - type: ComplexInteraction
     - type: CanBeLarvaQueued
+    - type: XenoLastStandable
 
 - type: entity
   parent: CMXenoParasiteBase


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
parity.

## Technical details
<!-- Summary of code changes for easier review. -->
If round doesn't end distress signal will check for min alive xenos (currently, 1) that count for slots, and if they're under that all get a new comp (if they have laststandable).

This new comp shows a popup, rejuvenates, and prevents ANY further heals from the rest of the xeno systems, for the most part.
I tried to catch everything that still didn't use CanHeal, and cleaned up some other code that was using it's own healing stuff. Some of these still show particles even without healing taking place - this can be cleaned up later.

This comp persists through evos. I haven't tested if it actually works in the game rule, but it *should*.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->


https://github.com/user-attachments/assets/18d3ae97-76b6-4b6e-9a4a-f3e35993dabf


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added Xeno Last Stand. When there is one xeno left they get told this, fully healed, and can no longer heal from any sources, unless they're a queen.
