### PR TITLE
Blitz + pierce stay selected on use

### DIFF
--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
@@ -1029,6 +1029,7 @@
   - type: TargetAction
     range: 15
     checkCanAccess: false
+    repeat: true
   - type: WorldTargetAction
     event: !type:XenoPierceActionEvent
   - type: ActionBlockIfResting
@@ -1051,6 +1052,7 @@
   components:
   - type: Action
     useDelay: 0
+    repeat: true
   - type: ActionBlockIfResting
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
@@ -1026,10 +1026,10 @@
       sprite: _RMC14/Actions/xeno_actions.rsi
       state: prae_pierce
     useDelay: 3
-    repeat: true
   - type: TargetAction
     range: 15
     checkCanAccess: false
+    repeat: true
   - type: WorldTargetAction
     event: !type:XenoPierceActionEvent
   - type: ActionBlockIfResting
@@ -1052,6 +1052,7 @@
   components:
   - type: Action
     useDelay: 0
+  - type: TargetAction
     repeat: true
   - type: ActionBlockIfResting
 

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
@@ -1026,10 +1026,10 @@
       sprite: _RMC14/Actions/xeno_actions.rsi
       state: prae_pierce
     useDelay: 3
+    repeat: true
   - type: TargetAction
     range: 15
     checkCanAccess: false
-    repeat: true
   - type: WorldTargetAction
     event: !type:XenoPierceActionEvent
   - type: ActionBlockIfResting


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Both are abilities you either can spam often (pierce) or can be immediately used after use (blitz).

## Technical details
<!-- Summary of code changes for easier review. -->
yml.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Vanguard pierce + blitz no longer deselect on use.
