### PR TITLE
Extends harm mode to match pulling target range

### DIFF
--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
@@ -219,7 +219,7 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
             target = screen.GetClickedEntity(mousePos);
 
         var attackerPos = TransformSystem.GetMapCoordinates(attacker);
-        if (mousePos.MapId != attackerPos.MapId || (attackerPos.Position - mousePos.Position).Length() > _rmcMeleeWeapon.RMCGetUserDisarmRange(attacker, target, meleeComponent))
+        if (mousePos.MapId != attackerPos.MapId || (attackerPos.Position - mousePos.Position).Length() > _rmcMeleeWeapon.GetUserDisarmRange(attacker, target, meleeComponent))
             return;
 
         _rmcLagCompensation.SendLastRealTick(); // RMC14

--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
@@ -218,7 +218,7 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
         if (_stateManager.CurrentState is GameplayStateBase screen)
             target = screen.GetClickedEntity(mousePos);
         var attackerPos = TransformSystem.GetMapCoordinates(attacker);
-        if (mousePos.MapId != attackerPos.MapId || (attackerPos.Position - mousePos.Position).Length() > _rmcMeleeWeapon.GetUserDisarmRange(attacker, target, meleeComponent))
+        if (mousePos.MapId != attackerPos.MapId || (attackerPos.Position - mousePos.Position).Length() > _rmcMeleeWeapon.RMCGetUserDisarmRange(attacker, target, meleeComponent))
             return;
         _rmcLagCompensation.SendLastRealTick(); // RMC14
         RaisePredictiveEvent(new DisarmAttackEvent(GetNetEntity(target), GetNetCoordinates(coordinates)));

--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
@@ -218,12 +218,8 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
         if (_stateManager.CurrentState is GameplayStateBase screen)
             target = screen.GetClickedEntity(mousePos);
         var attackerPos = TransformSystem.GetMapCoordinates(attacker);
-        if (mousePos.MapId != attackerPos.MapId || (attackerPos.Position - mousePos.Position).Length() > meleeComponent.Range)
-        {
-            var RMCGetTackleRangeEvent = new RMCGetTackleRangeEvent(target, meleeComponent.Range);
-            RaiseLocalEvent(attacker, ref RMCGetTackleRangeEvent);
+        if (mousePos.MapId != attackerPos.MapId || (attackerPos.Position - mousePos.Position).Length() > _rmcMeleeWeapon.GetUserDisarmRange(attacker, target, meleeComponent))
             return;
-        }
         _rmcLagCompensation.SendLastRealTick(); // RMC14
         RaisePredictiveEvent(new DisarmAttackEvent(GetNetEntity(target), GetNetCoordinates(coordinates)));
     }

--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
@@ -217,9 +217,11 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
 
         if (_stateManager.CurrentState is GameplayStateBase screen)
             target = screen.GetClickedEntity(mousePos);
+
         var attackerPos = TransformSystem.GetMapCoordinates(attacker);
         if (mousePos.MapId != attackerPos.MapId || (attackerPos.Position - mousePos.Position).Length() > _rmcMeleeWeapon.RMCGetUserDisarmRange(attacker, target, meleeComponent))
             return;
+
         _rmcLagCompensation.SendLastRealTick(); // RMC14
         RaisePredictiveEvent(new DisarmAttackEvent(GetNetEntity(target), GetNetCoordinates(coordinates)));
     }

--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
@@ -217,11 +217,13 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
 
         if (_stateManager.CurrentState is GameplayStateBase screen)
             target = screen.GetClickedEntity(mousePos);
-
         var attackerPos = TransformSystem.GetMapCoordinates(attacker);
         if (mousePos.MapId != attackerPos.MapId || (attackerPos.Position - mousePos.Position).Length() > meleeComponent.Range)
+        {
+            var RMCGetTackleRangeEvent = new RMCGetTackleRangeEvent(target, meleeComponent.Range);
+            RaiseLocalEvent(attacker, ref RMCGetTackleRangeEvent);
             return;
-
+        }
         _rmcLagCompensation.SendLastRealTick(); // RMC14
         RaisePredictiveEvent(new DisarmAttackEvent(GetNetEntity(target), GetNetCoordinates(coordinates)));
     }

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -985,7 +985,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
                 return false;
             }
         }
-
+        // RMC14 range disarm distance
         if (!InRange(user, target.Value, _rmcMelee.GetUserDisarmRange(user, target, component), session))
         {
             return false;

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -985,6 +985,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
                 return false;
             }
         }
+
         // RMC14 range disarm distance
         if (!InRange(user, target.Value, _rmcMelee.GetUserDisarmRange(user, target, component), session))
         {

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -986,7 +986,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
             }
         }
 
