### PR TITLE
[Fix] Scout/Sniper Cloak fix

### DIFF
--- a/Content.Shared/_RMC14/Armor/Ghillie/SharedGhillieSuitSystem.cs
+++ b/Content.Shared/_RMC14/Armor/Ghillie/SharedGhillieSuitSystem.cs
@@ -13,6 +13,9 @@ using Content.Shared.Inventory.Events;
 using Content.Shared._RMC14.Chemistry;
 using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared._RMC14.Armor.ThermalCloak;
+using Content.Shared._RMC14.Fireman;
+using Content.Shared._RMC14.Pulling;
+using Content.Shared.Buckle.Components;
 
 namespace Content.Shared._RMC14.Armor.Ghillie;
 
@@ -27,6 +30,7 @@ public sealed class SharedGhillieSuitSystem : EntitySystem
     [Dependency] private readonly InventorySystem _inventory = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly ThermalCloakSystem _thermalCloak = default!;
+    [Dependency] private readonly RMCPullingSystem _rmcPulling = default!;
 
     public override void Initialize()
     {
@@ -41,6 +45,9 @@ public sealed class SharedGhillieSuitSystem : EntitySystem
 
         SubscribeLocalEvent<RMCPassiveStealthComponent, VaporHitEvent>(OnVaporHit);
         SubscribeLocalEvent<RMCPassiveStealthComponent, MoveInputEvent>(OnMove);
+        SubscribeLocalEvent<RMCPassiveStealthComponent, MoveEvent>(OnGhilliePulledMove);
+        SubscribeLocalEvent<BeingFiremanCarriedComponent, ComponentStartup>(OnGhillieFiremanCarriedStartup);
+        SubscribeLocalEvent<RMCPassiveStealthComponent, BuckledEvent>(OnGhillieBuckled);
 
         SubscribeLocalEvent<GunComponent, GunShotEvent>(OnGunShot);
     }
@@ -222,6 +229,24 @@ public sealed class SharedGhillieSuitSystem : EntitySystem
         }
 
         return null;
+    }
+
+    private void OnGhilliePulledMove(Entity<RMCPassiveStealthComponent> ent, ref MoveEvent args)
+    {
+        if (!_rmcPulling.IsBeingPulled(ent.Owner, out _))
+            return;
+
+        TryToggleInvisibility(ent.Owner, false);
+    }
+
+    private void OnGhillieFiremanCarriedStartup(Entity<BeingFiremanCarriedComponent> ent, ref ComponentStartup args)
+    {
+        TryToggleInvisibility(ent.Owner, false);
+    }
+
+    private void OnGhillieBuckled(Entity<RMCPassiveStealthComponent> ent, ref BuckledEvent args)
+    {
+        TryToggleInvisibility(ent.Owner, false);
     }
 
     private void OnVaporHit(Entity<RMCPassiveStealthComponent> ent, ref VaporHitEvent args)

--- a/Content.Shared/_RMC14/Clothing/ClothingRequireEquippedComponent.cs
+++ b/Content.Shared/_RMC14/Clothing/ClothingRequireEquippedComponent.cs
@@ -15,4 +15,7 @@ public sealed partial class ClothingRequireEquippedComponent : Component
 
     [DataField, AutoNetworkedField]
     public bool AutoUnequip = false;
+
+    [DataField, AutoNetworkedField]
+    public bool HandsValid;
 }

--- a/Content.Shared/_RMC14/Clothing/RMCClothingSystem.cs
+++ b/Content.Shared/_RMC14/Clothing/RMCClothingSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared._RMC14.Explosion;
 using Content.Shared._RMC14.UniformAccessories;
+using Content.Shared.Clothing;
 using Content.Shared.Clothing.Components;
 using Content.Shared.Clothing.EntitySystems;
 using Content.Shared.Hands.EntitySystems;
@@ -36,8 +37,7 @@ public sealed class RMCClothingSystem : EntitySystem
 
         SubscribeLocalEvent<ClothingRequireEquippedComponent, BeingEquippedAttemptEvent>(OnRequireEquippedBeingEquippedAttempt);
 
-        // this is here so clothing with ClothingRequireEquippedComponent can drop when required clothing is unequipped
-        // ex: scout cloak should not stay on when they take off the armor required for it
+        SubscribeLocalEvent<ClothingComponent, ClothingGotUnequippedEvent>(OnClothingGotUnequipped);
         SubscribeLocalEvent<ClothingComponent, DroppedEvent>(OnDropped);
 
         SubscribeLocalEvent<NoClothingSlowdownComponent, ComponentStartup>(OnNoClothingSlowUpdate);
