### PR TITLE
Add overlays for box moves + fix flurry

### DIFF
--- a/Content.Client/_RMC14/Xenonids/Targeting/XenoAbilityPreviewOverlay.cs
+++ b/Content.Client/_RMC14/Xenonids/Targeting/XenoAbilityPreviewOverlay.cs
@@ -564,12 +564,12 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
     }
 
     private void DrawScissors(
-    in OverlayDrawArgs args,
-    EntityUid player,
-    TransformComponent xform,
-    MapCoordinates originMap,
-    MapCoordinates mousePos,
-    XenoScissorCutComponent scissors)
+        in OverlayDrawArgs args,
+        EntityUid player,
+        TransformComponent xform,
+        MapCoordinates originMap,
+        MapCoordinates mousePos,
+        XenoScissorCutComponent scissors)
     {
         var direction = (mousePos.Position - originMap.Position).ToAngle() - Angle.FromDegrees(90);
 
@@ -580,12 +580,12 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
     }
 
     private void DrawHighGallop(
-    in OverlayDrawArgs args,
-    EntityUid player,
-    TransformComponent xform,
-    MapCoordinates originMap,
-    MapCoordinates mousePos,
-    XenoHighGallopComponent gallop)
+        in OverlayDrawArgs args,
+        EntityUid player,
+        TransformComponent xform,
+        MapCoordinates originMap,
+        MapCoordinates mousePos,
+        XenoHighGallopComponent gallop)
     {
         var direction = (mousePos.Position - originMap.Position).ToAngle() - Angle.FromDegrees(90);
 
@@ -596,12 +596,12 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
     }
 
     private void DrawTailLash(
-    in OverlayDrawArgs args,
-    EntityUid player,
-    TransformComponent xform,
-    MapCoordinates originMap,
-    MapCoordinates mousePos,
-    XenoTailLashComponent lash)
+        in OverlayDrawArgs args,
+        EntityUid player,
+        TransformComponent xform,
+        MapCoordinates originMap,
+        MapCoordinates mousePos,
+        XenoTailLashComponent lash)
     {
         var direction = (mousePos.Position - originMap.Position).ToAngle() - Angle.FromDegrees(90);
 
@@ -612,12 +612,12 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
     }
 
     private void DrawFlurry(
-    in OverlayDrawArgs args,
-    EntityUid player,
-    TransformComponent xform,
-    MapCoordinates originMap,
-    MapCoordinates mousePos,
-    XenoFlurryComponent flurry)
+        in OverlayDrawArgs args,
+        EntityUid player,
+        TransformComponent xform,
+        MapCoordinates originMap,
+        MapCoordinates mousePos,
+        XenoFlurryComponent flurry)
     {
         var direction = (mousePos.Position - originMap.Position).ToAngle() - Angle.FromDegrees(90);
 

--- a/Content.Client/_RMC14/Xenonids/Targeting/XenoAbilityPreviewOverlay.cs
+++ b/Content.Client/_RMC14/Xenonids/Targeting/XenoAbilityPreviewOverlay.cs
@@ -622,7 +622,7 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
         var direction = (mousePos.Position - originMap.Position).ToAngle() - Angle.FromDegrees(90);
 
         var color = FlurryOutlineColor.WithAlpha(OutlineAlpha);
-        var box2 = Box2.CenteredAround(xform.Coordinates.Position, new(1, flurry.Range)).Translated(new(0, (flurry.Range / 2) + 0.5f));
+        var box2 = Box2.CenteredAround(xform.Coordinates.Position, new(flurry.Range, 1)).Translated(new(0, 1f));
         var rot = new Box2Rotated(box2, direction, xform.Coordinates.Position);
         DrawBorderFromBox2Rotated(args, rot, color);
     }

--- a/Content.Client/_RMC14/Xenonids/Targeting/XenoAbilityPreviewOverlay.cs
+++ b/Content.Client/_RMC14/Xenonids/Targeting/XenoAbilityPreviewOverlay.cs
@@ -37,6 +37,11 @@ using Robust.Shared.Maths;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Prototypes;
+using Content.Shared._RMC14.Xenonids.ScissorCut;
+using Robust.Shared.Utility;
+using Content.Shared._RMC14.Xenonids.HighGallop;
+using Content.Shared._RMC14.Xenonids.Tail_Lash;
+using Content.Shared._RMC14.Xenonids.Flurry;
 
 namespace Content.Client._RMC14.Xenonids.Targeting;
 
