### PR TITLE
Fix converted fragile eggs not losing the name modifier

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared._RMC14.Actions;
+using Content.Shared._RMC14.Actions;
 using Content.Shared._RMC14.Dropship;
 using Content.Shared._RMC14.Hands;
 using Content.Shared._RMC14.Marines;
@@ -813,6 +813,10 @@ public sealed class XenoEggSystem : EntitySystem
         }
         if (TryComp<XenoEggComponent>(ent, out var egg))
             SetEggSprite((ent, egg), egg.NormalSprite);
+
+        ent.Comp.ApplyNameModifier = false;
+        Dirty(ent);
+
         _nameModifier.RefreshNameModifiers(ent.Owner);
     }
 
@@ -824,7 +828,7 @@ public sealed class XenoEggSystem : EntitySystem
 
     private void OnFragileRefreshModifier(Entity<XenoFragileEggComponent> ent, ref RefreshNameModifiersEvent args)
     {
-        if (!TerminatingOrDeleted(ent))
+        if (!TerminatingOrDeleted(ent) && ent.Comp.ApplyNameModifier)
             args.AddModifier("rmc-xeno-fragile-egg-prefix");
     }
 

--- a/Content.Shared/_RMC14/Xenonids/Egg/XenoFragileEggComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Egg/XenoFragileEggComponent.cs
@@ -35,4 +35,7 @@ public sealed partial class XenoFragileEggComponent : Component
 
     [DataField, AutoNetworkedField]
     public bool InRange = true;
+
+    [DataField, AutoNetworkedField]
+    public bool ApplyNameModifier = true;
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug.

## Technical details
<!-- Summary of code changes for easier review. -->
New field that enables/disables the name modifier, set to false on shutdown.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed converted fragile eggs on hiveweeds still being called fragile.
