### PR TITLE
Flashlights are no longer melee weapons

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Tools/flashlights.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Tools/flashlights.yml
@@ -3,11 +3,6 @@
   parent: BaseItem
   id: RMCFlashlightBase
   components:
-  - type: MeleeWeapon
-    wideAnimationRotation: 90
-    damage:
-      types:
-        Blunt: 0
   - type: HandheldLight
     blinkingBehaviourId: blinking
     radiatingBehaviourId: radiating


### PR DESCRIPTION
## About the PR
Lantern and flashlight can no longer be swung for 0 blunt damage

## Why / Balance
You cannot quick equip your boot knife if a lantern or flashlight is in your belt/suit storage/pocket slots because it treated them like melee weapons and they took priority + this mechanic is mostly just used for LRP

## Technical details
Removes melee weapon component from RMCFlashlight

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Handheld sources of light like lanterns and flashlights are no longer melee weapons
