### PR TITLE
Hybrisa's map specific railings no longer yield metal

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Walls/Barricades/barricade_metal.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Walls/Barricades/barricade_metal.yml
@@ -353,35 +353,12 @@
       - state: handrail_hybrisa
       - map: [ "acided" ]
     - type: Construction
-      graph: BarricadeHandrailGraph
+      graph: RMCBarricadeHandrailPlasticGraph # none of hybrisa's map specific railing is meant to yield metal
       node: nodeHandrail
-
-- type: entity
-  parent: RMCBarricadeHandrail
-  id: RMCBarricadeHybrisaCenterRoad
-  components:
-    - type: Sprite
-      layers:
-      - state: centerroadbarrier2
-      - map: [ "acided" ]
-    - type: Construction
-      graph: BarricadeHandrailGraph
-      node: nodeHandrail
-
-- type: entity
-  parent: RMCBarricadeHybrisaCenterRoad
-  id: RMCBarricadeHybrisaCenterRoadDouble
-  suffix: Double
-  components:
-    - type: Sprite
-      offset: 0,-0.15
-      layers:
-      - state: centerroadbarrier1
-      - map: [ "acided" ]
 
 # Plastic Handrails
 - type: entity
-  parent: RMCBarricadeHandrail
+  parent: RMCBarricadeHybrisa
   id: RMCBarricadeHybrisaPlasticRoadBarrier
   name: plastic road barrier
   components:
@@ -389,9 +366,6 @@
       layers:
       - state: plasticroadbarrierred
       - map: [ "acided" ]
-    - type: Construction
-      graph: RMCBarricadeHandrailPlasticGraph
-      node: nodeHandrail
 
 - type: entity
   parent: RMCBarricadeHybrisaPlasticRoadBarrier
@@ -409,6 +383,26 @@
     - type: Sprite
       layers:
       - state: plasticroadbarrierblack
+      - map: [ "acided" ]
+
+- type: entity
+  parent: RMCBarricadeHybrisaPlasticRoadBarrier
+  id: RMCBarricadeHybrisaCenterRoad
+  components:
+    - type: Sprite
+      layers:
+      - state: centerroadbarrier2
+      - map: [ "acided" ]
+
+- type: entity
+  parent: RMCBarricadeHybrisaPlasticRoadBarrier
+  id: RMCBarricadeHybrisaCenterRoadDouble
+  suffix: Double
+  components:
+    - type: Sprite
+      offset: 0,-0.15
+      layers:
+      - state: centerroadbarrier1
       - map: [ "acided" ]
 
 # Metal Barricade Doors
@@ -481,7 +475,7 @@
       enum.DoorVisuals.State:
         enum.RMCDamageOverlayVisuals.DamageOverlay:
           Open: { sprite: _RMC14/Structures/Walls/Barricades/folding_metal_closed_cracks.rsi }
-          Closed: { sprite: _RMC14/Structures/Walls/Barricades/folding_metal_cracks.rsi }       
+          Closed: { sprite: _RMC14/Structures/Walls/Barricades/folding_metal_cracks.rsi }
   - type: DamageVisuals
     thresholds: [4, 8, 12]
     damageDivisor: 25

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Walls/Barricades/barricade_metal.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Walls/Barricades/barricade_metal.yml
@@ -356,7 +356,7 @@
       graph: RMCBarricadeHandrailPlasticGraph # none of hybrisa's map specific railing is meant to yield metal
       node: nodeHandrail
 
-# Plastic Handrails
+# Plastic road barriers
 - type: entity
   parent: RMCBarricadeHybrisa
   id: RMCBarricadeHybrisaPlasticRoadBarrier
@@ -385,8 +385,9 @@
       - state: plasticroadbarrierblack
       - map: [ "acided" ]
 
+# metal road barriers
 - type: entity
-  parent: RMCBarricadeHybrisaPlasticRoadBarrier
+  parent: RMCBarricadeHybrisa
   id: RMCBarricadeHybrisaCenterRoad
   components:
     - type: Sprite
@@ -395,7 +396,7 @@
       - map: [ "acided" ]
 
 - type: entity
-  parent: RMCBarricadeHybrisaPlasticRoadBarrier
+  parent: RMCBarricadeHybrisa
   id: RMCBarricadeHybrisaCenterRoadDouble
   suffix: Double
   components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Hybrisa's map specific railings no longer yield metal

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity

## Technical details
<!-- Summary of code changes for easier review. -->
Parent for all Hybrisa railings in parity;
"/obj/structure/barricade/handrail/hybrisa
	icon_state = "plasticroadbarrierred"
	stack_amount = 0 //we do not want it to drop any stuff when destroyed
	destroyed_stack_amount = 0"

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: All of Hybrisa's map specific railings no longer yield metal
