### PR TITLE
Fix: Removes Markup Text from Intel Clue Popups

### DIFF
--- a/Content.Shared/_RMC14/Intel/IntelSystem.cs
+++ b/Content.Shared/_RMC14/Intel/IntelSystem.cs
@@ -723,7 +723,7 @@ public sealed class IntelSystem : EntitySystem
         if (!storeGlobal)
             return AddPersonalClue(user, target, clue);
 
-        _popup.PopupEntity(clue, target, user, PopupType.Medium);
+        _popup.PopupEntity(FormattedMessage.RemoveMarkupOrThrow(clue), target, user, PopupType.Medium);
 
         RemovePersonalClueFromAll(target);
 


### PR DESCRIPTION
## About the PR
popups use drawstring so everytime a disk etc with a colour comes up in the intel clue computer it keeps the markup text. This strips the markup text from the popup.

## Why / Balance
QoL

## Technical details
1 line

## Media

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- fix: Markup text no longer appears on clue popups when entering into the intel computer