### PR TITLE
[Parity] Missile damage corrections

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/PowerLoader/Dropship/rmc_dropship_ammo.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/PowerLoader/Dropship/rmc_dropship_ammo.yml
@@ -142,9 +142,9 @@
   - type: DropshipAmmo
     travelTime: 3
     explosion:
-      total: 3000
-      slope: 5.5
-      max: 55
+      total: 2371
+      slope: 3.95
+      max: 30
 
 - type: entity
   parent: RMCDropshipAttachmentAmmoRocket
@@ -161,9 +161,9 @@
   - type: DropshipAmmo
     travelTime: 2
     explosion:
-      total: 905
-      slope: 15
-      max: 45
+      total: 694
+      slope: 24.95
+      max: 40
 
 - type: entity
   parent: RMCDropshipAttachmentAmmoRocket
@@ -180,9 +180,9 @@
   - type: DropshipAmmo # TODO RMC14 not usable in fire mission, only direct bombardment
     travelTime: 6
     explosion:
-      total: 1780
-      slope: 7.2
-      max: 50
+      total: 1749
+      slope: 2.25
+      max: 15
     fire:
       type: RMCTileFireNapalm
       range: 3
@@ -203,9 +203,9 @@
   - type: DropshipAmmo
     travelTime: 5
     explosion:
-      total: 1850
-      slope: 3.2
-      max: 32
+      total: 1702
+      slope: 1.75
+      max: 15
 
 - type: entity
   parent: RMCDropshipAttachmentAmmoRocket
@@ -248,9 +248,9 @@
   - type: DropshipAmmo
     travelTime: 6
     explosion:
-      total: 2000
-      slope: 5.5
-      max: 40
+      total: 1768
+      slope: 1.95
+      max: 17
     fire:
       type: RMCTileFireBanshee
       range: 1
@@ -290,9 +290,9 @@
   - type: DropshipAmmo
     ammoType: minirocket
     explosion:
-      total: 850
-      slope: 8
-      max: 40
+      total: 736
+      slope: 4.25
+      max: 20
     impactEffects:
     - RMCEffectExplosionParticle
     - RMCSmokeExplosionProofSmall

--- a/Resources/Prototypes/_RMC14/Entities/Objects/PowerLoader/Dropship/rmc_dropship_ammo.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/PowerLoader/Dropship/rmc_dropship_ammo.yml
@@ -182,7 +182,7 @@
     explosion:
       total: 1749
       slope: 2.25
-      max: 15
+      max: 20
     fire:
       type: RMCTileFireNapalm
       range: 3

--- a/Resources/Prototypes/_RMC14/Entities/Objects/PowerLoader/Dropship/rmc_dropship_ammo.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/PowerLoader/Dropship/rmc_dropship_ammo.yml
@@ -163,7 +163,7 @@
     explosion:
       total: 694
       slope: 24.95
-      max: 40
+      max: 45
 
 - type: entity
   parent: RMCDropshipAttachmentAmmoRocket

--- a/Resources/Prototypes/_RMC14/Entities/Structures/explosions.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/explosions.yml
@@ -179,7 +179,7 @@
     explosion:
       total: 1749
       slope: 2.25
-      max: 40
+      max: 20
     fire:
       type: RMCTileFireNapalm
       range: 3

--- a/Resources/Prototypes/_RMC14/Entities/Structures/explosions.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/explosions.yml
@@ -153,9 +153,9 @@
   - type: DropshipAmmo
     travelTime: 3
     explosion:
-      total: 3000
-      slope: 5.5
-      max: 55
+      total: 2371
+      slope: 3.95
+      max: 30
 
 - type: entity
   parent: RMCDropshipMissileExplosionBase
@@ -165,8 +165,8 @@
   - type: DropshipAmmo
     travelTime: 2
     explosion:
-      total: 905
-      slope: 15
+      total: 694
+      slope: 24.95
       max: 45
 
 - type: entity
@@ -177,9 +177,9 @@
   - type: DropshipAmmo
     travelTime: 6
     explosion:
-      total: 1780
-      slope: 7.2
-      max: 50
+      total: 1749
+      slope: 2.25
+      max: 40
     fire:
       type: RMCTileFireNapalm
       range: 3
