### PR TITLE
Make sure bursted doafter can't be cancelled even more

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
@@ -915,6 +915,7 @@ public abstract partial class SharedXenoParasiteSystem : EntitySystem
             BreakOnMove = false,
             BreakOnRest = false,
             RequireCanInteract = false,
+            RangeCheck = false,
             Hidden = true,
             BlockDuplicate = true,
             DuplicateCondition = DuplicateConditions.SameEvent

--- a/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
@@ -914,8 +914,8 @@ public abstract partial class SharedXenoParasiteSystem : EntitySystem
             BreakOnDamage = false,
             BreakOnMove = false,
             BreakOnRest = false,
+            RequireCanInteract = false,
             Hidden = true,
-            CancelDuplicate = true,
             BlockDuplicate = true,
             DuplicateCondition = DuplicateConditions.SameEvent
         };


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It got cancelled in a live round...again.

## Technical details
<!-- Summary of code changes for easier review. -->
No cancel dupe - block dupe already stops more from being made.

Make sure require interact and range check also can't stop the doafter.

I really hope that's all thats needed oogh.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
Still works.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed extremely rare cases where larva could fail to burst (hopefully).
