### PR TITLE
Intel detector now ignores the user + QoL

### DIFF
--- a/Content.Shared/_RMC14/Intel/Detector/IntelDetectorComponent.cs
+++ b/Content.Shared/_RMC14/Intel/Detector/IntelDetectorComponent.cs
@@ -51,6 +51,12 @@ public sealed partial class IntelDetectorComponent : Component, IDetectorCompone
 
     [DataField, AutoNetworkedField]
     public SoundSpecifier? ToggleSound = new SoundPathSpecifier("/Audio/_RMC14/Machines/click.ogg");
+
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
+    public TimeSpan NextSelfCheckAt;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan SelfCheckCooldown = TimeSpan.FromSeconds(5);
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/_RMC14/Intel/Detector/IntelDetectorSystem.cs
+++ b/Content.Shared/_RMC14/Intel/Detector/IntelDetectorSystem.cs
@@ -3,11 +3,13 @@ using Content.Shared._RMC14.MotionDetector;
 using Content.Shared._RMC14.Xenonids.Parasite;
 using Content.Shared.Coordinates;
 using Content.Shared.Examine;
+using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Inventory;
 using Content.Shared.Mobs;
+using Content.Shared.Popups;
 using Content.Shared.Storage;
 using Content.Shared.Verbs;
 using Robust.Shared.Audio.Systems;
@@ -29,9 +31,11 @@ public sealed class IntelDetectorSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedHandsSystem _hands = default!;
     [Dependency] private readonly InventorySystem _inventory = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
 
     private EntityQuery<IntelDetectorComponent> _detectorQuery;
     private EntityQuery<StorageComponent> _storageQuery;
+    private EntityQuery<IntelDetectorTrackedComponent> _trackedIntelQuery;
 
     private readonly HashSet<Entity<IntelDetectorTrackedComponent>> _tracked = new();
 
@@ -39,12 +43,14 @@ public sealed class IntelDetectorSystem : EntitySystem
     {
         _detectorQuery = GetEntityQuery<IntelDetectorComponent>();
         _storageQuery = GetEntityQuery<StorageComponent>();
+        _trackedIntelQuery = GetEntityQuery<IntelDetectorTrackedComponent>();
 
         SubscribeLocalEvent<XenoParasiteInfectEvent>(OnXenoInfect);
         SubscribeLocalEvent<MobStateChangedEvent>(OnMobStateChanged);
 
         SubscribeLocalEvent<IntelDetectorComponent, UseInHandEvent>(OnUseInHand);
         SubscribeLocalEvent<IntelDetectorComponent, ActivateInWorldEvent>(OnActivateInWorld);
+        SubscribeLocalEvent<IntelDetectorComponent, AfterInteractEvent>(OnAfterInteract);
         SubscribeLocalEvent<IntelDetectorComponent, GetVerbsEvent<AlternativeVerb>>(OnGetVerbs);
         SubscribeLocalEvent<IntelDetectorComponent, DroppedEvent>(OnDisable);
         SubscribeLocalEvent<IntelDetectorComponent, RMCDroppedEvent>(OnDisable);
@@ -84,6 +90,40 @@ public sealed class IntelDetectorSystem : EntitySystem
         args.Handled = true;
         Toggle(ent);
         _audio.PlayPredicted(ent.Comp.ToggleSound, ent, args.User);
+    }
+
+    private void OnAfterInteract(Entity<IntelDetectorComponent> ent, ref AfterInteractEvent args)
+    {
+        if (args.Handled || args.Target is not { } target || target != args.User)
+            return;
+
+        args.Handled = true;
+
+        if (!ent.Comp.Enabled)
+        {
+            _popup.PopupClient(Loc.GetString("rmc-intel-detector-not-on"), args.User, args.User);
+            return;
+        }
+
+        if (_timing.CurTime < ent.Comp.NextSelfCheckAt)
+        {
+            _popup.PopupClient(Loc.GetString("rmc-intel-detector-cooldown"), args.User, args.User);
+            return;
+        }
+
+        var hasIntel = HasIntelOnPerson(args.User);
+        var msg = hasIntel
+            ? Loc.GetString("rmc-intel-detector-has-intel")
+            : Loc.GetString("rmc-intel-detector-no-intel");
+
+        _popup.PopupClient(msg, args.User, args.User);
+
+        if (hasIntel)
+        {
+            _audio.PlayPredicted(ent.Comp.ScanSound, ent, args.User);
+            ent.Comp.NextSelfCheckAt = _timing.CurTime + ent.Comp.SelfCheckCooldown;
+            Dirty(ent);
+        }
     }
 
     private void OnGetVerbs(Entity<IntelDetectorComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
@@ -144,12 +184,66 @@ public sealed class IntelDetectorSystem : EntitySystem
         }
     }
 
