### PR TITLE
Fix rocket on hit damage

### DIFF
--- a/Content.Shared/_RMC14/Explosion/RMCExplosiveDamageOnHitComponent.cs
+++ b/Content.Shared/_RMC14/Explosion/RMCExplosiveDamageOnHitComponent.cs
@@ -1,0 +1,32 @@
+using Content.Shared.Damage;
+using Content.Shared.Explosion;
+using Content.Shared.Whitelist;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Explosion;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class RMCExplosiveDamageOnHitComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public List<RMCExplosiveDamageOnHit> Explosions = new();
+}
+
+[DataDefinition]
+[Serializable, NetSerializable]
+public partial struct RMCExplosiveDamageOnHit()
+{
+    [DataField]
+    public EntityWhitelist? Whitelist;
+
+    [DataField]
+    public ProtoId<ExplosionPrototype> ExplosionType = "RMC";
+
+    [DataField]
+    public DamageSpecifier Damage = new();
+
+    [DataField]
+    public int ArmorPiercing = 0;
+}

--- a/Content.Shared/_RMC14/Explosion/SharedRMCExplosionSystem.cs
+++ b/Content.Shared/_RMC14/Explosion/SharedRMCExplosionSystem.cs
@@ -262,49 +262,57 @@ public abstract class SharedRMCExplosionSystem : EntitySystem
 
     private void OnExplosiveDamageOnHitProjectileHit(Entity<RMCExplosiveDamageOnHitComponent> projectile, ref ProjectileHitEvent args)
     {
-        DoExplosiveDamage(projectile, args.Target, args.Shooter);
+        DoExplosiveHit(projectile, args.Target, args.Shooter);
     }
 
     private void OnExplosiveDamageOnMeleeHit(Entity<RMCExplosiveDamageOnHitComponent> projectile, ref MeleeHitEvent args)
     {
         foreach (var hit in args.HitEntities)
         {
-            DoExplosiveDamage(projectile, hit, args.User);
+            DoExplosiveHit(projectile, hit, args.User);
         }
     }
 
-    private void DoExplosiveDamage(Entity<RMCExplosiveDamageOnHitComponent> ent, EntityUid target, EntityUid? user)
+    private void DoExplosiveHit(Entity<RMCExplosiveDamageOnHitComponent> ent, EntityUid target, EntityUid? user)
     {
         foreach (var explosion in ent.Comp.Explosions)
         {
             if (_entityWhitelist.IsWhitelistFail(explosion.Whitelist, target))
                 continue;
 
-            var ev = new GetExplosionResistanceEvent(explosion.ExplosionType);
-            RaiseLocalEvent(target, ref ev);
-
-            // Effectively subtracts armor like normal armor piercing
-            // We must get explosion armor so we don't make the ent more vunerable
-            if (explosion.ArmorPiercing > 0)
-            {
-                var arev = new CMGetArmorEvent(SlotFlags.OUTERCLOTHING | SlotFlags.INNERCLOTHING);
-                RaiseLocalEvent(target, ref arev);
-                arev.ExplosionArmor = Math.Max(arev.ExplosionArmor, 0);
-
-                var resist = (float)Math.Pow(1.1, -Math.Min(arev.ExplosionArmor, explosion.ArmorPiercing) / 10.0);
-                ev.DamageCoefficient /= resist;
-            }
-
-            ev.DamageCoefficient = Math.Max(0, ev.DamageCoefficient);
-
-            var dam = _damage.TryChangeDamage(target, explosion.Damage * ev.DamageCoefficient, true, origin: user, tool: ent);
-
-            if (dam == null)
-                continue;
-
-            var exv = new ExplosionReceivedEvent(explosion.ExplosionType, _transform.ToMapCoordinates(ent.Owner.ToCoordinates()), dam);
-            RaiseLocalEvent(target, ref exv);
+            DoDirectExplosionDamage(ent, target, user, explosion.ExplosionType, explosion.Damage, explosion.ArmorPiercing);
         }
+    }
+
+    public void DoDirectExplosionDamage(EntityUid origin, EntityUid target, EntityUid? user,
+        ProtoId<ExplosionPrototype> explosionType, DamageSpecifier damage, int armorPiercing = 0)
+    {
+        var ev = new GetExplosionResistanceEvent(explosionType);
+        RaiseLocalEvent(target, ref ev);
+
+        // Effectively subtracts armor like normal armor piercing
+        // We must get explosion armor so we don't make the ent more vunerable
+        if (armorPiercing > 0)
+        {
+            var arev = new CMGetArmorEvent(SlotFlags.OUTERCLOTHING | SlotFlags.INNERCLOTHING);
+            RaiseLocalEvent(target, ref arev);
+            arev.ExplosionArmor = Math.Max(arev.ExplosionArmor, 0);
+
+            var resist = (float)Math.Pow(1.1, -Math.Min(arev.ExplosionArmor, armorPiercing) / 10.0);
+            ev.DamageCoefficient /= resist;
+        }
+
+        ev.DamageCoefficient = Math.Max(0, ev.DamageCoefficient);
+
+        // TODO RMC14 add BeforeExplosionReceived when merged in, with params to override direction
+
+        var dam = _damage.TryChangeDamage(target, damage * ev.DamageCoefficient, true, origin: user, tool: origin);
+
+        if (dam == null)
+            return;
+
+        var exv = new ExplosionReceivedEvent(explosionType, _transform.ToMapCoordinates(origin.ToCoordinates()), dam);
+        RaiseLocalEvent(target, ref exv);
     }
 
     public void DoEffect(Entity<CMExplosionEffectComponent> ent)

