### PR TITLE
[Fix] Barricades now are required to be anchored before upgrading or downgrading.

### DIFF
--- a/Content.Shared/_RMC14/Construction/Upgrades/RMCUpgradeSystem.cs
+++ b/Content.Shared/_RMC14/Construction/Upgrades/RMCUpgradeSystem.cs
@@ -84,6 +84,15 @@ public sealed class RMCUpgradeSystem : EntitySystem
             return;
         }
 
+        if (!Transform(ent).Anchored)
+        {
+            var failPopup = Loc.GetString("rmc-construction-require-anchored", ("ent", ent));
+            _popup.PopupClient(failPopup, ent, user, PopupType.SmallCaution);
+
+            args.Handled = true;
+            return;
+        }
+
         if (downgradeItem != null && ent.Comp.Downgrade != null)
         {
             RemoveUpgrade(ent, user);

--- a/Resources/Locale/en-US/_RMC14/construction/rmc-construction.ftl
+++ b/Resources/Locale/en-US/_RMC14/construction/rmc-construction.ftl
@@ -9,6 +9,7 @@ rmc-construction-upgrade-explosive = You applied a composite upgrade.
 rmc-construction-upgrade-burn = You applied a biohazardous upgrade.
 rmc-construction-upgrade-brute = You applied a reinforced upgrade.
 rmc-construction-downgrade = You strip off {THE($ent)}'s upgrade, making it a normal barricade.
+rmc-construction-require-anchored = You need to anchor {THE($ent)} first!
 
 rmc-construction-untrained-build = You are not trained to build this...
 rmc-construction-more-material = You need more {$material} to build the {$object}!


### PR DESCRIPTION
## About the PR
Title.
Also fixes bug where it would stack in certain situations leading to unintended situations similar to the double stacked resin issues.

## Why / Balance
Parity and fixes bug.

## Technical details
gates the upgrade/downgrade requiring anchored. A popup reminds you if it isnt anchored.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:

- fix: Fixed unanchored barricades stacking on top of anchored barricades when upgraded.
