### PR TITLE
[Parity] Updating Queen Scream Range

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Screech/XenoScreechComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Screech/XenoScreechComponent.cs
@@ -33,7 +33,7 @@ public sealed partial class XenoScreechComponent : Component
     public float ParalyzeRange = CircleAreaFromSquareAbilityRange(4f);
 
     [DataField, AutoNetworkedField]
-    public float ParasiteStunRange = CircleAreaFromSquareAbilityRange(9.5f);
+    public float ParasiteStunRange = CircleAreaFromSquareAbilityRange(10f);
 
     [DataField, AutoNetworkedField]
     public TimeSpan ParasiteStunTime = TimeSpan.FromSeconds(8);

--- a/Content.Shared/_RMC14/Xenonids/Screech/XenoScreechComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Screech/XenoScreechComponent.cs
@@ -27,7 +27,7 @@ public sealed partial class XenoScreechComponent : Component
 
     // TODO RMC14 stun less within 4 tiles
     [DataField, AutoNetworkedField]
-    public float StunRange = CircleAreaFromSquareAbilityRange(7f);
+    public float StunRange = CircleAreaFromSquareAbilityRange(6f);
 
     [DataField, AutoNetworkedField]
     public float ParalyzeRange = CircleAreaFromSquareAbilityRange(4f);

--- a/Content.Shared/_RMC14/Xenonids/Screech/XenoScreechComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Screech/XenoScreechComponent.cs
@@ -26,10 +26,10 @@ public sealed partial class XenoScreechComponent : Component
 
     // TODO RMC14 stun less within 4 tiles
     [DataField, AutoNetworkedField]
-    public float StunRange = 7;
+    public float StunRange = 8.4628f;
 
     [DataField, AutoNetworkedField]
-    public float ParalyzeRange = 4;
+    public float ParalyzeRange = 5.0777f;
 
     [DataField, AutoNetworkedField]
     public float ParasiteStunRange = 11.2838f;

--- a/Content.Shared/_RMC14/Xenonids/Screech/XenoScreechComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Screech/XenoScreechComponent.cs
@@ -2,6 +2,7 @@
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
+using static Content.Shared._RMC14.Maths.RMCMathExtensions;
 
 namespace Content.Shared._RMC14.Xenonids.Screech;
 
@@ -26,13 +27,13 @@ public sealed partial class XenoScreechComponent : Component
 
     // TODO RMC14 stun less within 4 tiles
     [DataField, AutoNetworkedField]
-    public float StunRange = 8.4628f;
+    public float StunRange = CircleAreaFromSquareAbilityRange(7f);
 
     [DataField, AutoNetworkedField]
-    public float ParalyzeRange = 5.0777f;
+    public float ParalyzeRange = CircleAreaFromSquareAbilityRange(4f);
 
     [DataField, AutoNetworkedField]
-    public float ParasiteStunRange = 11.2838f;
+    public float ParasiteStunRange = CircleAreaFromSquareAbilityRange(9.5f);
 
     [DataField, AutoNetworkedField]
     public TimeSpan ParasiteStunTime = TimeSpan.FromSeconds(8);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
In CM13, queen scream paralyzes marines at 4 tiles, and stuns them at 6 tiles.

When moving ranges to RMC14, we seem to have converted the parasite stun radius to its circle area equivalent (a radius of 11.2838 tiles, which seems to have been converted from a square range of 9.5 tiles) but the marine scream ranges seem to have been missed. This pr updates the paralyze and stun radii to 5.0777 and 7.3345 tiles respectively so that the area matches CM13's area. 

Notably, queen screech range in CM13 is actually 6 tiles and not 7, as noticed by @MidZik. See discussion below for why the original port likely missed this fact. This means that the paralyze range will be increasing more than the full stun range (1.08 versus 0.33 tiles). 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity. 

Also, it makes no sense that para stuns have a converted range but marine stuns don't. Should probably be one or the other. 

## Technical details
<!-- Summary of code changes for easier review. -->

Using the range conversion function for all 3 constants for the purposes of clarity. Used our default function for converting ranges, CircleAreaFromSquareAbilityRange which is just ((SquareRange * 2) + 1) / sqrt(pi).

Paralyze range has moved from 4 to 5.0777
Stun range has moved from 7 to 7.3345
Parasite stun range remains unchanged.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Queen scream paralyze area (not total stun area) has been increased to match CM13 parity area. 
