### PR TITLE
Adding lag compensation to queen screech

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Screech/SharedXenoScreechSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Screech/SharedXenoScreechSystem.cs
@@ -1,6 +1,7 @@
 using Content.Shared._RMC14.Deafness;
 using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.CameraShake;
+using Content.Shared._RMC14.Movement;
 using Content.Shared._RMC14.Xenonids.Parasite;
 using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared.Coordinates;
@@ -10,6 +11,7 @@ using Content.Shared.Mobs.Systems;
 using Content.Shared.Stunnable;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Network;
+using Robust.Shared.Player;
 using System.Linq;
 
 namespace Content.Shared._RMC14.Xenonids.Screech;
@@ -26,9 +28,11 @@ public sealed class XenoScreechSystem : EntitySystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly XenoSystem _xeno = default!;
     [Dependency] private readonly RMCCameraShakeSystem _cameraShake = default!;
+    [Dependency] private readonly SharedRMCLagCompensationSystem _rmcLagCompensation = default!;
 
     private readonly HashSet<Entity<MobStateComponent>> _mobs = new();
     private readonly HashSet<Entity<MobStateComponent>> _closeMobs = new();
+    private readonly HashSet<EntityUid> _closeStunned = new();
     private readonly HashSet<Entity<XenoParasiteComponent>> _parasites = new();
 
     public override void Initialize()
@@ -60,45 +64,52 @@ public sealed class XenoScreechSystem : EntitySystem
         if (_net.IsServer)
             _audio.PlayPvs(xeno.Comp.Sound, xeno);
 
+        var session = CompOrNull<ActorComponent>(xeno)?.PlayerSession;
+
         _closeMobs.Clear();
-        _entityLookup.GetEntitiesInRange(xform.Coordinates, xeno.Comp.ParalyzeRange, _closeMobs);
+        _closeStunned.Clear();
+        // Range widened by lagcomp margin to include entities that have moved.
+        _entityLookup.GetEntitiesInRange(xform.Coordinates, xeno.Comp.ParalyzeRange + xeno.Comp.LagCompensationLookupMargin, _closeMobs);
 
         foreach (var receiver in _closeMobs)
         {
             if (!_xeno.CanAbilityAttackTarget(xeno, receiver))
                 continue;
 
-            if (!Stun(xeno, receiver, xeno.Comp.ParalyzeTime, false))
+            if (!Stun(xeno, receiver, xeno.Comp.ParalyzeTime, false, xeno.Comp.ParalyzeRange, session))
                 continue;
 
+            // Track who was actually stunned here so we don't skip over
+            // targets beyond the paralyze range but still within stun range
+            _closeStunned.Add(receiver);
             _cameraShake.ShakeCamera(receiver, xeno.Comp.CloseScreenShakeShakes, xeno.Comp.CloseScreenShakeStrength);
-            Deafen(xeno, receiver, xeno.Comp.CloseDeafTime);
+            Deafen(xeno, receiver, xeno.Comp.CloseDeafTime, session);
         }
 
         _mobs.Clear();
-        _entityLookup.GetEntitiesInRange(xform.Coordinates, xeno.Comp.StunRange, _mobs);
+        _entityLookup.GetEntitiesInRange(xform.Coordinates, xeno.Comp.StunRange + xeno.Comp.LagCompensationLookupMargin, _mobs);
 
         foreach (var receiver in _mobs)
         {
             if (!_xeno.CanAbilityAttackTarget(xeno, receiver))
                 continue;
 
-            if (_closeMobs.Contains(receiver))
+            if (_closeStunned.Contains(receiver))
                 continue;
 
-            if (!Stun(xeno, receiver, xeno.Comp.StunTime, true))
+            if (!Stun(xeno, receiver, xeno.Comp.StunTime, true, xeno.Comp.StunRange, session))
                 continue;
 
             _cameraShake.ShakeCamera(receiver, xeno.Comp.FarScreenShakeShakes, xeno.Comp.FarScreenShakeStrength);
-            Deafen(xeno, receiver, xeno.Comp.FarDeafTime);
+            Deafen(xeno, receiver, xeno.Comp.FarDeafTime, session);
         }
 
         _parasites.Clear();
-        _entityLookup.GetEntitiesInRange(xform.Coordinates, xeno.Comp.ParasiteStunRange, _parasites);
+        _entityLookup.GetEntitiesInRange(xform.Coordinates, xeno.Comp.ParasiteStunRange + xeno.Comp.LagCompensationLookupMargin, _parasites);
 
         foreach (var receiver in _parasites)
         {
-            if (!Stun(xeno, receiver, xeno.Comp.ParasiteStunTime, true, false))
+            if (!Stun(xeno, receiver, xeno.Comp.ParasiteStunTime, true, xeno.Comp.ParasiteStunRange, session, false))
                 continue;
 
             _cameraShake.ShakeCamera(receiver, xeno.Comp.CloseScreenShakeShakes, xeno.Comp.CloseScreenShakeStrength);
@@ -108,12 +119,17 @@ public sealed class XenoScreechSystem : EntitySystem
             SpawnAttachedTo(xeno.Comp.Effect, xeno.Owner.ToCoordinates());
     }
 
