### PR TITLE
Sorokyne corpse parity

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Markers/Spawners/Corpses/spp.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Markers/Spawners/Corpses/spp.yml
@@ -6,3 +6,19 @@
   components:
   - type: CorpseSpawner
     spawn: RMCCorpseSPPSoldier
+#SPP Colonist (Random job)
+- type: entity
+  parent: RMCSpawnerCorpse
+  id: RMCSpawnerCorpseSPPColonist
+  name: Corpse Spawner - SPP Colonist (Randomized Job)
+  components:
+  - type: CorpseSpawner
+    spawn: RMCCorpseSPPColonist
+#SPP Chef
+- type: entity
+  parent: RMCSpawnerCorpse
+  id: RMCSpawnerCorpseSPPChef
+  name: Corpse Spawner - SPP Chef
+  components:
+  - type: CorpseSpawner
+    spawn: RMCCorpseSPPChef

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Corpses/spp.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Corpses/spp.yml
@@ -30,3 +30,140 @@
   storage:
     outerClothing:
     - RMCBinoculars
+
+# SPP Chef
+- type: randomHumanoidSettings
+  parent: RMCCorpse
+  id: RMCCorpseSPPChef
+  components:
+  - type: Loadout
+    prototypes: [ RMCGearCorpseSPPChef ]
+
+- type: startingGear
+  id: RMCGearCorpseSPPChef
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitChef
+    back: CMSatchel
+    shoes: RMCShoesBlack
+    head: ClothingHeadHatChef
+    outerClothing: RMCChefApron
+    id: RMCIDCardChefCorpse
+    ears: RMCHeadsetSPP
+  storage:
+    back:
+    - RMCRadioHandheldColonyOff
+
+# SPP Colonist (Randomly selects a loadout job (Civilian, Doctor, Engineer, Scientist, Miner, Security))
+- type: randomHumanoidSettings
+  parent: RMCCorpse
+  id: RMCCorpseSPPColonist
+  components:
+  - type: Loadout
+    prototypes: [ RMCGearCorpseSPPColonist,
+                  RMCGearCorpseSPPDoctor,
+                  RMCGearCorpseSPPEngineer,
+                  RMCGearCorpseSPPScientist,
+                  RMCGearCorpseSPPMiner,
+                  RMCGearCorpseSPPSecurity ]
+
+# Civilian Job
+- type: startingGear
+  id: RMCGearCorpseSPPColonist
+  equipment:
+    jumpsuit: CMJumpsuitSPP
+    back: CMSatchel
+    shoes: CMBootsBlack
+    id: CMIDCardColonist
+    ears: RMCHeadsetSPP
+
+# Doctor job
+- type: startingGear
+  id: RMCGearCorpseSPPDoctor
+  equipment:
+    jumpsuit: CMJumpsuitSPPMedic
+    back: CMSatchelMedical
+    shoes: CMBootsBlackFilled
+    eyes: RMCGlassesMedicalHUDGlasses
+    gloves: CMHandsLatex
+    id: CMIDCardColonistDoctor
+    ears: RMCHeadsetSPP
+    mask: CMMaskSterile
+    outerClothing: RMCMedicalApron
+  storage:
+    back:
+    - RMCRadioHandheldColonyOff
+
+#Engineer job
+- type: startingGear
+  id: RMCGearCorpseSPPEngineer
+  equipment:
+    jumpsuit: CMJumpsuitSPPEngi
+    back: CMSatchelEngineer
+    shoes: CMBootsBlackFilled
+    head: RMCHardHat
+    eyes: RMCWeldingGoggles
+    gloves: CMHandsInsulated
+    outerClothing: RMCHazardVest
+    id: CMIDCardColonistEngineer
+    ears: RMCHeadsetSPPEngineer
+    belt: CMBeltUtilityFilled
+  storage:
+    back:
+    - RMCRadioHandheldColonyOff
+
+# Scientist job
+- type: startingGear
+  id: RMCGearCorpseSPPScientist
+  equipment:
+    jumpsuit: RMCJumpsuitCivilianVirologist
+    back: RMCSatchelVirology
+    shoes: CMBootsBlackFilled
+    gloves: CMHandsLatex
+    outerClothing: RMCLabcoat
+    id: RMCIDCardColonistScientist
+    mask: CMMaskSterile
+    eyes: RMCGlassesReagentHUDGlasses
+    ears: RMCHeadsetSPP
+    head: CMHeadCapSurgGreen
+  storage:
+    back:
+    - RMCRadioHandheldColonyOff
+    - RMCMotionDetector
+#    # T3 research notes
+
+# Miner job
+- type: startingGear
+  id: RMCGearCorpseSPPMiner
+  equipment:
+    jumpsuit: RMCJumpsuitTMCC
+    back: CMBackpackEngineer
+    shoes: RMCShoesJackboots
+    head: RMCHardhatRedTMCC
+    outerClothing: RMCArmorTMCCAlt
+    id: RMCIDCardMinerCorpse
+    ears: RMCHeadsetSPP
+    pocket1: RMCPouchToolsFill
+    gloves: RMCHandsCombat
+  storage:
+    back:
+    - RMCFlashlightLantern
+    - RMCRadioHandheldColonyOff
+
+# Security job
+- type: startingGear
+  id: RMCGearCorpseSPPSecurity
+  equipment:
+    jumpsuit: CMJumpsuitSPP
+    back: CMSatchelSecurity
+    head: ArmorHelmetSPP
+    outerClothing: RMCArmorSPP
+    shoes: RMCBootsSPPFilled
+    eyes: CMGlassesSecurity
+    gloves: CMHandsBlackMarine
+    id: CMIDCardColonistSecurity
+    ears: RMCHeadsetSPP
+    belt: CMBeltSecurityMPFilled
+  storage:
+    back:
+    - RMCM5Bayonet
+    - RMCRadioHandheldColonyOff


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixes https://github.com/RMC-14/RMC-14/issues/10480

