### PR TITLE
Permissions xenos

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestComponent.cs
@@ -11,4 +11,7 @@ public sealed partial class XenoNestComponent : Component
 
     [DataField, AutoNetworkedField]
     public EntityUid? Nested;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan UnnestDelay = TimeSpan.FromSeconds(3);
 }

--- a/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestSystem.cs
@@ -31,6 +31,7 @@ using Content.Shared.Popups;
 using Content.Shared.Standing;
 using Content.Shared.Stunnable;
 using Content.Shared.Throwing;
+using Content.Shared.Verbs;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Network;
@@ -89,6 +90,10 @@ public sealed class XenoNestSystem : EntitySystem
 
         SubscribeLocalEvent<XenoNestComponent, ComponentRemove>(OnNestRemove);
         SubscribeLocalEvent<XenoNestComponent, EntityTerminatingEvent>(OnNestTerminating);
+        SubscribeLocalEvent<XenoNestComponent, GetVerbsEvent<InteractionVerb>>(OnNestGetVerbs);
+        SubscribeLocalEvent<XenoNestComponent, XenoUnnestDoAfterEvent>(OnUnnestDoAfter);
+        SubscribeLocalEvent<XenoNestComponent, AttackAttemptEvent>(OnNestAttackAttempt);
+        SubscribeLocalEvent<XenoNestSurfaceComponent, AttackAttemptEvent>(OnNestSurfaceAttackAttempt);
 
         SubscribeLocalEvent<XenoNestableComponent, BeforeRangedInteractEvent>(OnNestableBeforeRangedInteract);
         SubscribeLocalEvent<XenoNestableComponent, ShouldHandleVirtualItemInteractEvent>(OnNestableShouldHandle);
@@ -140,6 +145,113 @@ public sealed class XenoNestSystem : EntitySystem
     private void OnNestTerminating(Entity<XenoNestComponent> ent, ref EntityTerminatingEvent args)
     {
         DetachNested(ent, ent.Comp.Nested);
+    }
+
+    private void OnNestGetVerbs(Entity<XenoNestComponent> ent, ref GetVerbsEvent<InteractionVerb> args)
+    {
+        if (!args.CanAccess || !args.CanInteract)
+            return;
+
+        if (ent.Comp.Nested is null)
+            return;
+
+        if (!HasComp<XenoComponent>(args.User) || !_hive.FromSameHive(ent.Owner, args.User))
+            return;
+
+        var user = args.User;
+        var nest = ent.Owner;
+        args.Verbs.Add(new InteractionVerb
+        {
+            Text = Loc.GetString("rmc-xeno-nest-unnest-verb"),
+            Act = () => TryStartUnnest(user, nest),
+        });
+    }
+
+    public bool TryStartUnnest(EntityUid user, Entity<XenoNestComponent?> nest)
+    {
+        if (!Resolve(nest, ref nest.Comp, false) || nest.Comp.Nested is not { } nested)
+            return false;
+
+        if (!_hive.CanXenoUnnest(user))
+        {
+            _popup.PopupClient(Loc.GetString("rmc-xeno-nest-unnest-permission-denied"), nest.Owner, user, PopupType.MediumCaution);
+            return false;
+        }
+
+        var ev = new XenoUnnestDoAfterEvent();
+        var doAfter = new DoAfterArgs(EntityManager, user, nest.Comp.UnnestDelay, ev, nest.Owner, nest.Owner)
+        {
+            BreakOnMove = true,
+            BreakOnDamage = true,
+        };
+
+        if (_doAfter.TryStartDoAfter(doAfter))
+            _popup.PopupClient(Loc.GetString("rmc-xeno-nest-unnest-start", ("target", nested)), user, user);
+
+        return true;
+    }
+
+    private void OnUnnestDoAfter(Entity<XenoNestComponent> ent, ref XenoUnnestDoAfterEvent args)
+    {
+        if (args.Cancelled || args.Handled)
+            return;
+
+        if (ent.Comp.Nested is not { } nested)
+            return;
+
+        if (!_hive.CanXenoUnnest(args.User))
+            return;
+
+        args.Handled = true;
+
+        if (_net.IsClient)
+            return;
+
+        DetachNested(ent.Owner, nested);
+        _adminLog.Add(LogType.RMCXenoNest, $"{ToPrettyString(args.User):user} released {ToPrettyString(nested):victim} from nest {ToPrettyString(ent.Owner):nest}");
+    }
+
+    private void OnNestAttackAttempt(Entity<XenoNestComponent> ent, ref AttackAttemptEvent args)
+    {
+        if (args.Disarm || ent.Comp.Nested is null)
+            return;
+
+        if (!HasComp<XenoComponent>(args.Uid) || !_hive.FromSameHive(ent.Owner, args.Uid))
+            return;
+
+        if (_hive.CanXenoUnnest(args.Uid))
+            return;
+
+        args.Cancel();
+        _popup.PopupClient(Loc.GetString("rmc-xeno-nest-unnest-permission-denied"), ent.Owner, args.Uid, PopupType.MediumCaution);
+    }
+
+    private void OnNestSurfaceAttackAttempt(Entity<XenoNestSurfaceComponent> ent, ref AttackAttemptEvent args)
+    {
+        if (args.Disarm || ent.Comp.Nests.Count == 0)
+            return;
+
+        if (!HasComp<XenoComponent>(args.Uid) || !_hive.FromSameHive(ent.Owner, args.Uid))
+            return;
+
+        if (_hive.CanXenoUnnest(args.Uid))
+            return;
+
+        var occupied = false;
+        foreach (var nestUid in ent.Comp.Nests.Values)
+        {
+            if (_xenoNestQuery.TryComp(nestUid, out var nestComp) && nestComp.Nested != null)
+            {
+                occupied = true;
+                break;
+            }
+        }
+
+        if (!occupied)
+            return;
+
+        args.Cancel();
+        _popup.PopupClient(Loc.GetString("rmc-xeno-nest-unnest-permission-denied"), ent.Owner, args.Uid, PopupType.MediumCaution);
     }
 
     private void OnNestableBeforeRangedInteract(Entity<XenoNestableComponent> ent, ref BeforeRangedInteractEvent args)

