### PR TITLE
[Fix] Synth Fixes - Skill, Health, Examine and Repair

### DIFF
--- a/Content.Shared/_RMC14/Medical/Examine/RMCMedicalExamineSystem.cs
+++ b/Content.Shared/_RMC14/Medical/Examine/RMCMedicalExamineSystem.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Shared._RMC14.Medical.Unrevivable;
 using Content.Shared._RMC14.Stun;
+using Content.Shared._RMC14.Synth;
 using Content.Shared.Body.Components;
 using Content.Shared.Examine;
 using Content.Shared.Mobs.Systems;
@@ -14,6 +15,7 @@ public sealed class RMCMedicalExamineSystem : EntitySystem
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly RMCSizeStunSystem _sizeStun = default!;
     [Dependency] private readonly RMCUnrevivableSystem _unrevivable = default!;
+    [Dependency] private readonly SharedSynthSystem _synth = default!;
 
     public override void Initialize()
     {
@@ -50,7 +52,12 @@ public sealed class RMCMedicalExamineSystem : EntitySystem
         LocId? stateText = null;
 
         if (_mobState.IsDead(ent))
-            stateText = _unrevivable.IsUnrevivable(ent) ? ent.Comp.UnrevivableText : ent.Comp.DeadText;
+        {
+            if (HasComp<SynthComponent>(ent) && _synth.TryGetDeadExamineText(ent.Owner, out var synthText))
+                stateText = synthText;
+            else
+                stateText = _unrevivable.IsUnrevivable(ent) ? ent.Comp.UnrevivableText : ent.Comp.DeadText;
+        }
         else if (_mobState.IsCritical(ent) || _sizeStun.IsKnockedOut(ent))
             stateText = ent.Comp.CritText;
 

--- a/Content.Shared/_RMC14/Synth/SharedSynthGenerationSystem.cs
+++ b/Content.Shared/_RMC14/Synth/SharedSynthGenerationSystem.cs
@@ -117,19 +117,19 @@ public sealed class SharedSynthGenerationSystem : EntitySystem
             return;
 
         var options = new List<DialogOption>();
-        HashSet<EntProtoId<SynthGenerationComponent>> synthTypes = [];
+        var synthTypes = new List<(EntityPrototype Proto, int Priority)>();
 
         foreach (var proto in _prototype.EnumeratePrototypes<EntityPrototype>())
         {
-            if (proto.HasComponent<SynthGenerationComponent>())
-                synthTypes.Add(proto.ID);
+            if (proto.TryGetComponent(out SynthGenerationComponent? gen, _compFactory))
+                synthTypes.Add((proto, gen.Priority));
         }
 
-        foreach (var synth in synthTypes)
+        synthTypes.Sort((a, b) => a.Priority.CompareTo(b.Priority));
+
+        foreach (var (proto, _) in synthTypes)
         {
-            if (!_prototype.TryIndex(synth, out var proto))
-                continue;
-            options.Add(new DialogOption($"{proto.Name}", new GenerationSelectedActionEvent(synth)));
+            options.Add(new DialogOption($"{proto.Name}", new GenerationSelectedActionEvent(proto.ID)));
         }
 
         _dialog.OpenOptions(ent.Owner, "Select a Generation", options, "Available Generations");

--- a/Content.Shared/_RMC14/Synth/SharedSynthSystem.cs
+++ b/Content.Shared/_RMC14/Synth/SharedSynthSystem.cs
@@ -12,6 +12,7 @@ using Content.Shared.DoAfter;
 using Content.Shared.FixedPoint;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
+using Content.Shared.Medical;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
@@ -41,6 +42,7 @@ public abstract class SharedSynthSystem : EntitySystem
     [Dependency] private readonly SharedStackSystem _stack = default!;
     [Dependency] private readonly RMCStatusEffectSystem _rmcStatusEffects = default!;
     [Dependency] private readonly MobThresholdSystem _mobThreshold = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
     [Dependency] private readonly SharedSynthGenerationSystem _synthGeneration = default!;
     [Dependency] private readonly INetManager _net = default!;
@@ -56,6 +58,7 @@ public abstract class SharedSynthSystem : EntitySystem
         SubscribeLocalEvent<SynthComponent, TryingToSleepEvent>(OnSleepAttempt);
         SubscribeLocalEvent<SynthComponent, InteractUsingEvent>(OnSynthInteractUsing);
         SubscribeLocalEvent<SynthComponent, RMCSynthRepairEvent>(OnSynthRepairDoAfter);
+        SubscribeLocalEvent<SynthComponent, TargetDefibrillatedEvent>(OnSynthResetKey);
 
         SubscribeLocalEvent<UseOnSynthBlockedComponent, BeforeRangedInteractEvent>(OnSynthBlockedBeforeRangedInteract);
     }
