### PR TITLE
Tactical map: planet name, click-to-watch for xenos, click-to-teleport for ghosts

### DIFF
--- a/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml
+++ b/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml
@@ -8,6 +8,8 @@
                         StyleClasses="LabelKeyText"/>
                 <CheckBox Name="RMCChatSquadColorModeCheckBox" Text="{Loc 'rmc-ui-options-chat-squad-color-mode'}" />
                 <CheckBox Name="RMCUseAlternateSpritesCheckBox" Text="{Loc 'rmc-ui-options-alternate-sprites'}" />
+                <CheckBox Name="RMCTacMapXenoClickWatchCheckBox" Text="{Loc 'rmc-ui-options-tacmap-xeno-click-watch'}" />
+                <CheckBox Name="RMCTacMapGhostClickTeleportCheckBox" Text="{Loc 'rmc-ui-options-tacmap-ghost-click-teleport'}" />
                 <Label Text="{Loc 'ui-options-accessability-header-visuals'}"
                        StyleClasses="LabelKeyText"/>
                 <CheckBox Name="ReducedMotionCheckBox" Text="{Loc 'ui-options-reduced-motion'}" />

--- a/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml.cs
@@ -28,6 +28,8 @@ public sealed partial class AccessibilityTab : Control
         Control.AddOptionCheckBox(RMCCVars.RMCChatSquadColorMode, RMCChatSquadColorModeCheckBox); // RMC14
         Control.AddOptionCheckBox(RMCCVars.RMCXenoAbilityPreviews, XenoAbilityPreviewsCheckBox); // RMC14
         Control.AddOptionCheckBox(RMCCVars.RMCMarineEquipmentPreviews, MarineEquipmentPreviewsCheckBox); // RMC14
+        Control.AddOptionCheckBox(RMCCVars.RMCTacticalMapXenoClickWatch, RMCTacMapXenoClickWatchCheckBox); // RMC14
+        Control.AddOptionCheckBox(RMCCVars.RMCTacticalMapGhostClickTeleport, RMCTacMapGhostClickTeleportCheckBox); // RMC14
 
         Control.AddOptionCheckBox(CCVars.AccessibilityClientCensorNudity, CensorNudityCheckBox);
 

--- a/Content.Client/_RMC14/TacticalMap/TacticalMapComputerBui.cs
+++ b/Content.Client/_RMC14/TacticalMap/TacticalMapComputerBui.cs
@@ -6,6 +6,7 @@ using Content.Shared._RMC14.TacticalMap;
 using JetBrains.Annotations;
 using Robust.Client.Player;
 using Robust.Client.UserInterface.Controls;
+using Robust.Shared.Prototypes;
 
 namespace Content.Client._RMC14.TacticalMap;
 
@@ -13,6 +14,7 @@ namespace Content.Client._RMC14.TacticalMap;
 public sealed class TacticalMapComputerBui(EntityUid owner, Enum uiKey) : RMCPopOutBui<TacticalMapWindow>(owner, uiKey)
 {
     [Dependency] private readonly IPlayerManager _player = default!;
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
 
     protected override TacticalMapWindow? Window { get; set; }
     private bool _refreshed;
@@ -88,6 +90,7 @@ public sealed class TacticalMapComputerBui(EntityUid owner, Enum uiKey) : RMCPop
             _currentMapName = tacticalState.MapName;
             Window?.SetMapEntity(_currentMapName);
             Window?.Wrapper.SetMapEntity(_currentMapName);
+            Window?.Wrapper.SetPlanetName(TacticalMapUserBui.GetLocalizedMapName(tacticalState, _prototype));
         }
     }
 

--- a/Content.Client/_RMC14/TacticalMap/TacticalMapControl.xaml.cs
+++ b/Content.Client/_RMC14/TacticalMap/TacticalMapControl.xaml.cs
@@ -100,11 +100,14 @@ public sealed partial class TacticalMapControl : TextureRect
     public float BlipSizeMultiplier { get; set; } = 1.0f;
     public float LineThickness { get; set; } = 2.0f;
     public bool QueenEyeMode { get; set; }
+    public bool GhostTeleportMode { get; set; }
 
     public Action<Vector2i>? OnBlipClicked;