--- a/Content.Shared/_RMC14/Explosion/SharedRMCExplosionSystem.cs
+++ b/Content.Shared/_RMC14/Explosion/SharedRMCExplosionSystem.cs
@@ -7,11 +7,14 @@ using Content.Shared._RMC14.Xenonids.Acid;
 using Content.Shared._RMC14.Xenonids.Construction.Nest;
 using Content.Shared.Body.Systems;
 using Content.Shared.Coordinates;
+using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.Explosion;
+using Content.Shared.Explosion.Components;
 using Content.Shared.FixedPoint;
 using Content.Shared.Flash.Components;
 using Content.Shared.Inventory;
+using Content.Shared.Projectiles;
 using Content.Shared.Standing;
 using Content.Shared.StatusEffect;
 using Content.Shared.Sticky.Components;
@@ -44,6 +47,7 @@ public abstract class SharedRMCExplosionSystem : EntitySystem
     [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
     [Dependency] private readonly SharedDeafnessSystem _deafness = default!;
     [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly DamageableSystem _damage = default!;
 
     private static readonly ProtoId<DamageTypePrototype> StructuralDamage = "Structural";
     private static readonly ProtoId<StatusEffectPrototype> FlashedKey = "Flashed";
@@ -66,6 +70,8 @@ public abstract class SharedRMCExplosionSystem : EntitySystem
         SubscribeLocalEvent<DestroyedByExplosionComponent, ExplosionReceivedEvent>(OnDestroyedByExplosionReceived);
 
         SubscribeLocalEvent<MobGibbedByExplosionTypeComponent, ExplosionReceivedEvent>(OnMobGibbedByExplosionReceived);
+
+        SubscribeLocalEvent<RMCExplosiveDamageOnHitComponent, ProjectileHitEvent>(OnExplosiveDamageOnHitProjectileHit);
     }
 
     private void OnExplosionEffectTriggered(Entity<CMExplosionEffectComponent> ent, ref CMExplosiveTriggeredEvent args)
@@ -250,6 +256,39 @@ public abstract class SharedRMCExplosionSystem : EntitySystem
 
         if (!TerminatingOrDeleted(ent))
             _body.GibBody(ent, true);
+    }
+
+    private void OnExplosiveDamageOnHitProjectileHit(Entity<RMCExplosiveDamageOnHitComponent> projectile, ref ProjectileHitEvent args)
+    {
+        foreach (var explosion in projectile.Comp.Explosions)
+        {
+            if (_entityWhitelist.IsWhitelistFail(explosion.Whitelist, args.Target))
+                continue;
+
+            var ev = new GetExplosionResistanceEvent(explosion.ExplosionType);
+            RaiseLocalEvent(args.Target, ref ev);
+
+            // Effectively subtracts armor like normal armor piercing
+            // We must get base resistance so we don't over damage
+            // If there's ever anything thats supposed to make ents take MORE explosive damage than normal
+            // Change this
+            if (explosion.ArmorPiercing > 0 && TryComp<ExplosionResistanceComponent>(args.Target, out var baseResist))
+            {
+                var resist = (float)Math.Pow(1.1, -explosion.ArmorPiercing / 10.0);
+                ev.DamageCoefficient /= resist;
+                ev.DamageCoefficient = Math.Min(baseResist.DamageCoefficient, ev.DamageCoefficient);
+            }
+
+            ev.DamageCoefficient = Math.Max(0, ev.DamageCoefficient);
+
+            var dam = _damage.TryChangeDamage(args.Target, explosion.Damage * ev.DamageCoefficient, true, origin: args.Shooter, tool: projectile);
+
+            if (dam == null)
+                continue;
+
+            var exv = new ExplosionReceivedEvent(explosion.ExplosionType, _transform.ToMapCoordinates(projectile.Owner.ToCoordinates()), dam);
+            RaiseLocalEvent(args.Target, ref exv);
+        }
     }
 
     public void DoEffect(Entity<CMExplosionEffectComponent> ent)

