### PR TITLE
Adds: Button Coordinates Copy Range in Rangefinder UI

### DIFF
--- a/Content.Client/_RMC14/Rangefinder/RangefinderBui.cs
+++ b/Content.Client/_RMC14/Rangefinder/RangefinderBui.cs
@@ -11,13 +11,19 @@ namespace Content.Client._RMC14.Rangefinder;
 [UsedImplicitly]
 public sealed class RangefinderBui : BoundUserInterface
 {
+    [Dependency] private readonly IClipboardManager _clipboard = default!;
+
     private RangefinderWindow? _window;
 
     private readonly AreaSystem _area;
     private readonly SharedTransformSystem _transform;
 
+    private int _lastX;
+    private int _lastY;
+
     public RangefinderBui(EntityUid owner, Enum uiKey) : base(owner, uiKey)
     {
+        IoCManager.InjectDependencies(this);
         _area = EntMan.System<AreaSystem>();
         _transform = EntMan.System<SharedTransformSystem>();
     }
@@ -27,6 +33,9 @@ public sealed class RangefinderBui : BoundUserInterface
         base.Open();
         _window = this.CreateWindow<RangefinderWindow>();
         _window.Header.SetMarkupPermissive(Loc.GetString("rmc-rangefinder-header"));
+
+        _window.CopyButton.OnPressed += _ => _clipboard.SetText($"Longitude ({_lastX}), Latitude ({_lastY})");
+
         Refresh();
     }
 
@@ -40,6 +49,9 @@ public sealed class RangefinderBui : BoundUserInterface
 
         if (rangefinder.LastTarget is { } target)
         {
+            _lastX = target.X;
+            _lastY = target.Y;
+
             var msg = Loc.GetString("rmc-rangefinder-longitude", ("x", target.X));
             _window.Longitude.SetMarkupPermissive(msg);
 

--- a/Content.Client/_RMC14/Rangefinder/RangefinderWindow.xaml
+++ b/Content.Client/_RMC14/Rangefinder/RangefinderWindow.xaml
@@ -6,10 +6,17 @@
     <BoxContainer Orientation="Vertical">
         <RichTextLabel Name="Header" Access="Public" />
         <userInterface:BlueHorizontalSeparator Margin="0 5" />
-        <RichTextLabel Name="Longitude" Access="Public" HorizontalAlignment="Center"
-                       VerticalAlignment="Center" Margin="0 20 0 0" />
-        <RichTextLabel Name="Latitude" Access="Public" HorizontalAlignment="Center"
-                       VerticalAlignment="Center" Margin="0 20 0 5" />
+        <BoxContainer Orientation="Horizontal" HorizontalAlignment="Center" Margin="0 20 0 0">
+            <RichTextLabel Name="Longitude" Access="Public" HorizontalAlignment="Center"
+                           VerticalAlignment="Center" />
+        </BoxContainer>
+        <BoxContainer Orientation="Horizontal" HorizontalAlignment="Center" Margin="0 20 0 5">
+            <RichTextLabel Name="Latitude" Access="Public" HorizontalAlignment="Center"
+                           VerticalAlignment="Center" />
+        </BoxContainer>
+        <BoxContainer Orientation="Horizontal" HorizontalAlignment="Center" Margin="0 10 0 0">
+            <Button Name="CopyButton" Access="Public" Text="{Loc 'rmc-rangefinder-copy-coordinates'}" MinWidth="120" />
+        </BoxContainer>
         <userInterface:BlueHorizontalSeparator Margin="0 5" />
         <BoxContainer Name="BottomContainer" Access="Public" Orientation="Vertical" Margin="5 0" />
     </BoxContainer>

--- a/Resources/Locale/en-US/_RMC14/rangefinder/rmc-rangefinder.ftl
+++ b/Resources/Locale/en-US/_RMC14/rangefinder/rmc-rangefinder.ftl
@@ -2,6 +2,7 @@
 rmc-rangefinder-header = [bold]SIMPLIFIED COORDINATES OF TARGET[/bold]
 rmc-rangefinder-longitude = [font size=28]LONGITUDE : {$x},[/font]
 rmc-rangefinder-latitude = [font size=28]LATITUDE : {$y}[/font]
+rmc-rangefinder-copy-coordinates = Copy Coordinates
 rmc-rangefinder-examine = {CAPITALIZE(THE($item))} reads: LONGITUDE {$x}, LATITUDE {$y}
 rmc-rangefinder-orbital-bombardment = Orbital Bombardment
 


### PR DESCRIPTION
## About the PR
Adds a button to the range ui to copy coordinates coming out to: "Longitude (x), Latitude (-y)"

## Why / Balance
parity

## Technical details


## Media
<img width="437" height="444" alt="image" src="https://github.com/user-attachments/assets/c88f4faf-8ffc-40df-9351-3a0fc5bda020" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Coordinates can now be copied to clipboard when using rangefinder.