### PR TITLE
Fix expand weeds having too long a cooldown on expanding

### DIFF
--- a/Content.Shared/_RMC14/Actions/SwappableActionComponent.cs
+++ b/Content.Shared/_RMC14/Actions/SwappableActionComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Actions;
+using Content.Shared.FixedPoint;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared._RMC14.Actions;
@@ -12,6 +13,9 @@ public sealed partial class SwappableActionComponent : Component
 
     [DataField, AutoNetworkedField]
     public string OriginalDescription = string.Empty;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan? OriginalUseDelay;
 
     [DataField, AutoNetworkedField]
     public bool IsSwapped;

--- a/Content.Shared/_RMC14/Actions/SwappableActionSystem.cs
+++ b/Content.Shared/_RMC14/Actions/SwappableActionSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared.Actions;
 using Content.Shared.Actions.Components;
 using Robust.Shared.GameStates;
@@ -37,9 +38,10 @@ public sealed class SwappableActionSystem : EntitySystem
     public bool SwapInstantToWorldTarget<TOriginalEvent>(
         EntityUid owner,
         string swappedName,
-        string swappedDescription) where TOriginalEvent : InstantActionEvent
+        string swappedDescription,
+        TimeSpan? swappedUseDelay) where TOriginalEvent : InstantActionEvent
     {
-        foreach (var (actionId, _) in _actions.GetActions(owner))
+        foreach (var (actionId, actionBase) in _actions.GetActions(owner))
         {
             if (!TryComp<InstantActionComponent>(actionId, out var instant) ||
                 instant.Event is not TOriginalEvent)
@@ -55,6 +57,7 @@ public sealed class SwappableActionSystem : EntitySystem
 
             swappable.OriginalName = MetaData(actionId).EntityName;
             swappable.OriginalDescription = MetaData(actionId).EntityDescription;
+            swappable.OriginalUseDelay = actionBase.UseDelay;
             swappable.IsSwapped = true;
             Dirty(actionId, swappable);
 
@@ -64,7 +67,7 @@ public sealed class SwappableActionSystem : EntitySystem
             targetAction.CheckCanAccess = false;
             targetAction.Range = -1;
             targetAction.DeselectOnMiss = false;
-            targetAction.Repeat = false;
+            targetAction.Repeat = true;
             Dirty(actionId, targetAction);
 
             EnsureComp<WorldTargetActionComponent>(actionId);
@@ -72,6 +75,7 @@ public sealed class SwappableActionSystem : EntitySystem
 
             _metaData.SetEntityName(actionId, swappedName);
             _metaData.SetEntityDescription(actionId, swappedDescription);
+            _actions.SetUseDelay(actionId, swappedUseDelay);
 
             return true;
         }
@@ -103,6 +107,7 @@ public sealed class SwappableActionSystem : EntitySystem
 
             _metaData.SetEntityName(actionId, swappable.OriginalName);
             _metaData.SetEntityDescription(actionId, swappable.OriginalDescription);
+            _actions.SetUseDelay(actionId, swappable.OriginalUseDelay);
 
             swappable.IsSwapped = false;
             Dirty(actionId, swappable);

--- a/Content.Shared/_RMC14/Xenonids/Eye/QueenEyeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Eye/QueenEyeSystem.cs
@@ -266,7 +266,8 @@ public sealed class QueenEyeSystem : EntitySystem
         _swappableAction.SwapInstantToWorldTarget<XenoPlantWeedsActionEvent>(
             queen.Owner,
             Loc.GetString("rmc-xeno-queen-eye-expand-weeds-name"),
-            Loc.GetString("rmc-xeno-queen-eye-expand-weeds-desc"));
+            Loc.GetString("rmc-xeno-queen-eye-expand-weeds-desc"),
+            TimeSpan.FromSeconds(0.5));
     }
 
     private void SwapPlantWeedsToInstant(Entity<QueenEyeActionComponent> queen)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug. Fixes #10466.

## Technical details
<!-- Summary of code changes for easier review. -->
Swappable action now stores original use delay, and switching the action to target action now passes in a use delay. Also it's repeating now because QoL.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

before fix

https://github.com/user-attachments/assets/04c63e0b-ede6-42ee-8fba-6e7c5a044974

after fix

https://github.com/user-attachments/assets/d9bc9611-600d-42b9-91c2-045440b2d658



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed expand weeds cooldown being too long (1s -> 0.5s). It no longer deselects on use.