@@ -54,6 +59,10 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
     private static readonly Color BlockerOutlineColor = new Color(0.65f, 0.65f, 0.65f);
     private static readonly Color AcidMineOutlineColor = new Color(0.6f, 0.9f, 0.2f);
     private static readonly Color DeployTrapsOutlineColor = new Color(0.8f, 0.6f, 0.2f);
+    private static readonly Color ScissorsOutlineColor = new Color(1f, 0f, 0f);
+    private static readonly Color HighGallopOutlineColor = new Color(0.5f, 0f, 0.5f);
+    private static readonly Color TailLashOutlineColor = new Color(0.8f, 0.67f, 0.28f);
+    private static readonly Color FlurryOutlineColor = new Color(1f, 0f, 0f);
 
     private const float OutlineAlpha = 0.8f;
     private const float OutlineThickness = 0.1f;
@@ -86,6 +95,10 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
     private readonly EntityQuery<XenoWeedsComponent> _weedsQ;
     private readonly EntityQuery<XenoAbductComponent> _abductQ;
     private readonly EntityQuery<XenoPierceComponent> _pierceQ;
+    private readonly EntityQuery<XenoScissorCutComponent> _scissorsQ;
+    private readonly EntityQuery<XenoHighGallopComponent> _highGallopQ;
+    private readonly EntityQuery<XenoTailLashComponent> _tailLashQ;
+    private readonly EntityQuery<XenoFlurryComponent> _flurryQ;
     private readonly EntityQuery<TransformComponent> _xformQ;
 
     public XenoAbilityPreviewOverlay(IEntityManager ents)
@@ -117,6 +130,10 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
         _weedsQ = ents.GetEntityQuery<XenoWeedsComponent>();
         _abductQ = ents.GetEntityQuery<XenoAbductComponent>();
         _pierceQ = ents.GetEntityQuery<XenoPierceComponent>();
+        _scissorsQ = ents.GetEntityQuery<XenoScissorCutComponent>();
+        _highGallopQ = ents.GetEntityQuery<XenoHighGallopComponent>();
+        _tailLashQ = ents.GetEntityQuery<XenoTailLashComponent>();
+        _flurryQ = ents.GetEntityQuery<XenoFlurryComponent>();
         _xformQ = ents.GetEntityQuery<TransformComponent>();
     }
 
@@ -218,6 +235,30 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
                 if (!_pierceQ.TryComp(player.Value, out var pierce))
                     return;
                 DrawPierce(args, player.Value, xform, originMap, mousePos, pierce);
+                break;
+
+            case XenoScissorCutActionEvent:
+                if (!_scissorsQ.TryComp(player.Value, out var scissors))
+                    return;
+                DrawScissors(args, player.Value, xform, originMap, mousePos, scissors);
+                break;
+
+            case XenoHighGallopActionEvent:
+                if (!_highGallopQ.TryComp(player.Value, out var highGallop))
+                    return;
+                DrawHighGallop(args, player.Value, xform, originMap, mousePos, highGallop);
+                break;
+
+            case XenoTailLashActionEvent:
+                if (!_tailLashQ.TryComp(player.Value, out var tailLash))
+                    return;
+                DrawTailLash(args, player.Value, xform, originMap, mousePos, tailLash);
+                break;
+
+            case XenoFlurryActionEvent:
+                if (!_flurryQ.TryComp(player.Value, out var flurry))
+                    return;
+                DrawFlurry(args, player.Value, xform, originMap, mousePos, flurry);
                 break;
         }
     }
@@ -474,7 +515,7 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
             mousePos = originMap.Offset(direction.Normalized() * range);
 
         var color = BurrowOutlineColor.WithAlpha(OutlineAlpha);
-        DrawLandingTile(args, mousePos, color);
+        DrawLandingSquare(args, mousePos, color);
     }
 
     private static bool IsBurrowed(XenoBurrowComponent burrow)
@@ -520,6 +561,70 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
 
         range = targetAction.Range;
         return true;
