### PR TITLE
Add Filled Engineer's Locker and Filled Welding Supplies

### DIFF
--- a/Resources/Prototypes/_RMC14/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Fills/Lockers/engineer.yml
@@ -56,3 +56,38 @@
     - id: RMCHandsTychoGloves
     - id: RMCSuitTychoRadiationSuit
     - id: RMCGeigerCounter
+
+- type: entity
+  parent: CMLockerEngineer
+  id: CMLockerEngineerFilled
+  suffix: Filled
+  components:
+  - type: StorageFill
+    contents:
+    - id: CMBackpackEngineer
+    - id: RMCFlashlight
+    - id: CMMaskGas
+    - id: RMCPouchToolsFill
+    - id: RMCPouchConstruction
+    - id: RMCPouchElectronicsFill
+    - id: RMCPouchGeneral
+    - id: RMCHazardVest
+    - id: CMWebbingBrown
+    - id: CMHeadsetEngineer
+    - id: RMCToolboxMechanicalFilled
+    - id: CMWebbing
+    - id: RMCHazardVestBlue
+
+- type: entity
+  parent: CMLockerEngineerWelder
+  id: CMLockerEngineerWelderFilled
+  suffix: Filled
+  components:
+  - type: StorageFill
+    contents:
+    - id: RMCWeldingKit
+      amount: 3
+    - id: CMWelder
+      amount: 3
+    - id: RMCHelmetWelding
+      amount: 3

--- a/Resources/Prototypes/_RMC14/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Fills/Lockers/engineer.yml
@@ -59,7 +59,7 @@
 
 - type: entity
   parent: CMLockerEngineer
-  id: CMLockerEngineerFilled
+  id: RMCLockerEngineerFilled
   suffix: Filled
   components:
   - type: StorageFill
@@ -67,20 +67,19 @@
     - id: CMBackpackEngineer
     - id: RMCFlashlight
     - id: CMMaskGas
-    - id: RMCPouchToolsFill
+    - id: RMCPouchTools
     - id: RMCPouchConstruction
-    - id: RMCPouchElectronicsFill
+    - id: RMCPouchElectronics
     - id: RMCPouchGeneral
     - id: RMCHazardVest
     - id: CMWebbingBrown
-    - id: CMHeadsetEngineer
     - id: RMCToolboxMechanicalFilled
     - id: CMWebbing
     - id: RMCHazardVestBlue
 
 - type: entity
   parent: CMLockerEngineerWelder
-  id: CMLockerEngineerWelderFilled
+  id: RMCLockerEngineerWelderFilled
   suffix: Filled
   components:
   - type: StorageFill

--- a/Resources/Prototypes/_RMC14/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Fills/Lockers/engineer.yml
@@ -75,7 +75,6 @@
     - id: CMWebbingBrown
     - id: RMCToolboxMechanicalFilled
     - id: CMWebbing
-    - id: RMCHazardVestBlue
 
 - type: entity
   parent: CMLockerEngineerWelder


### PR DESCRIPTION
## About the PR
Fills the Engineer's Locker and Welding Supplies Locker, Ready to be Mapped in to the Engineering Department

## Why / Balance
Parity

## Technical details


## Media
<img width="656" height="602" alt="welding locker filled" src="https://github.com/user-attachments/assets/1c033390-95ff-4274-9e4b-73b341508712" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added filled versions of the Engineer's Locker and Welding Locker for mapping
