### PR TITLE
Make explosions do half damage to prone targets + add more checks for xeno rest

### DIFF
--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
@@ -461,23 +461,28 @@ public sealed partial class ExplosionSystem
             GetEntitiesToDamage(uid, originalDamage, id);
             foreach (var (entity, damage) in _toDamage)
             {
-                if (damage.GetTotal() > 0 && TryComp<ActorComponent>(entity, out var actorComponent))
+                // TODO EXPLOSIONS turn explosions into entities, and pass the the entity in as the damage origin.
+                // RMC14
+                var bev = new BeforeExplosionRecievedEvent(id, epicenter, damage);
+                RaiseLocalEvent(entity, ref bev);
+                var finalDamage = bev.Damage;
+                // RMC14
+
+                if (finalDamage.GetTotal() > 0 && TryComp<ActorComponent>(entity, out var actorComponent))
                 {
                     // Log damage to player entities only, cause this will create a massive amount of log spam otherwise.
                     if (cause != null)
                     {
-                        _adminLogger.Add(LogType.ExplosionHit, LogImpact.Medium, $"Explosion of {ToPrettyString(cause):actor} dealt {damage.GetTotal()} damage to {ToPrettyString(entity):subject}");
+                        _adminLogger.Add(LogType.ExplosionHit, LogImpact.Medium, $"Explosion of {ToPrettyString(cause):actor} dealt {finalDamage.GetTotal()} damage to {ToPrettyString(entity):subject}");
                     }
                     else
                     {
-                        _adminLogger.Add(LogType.ExplosionHit, LogImpact.Medium, $"Explosion at {epicenter:epicenter} dealt {damage.GetTotal()} damage to {ToPrettyString(entity):subject}");
+                        _adminLogger.Add(LogType.ExplosionHit, LogImpact.Medium, $"Explosion at {epicenter:epicenter} dealt {finalDamage.GetTotal()} damage to {ToPrettyString(entity):subject}");
                     }
 
                 }
-
-                // TODO EXPLOSIONS turn explosions into entities, and pass the the entity in as the damage origin.
-                _damageableSystem.TryChangeDamage(entity, damage * _damageableSystem.UniversalExplosionDamageModifier, ignoreResistances: true);
-                var ev = new ExplosionReceivedEvent(id, epicenter, damage);
+                _damageableSystem.TryChangeDamage(entity, finalDamage * _damageableSystem.UniversalExplosionDamageModifier, ignoreResistances: true);
+                var ev = new ExplosionReceivedEvent(id, epicenter, finalDamage);
                 RaiseLocalEvent(entity, ref ev);
             }
         }

--- a/Content.Shared/_RMC14/Explosion/RMCProneExplosionMultComponent.cs
+++ b/Content.Shared/_RMC14/Explosion/RMCProneExplosionMultComponent.cs
@@ -23,6 +23,6 @@ public sealed partial class RMCProneExplosionMultComponent : Component
 /// <param name="Explosion"></param>
 /// <param name="Epicenter"></param>
 /// <param name="Damage"></param>
-/// <param name="HasDirection">Overrides epicenter range checks if set to true or false.</param>
+/// <param name="HasDirectionOverride">Overrides epicenter checks. True = not at epicenter, False = at epicenter.</param>
 [ByRefEvent]
-public record struct BeforeExplosionRecievedEvent(ProtoId<ExplosionPrototype> Explosion, MapCoordinates Epicenter, DamageSpecifier Damage, bool? HasDirection = null);
+public record struct BeforeExplosionRecievedEvent(ProtoId<ExplosionPrototype> Explosion, MapCoordinates Epicenter, DamageSpecifier Damage, bool? HasDirectionOverride = null);

--- a/Content.Shared/_RMC14/Explosion/RMCProneExplosionMultComponent.cs
+++ b/Content.Shared/_RMC14/Explosion/RMCProneExplosionMultComponent.cs
@@ -23,5 +23,6 @@ public sealed partial class RMCProneExplosionMultComponent : Component
 /// <param name="Explosion"></param>
 /// <param name="Epicenter"></param>
 /// <param name="Damage"></param>
+/// <param name="HasDirection">Overrides epicenter range checks if set to true or false.</param>
 [ByRefEvent]
