### PR TITLE
[Parity] Explosion armor formula and humanoid explosion coefficient fixes

### DIFF
--- a/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
+++ b/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
@@ -194,7 +194,7 @@ public sealed class CMArmorSystem : EntitySystem
         if (armor <= 0)
             return;
 
-        var resist = (float) Math.Pow(1.1, armor / 5.0);
+        var resist = (float) Math.Pow(1.1, armor / 10.0);
         args.Args.DamageCoefficient /= resist;
     }
 
@@ -204,7 +204,7 @@ public sealed class CMArmorSystem : EntitySystem
         if (armor <= 0)
             return;
 
-        var resist = (float) Math.Pow(1.1, armor / 5.0);
+        var resist = (float) Math.Pow(1.1, armor / 10.0);
         args.DamageCoefficient /= resist;
     }
 

--- a/Content.Shared/_RMC14/Shields/CrusherShieldSystem.cs
+++ b/Content.Shared/_RMC14/Shields/CrusherShieldSystem.cs
@@ -130,7 +130,7 @@ public sealed partial class CrusherShieldSystem : EntitySystem
 
         var explosionResist = ent.Comp.ExplosionResistance;
 
-        var resist = (float) Math.Pow(1.1, explosionResist / 5.0); // From armor calcualtion
+        var resist = (float) Math.Pow(1.1, explosionResist / 10.0); // From armor calcualtion
         args.DamageCoefficient /= resist;
     }
 }

--- a/Content.Shared/_RMC14/Shields/VanguardShieldSystem.cs
+++ b/Content.Shared/_RMC14/Shields/VanguardShieldSystem.cs
@@ -55,7 +55,7 @@ public sealed class VanguardShieldSystem : EntitySystem
 
         var explosionResist = xeno.Comp.ExplosionResistance;
 
-        var resist = (float)Math.Pow(1.1, explosionResist / 5.0); // From armor calcualtion
+        var resist = (float)Math.Pow(1.1, explosionResist / 10.0); // From armor calcualtion
         args.DamageCoefficient /= resist;
     }
 

--- a/Content.Shared/_RMC14/Xenonids/Fortify/XenoFortifySystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Fortify/XenoFortifySystem.cs
@@ -116,7 +116,7 @@ public sealed class XenoFortifySystem : EntitySystem
             if (armor <= 0)
                 return;
 
-            var resist = (float)Math.Pow(1.1, armor / 5.0);
+            var resist = (float)Math.Pow(1.1, armor / 10.0);
             args.DamageCoefficient /= resist;
         }
     }

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -227,6 +227,8 @@
     - AnomalyHost
   - type: MobGibbedByExplosionType
   - type: RMCCanBeFultoned
+  - type: ExplosionResistance
+    damageCoefficient: 1.2
 
 - type: entity
   save: false

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -228,7 +228,7 @@
   - type: MobGibbedByExplosionType
   - type: RMCCanBeFultoned
   - type: ExplosionResistance
-    damageCoefficient: 1.2
+    damageCoefficient: 1.2  # TODO RMC14: won't be necessary once limb damage is implemented to mimic parity
 
 - type: entity
   save: false


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Explosion armor now uses the formula `1.1^A/10.0` instead of its previous `1.1^A/5.0`.
This will decrease how effective explosion armor is. The below table is an estimate I made with the equation `(1.1^A/10 - 1.1^A/5) / 1.1^A/10)`.
| explosive armor | est. reduction in effectiveness |
|-------------------|----------------------------------|
| 0                         | N/A                                          |
| 10                       | ~9%                                         |
| 20                       | ~17.4%                                    |
| 30                       | ~24.9%                                    |
| 40                       | ~31.8%                                    |
| 50                       | ~37.9%                                    |
| 60                       | ~43.6%                                    |
| 70                       | ~48.7%                                    |
| 80                       | ~53.3%                                    |
| 90                       | ~57.6%                                    |
| 100                     | ~61.4%                                    |

Also resolves #10652.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity for both.
Because explosion damage is being calculated, `armor_steps = 10` should be used per `/datum/combat_configuration/xeno/explosive`. `armor_effect` is also defined as `0.1` by `/datum/combat_configuration/xeno`.
Previously we used `5.0` instead of the `10.0` `armor_steps` value, likely because when the damage math was ported, we assumed that explosion damage should use the same `armor_steps = 5.0` like other damage types do in CM13.
```dm
/mob/living/carbon/xenomorph/ex_act(severity, direction, datum/cause_data/cause_data, pierce=0, enviro=FALSE)
...
	if(armor>0)
		armor = armor * rand(100-c_config.armor_random_range,100) / 100
		armor_deflection_total = (1+armor_effect) ** (armor/c_config.armor_steps) //basically a concept of "Effective Health"
		effective_deflection = c_config.armor_ignore_integrity? 1 : armor_integrity/100


	damage /= armor_deflection_total
```
```dm
/proc/armor_damage_reduction(datum/combat_configuration/c_config, damage, armor=0, penetration=0, pen_armor_punch=0, damage_armor_punch=0, armor_integrity = 100)
...
/datum/combat_configuration/xeno
	armor_minimal_efficiency = 0.05
	armor_effective_health = 0.1
	armor_steps = 5
	non_null_damage_mult = 4
	armor_full_deflection_mult = 2
	armor_integrity_damage_mult = 4
	armor_ignore_integrity = TRUE

...

/datum/combat_configuration/xeno/explosive
	armor_steps = 10
	armor_minimal_efficiency = 0
	damage_initial_multiplier = 2
	armor_integrity_damage_mult = 4
```

Anything that parents from `BaseMobSpecies` will now take 1.2x explosion damage.

## Technical details
<!-- Summary of code changes for easier review. -->
Minor C# change.
Minor yml change.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
Here's a [graph](https://www.desmos.com/calculator/0kwmrbeorz) of some information regarding our explosive armor and CM13's explosive armor.
<img width="1400" height="828" alt="image" src="https://github.com/user-attachments/assets/62750675-7b63-4261-b6aa-0215d3f73f79" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Explosion armor now uses the correct equation
- fix: Humanoids now use the correct explosive damage coefficient