@@ -193,9 +193,9 @@
   - type: DropshipAmmo
     travelTime: 5
     explosion:
-      total: 1850
-      slope: 3.2
-      max: 32
+      total: 1702
+      slope: 1.75
+      max: 15
 
 - type: entity
   parent: RMCDropshipMissileExplosionBase
@@ -224,9 +224,9 @@
   - type: DropshipAmmo
     travelTime: 6
     explosion:
-      total: 2000
-      slope: 5.5
-      max: 40
+      total: 1768
+      slope: 1.95
+      max: 17
     fire:
       type: RMCTileFireBanshee
       range: 1
@@ -257,9 +257,9 @@
   components:
   - type: DropshipAmmo
     explosion:
-      total: 850
-      slope: 8
-      max: 40
+      total: 736
+      slope: 4.25
+      max: 20
     impactEffects:
     - RMCEffectExplosionParticle
     - RMCSmokeExplosionProofSmall


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I suggest not merging this without #10590.

Currently, our missiles do not follow parity as far as damage values go. This is in part due to the different explosion systems used on RMC compared to CM. However, if #10590 is merged, our missiles will cease to be a "good enough" approximation of what they are on CM. This PR aims to address that. I've adjusted the values in the explosion markers and the dropship ammo yamls to adjust.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Even without merging #10590, missiles are currently far too strong against (relatively) unarmored (explosive armor) targets and far too weak against (relatively) armored (explosive armor) targets. If merged, this change will decrease the lethality of missiles against weaker castes and increase lethality against armored castes.

Also, parity.

## Technical details
<!-- Summary of code changes for easier review. -->
I recreated CM's `cell_explosion` automata and RMC's tileflood intensity-budget explosion implementations in Python, verified they worked (at least to an acceptable degree, I believe my approximation of RMC is off by exactly 3 damage somehow), and then wrote a script to optimize for total intensity, slope, and max intensity values that produce the lowest root mean square error (RMSE) between CM's explosion damage per tile and RMC's. I think that these values, while not perfect tile per tile, are good enough and further tweaks can be left to post-parity.

I did my RMSE optimization while assuming all else equal on an open field, **with no wave-reflections or any of the weird bugs that CM's explosions have (like double-hits)**.

**Because of the differences between CM's `cell_explosion` and our tileflood intensity-budget model, our missiles will be stronger in enclosed areas, stronger on the cardinals, slightly stronger on the edges, and weaker on the ordinals.**

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
The damage values displayed in these graphs are _specifically to xenonids_, as that is where they are most relevant. Both RMC and CM have a 2x multiplier to explosive damage against xenonids, and in RMC, intensity is further multiplied by ten to get burn and brute damage (for CAS missiles, at least).