-        if (!InRange(user, target.Value, component.Range, session))
+        if (!InRange(user, target.Value, _rmcMelee.GetUserDisarmRange(user, target, component), session))
         {
             return false;
         }

--- a/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
+++ b/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
@@ -280,9 +280,8 @@ public sealed class RMCPullingSystem : EntitySystem
         var ev = new PullSlowdownAttemptEvent(puller.Pulling.Value);
         RaiseLocalEvent(ent, ref ev);
         if (ev.Cancelled)
-        {
             return;
-        }
+
         foreach (var slowdown in slow.Slowdowns)
         {
             if (_whitelist.IsWhitelistPass(slowdown.Whitelist, puller.Pulling.Value))
@@ -291,6 +290,7 @@ public sealed class RMCPullingSystem : EntitySystem
                 return;
             }
         }
+
         args.ModifySpeed(slow.Multiplier, slow.Multiplier);
     }
 

--- a/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
+++ b/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
@@ -256,6 +256,10 @@ public sealed class RMCPullingSystem : EntitySystem
     {
         if (ent.Owner == args.PullerUid)
         {
+            if (TryComp<MeleeWeaponComponent>(ent.Owner, out var increaseMeleeRange))
+            {
+                increaseMeleeRange.Range = 1.5f;
+            }
             RemComp<PullingSlowedComponent>(args.PullerUid);
             _movementSpeed.RefreshMovementSpeedModifiers(args.PullerUid);
         }
@@ -276,17 +280,21 @@ public sealed class RMCPullingSystem : EntitySystem
         var ev = new PullSlowdownAttemptEvent(puller.Pulling.Value);
         RaiseLocalEvent(ent, ref ev);
         if (ev.Cancelled)
+        {
             return;
-
+        }
         foreach (var slowdown in slow.Slowdowns)
         {
             if (_whitelist.IsWhitelistPass(slowdown.Whitelist, puller.Pulling.Value))
             {
+                if (TryComp<MeleeWeaponComponent>(ent.Owner, out var increaseMeleeRange))
+                {
+                    increaseMeleeRange.Range = 2.5f;
+                }
                 args.ModifySpeed(slowdown.Multiplier, slowdown.Multiplier);
                 return;
             }
         }
-
         args.ModifySpeed(slow.Multiplier, slow.Multiplier);
     }
 

--- a/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
+++ b/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
@@ -559,6 +559,7 @@ public sealed class RMCPullingSystem : EntitySystem
             args.Range = 4.0f;
         }
     }
+    
     public override void Update(float frameTime)
     {
         var blockDeadActive = EntityQueryEnumerator<BlockPullingDeadActiveComponent, PullerComponent>();

--- a/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
+++ b/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
@@ -31,6 +31,7 @@ using Content.Shared._RMC14.Xenonids.Crest;
 using Content.Shared._RMC14.Xenonids.Fortify;
 using Content.Shared._RMC14.Stun;
 using Content.Shared.IdentityManagement;
+using Content.Shared._RMC14.Tackle;
 
 namespace Content.Shared._RMC14.Pulling;
 
@@ -97,6 +98,9 @@ public sealed class RMCPullingSystem : EntitySystem
         SubscribeLocalEvent<PullerComponent, PullStoppedMessage>(OnPullerPullStopped);
 
         SubscribeLocalEvent<BeingPulledComponent, PullStoppedMessage>(OnBeingPulledPullStopped);
+
+        SubscribeLocalEvent<PullerComponent, RMCGetTackleRangeEvent>(ExtendTacklingRangeToPullingTarget);
+        SubscribeLocalEvent<PullerComponent, RMCMeleeUserGetRangeEvent>(ExtendAttackingRangeToPullingTarget);
     }
 
     private void OnGetPullTarget(Entity<BuckleComponent> ent, ref RMCGetPullTargetEvent ev)
