### PR TITLE
Defender Tailsweep Lag Compensation

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Sweep/XenoTailSweepComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Sweep/XenoTailSweepComponent.cs
@@ -16,6 +16,11 @@ public sealed partial class XenoTailSweepComponent : Component
     [DataField, AutoNetworkedField]
     public float Range = 1.5f;
 
+    //range we add to ability entity checking range. loosely based on the distance a vest marine can travel in 750ms.
+    //lagcomp will always be clamped to 750ms anyway, so only downside of larger values is a miniscule performance hit.
+    [DataField]
+    public float LagCompensationLookupMargin = 4f;
+
     [DataField, AutoNetworkedField]
     public float KnockBackDistance = 1f;
 

--- a/Content.Shared/_RMC14/Xenonids/Sweep/XenoTailSweepSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Sweep/XenoTailSweepSystem.cs
@@ -68,7 +68,7 @@ public sealed class XenoTailSweepSystem : EntitySystem
 
         _hit.Clear();
         // Range widened by lagcomp range to check entities that have moved
-        _entityLookup.GetEntitiesInRange(transform.Coordinates, xeno.Comp.Range + xeno.Comp.LagCompensationLookupMargin, _hit, LookupFlags.Dynamic | LookupFlags.Approximate);
+        _entityLookup.GetEntitiesInRange(transform.Coordinates, xeno.Comp.Range + xeno.Comp.LagCompensationLookupMargin, _hit, LookupFlags.Dynamic | LookupFlags.Static | LookupFlags.Approximate);
 
         var origin = _transform.GetMapCoordinates(xeno);
         foreach (var mob in _hit)

--- a/Content.Shared/_RMC14/Xenonids/Sweep/XenoTailSweepSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Sweep/XenoTailSweepSystem.cs
@@ -68,7 +68,7 @@ public sealed class XenoTailSweepSystem : EntitySystem
 
         _hit.Clear();
         // Range widened by lagcomp range to check entities that have moved
-        _entityLookup.GetEntitiesInRange(transform.Coordinates, xeno.Comp.Range + xeno.Comp.LagCompensationLookupMargin, _hit);
+        _entityLookup.GetEntitiesInRange(transform.Coordinates, xeno.Comp.Range + xeno.Comp.LagCompensationLookupMargin, _hit, LookupFlags.Dynamic | LookupFlags.Approximate);
 
         var origin = _transform.GetMapCoordinates(xeno);
         foreach (var mob in _hit)

--- a/Content.Shared/_RMC14/Xenonids/Sweep/XenoTailSweepSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Sweep/XenoTailSweepSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared._RMC14.Damage.ObstacleSlamming;
+using Content.Shared._RMC14.Movement;
 using Content.Shared._RMC14.Pulling;
 using Content.Shared._RMC14.Stun;
 using Content.Shared._RMC14.Xenonids.Plasma;
@@ -32,6 +33,7 @@ public sealed class XenoTailSweepSystem : EntitySystem
     [Dependency] private readonly SharedInteractionSystem _interact = default!;
     [Dependency] private readonly RMCSizeStunSystem _size = default!;
     [Dependency] private readonly RMCObstacleSlammingSystem _obstacleSlamming = default!;
+    [Dependency] private readonly SharedRMCLagCompensationSystem _rmcLagCompensation = default!;
 
     private readonly HashSet<Entity<MobStateComponent>> _hit = new();
 
@@ -42,7 +44,6 @@ public sealed class XenoTailSweepSystem : EntitySystem
 
     private void OnXenoTailSweepAction(Entity<XenoTailSweepComponent> xeno, ref XenoTailSweepActionEvent args)
     {
-        // TODO RMC14 lag compensation
         if (!TryComp(xeno, out TransformComponent? transform))
             return;
 
@@ -63,13 +64,20 @@ public sealed class XenoTailSweepSystem : EntitySystem
         if (_net.IsClient)
             return;
 
+        var session = CompOrNull<ActorComponent>(xeno)?.PlayerSession;
+
         _hit.Clear();
-        _entityLookup.GetEntitiesInRange(transform.Coordinates, xeno.Comp.Range, _hit);
+        // Range widened by lagcomp range to check entities that have moved
+        _entityLookup.GetEntitiesInRange(transform.Coordinates, xeno.Comp.Range + xeno.Comp.LagCompensationLookupMargin, _hit);
 
         var origin = _transform.GetMapCoordinates(xeno);
         foreach (var mob in _hit)
         {
             if (!_xeno.CanAbilityAttackTarget(xeno, mob))
+                continue;
+
+            // Range check against the target's lag-compensated position
+            if (!_rmcLagCompensation.IsWithinMargin(xeno.Owner, mob.Owner, session, xeno.Comp.Range))
                 continue;
 
             if (!_interact.InRangeUnobstructed(xeno.Owner, mob.Owner, xeno.Comp.Range))

--- a/Content.Shared/_RMC14/Xenonids/Sweep/XenoTailSweepSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Sweep/XenoTailSweepSystem.cs
@@ -76,8 +76,9 @@ public sealed class XenoTailSweepSystem : EntitySystem
             if (!_xeno.CanAbilityAttackTarget(xeno, mob))
                 continue;
 
-            // Range check against the target's lag-compensated position
-            if (!_rmcLagCompensation.IsWithinMargin(xeno.Owner, mob.Owner, session, xeno.Comp.Range))
+            // Range check against the target's lag-compensated position, without margin
+            var mobCoords = _rmcLagCompensation.GetCoordinates(mob, session);
+            if (!_transform.InRange(xeno.Owner.ToCoordinates(), mobCoords, xeno.Comp.Range))
                 continue;
 
             if (!_interact.InRangeUnobstructed(xeno.Owner, mob.Owner, xeno.Comp.Range))


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Defender tailsweep is now lag compensated.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It was listed as a TODO in the code, and also suffers quite badly from not being lagcomped, sometimes missing despite the defender colliding with marines on clientside. 

## Technical details
<!-- Summary of code changes for easier review. -->
Widens GetEntitiesInRange range by 4 tiles so that we grab all entities that could reasonably be in range. Then, checks each entity in range using the lagcomp margin with the base range of 1.5 tiles. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

Side-by-side video with extreme lag (250+ ms for defender client, 150 ms for marine client)

https://github.com/user-attachments/assets/72ffdd67-b990-4248-84ac-840c22edbc6d



Side-by-side video with lowest possible lag (0 ping for both clients, though prediction still causes a baseline 6 ticks of delay)

https://github.com/user-attachments/assets/022c9bf9-8cc0-4d35-850d-776bb8abffa3



Video demonstrating (on extremely high ping) that range is not expanded on client side against stationary OR moving targets:

https://github.com/user-attachments/assets/cdb0b36a-21d0-4ec7-813c-f3d9fc66961c


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Defender Tailsweep is now lag compensated
