### PR TITLE
FORECON synth rank + access fixes

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/forecon_synth.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/forecon_synth.yml
@@ -11,9 +11,9 @@
       time: 270000 # 75 hours
     RMCRankWarrantOfficer: [ ]
   supervisors: rmc-job-supervisors-commander
-  accessGroups: # TODO RMC14 verify parity access groups with FORECON synthetic, i can't find the actual file that stores this
-  - ColonistEngi
-  - Synth
+  accessGroups:
+  - Colony # ACCESS_LIST_COLONIAL_ALL
+  - ColonistSynthShipside # All medbay + engineering + synth accesses
   startingGear: RMCGearForeconSynthetic
   spawnMenuRoleName: FORECON Synthetic (Survivor)
   roleWeight: 0.25

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/forecon_synth.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/forecon_synth.yml
@@ -5,7 +5,11 @@
   description: rmc-job-description-forecon
   playTimeTracker: RMCJobSyntheticColony
   ranks:
-    RMCRankMasterSergeant: []
+    RMCRankChiefWarrantOfficer:
+    - !type:RoleTimeRequirement
+      role: RMCSurvivorForeconSynth
+      time: 270000 # 75 hours
+    RMCRankWarrantOfficer: [ ]
   supervisors: rmc-job-supervisors-commander
   accessGroups: # TODO RMC14 verify parity access groups with FORECON synthetic, i can't find the actual file that stores this
   - ColonistEngi

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/forecon_synth.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/forecon_synth.yml
@@ -7,7 +7,7 @@
   ranks:
     RMCRankChiefWarrantOfficer:
     - !type:RoleTimeRequirement
-      role: RMCSurvivorForeconSynth
+      role: RMCJobSyntheticColony
       time: 270000 # 75 hours
     RMCRankWarrantOfficer: [ ]
   supervisors: rmc-job-supervisors-commander


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Resolves #10486
Adds accesses from base synthsurv to FORECON synth
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Desired. Also puts them in a niche as far as command structure goes
Accesses are parity
## Technical details
<!-- Summary of code changes for easier review. -->
Yamlmaxxing
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
Small fix
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: FORECON synthetic now holds the rank of WO by default and CWO at 75 hours