@@ -256,10 +260,6 @@ public sealed class RMCPullingSystem : EntitySystem
     {
         if (ent.Owner == args.PullerUid)
         {
-            if (TryComp<MeleeWeaponComponent>(ent.Owner, out var increaseMeleeRange))
-            {
-                increaseMeleeRange.Range = 1.5f;
-            }
             RemComp<PullingSlowedComponent>(args.PullerUid);
             _movementSpeed.RefreshMovementSpeedModifiers(args.PullerUid);
         }
@@ -287,10 +287,6 @@ public sealed class RMCPullingSystem : EntitySystem
         {
             if (_whitelist.IsWhitelistPass(slowdown.Whitelist, puller.Pulling.Value))
             {
-                if (TryComp<MeleeWeaponComponent>(ent.Owner, out var increaseMeleeRange))
-                {
-                    increaseMeleeRange.Range = 2.5f;
-                }
                 args.ModifySpeed(slowdown.Multiplier, slowdown.Multiplier);
                 return;
             }
@@ -547,6 +543,27 @@ public sealed class RMCPullingSystem : EntitySystem
         return ev.Target;
     }
 
+
+    private void ExtendTacklingRangeToPullingTarget(Entity<PullerComponent> ent, ref RMCGetTackleRangeEvent args)
+    {
+        if (args.Target == ent.Comp.Pulling && args.Target != null)
+        {
+            if (TryComp<MeleeWeaponComponent>(ent, out var meleeComp))
+            {
+                Log.Info("Bigger tackle range");
+                meleeComp.Range = 3.0f;
+            }
+        }
+    }
+
+    private void ExtendAttackingRangeToPullingTarget(Entity<PullerComponent> ent, ref RMCMeleeUserGetRangeEvent args)
+    {
+        if (args.Target == ent.Comp.Pulling && args.Target != null)
+        {
+            Log.Info("Bigger Attack range");
+            args.Range = 3.0f;
+        }
+    }
     public override void Update(float frameTime)
     {
         var blockDeadActive = EntityQueryEnumerator<BlockPullingDeadActiveComponent, PullerComponent>();

--- a/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
+++ b/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
@@ -548,7 +548,6 @@ public sealed class RMCPullingSystem : EntitySystem
     {
         if (args.Target == ent.Comp.Pulling && args.Target != null)
         {
-            Log.Info("Bigger Tackling range 2.0V");
             args.Range = 4.0f;
         }
     }
@@ -557,7 +556,6 @@ public sealed class RMCPullingSystem : EntitySystem
     {
         if (args.Target == ent.Comp.Pulling && args.Target != null)
         {
-            Log.Info("Bigger Attack range");
             args.Range = 4.0f;
         }
     }

--- a/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
+++ b/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
@@ -99,7 +99,7 @@ public sealed class RMCPullingSystem : EntitySystem
 
         SubscribeLocalEvent<BeingPulledComponent, PullStoppedMessage>(OnBeingPulledPullStopped);
 
-        SubscribeLocalEvent<PullerComponent, GetUserDisarmRange>(ExtendTacklingRangeToPullingTarget);
+        SubscribeLocalEvent<PullerComponent, RMCGetUserDisarmRange>(ExtendTacklingRangeToPullingTarget);
         SubscribeLocalEvent<PullerComponent, RMCMeleeUserGetRangeEvent>(ExtendAttackingRangeToPullingTarget);
     }
 
@@ -544,7 +544,7 @@ public sealed class RMCPullingSystem : EntitySystem
     }
 
 
-    private void ExtendTacklingRangeToPullingTarget(Entity<PullerComponent> ent, ref GetUserDisarmRange args)
+    private void ExtendTacklingRangeToPullingTarget(Entity<PullerComponent> ent, ref RMCGetUserDisarmRange args)
     {
         if (args.Target == ent.Comp.Pulling && args.Target != null)
         {

--- a/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
+++ b/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
@@ -544,7 +544,7 @@ public sealed class RMCPullingSystem : EntitySystem
     }
 
 
-    private void ExtendTacklingRangeToPullingTarget(Entity<PullerComponent> ent, ref RMCGetUserDisarmRange args)
+    private void ExtendTacklingRangeToPullingTarget(Entity<PullerComponent> ent, ref RMCDisarmUserGetRangeEvent args)
     {
         if (args.Target == ent.Comp.Pulling && args.Target != null)
         {

--- a/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
+++ b/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
@@ -99,7 +99,7 @@ public sealed class RMCPullingSystem : EntitySystem
 
         SubscribeLocalEvent<BeingPulledComponent, PullStoppedMessage>(OnBeingPulledPullStopped);
 
-        SubscribeLocalEvent<PullerComponent, RMCGetUserDisarmRange>(ExtendTacklingRangeToPullingTarget);
+        SubscribeLocalEvent<PullerComponent, RMCDisarmUserGetRangeEvent>(ExtendTacklingRangeToPullingTarget);
         SubscribeLocalEvent<PullerComponent, RMCMeleeUserGetRangeEvent>(ExtendAttackingRangeToPullingTarget);
     }
 

--- a/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
+++ b/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
@@ -99,7 +99,7 @@ public sealed class RMCPullingSystem : EntitySystem
 
         SubscribeLocalEvent<BeingPulledComponent, PullStoppedMessage>(OnBeingPulledPullStopped);
 
-        SubscribeLocalEvent<PullerComponent, RMCGetTackleRangeEvent>(ExtendTacklingRangeToPullingTarget);
+        SubscribeLocalEvent<PullerComponent, GetUserDisarmRange>(ExtendTacklingRangeToPullingTarget);
         SubscribeLocalEvent<PullerComponent, RMCMeleeUserGetRangeEvent>(ExtendAttackingRangeToPullingTarget);
     }
 
@@ -544,15 +544,12 @@ public sealed class RMCPullingSystem : EntitySystem
     }
 
 