--- a/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoUnnestDoAfterEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoUnnestDoAfterEvent.cs
@@ -1,0 +1,7 @@
+using Content.Shared.DoAfter;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Xenonids.Construction.Nest;
+
+[Serializable, NetSerializable]
+public sealed partial class XenoUnnestDoAfterEvent : SimpleDoAfterEvent;

--- a/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
@@ -1505,6 +1505,14 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
 
     public bool CanOrderConstructionPopup(Entity<XenoConstructionComponent> xeno, EntityCoordinates target, EntProtoId? choice, bool popup = true)
     {
+        if (!_hive.CanXenoConstruct(xeno.Owner))
+        {
+            if (popup)
+                _popup.PopupClient(Loc.GetString("rmc-xeno-construction-permission-denied"), target, xeno, PopupType.MediumCaution);
+
+            return false;
+        }
+
         if (_queenEye.IsInQueenEye(xeno.Owner) &&
             !_queenEye.CanSeeTarget(xeno.Owner, target))
         {

--- a/Content.Shared/_RMC14/Xenonids/Hive/HiveComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hive/HiveComponent.cs
@@ -102,4 +102,31 @@ public sealed partial class HiveComponent : Component
 
     [DataField, AutoNetworkedField]
     public HashSet<GibbedXenoInfo> GibbedXenos = new();
+
+    [DataField, AutoNetworkedField]
+    public XenoHarmPermission HarmPermission = XenoHarmPermission.Allowed;
+
+    [DataField, AutoNetworkedField]
+    public XenoConstructionPermission ConstructionPermission = XenoConstructionPermission.Anyone;
+
+    [DataField, AutoNetworkedField]
+    public XenoConstructionPermission DeconstructionPermission = XenoConstructionPermission.Anyone;
+
+    [DataField, AutoNetworkedField]
+    public XenoUnnestPermission UnnestPermission = XenoUnnestPermission.Anyone;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan PermissionChangeCooldown = TimeSpan.FromSeconds(30);
+
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
+    public TimeSpan? HarmPermissionChangeAt;
+
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
+    public TimeSpan? ConstructionPermissionChangeAt;
+
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
+    public TimeSpan? DeconstructionPermissionChangeAt;
+
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
+    public TimeSpan? UnnestPermissionChangeAt;
 }

--- a/Content.Shared/_RMC14/Xenonids/Hive/HivePermission.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hive/HivePermission.cs
@@ -1,0 +1,26 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Xenonids.Hive;
+
+[Serializable, NetSerializable]
+public enum XenoHarmPermission : byte
+{
+    Forbidden,
+    RestrictedInfected,
+    Allowed,
+}
+
+[Serializable, NetSerializable]
+public enum XenoConstructionPermission : byte
+{
+    Queen,
+    Leaders,
+    Anyone,
+}
+
+[Serializable, NetSerializable]
+public enum XenoUnnestPermission : byte
+{
+    Builders,
+    Anyone,
+}

--- a/Content.Shared/_RMC14/Xenonids/Hive/SharedXenoHiveSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hive/SharedXenoHiveSystem.cs
@@ -5,6 +5,8 @@ using Content.Shared._RMC14.NightVision;
 using Content.Shared._RMC14.Xenonids.Announce;
 using Content.Shared._RMC14.Xenonids.Construction;
 using Content.Shared._RMC14.Xenonids.Evolution;
+using Content.Shared._RMC14.Xenonids.HiveLeader;
+using Content.Shared._RMC14.Xenonids.Parasite;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
 using Content.Shared.FixedPoint;
@@ -542,6 +544,126 @@ public abstract class SharedXenoHiveSystem : EntitySystem
     {
         // TODO RMC14
         return FromSameHive(a, b);
+    }
+
+    /// <summary>
+    /// Returns true if the queen has permitted harming the given victim, per the hive's harming permission.
+    /// The queen and hive leaders always ignore the hive's permission.
+    /// </summary>
+    public bool CanXenoHarm(EntityUid xeno, EntityUid victim)
+    {
+        if (HasComp<XenoActionsRestrictedComponent>(xeno))
+            return false;
+
+        if (GetHive(xeno) is not { } hive)
+            return true;
+
+        if (xeno == hive.Comp.CurrentQueen || HasComp<HiveLeaderComponent>(xeno))
+            return true;
+
+        return hive.Comp.HarmPermission switch
+        {
+            XenoHarmPermission.Allowed => true,
+            XenoHarmPermission.RestrictedInfected => !HasComp<VictimInfectedComponent>(victim),
+            XenoHarmPermission.Forbidden => false,
+            _ => true,
+        };
+    }
+
+    /// <summary>
+    /// Returns true if the xeno is permitted to place special hive structures (hive core, egg morpher, cluster,
+    /// recovery node, plasma tree), per the hive's construction permission.
+    /// </summary>
+    public bool CanXenoConstruct(EntityUid xeno)
+    {
+        return CanXenoBuildOrDestroy(xeno, hive => hive.Comp.ConstructionPermission);
+    }
+
+    /// <summary>
+    /// Returns true if the xeno is permitted to destroy special hive structures, per the hive's deconstruction
+    /// permission. Ordinary structures (walls, doors, membranes) are not covered by this.
+    /// </summary>
+    public bool CanXenoDeconstruct(EntityUid xeno)
+    {
+        return CanXenoBuildOrDestroy(xeno, hive => hive.Comp.DeconstructionPermission);
+    }
+
+    private bool CanXenoBuildOrDestroy(EntityUid xeno, Func<Entity<HiveComponent>, XenoConstructionPermission> getPermission)
+    {
+        if (HasComp<XenoActionsRestrictedComponent>(xeno))
+            return false;
+
+        if (GetHive(xeno) is not { } hive)
+            return true;
+
+        if (xeno == hive.Comp.CurrentQueen)
+            return true;
+
+        return getPermission(hive) switch
+        {
+            XenoConstructionPermission.Anyone => true,
+            XenoConstructionPermission.Leaders => HasComp<HiveLeaderComponent>(xeno),
+            XenoConstructionPermission.Queen => false,
+            _ => true,
+        };
+    }
+
+    /// <summary>
+    /// Returns true if the xeno is permitted to unnest a host, per the hive's unnesting permission.
+    /// </summary>
+    public bool CanXenoUnnest(EntityUid xeno)
+    {
+        if (HasComp<XenoActionsRestrictedComponent>(xeno))
+            return false;
+
+        if (GetHive(xeno) is not { } hive)
+            return true;
+
+        if (hive.Comp.UnnestPermission == XenoUnnestPermission.Anyone)
+            return true;
+
+        return HasComp<XenoBuilderCasteComponent>(xeno);
+    }
+
+    /// <summary>
+    /// Returns true (and the remaining time) if a permission toggle on this hive is still on cooldown.
+    /// </summary>
+    public bool IsPermissionChangeOnCooldown(TimeSpan? changeAt, out TimeSpan remaining)
+    {
+        remaining = TimeSpan.Zero;
+        if (changeAt is not { } at || _timing.CurTime >= at)
+            return false;
+
+        remaining = at - _timing.CurTime;
+        return true;
+    }
+
+    public void SetHarmPermission(Entity<HiveComponent> hive, XenoHarmPermission value)
+    {
+        hive.Comp.HarmPermission = value;
+        hive.Comp.HarmPermissionChangeAt = _timing.CurTime + hive.Comp.PermissionChangeCooldown;
+        Dirty(hive);
+    }
+
+    public void SetConstructionPermission(Entity<HiveComponent> hive, XenoConstructionPermission value)
+    {
+        hive.Comp.ConstructionPermission = value;
+        hive.Comp.ConstructionPermissionChangeAt = _timing.CurTime + hive.Comp.PermissionChangeCooldown;
+        Dirty(hive);
+    }
+
+    public void SetDeconstructionPermission(Entity<HiveComponent> hive, XenoConstructionPermission value)
+    {
+        hive.Comp.DeconstructionPermission = value;
+        hive.Comp.DeconstructionPermissionChangeAt = _timing.CurTime + hive.Comp.PermissionChangeCooldown;
+        Dirty(hive);
+    }
+
+    public void SetUnnestPermission(Entity<HiveComponent> hive, XenoUnnestPermission value)
+    {
+        hive.Comp.UnnestPermission = value;
+        hive.Comp.UnnestPermissionChangeAt = _timing.CurTime + hive.Comp.PermissionChangeCooldown;
+        Dirty(hive);
     }
 }
 