-public record struct BeforeExplosionRecievedEvent(ProtoId<ExplosionPrototype> Explosion, MapCoordinates Epicenter, DamageSpecifier Damage);
+public record struct BeforeExplosionRecievedEvent(ProtoId<ExplosionPrototype> Explosion, MapCoordinates Epicenter, DamageSpecifier Damage, bool? HasDirection = null);

--- a/Content.Shared/_RMC14/Explosion/RMCProneExplosionMultComponent.cs
+++ b/Content.Shared/_RMC14/Explosion/RMCProneExplosionMultComponent.cs
@@ -1,0 +1,27 @@
+using Content.Shared.Damage;
+using Content.Shared.Explosion;
+using Robust.Shared.GameStates;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._RMC14.Explosion;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(SharedRMCExplosionSystem))]
+public sealed partial class RMCProneExplosionMultComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public float ProneMultiplier = 0.5f;
+
+    [DataField, AutoNetworkedField]
+    public float NoMultCenterRadius = 0.5f;
+}
+
+/// <summary>
+/// Raise right before ExplosionRecievedEvent, containing resistance modified damage, meant to modify damage right before it happens.
+/// </summary>
+/// <param name="Explosion"></param>
+/// <param name="Epicenter"></param>
+/// <param name="Damage"></param>
+[ByRefEvent]
+public record struct BeforeExplosionRecievedEvent(ProtoId<ExplosionPrototype> Explosion, MapCoordinates Epicenter, DamageSpecifier Damage);

--- a/Content.Shared/_RMC14/Explosion/SharedRMCExplosionSystem.cs
+++ b/Content.Shared/_RMC14/Explosion/SharedRMCExplosionSystem.cs
@@ -253,13 +253,13 @@ public abstract class SharedRMCExplosionSystem : EntitySystem
 
     private void OnProneMultBeforeExplosionReceived(Entity<RMCProneExplosionMultComponent> ent, ref BeforeExplosionRecievedEvent args)
     {
-        if (args.HasDirection == null)
+        if (args.HasDirectionOverride == null)
         {
             var distance = (_transform.ToMapCoordinates(ent.Owner.ToCoordinates()).Position - args.Epicenter.Position).Length();
             if (distance <= ent.Comp.NoMultCenterRadius || (!_standing.IsDown(ent) && !HasComp<XenoRestingComponent>(ent)))
                 return;
         }
-        else if (!args.HasDirection.Value)
+        else if (!args.HasDirectionOverride.Value)
             return;
 
         args.Damage *= ent.Comp.ProneMultiplier;

--- a/Content.Shared/_RMC14/Explosion/SharedRMCExplosionSystem.cs
+++ b/Content.Shared/_RMC14/Explosion/SharedRMCExplosionSystem.cs
@@ -253,8 +253,13 @@ public abstract class SharedRMCExplosionSystem : EntitySystem
 
     private void OnProneMultBeforeExplosionReceived(Entity<RMCProneExplosionMultComponent> ent, ref BeforeExplosionRecievedEvent args)
     {
-        var distance = (_transform.ToMapCoordinates(ent.Owner.ToCoordinates()).Position - args.Epicenter.Position).Length();
-        if (distance <= ent.Comp.NoMultCenterRadius || (!_standing.IsDown(ent) && !HasComp<XenoRestingComponent>(ent)))
+        if (args.HasDirection == null)
+        {
+            var distance = (_transform.ToMapCoordinates(ent.Owner.ToCoordinates()).Position - args.Epicenter.Position).Length();
+            if (distance <= ent.Comp.NoMultCenterRadius || (!_standing.IsDown(ent) && !HasComp<XenoRestingComponent>(ent)))
+                return;
+        }
+        else if (!args.HasDirection.Value)
             return;
 
         args.Damage *= ent.Comp.ProneMultiplier;

--- a/Content.Shared/_RMC14/Explosion/SharedRMCExplosionSystem.cs
+++ b/Content.Shared/_RMC14/Explosion/SharedRMCExplosionSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared._RMC14.Slow;
 using Content.Shared._RMC14.Stun;
 using Content.Shared._RMC14.Xenonids.Acid;
 using Content.Shared._RMC14.Xenonids.Construction.Nest;
+using Content.Shared._RMC14.Xenonids.Rest;
 using Content.Shared.Body.Systems;
 using Content.Shared.Coordinates;
 using Content.Shared.Damage.Prototypes;
@@ -66,6 +67,8 @@ public abstract class SharedRMCExplosionSystem : EntitySystem
         SubscribeLocalEvent<DestroyedByExplosionComponent, ExplosionReceivedEvent>(OnDestroyedByExplosionReceived);
 
         SubscribeLocalEvent<MobGibbedByExplosionTypeComponent, ExplosionReceivedEvent>(OnMobGibbedByExplosionReceived);
+
+        SubscribeLocalEvent<RMCProneExplosionMultComponent, BeforeExplosionRecievedEvent>(OnProneMultBeforeExplosionReceived);
     }
 
     private void OnExplosionEffectTriggered(Entity<CMExplosionEffectComponent> ent, ref CMExplosiveTriggeredEvent args)
@@ -112,10 +115,6 @@ public abstract class SharedRMCExplosionSystem : EntitySystem
         var damage = args.Damage.GetTotal();
         var factor = Math.Round(damage.Double() * 0.05) / 2;
         factor = Math.Min(20, factor);
-
-        // TODO RMC14 don't reduce if explosion is on same tile
-        if (_standing.IsDown(ent))
-            factor *= 0.5;
 
         _sizeStun.TryGetSize(ent, out var size);
 
@@ -250,6 +249,15 @@ public abstract class SharedRMCExplosionSystem : EntitySystem
 
         if (!TerminatingOrDeleted(ent))
             _body.GibBody(ent, true);
+    }
+
+    private void OnProneMultBeforeExplosionReceived(Entity<RMCProneExplosionMultComponent> ent, ref BeforeExplosionRecievedEvent args)
+    {
+        var distance = (_transform.ToMapCoordinates(ent.Owner.ToCoordinates()).Position - args.Epicenter.Position).Length();
+        if (distance <= ent.Comp.NoMultCenterRadius || (!_standing.IsDown(ent) && !HasComp<XenoRestingComponent>(ent)))
+            return;
+
+        args.Damage *= ent.Comp.ProneMultiplier;
     }
 
     public void DoEffect(Entity<CMExplosionEffectComponent> ent)

