### PR TITLE
FORECON Spotter Corpse Icon

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
@@ -868,36 +868,6 @@
     sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/ghillie/forecon.rsi
   - type: ItemCamouflage
     camouflageVariations: { }
-
-# recon spotter m45
-- type: entity
-  parent: CMArmorM3Medium
-  id: RMCArmorUDEPForeconSpotter
-  name: battered UDEP thermal poncho # TODO id lock
-  description: UDEP or the Ultra Diffusive Environmental Poncho is a camouflaged rain-cover worn to protect against the elements and chemical spills. It's commonly treated with an infrared absorbing coating, making a marine almost invisible in the rain. Favoured by UNMC specialists for its comfort and practicality. This one seems battered enough as to not to be able to camouflage.
-  components:
-  - type: Corrodible
-    isCorrodible: false
-  - type: CMArmor
-    bio: 25
-  - type: RMCArmorSpeedTier
-    speedTier: light
-  - type: ClothingSpeedModifier # light armor speed
-    walkModifier: .725
-    sprintModifier: .725
-  - type: Sprite
-    sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/ghillie/forecon.rsi
-  - type: ItemCamouflage
-    camouflageVariations: { }
-  - type: SquadArmor
-    layer: Armor
-    slot: OUTERCLOTHING
-    rsi:
-      sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/armor_overlays.rsi
-      state: snpr-armor
-    leaderRsi:
-      sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/armor_overlays.rsi
-      state: snpr-armor
   
 # Smart Gun
 - type: entity

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
@@ -869,6 +869,36 @@
   - type: ItemCamouflage
     camouflageVariations: { }
 
+# recon spotter m45
+- type: entity
+  parent: CMArmorM3Medium
+  id: CMArmorM45
+  name: battered UDEP thermal poncho # TODO id lock
+  description: UDEP or the Ultra Diffusive Environmental Poncho is a camouflaged rain-cover worn to protect against the elements and chemical spills. It's commonly treated with an infrared absorbing coating, making a marine almost invisible in the rain. Favoured by UNMC specialists for its comfort and practicality. This one seems to have taken excessive damage, its cloaking capabilities missing outright.
+  components:
+  - type: Corrodible
+    isCorrodible: false
+  - type: CMArmor
+    bio: 25
+  - type: RMCArmorSpeedTier
+    speedTier: light
+  - type: ClothingSpeedModifier # light armor speed
+    walkModifier: .725
+    sprintModifier: .725
+  - type: Sprite
+    sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/ghillie/forecon.rsi
+  - type: ItemCamouflage
+    camouflageVariations: { }
+  - type: SquadArmor
+    layer: Armor
+    slot: OUTERCLOTHING
+    rsi:
+      sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/armor_overlays.rsi
+      state: snpr-armor
+    leaderRsi:
+      sprite: _RMC14/Objects/Clothing/OuterClothing/Armor/armor_overlays.rsi
+      state: snpr-armor
+  
 # Smart Gun
 - type: entity
   parent: [ RMCAllowSuitStorageClothingSmartgunner, CMArmorM3Medium ]

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
@@ -872,7 +872,7 @@
 # recon spotter m45
 - type: entity
   parent: CMArmorM3Medium
-  id: CMArmorM45ForeconSpotter
+  id: RMCArmorUDEPForeconSpotter
   name: battered UDEP thermal poncho # TODO id lock
   description: UDEP or the Ultra Diffusive Environmental Poncho is a camouflaged rain-cover worn to protect against the elements and chemical spills. It's commonly treated with an infrared absorbing coating, making a marine almost invisible in the rain. Favoured by UNMC specialists for its comfort and practicality. This one seems to have taken excessive damage, its cloaking capabilities missing outright.
   components:

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
@@ -872,7 +872,7 @@
 # recon spotter m45
 - type: entity
   parent: CMArmorM3Medium
-  id: CMArmorM45
+  id: CMArmorM45ForeconSpotter
   name: battered UDEP thermal poncho # TODO id lock
   description: UDEP or the Ultra Diffusive Environmental Poncho is a camouflaged rain-cover worn to protect against the elements and chemical spills. It's commonly treated with an infrared absorbing coating, making a marine almost invisible in the rain. Favoured by UNMC specialists for its comfort and practicality. This one seems to have taken excessive damage, its cloaking capabilities missing outright.
   components:

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/OuterClothing/marine_armor.yml
@@ -874,7 +874,7 @@
   parent: CMArmorM3Medium
   id: RMCArmorUDEPForeconSpotter
   name: battered UDEP thermal poncho # TODO id lock