--- a/Content.Shared/_RMC14/Xenonids/Hive/XenoActionsRestrictedComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hive/XenoActionsRestrictedComponent.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.Hive;
+
+/// <summary>
+///     Marks a xeno caste as fully locked out of hive-permission-gated actions
+///     (harming, construction, deconstruction, unnesting), regardless of what
+///     the hive's permissions are currently set to. Not attached to any caste
+///     by default - intended to be attached downstream to castes that should
+///     never be trusted with these actions (e.g. a griefable low-trust caste).
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(SharedXenoHiveSystem))]
+public sealed partial class XenoActionsRestrictedComponent : Component;

--- a/Content.Shared/_RMC14/Xenonids/Hive/XenoBuilderCasteComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hive/XenoBuilderCasteComponent.cs
@@ -1,0 +1,11 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.Hive;
+
+/// <summary>
+///     Marks a xeno caste as a "builder" for the purposes of hive permissions
+///     (construction, deconstruction and unnesting toggles set by the Queen).
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(SharedXenoHiveSystem))]
+public sealed partial class XenoBuilderCasteComponent : Component;

--- a/Content.Shared/_RMC14/Xenonids/ManageHive/ManageHivePermissionsConstructionChosenEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/ManageHive/ManageHivePermissionsConstructionChosenEvent.cs
@@ -1,0 +1,7 @@
+using Content.Shared._RMC14.Xenonids.Hive;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Xenonids.ManageHive;
+
+[Serializable, NetSerializable]
+public record ManageHivePermissionsConstructionChosenEvent(XenoConstructionPermission Choice);

--- a/Content.Shared/_RMC14/Xenonids/ManageHive/ManageHivePermissionsConstructionEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/ManageHive/ManageHivePermissionsConstructionEvent.cs
@@ -1,0 +1,7 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Xenonids.ManageHive;
+
+[ByRefEvent]
+[Serializable, NetSerializable]
+public readonly record struct ManageHivePermissionsConstructionEvent;

--- a/Content.Shared/_RMC14/Xenonids/ManageHive/ManageHivePermissionsDeconstructionChosenEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/ManageHive/ManageHivePermissionsDeconstructionChosenEvent.cs
@@ -1,0 +1,7 @@
+using Content.Shared._RMC14.Xenonids.Hive;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Xenonids.ManageHive;
+
+[Serializable, NetSerializable]
+public record ManageHivePermissionsDeconstructionChosenEvent(XenoConstructionPermission Choice);