--- a/Content.Shared/_RMC14/OnCollide/SharedOnCollideSystem.cs
+++ b/Content.Shared/_RMC14/OnCollide/SharedOnCollideSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared._RMC14.Xenonids;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Projectile;
 using Content.Shared._RMC14.Xenonids.Projectile.Spit;
+using Content.Shared._RMC14.Xenonids.Rest;
 using Content.Shared.Damage;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Standing;
@@ -113,7 +114,7 @@ public abstract class SharedOnCollideSystem : EntitySystem
 
         _xenoSpit.SetAcidCombo(other, ent.Comp.AcidComboDuration, ent.Comp.AcidComboDamage, ent.Comp.AcidComboParalyze, ent.Comp.AcidComboResists);
 
-        if (ent.Comp.Paralyze > TimeSpan.Zero && !_standing.IsDown(other) && (!_size.TryGetSize(other, out var size) || size < RMCSizes.Big))
+        if (ent.Comp.Paralyze > TimeSpan.Zero && !_standing.IsDown(other) && !HasComp<XenoRestingComponent>(ent) && (!_size.TryGetSize(other, out var size) || size < RMCSizes.Big))
         {
             _stun.TryParalyze(other, ent.Comp.Paralyze, true);
 

--- a/Content.Shared/_RMC14/Standing/RMCRestComponent.cs
+++ b/Content.Shared/_RMC14/Standing/RMCRestComponent.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.GameStates;
+using Robust.Shared.GameStates;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared._RMC14.Standing;

--- a/Content.Shared/_RMC14/Stun/RMCSizeStunSystem.cs
+++ b/Content.Shared/_RMC14/Stun/RMCSizeStunSystem.cs
@@ -1,14 +1,15 @@
-using System.Numerics;
 using Content.Shared._RMC14.Deafness;
 using Content.Shared._RMC14.Explosion;
 using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.Pulling;
 using Content.Shared._RMC14.Slow;
 using Content.Shared._RMC14.Stamina;
+using Content.Shared._RMC14.Xenonids.Rest;
 using Content.Shared.Coordinates;
 using Content.Shared.Eye.Blinding.Components;
 using Content.Shared.Flash;
 using Content.Shared.Interaction;
+using Content.Shared.Pointing;
 using Content.Shared.Popups;
 using Content.Shared.Projectiles;
 using Content.Shared.Speech.Muting;
@@ -19,13 +20,13 @@ using Content.Shared.Throwing;
 using Content.Shared.Whitelist;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
-using Content.Shared.Pointing;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
+using System.Numerics;
 
 namespace Content.Shared._RMC14.Stun;
 
@@ -124,7 +125,7 @@ public sealed class RMCSizeStunSystem : EntitySystem
                 continue;
 
             var distance = (_transform.GetMoverCoordinates(args.Target).Position - bullet.Comp.ShotFrom.Value.Position).Length();
-            if (distance > stun.MaxRange || _stand.IsDown(args.Target))
+            if (distance > stun.MaxRange || _stand.IsDown(args.Target) || HasComp<XenoRestingComponent>(args.Target))
                 return;
 
             if (!TryComp<RMCSizeComponent>(args.Target, out var size))

--- a/Content.Shared/_RMC14/Vehicle/Grid/GridVehicleMoveSystem.Collision.cs
+++ b/Content.Shared/_RMC14/Vehicle/Grid/GridVehicleMoveSystem.Collision.cs
@@ -20,6 +20,7 @@ using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Dynamics;
 using Robust.Shared.Collections;
+using Content.Shared._RMC14.Xenonids.Rest;
 
 namespace Content.Shared._RMC14.Vehicle;
 
@@ -161,7 +162,7 @@ public sealed partial class GridVehicleMoverSystem : EntitySystem
 
             if (candidate.CollisionClass == VehicleCollisionClass.SoftMob &&
                 candidate.MobState != null &&
-                _standing.IsDown(candidate.Entity))
+                (_standing.IsDown(candidate.Entity) || HasComp<XenoRestingComponent>(candidate.Entity)))
             {
                 continue;
             }
