### PR TITLE
[Fix] Expand Weeds not reading from it's Action Prototype.

### DIFF
--- a/Content.Shared/_RMC14/Actions/SwappableActionComponent.cs
+++ b/Content.Shared/_RMC14/Actions/SwappableActionComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Actions;
+using Content.Shared.FixedPoint;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared._RMC14.Actions;
@@ -12,6 +13,9 @@ public sealed partial class SwappableActionComponent : Component
 
     [DataField, AutoNetworkedField]
     public string OriginalDescription = string.Empty;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan? OriginalUseDelay;
 
     [DataField, AutoNetworkedField]
     public bool IsSwapped;

--- a/Content.Shared/_RMC14/Actions/SwappableActionComponent.cs
+++ b/Content.Shared/_RMC14/Actions/SwappableActionComponent.cs
@@ -1,6 +1,5 @@
-using Content.Shared.Actions;
-using Content.Shared.FixedPoint;
 using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared._RMC14.Actions;
 
@@ -8,21 +7,12 @@ namespace Content.Shared._RMC14.Actions;
 [Access(typeof(SwappableActionSystem))]
 public sealed partial class SwappableActionComponent : Component
 {
+    /// <summary>
+    ///     The action prototype swapped to.
+    /// </summary>
     [DataField, AutoNetworkedField]
-    public string OriginalName = string.Empty;
-
-    [DataField, AutoNetworkedField]
-    public string OriginalDescription = string.Empty;
-
-    [DataField, AutoNetworkedField]
-    public TimeSpan? OriginalUseDelay;
+    public EntProtoId? SwappedActionProto;
 
     [DataField, AutoNetworkedField]
     public bool IsSwapped;
-
-    [DataField, NonSerialized]
-    public BaseActionEvent? SwappedEventTemplate;
-
-    [DataField, NonSerialized]
-    public BaseActionEvent? OriginalEventTemplate;
 }

--- a/Content.Shared/_RMC14/Actions/SwappableActionSystem.cs
+++ b/Content.Shared/_RMC14/Actions/SwappableActionSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared.Actions;
 using Content.Shared.Actions.Components;
 using Robust.Shared.GameStates;
