### PR TITLE
Fix overwatch coordinate saving

### DIFF
--- a/Content.Client/_RMC14/Overwatch/OverwatchConsoleBui.cs
+++ b/Content.Client/_RMC14/Overwatch/OverwatchConsoleBui.cs
@@ -27,6 +27,7 @@ public sealed class OverwatchConsoleBui : RMCPopOutBui<OverwatchConsoleWindow>
     private const string GreenColor = "#229132";
     private const string RedColor = "#A42625";
     private const string YellowColor = "#CED22B";
+    private const float SavedLocationRowHeight = 35;
 
     protected override OverwatchConsoleWindow? Window { get; set; }
 
@@ -36,6 +37,7 @@ public sealed class OverwatchConsoleBui : RMCPopOutBui<OverwatchConsoleWindow>
     private readonly Dictionary<NetEntity, OverwatchSquadView> _squadViews = new();
     private readonly Dictionary<NetEntity, PanelContainer> _squads = new();
     private readonly Dictionary<NetEntity, Dictionary<NetEntity, OverwatchRow>> _rows = new();
+    private readonly Dictionary<BoxContainer, SavedLocationTableState> _savedLocationTables = new();
     private SquadObjectivesWindow? _objectivesWindow;
 
     public OverwatchConsoleBui(EntityUid owner, Enum uiKey) : base(owner, uiKey)
@@ -197,7 +199,7 @@ public sealed class OverwatchConsoleBui : RMCPopOutBui<OverwatchConsoleWindow>
                         var longitude = (int)monitor.Longitude.Value;
                         var latitude = (int)monitor.Latitude.Value;
                         var msg = new OverwatchConsoleSupplyDropSaveBuiMsg(longitude, latitude);
-                        SendPredictedMessage(msg);
+                        SendMessage(msg);
                     };
 
                 monitor.OrbitalLongitude.Value = console.OrbitalCoordinates.X;
@@ -211,10 +213,10 @@ public sealed class OverwatchConsoleBui : RMCPopOutBui<OverwatchConsoleWindow>
                 monitor.OrbitalSaveButton.OnPressed +=
                     _ =>
                     {
-                        var longitude = (int)monitor.Longitude.Value;
-                        var latitude = (int)monitor.Latitude.Value;
+                        var longitude = (int)monitor.OrbitalLongitude.Value;
+                        var latitude = (int)monitor.OrbitalLatitude.Value;
                         var msg = new OverwatchConsoleOrbitalSaveBuiMsg(longitude, latitude);
-                        SendPredictedMessage(msg);
+                        SendMessage(msg);
                     };
 
                 monitor.MessageSquadButton.OnPressed += _ =>
@@ -813,42 +815,44 @@ public sealed class OverwatchConsoleBui : RMCPopOutBui<OverwatchConsoleWindow>
             {
                 squad.HasCrate = supplyDrop.HasCrate;
                 squad.NextLaunchAt = supplyDrop.NextLaunchAt;
-
-                AddSaving(squad.Longitudes, squad.Latitudes, squad.Comments, squad.Saves, margin);
-                AddSavedLocation(
-                    console.SavedLocations,
-                    margin,
-                    squad.Longitudes,
-                    squad.Latitudes,
-                    squad.Comments,
-                    squad.Saves,
-                    location =>
-                    {
-                        squad.Longitude.Value = location.Longitude;
-                        squad.Latitude.Value = location.Latitude;
-
-                        SendPredictedMessage(new OverwatchConsoleSupplyDropLongitudeBuiMsg(location.Longitude));
-                        SendPredictedMessage(new OverwatchConsoleSupplyDropLatitudeBuiMsg(location.Latitude));
-                    }
-                );
             }
 