@@ -961,7 +962,7 @@ public sealed partial class GridVehicleMoverSystem : EntitySystem
         if (!ShouldPredictVehicleInteractions(vehicle))
             return;
 
-        if (_mobState.IsDead(mob, mobState) || _standing.IsDown(mob))
+        if (_mobState.IsDead(mob, mobState) || _standing.IsDown(mob) || HasComp<XenoRestingComponent>(mob))
             return;
 
         if (TryComp(vehicle, out GridVehicleMoverComponent? vehicleMover) &&

--- a/Content.Shared/_RMC14/Weapons/Ranged/CMGunSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/CMGunSystem.cs
@@ -52,6 +52,7 @@ using Robust.Shared.Random;
 using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
+using Content.Shared._RMC14.Xenonids.Rest;
 
 namespace Content.Shared._RMC14.Weapons.Ranged;
 
@@ -501,7 +502,7 @@ public sealed class CMGunSystem : EntitySystem
                 continue;
             }
 
-            if (_standing.IsDown(gunComp.Target.Value))
+            if (_standing.IsDown(gunComp.Target.Value) || HasComp<XenoRestingComponent>(gunComp.Target.Value))
             {
                 projectileComp.Damage *= gun.Comp.ProneDamageMult;
                 Dirty(projectile, projectileComp);

--- a/Content.Shared/_RMC14/Xenonids/Construction/AcidPillar/AcidPillarSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/AcidPillar/AcidPillarSystem.cs
@@ -1,7 +1,8 @@
-﻿using Content.Shared._RMC14.Animations;
+using Content.Shared._RMC14.Animations;
 using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.Xenonids.Construction.Nest;
 using Content.Shared._RMC14.Xenonids.Hive;
+using Content.Shared._RMC14.Xenonids.Rest;
 using Content.Shared._RMC14.Xenonids.Spray;
 using Content.Shared.Atmos.Components;
 using Content.Shared.Mobs.Systems;
@@ -42,6 +43,7 @@ public sealed class AcidPillarSystem : EntitySystem
 
         return !_mobState.IsIncapacitated(target) &&
                !_standingState.IsDown(target) &&
+               !HasComp<XenoRestingComponent>(target) &&
                !HasComp<StunnedComponent>(target);
     }
 

