### PR TITLE
Message to say why you can't late join as marine

### DIFF
--- a/Content.Client/LateJoin/LateJoinGui.cs
+++ b/Content.Client/LateJoin/LateJoinGui.cs
@@ -89,6 +89,29 @@ namespace Content.Client.LateJoin
             if (!_gameTicker.DisallowedLateJoin && _gameTicker.StationNames.Count == 0)
                 _sawmill.Warning("No stations exist, nothing to display in late-join GUI");
 
+            // RMC14
+            // Gives a helpful message to let people know why they can't join the round as a marine
+            if (_gameTicker.DisallowedLateJoin)
+                _base.AddChild(new BoxContainer()
+                    {
+                        Children =
+                        {
+                            new PanelContainer()
+                            {
+                                Children =
+                                {
+                                    new RichTextLabel()
+                                    {
+                                        StyleClasses = { "LabelBig" },
+                                        Text = $"\n{Loc.GetString("rmc-lobby-late-join-hijack-1")}\n\n{Loc.GetString("rmc-lobby-late-join-hijack-2")}",
+                                        HorizontalAlignment = HAlignment.Center,
+                                    },
+                                }
+                            }
+                        }
+                    });
+            // RMC14
+
             foreach (var (id, name) in _gameTicker.StationNames)
             {
                 var jobList = new BoxContainer

--- a/Content.Client/LateJoin/LateJoinGui.cs
+++ b/Content.Client/LateJoin/LateJoinGui.cs
@@ -103,7 +103,7 @@ namespace Content.Client.LateJoin
                                     new RichTextLabel()
                                     {
                                         StyleClasses = { "LabelBig" },
-                                        Text = $"\n{Loc.GetString("rmc-lobby-late-join-hijack-1")}\n\n{Loc.GetString("rmc-lobby-late-join-hijack-2")}",
+                                        Text = $"{Loc.GetString("rmc-lobby-late-join-hijack-1")}\n\n{Loc.GetString("rmc-lobby-late-join-hijack-2")}",
                                         HorizontalAlignment = HAlignment.Center,
                                     },
                                 }

--- a/Resources/Locale/en-US/_RMC14/rmc-lobby.ftl
+++ b/Resources/Locale/en-US/_RMC14/rmc-lobby.ftl
@@ -2,3 +2,6 @@
 rmc-lobby-no-burrowed-larva = No burrowed larva are available.
 rmc-lobby-burrowed-larva-available = The hive has burrowed larva available.
 rmc-lobby-join-as-larva = Join as Larva
+
+rmc-lobby-late-join-hijack-1 = [font size=15][color=red]The xenonids are invading the Almayer, you are not able to spawn as a marine anymore.[/color][/font]
+rmc-lobby-late-join-hijack-2 = [font size=15][color=white]Feel free to observe the end of the round or join the xenonid team![/color][/font]

--- a/Resources/Locale/en-US/_RMC14/rmc-lobby.ftl
+++ b/Resources/Locale/en-US/_RMC14/rmc-lobby.ftl
@@ -3,5 +3,5 @@ rmc-lobby-no-burrowed-larva = No burrowed larva are available.
 rmc-lobby-burrowed-larva-available = The hive has burrowed larva available.
 rmc-lobby-join-as-larva = Join as Larva
 
-rmc-lobby-late-join-hijack-1 = [font size=15][color=red]The xenonids are invading the Almayer, you are not able to spawn as a marine anymore.[/color][/font]
-rmc-lobby-late-join-hijack-2 = [font size=15][color=white]Feel free to observe the end of the round or join the xenonid team![/color][/font]
+rmc-lobby-late-join-hijack-1 = [font size=13][color=red]The xenonids are invading the Almayer, you will not be able to spawn as a marine until the next round.[/color][/font]
+rmc-lobby-late-join-hijack-2 = [font size=13][color=white]Feel free to observe the end of the round, or [/color][color=purple]join the attack on the metal hive![/color][/font]


### PR DESCRIPTION
## About the PR
Added some text in the Late Join box to let newer players know why they can't join the round as a marine anymore.

## Why / Balance
Helpful for new players, frees the Q&A channel from the 1000th time this has been asked.

fixes https://github.com/RMC-14/RMC-14/issues/5890

## Technical details
Only appears if there are no jobs available to select, as seen in video below.

## Media

<img width="490" height="318" alt="Screenshot 2026-07-23 023300" src="https://github.com/user-attachments/assets/8ba26f67-6182-44d9-82e3-610228a208a2" />


https://github.com/user-attachments/assets/2277e042-e433-4e65-a52e-a10f1983199c


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: CatAndHats
- tweak: The Late Join menu now lets you know why you cannot join the round after Hijack has occured