-    private void ExtendTacklingRangeToPullingTarget(Entity<PullerComponent> ent, ref RMCGetTackleRangeEvent args)
+    private void ExtendTacklingRangeToPullingTarget(Entity<PullerComponent> ent, ref GetUserDisarmRange args)
     {
         if (args.Target == ent.Comp.Pulling && args.Target != null)
         {
-            if (TryComp<MeleeWeaponComponent>(ent, out var meleeComp))
-            {
-                Log.Info("Bigger tackle range");
-                meleeComp.Range = 3.0f;
-            }
+            Log.Info("Bigger Tackling range 2.0V");
+            args.Range = 4.0f;
         }
     }
 
@@ -561,7 +558,7 @@ public sealed class RMCPullingSystem : EntitySystem
         if (args.Target == ent.Comp.Pulling && args.Target != null)
         {
             Log.Info("Bigger Attack range");
-            args.Range = 3.0f;
+            args.Range = 4.0f;
         }
     }
     public override void Update(float frameTime)

--- a/Content.Shared/_RMC14/Tackle/RMCDisarmUserGetRangeEvent.cs
+++ b/Content.Shared/_RMC14/Tackle/RMCDisarmUserGetRangeEvent.cs
@@ -1,3 +1,3 @@
 namespace Content.Shared._RMC14.Tackle;
 [ByRefEvent]
-public record struct RMCGetUserDisarmRange(EntityUid? Target, float Range);
+public record struct RMCDisarmUserGetRangeEvent(EntityUid? Target, float Range);

--- a/Content.Shared/_RMC14/Tackle/RMCDisarmUserGetRangeEvent.cs
+++ b/Content.Shared/_RMC14/Tackle/RMCDisarmUserGetRangeEvent.cs
@@ -1,0 +1,3 @@
+namespace Content.Shared._RMC14.Tackle;
+[ByRefEvent]
+public record struct GetUserDisarmRange(EntityUid? Target, float Range);

--- a/Content.Shared/_RMC14/Tackle/RMCDisarmUserGetRangeEvent.cs
+++ b/Content.Shared/_RMC14/Tackle/RMCDisarmUserGetRangeEvent.cs
@@ -1,3 +1,3 @@
 namespace Content.Shared._RMC14.Tackle;
 [ByRefEvent]
-public record struct GetUserDisarmRange(EntityUid? Target, float Range);
+public record struct RMCGetUserDisarmRange(EntityUid? Target, float Range);

--- a/Content.Shared/_RMC14/Tackle/RMCTackleUserGetRangeEvent.cs
+++ b/Content.Shared/_RMC14/Tackle/RMCTackleUserGetRangeEvent.cs
@@ -1,0 +1,4 @@
+namespace Content.Shared._RMC14.Tackle; // adjust namespace to match your project
+
+[ByRefEvent]
+public record struct RMCGetTackleRangeEvent(EntityUid? Target, float Range);

--- a/Content.Shared/_RMC14/Tackle/RMCTackleUserGetRangeEvent.cs
+++ b/Content.Shared/_RMC14/Tackle/RMCTackleUserGetRangeEvent.cs
@@ -1,4 +1,0 @@
-namespace Content.Shared._RMC14.Tackle; // adjust namespace to match your project
-
-[ByRefEvent]
-public record struct RMCGetTackleRangeEvent(EntityUid? Target, float Range);

--- a/Content.Shared/_RMC14/Weapons/Melee/SharedRMCMeleeWeaponSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Melee/SharedRMCMeleeWeaponSystem.cs
@@ -16,7 +16,7 @@ using Robust.Shared.Configuration;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
-
+using Content.Shared._RMC14.Tackle;
 namespace Content.Shared._RMC14.Weapons.Melee;
 
 public abstract class SharedRMCMeleeWeaponSystem : EntitySystem
