### PR TITLE
Make xeno armor resist bio damage + fix armor oversight

### DIFF
--- a/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
+++ b/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Text;
 using Content.Shared._RMC14.Map;
 using Content.Shared._RMC14.Medical.Surgery;
@@ -403,6 +403,7 @@ public sealed class CMArmorSystem : EntitySystem
         else
         {
             Resist(args.Damage, ev.XenoArmor, ArmorGroup, mod.RangedArmorModifier);
+            Resist(args.Damage, ev.XenoArmor, BioGroup, mod.RangedArmorModifier);
         }
     }
 

--- a/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
+++ b/Content.Shared/_RMC14/Armor/CMArmorSystem.cs
@@ -414,7 +414,8 @@ public sealed class CMArmorSystem : EntitySystem
             return;
 
         var resist = Math.Pow(1.1, armor / 5.0);
-        var types = _prototypes.Index(group).DamageTypes;
+        var damGroup = _prototypes.Index(group);
+        var types = damGroup.DamageTypes;
 
         foreach (var type in types)
         {
@@ -425,7 +426,7 @@ public sealed class CMArmorSystem : EntitySystem
             }
         }
 
-        var newDamage = damage.GetTotal();
+        var newDamage = damage.TryGetDamageInGroup(damGroup, out var damTotal) ? damTotal : damage.GetTotal();
         if (newDamage != FixedPoint2.Zero && newDamage < armor * 2)
         {
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title. The oversight is resist's armor check gets total damage even if the damage passed doesn't include a type it would reduce. I just added a check for that.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity! Literally only effects Xeno v Xeno as marines don't really do any kinda of bio damage (fire ignores armor after all). The other thing only really effects multidamage stuff that doesn't resist armor, like...bibles.

## Technical details
<!-- Summary of code changes for easier review. -->
Just add another Resist line for biogroup for xenos.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
no one's going to see this one atm.