### PR TITLE
Health analyzer update restrictions

### DIFF
--- a/Content.Client/_RMC14/Medical/Scanner/HealthScannerUiData.cs
+++ b/Content.Client/_RMC14/Medical/Scanner/HealthScannerUiData.cs
@@ -285,7 +285,7 @@ public sealed class HealthScannerUiData
             return;
 
         // Defibrillation related
-        if (_mob.IsDead(target))
+        if (uiState.State == Shared.Mobs.MobState.Dead)
         {
             if (_mobThresholds.TryGetDeadThreshold(target, out var deadThreshold))
             {
@@ -358,7 +358,7 @@ public sealed class HealthScannerUiData
         var airloss = uiState.Damage.DamageDict.GetValueOrDefault(AirlossGroup);
         var genetic = uiState.Damage.DamageDict.GetValueOrDefault(GeneticGroup);
 
-        if (airloss > 0 && !_mob.IsDead(target))
+        if (airloss > 0 && uiState.State != Shared.Mobs.MobState.Dead)
         {
             if (airloss > 10 && _mob.IsCritical(target))
                 AddAdvice(Loc.GetString("rmc-health-analyzer-advice-cpr-crit"), window);
@@ -370,7 +370,7 @@ public sealed class HealthScannerUiData
         if (brute > 30 &&
             uiState.Chemicals != null &&
             !uiState.Chemicals.ContainsReagent("CMBicaridine", null) &&
-            !_mob.IsDead(target))
+            uiState.State != Shared.Mobs.MobState.Dead)
         {
             AddAdvice(Loc.GetString("rmc-health-analyzer-advice-bicaridine"), window);
         }
@@ -378,7 +378,7 @@ public sealed class HealthScannerUiData
         if (burn > 30 &&
             uiState.Chemicals != null &&
             !uiState.Chemicals.ContainsReagent("CMKelotane", null) &&
-            !_mob.IsDead(target))
+            uiState.State != Shared.Mobs.MobState.Dead)
         {
             AddAdvice(Loc.GetString("rmc-health-analyzer-advice-kelotane"), window);
         }
@@ -387,7 +387,7 @@ public sealed class HealthScannerUiData
             uiState.Chemicals != null &&
             !uiState.Chemicals.ContainsReagent("CMDylovene", null) &&
             !uiState.Chemicals.ContainsReagent("Inaprovaline", null) &&
-            !_mob.IsDead(target))
+            uiState.State != Shared.Mobs.MobState.Dead)
         {
             AddAdvice(Loc.GetString("rmc-health-analyzer-advice-dylovene"), window);
         }

