### PR TITLE
don't close UI on using repeat ability (xeno acid qol)

### DIFF
--- a/Content.Client/ContextMenu/UI/EntityMenuUIController.cs
+++ b/Content.Client/ContextMenu/UI/EntityMenuUIController.cs
@@ -160,7 +160,7 @@ namespace Content.Client.ContextMenu.UI
                 // RMC: if a repeatable targeted abilityis still selected after this
                 // click, keep the menu open so the next can be targeted immediately
                 // instead of forcing the player to reopen the menu
-                if (_actionUi.SelectingTargetFor == null)
+                if (func != EngineKeyFunctions.Use || _actionUi.SelectingTargetFor == null)
                     _context.Close();
 
                 args.Handle();

--- a/Content.Client/ContextMenu/UI/EntityMenuUIController.cs
+++ b/Content.Client/ContextMenu/UI/EntityMenuUIController.cs
@@ -3,6 +3,7 @@ using System.Numerics;
 using Content.Client.CombatMode;
 using Content.Client.Examine;
 using Content.Client.Gameplay;
+using Content.Client.UserInterface.Systems.Actions;
 using Content.Client.Verbs;
 using Content.Client.Verbs.UI;
 using Content.Shared.CCVar;
@@ -46,6 +47,7 @@ namespace Content.Client.ContextMenu.UI
         [Dependency] private readonly IEyeManager _eyeManager = default!;
         [Dependency] private readonly ContextMenuUIController _context = default!;
         [Dependency] private readonly VerbMenuUIController _verb = default!;
+        [Dependency] private readonly ActionUIController _actionUi = default!;
 
         [UISystemDependency] private readonly VerbSystem _verbSystem = default!;
         [UISystemDependency] private readonly ExamineSystem _examineSystem = default!;
@@ -155,7 +157,12 @@ namespace Content.Client.ContextMenu.UI
                     inputSys.HandleInputCommand(session, func, message);
                 }
 
-                _context.Close();
+                // RMC: if a repeatable targeted abilityis still selected after this
+                // click, keep the menu open so the next can be targeted immediately
+                // instead of forcing the player to reopen the menu
+                if (_actionUi.SelectingTargetFor == null)
+                    _context.Close();
+
                 args.Handle();
             }
         }

--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -15,6 +15,7 @@ using Content.Client.UserInterface.Systems.Gameplay;
 using Content.Shared._RMC14.Actions;
 using Content.Shared._RMC14.Vehicle;
 using Content.Shared.Actions;
+using Content.Shared.Coordinates;
 using Content.Shared.Actions.Components;
 using Content.Shared.Charges.Systems;
 using Content.Shared.Input;
@@ -165,13 +166,29 @@ public sealed partial class ActionUIController : UIController, IOnStateChanged<G
         if (!_timing.IsFirstTimePredicted || _actionsSystem == null || SelectingTargetFor is not { } actionId)
             return false;
 
+        return TryFireSelectedAction(actionId, args);
+    }
+
+    /// RMC: fires the currently selected targeted action at <paramref name="target"/>
+    public bool TryUseSelectedActionOn(EntityUid target)
+    {
+        if (!_timing.IsFirstTimePredicted || _actionsSystem == null || SelectingTargetFor is not { } actionId)
+            return false;
+
+        var args = new PointerInputCmdArgs(null, target.ToCoordinates(), default, target, BoundKeyState.Down, null!);
+        return TryFireSelectedAction(actionId, args);
+    }
+
+    private bool TryFireSelectedAction(EntityUid actionId, in PointerInputCmdArgs args)
+    {
         if (_playerManager.LocalEntity is not { } user)
             return false;
 
         if (!EntityManager.TryGetComponent<ActionsComponent>(user, out var comp))
             return false;
 
-        if (_actionsSystem.GetAction(actionId) is not {} action ||
+        if (_actionsSystem == null ||
+            _actionsSystem.GetAction(actionId) is not {} action ||
             !EntityManager.TryGetComponent<TargetActionComponent>(action, out var target))
         {
             return false;

--- a/Content.Client/UserInterface/Systems/Storage/StorageUIController.cs
+++ b/Content.Client/UserInterface/Systems/Storage/StorageUIController.cs
@@ -5,6 +5,7 @@ using Content.Client.Hands.Systems;
 using Content.Client.Interaction;
 using Content.Client.Storage;
 using Content.Client.Storage.Systems;
+using Content.Client.UserInterface.Systems.Actions;
 using Content.Client.UserInterface.Systems.Hotbar.Widgets;
 using Content.Client.UserInterface.Systems.Info;
 using Content.Client.UserInterface.Systems.Storage.Controls;
@@ -242,6 +243,15 @@ public sealed class StorageUIController : UIController, IOnSystemChanged<Storage
     {
         if (IsDragging || !window.IsOpen)
             return;
+
+        // RMC
+        if (args.Function == ContentKeyFunctions.MoveStoredItem &&
+            UIManager.GetUIController<ActionUIController>().TryUseSelectedActionOn(control.Entity))
+        {
+            args.Handle();
+            window.FlagDirty();
+            return;
+        }
 
         if (args.Function == ContentKeyFunctions.MoveStoredItem)
         {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Makes it so that the storage UI (when you right click) doesn't dissapear on using a repeat ability on it
This is mostly just for xenos to acid stuff on the same tile

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->



https://github.com/user-attachments/assets/4c2d3d9b-f840-4de2-a1d3-f71b703a6d6f



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: The storage UI window will now not close on using a repeatable ability with a use function, this is mainly so xenonids can melt items on the same tile without having to reselect the ability 