+    private bool HasIntelOnPerson(EntityUid uid)
+    {
+        foreach (var held in _hands.EnumerateHeld(uid))
+        {
+            if (ItemHasIntel(held))
+                return true;
+        }
+
+        var slots = _inventory.GetSlotEnumerator(uid);
+        while (slots.MoveNext(out var slot))
+        {
+            if (slot.ContainedEntity is { } contained && ItemHasIntel(contained))
+                return true;
+        }
+
+        return false;
+    }
+
+    private bool ItemHasIntel(EntityUid ent)
+    {
+        if (_trackedIntelQuery.HasComp(ent))
+            return true;
+
+        if (_storageQuery.TryComp(ent, out var storage))
+        {
+            foreach (var stored in storage.StoredItems.Keys)
+            {
+                if (ItemHasIntel(stored))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    private bool TryGetCarrier(EntityUid item, out EntityUid carrier)
+    {
+        carrier = default;
+        var current = item;
+        while (_container.TryGetContainingContainer((current, null), out var container))
+        {
+            if (HasComp<HandsComponent>(container.Owner) || HasComp<InventoryComponent>(container.Owner))
+            {
+                carrier = container.Owner;
+                return true;
+            }
+
+            current = container.Owner;
+        }
+
+        return false;
+    }
+
     private void OnExamined(Entity<IntelDetectorComponent> ent, ref ExaminedEvent args)
     {
         using (args.PushGroup(nameof(IntelDetectorComponent)))
         {
             var mode = ent.Comp.Short ? "short" : "long";
             args.PushMarkup($"The motion detector is in [color=cyan]{mode}[/color] scanning mode.");
+            args.PushMarkup(Loc.GetString("rmc-intel-detector-self-check-examine"));
         }
     }
 
@@ -199,9 +293,18 @@ public sealed class IntelDetectorSystem : EntitySystem
             _tracked.Clear();
             _entityLookup.GetEntitiesInRange(uid.ToCoordinates(), range, _tracked);
 
+            TryGetCarrier(uid, out var detectorCarrier);
+
             detector.Blips.Clear();
             foreach (var tracked in _tracked)
             {
+                if (detectorCarrier != default &&
+                    TryGetCarrier(tracked.Owner, out var trackedCarrier) &&
+                    trackedCarrier == detectorCarrier)
+                {
+                    continue;
+                }
+
                 detector.Blips.Add(new Blip(_transform.GetMapCoordinates(tracked), false));
             }
 

--- a/Resources/Locale/en-US/_RMC14/intel.ftl
+++ b/Resources/Locale/en-US/_RMC14/intel.ftl
@@ -159,3 +159,9 @@ rmc-intel-tech-announcement-wake-troops = Additional troops are being taken out 
 rmc-intel-tech-announcement-wake-specialist = An additional specialist is being taken out of cryo.
 rmc-intel-tech-announcement-tier-4 = THREAT ASSESSMENT LEVEL INCREASED TO LEVEL 4. LEVEL 4 assets have been authorised to handle the situation.
 rmc-intel-tech-announcement-nuclear-device = The deployment of Nuclear Ordnance has been authorized and will be delivered to the Requisitions Department via ASRS.
+
+rmc-intel-detector-not-on = Turn the Device on first.
+rmc-intel-detector-has-intel = The Device has detected Intelligence on your person.
+rmc-intel-detector-no-intel = The Device does not react.
+rmc-intel-detector-cooldown = The Device needs to cooldown before another self-scan can be performed.
+rmc-intel-detector-self-check-examine = Use the Device on yourself to perform a self-scan for Intelligence.

--- a/Resources/Locale/en-US/_RMC14/intel.ftl
+++ b/Resources/Locale/en-US/_RMC14/intel.ftl
@@ -160,8 +160,8 @@ rmc-intel-tech-announcement-wake-specialist = An additional specialist is being 
 rmc-intel-tech-announcement-tier-4 = THREAT ASSESSMENT LEVEL INCREASED TO LEVEL 4. LEVEL 4 assets have been authorised to handle the situation.
 rmc-intel-tech-announcement-nuclear-device = The deployment of Nuclear Ordnance has been authorized and will be delivered to the Requisitions Department via ASRS.
 
-rmc-intel-detector-not-on = Turn the Device on first.
-rmc-intel-detector-has-intel = The Device has detected Intelligence on your person.
-rmc-intel-detector-no-intel = The Device does not react.
-rmc-intel-detector-cooldown = The Device needs to cooldown before another self-scan can be performed.
-rmc-intel-detector-self-check-examine = Use the Device on yourself to perform a self-scan for Intelligence.
+rmc-intel-detector-not-on = Turn the data detector on first.
+rmc-intel-detector-has-intel = The data detector has detected intelligence on your person.
+rmc-intel-detector-no-intel = The data detector does not react.
+rmc-intel-detector-cooldown = The data detector needs to cool down before another self-scan can be performed.
+rmc-intel-detector-self-check-examine = Use the data detector on yourself to perform a self-scan for intelligence.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The Intel detector now ignores intel which is on the holder but still pings intel on other players.
You can now use the intel detector on yourself to check if you carry any intel on you.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
<img width="907" height="113" alt="grafik" src="https://github.com/user-attachments/assets/7ee89b03-a220-4462-9f4d-8eca0ba064b2" />

I added the self check as I personally like knowing if I am carrying any intel on me. But like discussed in discord its rather really annoying getting pinged yourself.

## Technical details
<!-- Summary of code changes for easier review. -->
The data detector now checks every container on the user for Intel and if any is found it gives back a postive message when self scanned.
I added a short CD between self scans as a postive self scan plays the ping sound which coulda been spammed without the CD.


## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

https://github.com/user-attachments/assets/f907f079-6bac-48e0-bdcf-1f08f5884386


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: You can now click on yourself to perform a self-scan with the data detector, as it no longer pings if the user has intel on themselves!