-    private bool Stun(EntityUid xeno, EntityUid receiver, TimeSpan time, bool stun, bool occlusionCheck = true)
+    private bool Stun(EntityUid xeno, EntityUid receiver, TimeSpan time, bool stun, float range, ICommonSession? session, bool occlusionCheck = true)
     {
         if (_mobState.IsDead(receiver))
             return false;
 
-        if (occlusionCheck && !_examineSystem.InRangeUnOccluded(xeno, receiver))
+        // Non-expanded range check against the target's lag-compensated position
+        if (!_rmcLagCompensation.IsWithinMargin(xeno, receiver, session, range))
+            return false;
+
+        // Check line of sight against the target's lag-compensated position
+        if (occlusionCheck && !_examineSystem.InRangeUnOccluded(xeno, _rmcLagCompensation.GetCoordinates(receiver, session)))
             return false;
 
         if (stun)
@@ -122,12 +138,12 @@ public sealed class XenoScreechSystem : EntitySystem
         return _stun.TryParalyze(receiver, time, false);
     }
 
-    private void Deafen(EntityUid xeno, EntityUid receiver, TimeSpan time)
+    private void Deafen(EntityUid xeno, EntityUid receiver, TimeSpan time, ICommonSession? session)
     {
         if (_mobState.IsDead(receiver))
             return;
 
-        if (!_examineSystem.InRangeUnOccluded(xeno, receiver))
+        if (!_examineSystem.InRangeUnOccluded(xeno, _rmcLagCompensation.GetCoordinates(receiver, session)))
             return;
 
         _deaf.TryDeafen(receiver, time, false);

--- a/Content.Shared/_RMC14/Xenonids/Screech/XenoScreechComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Screech/XenoScreechComponent.cs
@@ -34,6 +34,11 @@ public sealed partial class XenoScreechComponent : Component
     [DataField, AutoNetworkedField]
     public float ParasiteStunRange = 11.2838f;
 
+    //range we add to ability entity checking range. loosely based on the distance a vest marine can travel in 750ms.
+    //lagcomp will always be clamped to 750ms anyway, so only downside of larger values is a miniscule performance hit.
+    [DataField]
+    public float LagCompensationLookupMargin = 4f;
+
     [DataField, AutoNetworkedField]
     public TimeSpan ParasiteStunTime = TimeSpan.FromSeconds(8);
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Queen Screech is now lag compensated

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

The grind to lag compensate xeno abilities continues. 

Queen is a central factor in how xenos perform each round, and screech is arguably her single most impactful trait. Without lag compensation, the difference between a queen with high ping and low ping is *massive*, to the point that it's easier to be a good queen if you have a good connection, and harder without. 

Just like for other abilities and projectiles in general, high ping should not prevent you from playing and enjoying the game. 

Note that because CC is not predicted or compensated, marines will not "teleport" back to the location they were screamed at on the queen's client, and will instead be paralyzed or stunned at their server location when the scream goes off. This is a good middle ground, similar to how runner and lurker CC works.

## Technical details
<!-- Summary of code changes for easier review. -->
The biggest issue was that unlike with defender sweep, we have to deal with InRangeUnOccluded, which doesn't have inherent lag compensation. I didn't want to meddle with the base code of InRangeUnOccluded since it's used in many places, but we can get around this by just feeding InRangeUnOccluded lag compensated coordinates, since ultimately it just ends up drawing a ray between two coords to check for occlusion. 

I used the same cap of 4 tiles of compensation here as I did for fender sweep, yet again based on the distance a vest marine travels in 750ms. Note that parasite stuns are also now lag compensated, as are the deafen effects at both scream ranges. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

First, let's look at how things are in the live server. All tests were performed with a third party viewer to minimize the impact of prediction, and performed with default delay for both marines (75ms) and extreme delay for queen for the purposes of demonstration (400ms). 

Here's screech behavior on live:

Marine moving towards queen (range should be 7 tiles):

https://github.com/user-attachments/assets/a4508a81-33b0-43c7-a221-31109b3b93da


Marine moving away from queen (range should be 7 tiles):

https://github.com/user-attachments/assets/2b586e07-0974-4855-babc-3d4ac8c5f70b


Marine moving into occlusion:

https://github.com/user-attachments/assets/9bbcc730-93a3-4471-ad99-36a9bcd1178a



Marine moving out of occlusion:

https://github.com/user-attachments/assets/db178937-65df-494a-89f3-bb9eac2f90d1




Note that you can scream a marine moving into occlusion or away from you while they're solidly in range, yet have them not be stunned. Likewise, notice how you can scream before a marine enters your range or leaves occlusion and still get a root you shouldn't have.



Now, let's look at the lag compensated version:

Marine moving towards queen (knockdown range of 4 tiles):

https://github.com/user-attachments/assets/a2984455-5918-4a29-84a8-ec287f3ecff2


Marine moving away from queen (knockdown range of 4 tiles):

https://github.com/user-attachments/assets/142720ae-1337-4326-9fe7-f3b50463b82a


Marine moving into occlusion :

https://github.com/user-attachments/assets/2f63c22c-5c07-472e-8f51-02dc2c23664d


Marine moving out of occlusion:

https://github.com/user-attachments/assets/acbf8011-60f3-4671-8b7b-3ae25dde5748



Notice that on the client side, these screams line up with what the queen player is expecting much better than on live. Real gameplay won't be this extreme the vast majority of the time, since our connection here is exceedingly poor. Note also that it's not strictly better for queen, since you now no longer hit screams on marines moving into your range that you shouldn't, and no longer are able to scream marines moving out of occlusion before they actually do so. 

This likely has the issue of slight difficulty hitting targets moving towards you and moving out of occlusion even on client side, but this should be fixed by https://github.com/RMC-14/RMC-14/pull/10103 just like defender tailsweep is. 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Queen Screech is now lag compensated
