### PR TITLE
Examine text additions for xenonid structures

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Construction/EggMorpher/EggMorpherSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/EggMorpher/EggMorpherSystem.cs
@@ -54,7 +54,9 @@ public sealed partial class EggMorpherSystem : EntitySystem
 
         using (args.PushGroup(nameof(EggMorpherComponent)))
         {
-            args.PushMarkup(Loc.GetString("rmc-xeno-construction-egg-morpher-examine", ("cur_paras", eggMorpher.Comp.CurParasites), ("max_paras", eggMorpher.Comp.MaxParasites)));
+            args.PushMarkup(Loc.GetString("rmc-xeno-construction-egg-morpher-examine-count", ("cur_paras", eggMorpher.Comp.CurParasites), ("max_paras", eggMorpher.Comp.MaxParasites)));
+            if (eggMorpher.Comp.NextSpawnAt is { } nextSpawnAt && eggMorpher.Comp.CurParasites < eggMorpher.Comp.GrowMaxParasites)
+                args.PushMarkup(Loc.GetString("rmc-xeno-construction-egg-morpher-examine-next-spawn", ("time_left", (int)(nextSpawnAt - _time.CurTime).TotalSeconds)));
         }
     }
 
@@ -147,6 +149,7 @@ public sealed partial class EggMorpherSystem : EntitySystem
         args.Handled = true;
         QueueDel(used);
         eggMorpher.Comp.CurParasites++;
+        Dirty(eggMorpher);
         _appearance.SetData(eggMorpher, EggmorpherOverlayVisuals.Number, eggMorpher.Comp.CurParasites);
     }
 

--- a/Content.Shared/_RMC14/Xenonids/Construction/EggMorpher/EggMorpherSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/EggMorpher/EggMorpherSystem.cs
@@ -49,10 +49,8 @@ public sealed partial class EggMorpherSystem : EntitySystem
 
     private void OnExamineEvent(Entity<EggMorpherComponent> eggMorpher, ref ExaminedEvent args)
     {
-        if (!HasComp<XenoComponent>(args.Examiner))
-        {
+        if (!HasComp<XenoComponent>(args.Examiner) && !HasComp<GhostComponent>(args.Examiner))
             return;
-        }
 
         using (args.PushGroup(nameof(EggMorpherComponent)))
         {

--- a/Content.Shared/_RMC14/Xenonids/Construction/PlasmaTree/PlasmaTreeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/PlasmaTree/PlasmaTreeSystem.cs
@@ -1,7 +1,10 @@
-using Content.Shared._RMC14.Xenonids.Plasma;
+using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.Xenonids.Hive;
+using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared._RMC14.Xenonids.Rest;
 using Content.Shared.DoAfter;
+using Content.Shared.Examine;
+using Content.Shared.Ghost;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Popups;
@@ -29,6 +32,7 @@ public sealed class PlasmaTreeSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<PlasmaTreeComponent, PlasmaTreeRecoverDoAfterEvent>(OnRecoveryDoAfter);
+        SubscribeLocalEvent<PlasmaTreeComponent, ExaminedEvent>(OnExamined);
     }
 
     public override void Update(float frameTime)
@@ -110,5 +114,11 @@ public sealed class PlasmaTreeSystem : EntitySystem
             return;
 
         _plasma.RegenPlasma(args.Target.Value, plasmaTree.Comp.PlasmaAmount);
+    }
+
+    private void OnExamined(Entity<PlasmaTreeComponent> ent, ref ExaminedEvent args)
+    {
+        if (HasComp<XenoComponent>(args.Examiner) || HasComp<GhostComponent>(args.Examiner))
+            args.PushMarkup(Loc.GetString("rmc-xeno-construction-plasma-tree-xeno-examine"));
     }
 }

--- a/Content.Shared/_RMC14/Xenonids/Construction/RecoveryNode/RecoveryNodeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/RecoveryNode/RecoveryNodeSystem.cs
@@ -1,9 +1,11 @@
+using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.Xenonids.Heal;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Rest;
-using Content.Shared.Coordinates;
 using Content.Shared.Damage;
 using Content.Shared.DoAfter;
+using Content.Shared.Examine;
+using Content.Shared.Ghost;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Popups;
@@ -11,11 +13,6 @@ using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Content.Shared._RMC14.Xenonids.Construction.RecoveryNode;
 
