### PR TITLE
Adds RMCPouchMedical Tag to Medical Kit Pouch, Medical Pouch, First Responder Pouch, Tactical Medical Pouch, and Pill Canisters

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Pouches/medical.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Pouches/medical.yml
@@ -27,6 +27,9 @@
       - PillPacket
       components:
       - Hypospray
+  - type: Tag
+    tags:
+    - RMCPouchMedical
 
 - type: entity
   parent: RMCPouchMedicalSoc
@@ -132,6 +135,9 @@
       components:
       - Hypospray
   - type: FixedItemSizeStorage
+  - type: Tag
+    tags:
+    - RMCPouchMedical
 
 - type: entity
   parent: RMCPouchFirstResponder

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Pouches/medical_kit_pouch.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Pouches/medical_kit_pouch.yml
@@ -75,6 +75,9 @@
     items:
       tags:
       - CMSurgicalCase
+  - type: Tag
+    tags:
+    - RMCPouchMedical
 
 - type: entity
   parent: RMCPouchMedkit

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Pouches/medical_pouch.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Pouches/medical_pouch.yml
@@ -35,6 +35,9 @@
       components:
       - Hypospray
   - type: FixedItemSizeStorage
+  - type: Tag
+    tags:
+    - RMCPouchMedical
 
 - type: entity
   parent: RMCPouchMedical

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Medical/pill_canisters.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Medical/pill_canisters.yml
@@ -80,6 +80,7 @@
     nestedWhitelist:
       tags:
       - RMCBeltMedical
+      - RMCPouchMedical
   - type: RMCSmartFridgeInsertable
     category: Pills
   - type: PhysicalComposition

--- a/Resources/Prototypes/_RMC14/rmc_tags.yml
+++ b/Resources/Prototypes/_RMC14/rmc_tags.yml
@@ -62,6 +62,9 @@
   id: SurvivalPouch
 
 - type: Tag
+  id: RMCPouchMedical
+
+- type: Tag
   id: LauncherCompatibleGrenade
 
 - type: Tag


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Medical Kit Pouch, Medical Pouch, First Responder Pouch, and Tactical Medical Pouch are updated, clicking on the Pill Bottle will take out any Pills from the Pill Bottle as how Medical Storage Rig and Lifesaver Bag are able to do

## Why / Balance
Parity, Quality of Life Feature for Hospital Corpsman, Doctor, Nurse, Chief Medical Officer, Doctor Survivor, CO, XO

## Technical details
Added RMCPouchMedical Tag to rmc_tags.yml, RMCPouchMedical is a Tag in the NestedWhitelist for Pill Canisters in pill_canisters.yml, RMCPouchMedical added to Medical Pouch in medical_pouch.yml, to Medical Kit Pouch in medical_kit_pouch.yml, Tactical Medical Pouch and First Responder Pouch in medical.yml

## Media

https://github.com/user-attachments/assets/16967bb0-c799-4729-861a-48cd341ab136


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: You no longer need to open Pill Bottles in any Medical Pouch that fit Pill Bottles to take out Pills from them.