@@ -37,9 +38,10 @@ public sealed class SwappableActionSystem : EntitySystem
     public bool SwapInstantToWorldTarget<TOriginalEvent>(
         EntityUid owner,
         string swappedName,
-        string swappedDescription) where TOriginalEvent : InstantActionEvent
+        string swappedDescription,
+        TimeSpan? swappedUseDelay) where TOriginalEvent : InstantActionEvent
     {
-        foreach (var (actionId, _) in _actions.GetActions(owner))
+        foreach (var (actionId, actionBase) in _actions.GetActions(owner))
         {
             if (!TryComp<InstantActionComponent>(actionId, out var instant) ||
                 instant.Event is not TOriginalEvent)
@@ -55,6 +57,7 @@ public sealed class SwappableActionSystem : EntitySystem
 
             swappable.OriginalName = MetaData(actionId).EntityName;
             swappable.OriginalDescription = MetaData(actionId).EntityDescription;
+            swappable.OriginalUseDelay = actionBase.UseDelay;
             swappable.IsSwapped = true;
             Dirty(actionId, swappable);
 
@@ -64,7 +67,7 @@ public sealed class SwappableActionSystem : EntitySystem
             targetAction.CheckCanAccess = false;
             targetAction.Range = -1;
             targetAction.DeselectOnMiss = false;
-            targetAction.Repeat = false;
+            targetAction.Repeat = true;
             Dirty(actionId, targetAction);
 
             EnsureComp<WorldTargetActionComponent>(actionId);
@@ -72,6 +75,7 @@ public sealed class SwappableActionSystem : EntitySystem
 
             _metaData.SetEntityName(actionId, swappedName);
             _metaData.SetEntityDescription(actionId, swappedDescription);
+            _actions.SetUseDelay(actionId, swappedUseDelay);
 
             return true;
         }
@@ -103,6 +107,7 @@ public sealed class SwappableActionSystem : EntitySystem
 
             _metaData.SetEntityName(actionId, swappable.OriginalName);
             _metaData.SetEntityDescription(actionId, swappable.OriginalDescription);
+            _actions.SetUseDelay(actionId, swappable.OriginalUseDelay);
 
             swappable.IsSwapped = false;
             Dirty(actionId, swappable);

--- a/Content.Shared/_RMC14/Actions/SwappableActionSystem.cs
+++ b/Content.Shared/_RMC14/Actions/SwappableActionSystem.cs
@@ -1,7 +1,7 @@
-using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared.Actions;
 using Content.Shared.Actions.Components;
 using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared._RMC14.Actions;
 
@@ -9,6 +9,8 @@ public sealed class SwappableActionSystem : EntitySystem
 {
     [Dependency] private readonly SharedActionsSystem _actions = default!;
     [Dependency] private readonly MetaDataSystem _metaData = default!;
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly IComponentFactory _compFactory = default!;
 
     public override void Initialize()
     {
@@ -21,27 +23,31 @@ public sealed class SwappableActionSystem : EntitySystem
     {
         if (ent.Comp.IsSwapped)
         {
-            if (!HasComp<WorldTargetActionComponent>(ent) || ent.Comp.SwappedEventTemplate == null)
-                return;
-
-            _actions.SetEvent(ent, ent.Comp.SwappedEventTemplate);
+            if (HasComp<WorldTargetActionComponent>(ent) &&
+                ent.Comp.SwappedActionProto is { } id &&
+                _prototype.TryIndex(id, out var proto) &&
+                proto.TryGetComponent<WorldTargetActionComponent>(out var world, _compFactory) &&
+                world.Event is { } ev)
+            {
+                _actions.SetEvent(ent, ev);
+            }
         }
         else
         {
-            if (!HasComp<InstantActionComponent>(ent) || ent.Comp.OriginalEventTemplate == null)
-                return;
-
-            _actions.SetEvent(ent, ent.Comp.OriginalEventTemplate);
+            if (HasComp<InstantActionComponent>(ent) &&
+                MetaData(ent).EntityPrototype is { } proto &&
+                proto.TryGetComponent<InstantActionComponent>(out var instant, _compFactory) &&
+                instant.Event is { } ev)
+            {
+                _actions.SetEvent(ent, ev);
+            }
         }
     }
 
-    public bool SwapInstantToWorldTarget<TOriginalEvent>(
-        EntityUid owner,
-        string swappedName,
-        string swappedDescription,
-        TimeSpan? swappedUseDelay) where TOriginalEvent : InstantActionEvent
+    public bool SwapInstantToWorldTarget<TOriginalEvent>(EntityUid owner)
+        where TOriginalEvent : InstantActionEvent
     {
-        foreach (var (actionId, actionBase) in _actions.GetActions(owner))
+        foreach (var (actionId, _) in _actions.GetActions(owner))
         {
             if (!TryComp<InstantActionComponent>(actionId, out var instant) ||
                 instant.Event is not TOriginalEvent)
@@ -50,33 +56,16 @@ public sealed class SwappableActionSystem : EntitySystem
             }
 
             if (!TryComp<SwappableActionComponent>(actionId, out var swappable) ||
-                swappable.SwappedEventTemplate == null)
+                swappable.SwappedActionProto is not { } protoId ||
+                !_prototype.TryIndex(protoId, out var proto))
             {
                 continue;
             }
 
-            swappable.OriginalName = MetaData(actionId).EntityName;
-            swappable.OriginalDescription = MetaData(actionId).EntityDescription;
-            swappable.OriginalUseDelay = actionBase.UseDelay;
             swappable.IsSwapped = true;
             Dirty(actionId, swappable);
 
-            RemComp<InstantActionComponent>(actionId);
-
-            var targetAction = EnsureComp<TargetActionComponent>(actionId);
-            targetAction.CheckCanAccess = false;
-            targetAction.Range = -1;
-            targetAction.DeselectOnMiss = false;
-            targetAction.Repeat = true;
-            Dirty(actionId, targetAction);
-
-            EnsureComp<WorldTargetActionComponent>(actionId);
-            _actions.SetEvent(actionId, swappable.SwappedEventTemplate);
-
-            _metaData.SetEntityName(actionId, swappedName);
-            _metaData.SetEntityDescription(actionId, swappedDescription);
-            _actions.SetUseDelay(actionId, swappedUseDelay);
-
+            SwapActionTo(actionId, proto);
             return true;
         }
 
@@ -96,21 +85,64 @@ public sealed class SwappableActionSystem : EntitySystem
                 continue;
             }
 
-            if (swappable.OriginalEventTemplate == null)
+            if (!swappable.IsSwapped ||
+                MetaData(actionId).EntityPrototype is not { } originalProto)
+            {
                 continue;
+            }
 
+            SwapActionTo(actionId, originalProto);
+
+            swappable.IsSwapped = false;
+            Dirty(actionId, swappable);
+        }
+    }
+
+    /// <summary>
+    ///     Swaps the action to the target action prototype
+    /// </summary>
+    private void SwapActionTo(EntityUid actionId, EntityPrototype proto)
+    {
+        _metaData.SetEntityName(actionId, proto.Name);
+        _metaData.SetEntityDescription(actionId, proto.Description);
+
+        if (proto.TryGetComponent<ActionComponent>(out var protoAction, _compFactory))
+        {
+            _actions.SetUseDelay(actionId, protoAction.UseDelay);
+            _actions.SetIcon(actionId, protoAction.Icon);
+            _actions.SetIconOn(actionId, protoAction.IconOn);
+            _actions.SetIconColor(actionId, protoAction.IconColor);
+        }
+
+        if (proto.TryGetComponent<WorldTargetActionComponent>(out var protoWorld, _compFactory))
+        {
+            RemComp<InstantActionComponent>(actionId);
+
+            var target = EnsureComp<TargetActionComponent>(actionId);
+            if (proto.TryGetComponent<TargetActionComponent>(out var protoTarget, _compFactory))
+            {
+                target.Repeat = protoTarget.Repeat;
+                target.DeselectOnMiss = protoTarget.DeselectOnMiss;
+                target.CheckCanAccess = protoTarget.CheckCanAccess;
+                target.Range = protoTarget.Range;
+            }
+            Dirty(actionId, target);
+
+            var world = EnsureComp<WorldTargetActionComponent>(actionId);
+            world.RotateOnUse = protoWorld.RotateOnUse;
+            Dirty(actionId, world);
+
+            if (protoWorld.Event is { } worldEv)
+                _actions.SetEvent(actionId, worldEv);
+        }
+        else if (proto.TryGetComponent<InstantActionComponent>(out var protoInstant, _compFactory))
+        {
             RemComp<WorldTargetActionComponent>(actionId);
             RemComp<TargetActionComponent>(actionId);
 
             EnsureComp<InstantActionComponent>(actionId);
-            _actions.SetEvent(actionId, swappable.OriginalEventTemplate);
-
-            _metaData.SetEntityName(actionId, swappable.OriginalName);
-            _metaData.SetEntityDescription(actionId, swappable.OriginalDescription);
-            _actions.SetUseDelay(actionId, swappable.OriginalUseDelay);
-
-            swappable.IsSwapped = false;
-            Dirty(actionId, swappable);
+            if (protoInstant.Event is { } instantEv)
+                _actions.SetEvent(actionId, instantEv);
         }
     }
 }

