### PR TITLE
Add the same specialization kits that SOs and the XO get to the CO's equipment vendor.

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/command.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/command.yml
@@ -468,6 +468,11 @@
       - id: CMArmorHelmetM11CCO
       - id: RMCHandsDeluxeMarine
       - id: CMBootsBlackFilled
+    - name: Specialisation Kit
+      takeOne: CMBundle
+      entries:
+      - id: CMVendorBundleCombatTechnicianEssentials
+      - id: CMVendorBundleSquadMedicalEssentials
     - name: Accessories
       choices: { CMAccessories: 1 }
       entries:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Title.

## Why / Balance
The XO, and even SOs, get this option. And it is great to have.
Wether it be hijack or deployment, being able to quickly get either kit can be important, but even if not, it is just a general quality of life which, for some reason, is given to the XO and SOs, but not the CO.

Furthermore, I would argue that a CO is MORE likely to need this then an XO, since CO can often be late joined, including in situations where they then need to act very quickly, such as with 30 seconds remaining before a dropship hits the almayer.

I know this is not parity, but I see no reason for a CO to not get this if the XO/SO's do.

## Technical details
I shamelessly copied #6777 (Which got closed as the person who opened that left RMC.), and yes I tested that it still works.

## Media
<img width="502" height="707" alt="image" src="https://github.com/user-attachments/assets/bb19aa99-f6de-46f9-9326-cfded595acc6" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl: Arcticular1, BramvanZijp
- add: Added the medical & engineering specialization kits that XOs & SOs get to the CO's equipment vendor.