+    public Action<Vector2i, int>? OnBlipEntityClicked;
     public Action<Vector2i, string>? OnBlipRightClicked;
     public Action? OnUserInteraction;
     public Action<Vector2i>? OnQueenEyeMove;
+    public Action<Vector2i>? OnGhostTeleport;
     public Action<Vector2i, string>? OnCreateLabel;
     public Action<Vector2i, string>? OnEditLabel;
     public Action<Vector2i>? OnDeleteLabel;
@@ -375,6 +378,11 @@ public sealed partial class TacticalMapControl : TextureRect
 
     private TacticalMapBlip? GetBlipAtPosition(Vector2 controlPosition)
     {
+        return GetBlipIndexAtPosition(controlPosition) is { } index ? _blips![index] : null;
+    }
+
+    private int? GetBlipIndexAtPosition(Vector2 controlPosition)
+    {
         if (_blips == null || Texture == null)
             return null;
 
@@ -382,8 +390,9 @@ public sealed partial class TacticalMapControl : TextureRect
         (Vector2 actualSize, Vector2 actualTopLeft, float overlayScale) = GetDrawParameters();
         float clickTolerance = ClickTolerance * overlayScale;
 
-        foreach (TacticalMapBlip blip in _blips)
+        for (int i = 0; i < _blips.Length; i++)
         {
+            TacticalMapBlip blip = _blips[i];
             Vector2 blipPosition = IndicesToPosition(blip.Indices) * overlayScale + actualTopLeft;
             float scaledBlipSize = GetScaledBlipSize(overlayScale);
 
@@ -393,7 +402,7 @@ public sealed partial class TacticalMapControl : TextureRect
             );
 
             if (blipRect.Contains(pixelPosition))
-                return blip;
+                return i;
         }
 
         return null;
@@ -745,6 +754,9 @@ public sealed partial class TacticalMapControl : TextureRect
             if (HandleQueenEyeClick(args))
                 return;
 
+            if (HandleGhostTeleportClick(args))
+                return;
+
             if (HandleLabelClick(args))
                 return;
 
@@ -801,12 +813,29 @@ public sealed partial class TacticalMapControl : TextureRect
         return true;
     }
 