--- a/Content.Shared/_RMC14/Xenonids/Eye/QueenEyeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Eye/QueenEyeSystem.cs
@@ -266,7 +266,8 @@ public sealed class QueenEyeSystem : EntitySystem
         _swappableAction.SwapInstantToWorldTarget<XenoPlantWeedsActionEvent>(
             queen.Owner,
             Loc.GetString("rmc-xeno-queen-eye-expand-weeds-name"),
-            Loc.GetString("rmc-xeno-queen-eye-expand-weeds-desc"));
+            Loc.GetString("rmc-xeno-queen-eye-expand-weeds-desc"),
+            TimeSpan.FromSeconds(0.5));
     }
 
     private void SwapPlantWeedsToInstant(Entity<QueenEyeActionComponent> queen)

--- a/Content.Shared/_RMC14/Xenonids/Eye/QueenEyeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Eye/QueenEyeSystem.cs
@@ -263,11 +263,7 @@ public sealed class QueenEyeSystem : EntitySystem
 
     private void SwapPlantWeedsToWorldTarget(Entity<QueenEyeActionComponent> queen)
     {
-        _swappableAction.SwapInstantToWorldTarget<XenoPlantWeedsActionEvent>(
-            queen.Owner,
-            Loc.GetString("rmc-xeno-queen-eye-expand-weeds-name"),
-            Loc.GetString("rmc-xeno-queen-eye-expand-weeds-desc"),
-            TimeSpan.FromSeconds(0.5));
+        _swappableAction.SwapInstantToWorldTarget<XenoPlantWeedsActionEvent>(queen.Owner);
     }
 
     private void SwapPlantWeedsToInstant(Entity<QueenEyeActionComponent> queen)

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_construction_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_construction_actions.yml
@@ -20,8 +20,7 @@
   - type: InstantAction
     event: !type:XenoPlantWeedsActionEvent
   - type: SwappableAction
-    swappedEventTemplate: !type:XenoExpandWeedsActionEvent
-    originalEventTemplate: !type:XenoPlantWeedsActionEvent
+    swappedActionProto: ActionXenoExpandWeeds
 
 - type: entity
   id: ActionXenoChooseStructure
@@ -267,6 +266,7 @@
     checkCanAccess: false
     range: -1
     deselectOnMiss: false
+    repeat: true
   - type: WorldTargetAction
     event: !type:XenoExpandWeedsActionEvent
 


### PR DESCRIPTION
## About the PR
Fixes #10466 
Supersedes #10468 
Refactored the Swappable Action System made for Queen Eye initially to use an action's prototype instead of the two hard coded event templates. (Much cleaner!)
Now it respects the yaml values like UseDelay instead of having to hardcode or duplicate it.

## Why / Balance
Clean is good.

## Technical details
Replaced the two event template fields on the component to one SwappedActionProto field.
SwapActionTo helper to that grabs the intended actions prototype.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl: 
- fix: Fixed expand weeds cooldown not reading from prototype (1s -> 0.5s). It no longer deselects on use by Vermidia.