--- a/Content.Shared/_RMC14/Xenonids/ManageHive/ManageHivePermissionsDeconstructionEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/ManageHive/ManageHivePermissionsDeconstructionEvent.cs
@@ -1,0 +1,7 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Xenonids.ManageHive;
+
+[ByRefEvent]
+[Serializable, NetSerializable]
+public readonly record struct ManageHivePermissionsDeconstructionEvent;

--- a/Content.Shared/_RMC14/Xenonids/ManageHive/ManageHivePermissionsEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/ManageHive/ManageHivePermissionsEvent.cs
@@ -1,0 +1,7 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Xenonids.ManageHive;
+
+[ByRefEvent]
+[Serializable, NetSerializable]
+public readonly record struct ManageHivePermissionsEvent;

--- a/Content.Shared/_RMC14/Xenonids/ManageHive/ManageHivePermissionsHarmChosenEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/ManageHive/ManageHivePermissionsHarmChosenEvent.cs
@@ -1,0 +1,7 @@
+using Content.Shared._RMC14.Xenonids.Hive;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Xenonids.ManageHive;
+
+[Serializable, NetSerializable]
+public record ManageHivePermissionsHarmChosenEvent(XenoHarmPermission Choice);

--- a/Content.Shared/_RMC14/Xenonids/ManageHive/ManageHivePermissionsHarmEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/ManageHive/ManageHivePermissionsHarmEvent.cs
@@ -1,0 +1,7 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Xenonids.ManageHive;
+
+[ByRefEvent]
+[Serializable, NetSerializable]
+public readonly record struct ManageHivePermissionsHarmEvent;

--- a/Content.Shared/_RMC14/Xenonids/ManageHive/ManageHivePermissionsUnnestChosenEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/ManageHive/ManageHivePermissionsUnnestChosenEvent.cs
@@ -1,0 +1,7 @@
+using Content.Shared._RMC14.Xenonids.Hive;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Xenonids.ManageHive;
+
+[Serializable, NetSerializable]
+public record ManageHivePermissionsUnnestChosenEvent(XenoUnnestPermission Choice);

--- a/Content.Shared/_RMC14/Xenonids/ManageHive/ManageHivePermissionsUnnestEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/ManageHive/ManageHivePermissionsUnnestEvent.cs
@@ -1,0 +1,7 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Xenonids.ManageHive;
+
+[ByRefEvent]
+[Serializable, NetSerializable]
+public readonly record struct ManageHivePermissionsUnnestEvent;

--- a/Content.Shared/_RMC14/Xenonids/ManageHive/ManageHiveSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/ManageHive/ManageHiveSystem.cs
@@ -2,6 +2,7 @@ using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Chat;
 using Content.Shared._RMC14.Commendations;
 using Content.Shared._RMC14.Dialog;
+using Content.Shared._RMC14.Xenonids.Announce;
 using Content.Shared._RMC14.Xenonids.Evolution;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.ManageHive.Boons;
@@ -38,6 +39,7 @@ public sealed class ManageHiveSystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly SharedCMChatSystem _rmcChat = default!;
+    [Dependency] private readonly SharedXenoAnnounceSystem _xenoAnnounce = default!;
     [Dependency] private readonly SharedXenoWatchSystem _xenoWatch = default!;
     [Dependency] private readonly XenoEvolutionSystem _xenoEvolution = default!;
     [Dependency] private readonly XenoPlasmaSystem _xenoPlasma = default!;
@@ -64,6 +66,16 @@ public sealed class ManageHiveSystem : EntitySystem
         SubscribeLocalEvent<ManageHiveComponent, ManageHiveDevolveMessageEvent>(OnManageHiveDevolveMessage);
         SubscribeLocalEvent<ManageHiveComponent, ManageHiveTeamsEvent>(OnManageHiveTeams);
 
+        SubscribeLocalEvent<ManageHiveComponent, ManageHivePermissionsEvent>(OnManageHivePermissions);
+        SubscribeLocalEvent<ManageHiveComponent, ManageHivePermissionsHarmEvent>(OnManageHivePermissionsHarm);
+        SubscribeLocalEvent<ManageHiveComponent, ManageHivePermissionsHarmChosenEvent>(OnManageHivePermissionsHarmChosen);
+        SubscribeLocalEvent<ManageHiveComponent, ManageHivePermissionsConstructionEvent>(OnManageHivePermissionsConstruction);
+        SubscribeLocalEvent<ManageHiveComponent, ManageHivePermissionsConstructionChosenEvent>(OnManageHivePermissionsConstructionChosen);
+        SubscribeLocalEvent<ManageHiveComponent, ManageHivePermissionsDeconstructionEvent>(OnManageHivePermissionsDeconstruction);
+        SubscribeLocalEvent<ManageHiveComponent, ManageHivePermissionsDeconstructionChosenEvent>(OnManageHivePermissionsDeconstructionChosen);
+        SubscribeLocalEvent<ManageHiveComponent, ManageHivePermissionsUnnestEvent>(OnManageHivePermissionsUnnest);
+        SubscribeLocalEvent<ManageHiveComponent, ManageHivePermissionsUnnestChosenEvent>(OnManageHivePermissionsUnnestChosen);
+
         Subs.CVar(_config, RMCCVars.RMCJelliesPerQueen, v => _jelliesPerQueen = v, true);
         Subs.CVar(_config, RMCCVars.RMCBurrowedLarvaSacrificeTimeMinutes, v => _burrowedLarvaSacrificeTime = TimeSpan.FromMinutes(v), true);
         Subs.CVar(_config, RMCCVars.RMCBurrowedLarvaEvolutionPointsPer, v => _burrowedLarvaEvolutionPointsPer = v, true);