--- a/Content.Client/_RMC14/Medical/Scanner/HealthScannerUiData.cs
+++ b/Content.Client/_RMC14/Medical/Scanner/HealthScannerUiData.cs
@@ -29,6 +29,7 @@ public sealed class HealthScannerUiData
 {
     [Dependency] private readonly IEntityManager _entities = default!;
     [Dependency] private readonly ISharedPlayerManager _player = default!;
+    [Dependency] private readonly IPrototypeManager _protoManager = default!;
 
     private HealthScannerWindow? _holocardWindow;
     private NetEntity _lastTarget;
@@ -75,18 +76,15 @@ public sealed class HealthScannerUiData
 
         window.PatientLabel.Text = Loc.GetString("rmc-health-analyzer-patient", ("name", Identity.Name(target, _entities, _player.LocalEntity)));
 
-        if (!_entities.TryGetComponent(target, out DamageableComponent? damageable))
-            return;
+        AddGroup(uiState.Damage, uiState.Wounds, uiState.WoundTypes, window.BruteLabel, Color.FromHex("#DF3E3E"), BruteGroup, Loc.GetString("rmc-health-analyzer-brute"));
+        AddGroup(uiState.Damage, uiState.Wounds, uiState.WoundTypes, window.BurnLabel, Color.FromHex("#FFB833"), BurnGroup, Loc.GetString("rmc-health-analyzer-burn"));
+        AddGroup(uiState.Damage, uiState.Wounds, uiState.WoundTypes, window.ToxinLabel, Color.FromHex("#25CA4C"), ToxinGroup, Loc.GetString("rmc-health-analyzer-toxin"));
+        AddGroup(uiState.Damage, uiState.Wounds, uiState.WoundTypes, window.OxygenLabel, Color.FromHex("#2E93DE"), AirlossGroup, Loc.GetString("rmc-health-analyzer-oxygen"));
 
-        var ent = new Entity<DamageableComponent>(target, damageable);
-        AddGroup(ent, window.BruteLabel, Color.FromHex("#DF3E3E"), BruteGroup, Loc.GetString("rmc-health-analyzer-brute"));
-        AddGroup(ent, window.BurnLabel, Color.FromHex("#FFB833"), BurnGroup, Loc.GetString("rmc-health-analyzer-burn"));
-        AddGroup(ent, window.ToxinLabel, Color.FromHex("#25CA4C"), ToxinGroup, Loc.GetString("rmc-health-analyzer-toxin"));
-        AddGroup(ent, window.OxygenLabel, Color.FromHex("#2E93DE"), AirlossGroup, Loc.GetString("rmc-health-analyzer-oxygen"));
-        if (damageable.DamagePerGroup.GetValueOrDefault(GeneticGroup) > 0)
+        if (uiState.Damage.DamageDict.GetValueOrDefault(GeneticGroup) > 0)
         {
             window.CloneBox.Visible = true;
-            AddGroup(ent, window.CloneLabel, Color.FromHex("#02c9c0"), GeneticGroup, Loc.GetString("rmc-health-analyzer-clone"));
+            AddGroup(uiState.Damage, uiState.Wounds, uiState.WoundTypes, window.CloneLabel, Color.FromHex("#02c9c0"), GeneticGroup, Loc.GetString("rmc-health-analyzer-clone"));
         }
         else
         {
@@ -97,7 +95,7 @@ public sealed class HealthScannerUiData
 
         if (_mobThresholds.TryGetIncapThreshold(target, out var threshold))
         {
-            var damage = threshold.Value - damageable.TotalDamage;
+            var damage = threshold.Value - uiState.Damage.GetTotal();
             window.HealthBar.MinValue = 0;
             window.HealthBar.MaxValue = 100;
 
@@ -235,7 +233,7 @@ public sealed class HealthScannerUiData
         {
             window.MedicalAdviceLabel.Visible = true;
             window.MedicalAdviceSeparator.Visible = true;
-            MedicalAdvice(ent, uiState, window);
+            MedicalAdvice(target, uiState, window);
             if (window.AdviceContainer.ChildCount == 0)
             {
                 window.MedicalAdviceLabel.Visible = false;
@@ -255,16 +253,16 @@ public sealed class HealthScannerUiData
             _entities.EntityNetManager.SendSystemNetworkMessage(new OpenHolocardFromScanEvent(target));
     }
 
-    private void AddGroup(Entity<DamageableComponent> damageable, RichTextLabel label, Color color, ProtoId<DamageGroupPrototype> group, string labelStr)
+    private void AddGroup(DamageSpecifier damageSpec, List<Wound> wounds, Dictionary<ProtoId<DamageGroupPrototype>, WoundType> woundTypes, RichTextLabel label, Color color, ProtoId<DamageGroupPrototype> group, string labelStr)
     {
         var msg = new FormattedMessage();
         msg.AddText($"{labelStr}: ");
         msg.PushColor(color);
 
-        var damage = damageable.Comp.DamagePerGroup.GetValueOrDefault(group)
+        var damage = damageSpec.GetDamagePerGroup(_protoManager).GetValueOrDefault(group)
             .Int()
             .ToString(CultureInfo.InvariantCulture);
-        msg.AddText(_wounds.HasUntreated(damageable.Owner, group)
+        msg.AddText(_wounds.HasUntreated(wounds, woundTypes, group)
             ? $"{{{damage}}}"
             : $"{damage}");
 
@@ -272,16 +270,15 @@ public sealed class HealthScannerUiData
         label.SetMessage(msg);
     }
 
-    private void MedicalAdvice(Entity<DamageableComponent> target, HealthScanState uiState, HealthScannerWindow window)
+    private void MedicalAdvice(EntityUid target, HealthScanState uiState, HealthScannerWindow window)
     {
-        _entities.TryGetComponent(target, out WoundedComponent? wounds);
         var hasBruteWounds = false;
         var hasBurnWounds = false;
 
-        if (wounds != null && _wounds.HasUntreated((target, wounds), wounds.BruteWoundGroup))
+        if (_wounds.HasUntreated(uiState.Wounds, uiState.WoundTypes, BruteGroup))
             hasBruteWounds = true;
 
-        if (wounds != null && _wounds.HasUntreated((target, wounds), wounds.BurnWoundGroup))
+        if (_wounds.HasUntreated(uiState.Wounds, uiState.WoundTypes, BurnGroup))
             hasBurnWounds = true;
 
         if (_player.LocalEntity is not { } viewer)
@@ -292,7 +289,7 @@ public sealed class HealthScannerUiData
         {
             if (_mobThresholds.TryGetDeadThreshold(target, out var deadThreshold))
             {
-                if (deadThreshold + 30 < target.Comp.Damage.GetTotal() &&
+                if (deadThreshold + 30 < uiState.Damage.GetTotal() &&
                     uiState.Chemicals != null &&
                     !uiState.Chemicals.ContainsReagent("CMEpinephrine", null))
                 {
@@ -301,9 +298,9 @@ public sealed class HealthScannerUiData
                 else
                 {
                     var defib = string.Empty;
-                    if (deadThreshold - 20 <= target.Comp.Damage.GetTotal() && wounds != null && !hasBruteWounds && !hasBurnWounds)
+                    if (deadThreshold - 20 <= uiState.Damage.GetTotal() && !hasBruteWounds && !hasBurnWounds)
                         defib = Loc.GetString("rmc-health-analyzer-advice-defib-repeated");
-                    else if (deadThreshold > target.Comp.Damage.GetTotal())
+                    else if (deadThreshold > uiState.Damage.GetTotal())
                         defib = Loc.GetString("rmc-health-analyzer-advice-defib");
 
                     if (defib != string.Empty && !_skills.HasAllSkills(viewer, _defibSkill))
@@ -355,11 +352,11 @@ public sealed class HealthScannerUiData
         // TODO RMC14 Pain related medical advice
 
         // Damage related
-        var brute = target.Comp.DamagePerGroup.GetValueOrDefault(BruteGroup);
-        var burn = target.Comp.DamagePerGroup.GetValueOrDefault(BurnGroup);
-        var toxin = target.Comp.DamagePerGroup.GetValueOrDefault(ToxinGroup);
-        var airloss = target.Comp.DamagePerGroup.GetValueOrDefault(AirlossGroup);
-        var genetic = target.Comp.DamagePerGroup.GetValueOrDefault(GeneticGroup);
+        var brute = uiState.Damage.DamageDict.GetValueOrDefault(BruteGroup);
+        var burn = uiState.Damage.DamageDict.GetValueOrDefault(BurnGroup);
+        var toxin = uiState.Damage.DamageDict.GetValueOrDefault(ToxinGroup);
+        var airloss = uiState.Damage.DamageDict.GetValueOrDefault(AirlossGroup);
+        var genetic = uiState.Damage.DamageDict.GetValueOrDefault(GeneticGroup);
 
         if (airloss > 0 && !_mob.IsDead(target))
         {

--- a/Content.Client/_RMC14/Medical/Scanner/HealthScannerUiData.cs
+++ b/Content.Client/_RMC14/Medical/Scanner/HealthScannerUiData.cs
@@ -352,11 +352,11 @@ public sealed class HealthScannerUiData
         // TODO RMC14 Pain related medical advice
 
         // Damage related
-        var brute = uiState.Damage.DamageDict.GetValueOrDefault(BruteGroup);
-        var burn = uiState.Damage.DamageDict.GetValueOrDefault(BurnGroup);
-        var toxin = uiState.Damage.DamageDict.GetValueOrDefault(ToxinGroup);
-        var airloss = uiState.Damage.DamageDict.GetValueOrDefault(AirlossGroup);
-        var genetic = uiState.Damage.DamageDict.GetValueOrDefault(GeneticGroup);
+        var brute = uiState.Damage.GetDamagePerGroup(_protoManager).GetValueOrDefault(BruteGroup);
+        var burn = uiState.Damage.GetDamagePerGroup(_protoManager).GetValueOrDefault(BurnGroup);
+        var toxin = uiState.Damage.GetDamagePerGroup(_protoManager).GetValueOrDefault(ToxinGroup);
+        var airloss = uiState.Damage.GetDamagePerGroup(_protoManager).GetValueOrDefault(AirlossGroup);
+        var genetic = uiState.Damage.GetDamagePerGroup(_protoManager).GetValueOrDefault(GeneticGroup);
 
         if (airloss > 0 && uiState.State != Shared.Mobs.MobState.Dead)
         {

--- a/Content.Server/_RMC14/Medical/Wounds/WoundsSystem.cs
+++ b/Content.Server/_RMC14/Medical/Wounds/WoundsSystem.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.InteropServices;
+using System.Runtime.InteropServices;
 using Content.Server.Body.Systems;
 using Content.Shared._RMC14.Damage;
 using Content.Shared._RMC14.Medical.Wounds;
@@ -71,12 +71,16 @@ public sealed class WoundsSystem : SharedWoundsSystem
                     toHeal < FixedPoint2.Zero &&
                     wound.Treated)
                 {
-                    var group = wound.Type switch
+                    ProtoId<DamageGroupPrototype>? group = null;
+
+                    foreach (var woundGroup in comp.WoundGroups)
                     {
-                        WoundType.Brute => comp.BruteWoundGroup,
-                        WoundType.Burn => comp.BurnWoundGroup,
-                        _ => default(ProtoId<DamageGroupPrototype>?)
-                    };
+                        if (woundGroup.Value == wound.Type)
+                        {
+                            group = woundGroup.Key;
+                            break;
+                        }
+                    }
 
                     if (group != null)
                     {

--- a/Content.Server/_RMC14/RMCMedicalRecords/RMCMedicalRecordsSystem.cs
+++ b/Content.Server/_RMC14/RMCMedicalRecords/RMCMedicalRecordsSystem.cs
@@ -14,6 +14,8 @@ using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.FixedPoint;
 using Content.Shared.GameTicking;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Components;
 using Robust.Shared.Prototypes;
 using System.Linq;
 
@@ -80,9 +82,11 @@ public sealed class RMCMedicalRecordsSystem : SharedRMCMedicalRecordsSystem
         var damage = TryComp<DamageableComponent>(target, out var dam) ? dam.Damage : new();
         var wounds = TryComp<WoundedComponent>(target, out var wound) ? wound.Wounds : new();
         var woundTypes = wound != null ? wound.WoundGroups : new();
+        var state = TryComp<MobStateComponent>(target, out var mobState) ? mobState.CurrentState : MobState.Alive;
 
         return new HealthScanState(
             GetNetEntity(target),
+            state,
             damage,
             wounds,
             woundTypes,

--- a/Content.Server/_RMC14/RMCMedicalRecords/RMCMedicalRecordsSystem.cs
+++ b/Content.Server/_RMC14/RMCMedicalRecords/RMCMedicalRecordsSystem.cs
@@ -1,9 +1,9 @@
-using System.Linq;
 using Content.Server.StationRecords.Systems;
 using Content.Shared._RMC14.Body;
 using Content.Shared._RMC14.Chemistry.Reagent;
 using Content.Shared._RMC14.Medical.Scanner;
 using Content.Shared._RMC14.Medical.Surgery.Steps.Parts;
+using Content.Shared._RMC14.Medical.Wounds;
 using Content.Shared._RMC14.Mobs;
 using Content.Shared._RMC14.RMCMedicalRecords;
 using Content.Shared._RMC14.Temperature;
@@ -15,6 +15,7 @@ using Content.Shared.Damage.Prototypes;
 using Content.Shared.FixedPoint;
 using Content.Shared.GameTicking;
 using Robust.Shared.Prototypes;
+using System.Linq;
 
 namespace Content.Server._RMC14.RMCMedicalRecords;
 
@@ -76,9 +77,15 @@ public sealed class RMCMedicalRecordsSystem : SharedRMCMedicalRecordsSystem
 
         var pulse = _rmcPulse.TryGetPulseReading(target, true, out _);
         var bleeding = _rmcBloodstream.IsBleeding(target);
+        var damage = TryComp<DamageableComponent>(target, out var dam) ? dam.Damage : new();
+        var wounds = TryComp<WoundedComponent>(target, out var wound) ? wound.Wounds : new();
+        var woundTypes = wound != null ? wound.WoundGroups : new();
 
         return new HealthScanState(
             GetNetEntity(target),
+            damage,
+            wounds,
+            woundTypes,
             blood,
             maxBlood,
             temperature,

--- a/Content.Shared/_RMC14/Medical/Scanner/HealthScannerComponent.cs
+++ b/Content.Shared/_RMC14/Medical/Scanner/HealthScannerComponent.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.Audio;
+using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared._RMC14.Medical.Scanner;

--- a/Content.Shared/_RMC14/Medical/Scanner/HealthScannerSystem.cs
+++ b/Content.Shared/_RMC14/Medical/Scanner/HealthScannerSystem.cs
@@ -1,6 +1,7 @@
 using Content.Shared._RMC14.Body;
 using Content.Shared._RMC14.Hands;
 using Content.Shared._RMC14.Marines.Skills;
+using Content.Shared._RMC14.Medical.Wounds;
 using Content.Shared._RMC14.Mobs;
 using Content.Shared._RMC14.Temperature;
 using Content.Shared.Damage;
@@ -12,6 +13,7 @@ using Content.Shared.Popups;
 using Content.Shared.Storage.Components;
 using Content.Shared.Storage.EntitySystems;
 using Content.Shared.Timing;
+using Content.Shared.UserInterface;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Network;
 using Robust.Shared.Timing;
@@ -34,12 +36,14 @@ public sealed class HealthScannerSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
     [Dependency] private readonly UseDelaySystem _useDelay = default!;
+    [Dependency] private readonly SharedInteractionSystem _interact = default!;
 
     public override void Initialize()
     {
         SubscribeLocalEvent<HealthScannerComponent, AfterInteractEvent>(OnAfterInteract);
         SubscribeLocalEvent<HealthScannerComponent, DoAfterAttemptEvent<HealthScannerDoAfterEvent>>(OnDoAfterAttempt);
         SubscribeLocalEvent<HealthScannerComponent, HealthScannerDoAfterEvent>(OnDoAfter);
+        SubscribeLocalEvent<HealthScannerComponent, ActivatableUIOpenAttemptEvent>(OnUIActivateAttempt);
     }
 
     private void OnAfterInteract(Entity<HealthScannerComponent> scanner, ref AfterInteractEvent args)
@@ -66,6 +70,19 @@ public sealed class HealthScannerSystem : EntitySystem
         }
 
         _doAfter.TryStartDoAfter(doAfter);
+    }
+
+    private void OnUIActivateAttempt(Entity<HealthScannerComponent> scanner, ref ActivatableUIOpenAttemptEvent args)
+    {
+        if (args.Cancelled)
+            return;
+
+        if (scanner.Comp.Target == null)
+        {
+            _popup.PopupClient(Loc.GetString("health-analyzer-window-no-patient-data-text"), scanner, args.User, PopupType.SmallCaution);
+
+            args.Cancel();
+        }
     }
 
     private void OnDoAfterAttempt(Entity<HealthScannerComponent> ent, ref DoAfterAttemptEvent<HealthScannerDoAfterEvent> args)
@@ -164,10 +181,14 @@ public sealed class HealthScannerSystem : EntitySystem
                 _ui.CloseUi(scanner.Owner, HealthScannerUIKey.Key);
 
             scanner.Comp.Target = null;
+            Dirty(scanner);
             return;
         }
 
-        if (!_rmcHands.TryGetHolder(scanner, out _))
+        if (!_rmcHands.TryGetHolder(scanner, out var user) || !_interact.InRangeAndAccessible(user, scanner.Comp.Target.Value))
+            return;
+
+        if (!TryComp(target, out DamageableComponent? damageable))
             return;
 
         FixedPoint2 blood = 0;
@@ -183,7 +204,11 @@ public sealed class HealthScannerSystem : EntitySystem
 
         var pulse = _rmcPulse.TryGetPulseReading(target, true, out _);
         var bleeding = _rmcBloodstream.IsBleeding(target);
-        var state = new HealthScanState(GetNetEntity(target), blood, maxBlood, temperature, pulse, chemicals, bleeding, scanner.Comp.DetailLevel);
+        var damage = TryComp<DamageableComponent>(target, out var dam) ? dam.Damage : new();
+        var wounds = TryComp<WoundedComponent>(target, out var wound) ? wound.Wounds : new();
+        var woundTypes = wound != null ? wound.WoundGroups : new();
+
+        var state = new HealthScanState(GetNetEntity(target), damage, wounds, woundTypes, blood, maxBlood, temperature, pulse, chemicals, bleeding, scanner.Comp.DetailLevel);
 
         _ui.SetUiState(scanner.Owner, HealthScannerUIKey.Key, new HealthScannerBuiState(state));
     }
@@ -201,7 +226,10 @@ public sealed class HealthScannerSystem : EntitySystem
                 continue;
 
             active.UpdateAt = time + active.UpdateCooldown;
-            UpdateUI((uid, active));
+
+            //Only update the UI if delay would be zero and its in our hands
+            if (_rmcHands.TryGetHolder(uid, out var user) && _skills.GetDelay(user, uid) <= TimeSpan.Zero)
+                UpdateUI((uid, active));
         }
     }
 }

--- a/Content.Shared/_RMC14/Medical/Scanner/HealthScannerSystem.cs
+++ b/Content.Shared/_RMC14/Medical/Scanner/HealthScannerSystem.cs
@@ -8,6 +8,7 @@ using Content.Shared.Damage;
 using Content.Shared.DoAfter;
 using Content.Shared.FixedPoint;
 using Content.Shared.Interaction;
+using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Popups;
 using Content.Shared.Storage.Components;
@@ -204,8 +205,9 @@ public sealed class HealthScannerSystem : EntitySystem
         var damage = TryComp<DamageableComponent>(target, out var dam) ? dam.Damage : new();
         var wounds = TryComp<WoundedComponent>(target, out var wound) ? wound.Wounds : new();
         var woundTypes = wound != null ? wound.WoundGroups : new();
+        var mobState = TryComp<MobStateComponent>(target, out var mob) ? mob.CurrentState : MobState.Alive;
 
-        var state = new HealthScanState(GetNetEntity(target), damage, wounds, woundTypes, blood, maxBlood, temperature, pulse, chemicals, bleeding, scanner.Comp.DetailLevel);
+        var state = new HealthScanState(GetNetEntity(target), mobState, damage, wounds, woundTypes, blood, maxBlood, temperature, pulse, chemicals, bleeding, scanner.Comp.DetailLevel);
 
         _ui.SetUiState(scanner.Owner, HealthScannerUIKey.Key, new HealthScannerBuiState(state));
     }

--- a/Content.Shared/_RMC14/Medical/Scanner/HealthScannerSystem.cs
+++ b/Content.Shared/_RMC14/Medical/Scanner/HealthScannerSystem.cs
@@ -188,9 +188,6 @@ public sealed class HealthScannerSystem : EntitySystem
         if (!_rmcHands.TryGetHolder(scanner, out var user) || !_interact.InRangeAndAccessible(user, scanner.Comp.Target.Value))
             return;
 
-        if (!TryComp(target, out DamageableComponent? damageable))
-            return;
-
         FixedPoint2 blood = 0;
         FixedPoint2 maxBlood = 0;
         if (_rmcBloodstream.TryGetBloodSolution(target, out var bloodstream))

--- a/Content.Shared/_RMC14/Medical/Scanner/HealthScannerUI.cs
+++ b/Content.Shared/_RMC14/Medical/Scanner/HealthScannerUI.cs
@@ -3,6 +3,7 @@ using Content.Shared.Chemistry.Components;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.FixedPoint;
+using Content.Shared.Mobs;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 
@@ -15,6 +16,7 @@ namespace Content.Shared._RMC14.Medical.Scanner;
 [DataRecord, Serializable, NetSerializable]
 public readonly record struct HealthScanState(
     NetEntity Target,
+    MobState State,
     DamageSpecifier Damage,
     List<Wound> Wounds,
     Dictionary<ProtoId<DamageGroupPrototype>, WoundType> WoundTypes,

--- a/Content.Shared/_RMC14/Medical/Scanner/HealthScannerUI.cs
+++ b/Content.Shared/_RMC14/Medical/Scanner/HealthScannerUI.cs
@@ -1,5 +1,9 @@
-﻿using Content.Shared.Chemistry.Components;
+using Content.Shared._RMC14.Medical.Wounds;
+using Content.Shared.Chemistry.Components;
+using Content.Shared.Damage;
+using Content.Shared.Damage.Prototypes;
 using Content.Shared.FixedPoint;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared._RMC14.Medical.Scanner;
@@ -11,6 +15,9 @@ namespace Content.Shared._RMC14.Medical.Scanner;
 [DataRecord, Serializable, NetSerializable]
 public readonly record struct HealthScanState(
     NetEntity Target,
+    DamageSpecifier Damage,
+    List<Wound> Wounds,
+    Dictionary<ProtoId<DamageGroupPrototype>, WoundType> WoundTypes,
     FixedPoint2 Blood,
     FixedPoint2 MaxBlood,
     float? Temperature,

--- a/Content.Shared/_RMC14/Medical/Wounds/SharedWoundsSystem.cs
+++ b/Content.Shared/_RMC14/Medical/Wounds/SharedWoundsSystem.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Runtime.InteropServices;
 using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Damage;
@@ -85,8 +86,10 @@ public abstract class SharedWoundsSystem : EntitySystem
 
         if (args.DamageIncreased)
         {
-            TryAddWound(ent, ent.Comp.BruteWoundGroup, args.DamageDelta, WoundType.Brute);
-            TryAddWound(ent, ent.Comp.BurnWoundGroup, args.DamageDelta, WoundType.Burn);
+            foreach (var woundGroup in ent.Comp.WoundGroups)
+            {
+                TryAddWound(ent, woundGroup.Key, args.DamageDelta, woundGroup.Value);
+            }
         }
     }
 
@@ -419,8 +422,10 @@ public abstract class SharedWoundsSystem : EntitySystem
         if (comp.Wounds.Count == 0)
             return;
 
-        HealOrRemove((uid, damageable, comp), comp.BruteWoundGroup, WoundType.Brute, damage, limit);
-        HealOrRemove((uid, damageable, comp), comp.BurnWoundGroup, WoundType.Burn, damage, limit);
+        foreach (var woundGroup in comp.WoundGroups)
+        {
+            HealOrRemove((uid, damageable, comp), woundGroup.Key, woundGroup.Value, damage, limit);
+        }
     }
 
     private void HealOrRemove(Entity<DamageableComponent, WoundedComponent> wounded,
@@ -513,8 +518,8 @@ public abstract class SharedWoundsSystem : EntitySystem
             }
         }
 
-        wounded.BruteWoundGroup = woundable.Comp.BruteWoundGroup;
-        wounded.BurnWoundGroup = woundable.Comp.BurnWoundGroup;
+        // Clone
+        wounded.WoundGroups = woundable.Comp.WoundGroups.ToDictionary();
 
         TimeSpan? newDuration = duration == TimeSpan.MaxValue ? null : time + duration;
         wounded.Wounds.Add(new Wound(total, FixedPoint2.Zero, bloodloss, newDuration, type, false));
@@ -542,13 +547,10 @@ public abstract class SharedWoundsSystem : EntitySystem
             return false;
         }
 
-        WoundType type;
-        if (group == wounded.Comp.BruteWoundGroup)
-            type = WoundType.Brute;
-        else if (group == wounded.Comp.BurnWoundGroup)
-            type = WoundType.Burn;
-        else
+        if (!wounded.Comp.WoundGroups.ContainsKey(group))
             return false;
+
+        WoundType type = wounded.Comp.WoundGroups[group];
 
         var wounds = CollectionsMarshal.AsSpan(wounded.Comp.Wounds);
         foreach (ref var wound in wounds)
@@ -558,5 +560,27 @@ public abstract class SharedWoundsSystem : EntitySystem
         }
 
         return false;
+    }
+
+    public bool HasUntreated(List<Wound> woundsList, Dictionary<ProtoId<DamageGroupPrototype>, WoundType> woundTypes, ProtoId<DamageGroupPrototype> group)
+    {
+        if (woundsList.Count == 0)
+            return false;
+
+        if (!woundTypes.ContainsKey(group))
+            return false;
+
+        var type = woundTypes[group];
+
+        var wounds = CollectionsMarshal.AsSpan(woundsList);
+
+        foreach (ref var wound in wounds)
+        {
+            if (wound.Type == type && !wound.Treated)
+                return true;
+        }
+
+        return false;
+
     }
 }

--- a/Content.Shared/_RMC14/Medical/Wounds/SharedWoundsSystem.cs
+++ b/Content.Shared/_RMC14/Medical/Wounds/SharedWoundsSystem.cs
@@ -518,8 +518,7 @@ public abstract class SharedWoundsSystem : EntitySystem
             }
         }
 
