### PR TITLE
Fixed the muzzle flash effect sometimes looping

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -3,14 +3,14 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: TimedDespawn
-    lifetime: 0.3
+    lifetime: 0.3 # RMC
   - type: Sprite
     drawdepth: BelowMobs
-    offset: 0.33, 0
+    offset: 0.33, 0 # RMC
     layers:
     - shader: unshaded
       map: ["enum.EffectLayers.Unshaded"]
-      sprite: _RMC14/Objects/Weapons/Guns/Projectiles/projectiles.rsi
+      sprite: _RMC14/Objects/Weapons/Guns/Projectiles/projectiles.rsi # RMC (obviously)
       state: muzzle_bullet_high_RMC
   - type: EffectVisuals
   - type: Tag
@@ -733,6 +733,7 @@
   - type: AnomalousParticle
     particleType: Sigma
 
+# Launcher projectiles (grenade / rocket)
 - type: entity
   id: BulletRocket
   name: rocket

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -3,7 +3,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: TimedDespawn
-    lifetime: 1.0
+    lifetime: 0.3
   - type: Sprite
     drawdepth: BelowMobs
     offset: 0.33, 0


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Shortens the lifetime of the muzzle flash effect in order to prevent it from sometimes looping. (See media for details)

The new lifetime value *is* shorter than the theoretical length of the animation ([0.06 * 6](https://github.com/RMC-14/RMC-14/blob/72742ed9b18def419d04e8aec47894da64633994/Resources/Textures/_RMC14/Objects/Weapons/Guns/Projectiles/projectiles.rsi/meta.json#L25-L34) = 0.36), but setting it to that value still causes the animation to loop for whatever reason. Maybe a floating point thing since they're such small numbers?

## Why / Balance
This isn't a particularly massive issue of course but I do notice it occasionally, so worth fixing. :)

## Media
### Before:
(First two shots are fine, next three show the bug)
<img width="287" height="287" alt="Before" src="https://github.com/user-attachments/assets/9b0fe1a9-6593-4dd4-9c42-adfe42f3873f" />

<hr>

#### Frame-by-frame:
<img width="861" height="574" alt="Frames" src="https://github.com/user-attachments/assets/93037659-bf35-41ba-9f0d-c7b70d2eca1d" />

### After:
<img width="288" height="287" alt="After" src="https://github.com/user-attachments/assets/f002e646-345e-4f56-95d7-6cc48f163a12" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed the muzzle flash effect sometimes looping back to the start on the last frame.