+    private bool HandleGhostTeleportClick(GUIBoundKeyEventArgs args)
+    {
+        if (GhostTeleportMode && !Drawing && !IsCanvas)
+        {
+            Vector2i clickPosition = PositionToIndices(args.RelativePosition);
+            OnGhostTeleport?.Invoke(clickPosition);
+            args.Handle();
+            return true;
+        }
+        return false;
+    }
+
     private bool HandleBlipClick(GUIBoundKeyEventArgs args)
     {
-        TacticalMapBlip? clickedBlip = GetBlipAtPosition(args.RelativePosition);
-        if (clickedBlip != null && !Drawing && !QueenEyeMode)
+        int? blipIndex = GetBlipIndexAtPosition(args.RelativePosition);
+        if (blipIndex != null && !Drawing && !QueenEyeMode)
         {
-            OnBlipClicked?.Invoke(clickedBlip.Value.Indices);
+            TacticalMapBlip clickedBlip = _blips![blipIndex.Value];
+            OnBlipClicked?.Invoke(clickedBlip.Indices);
+
+            if (_blipEntityIds != null && blipIndex.Value < _blipEntityIds.Length)
+                OnBlipEntityClicked?.Invoke(clickedBlip.Indices, _blipEntityIds[blipIndex.Value]);
+
             args.Handle();
             return true;
         }

--- a/Content.Client/_RMC14/TacticalMap/TacticalMapSystem.cs
+++ b/Content.Client/_RMC14/TacticalMap/TacticalMapSystem.cs
@@ -8,6 +8,11 @@ public sealed class TacticalMapSystem : SharedTacticalMapSystem
 {
     [Dependency] private readonly IPlayerManager _player = default!;
 
+    public void RequestGhostTeleport(Vector2i position)
+    {
+        RaiseNetworkEvent(new TacticalMapGhostTeleportRequestEvent(position));
+    }
+
     public override void Initialize()
     {
         base.Initialize();

--- a/Content.Client/_RMC14/TacticalMap/TacticalMapUserBui.cs
+++ b/Content.Client/_RMC14/TacticalMap/TacticalMapUserBui.cs
@@ -4,8 +4,11 @@ using Robust.Client.Player;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Localization;
 using Robust.Shared.Maths;
+using Robust.Shared.Prototypes;
 using Content.Shared._RMC14.Areas;
 using Content.Shared._RMC14.TacticalMap;
+using Content.Shared._RMC14.Xenonids;
+using Content.Shared.Ghost;
 using JetBrains.Annotations;
 
 namespace Content.Client._RMC14.TacticalMap;
@@ -14,6 +17,7 @@ namespace Content.Client._RMC14.TacticalMap;
 public sealed class TacticalMapUserBui(EntityUid owner, Enum uiKey) : RMCPopOutBui<TacticalMapWindow>(owner, uiKey)
 {
     [Dependency] private readonly IPlayerManager _player = default!;
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
     private static readonly ISawmill _logger = Logger.GetSawmill("tactical_map_settings");
 
     protected override TacticalMapWindow? Window { get; set; }
@@ -70,6 +74,19 @@ public sealed class TacticalMapUserBui(EntityUid owner, Enum uiKey) : RMCPopOutB
 
         Window.Wrapper.SetupUpdateButton(msg => SendPredictedMessage(msg));
         Window.Wrapper.Map.OnQueenEyeMove += position => SendPredictedMessage(new TacticalMapQueenEyeMoveMsg(position));
+
+        if (EntMan.HasComponent<XenoComponent>(Owner))
+        {
+            Window.Wrapper.Map.OnBlipEntityClicked += (_, entityId) =>
+                SendPredictedMessage(new TacticalMapWatchXenoMsg(new NetEntity(entityId)));
+        }
+
+        if (EntMan.HasComponent<GhostComponent>(Owner))
+        {
+            Window.Wrapper.Map.GhostTeleportMode = true;
+            Window.Wrapper.Map.OnGhostTeleport += position =>
+                SendPredictedMessage(new TacticalMapGhostTeleportMsg(position));
+        }
     }
 
     protected override void UpdateState(BoundUserInterfaceState state)
@@ -80,7 +97,16 @@ public sealed class TacticalMapUserBui(EntityUid owner, Enum uiKey) : RMCPopOutB
             Window?.SetMapEntity(_currentMapName);
             Window?.Wrapper.SetMapEntity(_currentMapName);
             Window?.Wrapper.UpdateSquadObjectivesFromState(tacticalState.SquadObjectives);
+            Window?.Wrapper.SetPlanetName(GetLocalizedMapName(tacticalState, _prototype));
         }
+    }
+
+    internal static string? GetLocalizedMapName(TacticalMapBuiState state, IPrototypeManager prototype)
+    {
+        if (state.MapId != null && prototype.TryIndex<EntityPrototype>(state.MapId, out var proto))
+            return proto.Name;
+
+        return string.IsNullOrWhiteSpace(state.MapName) ? null : state.MapName;
     }
 
     protected override void Dispose(bool disposing)

--- a/Content.Client/_RMC14/TacticalMap/TacticalMapUserBui.cs
+++ b/Content.Client/_RMC14/TacticalMap/TacticalMapUserBui.cs
@@ -78,14 +78,19 @@ public sealed class TacticalMapUserBui(EntityUid owner, Enum uiKey) : RMCPopOutB
         if (EntMan.HasComponent<XenoComponent>(Owner))
         {
             Window.Wrapper.Map.OnBlipEntityClicked += (_, entityId) =>
-                SendPredictedMessage(new TacticalMapWatchXenoMsg(new NetEntity(entityId)));
+            {
+                // Blips are frozen while the queen is off the ovipositor; watching from
+                // a stale blip would leak the xeno's current position.
+                if (EntMan.GetComponentOrNull<TacticalMapUserComponent>(Owner)?.LiveUpdate == true)
+                    SendPredictedMessage(new TacticalMapWatchXenoMsg(new NetEntity(entityId)));
+            };
         }
 
         if (EntMan.HasComponent<GhostComponent>(Owner))
         {
             Window.Wrapper.Map.GhostTeleportMode = true;
             Window.Wrapper.Map.OnGhostTeleport += position =>
-                SendPredictedMessage(new TacticalMapGhostTeleportMsg(position));
+                EntMan.System<TacticalMapSystem>().RequestGhostTeleport(position);
         }
     }
 