@@ -223,20 +226,25 @@ public abstract class SharedSynthSystem : EntitySystem
         {
             if (synth.Comp.WelderDamageToRepair != null)
                 _damageable.TryChangeDamage(synth, synth.Comp.WelderDamageToRepair, true, false, origin: user);
-
-            var selfMsg = Loc.GetString("rmc-synth-repair-brute-finish-self", ("user", user), ("target", synth), ("tool", used), ("limb", "chest"));
-            var othersMsg = Loc.GetString("rmc-synth-repair-brute-finish", ("user", user), ("target", synth), ("tool", used), ("limb", "chest"));
-            _popup.PopupPredicted(selfMsg, othersMsg, user, user);
         }
         else if (HasComp<RMCCableCoilComponent>(args.Used) && _stack.Use(args.Used.Value, 1))
         {
             if (synth.Comp.CableCoilDamageToRepair != null)
                 _damageable.TryChangeDamage(synth, synth.Comp.CableCoilDamageToRepair, true, false, origin: args.User);
-
-            var selfMsg = Loc.GetString("rmc-synth-repair-burn-finish-self", ("user", user), ("target", synth), ("tool", used), ("limb", "chest"));
-            var othersMsg = Loc.GetString("rmc-synth-repair-burn-finish", ("user", user), ("target", synth), ("tool", used), ("limb", "chest"));
-            _popup.PopupPredicted(selfMsg, othersMsg, user, user);
         }
+    }
+
+    private void OnSynthResetKey(Entity<SynthComponent> synth, ref TargetDefibrillatedEvent args)
+    {
+        // Only refresh if the reset key actually brought the synth out of the dead state.
+        if (_mobState.IsDead(synth))
+            return;
+
+        if (!TryComp<MobThresholdsComponent>(synth, out var thresholds))
+            return;
+
+        _mobThreshold.SetAllowRevives(synth.Owner, true, thresholds);
+        _mobThreshold.SetAllowRevives(synth.Owner, false, thresholds);
     }
 
     private void OnSynthBlockedBeforeRangedInteract(Entity<UseOnSynthBlockedComponent> ent, ref BeforeRangedInteractEvent args)
@@ -285,6 +293,36 @@ public abstract class SharedSynthSystem : EntitySystem
             return false;
 
         return true;
+    }
+
+    public bool TryGetDeadExamineText(Entity<SynthComponent?> synth, out LocId text)
+    {
+        text = default;
+        if (!Resolve(synth, ref synth.Comp, false))
+            return false;
+
+        text = WillResetKeyRevive((synth, synth.Comp))
+            ? synth.Comp.SynthRebootText
+            : synth.Comp.SynthTooDamagedText;
+        return true;
+    }
+
+    public bool WillResetKeyRevive(Entity<SynthComponent> synth)
+    {
+        if (!TryComp<DamageableComponent>(synth, out var damageable))
+            return false;
+
+        if (!_mobThreshold.TryGetThresholdForState(synth, MobState.Dead, out var deadThreshold))
+            return false;
+
+        var heal = FixedPoint2.Zero;
+        foreach (var group in synth.Comp.ResetKeyHealGroups)
+        {
+            if (damageable.DamagePerGroup.TryGetValue(group, out var groupDamage))
+                heal += FixedPoint2.Min(synth.Comp.ResetKeyHealPerGroup, groupDamage);
+        }
+
+        return damageable.TotalDamage - heal < deadThreshold.Value;
     }
 
     public void DoSynthUnableToUsePopup(EntityUid synth, EntityUid tool)

--- a/Content.Shared/_RMC14/Synth/SharedSynthSystem.cs
+++ b/Content.Shared/_RMC14/Synth/SharedSynthSystem.cs
@@ -214,24 +214,38 @@ public abstract class SharedSynthSystem : EntitySystem
         if (args.Cancelled || args.Handled)
             return;
 
-        args.Handled = true;
-
         var used = args.Used;
         var user = args.User;
 
         if (used == null)
             return;
 
-        if (HasComp<BlowtorchComponent>(used) && _repairable.UseFuel(used.Value, user, 5))
+        if (HasComp<BlowtorchComponent>(used) && _repairable.UseFuel(used.Value, user, 1))
         {
             if (synth.Comp.WelderDamageToRepair != null)
                 _damageable.TryChangeDamage(synth, synth.Comp.WelderDamageToRepair, true, false, origin: user);
+
+            if (HasDamage(synth, synth.Comp.WelderDamageGroup) &&
+                _repairable.UseFuel(used.Value, user, 1, true))
+            {
+                args.Repeat = true;
+                return;
+            }
         }