@@ -88,8 +100,234 @@ public sealed class ManageHiveSystem : EntitySystem
         options.Add(new DialogOption(Loc.GetString("rmc-hivemanagement-exchange-larva"), new ManageHiveSacrificeBurrowedEvent()));
         options.Add(new DialogOption(Loc.GetString("rmc-boon-activate"), new ManageHiveActivateBoonsEvent()));
         options.Add(new DialogOption(Loc.GetString("rmc-hivemanagement-manage-teams"), new ManageHiveTeamsEvent()));
+        options.Add(new DialogOption(Loc.GetString("rmc-hivemanagement-permissions"), new ManageHivePermissionsEvent()));
 
         _dialog.OpenOptions(manage, Loc.GetString("rmc-hivemanagement-hive-management"), options, Loc.GetString("rmc-hivemanagement-manage-the-hive"));
+    }
+
+    private void OnManageHivePermissions(Entity<ManageHiveComponent> manage, ref ManageHivePermissionsEvent args)
+    {
+        if (_net.IsClient)
+            return;
+
+        var options = new List<DialogOption>
+        {
+            new(Loc.GetString("rmc-hivemanagement-permissions-harming"), new ManageHivePermissionsHarmEvent()),
+            new(Loc.GetString("rmc-hivemanagement-permissions-construction"), new ManageHivePermissionsConstructionEvent()),
+            new(Loc.GetString("rmc-hivemanagement-permissions-deconstruction"), new ManageHivePermissionsDeconstructionEvent()),
+            new(Loc.GetString("rmc-hivemanagement-permissions-unnesting"), new ManageHivePermissionsUnnestEvent()),
+        };
+
+        _dialog.OpenOptions(manage, Loc.GetString("rmc-hivemanagement-permissions-title"), options);
+    }
+
+    private void OnManageHivePermissionsHarm(Entity<ManageHiveComponent> manage, ref ManageHivePermissionsHarmEvent args)
+    {
+        if (_net.IsClient)
+            return;
+
+        if (!CanChangePermissionPopup(manage, out var hive, h => h.Comp.HarmPermissionChangeAt))
+            return;
+
+        var options = new List<DialogOption>
+        {
+            new(Loc.GetString("rmc-hivemanagement-permissions-harm-forbidden"), new ManageHivePermissionsHarmChosenEvent(XenoHarmPermission.Forbidden)),
+            new(Loc.GetString("rmc-hivemanagement-permissions-harm-restricted"), new ManageHivePermissionsHarmChosenEvent(XenoHarmPermission.RestrictedInfected)),
+            new(Loc.GetString("rmc-hivemanagement-permissions-harm-allowed"), new ManageHivePermissionsHarmChosenEvent(XenoHarmPermission.Allowed)),
+        };
+
+        var current = Loc.GetString(GetPermissionLoc(hive.Comp.HarmPermission));
+        _dialog.OpenOptions(manage, Loc.GetString("rmc-hivemanagement-permissions-harming"), options, Loc.GetString("rmc-hivemanagement-permissions-current", ("value", current)));
+    }
+
+    private void OnManageHivePermissionsHarmChosen(Entity<ManageHiveComponent> manage, ref ManageHivePermissionsHarmChosenEvent args)
+    {
+        if (_net.IsClient)
+            return;
+
+        if (!CanChangePermissionPopup(manage, out var hive, h => h.Comp.HarmPermissionChangeAt))
+            return;
+
+        if (hive.Comp.HarmPermission == args.Choice)
+        {
+            _popup.PopupEntity(Loc.GetString("rmc-hivemanagement-permissions-already-set"), manage, manage, PopupType.MediumCaution);
+            return;
+        }
+
+        _hive.SetHarmPermission(hive, args.Choice);
+
+        var msg = Loc.GetString("rmc-hivemanagement-permissions-harm-announce", ("value", Loc.GetString(GetPermissionLoc(args.Choice))));
+        _xenoAnnounce.AnnounceToHive(manage.Owner, hive, msg);
+    }
+
+    private void OnManageHivePermissionsConstruction(Entity<ManageHiveComponent> manage, ref ManageHivePermissionsConstructionEvent args)
+    {
+        if (_net.IsClient)
+            return;
+
+        if (!CanChangePermissionPopup(manage, out var hive, h => h.Comp.ConstructionPermissionChangeAt))
+            return;
+
+        var options = GetConstructionPermissionOptions(false);
+        var current = Loc.GetString(GetPermissionLoc(hive.Comp.ConstructionPermission));
+        _dialog.OpenOptions(manage, Loc.GetString("rmc-hivemanagement-permissions-construction"), options, Loc.GetString("rmc-hivemanagement-permissions-current", ("value", current)));
+    }
+
+    private void OnManageHivePermissionsConstructionChosen(Entity<ManageHiveComponent> manage, ref ManageHivePermissionsConstructionChosenEvent args)
+    {
+        if (_net.IsClient)
+            return;
+
+        if (!CanChangePermissionPopup(manage, out var hive, h => h.Comp.ConstructionPermissionChangeAt))
+            return;
+
+        if (hive.Comp.ConstructionPermission == args.Choice)
+        {
+            _popup.PopupEntity(Loc.GetString("rmc-hivemanagement-permissions-already-set"), manage, manage, PopupType.MediumCaution);
+            return;
+        }
+
+        _hive.SetConstructionPermission(hive, args.Choice);
+
+        var msg = Loc.GetString("rmc-hivemanagement-permissions-construction-announce", ("value", Loc.GetString(GetPermissionLoc(args.Choice))));
+        _xenoAnnounce.AnnounceToHive(manage.Owner, hive, msg);
+    }
+
+    private void OnManageHivePermissionsDeconstruction(Entity<ManageHiveComponent> manage, ref ManageHivePermissionsDeconstructionEvent args)
+    {
+        if (_net.IsClient)
+            return;
+
+        if (!CanChangePermissionPopup(manage, out var hive, h => h.Comp.DeconstructionPermissionChangeAt))
+            return;
+
+        var options = GetConstructionPermissionOptions(true);
+        var current = Loc.GetString(GetPermissionLoc(hive.Comp.DeconstructionPermission));
+        _dialog.OpenOptions(manage, Loc.GetString("rmc-hivemanagement-permissions-deconstruction"), options, Loc.GetString("rmc-hivemanagement-permissions-current", ("value", current)));
+    }
+
+    private void OnManageHivePermissionsDeconstructionChosen(Entity<ManageHiveComponent> manage, ref ManageHivePermissionsDeconstructionChosenEvent args)
+    {
+        if (_net.IsClient)
+            return;
+
+        if (!CanChangePermissionPopup(manage, out var hive, h => h.Comp.DeconstructionPermissionChangeAt))
+            return;
+
+        if (hive.Comp.DeconstructionPermission == args.Choice)
+        {
+            _popup.PopupEntity(Loc.GetString("rmc-hivemanagement-permissions-already-set"), manage, manage, PopupType.MediumCaution);
+            return;
+        }
+
+        _hive.SetDeconstructionPermission(hive, args.Choice);
+
+        var msg = Loc.GetString("rmc-hivemanagement-permissions-deconstruction-announce", ("value", Loc.GetString(GetPermissionLoc(args.Choice))));
+        _xenoAnnounce.AnnounceToHive(manage.Owner, hive, msg);
+    }
+
+    private void OnManageHivePermissionsUnnest(Entity<ManageHiveComponent> manage, ref ManageHivePermissionsUnnestEvent args)
+    {
+        if (_net.IsClient)
+            return;
+
+        if (!CanChangePermissionPopup(manage, out var hive, h => h.Comp.UnnestPermissionChangeAt))
+            return;
+
+        var options = new List<DialogOption>
+        {
+            new(Loc.GetString("rmc-hivemanagement-permissions-unnest-builders"), new ManageHivePermissionsUnnestChosenEvent(XenoUnnestPermission.Builders)),
+            new(Loc.GetString("rmc-hivemanagement-permissions-level-anyone"), new ManageHivePermissionsUnnestChosenEvent(XenoUnnestPermission.Anyone)),
+        };
+
+        var current = Loc.GetString(GetPermissionLoc(hive.Comp.UnnestPermission));
+        _dialog.OpenOptions(manage, Loc.GetString("rmc-hivemanagement-permissions-unnesting"), options, Loc.GetString("rmc-hivemanagement-permissions-current", ("value", current)));
+    }
+
+    private void OnManageHivePermissionsUnnestChosen(Entity<ManageHiveComponent> manage, ref ManageHivePermissionsUnnestChosenEvent args)
+    {
+        if (_net.IsClient)
+            return;
+
+        if (!CanChangePermissionPopup(manage, out var hive, h => h.Comp.UnnestPermissionChangeAt))
+            return;
+
+        if (hive.Comp.UnnestPermission == args.Choice)
+        {
+            _popup.PopupEntity(Loc.GetString("rmc-hivemanagement-permissions-already-set"), manage, manage, PopupType.MediumCaution);
+            return;
+        }
+
+        _hive.SetUnnestPermission(hive, args.Choice);
+
+        var msg = Loc.GetString("rmc-hivemanagement-permissions-unnest-announce", ("value", Loc.GetString(GetPermissionLoc(args.Choice))));
+        _xenoAnnounce.AnnounceToHive(manage.Owner, hive, msg);
+    }
+
+    private List<DialogOption> GetConstructionPermissionOptions(bool deconstruction)
+    {
+        DialogOption Make(XenoConstructionPermission permission)
+        {
+            var ev = deconstruction
+                ? (object) new ManageHivePermissionsDeconstructionChosenEvent(permission)
+                : new ManageHivePermissionsConstructionChosenEvent(permission);
+            return new DialogOption(Loc.GetString(GetPermissionLoc(permission)), ev);
+        }
+
+        return new List<DialogOption>
+        {
+            Make(XenoConstructionPermission.Queen),
+            Make(XenoConstructionPermission.Leaders),
+            Make(XenoConstructionPermission.Anyone),
+        };
+    }
+
+    private bool CanChangePermissionPopup(Entity<ManageHiveComponent> manage, out Entity<HiveComponent> hive, Func<Entity<HiveComponent>, TimeSpan?> getChangeAt)
+    {
+        hive = default;
+        if (_hive.GetHive(manage.Owner) is not { } userHive)
+            return false;
+
+        hive = userHive;
+        if (_hive.IsPermissionChangeOnCooldown(getChangeAt(hive), out var remaining))
+        {
+            _popup.PopupEntity(Loc.GetString("rmc-hivemanagement-permissions-cooldown", ("seconds", (int) remaining.TotalSeconds)), manage, manage, PopupType.MediumCaution);
+            return false;
+        }
+
+        return true;
+    }
+
+    private static string GetPermissionLoc(XenoHarmPermission permission)
+    {
+        return permission switch
+        {
+            XenoHarmPermission.Forbidden => "rmc-hivemanagement-permissions-harm-forbidden",
+            XenoHarmPermission.RestrictedInfected => "rmc-hivemanagement-permissions-harm-restricted",
+            XenoHarmPermission.Allowed => "rmc-hivemanagement-permissions-harm-allowed",
+            _ => string.Empty,
+        };
+    }
+
+    private static string GetPermissionLoc(XenoConstructionPermission permission)
+    {
+        return permission switch
+        {
+            XenoConstructionPermission.Queen => "rmc-hivemanagement-permissions-level-queen",
+            XenoConstructionPermission.Leaders => "rmc-hivemanagement-permissions-level-leaders",
+            XenoConstructionPermission.Anyone => "rmc-hivemanagement-permissions-level-anyone",
+            _ => string.Empty,
+        };
+    }
+
+    private static string GetPermissionLoc(XenoUnnestPermission permission)
+    {
+        return permission switch
+        {
+            XenoUnnestPermission.Builders => "rmc-hivemanagement-permissions-unnest-builders",
+            XenoUnnestPermission.Anyone => "rmc-hivemanagement-permissions-level-anyone",
+            _ => string.Empty,
+        };
     }
 
     private void OnManageHiveDevolve(Entity<ManageHiveComponent> manage, ref ManageHiveDevolveEvent args)

