### PR TITLE
Make the guidebook window resizable horizontally

### DIFF
--- a/Content.Client/Guidebook/Controls/GuidebookWindow.xaml
+++ b/Content.Client/Guidebook/Controls/GuidebookWindow.xaml
@@ -6,7 +6,7 @@
                 MinSize="100 200"
                 Resizable="True"
                 Title="{Loc 'guidebook-window-title'}">
-    <SplitContainer Orientation="Horizontal" HorizontalExpand="True" Name="Split">
+    <SplitContainer Orientation="Horizontal" HorizontalExpand="True" Name="Split" Margin="6 0">
         <!-- Guide select -->
         <BoxContainer Orientation="Horizontal" Name="TreeBox">
             <fancyTree:FancyTree Name="Tree" VerticalExpand="True" HorizontalExpand="True" Access="Public"/>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The guidebook window can now be resized horizontally by dragging its left and right edges, like any normal window.

## Why / Balance
No balance impact — pure UI/UX fix.

The guidebook window is declared `Resizable="True"` and the engine supports dragging all four edges, but the side edges are unreachable in practice: the guide tree's rows (buttons) and the scrollbar sit flush against the window borders and consume mouse clicks before the window sees them. Horizontal resizing technically works only through tiny ~7px spots next to the title bar, which is unobvious and awkward. Vertical resizing was unaffected because the title bar and the document text don't consume clicks.

## Technical details
One line in `Content.Client/Guidebook/Controls/GuidebookWindow.xaml`: `Margin="6 0"` on the root `SplitContainer`. This leaves a 6px strip along the side edges where clicks fall through to the window itself, which already handles edge resizing (`FancyWindow.GetDragModeFor`). Same approach as the Air Alarm window — the only other `FancyWindow` with working side resize.

Note for reviewers: squeezing rich-text columns very narrow can trip a pre-existing word-wrap assert in the engine on **debug** builds (`WordWrap.NextRune`), and in a rarer configuration (an inline control wider than the line at the end of a paragraph) `WordWrap.FinalizeText` can throw on any build. Both are reachable **before** this PR via the pane splitter and the title-bar-corner resize zones — they are engine (RobustToolbox) issues and not addressed here. On release builds narrow columns degrade gracefully (per-character wrapping / clipping).

## Media

https://github.com/user-attachments/assets/8de7064f-31a8-4548-b977-dbd2e70580c6

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: The guidebook window can now be resized horizontally by dragging its side edges.
