### PR TITLE
Fix the dazed status effect not disabling actions

### DIFF
--- a/Content.Client/Actions/ActionsSystem.cs
+++ b/Content.Client/Actions/ActionsSystem.cs
@@ -76,6 +76,12 @@ namespace Content.Client.Actions
         {
             // TODO: Decouple this.
             ent.Comp.IconColor = _sharedCharges.GetCurrentCharges(ent.Owner) == 0 ? ent.Comp.DisabledIconColor : ent.Comp.OriginalIconColor;
+
+            //RMC14
+            if (!ent.Comp.Enabled)
+                ent.Comp.IconColor = ent.Comp.DisabledIconColor;
+            //RMC14
+
             base.UpdateAction(ent);
             if (_playerManager.LocalEntity != ent.Comp.AttachedEntity)
                 return;

--- a/Content.Shared/_RMC14/Stun/RMCDazedSystem.cs
+++ b/Content.Shared/_RMC14/Stun/RMCDazedSystem.cs
@@ -33,7 +33,7 @@ public sealed class RMCDazedSystem : EntitySystem
     /// <seealso cref="RMCDazeableActionComponent"/>
     private void OnDazed(Entity<RMCDazedComponent> ent, ref StatusEffectAppliedEvent args)
     {
-        foreach (var (actionId, _) in _actions.GetActions(ent))
+        foreach (var (actionId, _) in _actions.GetActions(args.Target))
         {
             if (TryComp(actionId, out RMCDazeableActionComponent? _))
             {
@@ -47,7 +47,7 @@ public sealed class RMCDazedSystem : EntitySystem
 
     private void OnDazedEnd(Entity<RMCDazedComponent> ent, ref StatusEffectRemovedEvent args)
     {
-        foreach (var (actionId, _) in _actions.GetActions(ent))
+        foreach (var (actionId, _) in _actions.GetActions(args.Target))
         {
             if (TryComp(actionId, out RMCDazeableActionComponent? _))
             {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

- The dazed status effect now again disables certain abilities/actions during it's duration.
- Disabled actions are now greyed out.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug fix.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix: Fixed the dazed status effect not disabling any abilities for it's duration.
