### PR TITLE
Xeno nesting name obfuscation

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestSystem.cs
@@ -432,7 +432,7 @@ public sealed class XenoNestSystem : EntitySystem
 
             if (_mobState.IsDead(victim.Value))
             {
-                var selfMessage = Loc.GetString("cm-xeno-nest-failed-dead", ("target", Identity.Name(victim.Value, EntityManager, user)));
+                var selfMessage = Loc.GetString("rmc-xeno-nest-failed-dead", ("target", Identity.Name(victim.Value, EntityManager, user)));
                 if (!silent)
                     _popup.PopupClient(selfMessage, surface, user);
 

--- a/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestSystem.cs
@@ -16,6 +16,7 @@ using Content.Shared.DoAfter;
 using Content.Shared.DragDrop;
 using Content.Shared.Ghost;
 using Content.Shared.Hands.Components;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Inventory.Events;
@@ -261,20 +262,24 @@ public sealed class XenoNestSystem : EntitySystem
         _standing.Stand(victim, force: true);
 
         // TODO RMC14 make a method to do this
-        _popup.PopupClient(Loc.GetString("cm-xeno-nest-securing-self", ("target", victim)), args.User, args.User);
+        var selfMessage = Loc.GetString("cm-xeno-nest-securing-self", ("target", Identity.Name(victim, EntityManager, args.User)));
+        _popup.PopupClient(selfMessage, args.User, args.User);
 
-        foreach (var session in Filter.PvsExcept(args.User).Recipients)
+        var others = Filter.PvsExcept(args.User).Recipients;
+        foreach (var other in others)
         {
-            if (session.AttachedEntity is not { } recipient)
+            if (other.AttachedEntity is not { } otherEnt)
                 continue;
 
-            if (recipient == victim)
+            if (otherEnt == victim)
             {
-                _popup.PopupEntity(Loc.GetString("cm-xeno-nest-securing-target", ("user", args.User)), args.User, recipient, PopupType.MediumCaution);
+                var victimMessage = Loc.GetString("cm-xeno-nest-securing-target", ("user", Identity.Name(args.User, EntityManager, victim)));
+                _popup.PopupEntity(victimMessage, args.User, otherEnt, PopupType.MediumCaution);
             }
             else
             {
-                _popup.PopupEntity(Loc.GetString("cm-xeno-nest-securing-observer", ("user", args.User), ("target", victim)), args.User, recipient);
+                var otherMessage = Loc.GetString("cm-xeno-nest-securing-observer", ("user", Identity.Name(args.User, EntityManager, otherEnt)), ("target", Identity.Name(victim, EntityManager, otherEnt)));
+                _popup.PopupEntity(otherMessage, args.User, otherEnt);
             }
         }
 
@@ -375,20 +380,24 @@ public sealed class XenoNestSystem : EntitySystem
             return true;
 
         // TODO RMC14 make a method to do this
-        _popup.PopupClient(Loc.GetString("cm-xeno-nest-pin-self", ("target", victim)), user, user);
+        var selfMessage = Loc.GetString("cm-xeno-nest-pin-self", ("target", Identity.Name(victim, EntityManager, user)));
+        _popup.PopupClient(selfMessage, user, user);
 
-        foreach (var session in Filter.PvsExcept(user).Recipients)
+        var others = Filter.PvsExcept(user).Recipients;
+        foreach (var other in others)
         {
-            if (session.AttachedEntity is not { } recipient)
+            if (other.AttachedEntity is not { } otherEnt)
                 continue;
 
-            if (recipient == victim)
+            if (otherEnt == victim)
             {
-                _popup.PopupEntity(Loc.GetString("cm-xeno-nest-pin-target", ("user", user)), user, recipient, PopupType.MediumCaution);
+                var victimMessage = Loc.GetString("cm-xeno-nest-pin-target", ("user", Identity.Name(user, EntityManager, victim)));
+                _popup.PopupEntity(victimMessage, user, otherEnt, PopupType.MediumCaution);
             }
             else
             {
-                _popup.PopupEntity(Loc.GetString("cm-xeno-nest-pin-observer", ("user", user), ("target", victim)), user, recipient);
+                var otherMessage = Loc.GetString("cm-xeno-nest-pin-observer", ("user", Identity.Name(user, EntityManager, otherEnt)), ("target", Identity.Name(victim, EntityManager, otherEnt)));
+                _popup.PopupEntity(otherMessage, user, otherEnt);
             }
         }
 
@@ -413,16 +422,19 @@ public sealed class XenoNestSystem : EntitySystem
         {
             if (!HasComp<XenoNestableComponent>(victim))
             {
+
+                var selfMessage = Loc.GetString("cm-xeno-nest-failed", ("target", Identity.Name(victim.Value, EntityManager, user)));
                 if (!silent)
-                    _popup.PopupClient(Loc.GetString("cm-xeno-nest-failed", ("target", victim)), surface, user);
+                    _popup.PopupClient(selfMessage, surface, user);
 
                 return false;
             }
 
             if (_mobState.IsDead(victim.Value))
             {
+                var selfMessage = Loc.GetString("cm-xeno-nest-failed-dead", ("target", Identity.Name(victim.Value, EntityManager, user)));
                 if (!silent)
-                    _popup.PopupClient(Loc.GetString("rmc-xeno-nest-failed-dead", ("target", victim)), surface, user);
+                    _popup.PopupClient(selfMessage, surface, user);
 
                 return false;
             }
@@ -478,8 +490,9 @@ public sealed class XenoNestSystem : EntitySystem
 
         if (victim != null && !_standing.IsDown(victim.Value))
         {
+            var selfMessage = Loc.GetString("cm-xeno-nest-failed-target-resisting", ("target", Identity.Name(victim.Value, EntityManager, user)));
             if (!silent)
-                _popup.PopupClient(Loc.GetString("cm-xeno-nest-failed-target-resisting", ("target", victim)), victim.Value, user, PopupType.MediumCaution);
+                _popup.PopupClient(selfMessage, victim.Value, user, PopupType.MediumCaution);
 
             return false;
         }

--- a/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestSystem.cs
@@ -263,7 +263,7 @@ public sealed class XenoNestSystem : EntitySystem
 
         // TODO RMC14 make a method to do this
         var selfMessage = Loc.GetString("cm-xeno-nest-securing-self", ("target", Identity.Name(victim, EntityManager, args.User)));
-        _popup.PopupClient(selfMessage, args.User, args.User);
+        _popup.PopupEntity(selfMessage, args.User, args.User);
 
         var others = Filter.PvsExcept(args.User).Recipients;
         foreach (var other in others)

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-nest.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-nest.ftl
@@ -10,4 +10,4 @@ cm-xeno-nest-failed = {$target} can't be put into a nest!
 cm-xeno-nest-failed-target-resisting = {$target} is resisting, ground them!
 cm-xeno-nest-failed-cant-there = We can't create a nest there!
 cm-xeno-nest-failed-cant-already-there = There is already someone nested there!
-rmc-xeno-nest-failed-dead = This host is dead.
+rmc-xeno-nest-failed-dead = {$target} has died, we can't nest them anymore.


### PR DESCRIPTION
## About the PR
Adds hidden identity to the nesting popups
also fixes the cm-xeno-nest-securing-self poup not appearing

## Why / Balance
To prevent metaknowledge

## Media
https://github.com/user-attachments/assets/b00d5a08-709a-4ce9-8fe3-4201524c5d91

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: CatAndHats
- fix: Nesting actions won't reveal people's names to the other faction anymore