-        // Clone
-        wounded.WoundGroups = woundable.Comp.WoundGroups.ToDictionary();
+        wounded.WoundGroups = woundable.Comp.WoundGroups;
 
         TimeSpan? newDuration = duration == TimeSpan.MaxValue ? null : time + duration;
         wounded.Wounds.Add(new Wound(total, FixedPoint2.Zero, bloodloss, newDuration, type, false));

--- a/Content.Shared/_RMC14/Medical/Wounds/WoundableComponent.cs
+++ b/Content.Shared/_RMC14/Medical/Wounds/WoundableComponent.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Damage.Prototypes;
+using Content.Shared.Damage.Prototypes;
 using Content.Shared.FixedPoint;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
@@ -10,10 +10,11 @@ namespace Content.Shared._RMC14.Medical.Wounds;
 public sealed partial class WoundableComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public ProtoId<DamageGroupPrototype> BruteWoundGroup = "Brute";
-
-    [DataField, AutoNetworkedField]
-    public ProtoId<DamageGroupPrototype> BurnWoundGroup = "Burn";
+    public Dictionary<ProtoId<DamageGroupPrototype>, WoundType> WoundGroups = new()
+    {
+        { "Brute", WoundType.Brute },
+        { "Burn", WoundType.Burn },
+    };
 
     [DataField, AutoNetworkedField]
     public FixedPoint2 BleedMinDamage = 10;