--- a/Content.Shared/_RMC14/Explosion/SharedRMCExplosionSystem.cs
+++ b/Content.Shared/_RMC14/Explosion/SharedRMCExplosionSystem.cs
@@ -20,6 +20,7 @@ using Content.Shared.StatusEffect;
 using Content.Shared.Sticky.Components;
 using Content.Shared.Stunnable;
 using Content.Shared.Throwing;
+using Content.Shared.Weapons.Melee.Events;
 using Content.Shared.Whitelist;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
@@ -72,6 +73,7 @@ public abstract class SharedRMCExplosionSystem : EntitySystem
         SubscribeLocalEvent<MobGibbedByExplosionTypeComponent, ExplosionReceivedEvent>(OnMobGibbedByExplosionReceived);
 
         SubscribeLocalEvent<RMCExplosiveDamageOnHitComponent, ProjectileHitEvent>(OnExplosiveDamageOnHitProjectileHit);
+        SubscribeLocalEvent<RMCExplosiveDamageOnHitComponent, MeleeHitEvent>(OnExplosiveDamageOnMeleeHit);
     }
 
     private void OnExplosionEffectTriggered(Entity<CMExplosionEffectComponent> ent, ref CMExplosiveTriggeredEvent args)
@@ -260,20 +262,33 @@ public abstract class SharedRMCExplosionSystem : EntitySystem
 
     private void OnExplosiveDamageOnHitProjectileHit(Entity<RMCExplosiveDamageOnHitComponent> projectile, ref ProjectileHitEvent args)
     {
-        foreach (var explosion in projectile.Comp.Explosions)
+        DoExplosiveDamage(projectile, args.Target, args.Shooter);
+    }
+
+    private void OnExplosiveDamageOnMeleeHit(Entity<RMCExplosiveDamageOnHitComponent> projectile, ref MeleeHitEvent args)
+    {
+        foreach (var hit in args.HitEntities)
         {
-            if (_entityWhitelist.IsWhitelistFail(explosion.Whitelist, args.Target))
+            DoExplosiveDamage(projectile, hit, args.User);
+        }
+    }
+
+    private void DoExplosiveDamage(Entity<RMCExplosiveDamageOnHitComponent> ent, EntityUid target, EntityUid? user)
+    {
+        foreach (var explosion in ent.Comp.Explosions)
+        {
+            if (_entityWhitelist.IsWhitelistFail(explosion.Whitelist, target))
                 continue;
 
             var ev = new GetExplosionResistanceEvent(explosion.ExplosionType);
-            RaiseLocalEvent(args.Target, ref ev);
+            RaiseLocalEvent(target, ref ev);
 
             // Effectively subtracts armor like normal armor piercing
             // We must get explosion armor so we don't make the ent more vunerable
             if (explosion.ArmorPiercing > 0)
             {
                 var arev = new CMGetArmorEvent(SlotFlags.OUTERCLOTHING | SlotFlags.INNERCLOTHING);
-                RaiseLocalEvent(args.Target, ref arev);
+                RaiseLocalEvent(target, ref arev);
                 arev.ExplosionArmor = Math.Max(arev.ExplosionArmor, 0);
 
                 var resist = (float)Math.Pow(1.1, -Math.Min(arev.ExplosionArmor, explosion.ArmorPiercing) / 10.0);
@@ -282,13 +297,13 @@ public abstract class SharedRMCExplosionSystem : EntitySystem
 
             ev.DamageCoefficient = Math.Max(0, ev.DamageCoefficient);
 
-            var dam = _damage.TryChangeDamage(args.Target, explosion.Damage * ev.DamageCoefficient, true, origin: args.Shooter, tool: projectile);
+            var dam = _damage.TryChangeDamage(target, explosion.Damage * ev.DamageCoefficient, true, origin: user, tool: ent);
 
             if (dam == null)
                 continue;
 
-            var exv = new ExplosionReceivedEvent(explosion.ExplosionType, _transform.ToMapCoordinates(projectile.Owner.ToCoordinates()), dam);
-            RaiseLocalEvent(args.Target, ref exv);
+            var exv = new ExplosionReceivedEvent(explosion.ExplosionType, _transform.ToMapCoordinates(ent.Owner.ToCoordinates()), dam);
+            RaiseLocalEvent(target, ref exv);
         }
     }
 

--- a/Content.Shared/_RMC14/Explosion/SharedRMCExplosionSystem.cs
+++ b/Content.Shared/_RMC14/Explosion/SharedRMCExplosionSystem.cs
@@ -274,6 +274,8 @@ public abstract class SharedRMCExplosionSystem : EntitySystem
             {
                 var arev = new CMGetArmorEvent(SlotFlags.OUTERCLOTHING | SlotFlags.INNERCLOTHING);
                 RaiseLocalEvent(args.Target, ref arev);
+                arev.ExplosionArmor = Math.Max(arev.ExplosionArmor, 0);
+
                 var resist = (float)Math.Pow(1.1, -Math.Min(arev.ExplosionArmor, explosion.ArmorPiercing) / 10.0);
                 ev.DamageCoefficient /= resist;
             }

--- a/Content.Shared/_RMC14/Explosion/SharedRMCExplosionSystem.cs
+++ b/Content.Shared/_RMC14/Explosion/SharedRMCExplosionSystem.cs
@@ -269,14 +269,12 @@ public abstract class SharedRMCExplosionSystem : EntitySystem
             RaiseLocalEvent(args.Target, ref ev);
 
             // Effectively subtracts armor like normal armor piercing
-            // We must get base resistance so we don't over damage
-            // If there's ever anything thats supposed to make ents take MORE explosive damage than normal
-            // Change this
-            if (explosion.ArmorPiercing > 0 && TryComp<ExplosionResistanceComponent>(args.Target, out var baseResist))
+            // We must get explosion armor so we don't make the ent more vunerable
+            if (explosion.ArmorPiercing > 0)
             {
-                var resist = (float)Math.Pow(1.1, -explosion.ArmorPiercing / 10.0);
+                var arev = new CMGetArmorEvent(SlotFlags.OUTERCLOTHING | SlotFlags.INNERCLOTHING);
+                var resist = (float)Math.Pow(1.1, -Math.Min(arev.ExplosionArmor, explosion.ArmorPiercing) / 10.0);
                 ev.DamageCoefficient /= resist;
-                ev.DamageCoefficient = Math.Min(baseResist.DamageCoefficient, ev.DamageCoefficient);
             }
 
             ev.DamageCoefficient = Math.Max(0, ev.DamageCoefficient);

--- a/Content.Shared/_RMC14/Explosion/SharedRMCExplosionSystem.cs
+++ b/Content.Shared/_RMC14/Explosion/SharedRMCExplosionSystem.cs
@@ -273,6 +273,7 @@ public abstract class SharedRMCExplosionSystem : EntitySystem
             if (explosion.ArmorPiercing > 0)
             {
                 var arev = new CMGetArmorEvent(SlotFlags.OUTERCLOTHING | SlotFlags.INNERCLOTHING);
+                RaiseLocalEvent(args.Target, ref arev);
                 var resist = (float)Math.Pow(1.1, -Math.Min(arev.ExplosionArmor, explosion.ArmorPiercing) / 10.0);
                 ev.DamageCoefficient /= resist;
             }

--- a/Content.Shared/_RMC14/Shields/CrusherShieldSystem.cs
+++ b/Content.Shared/_RMC14/Shields/CrusherShieldSystem.cs
@@ -30,6 +30,7 @@ public sealed partial class CrusherShieldSystem : EntitySystem
         SubscribeLocalEvent<CrusherShieldComponent, GetExplosionResistanceEvent>(OnGetExplosionResistance);
         SubscribeLocalEvent<CrusherShieldComponent, RemovedShieldEvent>(OnShieldRemove);
         SubscribeLocalEvent<CrusherShieldComponent, XenoDefensiveShieldActionEvent>(OnXenoDefensiveShieldAction);
+        SubscribeLocalEvent<CrusherShieldComponent, CMGetArmorEvent>(OnXenoDefensiveShieldGetArmor);
     }
 
     private void OnXenoDefensiveShieldAction(Entity<CrusherShieldComponent> xeno, ref XenoDefensiveShieldActionEvent args)
