### PR TITLE
Fixed Provost Clipboard taking anything in the pen slot

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Misc/clipboard.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Misc/clipboard.yml
@@ -94,6 +94,10 @@
     slots:
       pen_slot:
         startingItem: RMCProvostPen
+        whitelist:
+          tags:
+            - Write
+        insertOnInteract: true
   - type: StorageFill
     contents:
     - id: CMPaper


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Added the whitelist the clipboard entity had, because the Provost Clipboard does not inherit the whitelist for the pens.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug fix

## Technical details
<!-- Summary of code changes for easier review. -->
Added whitelist for Provost clipboard for the pen.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed the storage whitelist on the provost clipboard

