### PR TITLE
Release hosts

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestComponent.cs
@@ -11,4 +11,7 @@ public sealed partial class XenoNestComponent : Component
 
     [DataField, AutoNetworkedField]
     public EntityUid? Nested;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan UnnestDelay = TimeSpan.FromSeconds(3);
 }

--- a/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestSystem.cs
@@ -16,6 +16,7 @@ using Content.Shared.DoAfter;
 using Content.Shared.DragDrop;
 using Content.Shared.Ghost;
 using Content.Shared.Hands.Components;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Inventory.Events;
@@ -178,7 +179,10 @@ public sealed class XenoNestSystem : EntitySystem
         };
 
         if (_doAfter.TryStartDoAfter(doAfter))
-            _popup.PopupClient(Loc.GetString("rmc-xeno-nest-unnest-start", ("target", nested)), user, user);
+        {
+            var message = Loc.GetString("rmc-xeno-nest-unnest-start", ("target", Identity.Name(nested, EntityManager, user)));
+            _popup.PopupClient(message, user, user);
+        }
 
         return true;
     }

--- a/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestSystem.cs
@@ -31,6 +31,7 @@ using Content.Shared.Popups;
 using Content.Shared.Standing;
 using Content.Shared.Stunnable;
 using Content.Shared.Throwing;
+using Content.Shared.Verbs;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Network;
@@ -67,6 +68,8 @@ public sealed class XenoNestSystem : EntitySystem
     private EntityQuery<XenoNestSurfaceComponent> _xenoNestSurfaceQuery;
     private EntityQuery<XenoWeedableComponent> _xenoWeedableQuery;
 
+    private static readonly TimeSpan UnnestDoAfterDelay = TimeSpan.FromSeconds(3);
+
     public override void Initialize()
     {
         base.Initialize();
@@ -89,6 +92,8 @@ public sealed class XenoNestSystem : EntitySystem
 
         SubscribeLocalEvent<XenoNestComponent, ComponentRemove>(OnNestRemove);
         SubscribeLocalEvent<XenoNestComponent, EntityTerminatingEvent>(OnNestTerminating);
+        SubscribeLocalEvent<XenoNestComponent, GetVerbsEvent<InteractionVerb>>(OnNestGetVerbs);
+        SubscribeLocalEvent<XenoNestComponent, XenoUnnestDoAfterEvent>(OnUnnestDoAfter);
 
         SubscribeLocalEvent<XenoNestableComponent, BeforeRangedInteractEvent>(OnNestableBeforeRangedInteract);
         SubscribeLocalEvent<XenoNestableComponent, ShouldHandleVirtualItemInteractEvent>(OnNestableShouldHandle);
@@ -140,6 +145,61 @@ public sealed class XenoNestSystem : EntitySystem
     private void OnNestTerminating(Entity<XenoNestComponent> ent, ref EntityTerminatingEvent args)
     {
         DetachNested(ent, ent.Comp.Nested);
+    }
+
+    private void OnNestGetVerbs(Entity<XenoNestComponent> ent, ref GetVerbsEvent<InteractionVerb> args)
+    {
+        if (!args.CanAccess || !args.CanInteract)
+            return;
+
+        if (ent.Comp.Nested is null)
+            return;
+
+        if (!HasComp<XenoComponent>(args.User) || !_hive.FromSameHive(ent.Owner, args.User))
+            return;
+
+        var user = args.User;
+        var nest = ent.Owner;
+        args.Verbs.Add(new InteractionVerb
+        {
+            Text = Loc.GetString("rmc-xeno-nest-unnest-verb"),
+            Act = () => TryStartUnnest(user, nest),
+        });
+    }
+
+    public bool TryStartUnnest(EntityUid user, Entity<XenoNestComponent?> nest)
+    {
+        if (!Resolve(nest, ref nest.Comp, false) || nest.Comp.Nested is not { } nested)
+            return false;
+
+        var ev = new XenoUnnestDoAfterEvent();
+        var doAfter = new DoAfterArgs(EntityManager, user, UnnestDoAfterDelay, ev, nest.Owner, nest.Owner)
+        {
+            BreakOnMove = true,
+            BreakOnDamage = true,
+        };
+
+        if (_doAfter.TryStartDoAfter(doAfter))
+            _popup.PopupClient(Loc.GetString("rmc-xeno-nest-unnest-start", ("target", nested)), user, user);
+
+        return true;
+    }
+
+    private void OnUnnestDoAfter(Entity<XenoNestComponent> ent, ref XenoUnnestDoAfterEvent args)
+    {
+        if (args.Cancelled || args.Handled)
+            return;
+
+        if (ent.Comp.Nested is not { } nested)
+            return;
+
+        args.Handled = true;
+
+        if (_net.IsClient)
+            return;
+
+        DetachNested(ent.Owner, nested);
+        _adminLog.Add(LogType.RMCXenoNest, $"{ToPrettyString(args.User):user} released {ToPrettyString(nested):victim} from nest {ToPrettyString(ent.Owner):nest}");
     }
 
     private void OnNestableBeforeRangedInteract(Entity<XenoNestableComponent> ent, ref BeforeRangedInteractEvent args)

--- a/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestSystem.cs
@@ -68,8 +68,6 @@ public sealed class XenoNestSystem : EntitySystem
     private EntityQuery<XenoNestSurfaceComponent> _xenoNestSurfaceQuery;
     private EntityQuery<XenoWeedableComponent> _xenoWeedableQuery;
 
-    private static readonly TimeSpan UnnestDoAfterDelay = TimeSpan.FromSeconds(3);
-
     public override void Initialize()
     {
         base.Initialize();
@@ -173,7 +171,7 @@ public sealed class XenoNestSystem : EntitySystem
             return false;
 
         var ev = new XenoUnnestDoAfterEvent();
-        var doAfter = new DoAfterArgs(EntityManager, user, UnnestDoAfterDelay, ev, nest.Owner, nest.Owner)
+        var doAfter = new DoAfterArgs(EntityManager, user, nest.Comp.UnnestDelay, ev, nest.Owner, nest.Owner)
         {
             BreakOnMove = true,
             BreakOnDamage = true,

--- a/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoUnnestDoAfterEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoUnnestDoAfterEvent.cs
@@ -1,0 +1,7 @@
+using Content.Shared.DoAfter;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Xenonids.Construction.Nest;
+
+[Serializable, NetSerializable]
+public sealed partial class XenoUnnestDoAfterEvent : SimpleDoAfterEvent;

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-nest.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-nest.ftl
@@ -11,3 +11,6 @@ cm-xeno-nest-failed-target-resisting = {$target} is resisting, ground them!
 cm-xeno-nest-failed-cant-there = We can't create a nest there!
 cm-xeno-nest-failed-cant-already-there = There is already someone nested there!
 rmc-xeno-nest-failed-dead = This host is dead.
+
+rmc-xeno-nest-unnest-verb = Release host
+rmc-xeno-nest-unnest-start = We begin working {$target} free from the nest...


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Adds a "Release host" verb to xeno nests, letting hive members free a nested host early (with a short do-after).

This is split off from #10611 (Hive Permissions) at maintainer request -- that PR will add the Queen-configurable "who can unnest" permission on top of this once it's ready.

Closes https://github.com/RMC-14/RMC-14/issues/2993

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Xenos can now release a hosts from their nest early via the "Release host" verb.