--- a/Content.Client/_RMC14/TacticalMap/TacticalMapUserBui.cs
+++ b/Content.Client/_RMC14/TacticalMap/TacticalMapUserBui.cs
@@ -4,8 +4,10 @@ using Robust.Client.Player;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Localization;
 using Robust.Shared.Maths;
+using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
 using Content.Shared._RMC14.Areas;
+using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.TacticalMap;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared.Ghost;
@@ -16,6 +18,7 @@ namespace Content.Client._RMC14.TacticalMap;
 [UsedImplicitly]
 public sealed class TacticalMapUserBui(EntityUid owner, Enum uiKey) : RMCPopOutBui<TacticalMapWindow>(owner, uiKey)
 {
+    [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     private static readonly ISawmill _logger = Logger.GetSawmill("tactical_map_settings");
@@ -23,6 +26,7 @@ public sealed class TacticalMapUserBui(EntityUid owner, Enum uiKey) : RMCPopOutB
     protected override TacticalMapWindow? Window { get; set; }
     private bool _refreshed;
     private string? _currentMapName;
+    private bool _ghostTeleportCVarSubscribed;
 
     protected override void Open()
     {
@@ -79,6 +83,9 @@ public sealed class TacticalMapUserBui(EntityUid owner, Enum uiKey) : RMCPopOutB
         {
             Window.Wrapper.Map.OnBlipEntityClicked += (_, entityId) =>
             {
+                if (!_config.GetCVar(RMCCVars.RMCTacticalMapXenoClickWatch))
+                    return;
+
                 // Blips are frozen while the queen is off the ovipositor; watching from
                 // a stale blip would leak the xeno's current position.
                 if (EntMan.GetComponentOrNull<TacticalMapUserComponent>(Owner)?.LiveUpdate == true)
@@ -88,10 +95,18 @@ public sealed class TacticalMapUserBui(EntityUid owner, Enum uiKey) : RMCPopOutB
 
         if (EntMan.HasComponent<GhostComponent>(Owner))
         {
-            Window.Wrapper.Map.GhostTeleportMode = true;
+            Window.Wrapper.Map.GhostTeleportMode = _config.GetCVar(RMCCVars.RMCTacticalMapGhostClickTeleport);
+            _config.OnValueChanged(RMCCVars.RMCTacticalMapGhostClickTeleport, OnGhostTeleportCVarChanged);
+            _ghostTeleportCVarSubscribed = true;
             Window.Wrapper.Map.OnGhostTeleport += position =>
                 EntMan.System<TacticalMapSystem>().RequestGhostTeleport(position);
         }
+    }
+
+    private void OnGhostTeleportCVarChanged(bool enabled)
+    {
+        if (Window?.Wrapper.Map is { } map)
+            map.GhostTeleportMode = enabled;
     }
 
     protected override void UpdateState(BoundUserInterfaceState state)
@@ -116,6 +131,12 @@ public sealed class TacticalMapUserBui(EntityUid owner, Enum uiKey) : RMCPopOutB
 
     protected override void Dispose(bool disposing)
     {
+        if (disposing && _ghostTeleportCVarSubscribed)
+        {
+            _config.UnsubValueChanged(RMCCVars.RMCTacticalMapGhostClickTeleport, OnGhostTeleportCVarChanged);
+            _ghostTeleportCVarSubscribed = false;
+        }
+
         if (disposing && Window?.Wrapper != null)
         {
             try

--- a/Content.Client/_RMC14/TacticalMap/TacticalMapWrapper.xaml
+++ b/Content.Client/_RMC14/TacticalMap/TacticalMapWrapper.xaml
@@ -16,7 +16,7 @@
                     <Button Name="LabelsButton" Access="Public" Text="{Loc ui-tactical-map-labels-button}" StyleClasses="OpenBoth" Margin="0 0 2 0" MinWidth="60" />
                     <Button Name="FollowPlayerButton" Access="Public" Text="{Loc ui-tactical-map-centre-button}" StyleClasses="OpenBoth" Margin="0 0 2 0" MinWidth="50" />
                     <Button Name="ResetViewButton" Access="Public" Text="{Loc ui-tactical-map-reset-button}" StyleClasses="OpenBoth" Margin="0 0 2 0" MinWidth="50" />
-                    <Control HorizontalExpand="True" />
+                    <Label Name="PlanetNameLabel" Access="Public" HorizontalExpand="True" HorizontalAlignment="Center" VerticalAlignment="Center" StyleClasses="LabelHeading" />
                     <Button Name="SettingsToggleButton" Access="Public" Text="{Loc ui-tactical-map-settings-toggle-collapsed}" StyleClasses="OpenBoth" MinWidth="25" />
                 </BoxContainer>
 

--- a/Content.Client/_RMC14/TacticalMap/TacticalMapWrapper.xaml.cs
+++ b/Content.Client/_RMC14/TacticalMap/TacticalMapWrapper.xaml.cs
@@ -138,6 +138,11 @@ public sealed partial class TacticalMapWrapper : Control
         LoadSettings();
     }
 
+    public void SetPlanetName(string? name)
+    {
+        PlanetNameLabel.Text = name ?? string.Empty;
+    }
+
     public void LoadMapSpecificSettings(TacticalMapSettings settings, string? mapName)
     {
         SetMapEntity(mapName);

--- a/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.cs
@@ -201,6 +201,9 @@ public sealed partial class CMDistressSignalRuleSystem : GameRuleSystem<CMDistre
     public string? SelectedPlanetMapName => SelectedPlanetMap?.Proto.Name;
 
     [ViewVariables]
+    public string? SelectedPlanetMapId => SelectedPlanetMap?.Proto.ID;
+
+    [ViewVariables]
     public string? OperationName { get; private set; }
 
     public string? ActiveNightmareScenario { get; private set; }

--- a/Content.Server/_RMC14/TacticalMap/TacticalMapSystem.cs
+++ b/Content.Server/_RMC14/TacticalMap/TacticalMapSystem.cs
@@ -147,8 +147,9 @@ public sealed class TacticalMapSystem : SharedTacticalMapSystem
                 subs.Event<TacticalMapUpdateCanvasMsg>(OnUserUpdateCanvasMsg);
                 subs.Event<TacticalMapQueenEyeMoveMsg>(OnUserQueenEyeMoveMsg);
                 subs.Event<TacticalMapWatchXenoMsg>(OnUserWatchXenoMsg);
-                subs.Event<TacticalMapGhostTeleportMsg>(OnUserGhostTeleportMsg);
             });
+
+        SubscribeAllEvent<TacticalMapGhostTeleportRequestEvent>(OnGhostTeleportRequest);
 
         Subs.BuiEvents<TacticalMapComputerComponent>(TacticalMapComputerUi.Key,
             subs =>
@@ -633,16 +634,21 @@ public sealed class TacticalMapSystem : SharedTacticalMapSystem
         if (!TryGetEntity(args.Target, out var target))
             return;
 
+        // Only allow watching from live blips; stale snapshot blips would leak
+        // the xeno's current position.
+        if (!ent.Comp.LiveUpdate)
+            return;
+
         if (!HasComp<XenoComponent>(user) || !HasComp<XenoComponent>(target))
             return;
 
         _xenoWatch.Watch(user, target.Value);
     }
 
-    private void OnUserGhostTeleportMsg(Entity<TacticalMapUserComponent> ent, ref TacticalMapGhostTeleportMsg args)
+    private void OnGhostTeleportRequest(TacticalMapGhostTeleportRequestEvent args, EntitySessionEventArgs session)
     {
-        var user = args.Actor;
-        if (!HasComp<GhostComponent>(user))
+        if (session.SenderSession.AttachedEntity is not { } user ||
+            !HasComp<GhostComponent>(user))
             return;
 
         if (!TryGetTacticalMap(out var map) ||

--- a/Content.Server/_RMC14/TacticalMap/TacticalMapSystem.cs
+++ b/Content.Server/_RMC14/TacticalMap/TacticalMapSystem.cs
@@ -11,14 +11,17 @@ using Content.Shared._RMC14.Marines.Skills;
 using Content.Shared._RMC14.Marines.Squads;
 using Content.Shared._RMC14.Medical.Unrevivable;
 using Content.Shared._RMC14.TacticalMap;
+using Content.Shared._RMC14.Xenonids;
 using Content.Shared._RMC14.Xenonids.Egg;
 using Content.Shared._RMC14.Xenonids.Evolution;
 using Content.Shared._RMC14.Xenonids.Eye;
 using Content.Shared._RMC14.Xenonids.HiveLeader;
+using Content.Shared._RMC14.Xenonids.Watch;
 using Content.Shared._RMC14.Xenonids.Weeds;
 using Content.Shared.Actions;
 using Content.Shared.Atmos.Rotting;
 using Content.Shared.Database;
+using Content.Shared.Ghost;
 using Content.Shared.Mind.Components;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
@@ -32,6 +35,7 @@ using Robust.Shared.Configuration;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Network;
+using Robust.Shared.Physics.Systems;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
@@ -44,9 +48,11 @@ public sealed class TacticalMapSystem : SharedTacticalMapSystem
     [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] private readonly CMDistressSignalRuleSystem _distressSignal = default!;
     [Dependency] private readonly XenoEvolutionSystem _evolution = default!;
+    [Dependency] private readonly SharedMapSystem _map = default!;
     [Dependency] private readonly MarineAnnounceSystem _marineAnnounce = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SkillsSystem _skills = default!;
     [Dependency] private readonly SquadSystem _squad = default!;
@@ -55,6 +61,7 @@ public sealed class TacticalMapSystem : SharedTacticalMapSystem
     [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
     [Dependency] private readonly SharedXenoWeedsSystem _weeds = default!;
     [Dependency] private readonly XenoAnnounceSystem _xenoAnnounce = default!;
+    [Dependency] private readonly SharedXenoWatchSystem _xenoWatch = default!;
     [Dependency] private readonly RMCUnrevivableSystem _unrevivableSystem = default!;
 
     private EntityQuery<ActiveTacticalMapTrackedComponent> _activeTacticalMapTrackedQuery;
@@ -139,6 +146,8 @@ public sealed class TacticalMapSystem : SharedTacticalMapSystem
                 subs.Event<BoundUIClosedEvent>(OnUserBUIClosed);
                 subs.Event<TacticalMapUpdateCanvasMsg>(OnUserUpdateCanvasMsg);
                 subs.Event<TacticalMapQueenEyeMoveMsg>(OnUserQueenEyeMoveMsg);
+                subs.Event<TacticalMapWatchXenoMsg>(OnUserWatchXenoMsg);
+                subs.Event<TacticalMapGhostTeleportMsg>(OnUserGhostTeleportMsg);
             });
 
         Subs.BuiEvents<TacticalMapComputerComponent>(TacticalMapComputerUi.Key,
@@ -377,14 +386,14 @@ public sealed class TacticalMapSystem : SharedTacticalMapSystem
             squadObjectives = _squad.GetSquadObjectives((squad.Owner, squad.Comp));
         }
 
-        var state = new TacticalMapBuiState(mapName, squadObjectives);
+        var state = new TacticalMapBuiState(mapName, squadObjectives, _distressSignal.SelectedPlanetMapId);
         _ui.SetUiState(ent.Owner, TacticalMapUserUi.Key, state);
     }
 
     private void UpdateTacticalMapComputerState(Entity<TacticalMapComputerComponent> computer)
     {
         var mapName = _distressSignal.SelectedPlanetMapName ?? string.Empty;
-        var state = new TacticalMapBuiState(mapName);
+        var state = new TacticalMapBuiState(mapName, null, _distressSignal.SelectedPlanetMapId);
         _ui.SetUiState(computer.Owner, TacticalMapComputerUi.Key, state);
     }
 
@@ -616,6 +625,42 @@ public sealed class TacticalMapSystem : SharedTacticalMapSystem
         var worldPos = _transform.ToMapCoordinates(targetCoords);
 
         _transform.SetWorldPosition(eye, worldPos.Position);
+    }
+
+    private void OnUserWatchXenoMsg(Entity<TacticalMapUserComponent> ent, ref TacticalMapWatchXenoMsg args)
+    {
+        var user = args.Actor;
+        if (!TryGetEntity(args.Target, out var target))
+            return;
+
+        if (!HasComp<XenoComponent>(user) || !HasComp<XenoComponent>(target))
+            return;
+
+        _xenoWatch.Watch(user, target.Value);
+    }
+
+    private void OnUserGhostTeleportMsg(Entity<TacticalMapUserComponent> ent, ref TacticalMapGhostTeleportMsg args)
+    {
+        var user = args.Actor;
+        if (!HasComp<GhostComponent>(user))
+            return;
+
+        if (!TryGetTacticalMap(out var map) ||
+            !TryComp<MapGridComponent>(map.Owner, out var grid))
+            return;
+
+        if (!_map.TryGetTileRef(map.Owner, grid, args.Position, out var tile) || tile.Tile.IsEmpty)
+            return;
+
+        var tileCenter = new Vector2(args.Position.X + 0.5f, args.Position.Y + 0.5f) * grid.TileSize;
+        var targetCoords = new EntityCoordinates(map.Owner, tileCenter);
+
+        var xform = Transform(user);
+        _transform.SetCoordinates(user, xform, targetCoords);
+        _transform.AttachToGridOrMap(user, xform);
+        _physics.SetLinearVelocity(user, Vector2.Zero);
+
+        _adminLog.Add(LogType.GhostWarp, $"{ToPrettyString(user)} teleported to {args.Position} via the tactical map");
     }
 
     public void OpenComputerMap(Entity<TacticalMapComputerComponent?> computer, EntityUid user)

--- a/Content.Shared/_RMC14/CCVar/RMCCVars.cs
+++ b/Content.Shared/_RMC14/CCVar/RMCCVars.cs
@@ -525,6 +525,12 @@ public sealed partial class RMCCVars : CVars
     public static readonly CVarDef<bool> RMCMarineEquipmentPreviews =
         CVarDef.Create("rmc.marine_equipment_previews", true, CVar.CLIENTONLY | CVar.ARCHIVE);
 
+    public static readonly CVarDef<bool> RMCTacticalMapXenoClickWatch =
+        CVarDef.Create("rmc.tactical_map_xeno_click_watch", true, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    public static readonly CVarDef<bool> RMCTacticalMapGhostClickTeleport =
+        CVarDef.Create("rmc.tactical_map_ghost_click_teleport", true, CVar.CLIENTONLY | CVar.ARCHIVE);
+
     public static readonly CVarDef<int> RMCXenoDefaultNightVision =
         CVarDef.Create("rmc.xeno_default_night_vision", (int) NightVisionState.Half, CVar.CLIENT | CVar.ARCHIVE | CVar.REPLICATED);
 

--- a/Content.Shared/_RMC14/TacticalMap/TacticalMapComputerUi.cs
+++ b/Content.Shared/_RMC14/TacticalMap/TacticalMapComputerUi.cs
@@ -22,6 +22,18 @@ public sealed class TacticalMapQueenEyeMoveMsg(Vector2i position) : BoundUserInt
 }
 
 [Serializable, NetSerializable]
+public sealed class TacticalMapWatchXenoMsg(NetEntity target) : BoundUserInterfaceMessage
+{
+    public readonly NetEntity Target = target;
+}
+
+[Serializable, NetSerializable]
+public sealed class TacticalMapGhostTeleportMsg(Vector2i position) : BoundUserInterfaceMessage
+{
+    public readonly Vector2i Position = position;
+}
+
+[Serializable, NetSerializable]
 public sealed class TacticalMapCreateLabelMsg(Vector2i position, string text) : BoundUserInterfaceMessage
 {
     public readonly Vector2i Position = position;

--- a/Content.Shared/_RMC14/TacticalMap/TacticalMapComputerUi.cs
+++ b/Content.Shared/_RMC14/TacticalMap/TacticalMapComputerUi.cs
@@ -27,8 +27,12 @@ public sealed class TacticalMapWatchXenoMsg(NetEntity target) : BoundUserInterfa
     public readonly NetEntity Target = target;
 }
 
+/// <summary>
+/// Raised as a network event instead of a BUI message because ghosts fail the
+/// CanInteract check that validates incoming BUI messages server-side.
+/// </summary>
 [Serializable, NetSerializable]
-public sealed class TacticalMapGhostTeleportMsg(Vector2i position) : BoundUserInterfaceMessage
+public sealed class TacticalMapGhostTeleportRequestEvent(Vector2i position) : EntityEventArgs
 {
     public readonly Vector2i Position = position;
 }

--- a/Content.Shared/_RMC14/TacticalMap/TacticalMapUserUi.cs
+++ b/Content.Shared/_RMC14/TacticalMap/TacticalMapUserUi.cs
@@ -10,8 +10,9 @@ public enum TacticalMapUserUi
 }
 
 [Serializable, NetSerializable]
-public sealed class TacticalMapBuiState(string mapName, Dictionary<SquadObjectiveType, string>? squadObjectives = null) : BoundUserInterfaceState
+public sealed class TacticalMapBuiState(string mapName, Dictionary<SquadObjectiveType, string>? squadObjectives = null, string? mapId = null) : BoundUserInterfaceState
 {
     public readonly string MapName = mapName;
     public readonly Dictionary<SquadObjectiveType, string>? SquadObjectives = squadObjectives;
+    public readonly string? MapId = mapId;
 }

--- a/Resources/Locale/en-US/_RMC14/ui.ftl
+++ b/Resources/Locale/en-US/_RMC14/ui.ftl
@@ -4,6 +4,8 @@ rmc-ui-options-cassettes-volume = Cassette volume:
 rmc-ui-options-hijack-song-volume = Hijack song volume:
 rmc-ui-options-xeno-ability-previews = Show xeno ability previews
 rmc-ui-options-marine-equipment-previews = Show marine equipment previews
+rmc-ui-options-tacmap-xeno-click-watch = Tactical map: watch a xeno by clicking their blip
+rmc-ui-options-tacmap-ghost-click-teleport = Tactical map: teleport as a ghost by clicking the map
 
 rmc-ui-voicelines = Voicelines
 rmc-ui-options-tab-voicelines = Voicelines


### PR DESCRIPTION
## About the PR

Three quality-of-life improvements for the tactical map:

- The current planet's name is now shown in the header of the tactical map window (both the personal map and computers). The name is resolved client-side from the planet map entity prototype, so it follows the client's locale instead of the server's.
- Xenos can start watching another xeno by clicking their blip on the tactical map, reusing the existing xeno watch system. This only works while the map is live (queen on the ovipositor) — stale snapshot blips cannot be used to watch.
- Ghosts can teleport to any point of the planet by clicking that spot on the tactical map.

Both new click behaviours can be toggled separately in the options (RMC14 section, on by default).

## Why / Balance

- The planet name on the map helps players (especially new ones) learn the colony maps and communicate about them.
- Click-to-watch is a faster path to the same result as the existing "Watch xeno" action with its manual list — all of its restrictions still apply (living queen required, same hive only, unwatch on movement). Gating it behind live update means it reveals nothing that the frozen map does not already show: with the queen off the ovipositor, clicking a stale blip is simply ignored on both client and server.
- Ghost click-to-teleport grants no new information or power — ghosts can already fly anywhere and warp to entities; this is purely a navigation convenience.

## Technical details

- `TacticalMapBuiState` now carries the planet map prototype ID next to the server-resolved name. The client resolves `EntityPrototype.Name` through its own localization manager and falls back to the server-provided string. The name string keeps being used as the settings persistence key, so saved per-map window settings are unaffected.
- `TacticalMapControl` gets an `OnBlipEntityClicked` callback that carries the blip's entity id (the existing `OnBlipClicked` used by the tunnel selector is untouched), and a `GhostTeleportMode` handled with the same priority pattern as `QueenEyeMode`.
- Click-to-watch sends a new `TacticalMapWatchXenoMsg` BUI message; the server handler validates `LiveUpdate` and that both parties are xenos, then calls `SharedXenoWatchSystem.Watch()`.
- Ghost teleport uses a network event (`TacticalMapGhostTeleportRequestEvent`) instead of a BUI message, because BUI messages from ghosts are cancelled by the `CanInteract` validation in `SharedInteractionSystem.OnBoundInterfaceInteractAttempt` (only UI open messages are exempt for ghosts). This mirrors how vanilla ghost warps work. The server validates the sender is a ghost and the target tile exists, then teleports with the same `SetCoordinates` + `AttachToGridOrMap` + velocity reset sequence as `GhostSystem.WarpTo`, with an admin log entry.
- The two toggles are `CLIENTONLY | ARCHIVE` cvars (`rmc.tactical_map_xeno_click_watch`, `rmc.tactical_map_ghost_click_teleport`) with checkboxes in the accessibility tab; the ghost toggle applies live to an open map via an `OnValueChanged` subscription.

## Media

https://github.com/user-attachments/assets/e57ba3fd-d8e1-4bc4-92d7-78572cc1d701

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: The tactical map now shows the name of the current planet in its header.
- add: Xenos can watch another xeno by clicking their blip on the tactical map while the queen is on the ovipositor. This can be turned off in the options.
- add: Ghosts can teleport by clicking anywhere on the tactical map. This can be turned off in the options.