@@ -59,7 +60,7 @@ public sealed partial class CrusherShieldSystem : EntitySystem
     }
 
 
-    public void ApplyEffects(Entity<CrusherShieldComponent> ent)
+    private void ApplyEffects(Entity<CrusherShieldComponent> ent)
     {
         if (!TryComp<CMArmorComponent>(ent, out var armor))
             return;
@@ -70,7 +71,7 @@ public sealed partial class CrusherShieldSystem : EntitySystem
 
     }
 
-    public void OnShieldRemove(Entity<CrusherShieldComponent> ent, ref RemovedShieldEvent args)
+    private void OnShieldRemove(Entity<CrusherShieldComponent> ent, ref RemovedShieldEvent args)
     {
         if (args.Type == XenoShieldSystem.ShieldType.Crusher)
         {
@@ -103,7 +104,7 @@ public sealed partial class CrusherShieldSystem : EntitySystem
         }
     }
 
-    public void OnDamage(Entity<CrusherShieldComponent> ent, ref DamageModifyAfterResistEvent args)
+    private void OnDamage(Entity<CrusherShieldComponent> ent, ref DamageModifyAfterResistEvent args)
     {
         if (!TryComp<XenoShieldComponent>(ent, out var shield))
             return;
@@ -123,7 +124,7 @@ public sealed partial class CrusherShieldSystem : EntitySystem
         }
     }
 
