### PR TITLE
Allows players to see what's in a glass.

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Drinks/glasses.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Drinks/glasses.yml
@@ -84,3 +84,5 @@
   - type: Tag
     tags:
     - DrinkGlass
+  - type: ExaminableSolution
+    solution: drink

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Drinks/glasses.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Consumables/Drinks/glasses.yml
@@ -84,5 +84,4 @@
   - type: Tag
     tags:
     - DrinkGlass
-  - type: ExaminableSolution
-    solution: drink
+  - type: TransformableContainer


### PR DESCRIPTION

## About the PR
Allows players to see what reagent(s) are in a glass

## Why / Balance
QOL, allows for people to actually know what they might be drinking

## Technical details
Single YAML component

## Media
<img width="394" height="197" alt="image" src="https://github.com/user-attachments/assets/bbdaaffb-4e2b-41fa-b957-2e7b73d203a2" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Added the ability to see reagents in a glass.