### PR TITLE
[Parity] Grenade damage corrections

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/PowerLoader/Dropship/rmc_dropship_ammo.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/PowerLoader/Dropship/rmc_dropship_ammo.yml
@@ -142,9 +142,9 @@
   - type: DropshipAmmo
     travelTime: 3
     explosion:
-      total: 3000
-      slope: 5.5
-      max: 55
+      total: 2371
+      slope: 3.95
+      max: 30
 
 - type: entity
   parent: RMCDropshipAttachmentAmmoRocket
@@ -161,9 +161,9 @@
   - type: DropshipAmmo
     travelTime: 2
     explosion:
-      total: 905
-      slope: 15
-      max: 45
+      total: 694
+      slope: 24.95
+      max: 40
 
 - type: entity
   parent: RMCDropshipAttachmentAmmoRocket
@@ -180,9 +180,9 @@
   - type: DropshipAmmo # TODO RMC14 not usable in fire mission, only direct bombardment
     travelTime: 6
     explosion:
-      total: 1780
-      slope: 7.2
-      max: 50
+      total: 1749
+      slope: 2.25
+      max: 15
     fire:
       type: RMCTileFireNapalm
       range: 3
@@ -203,9 +203,9 @@
   - type: DropshipAmmo
     travelTime: 5
     explosion:
-      total: 1850
-      slope: 3.2
-      max: 32
+      total: 1702
+      slope: 1.75
+      max: 15
 
 - type: entity
   parent: RMCDropshipAttachmentAmmoRocket
@@ -248,9 +248,9 @@
   - type: DropshipAmmo
     travelTime: 6
     explosion:
-      total: 2000
-      slope: 5.5
-      max: 40
+      total: 1768
+      slope: 1.95
+      max: 17
     fire:
       type: RMCTileFireBanshee
       range: 1
@@ -290,9 +290,9 @@
   - type: DropshipAmmo
     ammoType: minirocket
     explosion:
-      total: 850
-      slope: 8
-      max: 40
+      total: 736
+      slope: 4.25
+      max: 20
     impactEffects:
     - RMCEffectExplosionParticle
     - RMCSmokeExplosionProofSmall

--- a/Resources/Prototypes/_RMC14/Entities/Objects/PowerLoader/Dropship/rmc_dropship_ammo.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/PowerLoader/Dropship/rmc_dropship_ammo.yml
@@ -182,7 +182,7 @@
     explosion:
       total: 1749
       slope: 2.25
-      max: 15
+      max: 20
     fire:
       type: RMCTileFireNapalm
       range: 3

--- a/Resources/Prototypes/_RMC14/Entities/Objects/PowerLoader/Dropship/rmc_dropship_ammo.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/PowerLoader/Dropship/rmc_dropship_ammo.yml
@@ -163,7 +163,7 @@
     explosion:
       total: 694
       slope: 24.95
-      max: 40
+      max: 45
 
 - type: entity
   parent: RMCDropshipAttachmentAmmoRocket

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -85,9 +85,9 @@
     sprite: _RMC14/Objects/Weapons/Grenades/m40hedp.rsi
   - type: ExplodeOnTrigger
   - type: Explosive
-    maxIntensity: 20 # max 100 brute, 100 burn
-    intensitySlope: 6
-    totalIntensity: 200
+    maxIntensity: 10
+    intensitySlope: 5.75
+    totalIntensity: 144
     canCreateVacuum: false
   - type: Ammo
   - type: CMExplosionEffect
@@ -246,9 +246,9 @@
   - type: Sprite
     sprite: _RMC14/Objects/Weapons/Grenades/m40hefa.rsi
   - type: Explosive
-    maxIntensity: 8 # max 40 brute 40 burn
-    intensitySlope: 4
-    totalIntensity: 110
+    maxIntensity: 8
+    intensitySlope: 1.05
+    totalIntensity: 47
     deleteAfterExplosion: false
   - type: ProjectileGrenade
     fillPrototype: CMProjectileShrapnel
@@ -277,9 +277,9 @@
   - type: Sprite
     sprite: _RMC14/Objects/Weapons/Grenades/m15frag.rsi
   - type: Explosive
