### PR TITLE
Add listen only mode for handheld radios

### DIFF
--- a/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
@@ -5,6 +5,7 @@ using Content.Server.Popups;
 using Content.Server.Power.Components;
 using Content.Server.Power.EntitySystems;
 using Content.Server.Radio.Components;
+using Content.Server._RMC14.Radio;
 using Content.Server.Speech;
 using Content.Server.Speech.Components;
 using Content.Shared._RMC14.Xenonids;
@@ -126,6 +127,30 @@ public sealed class RadioDeviceSystem : EntitySystem
         if (component.PowerRequired && !this.IsPowered(uid, EntityManager))
             return;
 
+        // RMC14
+        if (TryComp(uid, out RMCRadioListenOnlyModeComponent? comp))
+        {
+            if (!comp.Enabled && component.Enabled)
+            {
+                comp.Enabled = true;
+                EnsureComp<BlockListeningComponent>(uid);
+
+                if (user != null)
+                {
+                    var state = Loc.GetString("handheld-radio-component-listen-only-state");
+                    var message = Loc.GetString("handheld-radio-component-on-use", ("radioState", state));
+                    _popup.PopupEntity(message, user.Value, user.Value);
+                }
+
+                return;
+            }
+            else if (comp.Enabled && component.Enabled)
+            {
+                comp.Enabled = false;
+                RemCompDeferred<BlockListeningComponent>(uid);
+            }
+        }
+
         component.Enabled = enabled;
 
         if (!quiet && user != null)
@@ -153,6 +178,10 @@ public sealed class RadioDeviceSystem : EntitySystem
     public void SetSpeakerEnabled(EntityUid uid, EntityUid? user, bool enabled, bool quiet = false, RadioSpeakerComponent? component = null)
     {
         if (!Resolve(uid, ref component))
+            return;
+
+        // RMC14
+        if (TryComp(uid, out RMCRadioListenOnlyModeComponent? comp) && comp.Enabled && component.Enabled)
             return;
 
         component.Enabled = enabled;

--- a/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
@@ -214,6 +214,16 @@ public sealed class RadioDeviceSystem : EntitySystem
             args.PushMarkup(Loc.GetString("handheld-radio-component-on-examine", ("frequency", proto.Frequency)));
             args.PushMarkup(Loc.GetString("handheld-radio-component-chennel-examine",
                 ("channel", proto.LocalizedName)));
+
+            if (component.ToggleOnInteract)
+            {
+                var state = Loc.GetString(component.Enabled ? "handheld-radio-component-on-state" : "handheld-radio-component-off-state");
+
+                if (TryComp(uid, out RMCRadioListenOnlyModeComponent? comp) && comp.Enabled)
+                    state = Loc.GetString("handheld-radio-component-listen-only-state");
+
+                args.PushMarkup(Loc.GetString("handheld-radio-component-state-examine", ("radioState", state)));
+            }
         }
     }
 

--- a/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
@@ -109,6 +109,24 @@ public sealed class RadioDeviceSystem : EntitySystem
         if (!Resolve(uid, ref component))
             return;
 
+        // RMC14
+        if (TryComp(uid, out RMCRadioListenOnlyModeComponent? comp))
+        {
+            if (!comp.Enabled && component.Enabled)
+            {
+                comp.Enabled = true;
+                EnsureComp<BlockListeningComponent>(uid);
+
+                var state = Loc.GetString("handheld-radio-component-listen-only-state");
+                var message = Loc.GetString("handheld-radio-component-on-use", ("radioState", state));
+                _popup.PopupEntity(message, user, user);
+
+                _appearance.SetData(uid, RadioDeviceVisuals.Broadcasting, !comp.Enabled);
+
+                return;
+            }
+        }
+
         SetMicrophoneEnabled(uid, user, !component.Enabled, quiet, component);
     }
 
@@ -127,30 +145,6 @@ public sealed class RadioDeviceSystem : EntitySystem
         if (component.PowerRequired && !this.IsPowered(uid, EntityManager))
             return;
 
-        // RMC14
-        if (TryComp(uid, out RMCRadioListenOnlyModeComponent? comp))
-        {
-            if (!comp.Enabled && component.Enabled)
-            {
-                comp.Enabled = true;
-                EnsureComp<BlockListeningComponent>(uid);
-
-                if (user != null)
-                {
-                    var state = Loc.GetString("handheld-radio-component-listen-only-state");
-                    var message = Loc.GetString("handheld-radio-component-on-use", ("radioState", state));
-                    _popup.PopupEntity(message, user.Value, user.Value);
-                }
-
-                return;
-            }
-            else if (comp.Enabled && component.Enabled)
-            {
-                comp.Enabled = false;
-                RemCompDeferred<BlockListeningComponent>(uid);
-            }
-        }
-
         component.Enabled = enabled;
 
         if (!quiet && user != null)