@@ -88,7 +88,7 @@ public sealed class RMCClothingSystem : EntitySystem
         if (args.Cancelled)
             return;
 
-        if (HasEquippedItemsWithinWhitelist(args.EquipTarget, ent.Comp.Whitelist))
+        if (HasEquippedItemsWithinWhitelist(args.EquipTarget, ent.Comp.Whitelist, ent.Comp.HandsValid))
             return;
 
         args.Cancel();
@@ -97,30 +97,46 @@ public sealed class RMCClothingSystem : EntitySystem
         _popup.PopupClient(denyReason, args.EquipTarget, args.EquipTarget, PopupType.SmallCaution);
     }
 
+    private void OnClothingGotUnequipped(Entity<ClothingComponent> ent, ref ClothingGotUnequippedEvent args)
+    {
+        AutoUnequipDependents(ent.Owner, args.Wearer);
+    }
+
     private void OnDropped(Entity<ClothingComponent> ent, ref DroppedEvent args)
     {
-        var slots = _inventory.GetSlotEnumerator(args.User);
+        AutoUnequipDependents(ent.Owner, args.User);
+    }
+
+    private void AutoUnequipDependents(EntityUid item, EntityUid user)
+    {
+        var slots = _inventory.GetSlotEnumerator(user);
         while (slots.MoveNext(out var slot))
         {
             if (slot.ContainedEntity is not { } contained)
                 continue;
 
-            if (TryComp<ClothingRequireEquippedComponent>(contained, out var requiresEquipped) && requiresEquipped.AutoUnequip && _whitelist.IsWhitelistPassOrNull(requiresEquipped.Whitelist, ent.Owner))
-            {
-                if (HasEquippedItemsWithinWhitelist(args.User, requiresEquipped.Whitelist))
-                    continue;
+            if (!TryComp<ClothingRequireEquippedComponent>(contained, out var requiresEquipped) || !requiresEquipped.AutoUnequip)
+                continue;
 
-                _inventory.TryUnequip(args.User, slot.ID);
-            }
+            if (!_whitelist.IsWhitelistPassOrNull(requiresEquipped.Whitelist, item))
+                continue;
+
+            if (HasEquippedItemsWithinWhitelist(user, requiresEquipped.Whitelist, requiresEquipped.HandsValid))
+                continue;
+
+            _inventory.TryUnequip(user, slot.ID);
         }
     }
 
-    private bool HasEquippedItemsWithinWhitelist(EntityUid uid, EntityWhitelist? whitelist)
+    private bool HasEquippedItemsWithinWhitelist(EntityUid uid, EntityWhitelist? whitelist, bool handsValid = false)
     {
-        foreach (var held in _hands.EnumerateHeld(uid))
+        if (handsValid)
         {
-            if (_whitelist.IsWhitelistPassOrNull(whitelist, held))
-                return true;
+            foreach (var held in _hands.EnumerateHeld(uid))
+            {
+                if (_whitelist.IsWhitelistPassOrNull(whitelist, held))
+                    return true;
+            }
         }
 
         var slots = _inventory.GetSlotEnumerator(uid);

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Back/scabbards.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Back/scabbards.yml
@@ -186,6 +186,7 @@
     - back
   - type: ClothingIgnoreBlockBackpack
   - type: ClothingRequireEquipped
+    handsValid: true
     whitelist:
       components:
       - SmartGun

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Eyes/glasses.yml
@@ -153,6 +153,7 @@
       RMCSkillSmartGun: 1
     defaultState: half
   - type: ClothingRequireEquipped
+    handsValid: true
     whitelist:
       components:
       - SmartGun


### PR DESCRIPTION
## About the PR
Fixes Scout cloak not turning off or unequipping when taking of armor.
Fixes Pull/Move/Buck interactions with Snipers Ghillie while cloaked
Adds new field for ClothingRequireEquipped to toggle if hands slots are valid for whitelist checks.
Gave it to SmartGunner so functionally nothing changes as handsValid defaults to false.

## Why / Balance
Fixes. 

## Technical details
Yaml and subscribes to more events in the respective cloak/ghillie systems.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl: Thereisabear
- fix: Fixed Scout's Thermal Cloak not turning off and dropping when armor is unequipped.
- fix: Fixed Sniper's Ghillie not breaking on being moved or buckled. 