Below in order are damage heatmaps of RMC's old values, RMC's new values that this PR introduces, and CM's values.
<img width="600" height="600" alt="rmc_minimike_old" src="https://github.com/user-attachments/assets/03722282-f252-4374-8151-023bdec271b6" />
<img width="600" height="600" alt="rmc_minimike_new" src="https://github.com/user-attachments/assets/d7cb1231-5491-4db0-be14-9b39692ddd5a" />
<img width="600" height="600" alt="cm-minimike" src="https://github.com/user-attachments/assets/1e1bd43d-aa40-4a26-a65b-fffc688decf9" />
<img width="600" height="600" alt="rmc_banshee_old" src="https://github.com/user-attachments/assets/e9448776-b5b9-45f9-8da5-a9c0f23fd72f" />
<img width="600" height="600" alt="rmc_banshee_new" src="https://github.com/user-attachments/assets/4592c891-dd23-4722-8846-f3d1bdeba96d" />
<img width="600" height="600" alt="cm_banshee" src="https://github.com/user-attachments/assets/76708ca9-352b-4f48-b70c-ed164d2be693" />
<img width="600" height="600" alt="rmc_harpoon_old" src="https://github.com/user-attachments/assets/2368cf4d-dd4a-40e6-8a50-5b6998100436" />
<img width="600" height="600" alt="rmc_harpoon_new" src="https://github.com/user-attachments/assets/c160a74b-4991-491a-9192-03f1fb36660c" />
<img width="600" height="600" alt="cm_harpoon" src="https://github.com/user-attachments/assets/44aa9606-6d7d-46a8-af6b-e6780c49d0a6" />
<img width="600" height="600" alt="rmc_napalm_old" src="https://github.com/user-attachments/assets/88fc3915-bfd5-4153-a639-9d8946f729f0" />
<img width="600" height="600" alt="rmc_napalm_new" src="https://github.com/user-attachments/assets/61e64950-ab9b-4d8f-bf13-501d97473fb6" />
<img width="600" height="600" alt="cm_napalm" src="https://github.com/user-attachments/assets/ae23f34b-95a9-45b3-9f3f-23c1a917746b" />
<img width="600" height="600" alt="rmc_keeper_old" src="https://github.com/user-attachments/assets/4a97349d-604a-4ecd-a145-11845971fede" />
<img width="600" height="600" alt="rmc_keeper_onewpng" src="https://github.com/user-attachments/assets/aabaf907-0fdb-4d08-a50c-29254898b878" />
<img width="600" height="600" alt="cm_keeper" src="https://github.com/user-attachments/assets/57973548-8827-4970-9b55-0d74f3207228" />
<img width="600" height="600" alt="rmc_widow_old" src="https://github.com/user-attachments/assets/71a5fdf5-fbd6-47cd-bfb5-3c63a080c856" />
<img width="600" height="600" alt="rmc_widow_new" src="https://github.com/user-attachments/assets/144af470-4b90-476c-af70-4af99d432503" />
<img width="600" height="600" alt="cm_widow" src="https://github.com/user-attachments/assets/c77f44b4-b29b-47b1-891c-2fceb1b43e54" />

## Below are images that represent the difference between the new values proposed in this PR and CM's values. Red means CM's values result in more damage at the tile, blue means RMC's new values result in more damage at the tile.
<img width="800" height="800" alt="diff_minimike" src="https://github.com/user-attachments/assets/b12c5cf7-5236-4d05-9fba-a451a1de3fd3" />
<img width="800" height="800" alt="diff_banshee" src="https://github.com/user-attachments/assets/9505dfea-3fa1-45bc-b574-52549d64c80b" />
<img width="800" height="800" alt="diff_harpoon" src="https://github.com/user-attachments/assets/5414b227-6da0-466e-a7be-1a4120043702" />
<img width="800" height="800" alt="diff_napalm" src="https://github.com/user-attachments/assets/5e7f2191-9c34-40f7-93ca-a655517551a4" />
<img width="800" height="800" alt="diff_keeper" src="https://github.com/user-attachments/assets/bc8ace85-9afd-4604-871e-51ffe49ee7b5" />
<img width="800" height="800" alt="diff_widow" src="https://github.com/user-attachments/assets/7b3e67cb-2455-4626-9d28-61c7b785b1bb" />

## Below are graphs tile-by-tile of the damage delta (change) when going from RMC's old values to the values proposed in this PR.
<img width="800" height="800" alt="delta_minimike" src="https://github.com/user-attachments/assets/a6e47a27-828c-43dd-94c6-a758dd2e616a" />
<img width="800" height="800" alt="delta_banshee" src="https://github.com/user-attachments/assets/eaf65fe7-fd7e-466a-ad3f-230a2583947c" />
<img width="800" height="800" alt="delta_harpoon" src="https://github.com/user-attachments/assets/0d9a178c-df04-4d90-b526-5e143ed4cc83" />
<img width="800" height="800" alt="delta_napalm" src="https://github.com/user-attachments/assets/1e7a3381-8c23-43b8-a10f-832082887f5e" />
<img width="800" height="800" alt="delta_keeper" src="https://github.com/user-attachments/assets/0255e7a2-2b9d-4b12-ae36-04dbafebf23b" />
<img width="800" height="800" alt="delta_widow" src="https://github.com/user-attachments/assets/be46cbc1-0fcb-4add-9fc8-ebcc9083cfb9" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: CAS missiles have been adjusted to use values to produce explosions which more closely resemble their counterparts in parity