-            AddSaving(squad.OrbitalLongitudes, squad.OrbitalLatitudes, squad.OrbitalComments, squad.OrbitalSaves, margin);
-            AddSavedLocation(
-                console.SavedLocations,
+            UpdateSavedLocationTable(
+                console.SavedSupplyDropLocations,
                 margin,
-                squad.OrbitalLongitudes,
-                squad.OrbitalLatitudes,
-                squad.OrbitalComments,
-                squad.OrbitalSaves,
+                squad.Longitudes,
+                squad.Latitudes,
+                squad.Comments,
+                squad.Loads,
                 location =>
                 {
                     squad.Longitude.Value = location.Longitude;
                     squad.Latitude.Value = location.Latitude;
 
+                    SendPredictedMessage(new OverwatchConsoleSupplyDropLongitudeBuiMsg(location.Longitude));
+                    SendPredictedMessage(new OverwatchConsoleSupplyDropLatitudeBuiMsg(location.Latitude));
+                },
+                (index, comment) =>
+                    SendPredictedMessage(new OverwatchConsoleSupplyDropCommentBuiMsg(index, comment))
+            );
+
+            UpdateSavedLocationTable(
+                console.SavedOrbitalLocations,
+                margin,
+                squad.OrbitalLongitudes,
+                squad.OrbitalLatitudes,
+                squad.OrbitalComments,
+                squad.OrbitalLoads,
+                location =>
+                {
+                    squad.OrbitalLongitude.Value = location.Longitude;
+                    squad.OrbitalLatitude.Value = location.Latitude;
+
                     SendPredictedMessage(new OverwatchConsoleOrbitalLongitudeBuiMsg(location.Longitude));
                     SendPredictedMessage(new OverwatchConsoleOrbitalLatitudeBuiMsg(location.Latitude));
-                }
+                },
+                (index, comment) =>
+                    SendPredictedMessage(new OverwatchConsoleOrbitalCommentBuiMsg(index, comment))
             );
 
             squad.HasOrbital = console.HasOrbital;
@@ -856,11 +860,88 @@ public sealed class OverwatchConsoleBui : RMCPopOutBui<OverwatchConsoleWindow>
         }
     }
 