@@ -27,7 +24,6 @@ public sealed partial class RecoveryNodeSystem : EntitySystem
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly SharedXenoHealSystem _heal = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
-    [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly MobStateSystem _mob = default!;
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly SharedDoAfterSystem _doafter = default!;
@@ -36,7 +32,7 @@ public sealed partial class RecoveryNodeSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<RecoveryNodeComponent, RecoveryNodeRecoverDoAfterEvent>(OnRecoveryDoAfter);
-
+        SubscribeLocalEvent<RecoveryNodeComponent, ExaminedEvent>(OnExamined);
     }
 
     public override void Update(float frameTime)
@@ -107,5 +103,11 @@ public sealed partial class RecoveryNodeSystem : EntitySystem
             return;
 
         _heal.Heal(args.Target.Value, recoveryNode.Comp.HealAmount);
+    }
+
+    private void OnExamined(Entity<RecoveryNodeComponent> ent, ref ExaminedEvent args)
+    {
+        if (HasComp<XenoComponent>(args.Examiner) || HasComp<GhostComponent>(args.Examiner))
+            args.PushMarkup(Loc.GetString("rmc-xeno-construction-recovery-node-xeno-examine"));
     }
 }

--- a/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
@@ -55,6 +55,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using static Content.Shared.Physics.CollisionGroup;
+using Content.Shared.Ghost;
 
 namespace Content.Shared._RMC14.Xenonids.Construction;
 
@@ -1007,6 +1008,9 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
 
     private void OnHiveConstructionNodeExamined(Entity<HiveConstructionNodeComponent> node, ref ExaminedEvent args)
     {
+        if (!HasComp<XenoComponent>(args.Examiner) && !HasComp<GhostComponent>(args.Examiner))
+            return;
+
         var plasmaLeft = node.Comp.PlasmaCost - node.Comp.PlasmaStored;
         args.PushMarkup(Loc.GetString("cm-xeno-construction-plasma-left", ("construction", node.Owner), ("plasma", plasmaLeft)));
     }

--- a/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
@@ -36,6 +36,7 @@ using Content.Shared.DoAfter;
 using Content.Shared.Doors.Components;
 using Content.Shared.Examine;
 using Content.Shared.FixedPoint;
+using Content.Shared.Ghost;
 using Content.Shared.Interaction;
 using Content.Shared.Maps;
 using Content.Shared.Popups;
@@ -55,7 +56,6 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using static Content.Shared.Physics.CollisionGroup;
-using Content.Shared.Ghost;
 
 namespace Content.Shared._RMC14.Xenonids.Construction;
 

--- a/Content.Shared/_RMC14/Xenonids/Construction/Tunnel/XenoTunnelSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/Tunnel/XenoTunnelSystem.cs
@@ -18,6 +18,7 @@ using Content.Shared.Coordinates.Helpers;
 using Content.Shared.Database;
 using Content.Shared.DoAfter;
 using Content.Shared.Examine;
+using Content.Shared.Ghost;
 using Content.Shared.Hands;
 using Content.Shared.Interaction;
 using Content.Shared.Item.ItemToggle.Components;
@@ -148,27 +149,28 @@ public sealed class XenoTunnelSystem : EntitySystem
 
     private void OnExamine(Entity<XenoTunnelComponent> xenoTunnel, ref ExaminedEvent args)
     {
-        if (!HasComp<XenoComponent>(args.Examiner) || !_hive.FromSameHive(args.Examiner, xenoTunnel.Owner))
+        if (HasComp<GhostComponent>(args.Examiner) || (HasComp<XenoComponent>(args.Examiner) && _hive.FromSameHive(args.Examiner, xenoTunnel.Owner)))
         {
-            LocId message = "rmc-xeno-construction-tunnel-examine-not-xeno-empty";
-
-            var container = _container.EnsureContainer<Container>(xenoTunnel, XenoTunnelComponent.ContainedMobsContainerId);
-            if (container.ContainedEntities.Count > 0)
-                message = "rmc-xeno-construction-tunnel-examine-not-xeno";
+            if (!TryGetHiveTunnelName(xenoTunnel, out var tunnelName))
+                return;
 
             using (args.PushGroup(nameof(XenoTunnelComponent)))
             {
-                args.PushMarkup(Loc.GetString(message));
+                args.PushMarkup(Loc.GetString("rmc-xeno-construction-tunnel-examine", ("tunnelName", tunnelName)));
             }
+
             return;
         }
 
-        if (!TryGetHiveTunnelName(xenoTunnel, out var tunnelName))
-            return;
+        LocId message = "rmc-xeno-construction-tunnel-examine-not-xeno-empty";
+
+        var container = _container.EnsureContainer<Container>(xenoTunnel, XenoTunnelComponent.ContainedMobsContainerId);
+        if (container.ContainedEntities.Count > 0)
+            message = "rmc-xeno-construction-tunnel-examine-not-xeno";
 
         using (args.PushGroup(nameof(XenoTunnelComponent)))
         {
-            args.PushMarkup(Loc.GetString("rmc-xeno-construction-tunnel-examine", ("tunnelName", tunnelName)));
+            args.PushMarkup(Loc.GetString(message));
         }
     }
 

