### PR TITLE
Fix Loadout Points

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -1161,6 +1161,10 @@ namespace Content.Client.Lobby.UI
                                 loadout = new RoleLoadout(roleLoadoutProto.ID);
                                 loadout.SetDefault(Profile, _playerManager.LocalSession, _prototypeManager);
                             }
+                            else
+                            {
+                                loadout.RecalculatePoints(_prototypeManager); // RMC14 Loadout Fix
+                            }
 
                             OpenLoadout(job, loadout, roleLoadoutProto);
                         };

--- a/Content.Shared/Preferences/Loadouts/Effects/PointsCostLoadoutEffect.cs
+++ b/Content.Shared/Preferences/Loadouts/Effects/PointsCostLoadoutEffect.cs
@@ -25,7 +25,7 @@ public sealed partial class PointsCostLoadoutEffect : LoadoutEffect
             return true;
         }
 
-        if (loadout.Points <= Cost)
+        if (loadout.Points < Cost) // RMC14 Loadout Fix
         {
             reason = FormattedMessage.FromUnformatted("loadout-group-points-insufficient");
             return false;

--- a/Content.Shared/Preferences/Loadouts/RoleLoadout.cs
+++ b/Content.Shared/Preferences/Loadouts/RoleLoadout.cs
@@ -193,6 +193,8 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
         {
             SelectedLoadouts.Remove(value);
         }
+
+        RecalculatePoints(protoManager); // RMC14 Loadout Fix
     }
 
     private void Apply(LoadoutPrototype loadoutProto)
@@ -205,6 +207,33 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
         if (loadoutProto.Cost != null && Points != null)
             Points -= loadoutProto.Cost;
     }
+
+    // RMC14 Loadout Fix Start
+    public void RecalculatePoints(IPrototypeManager protoManager)
+    {
+        if (!protoManager.TryIndex(Role, out var roleProto) || roleProto.Points == null)
+        {
+            Points = null;
+            return;
+        }
+
+        var points = roleProto.Points.Value;
+
+        foreach (var (_, groupLoadouts) in SelectedLoadouts)
+        {
+            foreach (var selected in groupLoadouts)
+            {
+                if (!protoManager.TryIndex(selected.Prototype, out var loadoutProto))
+                    continue;
+
+                if (loadoutProto.Cost != null)
+                    points -= loadoutProto.Cost.Value;
+            }
+        }
+
+        Points = points;
+    }
+    // RMC14 Loadout Fix End
 
     /// <summary>
     /// Resets the selected loadouts to default if no data is present.
@@ -220,6 +249,8 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
         var collection = IoCManager.Instance!;
         var roleProto = protoManager.Index(Role);
 
+        Points = roleProto.Points; // RMC14 Loadout Fix
+
         for (var i = roleProto.Groups.Count - 1; i >= 0; i--)
         {
             var group = roleProto.Groups[i];
@@ -233,7 +264,7 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
             var loadouts = new List<Loadout>();
             SelectedLoadouts[group] = loadouts;
 
-            Points = roleProto.Points;
+            //Points = roleProto.Points; // RMC14 Loadout Fix
 
             if (groupProto.MinLimit > 0)
             {
@@ -261,6 +292,8 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
                 }
             }
         }
+
+        RecalculatePoints(protoManager); // RMC14 Loadout Fix
     }
 
     /// <summary>
@@ -340,6 +373,8 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
             Prototype = selectedLoadout,
         });
 
+        RecalculatePoints(protoManager); // RMC14 Loadout Fix
+
         return true;
     }
 
@@ -360,6 +395,7 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
                 continue;
 
             groupLoadouts.RemoveAt(i);
+            RecalculatePoints(protoManager); // RMC14 Loadout Fix
             return true;
         }
 


### PR DESCRIPTION
## About the PR
Fixes the loadout bug where selecting a bunch of items and saving would leave the loadout window with every button disabled (no select, no deselect)

## Why / Balance
`Points` never recalculated on click only on save so you could overspend in the UI, `Points` would go negative on save, and then everything looked unaffordable next time you opened the window

## Requirements
- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl: NotInButIn
- fix: Fixed the loadout window locking up after saving a character with an over-budget loadout selection.