--- a/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
@@ -11,6 +11,7 @@ using Content.Shared._RMC14.Rules;
 using Content.Shared._RMC14.Tackle;
 using Content.Shared._RMC14.Vendors;
 using Content.Shared._RMC14.Weapons.Melee;
+using Content.Shared._RMC14.Xenonids.Construction;
 using Content.Shared._RMC14.Xenonids.Construction.Nest;
 using Content.Shared._RMC14.Xenonids.Devour;
 using Content.Shared._RMC14.Xenonids.Egg;
@@ -38,6 +39,7 @@ using Content.Shared.DragDrop;
 using Content.Shared.FixedPoint;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction.Events;
+using Content.Shared.Popups;
 using Content.Shared.Lathe;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
@@ -88,6 +90,7 @@ public sealed partial class XenoSystem : EntitySystem
     [Dependency] private readonly WeldableSystem _weldable = default!;
     [Dependency] private readonly XenoPlasmaSystem _xenoPlasma = default!;
     [Dependency] private readonly SharedXenoWeedsSystem _weeds = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
 
     private static readonly ProtoId<DamageTypePrototype> HeatDamage = "Heat";
 
@@ -237,6 +240,19 @@ public sealed partial class XenoSystem : EntitySystem
             _victimInfectedQuery.HasComp(target) && !args.Disarm)
         {
             args.Cancel();
+            return;
+        }
+
+        if (!args.Disarm && HasComp<MarineComponent>(target) && !_hive.CanXenoHarm(xeno.Owner, target))
+        {
+            args.Cancel();
+            return;
+        }
+
+        if (!args.Disarm && HasComp<HiveConstructionLimitedComponent>(target) && !_hive.CanXenoDeconstruct(xeno.Owner))
+        {
+            args.Cancel();
+            _popup.PopupClient(Loc.GetString("rmc-xeno-construction-permission-denied-deconstruct"), target, xeno, PopupType.MediumCaution);
         }
     }
 

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-construction.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-construction.ftl
@@ -1,6 +1,8 @@
 cm-xeno-construction-failed-weeds = Bad place for a garden!
 cm-xeno-construction-failed-need-weeds = We can only shape on weeds. Find some resin before you start building!
 cm-xeno-construction-failed-cant-build = We can't build there!