-    maxIntensity: 20
-    intensitySlope: 6
-    totalIntensity: 240
+    maxIntensity: 11
+    intensitySlope: 2.75
+    totalIntensity: 396
     deleteAfterExplosion: false
   - type: ProjectileGrenade
     fillPrototype: CMProjectileShrapnel
@@ -306,9 +306,9 @@
   - type: Sprite
     sprite: _RMC14/Objects/Weapons/Grenades/m12blast.rsi
   - type: Explosive
-    maxIntensity: 35 # max 175 brute, 175 burn
-    intensitySlope: 5
-    totalIntensity: 280
+    maxIntensity: 18
+    intensitySlope: 4.05
+    totalIntensity: 396
   - type: Tag
     tags:
     - Grenade
@@ -468,9 +468,9 @@
     delay: 0
   - type: ExplodeOnTrigger
   - type: Explosive
-    maxIntensity: 16
-    intensitySlope: 6
-    totalIntensity: 160
+    maxIntensity: 10
+    intensitySlope: 2.75
+    totalIntensity: 313
     canCreateVacuum: false
   - type: Ammo
   - type: CMExplosionEffect

--- a/Resources/Prototypes/_RMC14/Entities/Structures/explosions.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/explosions.yml
@@ -179,7 +179,7 @@
     explosion:
       total: 1749
       slope: 2.25
-      max: 40
+      max: 20
     fire:
       type: RMCTileFireNapalm
       range: 3

--- a/Resources/Prototypes/_RMC14/Entities/Structures/explosions.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/explosions.yml
@@ -153,9 +153,9 @@
   - type: DropshipAmmo
     travelTime: 3
     explosion:
-      total: 3000
-      slope: 5.5
-      max: 55
+      total: 2371
+      slope: 3.95
+      max: 30
 
 - type: entity
   parent: RMCDropshipMissileExplosionBase
@@ -165,8 +165,8 @@
   - type: DropshipAmmo
     travelTime: 2
     explosion:
-      total: 905
-      slope: 15
+      total: 694
+      slope: 24.95
       max: 45
 
 - type: entity
@@ -177,9 +177,9 @@
   - type: DropshipAmmo
     travelTime: 6
     explosion:
-      total: 1780
-      slope: 7.2
-      max: 50
+      total: 1749
+      slope: 2.25
+      max: 40
     fire:
       type: RMCTileFireNapalm
       range: 3
@@ -193,9 +193,9 @@
   - type: DropshipAmmo
     travelTime: 5
     explosion:
-      total: 1850
-      slope: 3.2
-      max: 32
+      total: 1702
+      slope: 1.75
+      max: 15
 
 - type: entity
   parent: RMCDropshipMissileExplosionBase
@@ -224,9 +224,9 @@
   - type: DropshipAmmo
     travelTime: 6
     explosion:
-      total: 2000
-      slope: 5.5
-      max: 40
+      total: 1768
+      slope: 1.95
+      max: 17
     fire:
       type: RMCTileFireBanshee
       range: 1
@@ -257,9 +257,9 @@
   components:
   - type: DropshipAmmo
     explosion:
-      total: 850
-      slope: 8
-      max: 40
+      total: 736
+      slope: 4.25
+      max: 20
     impactEffects:
     - RMCEffectExplosionParticle
     - RMCSmokeExplosionProofSmall


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adjusted yaml.
#10647 but for grenades.
Should only be merged if #10590 is also merged.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
See https://github.com/RMC-14/RMC-14/pull/10647
In addition to the concerns mentioned in the above PR, some of the values my optimizations came out with _do not fit CM's values well_. This is because our falloff is not quite linear (though in a flat, open space it approaches linear on cardinal directions), and CM uses FALLOFF_SHAPE_EXPONENTIAL_HALF and FALLOFF_SHAPE_EXPONENTIAL for some of its grenades. In general, the higher the RMSE value on the diff graphs, the less accurate to parity the proposed values are. Damage values are displayed in relation to xenonids (with their 2x multiplier already applied).
## Technical details
<!-- Summary of code changes for easier review. -->
See https://github.com/RMC-14/RMC-14/pull/10647
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
<img width="600" height="600" alt="rmc_impact_he_old" src="https://github.com/user-attachments/assets/c0bff472-be2c-4551-92e9-2e7e591f328b" />
<img width="600" height="600" alt="rmc_impact_he_new" src="https://github.com/user-attachments/assets/e5113c94-f2f2-4dd2-a089-da0d49e4e8db" />
<img width="600" height="600" alt="cm_impact_he" src="https://github.com/user-attachments/assets/db4e651f-0d13-4792-a797-e3b393ad8f9a" />
<img width="600" height="600" alt="rmc_m12_old" src="https://github.com/user-attachments/assets/fd080e19-6576-4fb4-ba9b-5d3d3d40a3d5" />
<img width="600" height="600" alt="rmc_m12_new" src="https://github.com/user-attachments/assets/c43b880d-807f-46a1-bc4d-a8b575e830d4" />
<img width="600" height="600" alt="cm_m12" src="https://github.com/user-attachments/assets/11cfa013-e9bf-4e3f-b5d2-9271fbd7d537" />
<img width="600" height="600" alt="rmc_m15_old" src="https://github.com/user-attachments/assets/58c3ba75-bf3e-4120-9f8c-49179d0060d3" />
<img width="600" height="600" alt="rmc_m15_new" src="https://github.com/user-attachments/assets/e5487935-0ca6-4ec7-a5cd-721a297ea5de" />
<img width="600" height="600" alt="cm_m15" src="https://github.com/user-attachments/assets/abf6c96e-86b2-42b2-a5ea-3c3291e7a386" />
<img width="600" height="600" alt="rmc_hefa_old" src="https://github.com/user-attachments/assets/618d4233-eb8a-4858-8ec6-109f63b7c4ec" />
<img width="600" height="600" alt="rmc_hefa_new" src="https://github.com/user-attachments/assets/7fe82b24-ad38-4141-844d-8f222eb6dc02" />
<img width="600" height="600" alt="cm_hefa" src="https://github.com/user-attachments/assets/f7a4e464-8e18-41c3-bdce-f49b6c28da9f" />
<img width="600" height="600" alt="rmc_hedp_old" src="https://github.com/user-attachments/assets/7ffdea7d-98c7-4271-b864-fbb49bc7b3b9" />
<img width="600" height="600" alt="rmc_hedp_new" src="https://github.com/user-attachments/assets/9266224d-4847-47e6-ba47-99b1c92567a9" />
<img width="600" height="600" alt="cm_hedp" src="https://github.com/user-attachments/assets/837e794f-d927-4247-9923-e4a2741d0a8d" />

<img width="800" height="800" alt="diff_impact_he" src="https://github.com/user-attachments/assets/c549c7fe-d3f0-4d1e-8581-c40695b097dc" />
<img width="800" height="800" alt="diff_m12" src="https://github.com/user-attachments/assets/d623c3cf-262e-4e7a-ac2a-da728cc67428" />
<img width="800" height="800" alt="diff_m15" src="https://github.com/user-attachments/assets/d62ade53-d5f5-467b-a22b-66a4f8e8a71e" />
<img width="800" height="800" alt="diff_hefa" src="https://github.com/user-attachments/assets/c19dd636-f5e5-450d-9ddd-4a376b1bfaa8" />
<img width="800" height="800" alt="diff_hedp" src="https://github.com/user-attachments/assets/87fd9b7a-a985-46ec-b005-755e83a4be02" />

<img width="800" height="800" alt="delta_impact_he" src="https://github.com/user-attachments/assets/d9384e71-3512-4f7d-8992-f4753d77d43a" />
<img width="800" height="800" alt="delta_m12" src="https://github.com/user-attachments/assets/0085aac7-c908-4387-a234-1b5ef93a23ee" />
<img width="800" height="800" alt="delta_m15" src="https://github.com/user-attachments/assets/9cc52477-efef-4600-a9a7-e8abe2b0ac98" />
<img width="800" height="800" alt="delta_hefa" src="https://github.com/user-attachments/assets/069eec96-c850-428b-927c-5802783df8c3" />
<img width="800" height="800" alt="delta_hedp" src="https://github.com/user-attachments/assets/484aaf2e-b560-4134-87cc-e2522f2e4b5d" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Grenades have been adjusted to use values to produce explosions which more closely resemble their counterparts in parity
