### PR TITLE
fix: more scuttle explosion fixes

### DIFF
--- a/Content.Server/_RMC14/Nuke/RMCNukeSystem.cs
+++ b/Content.Server/_RMC14/Nuke/RMCNukeSystem.cs
@@ -1,5 +1,4 @@
 using Content.Server._RMC14.Power;
-using Content.Shared._RMC14.Gibbing;
 using Content.Shared._RMC14.Power;
 using Content.Shared._RMC14.Repairable;
 using Content.Shared._RMC14.Sensor;
@@ -8,6 +7,7 @@ using Content.Shared._RMC14.Xenonids.Construction.Tunnel;
 using Content.Shared.Damage;
 using Content.Shared.Mobs.Components;
 using Robust.Shared.Map;
+using Robust.Shared.Timing;
 
 namespace Content.Server._RMC14.Nuke;
 
@@ -15,16 +15,17 @@ public sealed class RMCNukeSystem : EntitySystem
 {
     [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly IEntityManager _entity = default!;
-    [Dependency] private readonly RMCGibSystem _rmcGib = default!;
     [Dependency] private readonly SensorTowerSystem _sensorTower = default!;
     [Dependency] private readonly RMCPowerSystem _power = default!;
 
     private readonly DamageSpecifier _damage = new() { DamageDict = { ["Blunt"] = 1e5, ["Heat"] = 1e5 } };
+    private EntityQuery<RMCApcComponent> _apc;
     private EntityQuery<RMCRepairableComponent> _repairable;
 
     public override void Initialize()
     {
         base.Initialize();
+        _apc = GetEntityQuery<RMCApcComponent>();
         _repairable = GetEntityQuery<RMCRepairableComponent>();
     }
 
@@ -58,8 +59,6 @@ public sealed class RMCNukeSystem : EntitySystem
             AddNukeTarget(uid, toDamage, toDelete);
         }
 
-        toDelete.ExceptWith(toDamage);
-
         // Mobs and repairables go through damage so death/destruction events can run before the map cleanup.
         foreach (var uid in toDamage)
         {
@@ -68,7 +67,6 @@ public sealed class RMCNukeSystem : EntitySystem
 
         foreach (var uid in toDelete)
         {
-            _rmcGib.ScatterInventoryItems(uid);
             _entity.TryQueueDeleteEntity(uid);
         }
 
@@ -92,7 +90,7 @@ public sealed class RMCNukeSystem : EntitySystem
 
     private void AddNukeTarget(EntityUid uid, HashSet<EntityUid> toDamage, HashSet<EntityUid> toDelete)
     {
-        if (HasComp<MobStateComponent>(uid) || _repairable.HasComp(uid))
+        if (HasComp<MobStateComponent>(uid) || _repairable.HasComp(uid) || _apc.HasComp(uid))
             toDamage.Add(uid);
         else
             toDelete.Add(uid);
@@ -100,7 +98,12 @@ public sealed class RMCNukeSystem : EntitySystem
 
     public void NukeMap(MapId mapId)
     {
-        for (var i = 0; i < 3; i++)
+        KillEverythingOnMap(mapId);
+
+        // Wait a seconds for warding and other things to turn off.
+        Timer.Spawn(System.TimeSpan.FromSeconds(1), () =>
+        {
             KillEverythingOnMap(mapId);
+        });
     }
 }


### PR DESCRIPTION
## About the PR

Some more scuttle related fixes. See in technical details.

## Why / Balance

APCs getting deleted and not turning off pumps was reported on discord.

## Technical details

- Damage instead of delete APCs.
- Only run twice. With the second time running a second after the first for effects to process.

## Media

[Screencast From 2026-07-10 19-55-23.webm](https://github.com/user-attachments/assets/2c58ad11-1eb8-4356-89da-b35eeba8b842)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- fix: The scuttle explosion show now hopefully kill everyone.
- fix: The scuttle explosion now disables APCs and pumps.
