### PR TITLE
Add Poppies as Helmet/Helmet Accessory

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -1561,6 +1561,10 @@
     entries:
       Taco: Poppy
       Burger: Poppy
+  - type: HelmetAccessory # Added for RMC
+    rsi:
+      sprite: Objects/Specific/Hydroponics/poppy.rsi
+      state: equipped-HELMET
 
 - type: entity
   name: lily


### PR DESCRIPTION
## About the PR
Allows upstream poppy plants to be worn as an accessory for headwear.

## Why / Balance
Poppies are a cute upstream compatible headwear that is, at the moment, obtainable in RMC via botany. In my experience it's been relatively common to be given one as shipside crew, but without anywhere to wear it (without taking off my cover) I felt compelled to PR this as an option.

Current version of this PR reuses the upstream headwear sprite state on the helmet but I'll add a new state with tweaks if desired.

I'm assuming this isn't parity, and it relies on tweaks to an upstream item. Perfectly understanding if this isn't accepted for either of those reasons.

## Technical details
Component `HelmetAccessory` added to upstream prototype `FoodPoppy` in yaml

## Media
<img width="436" height="453" alt="image" src="https://github.com/user-attachments/assets/34cd4656-28cd-4941-8539-69eb39ca3362" />
<img width="448" height="462" alt="image" src="https://github.com/user-attachments/assets/9914bb87-a3e4-4459-8a3a-d20c4339f46b" />
<img width="164" height="177" alt="image" src="https://github.com/user-attachments/assets/fce818a0-df7f-4a24-9b44-4eae3368b7ee" />
<img width="126" height="145" alt="image" src="https://github.com/user-attachments/assets/95f11454-bc95-4266-91b8-1a76f7244545" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Poppies can now be worn as a helmet accessory.