### PR TITLE
[Fix] Fixed Toggle Light Verb on Armour and Xenonids

### DIFF
--- a/Content.Server/_RMC14/Marines/Armor/RMCSuitLightSystem.cs
+++ b/Content.Server/_RMC14/Marines/Armor/RMCSuitLightSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared._RMC14.Marines.Armor;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared._RMC14.Xenonids.Devour;
 using Content.Shared._RMC14.Xenonids.Parasite;
+using Content.Shared.Actions;
 using Content.Shared.Clothing;
 using Content.Shared.Inventory;
 using Content.Shared.Light.Components;
@@ -24,6 +25,18 @@ public sealed class RMCSuitLightSystem : EntitySystem
         SubscribeLocalEvent<RMCSuitLightComponent, MobStateChangedEvent>(OnMobStateChanged);
         SubscribeLocalEvent<RMCSuitLightComponent, XenoParasiteInfectEvent>(OnParasiteInfect);
         SubscribeLocalEvent<RMCSuitLightComponent, XenoDevouredEvent>(OnDevour);
+        SubscribeLocalEvent<RMCSuitLightComponent, GetItemActionsEvent>(OnGetActions,
+            after: [typeof(HandheldLightSystem)]);
+    }
+
+    private void OnGetActions(Entity<RMCSuitLightComponent> ent, ref GetItemActionsEvent args)
+    {
+        if (args.InHands &&
+            TryComp(ent, out HandheldLightComponent? light) &&
+            light.ToggleActionEntity is { } action)
+        {
+            args.Actions.Remove(action);
+        }
     }
 
     private void OnUnequip(Entity<RMCSuitLightComponent> ent, ref ClothingGotUnequippedEvent args)

--- a/Content.Shared/_RMC14/Armor/RMCSuitLightVerbSystem.cs
+++ b/Content.Shared/_RMC14/Armor/RMCSuitLightVerbSystem.cs
@@ -1,0 +1,26 @@
+using Content.Shared._RMC14.Marines.Armor;
+using Content.Shared.Inventory;
+using Content.Shared.Light;
+using Content.Shared.Verbs;
+
+namespace Content.Shared._RMC14.Armor;
+
+public sealed class RMCSuitLightVerbSystem : EntitySystem
+{
+    [Dependency] private readonly InventorySystem _inventory = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<RMCSuitLightComponent, GetVerbsEvent<ActivationVerb>>(OnGetVerbs,
+            after: [typeof(SharedHandheldLightSystem)]);
+    }
+
+    private void OnGetVerbs(Entity<RMCSuitLightComponent> ent, ref GetVerbsEvent<ActivationVerb> args)
+    {
+        if (_inventory.InSlotWithFlags((ent, null, null), SlotFlags.OUTERCLOTHING))
+            return;
+
+        var text = Loc.GetString("verb-common-toggle-light");
+        args.Verbs.RemoveWhere(verb => verb.Text == text);
+    }
+}

--- a/Content.Shared/_RMC14/Interaction/RMCInteractionSystem.cs
+++ b/Content.Shared/_RMC14/Interaction/RMCInteractionSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Light.Components;
 using Content.Shared.Mobs.Components;
+using Content.Shared.Storage;
 using Content.Shared.Storage.Components;
 using Content.Shared.Whitelist;
 using Robust.Shared.Containers;
@@ -21,6 +22,15 @@ public sealed class RMCInteractionSystem : EntitySystem
         SubscribeLocalEvent<NoHandsInteractionBlockedComponent, GettingInteractedWithAttemptEvent>(OnNoHandsInteractionAttempt);
         SubscribeLocalEvent<InsertBlacklistComponent, ContainerIsInsertingAttemptEvent>(OnInsertBlacklistContainerIsInsertingAttempt);
         SubscribeLocalEvent<IgnoreInteractionRangeComponent, InRangeOverrideEvent>(OnInRangeOverride);
+        SubscribeLocalEvent<InteractedBlacklistComponent, StorageInteractAttemptEvent>(OnBlacklistStorageAttempt);
+    }
+    private void OnBlacklistStorageAttempt(Entity<InteractedBlacklistComponent> ent, ref StorageInteractAttemptEvent args)
+    {
+        if (args.Cancelled || ent.Comp.Blacklist == null)
+            return;
+
+        if (_whitelist.IsValid(ent.Comp.Blacklist, args.User))
+            args.Cancelled = true;
     }
 
     private void OnNoHandsInteractionAttempt(Entity<NoHandsInteractionBlockedComponent> ent, ref GettingInteractedWithAttemptEvent args)


### PR DESCRIPTION
## About the PR
Fixes #9941 
- Fixes benos being able to open hardhat inventory instead of toggling light upon left click.
- Fixes armour providing the Toggle Light action and verb while unequipped. (somehow we managed to parity the bug)

## Why / Balance
Parity.

## Technical details
- Added small shared RMC sided SuitLightVerbSystem to remove the Toggle Light Verb. 
_Couldn't put it in the RMCSuitLightSystem as that is server only currently._ 
- Added logic to RMCInteractionSystem so Benos interacting on something that has a toggled light and storage won't inadvertently trigger the storage due to the HandheldLightSystem allowing the interact. 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:

- fix: Fixed being unable to interact to turn off Hardhats as a Xenonid.
- fix: Fixed the Toggle Light action and verb appearing on action bar and armor while unequipped.