--- a/Content.Shared/_RMC14/Xenonids/Dislocate/XenoDislocateSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Dislocate/XenoDislocateSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared._RMC14.Slow;
 using Content.Shared._RMC14.Stun;
 using Content.Shared._RMC14.Weapons.Melee;
 using Content.Shared._RMC14.Xenonids.Abduct;
+using Content.Shared._RMC14.Xenonids.Rest;
 using Content.Shared._RMC14.Xenonids.Tail_Lash;
 using Content.Shared.Actions;
 using Content.Shared.Coordinates;
@@ -63,7 +64,8 @@ public sealed class XenoDislocateSystem : EntitySystem
                          HasComp<RMCSuperSlowdownComponent>(targetId) ||
                          HasComp<RMCRootedComponent>(targetId) ||
                          HasComp<StunnedComponent>(targetId) ||
-                         _standing.IsDown(targetId);
+                         _standing.IsDown(targetId) ||
+                         HasComp<XenoRestingComponent>(targetId);
 
         var damage = _damageable.TryChangeDamage(targetId, xeno.Comp.Damage, ignoreResistances: isDebuffed, origin: xeno, tool: xeno);
         if (damage?.GetTotal() > FixedPoint2.Zero)

--- a/Content.Shared/_RMC14/Xenonids/Dodge/SharedXenoDodgeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Dodge/SharedXenoDodgeSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared._RMC14.Actions;
+using Content.Shared._RMC14.Xenonids.Rest;
 using Content.Shared._RMC14.Xenonids.SwiftSteps;
 using Content.Shared.Actions;
 using Content.Shared.Mobs.Components;
@@ -120,7 +121,7 @@ public abstract class SharedXenoDodgeSystem : EntitySystem
             bool crowd = false;
             foreach (var mob in _crowd)
             {
-                if (_xeno.CanAbilityAttackTarget(uid, mob) && !_standing.IsDown(mob))
+                if (_xeno.CanAbilityAttackTarget(uid, mob) && !_standing.IsDown(mob) && !HasComp<XenoRestingComponent>(mob))
                 {
                     crowd = true;
                     break;

--- a/Content.Shared/_RMC14/Xenonids/Energy/XenoEnergySystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Energy/XenoEnergySystem.cs
@@ -10,6 +10,7 @@ using Content.Shared.Rejuvenate;
 using Content.Shared.Standing;
 using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.Timing;
+using Content.Shared._RMC14.Xenonids.Rest;
 
 namespace Content.Shared._RMC14.Xenonids.Energy;
 
@@ -68,7 +69,7 @@ public sealed class XenoEnergySystem : EntitySystem
                 return;
 
             isHit = true;
-            if (_stand.IsDown(hit))
+            if (_stand.IsDown(hit) || HasComp<XenoRestingComponent>(hit))
                 isDown = true;
             break;
         }

--- a/Content.Shared/_RMC14/Xenonids/Leap/XenoLeapSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Leap/XenoLeapSystem.cs
@@ -16,6 +16,7 @@ using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Invisibility;
 using Content.Shared._RMC14.Xenonids.Parasite;
 using Content.Shared._RMC14.Xenonids.Plasma;
+using Content.Shared._RMC14.Xenonids.Rest;
 using Content.Shared._RMC14.Xenonids.Spray;
 using Content.Shared._RMC14.Xenonids.Weeds;
 using Content.Shared.ActionBlocker;
@@ -507,7 +508,7 @@ public sealed class XenoLeapSystem : EntitySystem
             return false;
         }
 
-        if (_standing.IsDown(target))
+        if (_standing.IsDown(target) || HasComp<XenoRestingComponent>(target))
             return false;
 
         if (HasComp<LeapIncapacitatedComponent>(target))

--- a/Content.Shared/_RMC14/Xenonids/MeleeSlow/XenoMeleeSlowSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/MeleeSlow/XenoMeleeSlowSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared._RMC14.Slow;
+using Content.Shared._RMC14.Xenonids.Rest;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Standing;
 using Content.Shared.Weapons.Melee.Events;
