### PR TITLE
CBS parity tweak and damaged CBS

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/custombuilt.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/custombuilt.yml
@@ -69,8 +69,3 @@
       accuracyMultiplierUnwielded: 0.5  # BASE_ACCURACY_MULT - HIT_ACCURACY_MULT_TIER_10
     - type: GunDamageModifier
       multiplier: 0.9        # BASE_BULLET_DAMAGE_MULT - BULLET_DAMAGE_MULT_TIER_2
-    - type: AttachableHolder
-      slots:
-        rmc-aslot-barrel:
-          whitelist:
-            tags:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/custombuilt.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/custombuilt.yml
@@ -59,7 +59,7 @@
       shotsPerBurst: 1
     - type: RMCSelectiveFire
       recoilWielded: 3       # RECOIL_AMOUNT_TIER_3
-      recoilUnwielded: 1     # RECOIL_AMOUNT_TIER_1
+      recoilUnwielded: 5     # RECOIL_AMOUNT_TIER_1
       scatterWielded: 12     # SCATTER_AMOUNT_TIER_5
       scatterUnwielded: 30   # SCATTER_AMOUNT_TIER_1 
       baseFireRate: 0.5      # FIRE_DELAY_TIER_SHOTGUN_BASE 

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/custombuilt.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/custombuilt.yml
@@ -24,7 +24,7 @@
     recoilUnwielded: 4
     scatterWielded: 10
     scatterUnwielded: 20
-    baseFireRate: 0.85
+    baseFireRate: 0.714
     burstScatterMult: 7
     modifiers:
       Burst:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/custombuilt.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/custombuilt.yml
@@ -28,7 +28,7 @@
     burstScatterMult: 7
     modifiers:
       Burst:
-        fireDelay: 0.1665
+        fireDelay: 0.25
   - type: BallisticAmmoProvider
     cycleable: false
     whitelist:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/custombuilt.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/custombuilt.yml
@@ -25,7 +25,7 @@
     scatterWielded: 10
     scatterUnwielded: 20
     baseFireRate: 0.85
-    burstScatterMult: 4
+    burstScatterMult: 7
     modifiers:
       Burst:
         fireDelay: 0.1665
@@ -47,4 +47,30 @@
       rmc-aslot-rail: -0.025, 0.125
       rmc-aslot-underbarrel: 0.30, -0.31
 
-# Theres a damaged version of this with worse stats, make sure to use the "busted" state as the base/icon for it
+- type: entity
+  parent: WeaponShotgunCustomBuilt
+  id: WeaponShotgunCustomBuiltDamaged
+  name: damaged custom built shotgun
+  description: A cobbled-together pile of scrap and alien wood. Point end towards things you want to die. Has a burst fire feature, as if it needed it. Well, it had one, this one's barrel has apparently exploded outwards like an overripe grape. Guess that's what happens when you DIY a shotgun.
+  components:
+    - type: Sprite
+      state: busted
+    - type: Gun
+      shotsPerBurst: 1
+    - type: RMCSelectiveFire
+      recoilWielded: 3       # RECOIL_AMOUNT_TIER_3
+      recoilUnwielded: 1     # RECOIL_AMOUNT_TIER_1
+      scatterWielded: 12     # SCATTER_AMOUNT_TIER_5
+      scatterUnwielded: 30   # SCATTER_AMOUNT_TIER_1 
+      baseFireRate: 0.5      # FIRE_DELAY_TIER_SHOTGUN_BASE 
+      burstScatterMult: 8    # SCATTER_AMOUNT_TIER_3
+    - type: RMCWeaponAccuracy
+      accuracyMultiplier: 0.7  # BASE_ACCURACY_MULT - HIT_ACCURACY_MULT_TIER_6
+      accuracyMultiplierUnwielded: 0.5  # BASE_ACCURACY_MULT - HIT_ACCURACY_MULT_TIER_10
+    - type: GunDamageModifier
+      multiplier: 0.9        # BASE_BULLET_DAMAGE_MULT - BULLET_DAMAGE_MULT_TIER_2
+    - type: AttachableHolder
+      slots:
+        rmc-aslot-barrel:
+          whitelist:
+            tags:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Parity.
Changed the CBS' `burstScatterMult` to match parity.
Added the damaged CBS. Per parity, it has a burst amount of 1 and an unwielded recoil of 1 (presumably because it is broken).
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
RE the CBS' `burstScatterMult`;
```cs
    /// <summary>
    /// This is the multiplier applied to the additional scatter added by a SelectiveFireModifierSet with UseBurstScatterMult set to true.
    /// Conversion from 13 guns: burst_scatter_mult
    /// </summary>
 ```
 The CBS' `burst_scatter_mult` in parity uses `SCATTER_AMOUNT_TIER_4` which is defined as `7`. Previously this value was set to `4`.
## Technical details
<!-- Summary of code changes for easier review. -->
Yamlmaxxing
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added the damaged custom built shotgun
- tweak: The custom built shotgun now has the proper burst scatter multiplier