+rmc-xeno-construction-permission-denied = The Queen has not permitted us to designate hive structures!
+rmc-xeno-construction-permission-denied-deconstruct = The Queen has not permitted us to destroy hive structures!
 cm-xeno-construction-failed-select-structure = We need to select a structure to build first! Use the "Choose Resin Structure" action.
 cm-xeno-construction-failed-requires-support = {CAPITALIZE(MAKEPLURAL($choice))} need a wall or resin door next to them to stand up.
 

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-jellies.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-jellies.ftl
@@ -50,3 +50,29 @@ rmc-hivemanagement-cant-deevolve-larva = You cannot deevolve xenonids to larva.
 rmc-hivemanagement-cant-deevolve-other-hive = You cannot deevolve a member of another hive!
 rmc-hivemanagement-manage-teams = Manage Hive Teams
 
+# Hive Permissions UI
+rmc-hivemanagement-permissions = Permissions
+rmc-hivemanagement-permissions-title = Hive Permissions
+rmc-hivemanagement-permissions-harming = Harming
+rmc-hivemanagement-permissions-construction = Construction
+rmc-hivemanagement-permissions-deconstruction = Deconstruction
+rmc-hivemanagement-permissions-unnesting = Unnesting
+rmc-hivemanagement-permissions-current = Current setting: { $value }
+rmc-hivemanagement-permissions-cooldown = You must wait { $seconds } more seconds before changing this again.
+rmc-hivemanagement-permissions-already-set = That is already the current setting.
+
+rmc-hivemanagement-permissions-harm-forbidden = Forbidden
+rmc-hivemanagement-permissions-harm-restricted = Restricted - Infected Hosts
+rmc-hivemanagement-permissions-harm-allowed = Allowed
+
+rmc-hivemanagement-permissions-level-queen = Queen Only
+rmc-hivemanagement-permissions-level-leaders = Queen and Leaders
+rmc-hivemanagement-permissions-level-anyone = Anyone
+
+rmc-hivemanagement-permissions-unnest-builders = Builder Castes Only
+
+rmc-hivemanagement-permissions-harm-announce = The Queen has set harming permissions to: { $value }
+rmc-hivemanagement-permissions-construction-announce = The Queen has set construction permissions to: { $value }
+rmc-hivemanagement-permissions-deconstruction-announce = The Queen has set deconstruction permissions to: { $value }
+rmc-hivemanagement-permissions-unnest-announce = The Queen has set unnesting permissions to: { $value }
+

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-nest.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-nest.ftl
@@ -11,3 +11,7 @@ cm-xeno-nest-failed-target-resisting = {$target} is resisting, ground them!
 cm-xeno-nest-failed-cant-there = We can't create a nest there!
 cm-xeno-nest-failed-cant-already-there = There is already someone nested there!
 rmc-xeno-nest-failed-dead = This host is dead.
