### PR TITLE
Fix SSG-45 mag box refilling

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/ssg45.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/ssg45.yml
@@ -263,6 +263,8 @@
       map: ["enum.GunVisualLayers.Mag"]
     - state: ammo_band
       color: "#1F951F"
+  - type: RefillableByBulletBox
+    bulletType: RMCBoxBulletsRifleAP
 
 - type: entity
   parent: RMCMagazineRifleSSG45
@@ -289,6 +291,8 @@
       map: ["enum.GunVisualLayers.Mag"]
     - state: ammo_band
       color: "#9C9A19"
+  - type: RefillableByBulletBox
+    bulletType: null
 
 - type: entity
   parent: RMCMagazineRifleSSG45HEAP
@@ -322,6 +326,8 @@
       map: ["enum.GunVisualLayers.Mag"]
     - state: ammo_band
       color: "#771A10"
+  - type: RefillableByBulletBox
+    bulletType: RMCBoxBulletsRifleIncendiary
 
 - type: Tag
   id: RMCWeaponRifleSSG45


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Make the SSG mags refill from proper spam cans instead all from 10x24 normal ammo.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug fix

## Technical details
<!-- Summary of code changes for easier review. -->
Add the proper RefillableByBulletBox

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: SSG Mags refilling from proper ammo box.
