### PR TITLE
fix switching vehicle hardpoint haveing to be reselected to activate 

### DIFF
--- a/Content.Shared/_RMC14/Vehicle/Weapons/VehicleWeaponsComponents.cs
+++ b/Content.Shared/_RMC14/Vehicle/Weapons/VehicleWeaponsComponents.cs
@@ -22,7 +22,7 @@ public sealed partial class VehicleWeaponsComponent : Component
     public Dictionary<EntityUid, EntityUid> OperatorSelections = new();
 }
 
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true)]
 [Access(typeof(VehicleWeaponsSystem))]
 public sealed partial class VehicleWeaponsOperatorComponent : Component
 {

--- a/Content.Shared/_RMC14/Vehicle/Weapons/VehicleWeaponsSystem.cs
+++ b/Content.Shared/_RMC14/Vehicle/Weapons/VehicleWeaponsSystem.cs
@@ -61,6 +61,7 @@ public sealed partial class VehicleWeaponsSystem : EntitySystem
         SubscribeLocalEvent<VehicleWeaponsOperatorComponent, ShotAttemptedEvent>(OnOperatorShotAttempted);
         SubscribeLocalEvent<VehicleWeaponsOperatorComponent, VehicleHardpointSelectActionEvent>(OnHardpointActionSelect);
         SubscribeLocalEvent<VehicleWeaponsOperatorComponent, VehicleViewToggledEvent>(OnViewToggled);
+        SubscribeLocalEvent<VehicleWeaponsOperatorComponent, AfterAutoHandleStateEvent>(OnOperatorAfterState);
 
         SubscribeLocalEvent<VehicleWeaponsComponent, HardpointSlotsChangedEvent>(OnHardpointSlotsChanged);
 
@@ -496,6 +497,35 @@ public sealed partial class VehicleWeaponsSystem : EntitySystem
             {
                 vehicleEnt.Comp.HardpointOperators[selectedWeapon] = operatorUid;
             }
+        }
+    }
+
+    private void OnOperatorAfterState(Entity<VehicleWeaponsOperatorComponent> ent, ref AfterAutoHandleStateEvent args)
+    {
+        if (!_net.IsClient)
+            return;
+
+        if (ent.Comp.Vehicle is not { } vehicle || !TryComp(vehicle, out VehicleWeaponsComponent? weapons))
+            return;
+
+        foreach (var pair in weapons.HardpointOperators.ToArray())
+        {
+            if (pair.Value == ent.Owner)
+                weapons.HardpointOperators.Remove(pair.Key);
+        }
+
+        if (ent.Comp.SelectedWeapon is { } selectedWeapon)
+        {
+            weapons.OperatorSelections[ent.Owner] = selectedWeapon;
+            if (TryGetMountedWeaponHardpointType(vehicle, selectedWeapon, out var hardpointType) &&
+                !IsSharedHardpointType(hardpointType))
+            {
+                weapons.HardpointOperators[selectedWeapon] = ent.Owner;
+            }
+        }
+        else
+        {
+            weapons.OperatorSelections.Remove(ent.Owner);
         }
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
fix switching vehicle hardpoint haveing to be reselected to activate 
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
this fixes the ltaap issue it wasn't present with the other hardpoints because they are semi auto (I think at least)
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed having to reselect the LTAAP minigun after switching hardpoints 
