### PR TITLE
[PVE] SPP Role Language Cleanup

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/SPPoverwatch.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/SPPoverwatch.yml
@@ -19,6 +19,17 @@
   special:
   - !type:AddComponentSpecial
     components:
+    - type: Language
+      spokenLanguages:
+      - Russian
+      - English
+      - Chinese
+      understoodLanguages:
+      - Russian
+      - English
+      - Chinese
+      currentLanguage: Russian
+      defaultLanguage: Russian
     - type: NpcFactionMember
       factions:
       - SPP

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/corpsman.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/corpsman.yml
@@ -19,6 +19,15 @@
   special:
   - !type:AddComponentSpecial
     components:
+    - type: Language
+      spokenLanguages:
+      - Russian
+      - Chinese
+      understoodLanguages:
+      - Russian
+      - Chinese
+      currentLanguage: Russian
+      defaultLanguage: Russian
     - type: NpcFactionMember
       factions:
       - SPP

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/heavy_gunner.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/heavy_gunner.yml
@@ -15,6 +15,15 @@
   special:
   - !type:AddComponentSpecial
     components:
+    - type: Language
+      spokenLanguages:
+      - Russian
+      - Chinese
+      understoodLanguages:
+      - Russian
+      - Chinese
+      currentLanguage: Russian
+      defaultLanguage: Russian
     - type: NpcFactionMember
       factions:
       - SPP

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/rifleman.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/rifleman.yml
@@ -15,6 +15,15 @@
   special:
   - !type:AddComponentSpecial
     components:
+    - type: Language
+      spokenLanguages:
+      - Russian
+      - Chinese
+      understoodLanguages:
+      - Russian
+      - Chinese
+      currentLanguage: Russian
+      defaultLanguage: Russian
     - type: NpcFactionMember
       factions:
       - SPP

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/section_lead.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/section_lead.yml
@@ -15,6 +15,17 @@
   special:
   - !type:AddComponentSpecial
     components:
+    - type: Language
+      spokenLanguages:
+      - Russian
+      - English
+      - Chinese
+      understoodLanguages:
+      - Russian
+      - English
+      - Chinese
+      currentLanguage: Russian
+      defaultLanguage: Russian
     - type: NpcFactionMember
       factions:
       - SPP

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/squad_lead.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/squad_lead.yml
@@ -15,6 +15,15 @@
   special:
   - !type:AddComponentSpecial
     components:
+    - type: Language
+      spokenLanguages:
+      - Russian
+      - Chinese
+      understoodLanguages:
+      - Russian
+      - Chinese
+      currentLanguage: Russian
+      defaultLanguage: Russian
     - type: NpcFactionMember
       factions:
       - SPP

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/spp_command/Kommissar.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/spp_command/Kommissar.yml
@@ -15,6 +15,17 @@
   special:
   - !type:AddComponentSpecial
     components:
+    - type: Language
+      spokenLanguages:
+      - Russian
+      - English
+      - Chinese
+      understoodLanguages:
+      - Russian
+      - English
+      - Chinese
+      currentLanguage: Russian
+      defaultLanguage: Russian
     - type: RMCTrackable
     - type: NpcFactionMember
       factions:
@@ -106,6 +117,17 @@
   special:
   - !type:AddComponentSpecial
     components:
+    - type: Language
+      spokenLanguages:
+      - Russian
+      - English
+      - Chinese
+      understoodLanguages:
+      - Russian
+      - English
+      - Chinese
+      currentLanguage: Russian
+      defaultLanguage: Russian
     - type: RMCTrackable
     - type: NpcFactionMember
       factions:
@@ -177,6 +199,17 @@
   special:
   - !type:AddComponentSpecial
     components:
+    - type: Language
+      spokenLanguages:
+      - Russian
+      - English
+      - Chinese
+      understoodLanguages:
+      - Russian
+      - English
+      - Chinese
+      currentLanguage: Russian
+      defaultLanguage: Russian
     - type: RMCTrackable
     - type: NpcFactionMember
       factions:
@@ -248,6 +281,17 @@
   special:
   - !type:AddComponentSpecial
     components:
+    - type: Language
+      spokenLanguages:
+      - Russian
+      - English
+      - Chinese
+      understoodLanguages:
+      - Russian
+      - English
+      - Chinese
+      currentLanguage: Russian
+      defaultLanguage: Russian
     - type: RMCTrackable
     - type: NpcFactionMember
       factions:
@@ -319,6 +363,17 @@
   special:
   - !type:AddComponentSpecial
     components:
+    - type: Language
+      spokenLanguages:
+      - Russian
+      - English
+      - Chinese
+      understoodLanguages:
+      - Russian
+      - English
+      - Chinese
+      currentLanguage: Russian
+      defaultLanguage: Russian
     - type: RMCTrackable
     - type: NpcFactionMember
       factions:
@@ -390,6 +445,17 @@
   special:
   - !type:AddComponentSpecial
     components:
+    - type: Language
+      spokenLanguages:
+      - Russian
+      - English
+      - Chinese
+      understoodLanguages:
+      - Russian
+      - English
+      - Chinese
+      currentLanguage: Russian
+      defaultLanguage: Russian
     - type: RMCTrackable
     - type: NpcFactionMember
       factions:


### PR DESCRIPTION
## About the PR
PVE SPP squad roles now properly speak Russian and Chinese, and do not speak English. The Section Sergeant and Platoon Commander have been granted English for interacting with other factions.

Kommissars have also been adjusted, and now speak Russian, English, and Chinese.

## Why / Balance
Lore consistency.

## Technical details
yml

## Media
<img width="554" height="347" alt="image" src="https://github.com/user-attachments/assets/9160846b-8aa9-42f1-82ec-51cee7b8e12a" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: [PVE] Marines of the SPP's 17th Vega Naval Infantry now properly speak Russian and Chinese (and not English), as do the Party's Political Kommissars.