--- a/Content.Shared/_RMC14/Xenonids/Designer/WeedboundWallSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Designer/WeedboundWallSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared.Destructible;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
 using System.Linq;
+using Content.Shared.Examine;
 
 namespace Content.Shared._RMC14.Xenonids.Designer;
 
@@ -27,6 +28,7 @@ public sealed class WeedboundWallSystem : EntitySystem
         SubscribeLocalEvent<WeedboundWallComponent, MapInitEvent>(OnWeedboundMapInit);
         SubscribeLocalEvent<WeedboundWallComponent, EntityTerminatingEvent>(OnWeedboundTerminating);
         SubscribeLocalEvent<WeedboundWallComponent, ComponentRemove>(OnWeedboundRemove);
+        SubscribeLocalEvent<WeedboundWallComponent, ExaminedEvent>(OnWeedboundExamined);
     }
 
     private void OnWeedboundStartup(Entity<WeedboundWallComponent> ent, ref ComponentStartup args)
@@ -37,6 +39,12 @@ public sealed class WeedboundWallSystem : EntitySystem
     private void OnWeedboundMapInit(Entity<WeedboundWallComponent> ent, ref MapInitEvent args)
     {
         BindAndRegister(ent);
+    }
+
+    private void OnWeedboundExamined(Entity<WeedboundWallComponent> ent, ref ExaminedEvent args)
+    {
+        if (HasComp<XenoComponent>(args.Examiner))
+            args.PushText(Loc.GetString("rmc-xeno-weedbound-examined"));
     }
 
     private void BindAndRegister(Entity<WeedboundWallComponent> ent)

--- a/Content.Shared/_RMC14/Xenonids/Designer/WeedboundWallSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Designer/WeedboundWallSystem.cs
@@ -2,10 +2,9 @@ using Content.Shared._RMC14.Map;
 using Content.Shared._RMC14.Xenonids.Weeds;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared.Destructible;
+using Content.Shared.Examine;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
-using System.Linq;
-using Content.Shared.Examine;
 
 namespace Content.Shared._RMC14.Xenonids.Designer;
 

--- a/Content.Shared/_RMC14/Xenonids/Fruit/SharedXenoFruitSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Fruit/SharedXenoFruitSystem.cs
@@ -239,7 +239,14 @@ public sealed class SharedXenoFruitSystem : EntitySystem
         if (!HasComp<XenoComponent>(args.Examiner))
             return;
 
-        args.PushMarkup(Loc.GetString("rmc-xeno-fruit-speed", ("amount", fruit.SpeedModifier * 100), ("time", fruit.Duration.TotalSeconds)), -12);
+        string? modifier = null;
+        if (TryComp<MovementSpeedModifierComponent>(args.Examiner, out var movementSpeed))
+        {
+            modifier = (fruit.SpeedModifier.Float() / movementSpeed.BaseWalkSpeed).ToString("P0");
+        }
+        args.PushMarkup(Loc.GetString("rmc-xeno-fruit-speed",
+            ("amount", modifier ?? fruit.SpeedModifier.ToString()),
+            ("time", fruit.Duration.TotalSeconds)), -12);
     }
 
     private void OnXenoPlasmaFruitExamined(EntityUid uid, XenoFruitPlasmaComponent fruit, ExaminedEvent args)

