### PR TITLE
[Change] B8 Smart Scope zoom removal.

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/rail_attachments.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/rail_attachments.yml
@@ -441,7 +441,7 @@
     actionDesc: This civilian-grade scope is a common sight on hunting rifles due to its cheap price and great optics. Fixed at a modest 2x zoom.
 
 - type: entity
-  parent: RMCAttachmentS42xTelescopicMiniscope
+  parent: RMCRailAttachmentBase
   id: RMCAttachmentB8SmartScope
   name: B8 smart-scope
   description: An experimental B8 Smart-Scope. Based on the technologies used in the Smart Gun by AEGIS, this sight has integrated IFF systems. It can only attach to the M4SPR Battle Rifle and the M44 Combat Revolver.
@@ -452,21 +452,12 @@
     tags:
     - RMCAttachmentRail
     - RMCAttachmentB8SmartScope
-  - type: AttachableToggleable
-    doAfter: 0.8
-    icon:
-      sprite: _RMC14/Objects/Weapons/Guns/Attachments/rail.rsi
-      state: huntingscope
-    actionName: Look through B8 Smart-Scope
-    actionDesc: Lets you see further and shoot through your fellow marines without harming them.
+  - type: AttachableVisuals
   - type: AttachableIFF
   - type: AttachableWeaponRangedMods
     modifiers:
-    - damageAddMult: -0.2
-    - conditions:
-        wieldedOnly: true
-        inactiveOnly: true
-      accuracyAddMult: -0.05
+    - damageAddMult: -0.1
+      damageFalloffAddMult: 0.2
   - type: RMCLoreExaminable
     content: rmc-lore-examinable-b8-smart-scope
 


### PR DESCRIPTION
## About the PR
Changes the B8 smart scope itself to parity.
-  **Removed the ability to zoom with the scope.** 
_This always felt clunky due to the DoAfter for Zoom, locking your view in one direction and move penalties whilst zoomed. 
As an attachments aimed towards newer players it's alot to take in and  not abundantly clear what its supposed to do._

When attached to an appropriate gun:
- **20% reduced damage per bullet -> 10% reduced damage per bullet.**
- **+0.2 fall off modifier**  
(_causes more fall off when attached, only really feel this if shooting targets screen edge distance 10+ tiles_)

_TLDR It now just functions like an attachable sight that provides IFF at the cost of 10% reduced damage and more damage fall off outside of optimal range._

### Damage numbers - _Tested on unarmoured shooting target._

**M4SPR with no attachments.**
7,10, 14, 16 tiles(no attachments) = 56 damage

_**Current Smartscope - Has Zoom, No damagefalloff, 20% damage penalty**_
7 tiles = 52 damage
10 tiles = 48 damage
14 tiles (Zoom) = 48 damage
16 tiles (Zoom) = 48 damage

_**Proposed Smartscope - Zoom Removed, +0.2 damage fall off, 10% damage penalty**_ 
7 tiles = 52 damage
10 tiles = 49.4 damage
14 tiles (can't see target) = 46.28 damage
16 tiles (can't see target) = 44.72 damage

## Why / Balance
Parity
Alt IFF is another topic.  Even with our IFF currently, I see little reasons holding us back from changing it to match.

## Technical details
Yaml.

## Media
<img width="747" height="204" alt="image" src="https://github.com/user-attachments/assets/26e6228e-99d1-4eee-9b62-a762aa48cf5b" />

<img width="777" height="277" alt="image" src="https://github.com/user-attachments/assets/7a017069-6baf-4e82-a7eb-548a1e914bbb" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- tweak: B8 SmartScopes can no longer zoom; changed modifier values: 20% -> 10% reduced damage and +0.2 range falloff.

