### PR TITLE
Make ghost prop calling a cvar

### DIFF
--- a/Content.Server/_RMC14/PropCalling/PropCallingSystem.cs
+++ b/Content.Server/_RMC14/PropCalling/PropCallingSystem.cs
@@ -1,15 +1,20 @@
+using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.PropCalling;
 using Content.Shared._RMC14.PropCalling.Events;
 using Content.Shared.Actions;
 using Content.Shared.Toggleable;
+using JetBrains.FormatRipper.Elf;
+using Robust.Shared.Configuration;
 
 namespace Content.Server._RMC14.PropCalling;
 public sealed class PropCallingSystem : SharedPropCallingSystem
 {
     [Dependency] private readonly SharedActionsSystem _actions = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly IConfigurationManager _configuration = default!;
 
     private readonly HashSet<Entity<PropCallingComponent>> _callersSignedUp = new();
+    private bool _propCallingEnabled;
 
     public override void Initialize()
     {
@@ -24,16 +29,47 @@ public sealed class PropCallingSystem : SharedPropCallingSystem
 
         SubscribeLocalEvent<PropCallingComponent, ComponentShutdown>(OnPropCallingShutdown);
         SubscribeLocalEvent<PropCallerComponent, ComponentShutdown>(OnPropCallerShutdown);
+
+        Subs.CVar(_configuration, RMCCVars.RMCGhostPropCalling, OnGhostPropChange, true);
+    }
+
+    private void OnGhostPropChange(bool value, in CVarChangeInfo info)
+    {
+        _propCallingEnabled = value;
+
+        var callingQuery = EntityQueryEnumerator<PropCallingComponent>();
+        while (callingQuery.MoveNext(out var uid, out var propcalling))
+        {
+            if (_propCallingEnabled)
+            {
+                _actions.AddAction(uid, ref propcalling.TogglePropCallingEntity, propcalling.TogglePropCalling, uid);
+                if (!_callersSignedUp.TryGetValue((uid, propcalling), out _))
+                    _actions.SetToggled(propcalling.TogglePropCallingEntity, true);
+            }
+            else
+                _actions.RemoveAction(uid, propcalling.TogglePropCallingEntity);
+        }
+
+        var callerQuery = EntityQueryEnumerator<PropCallerComponent>();
+        while (callerQuery.MoveNext(out var uid, out var propCaller))
+        {
+            if (_propCallingEnabled)
+                _actions.AddAction(uid, ref propCaller.CallPropsEntity, propCaller.CallProps, uid);
+            else
+                _actions.RemoveAction(uid, propCaller.CallPropsEntity);
+        }
     }
 
     private void OnPropCallingComponentInit(EntityUid uid, PropCallingComponent comp, ComponentInit args)
     {
-        _actions.AddAction(uid, ref comp.TogglePropCallingEntity, comp.TogglePropCalling, uid);
+        if (_propCallingEnabled)
+            _actions.AddAction(uid, ref comp.TogglePropCallingEntity, comp.TogglePropCalling, uid);
     }
 
     private void OnPropCallerComponentInit(EntityUid uid, PropCallerComponent comp, ComponentInit args)
     {
-        _actions.AddAction(uid, ref comp.CallPropsEntity, comp.CallProps, uid);
+        if (_propCallingEnabled)
+            _actions.AddAction(uid, ref comp.CallPropsEntity, comp.CallProps, uid);
     }
 
     private void OnPropCallingShutdown(EntityUid uid, PropCallingComponent comp, ComponentShutdown args)

--- a/Content.Server/_RMC14/PropCalling/PropCallingSystem.cs
+++ b/Content.Server/_RMC14/PropCalling/PropCallingSystem.cs
@@ -38,16 +38,16 @@ public sealed class PropCallingSystem : SharedPropCallingSystem
         _propCallingEnabled = value;
 
         var callingQuery = EntityQueryEnumerator<PropCallingComponent>();
-        while (callingQuery.MoveNext(out var uid, out var propcalling))
+        while (callingQuery.MoveNext(out var uid, out var propCalling))
         {
             if (_propCallingEnabled)
             {
-                _actions.AddAction(uid, ref propcalling.TogglePropCallingEntity, propcalling.TogglePropCalling, uid);
-                if (!_callersSignedUp.TryGetValue((uid, propcalling), out _))
-                    _actions.SetToggled(propcalling.TogglePropCallingEntity, true);
+                _actions.AddAction(uid, ref propCalling.TogglePropCallingEntity, propCalling.TogglePropCalling, uid);
+                if (!_callersSignedUp.TryGetValue((uid, propCalling), out _))
+                    _actions.SetToggled(propCalling.TogglePropCallingEntity, true);
             }
             else
-                _actions.RemoveAction(uid, propcalling.TogglePropCallingEntity);
+                _actions.RemoveAction(uid, propCalling.TogglePropCallingEntity);
         }
 
         var callerQuery = EntityQueryEnumerator<PropCallerComponent>();

--- a/Content.Shared/_RMC14/CCVar/RMCCVars.cs
+++ b/Content.Shared/_RMC14/CCVar/RMCCVars.cs
@@ -604,4 +604,7 @@ public sealed partial class RMCCVars : CVars
 
     public static readonly CVarDef<float> RMCDoAfterCancelMaxProcessTimeMilliseconds =
         CVarDef.Create("rmc.do_after_cancel_max_process_time_milliseconds", 1f, CVar.REPLICATED | CVar.SERVER);
+
+    public static readonly CVarDef<bool> RMCGhostPropCalling =
+        CVarDef.Create("rmc.ghost_prop_calling", false, CVar.SERVER | CVar.SERVERONLY);
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title. Also disables it by default.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
GM Request.

## Technical details
<!-- Summary of code changes for easier review. -->
Works like disabling ghost boo mostly, with small differences (mainly toggling the action on if on change the ghost was on da list).

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

https://github.com/user-attachments/assets/c579a2fd-0968-44cf-b70e-79c43e3b52a2


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Ghost prop calling is now disabled by default.