--- a/Content.Shared/_RMC14/Xenonids/Fruit/SharedXenoFruitSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Fruit/SharedXenoFruitSystem.cs
@@ -191,7 +191,7 @@ public sealed class SharedXenoFruitSystem : EntitySystem
         };
 
         args.PushMarkup(Loc.GetString("rmc-xeno-fruit-examine-base",
-            ("growthStatus", Loc.GetString(state))));
+            ("growthStatus", Loc.GetString(state))), -9);
 
         if (!HasComp<XenoComponent>(args.Examiner))
             return;
@@ -239,7 +239,7 @@ public sealed class SharedXenoFruitSystem : EntitySystem
         if (!HasComp<XenoComponent>(args.Examiner))
             return;
 
-        args.PushMarkup(Loc.GetString("rmc-xeno-fruit-speed", ("amount", fruit.SpeedModifier), ("time", fruit.Duration.TotalSeconds)), -12);
+        args.PushMarkup(Loc.GetString("rmc-xeno-fruit-speed", ("amount", fruit.SpeedModifier * 100), ("time", fruit.Duration.TotalSeconds)), -12);
     }
 
     private void OnXenoPlasmaFruitExamined(EntityUid uid, XenoFruitPlasmaComponent fruit, ExaminedEvent args)

--- a/Content.Shared/_RMC14/Xenonids/Fruit/SharedXenoFruitSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Fruit/SharedXenoFruitSystem.cs
@@ -7,7 +7,6 @@ using Content.Shared._RMC14.Xenonids.Construction.ResinHole;
 using Content.Shared._RMC14.Xenonids.Egg;
 using Content.Shared._RMC14.Xenonids.Fruit.Components;
 using Content.Shared._RMC14.Xenonids.Fruit.Events;
-using Content.Shared._RMC14.Xenonids.Hedgehog;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Pheromones;
 using Content.Shared._RMC14.Xenonids.Plasma;
@@ -236,16 +235,16 @@ public sealed class SharedXenoFruitSystem : EntitySystem
 
     private void OnXenoSpeedFruitExamined(EntityUid uid, XenoFruitSpeedComponent fruit, ExaminedEvent args)
     {
-        if (!HasComp<XenoComponent>(args.Examiner))
-            return;
-
-        string? modifier = null;
-        if (TryComp<MovementSpeedModifierComponent>(args.Examiner, out var movementSpeed))
+        if (!TryComp<XenoComponent>(args.Examiner, out var xenoComp) ||
+            !TryComp<MovementSpeedModifierComponent>(args.Examiner, out var movementSpeed) ||
+            !_prototype.TryIndex(xenoComp.Role, out var casteJob))
         {
-            modifier = (fruit.SpeedModifier.Float() / movementSpeed.BaseWalkSpeed).ToString("P0");
+            return;
         }
+
         args.PushMarkup(Loc.GetString("rmc-xeno-fruit-speed",
-            ("amount", modifier ?? fruit.SpeedModifier.ToString()),
+            ("caste", Loc.GetString(casteJob.Name)),
+            ("amount", fruit.SpeedModifier / movementSpeed.BaseWalkSpeed * 100),
             ("time", fruit.Duration.TotalSeconds)), -12);
     }
 
@@ -688,7 +687,7 @@ public sealed class SharedXenoFruitSystem : EntitySystem
         // Can't feed non-xenos
         if (!HasComp<XenoComponent>(target))
         {
-            _popup.PopupClient(Loc.GetString("rmc-xeno-fruit-feed-refuse", ("target",target), ("fruit", fruit)), user, user, PopupType.SmallCaution);
+            _popup.PopupClient(Loc.GetString("rmc-xeno-fruit-feed-refuse", ("target", target), ("fruit", fruit)), user, user, PopupType.SmallCaution);
             return false;
         }
 
@@ -700,7 +699,7 @@ public sealed class SharedXenoFruitSystem : EntitySystem
         }
 
         // TODO: check for hive
