### PR TITLE
Stompable Cigarettes

### DIFF
--- a/Content.Server/Nutrition/EntitySystems/SmokingSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/SmokingSystem.cs
@@ -49,6 +49,7 @@ namespace Content.Server.Nutrition.EntitySystems
             InitializeCigars();
             InitializePipes();
             InitializeVapes();
+            InitializeRMC(); // RMC14
         }
 
         private void OnExtinguishEvent(Entity<SmokableComponent> ent, ref ExtinguishEvent args)

--- a/Content.Server/_RMC14/Nutrition/EntitySystems/SmokingSystem.RMC14.cs
+++ b/Content.Server/_RMC14/Nutrition/EntitySystems/SmokingSystem.RMC14.cs
@@ -1,0 +1,32 @@
+// ReSharper disable CheckNamespace
+
+using Content.Shared.Interaction;
+using Content.Shared.Nutrition.Components;
+using Content.Shared.Smoking;
+
+namespace Content.Server.Nutrition.EntitySystems
+{
+    public sealed partial class SmokingSystem
+    {
+        private void InitializeRMC()
+        {
+            SubscribeLocalEvent<SmokableComponent, ActivateInWorldEvent>(OnCigaretteActivatedEvent);
+        }
+
+        private void OnCigaretteActivatedEvent(Entity<SmokableComponent> entity, ref ActivateInWorldEvent args)
+        {
+            if (args.Handled || !args.Complex)
+                return;
+
+            if (!TryComp(entity, out SmokableComponent? smokable))
+                return;
+
+            if (smokable.State != SmokableState.Lit)
+                return;
+
+            SetSmokableState(entity, SmokableState.Burnt, smokable);
+            args.Handled = true;
+        }
+    }
+}
+


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Cigarettes can now be stomped to be put out just like cigars can.

## Why / Balance
Currently, only cigars can be stomped to be unlit. I wanted to be able to stomp cigarettes

## Technical details
Created a SmokingSystem.RMC14.cs, then copied the cigar stomping code over after subscribing to the proper event.

## Media
This is a very small change but can add media if needed.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [ X ] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Cigarettes can now be stamped out on the ground like cigars.
