### PR TITLE
Chem dispensers now come with free nutriment

### DIFF
--- a/Content.Shared/_RMC14/Chemistry/RMCChemicalDispenserComponent.cs
+++ b/Content.Shared/_RMC14/Chemistry/RMCChemicalDispenserComponent.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Chemistry.Reagent;
+using Content.Shared.Chemistry.Reagent;
 using Content.Shared.FixedPoint;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
@@ -28,13 +28,13 @@ public sealed partial class RMCChemicalDispenserComponent : Component
     public ProtoId<ReagentPrototype>[] Reagents =
     [
         "RMCAluminum", "RMCCarbon", "RMCChlorine", "RMCCopper", "RMCEthanol", "RMCFluorine",
-        "RMCHydrogen", "RMCIron", "RMCLithium", "RMCMercury", "RMCNitrogen", "RMCOxygen",
+        "RMCHydrogen", "RMCIron", "RMCLithium", "RMCMercury", "RMCNitrogen", "Nutriment", "RMCOxygen",
         "RMCPhosphorus", "RMCPotassium", "RMCRadium", "RMCSilicon", "RMCSodium", "RMCSugar",
         "RMCSulfur", "RMCSulphuricAcid", "Water",
     ];
 
     [DataField, AutoNetworkedField]
-    public HashSet<ProtoId<ReagentPrototype>> FreeReagents = ["Water"];
+    public HashSet<ProtoId<ReagentPrototype>> FreeReagents = ["Nutriment", "Water"];
 
     [DataField, AutoNetworkedField]
     public FixedPoint2 DispenseSetting = 5;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title. Intended to be merged with #10645.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
1. Nutriment is already basically free.
2. Energy-wise, you can harvest nutriment for 0 energy in CM: Get a syringe, draw out of a bar. There's your nutriment.
3. Since I want to fix carrot juice to mostly parity, doing this prevents requiring the click grinding of nutriment that was done before.

Ideally this stuff gets looked at after parity but since it's free anyway might as well stuff it in the chem dispenser and free up the one person who'd be forced to grind nutriment at the start of every shift.

## Technical details
<!-- Summary of code changes for easier review. -->
Just added stuff to the comp.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Nutriment is now available in chem dispensers for free.
