### PR TITLE
Fix xenos despawned by hijack being offered to players in the larva queue

### DIFF
--- a/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.Hijack.cs
+++ b/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.Hijack.cs
@@ -81,6 +81,8 @@ public sealed partial class CMDistressSignalRuleSystem
                 if (comp.CountedInSlots)
                     larva++;
 
+                RemComp<CanBeLarvaQueuedComponent>(xeno);
+
                 //Ghost player and send message
                 if (TryComp(xeno, out ActorComponent? actor))
                 {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Bodies of planet side xenonids that are despawned because of hijack no longer get offered to players in the larva queue.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Resolves #10617

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- fix: Xenonids despawned because of hijack no longer get offered to players in the larva queue.