-    private void AddSaving(BoxContainer longitudes, BoxContainer latitudes, BoxContainer comments, BoxContainer saves, Thickness margin)
+    private void UpdateSavedLocationTable(
+        OverwatchSavedLocation?[] locations,
+        Thickness margin,
+        BoxContainer longitudes,
+        BoxContainer latitudes,
+        BoxContainer comments,
+        BoxContainer loads,
+        Action<OverwatchSavedLocation> onSelect,
+        Action<int, string> onComment)
+    {
+        if (!_savedLocationTables.TryGetValue(comments, out var table) ||
+            !SavedLocationCoordinatesMatch(table.Locations, locations))
+        {
+            ResetSavedLocationColumns(longitudes, latitudes, comments, loads, margin);
+            var commentEdits = PopulateSavedLocationRows(
+                locations,
+                margin,
+                longitudes,
+                latitudes,
+                comments,
+                loads,
+                onSelect,
+                onComment);
+
+            _savedLocationTables[comments] = new SavedLocationTableState(locations.ToArray(), commentEdits);
+            return;
+        }
+
+        for (var i = 0; i < locations.Length; i++)
+        {
+            if (locations[i] is not { } location ||
+                !table.Comments.TryGetValue(i, out var commentEdit) ||
+                commentEdit.Control.HasKeyboardFocus())
+            {
+                continue;
+            }
+
+            commentEdit.Control.Text = location.Comment;
+            commentEdit.LastSubmitted = location.Comment;
+        }
+
+        table.Locations = locations.ToArray();
+    }
+
+    private static bool SavedLocationCoordinatesMatch(
+        OverwatchSavedLocation?[] previous,
+        OverwatchSavedLocation?[] current)
+    {
+        if (previous.Length != current.Length)
+            return false;
+
+        for (var i = 0; i < previous.Length; i++)
+        {
+            if (previous[i] is not { } previousLocation)
+            {
+                if (current[i] != null)
+                    return false;
+
+                continue;
+            }
+
+            if (current[i] is not { } currentLocation ||
+                previousLocation.Longitude != currentLocation.Longitude ||
+                previousLocation.Latitude != currentLocation.Latitude)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private void ResetSavedLocationColumns(
+        BoxContainer longitudes,
+        BoxContainer latitudes,
+        BoxContainer comments,
+        BoxContainer loads,
+        Thickness margin)
     {
         longitudes.DisposeAllChildren();
 
-        var panel = CreatePanel(50);
+        var panel = CreatePanel(SavedLocationRowHeight);
         panel.AddChild(new Label
         {
             Text = Loc.GetString("rmc-overwatch-console-longitude-short"),
@@ -869,7 +950,7 @@ public sealed class OverwatchConsoleBui : RMCPopOutBui<OverwatchConsoleWindow>
         longitudes.AddChild(panel);
 
         latitudes.DisposeAllChildren();
-        panel = CreatePanel(50);
+        panel = CreatePanel(SavedLocationRowHeight);
         panel.AddChild(new Label
         {
             Text = Loc.GetString("rmc-overwatch-console-latitude-short"),
@@ -878,7 +959,7 @@ public sealed class OverwatchConsoleBui : RMCPopOutBui<OverwatchConsoleWindow>
         latitudes.AddChild(panel);
 
         comments.DisposeAllChildren();
-        panel = CreatePanel(50);
+        panel = CreatePanel(SavedLocationRowHeight);
         panel.AddChild(new Label
         {
             Text = Loc.GetString("rmc-overwatch-console-comment"),
@@ -886,32 +967,34 @@ public sealed class OverwatchConsoleBui : RMCPopOutBui<OverwatchConsoleWindow>
         });
         comments.AddChild(panel);
 
-        saves.DisposeAllChildren();
-        panel = CreatePanel(50);
+        loads.DisposeAllChildren();
+        panel = CreatePanel(SavedLocationRowHeight);
         panel.AddChild(new Label
         {
             Text = " ",
             Margin = margin,
         });
 
-        saves.AddChild(panel);
+        loads.AddChild(panel);
     }
 
-    private void AddSavedLocation(
+    private Dictionary<int, SavedLocationCommentEdit> PopulateSavedLocationRows(
         OverwatchSavedLocation?[] locations,
         Thickness margin,
         BoxContainer longitudes,
         BoxContainer latitudes,
         BoxContainer comments,
-        BoxContainer saves,
-        Action<OverwatchSavedLocation> onSave)
+        BoxContainer loads,
+        Action<OverwatchSavedLocation> onSelect,
+        Action<int, string> onComment)
     {
+        var commentEdits = new Dictionary<int, SavedLocationCommentEdit>();
         for (var i = 0; i < locations.Length; i++)
         {
             if (locations[i] is not { } location)
                 continue;
 
-            var panel = CreatePanel(50);
+            var panel = CreatePanel(SavedLocationRowHeight);
             panel.AddChild(new Label
             {
                 Text = $"{location.Longitude}",
@@ -919,7 +1002,7 @@ public sealed class OverwatchConsoleBui : RMCPopOutBui<OverwatchConsoleWindow>
             });
             longitudes.AddChild(panel);
 
-            panel = CreatePanel(50);
+            panel = CreatePanel(SavedLocationRowHeight);
             panel.AddChild(new Label
             {
                 Text = $"{location.Latitude}",
@@ -927,30 +1010,43 @@ public sealed class OverwatchConsoleBui : RMCPopOutBui<OverwatchConsoleWindow>
             });
             latitudes.AddChild(panel);
 
-            var comment = new LineEdit { Text = $"{location.Comment}" };
             var index = i;
-            comment.OnTextEntered += args => SaveComment(index, args.Text);
+            var comment = new LineEdit
+            {
+                Text = location.Comment,
+                PlaceHolder = Loc.GetString("rmc-overwatch-console-comment-placeholder"),
+                ToolTip = Loc.GetString("rmc-overwatch-console-comment-autosave"),
+                IsValid = text => text.Length <= 50,
+            };
+            var commentEdit = new SavedLocationCommentEdit(comment, location.Comment);
+            commentEdits[index] = commentEdit;
+            comment.OnTextEntered += args =>
+                SubmitSavedLocationComment(index, args.Text, commentEdit, onComment);
+            comment.OnFocusExit += args =>
+                SubmitSavedLocationComment(index, args.Text, commentEdit, onComment);
 
-            panel = CreatePanel(50);
+            panel = CreatePanel(SavedLocationRowHeight);
             panel.AddChild(comment);
             comments.AddChild(panel);
 
-            panel = CreatePanel(50);
-            var saveButton = new Button
+            panel = CreatePanel(SavedLocationRowHeight);
+            var loadButton = new Button
             {
-                MaxWidth = 25,
+                MinWidth = 55,
                 MaxHeight = 25,
-                VerticalAlignment = VAlignment.Top,
+                VerticalAlignment = VAlignment.Center,
                 StyleClasses = { "OpenBoth" },
-                Text = "<",
+                Text = Loc.GetString("rmc-overwatch-console-load"),
                 ModulateSelfOverride = Color.FromHex("#D3B400"),
-                ToolTip = Loc.GetString("rmc-overwatch-console-save-comment"),
+                ToolTip = Loc.GetString("rmc-overwatch-console-load-coordinates"),
             };
-            saveButton.OnPressed += _ => onSave(location);
+            loadButton.OnPressed += _ => onSelect(location);
 
-            panel.AddChild(saveButton);
-            saves.AddChild(panel);
+            panel.AddChild(loadButton);
+            loads.AddChild(panel);
         }
+
+        return commentEdits;
     }
 
     private PanelContainer CreatePanel(float minHeight = 0, Thickness? thickness = null)
@@ -985,18 +1081,41 @@ public sealed class OverwatchConsoleBui : RMCPopOutBui<OverwatchConsoleWindow>
             : null;
     }
 
-    private void SaveComment(int index, string text)
+    private static void SubmitSavedLocationComment(
+        int index,
+        string comment,
+        SavedLocationCommentEdit commentEdit,
+        Action<int, string> onComment)
     {
-        if (text.Length > 50)
-            text = text[..50];
+        if (comment.Length > 50)
+            comment = comment[..50];
 
-        SendPredictedMessage(new OverwatchConsoleLocationCommentBuiMsg(index, text));
+        commentEdit.Control.Text = comment;
+        if (commentEdit.LastSubmitted == comment)
+            return;
+
+        commentEdit.LastSubmitted = comment;
+        onComment(index, comment);
     }
 
     public void Refresh()
     {
         if (State is OverwatchConsoleBuiState s)
             RefreshState(s);
+    }
+
+    private sealed class SavedLocationTableState(
+        OverwatchSavedLocation?[] locations,
+        Dictionary<int, SavedLocationCommentEdit> comments)
+    {
+        public OverwatchSavedLocation?[] Locations = locations;
+        public readonly Dictionary<int, SavedLocationCommentEdit> Comments = comments;
+    }
+
+    private sealed class SavedLocationCommentEdit(LineEdit control, string lastSubmitted)
+    {
+        public readonly LineEdit Control = control;
+        public string LastSubmitted = lastSubmitted;
     }
 
     private readonly record struct OverwatchRow(

--- a/Content.Client/_RMC14/Overwatch/OverwatchSquadView.xaml
+++ b/Content.Client/_RMC14/Overwatch/OverwatchSquadView.xaml
@@ -234,7 +234,7 @@
                                     <BoxContainer Orientation="Horizontal" Margin="5"
                                                   VerticalExpand="True">
                                         <BoxContainer Orientation="Vertical" HorizontalExpand="True">
-                                            <BoxContainer Orientation="Horizontal">
+                                            <BoxContainer Orientation="Horizontal" SeparationOverride="5">
                                                 <BoxContainer Name="LongitudeContainer" Access="Public" Orientation="Vertical">
                                                     <Label Text="{Loc rmc-overwatch-console-longitude}" />
                                                 </BoxContainer>
@@ -256,13 +256,13 @@
                                                     ModulateSelfOverride="#D3B400" TextAlign="Center" />
                                         </BoxContainer>
                                         <ui:BlueHorizontalSeparator SetWidth="2" Margin="5 0" />
-                                        <BoxContainer Orientation="Vertical" HorizontalExpand="True" Visible="False">
+                                        <BoxContainer Orientation="Vertical" HorizontalExpand="True">
                                             <Label Text="{Loc rmc-overwatch-console-max-coordinates}" />
                                             <BoxContainer Orientation="Horizontal">
                                                 <BoxContainer Name="Longitudes" Access="Public" Orientation="Vertical" />
                                                 <BoxContainer Name="Latitudes" Access="Public" Orientation="Vertical" />
                                                 <BoxContainer Name="Comments" Access="Public" Orientation="Vertical" HorizontalExpand="True" />
-                                                <BoxContainer Name="Saves" Access="Public" Orientation="Vertical" />
+                                                <BoxContainer Name="Loads" Access="Public" Orientation="Vertical" />
                                             </BoxContainer>
                                         </BoxContainer>
                                     </BoxContainer>
@@ -291,7 +291,7 @@
                                     <BoxContainer Orientation="Horizontal" Margin="5"
                                                   VerticalExpand="True">
                                         <BoxContainer Orientation="Vertical" HorizontalExpand="True">
-                                            <BoxContainer Orientation="Horizontal">
+                                            <BoxContainer Orientation="Horizontal" SeparationOverride="5">
                                                 <BoxContainer Name="OrbitalLongitudeContainer" Access="Public" Orientation="Vertical">
                                                     <Label Text="{Loc rmc-overwatch-console-longitude}" />
                                                 </BoxContainer>
@@ -319,7 +319,7 @@
                                                 <BoxContainer Name="OrbitalLongitudes" Access="Public" Orientation="Vertical" />
                                                 <BoxContainer Name="OrbitalLatitudes" Access="Public" Orientation="Vertical" />
                                                 <BoxContainer Name="OrbitalComments" Access="Public" Orientation="Vertical" HorizontalExpand="True" />
-                                                <BoxContainer Name="OrbitalSaves" Access="Public" Orientation="Vertical" />
+                                                <BoxContainer Name="OrbitalLoads" Access="Public" Orientation="Vertical" />
                                             </BoxContainer>
                                         </BoxContainer>
                                     </BoxContainer>

--- a/Content.Shared/_RMC14/Overwatch/OverwatchConsoleComponent.cs
+++ b/Content.Shared/_RMC14/Overwatch/OverwatchConsoleComponent.cs
@@ -8,6 +8,8 @@ namespace Content.Shared._RMC14.Overwatch;
 [Access(typeof(SharedOverwatchConsoleSystem))]
 public sealed partial class OverwatchConsoleComponent : Component
 {
+    public const int MaxSavedLocationCount = 5;
+
     [DataField, AutoNetworkedField]
     public NetEntity? Squad;
 
@@ -27,10 +29,10 @@ public sealed partial class OverwatchConsoleComponent : Component
     public HashSet<NetEntity> Hidden = new();
 
     [DataField, AutoNetworkedField]
-    public OverwatchSavedLocation?[] SavedLocations = new OverwatchSavedLocation?[3];
+    public OverwatchSavedLocation?[] SavedSupplyDropLocations = new OverwatchSavedLocation?[MaxSavedLocationCount];
 
     [DataField, AutoNetworkedField]
-    public int LastLocation;
+    public OverwatchSavedLocation?[] SavedOrbitalLocations = new OverwatchSavedLocation?[MaxSavedLocationCount];
 
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
     public TimeSpan LastMessage;

--- a/Content.Shared/_RMC14/Overwatch/OverwatchConsoleUI.cs
+++ b/Content.Shared/_RMC14/Overwatch/OverwatchConsoleUI.cs
@@ -112,7 +112,7 @@ public sealed class OverwatchConsoleSupplyDropSaveBuiMsg(int longitude, int lati
 }
 
 [Serializable, NetSerializable]
-public sealed class OverwatchConsoleLocationCommentBuiMsg(int index, string comment) : BoundUserInterfaceMessage
+public sealed class OverwatchConsoleSupplyDropCommentBuiMsg(int index, string comment) : BoundUserInterfaceMessage
 {
     public readonly int Index = index;
     public readonly string Comment = comment;

--- a/Content.Shared/_RMC14/Overwatch/SharedOverwatchConsoleSystem.cs
+++ b/Content.Shared/_RMC14/Overwatch/SharedOverwatchConsoleSystem.cs
@@ -123,12 +123,12 @@ public abstract class SharedOverwatchConsoleSystem : EntitySystem
             subs.Event<OverwatchConsoleSupplyDropLatitudeBuiMsg>(OnOverwatchSupplyDropLatitudeBui);
             subs.Event<OverwatchConsoleSupplyDropLaunchBuiMsg>(OnOverwatchSupplyDropLaunchBui);
             subs.Event<OverwatchConsoleSupplyDropSaveBuiMsg>(OnOverwatchSupplyDropSaveBui);
-            subs.Event<OverwatchConsoleLocationCommentBuiMsg>(OnOverwatchSupplyDropCommentBui);
+            subs.Event<OverwatchConsoleSupplyDropCommentBuiMsg>(OnOverwatchSupplyDropCommentBui);
             subs.Event<OverwatchConsoleOrbitalLongitudeBuiMsg>(OnOverwatchOrbitalCoordinatesBui);
             subs.Event<OverwatchConsoleOrbitalLatitudeBuiMsg>(OnOverwatchOrbitalCoordinatesBui);
             subs.Event<OverwatchConsoleOrbitalLaunchBuiMsg>(OnOverwatchOrbitalLaunchBui);
-            // subs.Event<OverwatchConsoleOrbitalSaveBuiMsg>(OnOverwatchOrbitalSaveBui);
-            // subs.Event<OverwatchConsoleOrbitalCommentBuiMsg>(OnOverwatchOrbitalCommentBui);
+            subs.Event<OverwatchConsoleOrbitalSaveBuiMsg>(OnOverwatchOrbitalSaveBui);
+            subs.Event<OverwatchConsoleOrbitalCommentBuiMsg>(OnOverwatchOrbitalCommentBui);
             subs.Event<OverwatchConsoleSendMessageBuiMsg>(OnOverwatchSendMessageBui);
             subs.Event<OverwatchConsoleSetSquadObjectiveBuiMsg>(OnOverwatchSetSquadObjectiveBui);
             subs.Event<OverwatchConsoleClearSquadObjectiveBuiMsg>(OnOverwatchClearSquadObjectiveBui);
@@ -477,44 +477,27 @@ public abstract class SharedOverwatchConsoleSystem : EntitySystem
 
     private void OnOverwatchSupplyDropSaveBui(Entity<OverwatchConsoleComponent> ent, ref OverwatchConsoleSupplyDropSaveBuiMsg args)
     {
-        var locations = ent.Comp.SavedLocations;
-        if (locations.Length == 0)
+        if (_net.IsClient)
             return;
 
-        ref var last = ref ent.Comp.LastLocation;
-        if (last >= locations.Length)
-            last = 0;
-
-        locations[last] = new OverwatchSavedLocation(args.Longitude, args.Latitude, string.Empty);
-
-        last++;
-        Dirty(ent);
+        SaveLocation(ent, ent.Comp.SavedSupplyDropLocations, args.Longitude, args.Latitude);
     }
 
-    private void OnOverwatchSupplyDropCommentBui(Entity<OverwatchConsoleComponent> ent, ref OverwatchConsoleLocationCommentBuiMsg args)
+    private void OnOverwatchSupplyDropCommentBui(Entity<OverwatchConsoleComponent> ent, ref OverwatchConsoleSupplyDropCommentBuiMsg args)
     {
-        var locations = ent.Comp.SavedLocations;
-        if (args.Index < 0 || args.Index >= locations.Length)
-            return;
-
-        if (locations[args.Index] is not { } location)
-            return;
-
-        var comment = args.Comment;
-        if (comment.Length > 50)
-            comment = comment[..50];
-
-        locations[args.Index] = location with { Comment = comment };
+        SaveLocationComment(ent, ent.Comp.SavedSupplyDropLocations, args.Index, args.Comment);
     }
 
     private void OnOverwatchOrbitalCoordinatesBui(Entity<OverwatchConsoleComponent> ent, ref OverwatchConsoleOrbitalLongitudeBuiMsg args)
     {
         ent.Comp.OrbitalCoordinates = new Vector2i(args.Longitude, ent.Comp.OrbitalCoordinates.Y);
+        Dirty(ent);
     }
 
     private void OnOverwatchOrbitalCoordinatesBui(Entity<OverwatchConsoleComponent> ent, ref OverwatchConsoleOrbitalLatitudeBuiMsg args)
     {
         ent.Comp.OrbitalCoordinates = new Vector2i(ent.Comp.OrbitalCoordinates.X, args.Latitude);
+        Dirty(ent);
     }
 
     private void OnOverwatchOrbitalLaunchBui(Entity<OverwatchConsoleComponent> ent, ref OverwatchConsoleOrbitalLaunchBuiMsg args)
@@ -532,15 +515,68 @@ public abstract class SharedOverwatchConsoleSystem : EntitySystem
         _orbitalCannon.Fire(cannon, ent.Comp.OrbitalCoordinates, args.Actor, squad);
     }
 
-    // private void OnOverwatchOrbitalSaveBui(Entity<OverwatchConsoleComponent> ent, ref OverwatchConsoleOrbitalSaveBuiMsg args)
-    // {
-    //     throw new NotImplementedException();
-    // }
-    //
-    // private void OnOverwatchOrbitalCommentBui(Entity<OverwatchConsoleComponent> ent, ref OverwatchConsoleOrbitalCommentBuiMsg args)
-    // {
-    //     throw new NotImplementedException();
-    // }
+    private void OnOverwatchOrbitalSaveBui(Entity<OverwatchConsoleComponent> ent, ref OverwatchConsoleOrbitalSaveBuiMsg args)
+    {
+        if (_net.IsClient)
+            return;
+
+        SaveLocation(ent, ent.Comp.SavedOrbitalLocations, args.Longitude, args.Latitude);
+    }
+
+    private void OnOverwatchOrbitalCommentBui(Entity<OverwatchConsoleComponent> ent, ref OverwatchConsoleOrbitalCommentBuiMsg args)
+    {
+        SaveLocationComment(ent, ent.Comp.SavedOrbitalLocations, args.Index, args.Comment);
+    }
+
+    private void SaveLocation(
+        Entity<OverwatchConsoleComponent> ent,
+        OverwatchSavedLocation?[] locations,
+        int longitude,
+        int latitude)
+    {
+        if (locations.Length == 0)
+            return;
+
+        if (locations.Any(location =>
+                location is { } saved &&
+                saved.Longitude == longitude &&
+                saved.Latitude == latitude))
+        {
+            return;
+        }
+
+        var index = Array.IndexOf(locations, null);
+        if (index < 0)
+        {
+            Array.Copy(locations, 1, locations, 0, locations.Length - 1);
+            index = locations.Length - 1;
+        }
+
+        locations[index] = new OverwatchSavedLocation(longitude, latitude, string.Empty);
+        Dirty(ent);
+    }
+
+    private void SaveLocationComment(
+        Entity<OverwatchConsoleComponent> ent,
+        OverwatchSavedLocation?[] locations,
+        int index,
+        string comment)
+    {
+        if (index < 0 || index >= locations.Length)
+            return;
+
+        if (locations[index] is not { } location)
+            return;
+
+        if (comment.Length > 50)
+            comment = comment[..50];
+
+        if (location.Comment == comment)
+            return;
+
+        locations[index] = location with { Comment = comment };
+        Dirty(ent);
+    }
 
     private void OnOverwatchSendMessageBui(Entity<OverwatchConsoleComponent> ent, ref OverwatchConsoleSendMessageBuiMsg args)
     {

--- a/Resources/Locale/en-US/_RMC14/overwatch.ftl
+++ b/Resources/Locale/en-US/_RMC14/overwatch.ftl
@@ -27,7 +27,7 @@ rmc-overwatch-console-status = STATUS
 rmc-overwatch-console-launch-supply-drop = Launch Supply Drop
 rmc-overwatch-console-confirm-supply-drop = Confirm Supply Drop?
 rmc-overwatch-console-save = Save
-rmc-overwatch-console-max-coordinates = Max 3 stored coordinates. Will overwrite oldest first.
+rmc-overwatch-console-max-coordinates = Max 5 stored coordinates. Will overwrite oldest first.
 rmc-overwatch-console-fire = Fire
 rmc-overwatch-console-confirm-fire = Confirm Fire Mission?
 rmc-overwatch-console-disabled-select-squad = OVERWATCH DISABLED - SELECT SQUAD
@@ -56,7 +56,10 @@ rmc-overwatch-console-hide-dead = Hide dead
 rmc-overwatch-console-longitude-short = LONG.
 rmc-overwatch-console-latitude-short = LAT.
 rmc-overwatch-console-comment = COMMENT
-rmc-overwatch-console-save-comment = Save Comment
+rmc-overwatch-console-comment-placeholder = Optional comment
+rmc-overwatch-console-comment-autosave = Saves when you press Enter or leave the field.
+rmc-overwatch-console-load = Load
+rmc-overwatch-console-load-coordinates = Load these coordinates
 rmc-overwatch-console-no-crate-loaded = [color=red][bold][ NO CRATE LOADED ][/bold][/color]
 rmc-overwatch-console-crate-loaded = [color=green][bold][ CRATE LOADED ][/bold][/color]
 rmc-overwatch-console-ready = [color=green][bold][ READY ][/bold][/color]


### PR DESCRIPTION
## About the PR
Fixes saved coordinates in the Overwatch console. Supply Drop and Orbital Bombardment now use separate lists with up to five unique entries. Coordinates load into the correct controls, and comments save on Enter or focus loss.

## Why / Balance
The Orbital Bombardment save handlers were disabled despite the visible Save button. Separate lists prevent Supply Drop and OB coordinates from overwriting each other. This does not change launch, firing, or cooldown mechanics.

## Technical details
- Added separate networked Supply Drop and OB coordinate lists.
- Implemented server-side OB saving and comment handling.
- Added FIFO replacement after five entries and duplicate-coordinate rejection.
- Made coordinate saving server-authoritative to prevent duplicated and reordered UI rows.
- Added comment validation, state replication

## Media
<img width="1538" height="392" alt="image" src="https://github.com/user-attachments/assets/e35ef79e-1afa-4bac-9267-7969db4c320b" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:GrigoriyGalintano
- fix: Fixed saving, loading, and commenting on coordinates in the Overwatch console.