### PR TITLE
Change the cost of watches to 1 point

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Loadouts/Items/accessories.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Loadouts/Items/accessories.yml
@@ -16,14 +16,14 @@
 
 - type: loadout
   id: WatchCheapRMC
-  cost: 2
+  cost: 1
   storage:
     back:
     - RMCWatchCheap
 
 - type: loadout
   id: WatchBasicRMC
-  cost: 2
+  cost: 1
   effects:
     - !type:JobRequirementLoadoutEffect
       requirement:
@@ -36,7 +36,7 @@
 
 - type: loadout
   id: WatchSurvRMC
-  cost: 2
+  cost: 1
   effects:
     - !type:JobRequirementLoadoutEffect
       requirement:
@@ -49,7 +49,7 @@
 
 - type: loadout
   id: WatchPilotRMC
-  cost: 2
+  cost: 1
   effects:
     - !type:JobRequirementLoadoutEffect
       requirement:
@@ -62,7 +62,7 @@
 
 - type: loadout
   id: WatchLiaisonRMC
-  cost: 2
+  cost: 1
   effects:
     - !type:JobRequirementLoadoutEffect
       requirement:
@@ -75,7 +75,7 @@
 
 - type: loadout
   id: WatchSynthRMC
-  cost: 2
+  cost: 1
   effects:
     - !type:JobRequirementLoadoutEffect
       requirement:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changes the cost of watches to one point

## Why / Balance
Parity. Watches are cosmetic items and are small, so it makes sense, and allows for more customization

## Technical details
YAL
## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Changed the cost of watches to one point.
