### PR TITLE
Reduce Watch Size (Medium -> Small)

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Accessory/watches.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Accessory/watches.yml
@@ -11,11 +11,11 @@
     hiddenByJacketRolling: false
   - type: RMCClock
   - type: Tag
-    tags: 
+    tags:
     - Watch
   - type: Item
-    size: Normal
-    
+    size: Small
+
 - type: entity
   abstract: true
   parent: [RMCBaseUniformAccessory, ClothingHandsBase]
@@ -29,12 +29,12 @@
     hiddenByJacketRolling: false
   - type: RMCClock
   - type: Tag
-    tags: 
+    tags:
     - Watch
   - type: Item
-    size: Normal
+    size: Small
 
-- type: entity 
+- type: entity
   parent: RMCWatchBaseL
   id: RMCWatchCheap
   name: cheap digital watch
@@ -47,13 +47,13 @@
     playerSprite:
       sprite: _RMC14/Objects/Clothing/Accessory/Watches/pdt.rsi
       state: watchL
-  - type: Clothing 
+  - type: Clothing
     sprite: _RMC14/Objects/Clothing/Accessory/Watches/pdt.rsi
   - type: Tag
-    tags: 
+    tags:
     - Watch
 
-- type: entity 
+- type: entity
   parent: RMCWatchBaseL
   id: RMCWatchBasic
   name: Seikaku Pulsemeter wristwatch
@@ -66,10 +66,10 @@
     playerSprite:
       sprite: _RMC14/Objects/Clothing/Accessory/Watches/black.rsi
       state: watchL
-  - type: Clothing 
+  - type: Clothing
     sprite: _RMC14/Objects/Clothing/Accessory/Watches/black.rsi
-    
-- type: entity 
+
+- type: entity
   parent: RMCWatchBaseL
   id: RMCWatchSynth
   name: Seikaku 13B6-2000 wristwatch
@@ -82,10 +82,10 @@
     playerSprite:
       sprite: _RMC14/Objects/Clothing/Accessory/Watches/black.rsi
       state: watchL
-  - type: Clothing 
+  - type: Clothing
     sprite: _RMC14/Objects/Clothing/Accessory/Watches/black.rsi
-    
-- type: entity 
+
+- type: entity
   parent: RMCWatchBaseL
   id: RMCWatchSurv
   name: Seikaku 13B6-3000 wristwatch
@@ -98,10 +98,10 @@
     playerSprite:
       sprite: _RMC14/Objects/Clothing/Accessory/Watches/silver.rsi
       state: watchL
-  - type: Clothing 
+  - type: Clothing
     sprite: _RMC14/Objects/Clothing/Accessory/Watches/silver.rsi
-    
-- type: entity 
+
+- type: entity
   parent: RMCWatchBaseL
   id: RMCWatchLiaison
   name: Seikaku H487-9098 wristwatch
@@ -114,10 +114,10 @@
     playerSprite:
       sprite: _RMC14/Objects/Clothing/Accessory/Watches/silver.rsi
       state: watchL
-  - type: Clothing 
+  - type: Clothing
     sprite: _RMC14/Objects/Clothing/Accessory/Watches/silver.rsi
 
-- type: entity 
+- type: entity
   parent: RMCWatchBaseL
   id: RMCWatchPilot
   name: Veniti E-338 wristwatch
@@ -130,5 +130,5 @@
     playerSprite:
       sprite: _RMC14/Objects/Clothing/Accessory/Watches/fancy.rsi
       state: watchL
-  - type: Clothing 
+  - type: Clothing
     sprite: _RMC14/Objects/Clothing/Accessory/Watches/fancy.rsi


### PR DESCRIPTION
## About the PR
Watches are now size small, instead of size medium. This allows them to fit in coats and other such containers.

## Why / Balance
Medium sized watches didn't make much sense (compared to other medium/small items), and were annoyingly difficult to store.

Per Verm on discord this is also parity, they are small in CM13.

## Technical details
yaml warrior (my IDE also decided to clean up some whitespace, I guess)

## Media
<img width="380" height="272" alt="image" src="https://github.com/user-attachments/assets/091fd0ba-53aa-4cb9-990e-a5b0b1603b92" />

CM13:
<img width="309" height="179" alt="image" src="https://github.com/user-attachments/assets/9147eac2-8fca-458a-bb92-027d4091e642" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
- tweak: Watches are now small, instead of medium-sized.