-    public void OnGetExplosionResistance(Entity<CrusherShieldComponent> ent, ref GetExplosionResistanceEvent args)
+    private void OnGetExplosionResistance(Entity<CrusherShieldComponent> ent, ref GetExplosionResistanceEvent args)
     {
         if (!ent.Comp.ExplosionResistApplying)
             return;
@@ -132,5 +133,13 @@ public sealed partial class CrusherShieldSystem : EntitySystem
 
         var resist = (float) Math.Pow(1.1, explosionResist / 5.0); // From armor calcualtion
         args.DamageCoefficient /= resist;
+    }
+
+    private void OnXenoDefensiveShieldGetArmor(Entity<CrusherShieldComponent> ent, ref CMGetArmorEvent args)
+    {
+        if (!ent.Comp.ExplosionResistApplying)
+            return;
+
+        args.ExplosionArmor += ent.Comp.ExplosionResistance;
     }
 }

--- a/Content.Shared/_RMC14/Shields/VanguardShieldSystem.cs
+++ b/Content.Shared/_RMC14/Shields/VanguardShieldSystem.cs
@@ -21,6 +21,7 @@ public sealed class VanguardShieldSystem : EntitySystem
         SubscribeLocalEvent<VanguardShieldComponent, DamageModifyAfterResistEvent>(OnVanguardShieldHit, before: [typeof(XenoShieldSystem)]);
         SubscribeLocalEvent<VanguardShieldComponent, GetExplosionResistanceEvent>(OnVanguardShieldGetResistance);
         SubscribeLocalEvent<VanguardShieldComponent, RemovedShieldEvent>(OnVanguardShieldRemoved);
