### PR TITLE
VC and MST rank changes

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/crewman.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/crewman.yml
@@ -12,7 +12,15 @@
     role: CMJobCombatTech
     time: 18000 # 5 hours
   ranks:
-    RMCRankCorporal: []
+    RMCRankSergeant:
+    - !type:RoleTimeRequirement
+      role: CMJobVehicleCrewman
+      time: 252000 # 70 hours
+    RMCRankCorporal:
+    - !type:RoleTimeRequirement
+      role: CMJobVehicleCrewman
+      time: 36000 # 10 hours
+    RMCRankLanceCorporal: []
   startingGear: CMGearVehicleCrewman
   icon: "CMJobIconVehicleCrewman"
   joinNotifyCrew: false

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/mess_tech.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/mess_tech.yml
@@ -9,10 +9,18 @@
     department: CMSquad
     time: 7200 # 2 hours
   ranks:
-    RMCRankLanceCorporal:
+    RMCRankSergeant:
+    - !type:RoleTimeRequirement
+      role: CMJobMessTech
+      time: 630000 # 175 hours
+    RMCRankCorporal:
     - !type:RoleTimeRequirement
       role: CMJobMessTech
       time: 252000 # 70 hours
+    RMCRankLanceCorporal:
+    - !type:RoleTimeRequirement
+      role: CMJobMessTech
+      time: 90000 # 25 hours
     RMCRankPrivateFirstClass:
     - !type:RoleTimeRequirement
       role: CMJobMessTech


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
new parity MST rankup: E1 -> E2 -> E3 -> E4 -> E5
non-parity VC ranks: E3 -> E4 -> E5

## Why / Balance
MST rankup is new on CM13, but is something fun to give a roleplay role and doesn't cause issues with anyone outranking anybody else.

VCs have been given the WS rank progression because they lacked rank progression, this specifically also means they won't outrank SLs still which can be important due to being placed under their command sometimes.

It is very unlikely that other rankup changing PRs would be accepted, these two are exceptions.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: CatAndHats
- tweak: Changed Mess Technician and Vehicle Crewman rankups! MSTs progression is now E1, E2, E3, E4, E5 (instead of E1, E2, E3), VCs progression is now E3, E4, E5 (instead of just E4)
