### PR TITLE
Remove evil hammerspace fuckery

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/gun_cases.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/gun_cases.yml
@@ -18,6 +18,12 @@
     contents:
     - id: RMCWeaponPistolSU6
     - id: RMCBeltSmartPistolFilled
+  - type: LimitedStorage
+    limits:
+    - popup: rmc-storage-limit-cant-fit
+      whitelist:
+        tags:
+        - RMCSmartPistolHolster
 
 # MK80
 - type: entity
@@ -380,6 +386,12 @@
     items:
       tags:
       - RMCBeltHolsterM13
+  - type: LimitedStorage
+    limits:
+    - popup: rmc-storage-limit-cant-fit
+      whitelist:
+        tags:
+        - RMCBeltHolsterM13
 
 # L14 Custom
 - type: entity
@@ -585,6 +597,12 @@
       - RMCWeaponShotgunXM51
       - RMCMagazineShotgunXM51
       - RMCXM51Holster
+  - type: LimitedStorage
+    limits:
+    - popup: rmc-storage-limit-cant-fit
+      whitelist:
+        tags:
+        - RMCXM51Holster
 
 # MOU53
 - type: entity
@@ -789,6 +807,12 @@
     - id: CMScrewdriver
     - id: RMCPamphletHeavyMachineGunner
     - id: RMCBeltMachineGunner
+  - type: LimitedStorage
+    limits:
+    - popup: rmc-storage-limit-cant-fit
+      whitelist:
+        tags:
+        - RMCMachineGunnerRig
 
 - type: entity
   parent: RMCGunCaseBase
@@ -815,3 +839,9 @@
     - id: RMCMagazineM2C
     - id: RMCMagazineM2C
     - id: RMCBeltMachineGunner
+  - type: LimitedStorage
+    limits:
+    - popup: rmc-storage-limit-cant-fit
+      whitelist:
+        tags:
+        - RMCMachineGunnerRig


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added a limit to the number of holsters (XM51 case, SU-6 case) or belts (M2C case, ML66D case) that the corresponding case can hold.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This is technically nonparity, but holding seven XM51 rigs in one weapon case is goofy and feels super unintended.

## Technical details
<!-- Summary of code changes for easier review. -->
Added `LimitedStorageComponent` to a few weapon cases in yaml.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
yamlslop
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: SU-6, XM51, ML66D, and M2C cases can only hold one of their corresponding holsters/belts