### PR TITLE
Queen time requirment on evolve for 2.5m

### DIFF
--- a/Content.Server/_RMC14/Xenonids/XenoRoleSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/XenoRoleSystem.cs
@@ -4,6 +4,7 @@ using Content.Server.Players.PlayTimeTracking;
 using Content.Server.Roles;
 using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Xenonids;
+using Content.Shared._RMC14.Xenonids.Evolution;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Maturing;
 using Content.Shared._RMC14.Xenonids.Name;
@@ -57,6 +58,8 @@ public sealed class XenoRoleSystem : EntitySystem
         SubscribeLocalEvent<ActorComponent, HiveChangedEvent>(OnHiveChanged);
 
         SubscribeLocalEvent<XenoRankComponent, RefreshNameModifiersEvent>(OnRankRefreshName, before: new[] { typeof(SharedXenoNameSystem) });
+
+        SubscribeLocalEvent<XenoEvolveQueenAllowedEvent>(OnXenoEvolveQueenAllowed);
 
         Subs.CVar(_config, RMCCVars.RMCPlaytimeBronzeMedalTimeHours, v => _rankTwoTime = TimeSpan.FromHours(v), true);
         Subs.CVar(_config, RMCCVars.RMCPlaytimeSilverMedalTimeHours, v => _rankThreeTime = TimeSpan.FromHours(v), true);
@@ -124,6 +127,15 @@ public sealed class XenoRoleSystem : EntitySystem
             return;
 
         args.AddModifier(rank.Value);
+    }
+
+    private void OnXenoEvolveQueenAllowed(ref XenoEvolveQueenAllowedEvent ev)
+    {
+        if (!TryComp(ev.Xeno, out ActorComponent? actor))
+            return;
+
+        if (!_playTime.IsAllowed(actor.PlayerSession, "CMXenoQueen"))
+            ev.Allowed = false;
     }
 
     private void UpdateRank(EntityUid xeno, ICommonSession player, string jobId, HumanoidCharacterProfile profile)

--- a/Content.Shared/_RMC14/CCVar/RMCCVars.cs
+++ b/Content.Shared/_RMC14/CCVar/RMCCVars.cs
@@ -124,8 +124,8 @@ public sealed partial class RMCCVars : CVars
     public static readonly CVarDef<int> RMCEvolutionPointsAccumulateBeforeMinutes =
         CVarDef.Create("rmc.evolution_points_accumulate_before_minutes", 15, CVar.REPLICATED | CVar.SERVER);
 
-    public static readonly CVarDef<int> RMCXenoQueenRequirementGracePeriodMinutes =
-        CVarDef.Create("rmc.xeno_queen_requirement_grace_period_minutes", 5, CVar.REPLICATED | CVar.SERVER);
+    public static readonly CVarDef<float> RMCXenoQueenRequirementGracePeriodMinutes =
+        CVarDef.Create("rmc.xeno_queen_requirement_grace_period_minutes", 2.5f, CVar.REPLICATED | CVar.SERVER);
 
     public static readonly CVarDef<bool> RMCAtmosTileEqualize =
         CVarDef.Create("rmc.atmos_tile_equalize", false, CVar.REPLICATED | CVar.SERVER);

--- a/Content.Shared/_RMC14/CCVar/RMCCVars.cs
+++ b/Content.Shared/_RMC14/CCVar/RMCCVars.cs
@@ -124,6 +124,9 @@ public sealed partial class RMCCVars : CVars
     public static readonly CVarDef<int> RMCEvolutionPointsAccumulateBeforeMinutes =
         CVarDef.Create("rmc.evolution_points_accumulate_before_minutes", 15, CVar.REPLICATED | CVar.SERVER);
 
+    public static readonly CVarDef<int> RMCXenoQueenRequirementGracePeriodMinutes =
+        CVarDef.Create("rmc.xeno_queen_requirement_grace_period_minutes", 5, CVar.REPLICATED | CVar.SERVER);
+
     public static readonly CVarDef<bool> RMCAtmosTileEqualize =
         CVarDef.Create("rmc.atmos_tile_equalize", false, CVar.REPLICATED | CVar.SERVER);
 

--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
@@ -408,11 +408,11 @@ public sealed class XenoEvolutionSystem : EntitySystem
                 return false;
             }
 
-            var noQueenSince = _xenoHive.GetHive(xeno.Owner) is { } hive
-                ? hive.Comp.LastQueenDeath ?? _gameTicker.RoundStartTimeSpan
+            var queenEvolvableAt = _xenoHive.GetHive(xeno.Owner) is { } hive
+                ? hive.Comp.NewQueenAt ?? _gameTicker.RoundStartTimeSpan
                 : _gameTicker.RoundStartTimeSpan;
 
