### PR TITLE
Tweak: Intel UI now remembers scroll depth and searchbar

### DIFF
--- a/Content.Client/_RMC14/Intel/ViewIntelObjectivesBui.cs
+++ b/Content.Client/_RMC14/Intel/ViewIntelObjectivesBui.cs
@@ -12,6 +12,7 @@ public sealed class ViewIntelObjectivesBui(EntityUid owner, Enum uiKey) : BoundU
     private ViewIntelObjectivesWindow? _window;
 
     private readonly List<(string PlainClue, Control Row, Control? AreaLabel)> _allClueRows = new();
+    private readonly Dictionary<string, (ScrollContainer Scroll, BoxContainer Container)> _clueTabs = new();
     private bool _hideAreas;
 
     protected override void Open()
@@ -44,15 +45,12 @@ public sealed class ViewIntelObjectivesBui(EntityUid owner, Enum uiKey) : BoundU
         _window.ColonyPowerLabel.Text = Loc.GetString("rmc-ui-intel-colony-status", ("online", tree.ColonyPower));
 
         _allClueRows.Clear();
-        if (_window.CluesSearchBar != null)
-            _window.CluesSearchBar.Text = string.Empty;
 
-        _window.CluesContainer.DisposeAllChildren();
         if (comp.PersonalClues.Count > 0)
-            AddClueTab("rmc-intel-personal", comp.PersonalClues.Values);
+            UpdateClueTab("rmc-intel-personal", comp.PersonalClues.Values);
 
         foreach (var (category, clues) in comp.Tree.Clues)
-            AddClueTab(category, clues.Values);
+            UpdateClueTab(category, clues.Values);
 
         if (_window.CluesSearchBar != null)
         {
@@ -67,6 +65,7 @@ public sealed class ViewIntelObjectivesBui(EntityUid owner, Enum uiKey) : BoundU
             UpdateHideAreasButton();
         }
 
+        ApplyFilter(_window.CluesSearchBar?.Text.Trim() ?? string.Empty);
         ApplyAreaVisibility();
     }
 
@@ -130,12 +129,14 @@ public sealed class ViewIntelObjectivesBui(EntityUid owner, Enum uiKey) : BoundU
         return result.ToString();
     }
 
-    private void AddClueTab(string category, IEnumerable<string> clues)
+    private void UpdateClueTab(string category, IEnumerable<string> clues)
     {
         if (_window is not { IsOpen: true })
             return;
 
-        var scroll = new ScrollContainer
+        if (!_clueTabs.TryGetValue(category, out var tab))
+        {
+            var scroll = new ScrollContainer
         {
             HScrollEnabled = false,
             VScrollEnabled = true,
@@ -147,18 +148,24 @@ public sealed class ViewIntelObjectivesBui(EntityUid owner, Enum uiKey) : BoundU
             Margin = new Thickness(4),
         };
 
+           scroll.AddChild(container);
+           _window.CluesContainer.AddChild(scroll);
+           TabContainer.SetTabTitle(scroll, Loc.GetString(category));
+
+           tab = (scroll, container);
+           _clueTabs[category] = tab;
+        }
+
+        tab.Container.DisposeAllChildren();
+
         var sortedClues = clues.OrderBy(c => StripMarkup(c).ToLowerInvariant());
 
         foreach (var clue in sortedClues)
         {
             var (row, areaLabel) = BuildClueRow(clue);
-            container.AddChild(row);
+            tab.Container.AddChild(row);
             _allClueRows.Add((StripMarkup(clue), row, areaLabel));
         }
-
-        scroll.AddChild(container);
-        _window.CluesContainer.AddChild(scroll);
-        TabContainer.SetTabTitle(scroll, Loc.GetString(category));
     }
 
     private static (Control Row, Control? AreaLabel) BuildClueRow(string clue)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The intel UI will now remember the scroll depth and what you typed into the searchbar instead of resetting it everytime a new clue gets added

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Was really annoying when you tried to search for a password but another intel staff would type in new clues and it would keep reseting you to the top of the page and remove your search

## Technical details
<!-- Summary of code changes for easier review. -->
Tab scroll containers are now reused instead of recreated on every refresh, so scrolling down no longer gets reset to the top when a new clue comes in
The search filter box no longer gets cleared on each refresh 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added another braincell to the intel UI, it will now nolonger reset your tab when a new clue gets added to the database!