-        if(!_hive.FromSameHive(fruit.Owner, user))
+        if (!_hive.FromSameHive(fruit.Owner, user))
         {
             _popup.PopupClient(Loc.GetString("rmc-xeno-fruit-wrong-hive"), user, user, PopupType.SmallCaution);
             return false;

--- a/Content.Shared/_RMC14/Xenonids/Fruit/SharedXenoFruitSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Fruit/SharedXenoFruitSystem.cs
@@ -243,7 +243,7 @@ public sealed class SharedXenoFruitSystem : EntitySystem
         }
 
         args.PushMarkup(Loc.GetString("rmc-xeno-fruit-speed",
-            ("caste", Loc.GetString(casteJob.Name)),
+            ("caste", casteJob.LocalizedName),
             ("amount", fruit.SpeedModifier / movementSpeed.BaseWalkSpeed * 100),
             ("time", fruit.Duration.TotalSeconds)), -12);
     }

--- a/Resources/Locale/en-US/_RMC14/structures/walls.ftl
+++ b/Resources/Locale/en-US/_RMC14/structures/walls.ftl
@@ -8,3 +8,8 @@ rmc-structure-wall-repair-examine-tip = [color=cyan]Alt+click[/color] this wall 
 rmc-structure-damaged-girder-examine-tip = Use a [color=lightgreen]welder[/color] to repair it.
 
 rmc-structure-displaced-examine-tip = It looks dislodged. [color=lightgreen]Crowbar[/color] to secure it.
+
+rmc-xeno-structure-damaged-1 = [color=lightgreen]It looks healthy![/color]
+rmc-xeno-structure-damaged-2 = [color=yellow]It looks slightly damaged.[/color]
+rmc-xeno-structure-damaged-3 = [color=orange]It looks severely damaged.[/color]
+rmc-xeno-structure-damaged-4 = [color=red]It's about to fall apart![/color]

