### PR TITLE
make lexorin impossible to create

### DIFF
--- a/Resources/Prototypes/_RMC14/Recipes/Reactions/toxins.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Reactions/toxins.yml
@@ -1,6 +1,8 @@
 - type: reaction
   id: RMCLexorin
   reactants:
+    RMCBlackGoo:
+      amount: 0.5
     RMCPhoron:
       amount: 1
     RMCHydrogen:


### PR DESCRIPTION
## About the PR
Lexorin now requires black goo to create.

## Why / Balance
Players shouldn't be able to create toxins for no reason. Just about every use for lexorin is nefarious

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: The ability to make Lexorin has been disabled.
