### PR TITLE
Fixes tsepa survsynth not having an icon and FORECON synth not knowing languages

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/forecon_synth.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/forecon_synth.yml
@@ -18,6 +18,8 @@
   special:
   - !type:AddComponentSpecial
     components:
+    - type: Language
+      preset: RMCLanguagePresetSynthColonist
     - type: LanguageLearning
       preset: RMCLanguageLearningPresetSynthColonist
     - type: RMCAllowSuitStorage

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Hybrisa_Prospera/Synth/tsepa.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Hybrisa_Prospera/Synth/tsepa.yml
@@ -6,6 +6,7 @@
   ranks:
     RMCRankTSEPAConstable: [ ]
   icon: "RMCJobIconTSEPASynth"
+  hasIcon: true
   special:
   - !type:AddComponentSpecial
     components:


### PR DESCRIPTION
## About the PR
TSEPA support synthetic survivor now has an icon

FORECON synth now knows all synth languages

## Why / Balance
Resolves https://github.com/RMC-14/RMC-14/issues/10438
Resolves https://github.com/RMC-14/RMC-14/issues/10322

## Technical details
One line of yaml

## Media
<img width="342" height="141" alt="obraz" src="https://github.com/user-attachments/assets/5aa50ab1-3f60-4671-9518-d43c85cf2974" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed TSEPA support synthetic survivor missing their HUD icon
- fix: Fixed FORECON synth only knowing English