### PR TITLE
Fixes: Temporary Welding Flash/Blindness When Equipping New Goggles

### DIFF
--- a/Content.Shared/Eye/Blinding/Components/EyeProtectionComponent.cs
+++ b/Content.Shared/Eye/Blinding/Components/EyeProtectionComponent.cs
@@ -1,15 +1,17 @@
+using Robust.Shared.GameStates;
+
 namespace Content.Shared.Eye.Blinding.Components;
 
 /// <summary>
 /// For welding masks, sunglasses, etc.
 /// </summary>
-[RegisterComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class EyeProtectionComponent : Component
 {
     /// <summary>
     /// How many seconds to subtract from the status effect. If it's greater than the source
     /// of blindness, do not blind.
     /// </summary>
-    [DataField("protectionTime")]
+    [DataField("protectionTime"), AutoNetworkedField]
     public TimeSpan ProtectionTime = TimeSpan.FromSeconds(10);
 }


### PR DESCRIPTION
## About the PR
Previously when selecting goggles from vendor or equipping them in the on state and then welding something it would flash the blindness overlay for a second and then fix itself.

## Why / Balance
Bug

## Technical details
networked eyeprotection

## Media

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: First weld upon equipping new welding goggles no longer flashes blindness effect 