--- a/Resources/Locale/en-US/_RMC14/structures/walls.ftl
+++ b/Resources/Locale/en-US/_RMC14/structures/walls.ftl
@@ -9,7 +9,7 @@ rmc-structure-damaged-girder-examine-tip = Use a [color=lightgreen]welder[/color
 
 rmc-structure-displaced-examine-tip = It looks dislodged. [color=lightgreen]Crowbar[/color] to secure it.
 
-rmc-xeno-structure-damaged-1 = [color=lightgreen]It looks healthy![/color]
+rmc-xeno-structure-damaged-1 = [color=lightgreen]It looks fully intact.[/color]
 rmc-xeno-structure-damaged-2 = [color=yellow]It looks slightly damaged.[/color]
 rmc-xeno-structure-damaged-3 = [color=orange]It looks severely damaged.[/color]
 rmc-xeno-structure-damaged-4 = [color=red]It's about to fall apart![/color]

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-construction.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-construction.ftl
@@ -94,7 +94,8 @@ rmc-xeno-construction-egg-morpher-already-full = This egg morpher is already ful
 
 rmc-xeno-egg-morpher-return-self = {CAPITALIZE($parasite)} crawls into the egg morpher.
 
-rmc-xeno-construction-egg-morpher-examine = Sheltering: {$cur_paras}/{$max_paras} children.
+rmc-xeno-construction-egg-morpher-examine-count = Sheltering: {$cur_paras}/{$max_paras} children.
+rmc-xeno-construction-egg-morpher-examine-next-spawn = A new child will grow in [bold]{$time_left}[/bold] seconds.
 
 rmc-xeno-construction-recovery-node-heal-target = We feel a warm aura envelop us.
 rmc-xeno-construction-recovery-node-heal-other = {CAPITALIZE(THE($target))} glows as a warm aura envelops them.

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-construction.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-construction.ftl
@@ -73,7 +73,7 @@ rmc-xeno-construction-default-tunnel-name = {$areaName} ({$coordX}, {$coordY}) {
 rmc-xeno-construction-default-area-name = Unknown
 
 rmc-xeno-construction-failed-tunnel-rename = Tunnel names must be unique!
-rmc-xeno-construction-tunnel-examine = The pheromone scent reads: {$tunnelName}
+rmc-xeno-construction-tunnel-examine = The pheromone scent reads: '{$tunnelName}'
 rmc-xeno-construction-tunnel-examine-not-xeno-empty = [color=purple][italic]It's a dark abyss...[/italic][/color]
 rmc-xeno-construction-tunnel-examine-not-xeno = [color=purple][italic]It's a dark abyss with a few little...lights...almost like something is watching.[/italic][/color]
 

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-construction.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-construction.ftl
@@ -98,6 +98,8 @@ rmc-xeno-construction-egg-morpher-examine = Sheltering: {$cur_paras}/{$max_paras
 
 rmc-xeno-construction-recovery-node-heal-target = We feel a warm aura envelop us.
 rmc-xeno-construction-recovery-node-heal-other = {CAPITALIZE(THE($target))} glows as a warm aura envelops them.
+rmc-xeno-construction-recovery-node-xeno-examine = Recovers the [color=green]health[/color] of adjacent Xenonids.
+rmc-xeno-construction-plasma-tree-xeno-examine = Recovers the [color=cyan]plasma[/color] of adjacent Xenonids.
 
 rmc-xeno-construction-no-map-structure = The ground isn't solid.
 rmc-xeno-construction-must-have-weeds-structure = We can only make this on weeds!

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-construction.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-construction.ftl
@@ -123,3 +123,5 @@ rmc-xeno-designer-greater-surge-cooldown = We need to wait before using Greater 
 rmc-xeno-designer-greater-surge-none = There's no design nodes nearby.
 rmc-xeno-designer-greater-surge-success = We convert {$count} design nodes into reflective resin walls.
 rmc-xeno-designer-infuse-node = You infuse the node with plasma.
+
+rmc-xeno-weedbound-examined = You sense that this structure will collapse if the weeds it is merged with disappear.

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-fruit.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-fruit.ftl
@@ -105,5 +105,5 @@ rmc-xeno-fruit-instant-heal = Instantly restores [bold]{$amount}[/bold] health.
 rmc-xeno-fruit-regen-heal = Regenerates [bold]{$amount}[/bold] health per second for {$time} seconds.
 rmc-xeno-fruit-shield = Grants an overshield equal to [bold]{$percent}%[/bold] of our max health, up to [bold]{$max}[/bold] max. It decays after {$duration} seconds, losing {$decay} per second.
 rmc-xeno-fruit-cooldown = Slashes give you an ongoing [bold]{$amount}%[/bold] cooldown reduction, up to [bold]{$max}%[/bold]. Benefits expire {$time} seconds after consumption.
-rmc-xeno-fruit-speed = Boosts our speed by [bold]{$amount}[/bold] for {$time} seconds.
+rmc-xeno-fruit-speed = Boosts our speed by [bold]{$amount}%[/bold] for {$time} seconds.
 rmc-xeno-fruit-regen-plasma = Regenerates [bold]{$amount}[/bold] plasma per second for {$time} seconds.

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-fruit.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-fruit.ftl
@@ -105,5 +105,5 @@ rmc-xeno-fruit-instant-heal = Instantly restores [bold]{$amount}[/bold] health.
 rmc-xeno-fruit-regen-heal = Regenerates [bold]{$amount}[/bold] health per second for {$time} seconds.
 rmc-xeno-fruit-shield = Grants an overshield equal to [bold]{$percent}%[/bold] of our max health, up to [bold]{$max}[/bold] max. It decays after {$duration} seconds, losing {$decay} per second.
 rmc-xeno-fruit-cooldown = Slashes give you an ongoing [bold]{$amount}%[/bold] cooldown reduction, up to [bold]{$max}%[/bold]. Benefits expire {$time} seconds after consumption.
-rmc-xeno-fruit-speed = Boosts our speed by [bold]{$amount}%[/bold] for {$time} seconds.
+rmc-xeno-fruit-speed = Boosts our speed by [bold]{$amount}[/bold] for {$time} seconds.
 rmc-xeno-fruit-regen-plasma = Regenerates [bold]{$amount}[/bold] plasma per second for {$time} seconds.

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-fruit.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-fruit.ftl
@@ -105,5 +105,9 @@ rmc-xeno-fruit-instant-heal = Instantly restores [bold]{$amount}[/bold] health.
 rmc-xeno-fruit-regen-heal = Regenerates [bold]{$amount}[/bold] health per second for {$time} seconds.
 rmc-xeno-fruit-shield = Grants an overshield equal to [bold]{$percent}%[/bold] of our max health, up to [bold]{$max}[/bold] max. It decays after {$duration} seconds, losing {$decay} per second.
 rmc-xeno-fruit-cooldown = Slashes give you an ongoing [bold]{$amount}%[/bold] cooldown reduction, up to [bold]{$max}%[/bold]. Benefits expire {$time} seconds after consumption.
-rmc-xeno-fruit-speed = Boosts our speed by [bold]{$amount}[/bold] for {$time} seconds.
+rmc-xeno-fruit-speed = As {$caste ->
+        [Queen] the {$caste}
+        [King] the {$caste}
+        *[other] a {$caste}
+    }, boosts our speed by [bold]{$amount}%[/bold] for {$time} seconds.
 rmc-xeno-fruit-regen-plasma = Regenerates [bold]{$amount}[/bold] plasma per second for {$time} seconds.

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-fruit.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-fruit.ftl
@@ -109,5 +109,5 @@ rmc-xeno-fruit-speed = As {$caste ->
         [Queen] the {$caste}
         [King] the {$caste}
         *[other] a {$caste}
-    }, boosts our speed by [bold]{$amount}%[/bold] for {$time} seconds.
+    }, it boosts our speed by [bold]{$amount}%[/bold] for {$time} seconds.
 rmc-xeno-fruit-regen-plasma = Regenerates [bold]{$amount}[/bold] plasma per second for {$time} seconds.

--- a/Resources/Prototypes/_RMC14/Damage/examine_messages.yml
+++ b/Resources/Prototypes/_RMC14/Damage/examine_messages.yml
@@ -1,0 +1,7 @@
+- type: examinableDamage
+  id: XenoStructureMessages
+  messages:
+    - rmc-xeno-structure-damaged-1
+    - rmc-xeno-structure-damaged-2
+    - rmc-xeno-structure-damaged-3
+    - rmc-xeno-structure-damaged-4

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Base/base_structure.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Base/base_structure.yml
@@ -66,6 +66,8 @@
     damage:
       types:
         Heat: 4.8
+  - type: ExaminableDamage
+    messages: XenoStructureMessages
 
 - type: entity
   id: CMCorrodible

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/Hive/xeno_base_hive.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/Hive/xeno_base_hive.yml
@@ -39,6 +39,8 @@
         Heat: 3.8
   - type: QueenEyeVision
   - type: XenoChargeDontHit
+  - type: ExaminableDamage
+    messages: XenoStructureMessages
 
 - type: entity
   abstract: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds special examine text to a whole bunch of different things, plus some other related changes. (Most of these are ported from CM.)
Specifically:
- Observers can now see how many parasites are currently in an egg morpher.
- Observers can now see tunnel names.
- Marines can no longer see the 'It requires x more plasma' message when examining unbuilt hive structures.
- The 'growth state' line when examining resin fruit now gets ordered under the "This is a **large** item" message.
- The speed boost from Alacrit is now displayed as a percentage increase to your caste's base speed in its description, rather than its value of '0.2'.
- Recovery nodes and plasma trees have a line explaining what they do. (Only visible to xenos and observers)
- Egg morphers now show the time left until they grow a new parasite.
- Fixed putting a hugger back into an egg morpher by hand not dirtying the morpher component. (not examine related just something I spotted.)
- Weedbound walls and doors have a line for xenos explaining that they'll collapse if the weeds die.
- Examining a xeno structure (walls, doors, hive structures, etc.) now shows how damaged it is, the same as regular walls and barricades. (Resolves #10236)

Each of these are shown in the media section below.

This PR had some pretty extreme scope creep so sorry about the mess of different changes. I tried to keep each thing in separate commits to help with reviewing.

## Why / Balance
Nice QOL stuff mostly.

## Technical details
Most of this is pretty self-explanatory `ExaminedEvent` handlers but I should mention that the big diff in `XenoTunnelSystem.cs` is just due to flipping around the initial `if ()` check and unindenting the contents.

`SharedXenoFruitSystem.cs` L194 is set to -9 in order to put it one above the -10 on L199, but below the item size line from `SharedItemSystem.cs`.

## Media

| | **Before** | **After** |
| :-: | :-: | :-: |
| **Egg Morpher** | <img width="386" height="173" alt="Egg morpher before" src="https://github.com/user-attachments/assets/df5100d2-42be-4b21-8187-2f3b82b5e1a3" /> | <img width="386" height="217" alt="egg morpher" src="https://github.com/user-attachments/assets/a61232be-05dd-45d1-9090-1cb8fad93052" /> |
| **Tunnel (as observer)** | <img width="390" height="111" alt="Tunnel observer before" src="https://github.com/user-attachments/assets/8eb51aaa-737e-41f7-b98c-29fe899111c8" /> | <img width="390" height="133" alt="Tunnel observer after" src="https://github.com/user-attachments/assets/e9ca87d7-cb9c-432a-b26e-6807295f09a4" /> |
| **Hive construction (as marine)** | <img width="397" height="173" alt="Construction marine before" src="https://github.com/user-attachments/assets/c6e44d5e-a989-43c9-9114-2981032560cf" /> | <img width="397" height="129" alt="Construction marine after" src="https://github.com/user-attachments/assets/5d4f37bd-9a88-4e47-86e7-0a458677323b" /> |
| **Recovery node** | <img width="400" height="129" alt="Recovery node before" src="https://github.com/user-attachments/assets/4770adcb-0d95-48bb-9aba-efde47b5d063" /> | <img width="400" height="173" alt="Recovery node" src="https://github.com/user-attachments/assets/831702b4-3f34-4b41-8544-fb7d3e3d8203" /> |
| **Plasma tree** | <img width="369" height="129" alt="Plasma tree before" src="https://github.com/user-attachments/assets/25f39b29-5028-4882-906c-dbccfc35baee" /> | <img width="369" height="173" alt="plasma tree" src="https://github.com/user-attachments/assets/d3e591c2-2285-441d-b521-9925da784fb5" /> |
| **Weedbound** | <img width="396" height="107" alt="Weedbound before" src="https://github.com/user-attachments/assets/6d261e1d-81e0-4d7d-8a42-e901ab1e3371" /> | <img width="396" height="173" alt="weedbound" src="https://github.com/user-attachments/assets/c6916add-3d0d-44fe-807c-1917bd53cf1a" /> |
| **Structure damage 1** | <img width="300" height="67" alt="Wall health before" src="https://github.com/user-attachments/assets/4b4819ba-2a02-4eee-a077-7e0bd5363b27" /> | <img width="300" height="89" alt="Damage 1" src="https://github.com/user-attachments/assets/ecf0d409-1625-4854-a0c5-bd534fbe11d1" /> |
| **Structure damage 2** | <img width="300" height="67" alt="Wall health before" src="https://github.com/user-attachments/assets/4b4819ba-2a02-4eee-a077-7e0bd5363b27" /> | <img width="300" height="89" alt="damage 2" src="https://github.com/user-attachments/assets/9db73491-dcac-4edf-b125-523b0b14e411" /> |
| **Structure damage 3** | <img width="300" height="67" alt="Wall health before" src="https://github.com/user-attachments/assets/4b4819ba-2a02-4eee-a077-7e0bd5363b27" /> | <img width="300" height="89" alt="damage 3" src="https://github.com/user-attachments/assets/cf134866-3f25-422e-8d1d-a294a2584c62" /> |
| **Structure damage 4** | <img width="300" height="67" alt="Wall health before" src="https://github.com/user-attachments/assets/4b4819ba-2a02-4eee-a077-7e0bd5363b27" /> | <img width="300" height="89" alt="damage 4" src="https://github.com/user-attachments/assets/3bb859f7-83b9-4aac-bd37-893462ed09af" /> |

### Alacrit
| **Before** | <img width="320" height="177" alt="Alacrit before" src="https://github.com/user-attachments/assets/92785e66-594a-48c0-9843-702d42dd60b3" /> |
| :-: | :-: |
| **Drone** (After)<br>2.2 -> 2.4 | <img width="344" height="199" alt="Drone" src="https://github.com/user-attachments/assets/ce22c07b-2e14-448e-b016-cfab28699c51" /> |
| **Runner** (After)<br>5.55 -> 5.75 | <img width="352" height="199" alt="Runner" src="https://github.com/user-attachments/assets/6901d00d-b01f-406e-b3e3-041e56310548" /> |
| **Queen** (After)<br>1.4 -> 1.6 | <img width="372" height="199" alt="Queen" src="https://github.com/user-attachments/assets/7d1168b1-2195-4fda-93c3-9bbada0cab3b" /> |

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Xenonid structures now show how damaged they are when examined.
- add: Added extra examine text to egg morphers, recovery nodes, plasma trees, and weedbound structures.
- add: Examining Alacrit fruit now shows its speed boost as a percent increase to your caste's base speed, rather than just its value of '0.2'.
- add: Observers can now see tunnel names and egg morpher details.