+        SubscribeLocalEvent<VanguardShieldComponent, CMGetArmorEvent>(OnVanguardShieldGetArmor);
     }
 
     private void OnVanguardShieldInit(Entity<VanguardShieldComponent> xeno, ref MapInitEvent args)
@@ -95,6 +96,17 @@ public sealed class VanguardShieldSystem : EntitySystem
 
             Dirty(uid, shield);
         }
+    }
+
+    private void OnVanguardShieldGetArmor(Entity<VanguardShieldComponent> xeno, ref CMGetArmorEvent args)
+    {
+        if (!TryComp<XenoShieldComponent>(xeno, out var shield) || shield.Shield != XenoShieldSystem.ShieldType.Vanguard)
+            return;
+
+        if (shield.ShieldAmount <= 0)
+            return;
+
+        args.ExplosionArmor += xeno.Comp.ExplosionResistance;
     }
 
     //Returns whether something applies for the shield buff (for cleave)

--- a/Content.Shared/_RMC14/Xenonids/Destroy/SharedXenoDestroySystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Destroy/SharedXenoDestroySystem.cs
@@ -75,6 +75,7 @@ public abstract class SharedXenoDestroySystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly RMCPullingSystem _rmcPull = default!;
     [Dependency] private readonly ActionBlockerSystem _blocker = default!;
+    [Dependency] private readonly SharedRMCExplosionSystem _explosion = default!;
 
     private readonly HashSet<Entity<MobStateComponent>> _mobs = new();
 
@@ -237,18 +238,7 @@ public abstract class SharedXenoDestroySystem : EntitySystem
 
                 if (_whitelist.IsWhitelistPass(xeno.Comp.Structures, ent))
                 {
-                    var ev = new GetExplosionResistanceEvent(xeno.Comp.ExplosionType.Id);
-                    RaiseLocalEvent(ent, ref ev);
-
-                    ev.DamageCoefficient = Math.Max(0, ev.DamageCoefficient);
-
-                    var dam = _damage.TryChangeDamage(ent, xeno.Comp.StructureDamage * ev.DamageCoefficient, true, origin: xeno, tool: xeno);
-
-                    if (dam == null)
-                        continue;
-
-                    var exv = new ExplosionReceivedEvent(xeno.Comp.ExplosionType, _transform.ToMapCoordinates(xeno.Owner.ToCoordinates()), dam);
-                    RaiseLocalEvent(ent, ref exv);
+                    _explosion.DoDirectExplosionDamage(xeno, ent, xeno, xeno.Comp.ExplosionType, xeno.Comp.StructureDamage);
                     continue;
                 }
             }

--- a/Content.Shared/_RMC14/Xenonids/Destroy/SharedXenoDestroySystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Destroy/SharedXenoDestroySystem.cs
@@ -4,6 +4,7 @@ using Content.Shared._RMC14.Areas;
 using Content.Shared._RMC14.CameraShake;
 using Content.Shared._RMC14.Emote;
 using Content.Shared._RMC14.Entrenching;
+using Content.Shared._RMC14.Explosion;
 using Content.Shared._RMC14.Gibbing;
 using Content.Shared._RMC14.Map;
 using Content.Shared._RMC14.Marines;
@@ -18,6 +19,7 @@ using Content.Shared.ActionBlocker;
 using Content.Shared.Actions;
 using Content.Shared.Body.Components;
 using Content.Shared.Body.Systems;
+using Content.Shared.Coordinates;
 using Content.Shared.Damage;
 using Content.Shared.DoAfter;
 using Content.Shared.Explosion;
@@ -238,7 +240,15 @@ public abstract class SharedXenoDestroySystem : EntitySystem
                     var ev = new GetExplosionResistanceEvent(xeno.Comp.ExplosionType.Id);
                     RaiseLocalEvent(ent, ref ev);
 