+    }
+
+    private void DrawScissors(
+    in OverlayDrawArgs args,
+    EntityUid player,
+    TransformComponent xform,
+    MapCoordinates originMap,
+    MapCoordinates mousePos,
+    XenoScissorCutComponent scissors)
+    {
+        var direction = (mousePos.Position - originMap.Position).ToAngle() - Angle.FromDegrees(90);
+
+        var color = ScissorsOutlineColor.WithAlpha(OutlineAlpha);
+        var box2 = Box2.CenteredAround(xform.Coordinates.Position, new(1, scissors.Range)).Translated(new(0, (scissors.Range / 2) + 0.5f));
+        var rot = new Box2Rotated(box2, direction, xform.Coordinates.Position);
+        DrawBorderFromBox2Rotated(args, rot, color);
+    }
+
+    private void DrawHighGallop(
+    in OverlayDrawArgs args,
+    EntityUid player,
+    TransformComponent xform,
+    MapCoordinates originMap,
+    MapCoordinates mousePos,
+    XenoHighGallopComponent gallop)
+    {
+        var direction = (mousePos.Position - originMap.Position).ToAngle() - Angle.FromDegrees(90);
+
+        var color = HighGallopOutlineColor.WithAlpha(OutlineAlpha);
+        var box2 = Box2.CenteredAround(xform.Coordinates.Position, new(gallop.Width, gallop.Height)).Translated(new(0, (gallop.Height / 2) + 0.5f));
+        var rot = new Box2Rotated(box2, direction, xform.Coordinates.Position);
+        DrawBorderFromBox2Rotated(args, rot, color);
+    }
+
+    private void DrawTailLash(
+    in OverlayDrawArgs args,
+    EntityUid player,
+    TransformComponent xform,
+    MapCoordinates originMap,
+    MapCoordinates mousePos,
+    XenoTailLashComponent lash)
+    {
+        var direction = (mousePos.Position - originMap.Position).ToAngle() - Angle.FromDegrees(90);
+
+        var color = TailLashOutlineColor.WithAlpha(OutlineAlpha);
+        var box2 = Box2.CenteredAround(xform.Coordinates.Position, new(lash.Width, lash.Height)).Translated(new(0, (lash.Height / 2) + 0.5f));
+        var rot = new Box2Rotated(box2, direction, xform.Coordinates.Position);
+        DrawBorderFromBox2Rotated(args, rot, color);
+    }
+
+    private void DrawFlurry(
+    in OverlayDrawArgs args,
+    EntityUid player,
+    TransformComponent xform,
+    MapCoordinates originMap,
+    MapCoordinates mousePos,
+    XenoFlurryComponent flurry)
+    {
+        var direction = (mousePos.Position - originMap.Position).ToAngle() - Angle.FromDegrees(90);
+
+        var color = FlurryOutlineColor.WithAlpha(OutlineAlpha);
+        var box2 = Box2.CenteredAround(xform.Coordinates.Position, new(1, flurry.Range)).Translated(new(0, (flurry.Range / 2) + 0.5f));
+        var rot = new Box2Rotated(box2, direction, xform.Coordinates.Position);
+        DrawBorderFromBox2Rotated(args, rot, color);
     }
 
     private void DrawLinePreview(
@@ -570,14 +675,26 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
         }
     }
 
-    private void DrawLandingTile(in OverlayDrawArgs args, MapCoordinates target, Color color)
+    private void DrawBorderFromBox2Rotated(in OverlayDrawArgs args, Box2Rotated box, Color color)
+    {
+        var vertices = new HashSet<Vector2>
+        {
+            box.BottomLeft,
+            box.BottomRight,
+            box.TopRight,
+            box.TopLeft
+        };
+
+        DrawPolygonBorder(args.WorldHandle, vertices, color);
+    }
+
+    private void DrawLandingSquare(in OverlayDrawArgs args, MapCoordinates target, Color color)
     {
         if (!_mapManager.TryFindGridAt(target, out var gridUid, out var grid))
             return;
 
-        var indices = _mapSystem.CoordinatesToTile(gridUid, grid, target);
-        var tiles = new HashSet<Vector2i> { indices };
-        DrawTileBorder(args.WorldHandle, gridUid, grid, tiles, color);
+        var box = Box2.CenteredAround(target.Position, Vector2.One);
+        DrawBorderFromBox2Rotated(args, new Box2Rotated(box), color);
     }
 
     private bool TryGetResinSurgeDirectTarget(MapCoordinates mousePos, out TileInfo target)