@@ -289,6 +289,12 @@ public abstract class SharedRMCMeleeWeaponSystem : EntitySystem
     public float GetUserLightAttackRange(EntityUid user, EntityUid? target, MeleeWeaponComponent melee)
     {
         var ev = new RMCMeleeUserGetRangeEvent(target, melee.Range);
+        RaiseLocalEvent(user, ref ev);
+        return ev.Range;
+    }
+    public float GetUserDisarmRange(EntityUid user, EntityUid? target, MeleeWeaponComponent melee)
+    {
+        var ev = new GetUserDisarmRange(target, melee.Range);
         RaiseLocalEvent(user, ref ev);
         return ev.Range;
     }

--- a/Content.Shared/_RMC14/Weapons/Melee/SharedRMCMeleeWeaponSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Melee/SharedRMCMeleeWeaponSystem.cs
@@ -293,7 +293,7 @@ public abstract class SharedRMCMeleeWeaponSystem : EntitySystem
         RaiseLocalEvent(user, ref ev);
         return ev.Range;
     }
-    public float RMCGetUserDisarmRange(EntityUid user, EntityUid? target, MeleeWeaponComponent melee)
+    public float GetUserDisarmRange(EntityUid user, EntityUid? target, MeleeWeaponComponent melee)
     {
         var ev = new RMCDisarmUserGetRangeEvent(target, melee.Range);
         RaiseLocalEvent(user, ref ev);

--- a/Content.Shared/_RMC14/Weapons/Melee/SharedRMCMeleeWeaponSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Melee/SharedRMCMeleeWeaponSystem.cs
@@ -293,6 +293,7 @@ public abstract class SharedRMCMeleeWeaponSystem : EntitySystem
         RaiseLocalEvent(user, ref ev);
         return ev.Range;
     }
+    
     public float GetUserDisarmRange(EntityUid user, EntityUid? target, MeleeWeaponComponent melee)
     {
         var ev = new RMCDisarmUserGetRangeEvent(target, melee.Range);

--- a/Content.Shared/_RMC14/Weapons/Melee/SharedRMCMeleeWeaponSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Melee/SharedRMCMeleeWeaponSystem.cs
@@ -17,6 +17,7 @@ using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Content.Shared._RMC14.Tackle;
+
 namespace Content.Shared._RMC14.Weapons.Melee;
 
 public abstract class SharedRMCMeleeWeaponSystem : EntitySystem

--- a/Content.Shared/_RMC14/Weapons/Melee/SharedRMCMeleeWeaponSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Melee/SharedRMCMeleeWeaponSystem.cs
@@ -295,7 +295,7 @@ public abstract class SharedRMCMeleeWeaponSystem : EntitySystem
     }
     public float RMCGetUserDisarmRange(EntityUid user, EntityUid? target, MeleeWeaponComponent melee)
     {
-        var ev = new RMCGetUserDisarmRange(target, melee.Range);
+        var ev = new RMCDisarmUserGetRangeEvent(target, melee.Range);
         RaiseLocalEvent(user, ref ev);
         return ev.Range;
     }

--- a/Content.Shared/_RMC14/Weapons/Melee/SharedRMCMeleeWeaponSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Melee/SharedRMCMeleeWeaponSystem.cs
@@ -292,9 +292,9 @@ public abstract class SharedRMCMeleeWeaponSystem : EntitySystem
         RaiseLocalEvent(user, ref ev);
         return ev.Range;
     }
-    public float GetUserDisarmRange(EntityUid user, EntityUid? target, MeleeWeaponComponent melee)
+    public float RMCGetUserDisarmRange(EntityUid user, EntityUid? target, MeleeWeaponComponent melee)
     {
-        var ev = new GetUserDisarmRange(target, melee.Range);
+        var ev = new RMCGetUserDisarmRange(target, melee.Range);
         RaiseLocalEvent(user, ref ev);
         return ev.Range;
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Extends harm mode to match pulling target range

## Why / Balance
QOL change specially for xenos, there is nothing more frustating than dragging but going "Oops i was too far when i started dragging now i cant tackle the tall, guess i lose the cap :("

## Technical details
Checks if the target ID from RMCGetUserDisarmRange and RMCMeleeUserGetRangeEvent is the same as the Pulling ID, if yes extends the action of the attack/disarm to 4 tiles.

## Media
When pulling something, your harm range to it gets extended to only the thing your pulling

https://github.com/user-attachments/assets/05f93603-54d7-4262-a82c-e7986c10d586

Marines are also benefited from this

https://github.com/user-attachments/assets/bda265d4-ab59-402c-ad5a-72236f538fcd

Ps: Shoutout to sister EF-EE for helping me out in my first C# project
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Makes the pulling target always be able to be targeted in harm mode.