### PR TITLE
Adds the chess and checkerboard to the rec vend

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/general.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/general.yml
@@ -38,9 +38,13 @@
         amount: 10
       - id: RMCCassetteTapeCustom
         amount: 20
-    - name: Cards
+    - name: Entertainment
       entries:
       - id: RMCPlayingCardDeck
+        amount: 10
+      - id: ChessBoard
+        amount: 10
+      - id: CheckerBoard
         amount: 10
     - name: Magazines
       entries:


### PR DESCRIPTION
## About the PR
Title

## Why / Balance
Cards are already in and I feel these could add some soul to a round

## Technical details
few lines of YAML

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: Chess and checkers sets are now available in the rec vend