@@ -27,7 +28,7 @@ public sealed class XenoMeleeSlowSystem : EntitySystem
             if (!_xeno.CanAbilityAttackTarget(xeno, entity))
                 return;
 
-            if (xeno.Comp.RequiresKnockDown && !_standing.IsDown(entity))
+            if (xeno.Comp.RequiresKnockDown && !(_standing.IsDown(entity) || HasComp<XenoRestingComponent>(entity)))
                 return;
 
             var slow = xeno.Comp.HigherOnXenos ? _xeno.TryApplyXenoDebuffMultiplier(entity, xeno.Comp.SlowTime) : xeno.Comp.SlowTime;

--- a/Content.Shared/_RMC14/Xenonids/Rest/XenoRestSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Rest/XenoRestSystem.cs
@@ -19,7 +19,6 @@ using Content.Shared.Interaction.Events;
 using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Popups;
-using Content.Shared.Standing;
 using Robust.Shared.Timing;
 
 namespace Content.Shared._RMC14.Xenonids.Rest;
@@ -32,7 +31,6 @@ public sealed class XenoRestSystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedRMCActionsSystem _rmcActions = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
-    [Dependency] private readonly StandingStateSystem _standing = default!;
 
     public override void Initialize()
     {
@@ -58,7 +56,6 @@ public sealed class XenoRestSystem : EntitySystem
         SubscribeLocalEvent<XenoRestingComponent, EvasionRefreshModifiersEvent>(OnXenoRestingEvasionRefresh);
         SubscribeLocalEvent<XenoRestingComponent, AttemptMobCollideEvent>(OnXenoRestingMobCollide);
         SubscribeLocalEvent<XenoRestingComponent, AttemptMobTargetCollideEvent>(OnXenoRestingMobTargetCollide);
-        SubscribeLocalEvent<XenoRestingComponent, EvasionRefreshModifiersEvent>(OnXenoRestingRefreshEvasion);
 
         SubscribeLocalEvent<ActionBlockIfRestingComponent, RMCActionUseAttemptEvent>(OnXenoRestingActionUseAttempt);
     }
@@ -212,12 +209,6 @@ public sealed class XenoRestSystem : EntitySystem
     private void OnXenoRestingMobTargetCollide(Entity<XenoRestingComponent> ent, ref AttemptMobTargetCollideEvent args)
     {
         args.Cancelled = true;
-    }
-
-    private void OnXenoRestingRefreshEvasion(Entity<XenoRestingComponent> ent, ref EvasionRefreshModifiersEvent args)
-    {
-        if (!_standing.IsDown(ent)) // Don't double up on downed evasion
-            args.Evasion += (int)EvasionModifiers.Rest;
     }
 
     public bool IsResting(Entity<XenoRestingComponent?> ent)

--- a/Content.Shared/_RMC14/Xenonids/Rest/XenoRestSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Rest/XenoRestSystem.cs
@@ -19,6 +19,7 @@ using Content.Shared.Interaction.Events;
 using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Popups;
+using Content.Shared.Standing;
 using Robust.Shared.Timing;
 
 namespace Content.Shared._RMC14.Xenonids.Rest;
@@ -31,6 +32,7 @@ public sealed class XenoRestSystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedRMCActionsSystem _rmcActions = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly StandingStateSystem _standing = default!;
 
     public override void Initialize()
     {
@@ -56,6 +58,7 @@ public sealed class XenoRestSystem : EntitySystem
         SubscribeLocalEvent<XenoRestingComponent, EvasionRefreshModifiersEvent>(OnXenoRestingEvasionRefresh);
         SubscribeLocalEvent<XenoRestingComponent, AttemptMobCollideEvent>(OnXenoRestingMobCollide);
         SubscribeLocalEvent<XenoRestingComponent, AttemptMobTargetCollideEvent>(OnXenoRestingMobTargetCollide);
+        SubscribeLocalEvent<XenoRestingComponent, EvasionRefreshModifiersEvent>(OnXenoRestingRefreshEvasion);
 
         SubscribeLocalEvent<ActionBlockIfRestingComponent, RMCActionUseAttemptEvent>(OnXenoRestingActionUseAttempt);
     }