@@ -708,6 +825,33 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
         }
     }
 
+    private void DrawPolygonBorder(DrawingHandleWorld handle, HashSet<Vector2> vertices, Color color)
+    {
+        if (vertices.Count == 0)
+            return;
+
+        var isFirst = true;
+        Vector2? first = vertices.FirstOrNull();
+        Vector2? previous = first;
+
+        foreach (var vertex in vertices)
+        {
+            if (isFirst)
+            {
+                isFirst = false;
+                continue;
+            }
+
+            if (previous != null)
+                DrawEdge(handle, previous.Value, vertex, color);
+
+            previous = vertex;
+        }
+
+        if (previous != null && first != null)
+            DrawEdge(handle, previous.Value, first.Value, color);
+    }
+
     private int GetBombardRadius(EntProtoId projectile)
     {
         if (!_prototypes.TryIndex<EntityPrototype>(projectile, out var projectileProto))
@@ -834,7 +978,7 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
 
         var length = delta.Length();
         var mid = (from + to) * 0.5f;
-        var angle = delta.ToWorldAngle();
+        var angle = delta.ToAngle();
         var rect = new Box2(-length / 2f, -half, length / 2f, half);
         var rotated = new Box2Rotated(rect.Translated(mid), angle, mid);
         handle.DrawRect(rotated, color);

--- a/Content.Shared/_RMC14/Xenonids/Flurry/XenoFlurryComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Flurry/XenoFlurryComponent.cs
@@ -13,7 +13,7 @@ public sealed partial class XenoFlurryComponent : Component
     public DamageSpecifier Damage = new();
 
     [DataField, AutoNetworkedField]
-    public float Range = 2;
+    public float Range = 3;
 
     [DataField, AutoNetworkedField]
     public int? MaxTargets = 4;

--- a/Content.Shared/_RMC14/Xenonids/Flurry/XenoFlurrySystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Flurry/XenoFlurrySystem.cs
@@ -55,7 +55,7 @@ public sealed class XenoFlurrySystem : EntitySystem
         var direction = (args.Target.Position - _transform.GetMoverCoordinates(xeno).Position).Normalized().ToAngle() - Angle.FromDegrees(90);
 
         var xenoCoord = _transform.GetMoverCoordinates(xeno);
-        var area = Box2.CenteredAround(xenoCoord.Position, new(1, xeno.Comp.Range)).Translated(new(0, (xeno.Comp.Range / 2) + 0.5f));
+        var area = Box2.CenteredAround(xenoCoord.Position, new(xeno.Comp.Range, 1)).Translated(new(0, 1f));
         var rot = new Box2Rotated(area, direction, xenoCoord.Position); // Correct the angle
 
         List<EntityUid> mobs = new();


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Anything that uses an area and isn't tile locked, basically.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Good QoL.

## Technical details
<!-- Summary of code changes for easier review. -->
Fixed the ability overlay preview code wrongly rotating the edges (used the wrong angle!)

Added a DrawBorderFromBox2Rotated and DrawPolygon funcs to draw freeform boxes.

Added high gallop, scissor cut, tail lash, and flurry to the ability previews. Changed burrow preview to not be locked to a tile (because burrow isn't!).

Note these don't check blockers atm as that would require more complicated code (probably).

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

https://github.com/user-attachments/assets/e48debd4-40fa-458d-bf97-df85ef652349

(note valk's high gallop became more purple).

<img width="168" height="207" alt="image" src="https://github.com/user-attachments/assets/b117e5f9-0d15-4944-886a-97909787e6a9" />
(See wrong range in the video)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added ability previews for High Gallop, Scissor Cut, Tail Lash, and Flurry.
- fix: Fixed burrow landing preview being tile locked (the ability itself is not).
- fix: Fixed Vampire Lurker Flurry being a horizontal 1x2 instead of a vertical 1x3.
