### PR TITLE
Basira parity

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/BoltAction/hunting_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/BoltAction/hunting_rifle.yml
@@ -23,10 +23,10 @@
   - type: RMCSelectiveFire
     baseFireModes:
     - SemiAuto
-    recoilWielded: 2
-    recoilUnwielded: 4
-    scatterWielded: 10
-    scatterUnwielded: 20
+    recoilWielded: 0
+    recoilUnwielded: 6
+    scatterWielded: 2
+    scatterUnwielded: 1 #yeah uh i got no fucking clue
     baseFireRate: 1.25
     burstScatterMult: 5
   - type: RMCWeaponAccuracy
@@ -95,6 +95,7 @@
   parent: CMMagazineRifleBase
   id: RMCMagazineRifleHunting
   name: "Basira-Armstrong magazine (6.5mm)"
+  description: A magazine for the Basira-Armstrong hunting rifle. Compliant with the 10-cartridge limit on civilian hunting rifles.
   components:
   - type: Item
     size: Small
@@ -121,8 +122,8 @@
 - type: entity
   parent: CMBaseCartridgeRifle
   id: RMCCartridgeBoltActionRifle
-  name: Cartridge (5.56x45)
-  description: A Cartridge for the Basira-Armstrong hunting rifle. Compliant with the 15-cartridge limit on civilian hunting rifles.
+  name: Cartridge (6.5mm)
+  description: A cartridge for the Basira-Armstrong hunting rifle.
   components:
   - type: Tag
     tags:
@@ -132,7 +133,7 @@
     proto: RMCBulletRifleHunting
 
 - type: entity
-  parent: BulletRifle10x24mm
+  parent: CMBulletSniper10x28mm
   id: RMCBulletRifleHunting
   categories: [ HideSpawnMenu ]
   components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
changed the stats of the Basira to match its current CM13 stats.
Stat change was most likely missed due to being contained in a sprite refactor. 
 
Note: I believe the unwielded stat is a mistake on CM13s end due to how scatter is inversed in tier compared to the rest of the stats
 
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
parity

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Basira is now actually notorious for its accuracy
