### PR TITLE
Fix needing LOS for spray acid + fix pierce overlay

### DIFF
--- a/Content.Client/_RMC14/Xenonids/Targeting/XenoAbilityPreviewOverlay.cs
+++ b/Content.Client/_RMC14/Xenonids/Targeting/XenoAbilityPreviewOverlay.cs
@@ -364,7 +364,7 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
             mousePos = originMap.Offset(direction.Normalized() * (int)pierce.Range);
 
         var color = PierceOutlineColor.WithAlpha(OutlineAlpha);
-        DrawLinePreview(args, player, xform.Coordinates, mousePos, (int)pierce.Range, color);
+        DrawLinePreview(args, player, xform.Coordinates, mousePos, (int)pierce.Range, color, ignoreCades: true);
     }
 
     private void DrawBombard(
@@ -528,10 +528,11 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
         EntityCoordinates fromCoordinates,
         MapCoordinates target,
         float range,
-        Color color)
+        Color color,
+        bool ignoreCades = false)
     {
         var toCoordinates = _transform.ToCoordinates(player, target);
-        var tiles = _line.DrawLine(fromCoordinates, toCoordinates, TimeSpan.Zero, range, out var blocker, hitBlocker: true);
+        var tiles = _line.DrawLine(fromCoordinates, toCoordinates, TimeSpan.Zero, range, out var blocker, hitBlocker: true, ignoreBarricades: ignoreCades);
         if (tiles.Count == 0)
             return;
 

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
@@ -487,6 +487,7 @@
     useDelay: 8
   - type: TargetAction
     range: 15
+    checkCanAccess: false
   - type: WorldTargetAction
     event: !type:XenoSprayAcidActionEvent
   - type: ActionBlockIfResting
@@ -613,6 +614,7 @@
     useDelay: 12
   - type: TargetAction
     range: 15
+    checkCanAccess: false
   - type: EntityTargetAction
   - type: WorldTargetAction
     event: !type:XenoBoneChipsActionEvent


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
QoL and bug.

## Technical details
<!-- Summary of code changes for easier review. -->
YML. Spray acid and bone chips don't need LOS no more. Pierce preview now will correctly assume the ability goes over cades.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed spray acid and bone chips needing LOS to use on a tile.
- fix: Fixed pierce preview showing it'd be blocked by cades.
