### PR TITLE
Fix completed intel objectives reappearing in the UI

### DIFF
--- a/Content.Shared/_RMC14/Intel/IntelSystem.cs
+++ b/Content.Shared/_RMC14/Intel/IntelSystem.cs
@@ -718,6 +718,9 @@ public sealed class IntelSystem : EntitySystem
 
     private bool ShowClue(EntityUid target, IntelCluesComponent clues, EntityUid user, bool storeGlobal)
     {
+        if (IsClueResolved(target))
+            return false;
+
         var clue = GetClueMessage(target, clues);
 
         if (!storeGlobal)
@@ -738,6 +741,29 @@ public sealed class IntelSystem : EntitySystem
         Dirty(tree);
         UpdateTree(tree);
         return true;
+    }
+
+    private bool IsClueResolved(EntityUid target)
+    {
+        if (TryComp(target, out IntelReadObjectiveComponent? read) &&
+            read.State == IntelObjectiveState.Complete)
+        {
+            return true;
+        }
+
+        if (TryComp(target, out IntelRetrieveItemObjectiveComponent? retrieve) &&
+            retrieve.State == IntelObjectiveState.Complete)
+        {
+            return true;
+        }
+
+        if (TryComp(target, out IntelDataDiskComponent? disk) && disk.Completed)
+            return true;
+
+        if (TryComp(target, out IntelDataTerminalComponent? terminal) && terminal.Completed)
+            return true;
+
+        return TryComp(target, out IntelSafeObjectiveComponent? safe) && safe.Completed;
     }
 
     private Dictionary<NetEntity, string> GetPersonalClues(EntityUid user)


### PR DESCRIPTION
## About the PR

Prevents completed intel objectives from being added back to the Marine Tech Tree Objectives UI.

## Why / Balance

Intel targets can be linked to multiple clue sources. After a target was completed and removed from the UI, processing another source linked to the same target could add it back.

These stale entries could not be removed by reading, uploading, or retrieving the target again because its objective was already complete. This caused manuals, disks, and retrievable items to accumulate in the UI during longer rounds.

This is a bug fix with no balance changes. Intel rewards and objective progression are unchanged.

## Technical details

Added an `IsClueResolved` check before publishing personal or global clues.

A clue is considered resolved when its associated:

- Read objective is complete.
- Retrieve objective is complete.
- Data disk has been uploaded.
- Data terminal has been completed.
- Intel safe has been opened.

Resolved targets are no longer passed through the clue publication path.


## Media

Not applicable  this is a small UI logic fix.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:GrigoriyGalintano
- fix: Completed intel objectives no longer reappear or remain stuck in the Marine Tech Tree Objectives UI.