### PR TITLE
Fix vanguard not properly updating last combat time

### DIFF
--- a/Content.Shared/_RMC14/Shields/VanguardShieldSystem.cs
+++ b/Content.Shared/_RMC14/Shields/VanguardShieldSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared._RMC14.Damage;
 using Content.Shared.Damage;
 using Content.Shared.Explosion;
 using Content.Shared.Popups;
+using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.Network;
 using Robust.Shared.Timing;
 
@@ -18,6 +19,7 @@ public sealed class VanguardShieldSystem : EntitySystem
     public override void Initialize()
     {
         SubscribeLocalEvent<VanguardShieldComponent, MapInitEvent>(OnVanguardShieldInit);
+        SubscribeLocalEvent<VanguardShieldComponent, MeleeHitEvent>(OnVanguardShieldMelee);
         SubscribeLocalEvent<VanguardShieldComponent, DamageModifyAfterResistEvent>(OnVanguardShieldHit, before: [typeof(XenoShieldSystem)]);
         SubscribeLocalEvent<VanguardShieldComponent, GetExplosionResistanceEvent>(OnVanguardShieldGetResistance);
         SubscribeLocalEvent<VanguardShieldComponent, RemovedShieldEvent>(OnVanguardShieldRemoved);
@@ -28,13 +30,20 @@ public sealed class VanguardShieldSystem : EntitySystem
         RegenShield(xeno);
     }
 
-    private void OnVanguardShieldHit(Entity<VanguardShieldComponent> xeno, ref DamageModifyAfterResistEvent args)
+    private void OnVanguardShieldMelee(Entity<VanguardShieldComponent> xeno, ref MeleeHitEvent args)
     {
-        if (args.Damage.GetTotal() <= 0 || (!TryComp<XenoShieldComponent>(xeno, out var shield)) || shield.Shield != XenoShieldSystem.ShieldType.Vanguard)
+        if (args.HitEntities.Count <= 0 || _net.IsServer)
             return;
 
+        xeno.Comp.LastTimeHit = _timing.CurTime;
+    }
+    private void OnVanguardShieldHit(Entity<VanguardShieldComponent> xeno, ref DamageModifyAfterResistEvent args)
+    {
         if (_net.IsServer)
             xeno.Comp.LastTimeHit = _timing.CurTime;
+
+        if (args.Damage.GetTotal() <= 0 || (!TryComp<XenoShieldComponent>(xeno, out var shield)) || shield.Shield != XenoShieldSystem.ShieldType.Vanguard)
+            return;
 
         if (!xeno.Comp.WasHit && args.Damage.GetTotal() > xeno.Comp.DecayThreshold)
         {

--- a/Content.Shared/_RMC14/Shields/VanguardShieldSystem.cs
+++ b/Content.Shared/_RMC14/Shields/VanguardShieldSystem.cs
@@ -37,6 +37,7 @@ public sealed class VanguardShieldSystem : EntitySystem
 
         xeno.Comp.LastTimeHit = _timing.CurTime;
     }
+
     private void OnVanguardShieldHit(Entity<VanguardShieldComponent> xeno, ref DamageModifyAfterResistEvent args)
     {
         if (_net.IsServer)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug.

## Technical details
<!-- Summary of code changes for easier review. -->
Before: If there was not a vanguard shield, last combat time wouldn't update at all.

Now: Last combat time updates on hit OR on hitting something with a slash, no matter if theres even a shield or not. Parity.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed vanguard shield not properly counting the vanguard's slashes as being in combat, and not updating last combat time if the vanguard shield wasn't present (It should no longer fail to regen sometimes).