@@ -158,6 +152,13 @@ public sealed class RadioDeviceSystem : EntitySystem
             var state = Loc.GetString(component.Enabled ? "handheld-radio-component-on-state" : "handheld-radio-component-off-state");
             var message = Loc.GetString("handheld-radio-component-on-use", ("radioState", state));
             _popup.PopupEntity(message, user.Value, user.Value);
+        }
+
+        // RMC14
+        if (TryComp(uid, out RMCRadioListenOnlyModeComponent? comp) && comp.Enabled && !enabled)
+        {
+            comp.Enabled = false;
+            RemCompDeferred<BlockListeningComponent>(uid);
         }
 
         _appearance.SetData(uid, RadioDeviceVisuals.Broadcasting, component.Enabled);
@@ -172,16 +173,16 @@ public sealed class RadioDeviceSystem : EntitySystem
         if (!Resolve(uid, ref component))
             return;
 
+        // RMC14
+        if (TryComp(uid, out RMCRadioListenOnlyModeComponent? comp) && comp.Enabled && component.Enabled)
+            return;
+
         SetSpeakerEnabled(uid, user, !component.Enabled, quiet, component);
     }
 
     public void SetSpeakerEnabled(EntityUid uid, EntityUid? user, bool enabled, bool quiet = false, RadioSpeakerComponent? component = null)
     {
         if (!Resolve(uid, ref component))
-            return;
-
-        // RMC14
-        if (TryComp(uid, out RMCRadioListenOnlyModeComponent? comp) && comp.Enabled && component.Enabled)
             return;
 
         component.Enabled = enabled;

--- a/Content.Server/_RMC14/Radio/RMCRadioListenOnlyModeComponent.cs
+++ b/Content.Server/_RMC14/Radio/RMCRadioListenOnlyModeComponent.cs
@@ -1,0 +1,11 @@
+using Content.Server.Radio.EntitySystems;
+
+namespace Content.Server._RMC14.Radio;
+
+[RegisterComponent]
+[Access(typeof(RadioDeviceSystem))]
+public sealed partial class RMCRadioListenOnlyModeComponent : Component
+{
+    [DataField]
+    public bool Enabled = false;
+}

--- a/Resources/Locale/en-US/radio/components/handheld-radio-component.ftl
+++ b/Resources/Locale/en-US/radio/components/handheld-radio-component.ftl
@@ -1,5 +1,6 @@
 handheld-radio-component-on-use = The radio is now {$radioState}.
 handheld-radio-component-on-examine = It's set to broadcast over the {$frequency} frequency.
+handheld-radio-component-state-examine = Radio is currently {$radioState}.
 handheld-radio-component-on-state = on
 handheld-radio-component-off-state = off
 handheld-radio-component-listen-only-state = listen only

--- a/Resources/Locale/en-US/radio/components/handheld-radio-component.ftl
+++ b/Resources/Locale/en-US/radio/components/handheld-radio-component.ftl
@@ -2,5 +2,6 @@ handheld-radio-component-on-use = The radio is now {$radioState}.
 handheld-radio-component-on-examine = It's set to broadcast over the {$frequency} frequency.
 handheld-radio-component-on-state = on
 handheld-radio-component-off-state = off
+handheld-radio-component-listen-only-state = listen only
 handheld-radio-component-channel-set = Channel set to {$channel}
 handheld-radio-component-chennel-examine = The current channel is {$channel}.

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Devices/Electronics/radio.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Devices/Electronics/radio.yml
@@ -24,6 +24,7 @@
     tags:
     - Radio
   - type: ChatRepeatIgnoreSender # RMC14
+  - type: RMCRadioListenOnlyMode # RMC14
   - type: InteractedBlacklist
     blacklist:
       components:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Devices/radio.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Devices/radio.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   abstract: true
   parent: RadioHandheld
   id: RMCRadioHandheldColonyBase
@@ -23,6 +23,7 @@
     materialComposition:
       CMSteel: 75
       CMGlass: 25
+  - type: RMCRadioListenOnlyMode
 
 - type: entity
   parent: RMCRadioHandheldColonyBase


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds listen only mode for handheld radios, activated by cycling through radio states ( on/listenonly/off )
Also examine text shows current radio state now

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Resolves #10628
QOL, makes survs and reporters life a tiny bit easier

## Technical details
<!-- Summary of code changes for easier review. -->
Added RMCRadioListenOnlyModeComponent that implements listen only mode for radios
Modified yml for RMCRadioHandheldColonyBase and CMRadioHandheld to support listen only mode

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

https://github.com/user-attachments/assets/3cf1cf15-f067-4b78-a62d-26bb6195cc76


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Handheld radios can be now switched to listen-only mode.
