### PR TITLE
Add Fire alarm

### DIFF
--- a/Content.Shared/_RMC14/AlertLevel/RMCAlertLevelSystem.cs
+++ b/Content.Shared/_RMC14/AlertLevel/RMCAlertLevelSystem.cs
@@ -37,8 +37,14 @@ public sealed class RMCAlertLevelSystem : EntitySystem
     public override void Initialize()
     {
         SubscribeLocalEvent<DropshipHijackLandedEvent>(OnDropshipHijackLanded);
+        SubscribeLocalEvent<RMCAlertLevelDisplayComponent, MapInitEvent>(OnAlertLevelDisplayMapInit);
 
         _ghostQuery = GetEntityQuery<GhostComponent>();
+    }
+
+    private void OnAlertLevelDisplayMapInit(Entity<RMCAlertLevelDisplayComponent> ent, ref MapInitEvent args)
+    {
+        _appearance.SetData(ent.Owner, RMCAlertLevelsVisuals.Alert, Get() ?? RMCAlertLevels.Green);
     }
 
     private void OnDropshipHijackLanded(ref DropshipHijackLandedEvent ev)

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Wallmounts/fire_alarm.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Wallmounts/fire_alarm.yml
@@ -1,0 +1,47 @@
+# TODO RMC14: Port fire alarm activation, heat detection, shutters, damage, wires, and construction.
+- type: entity
+  id: RMCFireAlarm
+  name: fire alarm
+  description: '"Pull this in case of emergency". Thus, keep pulling it forever.'
+  placement:
+    mode: SnapgridCenter
+    snap:
+    - Wallmount
+  components:
+  - type: Transform
+    anchored: true
+  - type: Sprite
+    sprite: _RMC14/Structures/monitors.rsi
+    drawdepth: WallMountedItems
+    layers:
+    - state: firep
+      map: [ "unpowered" ]
+      visible: false
+    - state: fire0
+      map: [ "alert" ]
+  - type: Appearance
+  - type: GenericVisualizer
+    visuals:
+      enum.RMCAlertLevelsVisuals.Alert:
+        alert:
+          Green: { state: fire0 }
+          Blue: { state: fireblue }
+          Red: { state: firered }
+          Delta: { state: firered }
+      enum.PowerDeviceVisuals.Powered:
+        alert:
+          True: { visible: true }
+          False: { visible: false }
+        unpowered:
+          True: { visible: false }
+          False: { visible: true }
+  - type: RMCAlertLevelDisplay
+  - type: ApcPowerReceiver
+  - type: RMCPowerReceiver
+    idleLoad: 2
+    activeLoad: 6
+    channel: Environment
+  - type: WallMount
+    arc: 360
+  - type: Clickable
+  - type: InteractionOutline


### PR DESCRIPTION
## About the PR

Adds the CMSS13-style fire alarm as a wall-mounted display for the global RMC alert level.

The fire alarm is currently visual-only and cannot be activated manually. It is not placed on any maps in this PR.

## Why / Balance

This provides a compact wall-mounted indicator for the ship's current alert level while reusing the existing CMSS13 fire alarm sprites.

There is no direct gameplay or balance impact because the entity does not activate a fire alarm, control shutters, affect atmospherics, or interact with other machinery. It requires APC power and displays an unpowered state when power is unavailable.

The remaining fire alarm functionality is left as a TODO for a future implementation.

## Technical details

- Added the `RMCFireAlarm` entity prototype.
- Reused `_RMC14/Structures/monitors.rsi`.
- Added alert-level visuals:
  - Green: `fire0`
  - Blue: `fireblue`
  - Red: `firered`
  - Delta: `firered`
- Reused `RMCAlertLevelDisplay` to receive global RMC alert-level updates.
- Added `ApcPowerReceiver` and `RMCPowerReceiver` on the Environment power channel.
- Displays `firep` while unpowered.
- Synchronizes alert-level displays during `MapInit`, including displays spawned after the alert level has changed.
- Added a TODO for manual activation, heat detection, shutters, damage, wires, and construction.
- Does not modify any maps.

## Media

<!-- Attach a screenshot or video showing the Green, Blue, Red, and unpowered states. -->
<img width="347" height="257" alt="image" src="https://github.com/user-attachments/assets/65409da6-e16c-4115-992b-2bc0bfa339fd" />

## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

- add: Added a wall-mounted RMC fire alarm that displays the current alert level.