-        else if (HasComp<RMCCableCoilComponent>(args.Used) && _stack.Use(args.Used.Value, 1))
+        else if (HasComp<RMCCableCoilComponent>(used) && _stack.Use(used.Value, 1))
         {
             if (synth.Comp.CableCoilDamageToRepair != null)
-                _damageable.TryChangeDamage(synth, synth.Comp.CableCoilDamageToRepair, true, false, origin: args.User);
+                _damageable.TryChangeDamage(synth, synth.Comp.CableCoilDamageToRepair, true, false, origin: user);
+
+            if (HasDamage(synth, synth.Comp.CableCoilDamageGroup) &&
+                HasComp<RMCCableCoilComponent>(used))
+            {
+                args.Repeat = true;
+                return;
+            }
         }
+
+        args.Handled = true;
     }
 
     private void OnSynthResetKey(Entity<SynthComponent> synth, ref TargetDefibrillatedEvent args)

--- a/Content.Shared/_RMC14/Synth/SynthComponent.cs
+++ b/Content.Shared/_RMC14/Synth/SynthComponent.cs
@@ -74,13 +74,13 @@ public sealed partial class SynthComponent : Component
     /// The time it takes to repair the synth.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public TimeSpan RepairTime = TimeSpan.FromSeconds(0);
+    public TimeSpan RepairTime = TimeSpan.FromSeconds(0.5);
 
     /// <summary>
     /// The time it takes to repair the synth, if you are the synth.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public TimeSpan SelfRepairTime = TimeSpan.FromSeconds(30);
+    public TimeSpan SelfRepairTime = TimeSpan.FromSeconds(3);
 
     [DataField, AutoNetworkedField]
     public FixedPoint2 CritThreshold = FixedPoint2.New(199);
@@ -117,6 +117,18 @@ public sealed partial class SynthComponent : Component
 
     [DataField, AutoNetworkedField]
     public ProtoId<DamageGroupPrototype> CableCoilDamageGroup = "Burn";
+
+    [DataField, AutoNetworkedField]
+    public LocId SynthRebootText = "rmc-species-synth-reset-key-needed";
+
+    [DataField, AutoNetworkedField]
+    public LocId SynthTooDamagedText = "rmc-species-synth-reset-key-too-damaged";
+
+    [DataField, AutoNetworkedField]
+    public List<ProtoId<DamageGroupPrototype>> ResetKeyHealGroups = new() { "Brute", "Burn" };
+
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 ResetKeyHealPerGroup = 12;
 
     [DataField, AutoNetworkedField]
     public string DamageVisualsColor = "#EEEEEE";

--- a/Content.Shared/_RMC14/Synth/SynthGenerationComponent.cs
+++ b/Content.Shared/_RMC14/Synth/SynthGenerationComponent.cs
@@ -21,4 +21,7 @@ public sealed partial class SynthGenerationComponent : Component
 
     [DataField]
     public ProtoId<DamageModifierSetPrototype>? DamageModifier;
+
+    [DataField]
+    public int Priority;
 }

--- a/Resources/Locale/en-US/_RMC14/species/synth.ftl
+++ b/Resources/Locale/en-US/_RMC14/species/synth.ftl
@@ -5,6 +5,9 @@ rmc-species-synth-programming-prevents-use = Your programming prevents you from 
 rmc-species-synth-defib-attempt = You can't defibrilate {$target}. You need a synthetic reset key for reboot!
 rmc-species-synth-reset-key-invalid = You can't use the reset key on them, they aren't a synth!
 
+rmc-species-synth-reset-key-needed = [color=yellow]A synthetic reset key is needed to get { OBJECT($victim) } functioning.[/color]
+rmc-species-synth-reset-key-too-damaged = [color=red]{ CAPITALIZE(SUBJECT($victim)) } { CONJUGATE-BE($victim) } too damaged to use a reset key on.[/color]
+
 rmc-synth-repair-brute-start-others = {THE($user)} begins fixing some dents on {THE($target)}'s {$limb}.
 rmc-synth-repair-brute-start-self = You begin to carefully patch some dents on your {$limb} so as not to void your warranty.
 rmc-synth-repair-brute-start-target-self = You begin fixing some dents on {THE($target)}'s {$limb}.