+
+rmc-xeno-nest-unnest-verb = Release host
+rmc-xeno-nest-unnest-permission-denied = We shouldn't interfere with the nest, leave that to the builders.
+rmc-xeno-nest-unnest-start = We begin working {$target} free from the nest...

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/burrower.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/burrower.yml
@@ -11,6 +11,7 @@
   name: Burrower
   description: A beefy alien with sharp claws.
   components:
+  - type: XenoBuilderCaste
   - type: CanBuildThickFromConstructNode
   - type: GuideHelp
     guides:

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/carrier.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/carrier.yml
@@ -11,6 +11,7 @@
   description: A strange-looking alien creature. It carries a number of scuttling jointed crablike creatures.
   abstract: true
   components:
+  - type: XenoBuilderCaste
   - type: CanBuildThickFromConstructNode
   - type: GhostRole
     name: cm-job-name-xeno-carrier

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/drone.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/drone.yml
@@ -12,6 +12,7 @@
   name: Drone
   description: An alien drone.
   components:
+  - type: XenoBuilderCaste
   - type: MobState
     allowedStates:
     - Alive

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/hivelord.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/hivelord.yml
@@ -11,6 +11,7 @@
   name: Hivelord
   description: A builder of really big hives.
   components:
+  - type: XenoBuilderCaste
   - type: MobState
     allowedStates:
     - Alive

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
@@ -10,6 +10,7 @@
   name: Queen
   description: A huge, looming alien creature. The biggest and the baddest.
   components:
+  - type: XenoBuilderCaste
   - type: CanBuildThickFromConstructNode
   - type: GuideHelp
     guides:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
## About the PR
**⚠️ Depends on #10660** (xeno nest unnesting / "Release host" verb) -- please review and merge that PR first. This PR will need a quick follow-up rebase to hook the Queen's unnesting permission into the unnest verb once it lands.

Adds a Queen-configurable Hive Permissions system, accessible from the "Manage The Hive" menu as a new "Permissions" entry with four toggles:
- **Harming** - who xenos are allowed to attack. `Forbidden` (nobody), `Restricted - Infected Hosts` (infected hosts can't be harmed, everyone else can), `Allowed` (no restriction). The Queen and Hive Leaders always ignore this setting.
- **Construction** - who can place special hive structures (hive core, egg morpher, cluster, recovery node, plasma tree - ordinary walls/doors/membranes are always unrestricted). `Queen Only`, `Queen and Leaders`, `Anyone` (any builder caste: Drone, Hivelord, Carrier, Burrower, Queen).
- **Deconstruction** - who can destroy those same special hive structures. Same three levels as Construction.
- **Unnesting** - who can release a nested host without destroying the nest structure. `Builder Castes Only` (Drone, Hivelord, Carrier, Burrower, Queen - not Lesser Drone), `Anyone`. When restricted, attacking the occupied nest or the wall it's attached to is blocked too, so it can't be bypassed by just destroying it.
Each toggle has a 30 second cooldown between changes.
## Why / Balance
Currently every caste can, without any restriction: attack hosts, construct special hive structures (hive core, egg morpher, cluster, recovery node, plasma tree), destroy them, and release hosts from nests. This gives the Queen a tool against accidental or destructive actions (a hive core placed in a bad spot, young xenos destroying important structures, a host being griefed loose) without fully taking away player agency - options range from fully open to Queen-only.
aaandd... parity.....
## Technical details
- `HiveComponent`: 4 new permission fields (`HarmPermission`, `ConstructionPermission`, `DeconstructionPermission`, `UnnestPermission`) and per-permission cooldown timestamps (30s between toggles).
- New marker component `XenoBuilderCasteComponent`, attached to Queen/Drone/Hivelord/Carrier/Burrower (not Lesser Drone), used for the "builder caste" permission tier.
- New marker component `XenoActionsRestrictedComponent` - a modular full-lockout hook (harm/construct/deconstruct/unnest) for a specific caste, independent of the hive's permission settings. Not attached to anything by default.
- `SharedXenoHiveSystem`: added `CanXenoHarm`/`CanXenoConstruct`/`CanXenoDeconstruct`/`CanXenoUnnest` checks and permission setters with cooldown enforcement.
- New "Permissions" submenu in `ManageHiveSystem` (Manage The Hive) with 4 nested options.
- Harm permission is enforced in `XenoSystem`'s attack-attempt handling; the Queen and Hive Leaders always bypass it. "Restricted - Infected Hosts" blocks harming any infected victim, not only ones nested in resin.
- Construction/deconstruction permission only applies to special hive structures (hive core, egg morpher, cluster, recovery node, plasma tree) - ordinary walls, doors and membranes remain unrestricted.
- New "Release host" verb on the nest structure, releasing a nested victim without needing to destroy the structure in combat, gated by unnesting permission with a 3 second doAfter.
- Attacking the nest itself (while occupied), or the wall/resin an occupied nest is attached to, is now also gated by unnesting permission, closing a bypass where breaking the surface would force-release the host regardless of the permission set.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->


https://github.com/user-attachments/assets/68fe13f3-2197-4c5a-89d1-81db40f4cfe7



https://github.com/user-attachments/assets/be7024b6-d887-4b81-9ad2-6ebdcb33d8a3




https://github.com/user-attachments/assets/816bc957-d6dd-4712-832a-26b8451d6691


https://github.com/user-attachments/assets/c412f40d-5b21-4c29-beaf-831c1d9096cf


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: The Queen can now configure hive permissions - harming, special structure construction/deconstruction, and unnesting - from the "Manage The Hive" -> "Permissions" menu.