-  description: UDEP or the Ultra Diffusive Environmental Poncho is a camouflaged rain-cover worn to protect against the elements and chemical spills. It's commonly treated with an infrared absorbing coating, making a marine almost invisible in the rain. Favoured by UNMC specialists for its comfort and practicality. This one seems to have taken excessive damage, its cloaking capabilities missing outright.
+  description: UDEP or the Ultra Diffusive Environmental Poncho is a camouflaged rain-cover worn to protect against the elements and chemical spills. It's commonly treated with an infrared absorbing coating, making a marine almost invisible in the rain. Favoured by UNMC specialists for its comfort and practicality. This one seems battered enough as to not to be able to camouflage.
   components:
   - type: Corrodible
     isCorrodible: false

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Corpses/forecon.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Corpses/forecon.yml
@@ -7,6 +7,16 @@
     prototypes: [ RMCGearCorpseFORECONSpotter ]
   - type: Rank
     rank: RMCRankSergeant
+  - type: SquadTeam
+    background:
+      sprite: _RMC14/Interface/job_icons/UNMC/marine.rsi
+      state: hudsquad
+    color: "#32CD32"
+    blacklistedSquadArmor:
+    - Helmet
+    - Goggles
+    - Armor
+    - Gloves
   - type: Marine
     parent: CMJobIconBase
     icon:

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Corpses/forecon.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Corpses/forecon.yml
@@ -7,7 +7,7 @@
     prototypes: [ RMCGearCorpseFORECONSpotter ]
   - type: Rank
     rank: RMCRankSergeant
- -  type: SquadMember
+  - type: SquadMember
     background:
       sprite: _RMC14/Interface/job_icons/UNMC/marine.rsi
       state: hudsquad

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Corpses/forecon.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Corpses/forecon.yml
@@ -8,6 +8,7 @@
   - type: Rank
     rank: RMCRankSergeant
   - type: Marine
+    parent: CMJobIconBase
     icon:
       sprite: _RMC14/Interface/job_icons/UNMC/marine.rsi
       state: hudsquad_ass

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Corpses/forecon.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Corpses/forecon.yml
@@ -7,6 +7,10 @@
     prototypes: [ RMCGearCorpseFORECONSpotter ]
   - type: Rank
     rank: RMCRankSergeant
+  - type: Marine
+    icon:
+      sprite: _RMC14/Interface/job_icons/UNMC/hudsquad_ass.rsi
+      state: spotter
 
 - type: startingGear
   id: RMCGearCorpseFORECONSpotter

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Corpses/forecon.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Corpses/forecon.yml
@@ -27,6 +27,7 @@
   equipment:
     jumpsuit: RMCJumpsuitSurvivorMarineDropPouch
     back: CMSatchelMarine
+    outerClothing: RMCArmorUDEPForeconSpotter
     shoes: CMBootsBlackFilled
     id: RMCIDCardFORECONSpotter
     pocket1: RMCPouchFirstAidInjectors

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Corpses/forecon.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Corpses/forecon.yml
@@ -7,11 +7,11 @@
     prototypes: [ RMCGearCorpseFORECONSpotter ]
   - type: Rank
     rank: RMCRankSergeant
-  - type: SquadTeam
+ -  type: SquadMember
     background:
       sprite: _RMC14/Interface/job_icons/UNMC/marine.rsi
       state: hudsquad
-    color: "#32CD32"
+    backgroundColor: "#32CD32"
     blacklistedSquadArmor:
     - Helmet
     - Goggles

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Corpses/forecon.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Corpses/forecon.yml
@@ -27,7 +27,6 @@
   equipment:
     jumpsuit: RMCJumpsuitSurvivorMarineDropPouch
     back: CMSatchelMarine
-    outerClothing: RMCArmorUDEPForeconSpotter
     shoes: CMBootsBlackFilled
     id: RMCIDCardFORECONSpotter
     pocket1: RMCPouchFirstAidInjectors

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Corpses/forecon.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Corpses/forecon.yml
@@ -18,7 +18,6 @@
     - Armor
     - Gloves
   - type: Marine
-    parent: CMJobIconBase
     icon:
       sprite: _RMC14/Interface/job_icons/UNMC/marine.rsi
       state: hudsquad_ass

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Corpses/forecon.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Corpses/forecon.yml
@@ -9,8 +9,8 @@
     rank: RMCRankSergeant
   - type: Marine
     icon:
-      sprite: _RMC14/Interface/job_icons/UNMC/hudsquad_ass.rsi
-      state: spotter
+      sprite: _RMC14/Interface/job_icons/UNMC/marine.rsi
+      state: hudsquad_ass
 
 - type: startingGear
   id: RMCGearCorpseFORECONSpotter


### PR DESCRIPTION
## About the PR
Adds a marine HUD icon to the FORECON spotter corpse. Thank you to Vermidia for helping me with the icon YAML!

## Why / Balance
Parity (I think) and environmental storytelling.

## Technical details
- Adds the `SquadMember` and `Marine` components to the spotter corpse in order to cosmetically present an icon. Otherwise does not interface with the actual squad system.

## Media
<img width="342" height="421" alt="Screenshot 2026-07-28 014745" src="https://github.com/user-attachments/assets/5d16a0c0-df1c-408c-a23a-718ba850f9bc" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: The FORECON Spotter now has a HUD icon.