### PR TITLE
Fix opened lockers blocking projectiles, abilities

### DIFF
--- a/Content.Shared/Storage/Components/SharedEntityStorageComponent.cs
+++ b/Content.Shared/Storage/Components/SharedEntityStorageComponent.cs
@@ -22,7 +22,8 @@ public abstract partial class SharedEntityStorageComponent : Component
     public readonly int MasksToRemove = (int) (
         CollisionGroup.MidImpassable |
         CollisionGroup.HighImpassable |
-        CollisionGroup.LowImpassable);
+        CollisionGroup.LowImpassable |
+        CollisionGroup.BulletImpassable);
 
     /// <summary>
     ///     Collision masks that were removed from ANY layer when the storage was opened;

--- a/Content.Shared/Storage/Components/SharedEntityStorageComponent.cs
+++ b/Content.Shared/Storage/Components/SharedEntityStorageComponent.cs
@@ -23,6 +23,7 @@ public abstract partial class SharedEntityStorageComponent : Component
         CollisionGroup.MidImpassable |
         CollisionGroup.HighImpassable |
         CollisionGroup.LowImpassable |
+        // RMC14
         CollisionGroup.BulletImpassable);
 
     /// <summary>

--- a/Content.Shared/_RMC14/Line/LineSystem.cs
+++ b/Content.Shared/_RMC14/Line/LineSystem.cs
@@ -3,10 +3,13 @@ using System.Linq;
 using System.Numerics;
 using Content.Shared._RMC14.Barricade;
 using Content.Shared._RMC14.Entrenching;
+using Content.Shared._RMC14.Storage;
 using Content.Shared.Beam.Components;
 using Content.Shared.Coordinates.Helpers;
 using Content.Shared.Doors.Components;
 using Content.Shared.Physics;
+using Content.Shared.Storage.Components;
+using Content.Shared.Storage.EntitySystems;
 using Content.Shared.Tag;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
@@ -20,6 +23,7 @@ namespace Content.Shared._RMC14.Line;
 
 public sealed class LineSystem : EntitySystem
 {
+    [Dependency] private readonly SharedEntityStorageSystem _entityStorage = default!;
     [Dependency] private readonly IMapManager _mapManager = default!;
     [Dependency] private readonly SharedMapSystem _mapSystem = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
@@ -36,12 +40,14 @@ public sealed class LineSystem : EntitySystem
 
     private EntityQuery<BarricadeComponent> _barricadeQuery;
     private EntityQuery<DoorComponent> _doorQuery;
+    private EntityQuery<RMCEntityStorageLineBlockableComponent> _lockerQuery;
     private EntityQuery<MapGridComponent> _mapGridQuery;
 
     public override void Initialize()
     {
         _barricadeQuery = GetEntityQuery<BarricadeComponent>();
         _doorQuery = GetEntityQuery<DoorComponent>();
+        _lockerQuery = GetEntityQuery<RMCEntityStorageLineBlockableComponent>();
         _mapGridQuery = GetEntityQuery<MapGridComponent>();
     }
 
@@ -197,6 +203,14 @@ public sealed class LineSystem : EntitySystem
             else if (_doorQuery.TryComp(uid, out var door))
             {
                 if (door.State != DoorState.Closed && door.State != DoorState.Denying && door.State != DoorState.Welded)
+                    continue;
+
+                blocker = uid.Value;
+                return true;
+            }
+            else if (_lockerQuery.TryComp(uid, out _))
+            {
+                if (_entityStorage.IsOpen(uid.Value))
                     continue;
 
                 blocker = uid.Value;

--- a/Content.Shared/_RMC14/Line/LineSystem.cs
+++ b/Content.Shared/_RMC14/Line/LineSystem.cs
@@ -208,7 +208,7 @@ public sealed class LineSystem : EntitySystem
                 blocker = uid.Value;
                 return true;
             }
-            else if (_lockerQuery.TryComp(uid, out _))
+            else if (_lockerQuery.HasComp(uid))
             {
                 if (_entityStorage.IsOpen(uid.Value))
                     continue;

--- a/Content.Shared/_RMC14/Storage/RMCEntityStorageLineBlockableComponent.cs
+++ b/Content.Shared/_RMC14/Storage/RMCEntityStorageLineBlockableComponent.cs
@@ -1,0 +1,8 @@
+using Content.Shared._RMC14.Line;
+using Content.Shared.Whitelist;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Storage;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class RMCEntityStorageLineBlockableComponent : Component;

--- a/Content.Shared/_RMC14/Storage/RMCEntityStorageLineBlockableComponent.cs
+++ b/Content.Shared/_RMC14/Storage/RMCEntityStorageLineBlockableComponent.cs
@@ -1,5 +1,3 @@
-using Content.Shared._RMC14.Line;
-using Content.Shared.Whitelist;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared._RMC14.Storage;

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Storage/closets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Storage/closets.yml
@@ -60,6 +60,18 @@
     damage:
       types:
         Blunt: 40
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.25,-0.48,0.25,0.48"
+        density: 75
+        mask:
+        - MachineMask
+        layer:
+        - MachineLayer
+        - BulletImpassable
 
 - type: entity
   parent: CMClosetBaseUnanchored

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Storage/closets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Storage/closets.yml
@@ -55,6 +55,7 @@
           params:
             volume: -6
   - type: EntityStorageCloseOnMapInit
+  - type: RMCEntityStorageLineBlockable
   - type: XenoToggleChargingDamage
     stageLoss: 2
     damage:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Storage/crates.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Storage/crates.yml
@@ -117,6 +117,7 @@
   - type: AnimationPlayer
   - type: RMCMesonsNonviewable
   - type: EntityStorageCloseOnMapInit
+  - type: RMCEntityStorageLineBlockable
 
 - type: entity
   parent: RMCCrateBase

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Storage/lockers.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Storage/lockers.yml
@@ -34,18 +34,6 @@
   - type: Lock
   - type: XenoCrusherChargable
     instantDestroy: true
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeAabb
-          bounds: "-0.25,-0.48,0.25,0.48"
-        density: 75
-        mask:
-        - MachineMask
-        layer:
-        - MachineLayer
-        - BulletImpassable
 
 - type: entity
   parent: CMLockerBase


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Opened lockers no longer block projectiles ( bullets, xeno spits ) and anything that uses linesystem ( flamethrower, opressor pull, acid spray and etc ) 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Resolves #10629

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

https://github.com/user-attachments/assets/6ad5f20e-a45f-420d-8050-aba0c838a820



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Opened lockers no longer block projectiles or xeno abilities.
