### PR TITLE
[Fix] X not contained in expected container 

### DIFF
--- a/Content.Shared/_RMC14/Attachable/Systems/AttachableToggleableSystem.cs
+++ b/Content.Shared/_RMC14/Attachable/Systems/AttachableToggleableSystem.cs
@@ -27,6 +27,7 @@ using Content.Shared.Whitelist;
 using Content.Shared.Wieldable.Components;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
+using Robust.Shared.Network;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Timing;
@@ -47,6 +48,7 @@ public sealed class AttachableToggleableSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
     [Dependency] private readonly UseDelaySystem _useDelaySystem = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+    [Dependency] private readonly INetManager _net = default!;
 
     private const string AttachableToggleUseDelayId = "RMCAttachableToggle";
 
@@ -767,6 +769,18 @@ public sealed class AttachableToggleableSystem : EntitySystem
         }
 
         var exists = ent.Comp.Action != null;
+        if (exists &&
+            ent.Comp.Action is { } pending &&
+            Exists(pending) &&
+            actionsContainerComponent.Container?.Contains(pending) != true)
+        {
+            if (_net.IsServer)
+            {
+                ent.Comp.Action = null;
+                Dirty(ent);
+            }
+            return;
+        }
         _actionContainerSystem.EnsureAction(ent, ref ent.Comp.Action, ent.Comp.ActionId, actionsContainerComponent);
 
         if (ent.Comp.Action is not { } actionId)


### PR DESCRIPTION
## About the PR
Should fix for most attachments that spam the error.
No behaviour changes as the action bar ability always appears.
Just fixes the mismatch ref so it stops spamming errors.

## Why / Balance
Fix and less errors is always nice.

## Technical details
Game sometimes confused, action still there just not in its "expected" but it never clears the mismatched reference so Ensure kept looping with the bad ref causing the logs whilst still functioning.
No changes for player as ability action is always put onto action bar.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- fix: Fixed some console errors from attachments.

