### PR TITLE
add: medium document pouch

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Pouches/storage.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Pouches/storage.yml
@@ -390,6 +390,17 @@
     grid:
     - 0,0,13,1 #7 slots
 
+# Medium Documents Pouch
+- type: entity
+  parent: RMCPouchDocument
+  id: RMCPouchDocumentMedium
+  name: medium document pouch
+  description: A slighly smaller version of the document pouch. It can contain papers, folders, disks, technical manuals, and clipboards.
+  components:
+  - type: Storage
+    grid:
+    - 0,0,13,3 #14 slots
+
 # Flare Pouch
 - type: entity
   parent: RMCPouchFill

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
@@ -240,6 +240,8 @@
         amount: 5
       - id: RMCPouchFuelTank
         amount: 4
+      - id: RMCPouchDocumentMedium
+        amount: 1
       - id: RMCPouchGeneralLarge
         amount: 1
       - id: RMCPouchMagazineLarge


### PR DESCRIPTION
## About the PR

This PR adds a medium sized (14 slots) document pouch. This is post-parity.

## Why / Balance

The difference between the small (7 slots) and the large (21 slots) document pouch is quite large. This adds a sizing exactly in the middle between them for anyone wanting to intel-rifleman. I have for now only added it to requisitions with a scale of 1 as to make it somewhat rare.

## Technical details

YAML Warrior

## Media

<img width="523" height="211" alt="Screenshot From 2026-07-12 17-11-13" src="https://github.com/user-attachments/assets/1f194da9-401b-48e4-b838-eba5d6498868" />
<img width="535" height="150" alt="Screenshot From 2026-07-12 17-10-55" src="https://github.com/user-attachments/assets/51294044-2261-423f-84fd-46a97805aa58" />



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- add: Requisitions can now provide you with a medium sized document pouch.