-            var graceLeft = noQueenSince + _queenRequirementGracePeriod - _timing.CurTime;
+            var graceLeft = queenEvolvableAt + _queenRequirementGracePeriod - _timing.CurTime;
             if (graceLeft > TimeSpan.Zero)
             {
                 var allowedEv = new XenoEvolveQueenAllowedEvent(xeno.Owner);

--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
@@ -69,6 +69,7 @@ public sealed class XenoEvolutionSystem : EntitySystem
     private TimeSpan _evolutionAccumulatePointsBefore;
     private TimeSpan _evolveSameCasteCooldown;
     private TimeSpan _earlyEvoBoostBefore;
+    private TimeSpan _queenRequirementGracePeriod;
 
     private readonly HashSet<EntityUid> _climbable = new();
     private readonly HashSet<EntityUid> _doors = new();
@@ -114,6 +115,7 @@ public sealed class XenoEvolutionSystem : EntitySystem
         Subs.CVar(_config, RMCCVars.RMCEvolutionPointsAccumulateBeforeMinutes, v => _evolutionAccumulatePointsBefore = TimeSpan.FromMinutes(v), true);
         Subs.CVar(_config, RMCCVars.RMCXenoEvolveSameCasteCooldownSeconds, v => _evolveSameCasteCooldown = TimeSpan.FromSeconds(v), true);
         Subs.CVar(_config, RMCCVars.RMCXenoEarlyEvoPointBoostBeforeMinutes, v => _earlyEvoBoostBefore = TimeSpan.FromMinutes(v), true);
+        Subs.CVar(_config, RMCCVars.RMCXenoQueenRequirementGracePeriodMinutes, v => _queenRequirementGracePeriod = TimeSpan.FromMinutes(v), true);
     }
 
     private void OnXenoOpenDevolveAction(Entity<XenoDevolveComponent> xeno, ref XenoOpenDevolveActionEvent args)
@@ -397,11 +399,43 @@ public sealed class XenoEvolutionSystem : EntitySystem
         if (!ContainedCheckPopup(xeno, doPopup))
             return false;
 
-        if (prototype.HasComponent<XenoEvolutionGranterComponent>(_compFactory) && HiveHasLivingQueen(xeno.Owner))
+        if (prototype.HasComponent<XenoEvolutionGranterComponent>(_compFactory))
         {
-            if (doPopup)
-                _popup.PopupEntity(Loc.GetString("rmc-xeno-evolution-failed-queen-exists"), xeno, xeno, PopupType.MediumCaution);
-            return false;
+            if (HiveHasLivingQueen(xeno.Owner))
+            {
+                if (doPopup)
+                    _popup.PopupEntity(Loc.GetString("rmc-xeno-evolution-failed-queen-exists"), xeno, xeno, PopupType.MediumCaution);
+                return false;
+            }
+
+            var noQueenSince = _xenoHive.GetHive(xeno.Owner) is { } hive
+                ? hive.Comp.LastQueenDeath ?? _gameTicker.RoundStartTimeSpan
+                : _gameTicker.RoundStartTimeSpan;
+
+            var graceLeft = noQueenSince + _queenRequirementGracePeriod - _timing.CurTime;
+            if (graceLeft > TimeSpan.Zero)
+            {
+                var allowedEv = new XenoEvolveQueenAllowedEvent(xeno.Owner);
+                RaiseLocalEvent(ref allowedEv);
+                if (!allowedEv.Allowed)
+                {
+                    if (doPopup)
+                    {
+                        var msg = Loc.GetString("rmc-xeno-evolution-failed-queen-requirement-minutes",
+                            ("minutes", graceLeft.Minutes),
+                            ("seconds", graceLeft.Seconds));
+                        if (graceLeft.Minutes == 0)
+                        {
+                            msg = Loc.GetString("rmc-xeno-evolution-failed-queen-requirement-seconds",
+                                ("seconds", graceLeft.Seconds));
+                        }
+
+                        _popup.PopupEntity(msg, xeno, xeno, PopupType.MediumCaution);
+                    }
+
+                    return false;
+                }
+            }
         }
 
         // TODO RMC14 revive jelly when added should not bring back dead queens

--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolveQueenAllowedEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolveQueenAllowedEvent.cs
@@ -1,0 +1,7 @@
+namespace Content.Shared._RMC14.Xenonids.Evolution;
+
+[ByRefEvent]
+public record struct XenoEvolveQueenAllowedEvent(EntityUid Xeno)
+{
+    public bool Allowed = true;
+}

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
@@ -75,6 +75,8 @@ rmc-xeno-evolution-failed-early-weeds = The hive hasn't developed enough yet for
 rmc-xeno-evolution-failed-bad-location = We can't evolve here.
 rmc-xeno-evolution-failed-marines-dropped = The sky talls have already landed, we can no longer evolve into this form.
 rmc-xeno-evolution-failed-queen-exists = The hive already has a Queen!
+rmc-xeno-evolution-failed-queen-requirement-minutes = We have not yet proven ourselves worthy to lead the hive. Anyone will be able to answer the call in {$minutes} minutes and {$seconds} seconds if no one else does.
+rmc-xeno-evolution-failed-queen-requirement-seconds = We have not yet proven ourselves worthy to lead the hive. Anyone will be able to answer the call in {$seconds} seconds if no one else does.
 rmc-xeno-evolution-start-self = We begin to twist and contort.
 rmc-xeno-evolution-start-others = {$xeno} begins to twist and contort.
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The time requirment for evolving to Queen is now applied, it can be bypassed after 2.5m elapsing of no one evolving to Queen
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: The time requirment for evolving to Queen is now applied, it can be bypassed after 2.5m elapsing of no one evolving to Queen
