### PR TITLE
add: mindless larvae can now be returned to the hive core

### DIFF
--- a/Content.Server/_RMC14/Xenonids/Construction/XenoPylonSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Construction/XenoPylonSystem.cs
@@ -2,7 +2,7 @@ using Content.Server._RMC14.Damage;
 using Content.Server.GameTicking;
 using Content.Server.Ghost.Roles;
 using Content.Server.Ghost.Roles.Events;
-using Content.Shared._RMC14.Dropship;
+using Content.Server.Mind;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared._RMC14.Xenonids.Construction;
 using Content.Shared._RMC14.Xenonids.Egg;
@@ -12,15 +12,16 @@ using Content.Shared.Damage;
 using Content.Shared.Destructible;
 using Content.Shared.FixedPoint;
 using Content.Shared.Ghost.Roles.Components;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Popups;
-using Robust.Shared.Network;
-using Robust.Shared.Player;
-using Robust.Shared.Timing;
-using Robust.Shared.Utility;
 using Content.Shared.StepTrigger.Systems;
 using Content.Shared.Tag;
-using Content.Shared.IdentityManagement;
+using Robust.Shared.Network;
+using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
+using Robust.Shared.Utility;
 
 namespace Content.Server._RMC14.Xenonids.Construction;
 
@@ -30,6 +31,7 @@ public sealed class XenoPylonSystem : SharedXenoPylonSystem
     [Dependency] private readonly XenoEvolutionSystem _evolution = default!;
     [Dependency] private readonly GhostRoleSystem _ghostRole = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
+    [Dependency] private readonly MindSystem _mind = default!;
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly RMCDamageableSystem _rmcDamageable = default!;
@@ -37,6 +39,8 @@ public sealed class XenoPylonSystem : SharedXenoPylonSystem
     [Dependency] private readonly GameTicker _gameTicker = default!;
     [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
     [Dependency] private readonly TagSystem _tagSystem = default!;
+
+    private static readonly ProtoId<TagPrototype> Larva = "RMCXenoLarva";
 
     public override void Initialize()
     {
@@ -55,13 +59,12 @@ public sealed class XenoPylonSystem : SharedXenoPylonSystem
 
     private void OnHiveCoreDestruction(Entity<HiveCoreComponent> ent, ref DestructionEventArgs args)
     {
-        if (_hive.GetHive(ent.Owner) is {} hive &&
+        if (_hive.GetHive(ent.Owner) is { } hive &&
             _gameTicker.RoundDuration() > hive.Comp.PreSetupCutoff)
         {
             hive.Comp.NewCoreAt = _timing.CurTime + hive.Comp.NewCoreCooldown;
             hive.Comp.AnnouncedHiveCoreCooldownOver = false;
         }
-
     }
 
     private void OnXenoSpawnerUsed(Entity<XenoComponent> xeno, ref GhostRoleSpawnerUsedEvent args)
@@ -157,7 +160,7 @@ public sealed class XenoPylonSystem : SharedXenoPylonSystem
 
     private bool CanTrigger(EntityUid user)
     {
-        return _tagSystem.HasTag(user, "RMCXenoLarva") && _mobState.IsDead(user);
+        return _tagSystem.HasTag(user, Larva) && (_mobState.IsDead(user) || _mind.GetMind(user) == null);
     }
 
     private void OnHiveCoreStepTriggered(Entity<HiveCoreComponent> core, ref StepTriggeredOffEvent args)
@@ -166,18 +169,16 @@ public sealed class XenoPylonSystem : SharedXenoPylonSystem
         if (CanTrigger(tripper))
         {
             var othersFilter = Filter.Pvs(core);
-                foreach (var other in othersFilter.Recipients)
-                {
-                    if (other.AttachedEntity is not { } otherEnt)
-                        continue;
+            foreach (var other in othersFilter.Recipients)
+            {
+                if (other.AttachedEntity is not { } otherEnt)
+                    continue;
 
-                    _popup.PopupEntity(Loc.GetString("rmc-xeno-larva-recovered", ("larva", Identity.Name(tripper, EntityManager, otherEnt))),
-                    core, othersFilter, true, PopupType.Medium);
-                }
+                _popup.PopupEntity(Loc.GetString("rmc-xeno-larva-recovered", ("larva", Identity.Name(tripper, EntityManager, otherEnt))),
+                core, othersFilter, true, PopupType.Medium);
+            }
             _hive.ChangeBurrowedLarva(1);
             QueueDel(tripper);
         }
     }
-
 }
-


### PR DESCRIPTION
## About the PR

title

## Why / Balance

fixes #2197, also cleaned up the file a bit.

## Technical details

check if it has a mind, so only the "blue" ssd

## Media


https://github.com/user-attachments/assets/4868644d-ed57-4cbe-a093-4dde20854d6b



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- add: Mindless larvae can now be returned to the hive core to gain a burrowed larva.