--- a/Content.Shared/_RMC14/Medical/Wounds/WoundedComponent.cs
+++ b/Content.Shared/_RMC14/Medical/Wounds/WoundedComponent.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Damage.Prototypes;
+using Content.Shared.Damage.Prototypes;
 using Content.Shared.FixedPoint;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
@@ -12,10 +12,11 @@ namespace Content.Shared._RMC14.Medical.Wounds;
 public sealed partial class WoundedComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public ProtoId<DamageGroupPrototype> BruteWoundGroup = "Brute";
-
-    [DataField, AutoNetworkedField]
-    public ProtoId<DamageGroupPrototype> BurnWoundGroup = "Burn";
+    public Dictionary<ProtoId<DamageGroupPrototype>, WoundType> WoundGroups = new()
+    {
+        { "Brute", WoundType.Brute },
+        { "Burn", WoundType.Burn },
+    };
 
     [DataField, AutoNetworkedField]
     public List<Wound> Wounds = new();


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title. Health analyzers no longer update if the user holding one would require a doafter to use it. They also stop updating if the user gets out of range of the target.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Mostly to match parity without killing the QoL.

## Technical details
<!-- Summary of code changes for easier review. -->
Changed the brute and burn protos for wound types to be a dict to be easier to modify if needed (and makes it easier to pass to the health scanner states)

health scanner states now take a mobstate, damage spec. wound list, and wound type dict to store said information without having to update due to the target wandering off etc.

Everything but the holocard now updates when looking at the health analyzer (I don't want to deal with storing that too right now).

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

https://github.com/user-attachments/assets/557f8e8f-b138-4320-b225-0c294e1a307d



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Health analyzers no longer update continuously if you are too far from the scanned target, or if the user would require a doafter to use the analyzer.
