### PR TITLE
fix: do not count synths as marines in the end round check

### DIFF
--- a/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.RoundEnd.cs
+++ b/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.RoundEnd.cs
@@ -8,6 +8,7 @@ using Content.Shared._RMC14.Dropship;
 using Content.Shared._RMC14.Light;
 using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.Rules;
+using Content.Shared._RMC14.Synth;
 using Content.Shared._RMC14.Thunderdome;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared._RMC14.Xenonids.Evolution;
@@ -126,6 +127,9 @@ public sealed partial class CMDistressSignalRuleSystem
             {
                 continue;
             }
+
+            if (HasComp<SynthComponent>(marineId))
+                continue;
 
             if (_containers.IsEntityInContainer(marineId))
                 continue;


### PR DESCRIPTION
## About the PR

Title. See round number 13095 that only ended after the synth podded out.

## Why / Balance

Xenos can choose to ignore synths.

## Technical details

check if comp

## Media

Nah

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- fix: Living synthetics on the warship no longer prevent the round from ending.
