### PR TITLE
Fixed `LarvaQueuedComponent` exception when a xeno is deleted

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/JoinXeno/LarvaQueueSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/JoinXeno/LarvaQueueSystem.cs
@@ -121,10 +121,10 @@ public sealed class LarvaQueueSystem : EntitySystem
 
     private void OnMindRemoved(Entity<CanBeLarvaQueuedComponent> ent, ref MindRemovedMessage _)
     {
-        if (_net.IsClient || !HasComp<XenoComponent>(ent))
+        if (_net.IsClient || TerminatingOrDeleted(ent) || !HasComp<XenoComponent>(ent))
             return;
 
-        if (TerminatingOrDeleted(ent) || _mobState.IsDead(ent))
+        if (_mobState.IsDead(ent))
             return;
 
         EnsureComp<LarvaQueuedComponent>(ent);

--- a/Content.Shared/_RMC14/Xenonids/JoinXeno/LarvaQueueSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/JoinXeno/LarvaQueueSystem.cs
@@ -124,7 +124,7 @@ public sealed class LarvaQueueSystem : EntitySystem
         if (_net.IsClient || !HasComp<XenoComponent>(ent))
             return;
 
-        if (_mobState.IsDead(ent))
+        if (TerminatingOrDeleted(ent) || _mobState.IsDead(ent))
             return;
 
         EnsureComp<LarvaQueuedComponent>(ent);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed this exception when a player-controlled xeno is deleted:
```
[ERRO] entity: Caught exception while raising event EntityTerminatingEvent on entity Young Defender (AB-559-CD) (2318/n2318, CMXenoDefender, localhost@JoeGenero)
Robust.Shared.Utility.DebugAssertException: Attempted to add a LarvaQueuedComponent component to an entity (Young Defender (AB-559-CD) (2318/n2318, CMXenoDefender, localhost@JoeGenero)) while it is terminating
   at Robust.Shared.Utility.DebugTools.Assert(Boolean condition, AssertInterpolatedStringHandler& message) in F:\Code Things\SS13\SS14 Masters\RMC-14\RobustToolbox\Robust.Shared\Utility\DebugTools.cs:line 215
   at Robust.Shared.GameObjects.EntityManager.AddComponentInternal[T](EntityUid uid, T component, ComponentRegistration reg, Boolean overwrite, Boolean skipInit, MetaDataComponent metadata) in F:\Code Things\SS13\SS14 Masters\RMC-14\RobustToolbox\Robust.Shared\GameObjects\EntityManager.Components.cs:line 355
   at Robust.Shared.GameObjects.EntityManager.AddComponentInternal[T](EntityUid uid, T component, Boolean overwrite, Boolean skipInit, MetaDataComponent metadata) in F:\Code Things\SS13\SS14 Masters\RMC-14\RobustToolbox\Robust.Shared\GameObjects\EntityManager.Components.cs:line 347
   at Robust.Shared.GameObjects.EntityManager.AddComponent[T](EntityUid uid, T component, Boolean overwrite, MetaDataComponent metadata) in F:\Code Things\SS13\SS14 Masters\RMC-14\RobustToolbox\Robust.Shared\GameObjects\EntityManager.Components.cs:line 321
   at Robust.Shared.GameObjects.EntityManager.AddComponent[T](EntityUid uid) in F:\Code Things\SS13\SS14 Masters\RMC-14\RobustToolbox\Robust.Shared\GameObjects\EntityManager.Components.cs:line 251
   at Content.Shared._RMC14.Xenonids.JoinXeno.LarvaQueueSystem.OnMindRemoved(Entity`1 ent, MindRemovedMessage& _) in F:\Code Things\SS13\SS14 Masters\RMC-14\Content.Shared\_RMC14\Xenonids\JoinXeno\LarvaQueueSystem.cs:line 130
```

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
N/A
(No player-facing effects)