-                    _damage.TryChangeDamage(ent, xeno.Comp.StructureDamage * ev.DamageCoefficient, true, origin: xeno, tool: xeno);
+                    ev.DamageCoefficient = Math.Max(0, ev.DamageCoefficient);
+
+                    var dam = _damage.TryChangeDamage(ent, xeno.Comp.StructureDamage * ev.DamageCoefficient, true, origin: xeno, tool: xeno);
+
+                    if (dam == null)
+                        continue;
+
+                    var exv = new ExplosionReceivedEvent(xeno.Comp.ExplosionType, _transform.ToMapCoordinates(xeno.Owner.ToCoordinates()), dam);
+                    RaiseLocalEvent(ent, ref exv);
                     continue;
                 }
             }

--- a/Content.Shared/_RMC14/Xenonids/Fortify/XenoFortifySystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Fortify/XenoFortifySystem.cs
@@ -99,6 +99,7 @@ public sealed class XenoFortifySystem : EntitySystem
 
         args.XenoArmor += xeno.Comp.Armor;
         args.FrontalArmor += xeno.Comp.FrontalArmor;
+        args.ExplosionArmor += xeno.Comp.ExplosionArmor;
     }
 
     private void OnXenoFortifyBeforeStatusAdded(Entity<XenoFortifyComponent> xeno, ref BeforeStatusEffectAddedEvent args)

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/king.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/king.yml
@@ -174,10 +174,12 @@
   - type: XenoDestroy
     structureDamage:
       types:
-        Blunt: 1000
+        Blunt: 500
+        Heat: 500
     mobDamage:
       types:
-        Blunt: 1000
+        Blunt: 500
+        Heat: 500
     structures:
       tags:
       - Structure

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m5_atl_rocket_launcher.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m5_atl_rocket_launcher.yml
@@ -179,6 +179,16 @@
     intensitySlope: 10
     totalIntensity: 290
     maxTileBreak: 0
+  - type: RMCExplosiveDamageOnHit
+    explosions:
+      - whitelist:
+          components:
+            - Marine
+        damage:
+          types:
+            Blunt: 175
+            Heat: 175
+        armorPiercing: 100
   - type: CMExplosionEffect
   - type: RMCScorchEffect
   - type: PointLight

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m5_atl_rocket_launcher.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m5_atl_rocket_launcher.yml
@@ -219,13 +219,25 @@
     impactEffect: BulletImpactEffect
     damage:
       types:
-        Blunt: 160
-        Heat: 150
-        # 10 brute damage + 150 brute and 150 burn to simulate direct explosive damage.
-        # Temporary mechanic to make it consistent with intended main target damage.
+        Blunt: 10
     maxFixedRange: 5 # 6 tiles
   - type: CMArmorPiercing
-    amount: 100 # Ignores all armor.
+    amount: 50
+  - type: RMCExplosiveDamageOnHit
+    explosions:
+      - damage:
+          types:
+            Blunt: 75
+            Heat: 75
+        armorPiercing: 100
+      - whitelist:
+          components:
+            - Marine
+        damage:
+          types:
+            Blunt: 150
+            Heat: 150
+        armorPiercing: 100
   - type: Sprite
     sprite: _RMC14/Objects/Weapons/Guns/Ammunition/Projectiles/m5spec_projectiles.rsi
     layers:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It's been a todo for a long time.

## Technical details
<!-- Summary of code changes for easier review. -->
Like destroy, new comp that does fake explosion damage on hit (with accompanying events n stuff so stun works).

The armor piercing calc is a bit finicky since I had to go back and make sure all instances the boost explosive resist also boost explosive armor when applicable, but it works. Yes ATL rockets do an extra 300 to humanoids. Parity. HE also do a ton. Parity really hates em.

Note #10590's calculation is used for determining the armor piercing here.

Also fixed up destroy to better line it up with what's expected in explosion damage.

Note this should have the #10661 event so it has the exact same events (it counts as having a direction so that'll be fixed with the override).

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
https://discord.com/channels/1168210010233376858/1168210011823026270/1535080385350729750

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed how AP rocket direct hit damage is handled. It's properly treated as explosive damage with 100 AP, and does more damage to humanoids. HE rocket direct hits will also do a ton of damage to humanoids with 100 AP.
