### PR TITLE
Fix loadout equipment sometimes spawning on the floor

### DIFF
--- a/Content.Shared/Station/SharedStationSpawningSystem.cs
+++ b/Content.Shared/Station/SharedStationSpawningSystem.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.Shared._RMC14.Inventory;
 using Content.Shared._RMC14.Loadout;
 using Content.Shared._RMC14.Storage;
 using Content.Shared.Hands.Components;
@@ -25,6 +26,10 @@ public abstract class SharedStationSpawningSystem : EntitySystem
     [Dependency] private readonly MetaDataSystem _metadata = default!;
     [Dependency] private readonly SharedStorageSystem _storage = default!;
     [Dependency] private readonly SharedTransformSystem _xformSystem = default!;
+
+    //RMC14
+    [Dependency] private readonly SharedCMInventorySystem _cmInventorySystem = default!;
+    //RMC14
 
     private EntityQuery<HandsComponent> _handsQuery;
     private EntityQuery<InventoryComponent> _inventoryQuery;
@@ -135,11 +140,17 @@ public abstract class SharedStationSpawningSystem : EntitySystem
             foreach (var slot in slotDefinitions)
             {
                 var equipmentStr = startingGear.GetGear(slot.Name);
-                if (!string.IsNullOrEmpty(equipmentStr))
-                {
-                    var equipmentEntity = Spawn(equipmentStr, xform.Coordinates);
-                    InventorySystem.TryEquip(entity, equipmentEntity, slot.Name, silent: true, force: true);
-                }
+
+                //RMC14
+                if (string.IsNullOrEmpty(equipmentStr))
+                    continue;
+
+                var equipmentEntity = Spawn(equipmentStr, xform.Coordinates);
+                if (InventorySystem.TryEquip(entity, equipmentEntity, slot.Name, silent: true, force: true))
+                    continue;
+
+                _cmInventorySystem.TryStoreInBackpack(entity, equipmentEntity);
+                //RMC14
             }
         }
 

--- a/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
+++ b/Content.Shared/_RMC14/Inventory/SharedCMInventorySystem.cs
@@ -73,6 +73,8 @@ public abstract class SharedCMInventorySystem : EntitySystem
         SlotFlags.LEGS
     ];
 
+    private const string BackpackSlot = "back";
+
     private EntityQuery<RMCPickupDroppedItemsComponent> _pickupDroppedItemsQuery;
     private EntityQuery<TransformComponent> _xformQuery;
 
@@ -865,5 +867,16 @@ public abstract class SharedCMInventorySystem : EntitySystem
         {
             return system.HasComp<InventoryComponent>(user) || system.HasComp<HandsComponent>(user);
         }
+    }
+
+    public bool TryStoreInBackpack(EntityUid entity, EntityUid item)
+    {
+        if (!TryComp(entity,  out InventoryComponent? inventory) ||
+        !_inventory.TryGetSlotEntity(entity, BackpackSlot, out var backpack, inventoryComponent: inventory))
+        {
+            return false;
+        }
+
+        return _storage.Insert(backpack.Value, item, out _, playSound: false);
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Loadout equipment that fails to equip now gets inserted into an equipped backpack/satchel instead of staying on the floor.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fewer loadout items on the floor if someone selects multiple hats.
Also fixes an issue where imaginary friends with multiple loadout options for the same slot would spawn items on the floor.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix: Fixed loadout equipment sometimes spawning on the floor.
