### PR TITLE
Weedkiller info added to Area Alert

### DIFF
--- a/Content.Shared/_RMC14/TacticalMap/AreaInfoSystem.cs
+++ b/Content.Shared/_RMC14/TacticalMap/AreaInfoSystem.cs
@@ -201,14 +201,13 @@ public sealed class AreaInfoSystem : EntitySystem
 
         var weedkillerZones = new List<string>();
         var check = new string(area.Value.Comp.LinkedLz);
-        var numbersToWords = new List<string> { "Zero", "One", "Two", "Three", "Four", "Five" };
         if (!string.IsNullOrWhiteSpace(check))
-            for (int i = 0; i <= 5; i++)
-            {
-                string place = i.ToString();
-                if (check.Contains(place))
-                    weedkillerZones.Add("Landing Zone " + numbersToWords[i]);
-            }
+            if (check.Contains("dropship_lz1"))
+                weedkillerZones.Add("Landing Zone One");
+            if (check.Contains("dropship_lz2"))
+                weedkillerZones.Add("Landing Zone Two");
+            if (check.Contains("dropship_lz3"))
+                weedkillerZones.Add("Landing Zone Three");
 
         var protectionSource = "";
         if (hasHiveCoreProtection)

--- a/Content.Shared/_RMC14/TacticalMap/AreaInfoSystem.cs
+++ b/Content.Shared/_RMC14/TacticalMap/AreaInfoSystem.cs
@@ -199,6 +199,14 @@ public sealed class AreaInfoSystem : EntitySystem
         else if (!area.Value.Comp.ResinAllowed)
             restrictedActions.Add("Resin Structures");
 
+        var weedkillerZones = new List<string>();
+        var check = new string(area.Value.Comp.LinkedLz);
+        if (!string.IsNullOrWhiteSpace(check))
+            if (check.Contains("dropship_lz1"))
+                weedkillerZones.Add("Landing Zone One");
+            if (check.Contains("dropship_lz2"))
+                weedkillerZones.Add("Landing Zone Two");
+
         var protectionSource = "";
         if (hasHiveCoreProtection)
             protectionSource = "\nProtection: Hive Core";
@@ -217,6 +225,12 @@ public sealed class AreaInfoSystem : EntitySystem
         {
             restrictionsStr += "\n\nBlocked:";
             restrictionsStr += "\n• " + string.Join("\n• ", restrictedActions);
+        }
+
+        if (weedkillerZones.Count > 0)
+        {
+            restrictionsStr += "\n\nWeedkiller:";
+            restrictionsStr += "\n• " + string.Join("\n• ", weedkillerZones);
         }
 
         return (areaProto.Name, severityToUse, restrictionsStr);

--- a/Content.Shared/_RMC14/TacticalMap/AreaInfoSystem.cs
+++ b/Content.Shared/_RMC14/TacticalMap/AreaInfoSystem.cs
@@ -201,11 +201,14 @@ public sealed class AreaInfoSystem : EntitySystem
 
         var weedkillerZones = new List<string>();
         var check = new string(area.Value.Comp.LinkedLz);
+        var numbersToWords = new List<string> { "Zero", "One", "Two", "Three", "Four", "Five" };
         if (!string.IsNullOrWhiteSpace(check))
-            if (check.Contains("dropship_lz1"))
-                weedkillerZones.Add("Landing Zone One");
-            if (check.Contains("dropship_lz2"))
-                weedkillerZones.Add("Landing Zone Two");
+            for (int i = 0; i <= 5; i++)
+            {
+                string place = i.ToString();
+                if (check.Contains(place))
+                    weedkillerZones.Add("Landing Zone " + numbersToWords[i]);
+            }
 
         var protectionSource = "";
         if (hasHiveCoreProtection)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added a section to the Area Info Alert stating what weedkiller affects the area

## Why / Balance
All information should be available in-game, xenonids currently need to use external website maps to find out weedkiller zones which is bad.

## Media
<img width="1160" height="639" alt="image" src="https://github.com/user-attachments/assets/99ef944c-e01e-4ee2-b8c9-8571bb9774e4" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl: CatAndHats
- add: The Area Info HUD alert now gives weedkiller information
