### PR TITLE
Add: QoL for Squad objectives

### DIFF
--- a/Resources/Locale/en-US/_RMC14/overwatch.ftl
+++ b/Resources/Locale/en-US/_RMC14/overwatch.ftl
@@ -98,9 +98,9 @@ rmc-overwatch-console-objective-secondary = [bold]Secondary Objective[/bold]
 rmc-overwatch-console-objective-placeholder = Enter objective text...
 rmc-overwatch-console-objective-update = Update
 rmc-overwatch-console-objective-cancel = Cancel
-rmc-overwatch-console-announce-objective-updated = [color=#50ECA3][bold]Overwatch:[/bold] { $operatorName } [bold]updated[/bold] the squad { $objectiveType }: [font size=16][bold]{ $objective }[/bold][/font][/color]
-rmc-overwatch-console-announce-objective-cancelled = [color=#50ECA3][bold]Overwatch:[/bold] { $operatorName } [bold]cancelled[/bold] the squad { $objectiveType }: [font size=16][bold]{ $objective }[/bold][/font][/color]
-rmc-overwatch-console-objective-updated = [bold][color=#7FFFD4]'{ $squadName }' { $objectiveType } updated: '{ $objective }'.[/color][/bold]
-rmc-overwatch-console-objective-cancelled = [bold][color=#7FFFD4]'{ $squadName }' { $objectiveType } '{ $objective }' cancelled.[/color][/bold]
+rmc-overwatch-console-announce-objective-updated = [color=#50ECA3][bold]Overwatch:[/bold] { $operatorName } [color=#008000][bold]updated[/bold][color=#50ECA3] the squad { $objectiveType }: [font size=16][bold]{ $objective }[/bold][/font][/color]
+rmc-overwatch-console-announce-objective-cancelled = [color=#50ECA3][bold]Overwatch:[/bold] { $operatorName } [color=#FF0000][bold]cancelled[/bold][color=#50ECA3] the squad { $objectiveType }: [font size=16][bold]{ $objective }[/bold][/font][/color]
+rmc-overwatch-console-objective-updated = [bold][color=#7FFFD4]'{ $squadName }' { $objectiveType } [color=#008000]updated[/color]: '{ $objective }'.[/color][/bold]
+rmc-overwatch-console-objective-cancelled = [bold][color=#7FFFD4]'{ $squadName }' { $objectiveType } '{ $objective }' [color=#FF0000]cancelled[/color].[/bold]
 rmc-overwatch-console-objectives = Your squad objectives:
     { $objectives }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Changes the color of the updated/cancelled text to be easier to read on a glance

> Currently, when an SO cancels an objective, it will appear in the chatbox in an almost identical way to an objective being set or updated. This makes it quite confusing, particularly in the middle of a fight, to see whether a new objective is being set, updated, or an old one is being cancelled. Due to how objectives are used, I do not think that it is usually even worth it to have this announcement appear (an objective being cancelled means very little on its own), and it just leads to unnecessary confusion. 


## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://discord.com/channels/1168210010233376858/1526725308101689435
## Technical details
<!-- Summary of code changes for easier review. -->
.ftl changes
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
<img width="536" height="160" alt="grafik" src="https://github.com/user-attachments/assets/3dac01a0-7657-4a5c-8a3f-87ac44b8b8a7" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Made it now easier to differentiate the updated/cancelled squad objectives!