@@ -209,6 +212,12 @@ public sealed class XenoRestSystem : EntitySystem
     private void OnXenoRestingMobTargetCollide(Entity<XenoRestingComponent> ent, ref AttemptMobTargetCollideEvent args)
     {
         args.Cancelled = true;
+    }
+
+    private void OnXenoRestingRefreshEvasion(Entity<XenoRestingComponent> ent, ref EvasionRefreshModifiersEvent args)
+    {
+        if (!_standing.IsDown(ent)) // Don't double up on downed evasion
+            args.Evasion += (int)EvasionModifiers.Rest;
     }
 
     public bool IsResting(Entity<XenoRestingComponent?> ent)

--- a/Content.Shared/_RMC14/Xenonids/Retrieve/XenoRetrieveSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Retrieve/XenoRetrieveSystem.cs
@@ -79,7 +79,8 @@ public sealed class XenoRetrieveSystem : EntitySystem
             size > xeno.Comp.SizeLimit &&
             _mobState.IsAlive(target) &&
             !HasComp<XenoRestingComponent>(target) &&
-            !_standing.IsDown(target))
+            !_standing.IsDown(target) &&
+            !HasComp<XenoRestingComponent>(target))
         {
             var msg = Loc.GetString("rmc-xeno-retrieve-too-big", ("target", target));
             _popup.PopupClient(msg, xeno, xeno, PopupType.SmallCaution);

--- a/Content.Shared/_RMC14/Xenonids/Stomp/SharedXenoStompSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Stomp/SharedXenoStompSystem.cs
@@ -2,6 +2,7 @@ using Content.Shared._RMC14.Actions;
 using Content.Shared._RMC14.Slow;
 using Content.Shared._RMC14.Stun;
 using Content.Shared._RMC14.Xenonids.Plasma;
+using Content.Shared._RMC14.Xenonids.Rest;
 using Content.Shared.Actions;
 using Content.Shared.Coordinates;
 using Content.Shared.Damage;
@@ -114,7 +115,7 @@ public sealed class XenoStompSystem : EntitySystem
 
             if (xform.Coordinates.TryDistance(EntityManager, receiver.Owner.ToCoordinates(), out var distance) && distance <= xeno.Comp.ShortRange)
             {
-                if (!_standing.IsDown(receiver))
+                if (!_standing.IsDown(receiver) && !HasComp<XenoRestingComponent>(receiver))
                     continue;
 
                 var damage = _damageable.TryChangeDamage(receiver, _xeno.TryApplyXenoSlashDamageMultiplier(receiver, xeno.Comp.Damage), origin: xeno, tool: xeno);

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/base.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   save: false
   parent: BaseMobSpecies
   id: RMCBaseMobSpeciesOrganic
@@ -342,6 +342,7 @@
   - type: RMCDisarm
   - type: RMCDisarmable
   - type: StunOnExplosionReceived
+  - type: RMCProneExplosionMult
   - type: DeafenWhileCrit
   - type: RMCStopDropRollVisuals
   - type: XenoToggleChargingDamage

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
@@ -296,6 +296,7 @@
     color: "#459A62"
   - type: ExplosionResistance
     damageCoefficient: 2
+  - type: RMCProneExplosionMult
   - type: NpcFactionMember
     factions:
     - RMCXeno


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
parity! Fixes  #10651.

Also went through various stuff that checked is downed and didn't check for xeno resting, so fixed some stuff there.

## Technical details
<!-- Summary of code changes for easier review. -->
New before explosion received so we can get the epicenter and damage and new comp to half it if prone and not too close to the epicenter. There's an override so fake explosions (like destroy, rocket in a diff PR) can override the value to whatever they want later.

Technically in parity the damage is halved before armor is considered but uh, there's not an easy way to get the epicenter before that. I don't think it super matters as the coeff doesn't depend on damage so.

The rest is checking HasComp stuff.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

https://github.com/user-attachments/assets/2d363cf0-0f9b-4277-8132-844682f76b6a



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed explosions not doing half damage to prone targets (including targets right on the epicenter)
- fix: Fixed various actions (PBs, ammo stuns, retrieve, vehicle colliding & running over, etc) not counting xeno resting as prone.
