### PR TITLE
Miyahira Colony Crawler Change

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/prop_vehicles2.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/prop_vehicles2.yml
@@ -109,7 +109,7 @@
   id: RMCPropVehicleCrawler
   suffix: Use East, West
   name: colony crawler
-  description: It is a tread bound crawler used in harsh conditions. Supplied by Orbital Blue International; 'Your friends, in the Aerospace business.' A subsidiary of We-Ya.
+  description: It is a tread bound crawler used in harsh conditions. Manufactured by Miyahira, a subsidiary of We-Ya dedicated towards designing and manufacturing vehicles for the civilian market.
   components:
   - type: Sprite
     state: crawler
@@ -126,8 +126,6 @@
 - type: entity
   parent: RMCPropVehicleCrawler
   id: RMCPropVehicleCrawlerCovered
-  name: colony crawler
-  description: It is a tread bound crawler used in harsh conditions. Supplied by Orbital Blue International; 'Your friends, in the Aerospace business.' A subsidiary of We-Ya.
   components:
   - type: Sprite
     state: crawler_covered_bed
@@ -135,8 +133,6 @@
 - type: entity
   parent: RMCPropVehicleCrawler
   id: RMCPropVehicleCrawlerCrate
-  name: colony crawler
-  description: It is a tread bound crawler used in harsh conditions. Supplied by Orbital Blue International; 'Your friends, in the Aerospace business.' A subsidiary of We-Ya.
   components:
   - type: Sprite
     state: crawler_crate
@@ -144,8 +140,6 @@
 - type: entity
   parent: RMCPropVehicleCrawler
   id: RMCPropVehicleCrawlerCrate2
-  name: colony crawler
-  description: It is a tread bound crawler used in harsh conditions. Supplied by Orbital Blue International; 'Your friends, in the Aerospace business.' A subsidiary of We-Ya.
   components:
   - type: Sprite
     state: crawler_crate_alt
@@ -153,8 +147,6 @@
 - type: entity
   parent: RMCPropVehicleCrawler
   id: RMCPropVehicleCrawlerCrate3
-  name: colony crawler
-  description: It is a tread bound crawler used in harsh conditions. Supplied by Orbital Blue International; 'Your friends, in the Aerospace business.' A subsidiary of We-Ya.
   components:
   - type: Sprite
     state: crawler_crate_alt2
@@ -162,8 +154,6 @@
 - type: entity
   parent: RMCPropVehicleCrawler
   id: RMCPropVehicleCrawlerCrateWY
-  name: colony crawler
-  description: It is a tread bound crawler used in harsh conditions. Supplied by Orbital Blue International; 'Your friends, in the Aerospace business.' A subsidiary of We-Ya.
   components:
   - type: Sprite
     state: crawler_crate_wy
@@ -171,8 +161,6 @@
 - type: entity
   parent: RMCPropVehicleCrawler
   id: RMCPropVehicleCrawlerFuel
-  name: colony crawler
-  description: It is a tread bound crawler used in harsh conditions. Supplied by Orbital Blue International; 'Your friends, in the Aerospace business.' A subsidiary of We-Ya.
   components:
   - type: Sprite
     state: crawler_fuel


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changes the description of the colony crawlers to mention Miyahira, instead of "Orbital Blue". Also cleans up some unneeded code.

## Why / Balance
Orbital Blue has no mention or presence within the lore; streamlining it to be another product produced by a vehicle manufacturer we do have would be better

## Technical details
Yaml

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: Changed the description of the colony crawler to mention Miyahira instead of Orbital Blue