## Why / Balance
Parity corpse spawners; also gives every corpse the correct headset

## Technical details
Merges RMCSpawnerCorpse(unknown corpse) RMCSpawnerCorpseDoctor RMCSpawnerCorpseEngineer RMCSpawnerCorpseLiaison RMCSpawnerCorpseMiner RMCSpawnerCorpseScientist into RMCCorpseSPPColonist so it mirrors parity with randomized corpse jobs

Also adds RMCCorpseSPPChef so it mirrors parity in where the chef spawns at

No corpse spawner entities were added or subtracted; all were modified to the SPP variant (minus the AEGIS and SPP soldier spawners that were left alone)
## Media
On CM13 the corpse spawners spawns a colonist with a random job
<img width="1251" height="1037" alt="image" src="https://github.com/user-attachments/assets/dd6805b3-721f-45d4-838f-aef08d52b5be" />
Also on CM13 Chef spawner is separate
<img width="1247" height="1032" alt="image" src="https://github.com/user-attachments/assets/68552203-b4e8-4292-9382-e9e99e84c1db" />

Scientist Corpse
<img width="579" height="563" alt="image" src="https://github.com/user-attachments/assets/f002e5a9-efce-47e1-b572-9802bc9b16c1" />
Engineer Corpse
<img width="598" height="585" alt="image" src="https://github.com/user-attachments/assets/f3388d31-8c10-4e89-a38f-9c6b9987088a" />
Security Corpse
<img width="603" height="560" alt="image" src="https://github.com/user-attachments/assets/8f95aabf-0b50-4186-906b-fbf2d41543ab" />
Civilian Corpse
<img width="576" height="560" alt="image" src="https://github.com/user-attachments/assets/51024a5e-3a9a-4bd7-b5c9-b7504b57f629" />
Doctor Corpse
<img width="594" height="552" alt="image" src="https://github.com/user-attachments/assets/045d8349-1e5d-4571-b172-fcc6326b7c10" />
Miner Corpse
<img width="587" height="556" alt="image" src="https://github.com/user-attachments/assets/58adc0b0-92d4-42bc-9b6d-3d026f58bcf2" />
Chef Corpse
<img width="589" height="573" alt="image" src="https://github.com/user-attachments/assets/5ba16d49-a96b-4f78-83ad-93cd7d207557" />

New SPP corpse entities
<img width="599" height="228" alt="image" src="https://github.com/user-attachments/assets/98e99d1c-91cc-44fd-af67-4ef77e1ac4c1" />


PS: My first PR ever, any feedback is greatly appreciated
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Sorokyne parity corpses

