### PR TITLE
Sort abilities properly for immature and matured queens

### DIFF
--- a/Content.Server/_RMC14/Actions/RMCActionsSystem.cs
+++ b/Content.Server/_RMC14/Actions/RMCActionsSystem.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using System.Linq;
 using Content.Server.Actions;
 using Content.Shared._RMC14.Actions;
@@ -13,6 +13,7 @@ public sealed class RMCActionsSystem : SharedRMCActionsSystem
 {
     [Dependency] private readonly ActionsSystem _actions = default!;
     [Dependency] private readonly RMCActionsManager _manager = default!;
+    [Dependency] private readonly ISharedPlayerManager _player = default!;
 
     private readonly HashSet<EntProtoId> _actionsPresent = new();
     private readonly Dictionary<(NetUserId User, EntProtoId Id), List<EntProtoId>> _toUpdate = new();
@@ -25,6 +26,7 @@ public sealed class RMCActionsSystem : SharedRMCActionsSystem
 
         SubscribeNetworkEvent<RMCActionOrderChangeEvent>(OnActionOrder);
 
+        SubscribeLocalEvent<RMCActionOrderComponent, ComponentStartup>(OnOrderStartup);
         SubscribeLocalEvent<RMCActionOrderComponent, PlayerAttachedEvent>(OnOrderAttached);
     }
 
@@ -64,10 +66,27 @@ public sealed class RMCActionsSystem : SharedRMCActionsSystem
         _toUpdate[(args.SenderSession.UserId, order.Id)] = msg.Actions;
     }
 
+    private void OnOrderStartup(Entity<RMCActionOrderComponent> ent, ref ComponentStartup args)
+    {
+        // Entities swap this component out to change which order they use, e.g. queen maturing into extra abilities.
+        if (_player.TryGetSessionByEntity(ent, out var player))
+            LoadOrder(ent, player);
+    }
+
     private void OnOrderAttached(Entity<RMCActionOrderComponent> ent, ref PlayerAttachedEvent args)
     {
-        ent.Comp.Order = _manager.GetOrder(args.Player.UserId, ent.Comp.Id);
+        LoadOrder(ent, args.Player);
+    }
+
+    private void LoadOrder(Entity<RMCActionOrderComponent> ent, ICommonSession player)
+    {
+        var order = _manager.GetOrder(player.UserId, ent.Comp.Id);
+        ent.Comp.Order = order;
         Dirty(ent);
+
+        // The actions saved under this id are not the ones the client sorted itself by, so make it sort again.
+        var ev = new RMCActionOrderLoadedEvent(order?.ToList() ?? new List<EntProtoId>());
+        RaiseNetworkEvent(ev, player);
     }
 
     private void OnLoaded(ICommonSession user, Dictionary<EntProtoId, ImmutableArray<EntProtoId>>? allActions)

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
@@ -215,6 +215,9 @@
     addComponents:
     - type: XenoScreech
     - type: XenoToggleSpit
+    # Overwrites the immature order, so matured queens order their extra abilities correctly
+    - type: RMCActionOrder
+      id: CMXenoQueen
     addActions:
     - ActionXenoScreech
     - ActionXenoSpitQueen
@@ -290,12 +293,18 @@
     - type: Gibbable
     - type: CanBeLarvaQueued
 
+# Queens start immature, so this is the id their action bar order is saved under until they mature
+- type: entity
+  abstract: true
+  id: CMXenoQueenImmature
+
 - type: entity
   parent: RMCXenoQueenBase
   id: CMXenoQueen
   components:
+  # XenoMaturing moves this ordering onto CMXenoQueen once they mature
   - type: RMCActionOrder
-    id: CMXenoQueen
+    id: CMXenoQueenImmature
     #  - type: XenoEvolution #can be enabled for events like april fools.
     #    strains:
     #    - RMCXenoQueenMaid
@@ -325,6 +334,9 @@
       visible: false
     - map: [ "enum.RMCDamageVisualLayers.Base" ]
       visible: false
+  # Reskin of the queen with the same actions, so it shares her action bar order
+  - type: RMCActionOrder
+    id: CMXenoQueenImmature
   - type: XenoStrain
     name: rmc-xeno-maid-name
     description: rmc-xeno-maid-description
@@ -351,6 +363,9 @@
       visible: false
     - map: [ "enum.RMCDamageVisualLayers.Base" ]
       visible: false
+  # Reskin of the queen with the same actions, so it shares her action bar order
+  - type: RMCActionOrder
+    id: CMXenoQueenImmature
   - type: XenoStrain
     name: rmc-xeno-magicalgirl-name
     description: rmc-xeno-magicalgirl-description


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title. Now, immature and matured queens save separate ability orders. This makes it so that you don't have to re-sort your ability bar every round as queen both when you spawn and when you mature. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
QOL.

## Technical details
<!-- Summary of code changes for easier review. -->
- Queen's `RMCActionOrder` now starts as `CMXenoQueenImmature`. Then `XenoMaturing.addComponents` overwrites it with `CMXenoQueen` on maturing, since `EntityManager.AddComponents` defaults to `removeExisting: true`.
- `CMXenoQueenImmature` is an abstract prototype used as the id the immature order is saved under.
- Server `RMCActionsSystem` now loads the saved order on `ComponentStartup` as well as `PlayerAttachedEvent`, through one `LoadOrder` helper that also raises `RMCActionOrderLoadedEvent` so the client re-sorts.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

https://github.com/user-attachments/assets/e17c4059-fd1f-4a64-902c-fc1e91a1d2c9

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Vexerot
- fix: Queen now differentiates between immature and mature to properly persist ability bar ordering.