### PR TITLE
Fix acid ball behavior

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileComponent.cs
@@ -8,4 +8,10 @@ public sealed partial class XenoProjectileComponent : Component
 {
     [DataField, AutoNetworkedField]
     public bool DeleteOnFriendlyXeno;
+
+    [DataField, AutoNetworkedField]
+    public bool StopOnFriendlyXeno;
+
+    [DataField, AutoNetworkedField]
+    public bool StopOnCollide;
 }

--- a/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
@@ -26,7 +26,6 @@ using Robust.Shared.Physics.Systems;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
-using Robust.Shared.Serialization.Manager.Exceptions;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
@@ -41,7 +40,6 @@ public sealed class XenoProjectileSystem : EntitySystem
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly SharedProjectileSystem _projectile = default!;
-    [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly SharedRMCLagCompensationSystem _rmcLag = default!;
     [Dependency] private readonly CMPoweredLightSystem _rmcPoweredLight = default!;
     [Dependency] private readonly RMCPseudoRandomSystem _rmcPseudoRandom = default!;
@@ -77,6 +75,7 @@ public sealed class XenoProjectileSystem : EntitySystem
         SubscribeLocalEvent<XenoProjectileComponent, PreventCollideEvent>(OnPreventCollide);
         SubscribeLocalEvent<XenoProjectileComponent, ProjectileHitEvent>(OnProjectileHit);
         SubscribeLocalEvent<XenoProjectileComponent, CMClusterSpawnedEvent>(OnClusterSpawned);
+        SubscribeLocalEvent<XenoProjectileComponent, StartCollideEvent>(OnClusterProjectileStartCollide);
 
         UpdatesBefore.Add(typeof(SharedPhysicsSystem));
     }
@@ -351,11 +350,12 @@ public sealed class XenoProjectileSystem : EntitySystem
             return;
         }
 
-        if (ent.Comp.DeleteOnFriendlyXeno)
+        if (ent.Comp.DeleteOnFriendlyXeno || ent.Comp.StopOnFriendlyXeno)
             return;
 
         if (_hive.FromSameHive(ent.Owner, args.OtherEntity) &&
-            (HasComp<XenoComponent>(args.OtherEntity) || HasComp<HiveCoreComponent>(args.OtherEntity)))
+            (HasComp<XenoComponent>(args.OtherEntity) || HasComp<HiveCoreComponent>(args.OtherEntity)) &&
+            !HasComp<XenoConstructComponent>(args.OtherEntity))
             args.Cancelled = true;
     }
 
@@ -364,6 +364,9 @@ public sealed class XenoProjectileSystem : EntitySystem
         if (_hive.FromSameHive(ent.Owner, args.Target))
         {
             args.Handled = true;
+
+            if (!ent.Comp.DeleteOnFriendlyXeno && !HasComp<XenoConstructComponent>(args.Target) || ent.Comp.StopOnFriendlyXeno)
+                return;
 
             if (_net.IsServer || IsClientSide(ent))
                 QueueDel(ent);
@@ -391,6 +394,18 @@ public sealed class XenoProjectileSystem : EntitySystem
         {
             _hive.SetHive(spawned, hive);
         }
+    }
+
+    private void OnClusterProjectileStartCollide(Entity<XenoProjectileComponent> ent, ref StartCollideEvent args)
+    {
+        var shouldStop = _hive.FromSameHive(ent.Owner, args.OtherEntity)
+            ? ent.Comp.StopOnFriendlyXeno
+            : ent.Comp.StopOnCollide;
+
+        if (!shouldStop)
+            return;
+
+        _physics.SetLinearVelocity(ent, Vector2.Zero);
     }
 
     /// <summary>

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_projectiles.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_projectiles.yml
@@ -373,6 +373,8 @@
     accuracy: 110
   - type: ProjectileMaxRange
     max: 3
+  - type: XenoProjectile
+    deleteOnFriendlyXeno: false
 
 - type: entity
   parent: XenoAcidBallSpitProjectile
@@ -426,7 +428,7 @@
       projectile:
         shape:
           !type:PhysShapeAabb
-          bounds: "-0.1,-0.1,0.1,0.1"
+          bounds: "-0.15,-0.15,0.15,0.15"
         hard: false
         mask:
         - Impassable
@@ -435,11 +437,12 @@
       fix2:
         shape:
           !type:PhysShapeAabb
-          bounds: "-0.1,-0.1,0.1,0.1"
+          bounds: "-0.15,-0.15,0.15,0.15"
         hard: true
         mask:
         - Impassable
         - BarricadeImpassable
+        - HighImpassable
   - type: Sprite
     sprite: _RMC14/Objects/Xeno/xeno_acid_ball.rsi
     layers:
@@ -462,6 +465,9 @@
   - type: ContainerContainer
     containers:
       cluster-payload: !type:Container
+  - type: XenoProjectile
+    stopOnFriendlyXeno: true
+    stopOnCollide: true
 
 - type: entity
   parent: XenoBaseProjectile


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

- The Praetorian's acid ball projectile no longer disappears when hitting friendly xeno structures.
- The Praetorian's acid ball projectile now stops when hitting xenos or marines.
- Shooting an acid ball against a wall no longer makes all payload projectiles hit the wall.
- Acid ball payload projectiles no longer disappear when hitting friendly xenos.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug fixes.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix: Praetorian acid ball projectiles no longer disappear when hitting friendly xeno structures.
- fix: Praetorian acid ball projectiles now stop when hitting xenos or marines.
- fix: Shooting an acid ball against a wall no longer makes all payload projectiles hit the wall.
- fix: Acid ball payload projectiles no longer disappear when hitting friendly xenos.
