### PR TITLE
[Fix] Attachment/Scope Fixes

### DIFF
--- a/Content.Shared/_RMC14/Attachable/Systems/AttachableToggleableSystem.cs
+++ b/Content.Shared/_RMC14/Attachable/Systems/AttachableToggleableSystem.cs
@@ -22,6 +22,7 @@ using Content.Shared.Physics;
 using Content.Shared.Popups;
 using Content.Shared.Timing;
 using Content.Shared.Toggleable;
+using Content.Shared.Verbs;
 using Content.Shared.Weapons.Ranged.Systems;
 using Content.Shared.Whitelist;
 using Content.Shared.Wieldable.Components;
@@ -71,6 +72,8 @@ public sealed class AttachableToggleableSystem : EntitySystem
         //SubscribeLocalEvent<AttachableToggleableComponent, UniqueActionEvent>(OnUniqueAction);
         SubscribeLocalEvent<AttachableToggleableComponent, GrantAttachableActionsEvent>(OnGrantAttachableActions);
         SubscribeLocalEvent<AttachableToggleableComponent, RemoveAttachableActionsEvent>(OnRemoveAttachableActions);
+        SubscribeLocalEvent<AttachableToggleableComponent, GetVerbsEvent<ActivationVerb>>(OnGetActivationVerbs,
+            after: new[] { typeof(SharedHandheldLightSystem) });
         SubscribeLocalEvent<AttachableToggleableComponent, AttachableRelayedEvent<HandDeselectedEvent>>(OnHandDeselected);
         SubscribeLocalEvent<AttachableToggleableComponent, AttachableRelayedEvent<GotEquippedHandEvent>>(OnGotEquippedHand);
         SubscribeLocalEvent<AttachableToggleableComponent, AttachableRelayedEvent<GotUnequippedHandEvent>>(OnGotUnequippedHand);
@@ -874,6 +877,14 @@ public sealed class AttachableToggleableSystem : EntitySystem
     {
         if (attachable.Comp.AttachedOnly && !attachable.Comp.Attached)
             args.Handled = true;
+    }
+
+    private void OnGetActivationVerbs(Entity<AttachableToggleableComponent> ent, ref GetVerbsEvent<ActivationVerb> args)
+    {
+        if (!ent.Comp.AttachedOnly || ent.Comp.Attached)
+            return;
+
+        args.Verbs.RemoveWhere(v => v.Text == Loc.GetString("verb-common-toggle-light"));
     }
 #endregion
 }

--- a/Content.Shared/_RMC14/Scoping/SharedScopeSystem.cs
+++ b/Content.Shared/_RMC14/Scoping/SharedScopeSystem.cs
@@ -103,6 +103,9 @@ public abstract partial class SharedScopeSystem : EntitySystem
 
     private void OnGetActions(Entity<ScopeComponent> ent, ref GetItemActionsEvent args)
     {
+        if (ent.Comp.Attachment && !TryGetActiveEntity(ent, out _))
+            return;
+
         if (ent.Comp.ScopingToggleAction != null)
             args.AddAction(ref ent.Comp.ScopingToggleActionEntity, ent.Comp.ScopingToggleAction);
 

--- a/Content.Shared/_RMC14/Scoping/SharedScopeSystem.cs
+++ b/Content.Shared/_RMC14/Scoping/SharedScopeSystem.cs
@@ -207,7 +207,7 @@ public abstract partial class SharedScopeSystem : EntitySystem
         var ent = scope.Owner;
         if (scope.Comp.Attachment && !TryGetActiveEntity(scope, out ent))
         {
-            var msgError = Loc.GetString("cm-action-popup-scoping-must-attach", ("scope", ent));
+            var msgError = Loc.GetString("cm-action-popup-scoping-must-attach", ("scope", scope.Owner));
             _popup.PopupClient(msgError, user, user);
             return false;
         }

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Attachables/rmc_attachable_base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Attachables/rmc_attachable_base.yml
@@ -14,5 +14,3 @@
   id: RMCAttachableToggleableBase
   components:
   - type: AttachableToggleable
-  - type: UseDelay
-    delay: 0


### PR DESCRIPTION
## About the PR
Fixes #9941 
- Removes right click verb toggle on rail flashlights and flashlight grips. (oversight)
- Scopes attachments now only "add" the button on action bar if attached to whichever its allowed to attach.
- Fixes popup text when trying to "use" unattached scopes.

## Why / Balance
Fixes are nice.

## Technical details
- Adds handler that removes the Toggle Light verb for attachments that are AttachOnly but not currently attached.
- Removed the UseDelay from the RMCAttachableToggleableBase, it was at 0 and causing ghost usedelay flickers when pressing Z, wasn't actually gating anything.
- Skipped adding any scopes action bar toggle unless its attached.
- Fixed the popup text when trying to use unattached scope.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- tweak: Scope attachments now only show its Action Bar button once attached to appropriate gun.
- fix: Fixed the popup text when trying to use unattached scopes.
- fix: Fixed being able to toggle Flashlight rail and grip via the verb.