--- a/Resources/Locale/en-US/_RMC14/species/synth.ftl
+++ b/Resources/Locale/en-US/_RMC14/species/synth.ftl
@@ -5,8 +5,8 @@ rmc-species-synth-programming-prevents-use = Your programming prevents you from 
 rmc-species-synth-defib-attempt = You can't defibrilate {$target}. You need a synthetic reset key for reboot!
 rmc-species-synth-reset-key-invalid = You can't use the reset key on them, they aren't a synth!
 
-rmc-species-synth-reset-key-needed = [color=yellow]A synthetic reset key is needed to get { OBJECT($victim) } functioning.[/color]
-rmc-species-synth-reset-key-too-damaged = [color=red]{ CAPITALIZE(SUBJECT($victim)) } { CONJUGATE-BE($victim) } too damaged to use a reset key on.[/color]
+rmc-species-synth-reset-key-needed = [color=ForestGreen]Use a synthetic reset key to get { OBJECT($victim) } functioning.[/color]
+rmc-species-synth-reset-key-too-damaged = [color=FireBrick]{ CAPITALIZE(SUBJECT($victim)) } { CONJUGATE-BE($victim) } too damaged to use a reset key on.[/color]
 
 rmc-synth-repair-brute-start-others = {THE($user)} begins fixing some dents on {THE($target)}'s {$limb}.
 rmc-synth-repair-brute-start-self = You begin to carefully patch some dents on your {$limb} so as not to void your warranty.

--- a/Resources/Prototypes/_RMC14/Synthetic/synth_generations.yml
+++ b/Resources/Prototypes/_RMC14/Synthetic/synth_generations.yml
@@ -5,6 +5,7 @@
   - type: SynthGeneration
     generation: RMCSynthGenOne
     damageModifier: RMCSynthGenOne
+    priority: 1
   - type: Skills
     skills:
       RMCSkillCqc: 3
@@ -48,6 +49,7 @@
   - type: SynthGeneration
     generation: RMCSynthGenTwo
     damageModifier: RMCSynthGenTwo
+    priority: 2
   - type: Skills
     skills:
       RMCSkillCqc: 3
@@ -84,6 +86,7 @@
   components:
   - type: SynthGeneration
     generation: RMCSynthGenThree
+    priority: 3
   - type: Skills
     skills:
       RMCSkillCqc: 5

--- a/Resources/Prototypes/_RMC14/Synthetic/synth_generations.yml
+++ b/Resources/Prototypes/_RMC14/Synthetic/synth_generations.yml
@@ -30,7 +30,6 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      399: Critical
       400: Dead
   - type: MovementSpeedModifier
     baseSprintSpeed: 3.625
@@ -68,6 +67,10 @@
       RMCSkillJtac: 1
       RMCSkillIntel: 1
       RMCSkillDomestics: 2
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      400: Dead
   - type: ShowHealthIcons
   - type: ShowHealthBars
   - type: RMCAllowSuitStorage
@@ -84,7 +87,6 @@
   - type: Skills
     skills:
       RMCSkillCqc: 5
-      RMCSkillEndurance: 1
       RMCSkillEngineer: 4
       RMCSkillConstruction: 3
       RMCSkillFirearms: 2
@@ -102,6 +104,10 @@
       RMCSkillIntel: 2
       RMCSkillDomestics: 2
       RMCSkillNavigations: 1
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      350: Dead
   - type: ShowHealthIcons
   - type: ShowHealthBars
   - type: RMCAllowSuitStorage


### PR DESCRIPTION
## About the PR

- Removed accidental Endurance 1 on Gen 3s
- Gave Gen 2s and 3s their robust health.
- Fixed Synth self repair taking 30 seconds. ( its meant to be 3 secondsbut CM code uses deciseconds which showed as 30)
- Replaced the dead examine text on Synths to show when a Reset key will work.
- Fixed redundant double popups when repairing.
- Fixed the order of the Generations in the menu.

## Why / Balance
Fixes

## Technical details
New branch on the Dead examine.
Yaml fixes and component tweaks.

## Media
<img width="866" height="637" alt="image" src="https://github.com/user-attachments/assets/e07730f0-f638-49f0-90c3-4aee7066d921" />
<img width="707" height="620" alt="image" src="https://github.com/user-attachments/assets/7986bd72-6ec2-4f74-8b30-6d6d62a6542d" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: New dead examine text for Synths so you know when a Synthetic Reset key will work, instead of silently consuming the charge.
- fix: Fixed Gen 2 & 3 synths not having their proper health
- fix: Fixed Synth self repair taking too long (30s to 3s).

