### PR TITLE
[Fix] Fix being unable to plant weeds on tiles with ledges

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Weeds/SharedXenoWeedsSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Weeds/SharedXenoWeedsSystem.cs
@@ -19,6 +19,7 @@ using Content.Shared._RMC14.Xenonids.Rest;
 using Content.Shared._RMC14.Xenonids.Designer;
 using Content.Shared.Climbing.Components;
 using Content.Shared.Coordinates;
+using Content.Shared.Tag;
 using Content.Shared.Coordinates.Helpers;
 using Content.Shared.Damage;
 using Content.Shared.Examine;
@@ -71,6 +72,9 @@ public abstract class SharedXenoWeedsSystem : EntitySystem
     [Dependency] private readonly SharedXenoAnnounceSystem _xenoAnnounce = default!;
     [Dependency] private readonly WeedboundWallSystem _weedboundWall = default!;
     [Dependency] private readonly DesignerNodeBindingSystem _designerBinding = default!;
+    [Dependency] private readonly TagSystem _tags = default!;
+
+    private static readonly ProtoId<TagPrototype> PlatformTag = "Platform";
 
     private readonly HashSet<EntityUid> _toUpdate = new();
     private readonly HashSet<EntityUid> _intersecting = new();
@@ -603,7 +607,8 @@ public abstract class SharedXenoWeedsSystem : EntitySystem
             foreach (var entity in entities)
             {
                 if (!HasComp<ClimbableComponent>(entity) && !HasComp<RMCReactorPoweredLightComponent>(entity) ||
-                    HasComp<BarricadeComponent>(entity))
+                    HasComp<BarricadeComponent>(entity) ||
+                    _tags.HasTag(entity, PlatformTag))
                     continue;
 
                 _popup.PopupClient(Loc.GetString("rmc-xeno-weeds-blocked"), popupAt ?? xeno.ToCoordinates(), xeno, PopupType.SmallCaution);

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Platforms/platform.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Platforms/platform.yml
@@ -16,6 +16,11 @@
   - type: Tag
     tags:
     - Platform
+  - type: MeleeReceivedMultiplier
+    xenoDamage:
+      types:
+        Slash: 40
+    otherMultiplier: 1.2
 
 - type: entity
   abstract: true
@@ -40,12 +45,6 @@
     damageContainer: Inorganic
   - type: Destructible
     thresholds:
-      - trigger:
-          !type:DamageTrigger
-          damage: 110 # Excessive damage
-        behaviors:
-          - !type:DoActsBehavior
-            acts: ["Destruction"]
       - trigger:
           !type:DamageTrigger
           damage: 90
@@ -100,7 +99,7 @@
     node: start
 
 - type: entity
-  parent: CMPlatformBaseDestructible
+  parent: CMPlatformBase
   id: CMPlatformCorner
   name: platform
   description: A square metal surface resting on four legs.
@@ -109,6 +108,16 @@
     snap:
     - Wall
   components:
+  - type: Damageable
+    damageContainer: Inorganic
+  - type: Destructible
+    thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 90
+        behaviors:
+          - !type:DoActsBehavior
+            acts: ["Destruction"]
   - type: Physics
   - type: Fixtures
     fixtures:
@@ -155,14 +164,6 @@
         behaviors:
           - !type:DoActsBehavior
             acts: ["Destruction"]
-      - trigger:
-          !type:DamageTrigger
-          damage: 30
-        behaviors:
-          - !type:ChangeConstructionNodeBehavior
-            node: platformBroken
-          - !type:DoActsBehavior
-            acts: ["Breakage"]
   - type: Fixtures
     fixtures:
       fix1:
@@ -195,18 +196,10 @@
     thresholds:
       - trigger:
           !type:DamageTrigger
-          damage: 135 # Excessive damage
+          damage: 90 # Excessive damage
         behaviors:
           - !type:DoActsBehavior
             acts: ["Destruction"]
-      - trigger:
-          !type:DamageTrigger
-          damage: 110
-        behaviors:
-          - !type:ChangeConstructionNodeBehavior
-            node: platformBroken
-          - !type:DoActsBehavior
-            acts: ["Breakage"]
   - type: Fixtures
     fixtures:
       fix1:


### PR DESCRIPTION
## About the PR
Fixed being unable to weed on the "front" side of ledges.
Standardised the amount of hits to destroy ledges for both the average Marine and Xenos.  3 hits.

## Why / Balance
Parity 
No one likes ledges.  
_A good middle ground substitute until we have auto vault or a variation of it._

## Technical details
Half the logic was already in the construction system, just needed to bring it over to the weed system

## Media
<img width="170" height="146" alt="image" src="https://github.com/user-attachments/assets/d1d4a49a-ab22-4083-9596-582e945e1df7" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- tweak: Standardised the amount of hits required to break ledges for most Marines and Xenonids. (3 hits)
- fix: Fixed being unable to weed on the "front" of ledges.
