### PR TITLE
Weakened reflective wall grammar fix

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_walls.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_walls.yml
@@ -309,7 +309,7 @@
   parent: WallXenoResinReflective
   id: WallXenoResinReflectiveUnstable
   name: weakened reflective wall
-  description: Weird slime with strange, hardened fragments solidified into a wall. It looks like it will last for a moment before it collapses.
+  description: "Weird slime with strange, hardened fragments solidified into a wall.\nIt looks ready to collapse at any moment."
   components:
   - type: TimedDespawn
     lifetime: 13.0

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_walls.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_walls.yml
@@ -309,7 +309,7 @@
   parent: WallXenoResinReflective
   id: WallXenoResinReflectiveUnstable
   name: weakened reflective wall
-  description: Weird slime with strange hardened fragments solidified into a wall. It looks like it last for moment before it will collapse.
+  description: Weird slime with strange hardened fragments solidified into a wall. It looks like it last for a moment before it will collapse.
   components:
   - type: TimedDespawn
     lifetime: 13.0

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_walls.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_walls.yml
@@ -309,7 +309,7 @@
   parent: WallXenoResinReflective
   id: WallXenoResinReflectiveUnstable
   name: weakened reflective wall
-  description: Weird slime with strange hardened fragments solidified into a wall. It looks like it last for a moment before it will collapse.
+  description: Weird slime with strange, hardened fragments solidified into a wall. It looks like it will last for a moment before it will collapse.
   components:
   - type: TimedDespawn
     lifetime: 13.0

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_walls.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_walls.yml
@@ -309,7 +309,7 @@
   parent: WallXenoResinReflective
   id: WallXenoResinReflectiveUnstable
   name: weakened reflective wall
-  description: Weird slime with strange, hardened fragments solidified into a wall. It looks like it will last for a moment before it will collapse.
+  description: Weird slime with strange, hardened fragments solidified into a wall. It looks like it will last for a moment before it collapses.
   components:
   - type: TimedDespawn
     lifetime: 13.0


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Makes the weakened reflective wall description grammar correct (reported in https://discord.com/channels/1168210010233376858/1530753317766959144/1530753317766959144)

## Why / Balance
Grammar

## Technical details
Weird slime with strange hardened fragments solidified into a wall. It looks like it last for moment before it will collapse. -> "Weird slime with strange, hardened fragments solidified into a wall.(\n)
       It looks ready to collapse at any moment."

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
