### PR TITLE
Add heavy M44 ammunition with reusable buildup effects

### DIFF
--- a/Content.Shared/_RMC14/Effects/Buildup/RMCApplyBuildupOnHitComponent.cs
+++ b/Content.Shared/_RMC14/Effects/Buildup/RMCApplyBuildupOnHitComponent.cs
@@ -1,0 +1,15 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._RMC14.Effects.Buildup;
+
+[Access(typeof(RMCBuildupSystem))]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class RMCApplyBuildupOnHitComponent : Component
+{
+    [DataField(required: true), AutoNetworkedField]
+    public ProtoId<RMCBuildupPrototype> Buildup;
+
+    [DataField, AutoNetworkedField]
+    public int Amount = 1;
+}

--- a/Content.Shared/_RMC14/Effects/Buildup/RMCBuildupComponent.cs
+++ b/Content.Shared/_RMC14/Effects/Buildup/RMCBuildupComponent.cs
@@ -1,0 +1,23 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Effects.Buildup;
+
+[Access(typeof(RMCBuildupSystem))]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class RMCBuildupComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public Dictionary<ProtoId<RMCBuildupPrototype>, RMCBuildupState> States = new();
+}
+
+[DataDefinition, Serializable, NetSerializable]
+public sealed partial class RMCBuildupState
+{
+    [DataField]
+    public int Current;
+
+    [DataField]
+    public TimeSpan? NextDecayAt;
+}

--- a/Content.Shared/_RMC14/Effects/Buildup/RMCBuildupEvent.cs
+++ b/Content.Shared/_RMC14/Effects/Buildup/RMCBuildupEvent.cs
@@ -1,0 +1,17 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._RMC14.Effects.Buildup;
+
+[ByRefEvent]
+public record struct RMCBuildupTriggeredEvent(
+    EntityUid Target,
+    ProtoId<RMCBuildupPrototype> Buildup,
+    EntityUid? User);
+
+public enum RMCBuildupApplyResult : byte
+{
+    None,
+    Applied,
+    Started,
+    Triggered,
+}

--- a/Content.Shared/_RMC14/Effects/Buildup/RMCBuildupPrototype.cs
+++ b/Content.Shared/_RMC14/Effects/Buildup/RMCBuildupPrototype.cs
@@ -1,0 +1,49 @@
+using Content.Shared._RMC14.Stun;
+using Content.Shared.Popups;
+using Content.Shared.Whitelist;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._RMC14.Effects.Buildup;
+
+[Prototype("rmcBuildup")]
+public sealed partial class RMCBuildupPrototype : IPrototype
+{
+    [IdDataField]
+    public string ID { get; private set; } = string.Empty;
+
+    [DataField]
+    public int Threshold = 1;
+
+    [DataField]
+    public int DecayAmount = 1;
+
+    [DataField]
+    public TimeSpan DecayEvery = TimeSpan.FromSeconds(2);
+
+    [DataField]
+    public bool RefreshDecayOnApply;
+
+    [DataField]
+    public bool AffectsDead;
+
+    [DataField]
+    public RMCSizes? MinimumSize;
+
+    [DataField]
+    public RMCSizes? MaximumSize;
+
+    [DataField]
+    public EntityWhitelist? Whitelist;
+
+    [DataField]
+    public LocId? AppliedPopup;
+
+    [DataField]
+    public PopupType AppliedPopupType = PopupType.MediumCaution;
+
+    [DataField]
+    public LocId? TriggeredPopup;
+
+    [DataField]
+    public PopupType TriggeredPopupType = PopupType.MediumCaution;
+}

--- a/Content.Shared/_RMC14/Effects/Buildup/RMCBuildupSystem.cs
+++ b/Content.Shared/_RMC14/Effects/Buildup/RMCBuildupSystem.cs
@@ -1,0 +1,198 @@
+using Content.Shared._RMC14.Stun;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.Popups;
+using Content.Shared.Projectiles;
+using Content.Shared.Whitelist;
+using Robust.Shared.Network;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
+
+namespace Content.Shared._RMC14.Effects.Buildup;
+
+public sealed class RMCBuildupSystem : EntitySystem
+{
+    [Dependency] private readonly EntityWhitelistSystem _entityWhitelist = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
+    [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly RMCSizeStunSystem _size = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    private readonly List<ProtoId<RMCBuildupPrototype>> _remove = new();
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<RMCApplyBuildupOnHitComponent, ProjectileHitEvent>(OnProjectileHit);
+        SubscribeLocalEvent<RMCBuildupComponent, EntityUnpausedEvent>(OnBuildupUnpaused);
+    }
+
+    private void OnProjectileHit(Entity<RMCApplyBuildupOnHitComponent> ent, ref ProjectileHitEvent args)
+    {
+        if (_net.IsClient)
+            return;
+
+        if (TryApply(args.Target, ent.Comp.Buildup, ent.Comp.Amount) != RMCBuildupApplyResult.Triggered)
+            return;
+
+        var triggered = new RMCBuildupTriggeredEvent(args.Target, ent.Comp.Buildup, args.Shooter);
+        RaiseLocalEvent(ent, ref triggered);
+    }
+
+    private void OnBuildupUnpaused(Entity<RMCBuildupComponent> ent, ref EntityUnpausedEvent args)
+    {
+        foreach (var state in ent.Comp.States.Values)
+        {
+            if (state.NextDecayAt != null)
+                state.NextDecayAt += args.PausedTime;
+        }
+
+        Dirty(ent);
+    }
+
+    public RMCBuildupApplyResult TryApply(
+        EntityUid target,
+        ProtoId<RMCBuildupPrototype> buildupId,
+        int amount)
+    {
+        if (_net.IsClient || amount <= 0)
+            return RMCBuildupApplyResult.None;
+
+        var buildupPrototype = _prototype.Index(buildupId);
+        if (!CanApply(target, buildupPrototype))
+            return RMCBuildupApplyResult.None;
+
+        var buildup = EnsureComp<RMCBuildupComponent>(target);
+        var started = false;
+        if (!buildup.States.TryGetValue(buildupId, out var state))
+        {
+            started = true;
+            state = new RMCBuildupState
+            {
+                NextDecayAt = GetNextDecayAt(buildupPrototype),
+            };
+            buildup.States.Add(buildupId, state);
+
+            if (buildupPrototype.AppliedPopup is { } appliedPopup)
+            {
+                _popup.PopupEntity(
+                    Loc.GetString(appliedPopup),
+                    target,
+                    target,
+                    buildupPrototype.AppliedPopupType);
+            }
+        }
+        else if (buildupPrototype.RefreshDecayOnApply)
+        {
+            state.NextDecayAt = GetNextDecayAt(buildupPrototype);
+        }
+
+        state.Current += amount;
+        if (state.Current < Math.Max(1, buildupPrototype.Threshold))
+        {
+            Dirty(target, buildup);
+            return started ? RMCBuildupApplyResult.Started : RMCBuildupApplyResult.Applied;
+        }
+
+        buildup.States.Remove(buildupId);
+        if (buildup.States.Count == 0)
+            RemCompDeferred<RMCBuildupComponent>(target);
+        else
+            Dirty(target, buildup);
+
+        if (buildupPrototype.TriggeredPopup is { } triggeredPopup)
+        {
+            _popup.PopupEntity(
+                Loc.GetString(triggeredPopup),
+                target,
+                target,
+                buildupPrototype.TriggeredPopupType);
+        }
+
+        return RMCBuildupApplyResult.Triggered;
+    }
+
+    private bool CanApply(EntityUid target, RMCBuildupPrototype buildup)
+    {
+        if (!_entityWhitelist.IsWhitelistPassOrNull(buildup.Whitelist, target) ||
+            (!buildup.AffectsDead && _mobState.IsDead(target)))
+        {
+            return false;
+        }
+
+        if (buildup.MinimumSize == null && buildup.MaximumSize == null)
+            return true;
+
+        if (!_size.TryGetSize(target, out var size))
+            return false;
+
+        return (buildup.MinimumSize == null || size >= buildup.MinimumSize) &&
+               (buildup.MaximumSize == null || size <= buildup.MaximumSize);
+    }
+
+    private TimeSpan? GetNextDecayAt(RMCBuildupPrototype buildup)
+    {
+        return buildup.DecayEvery > TimeSpan.Zero
+            ? _timing.CurTime + buildup.DecayEvery
+            : null;
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        if (_net.IsClient)
+            return;
+
+        var time = _timing.CurTime;
+        var query = EntityQueryEnumerator<RMCBuildupComponent>();
+        while (query.MoveNext(out var uid, out var buildup))
+        {
+            var changed = false;
+            _remove.Clear();
+
+            foreach (var (id, state) in buildup.States)
+            {
+                if (state.NextDecayAt is not { } nextDecayAt || time < nextDecayAt)
+                    continue;
+
+                if (!_prototype.TryIndex(id, out var buildupPrototype) ||
+                    buildupPrototype.DecayAmount <= 0 ||
+                    buildupPrototype.DecayEvery <= TimeSpan.Zero)
+                {
+                    state.NextDecayAt = null;
+                    changed = true;
+                    continue;
+                }
+
+                var elapsedPeriods = (int)((time - nextDecayAt).Ticks / buildupPrototype.DecayEvery.Ticks) + 1;
+                state.Current -= elapsedPeriods * buildupPrototype.DecayAmount;
+                changed = true;
+
+                if (state.Current <= 0)
+                {
+                    _remove.Add(id);
+                    continue;
+                }
+
+                state.NextDecayAt += buildupPrototype.DecayEvery * elapsedPeriods;
+            }
+
+            foreach (var id in _remove)
+            {
+                buildup.States.Remove(id);
+            }
+
+            if (buildup.States.Count == 0)
+            {
+                RemCompDeferred<RMCBuildupComponent>(uid);
+                continue;
+            }
+
+            if (changed)
+                Dirty(uid, buildup);
+        }
+    }
+}

--- a/Content.Shared/_RMC14/Effects/Buildup/RMCKnockdownOnBuildupComponent.cs
+++ b/Content.Shared/_RMC14/Effects/Buildup/RMCKnockdownOnBuildupComponent.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Effects.Buildup;
+
+[Access(typeof(RMCKnockdownOnBuildupSystem))]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class RMCKnockdownOnBuildupComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public TimeSpan Duration = TimeSpan.FromSeconds(1);
+
+    [DataField, AutoNetworkedField]
+    public bool Refresh;
+}

--- a/Content.Shared/_RMC14/Effects/Buildup/RMCKnockdownOnBuildupSystem.cs
+++ b/Content.Shared/_RMC14/Effects/Buildup/RMCKnockdownOnBuildupSystem.cs
@@ -1,0 +1,25 @@
+using Content.Shared.Stunnable;
+using Robust.Shared.Network;
+
+namespace Content.Shared._RMC14.Effects.Buildup;
+
+public sealed class RMCKnockdownOnBuildupSystem : EntitySystem
+{
+    [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly SharedStunSystem _stun = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<RMCKnockdownOnBuildupComponent, RMCBuildupTriggeredEvent>(OnBuildupTriggered);
+    }
+
+    private void OnBuildupTriggered(Entity<RMCKnockdownOnBuildupComponent> ent, ref RMCBuildupTriggeredEvent args)
+    {
+        if (_net.IsClient)
+            return;
+
+        _stun.TryKnockdown(args.Target, ent.Comp.Duration, ent.Comp.Refresh);
+    }
+}

--- a/Resources/Locale/en-US/_RMC14/weapons/guns.ftl
+++ b/Resources/Locale/en-US/_RMC14/weapons/guns.ftl
@@ -74,3 +74,5 @@ rmc-flare-gun-examine = The last signal flare fired has the designation: [color=
 
 expendable-light-starshell-ash-empty-name = extinguished star shell ash
 expendable-light-starshell-ash-empty-desc = Burnt out remains of a star shell
+rmc-heavy-revolver-buildup = We struggle to remain on our feet!
+rmc-heavy-revolver-knockdown = The massive impact knocks us off balance!

--- a/Resources/Prototypes/_RMC14/Catalog/Cargo/requisitions_catalog.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Cargo/requisitions_catalog.yml
@@ -69,6 +69,8 @@
       - cost: 3000
         crate: RMCCrateBoxMagazineRevolverM44Marksman
       - cost: 4000
+        crate: RMCCrateBoxMagazineRevolverM44Heavy
+      - cost: 4000
         crate: RMCCrateBoxMagazineSentry
       - cost: 4000
         crate: RMCCrateMagazineNapthalUT

--- a/Resources/Prototypes/_RMC14/Catalog/Fills/Crates/magazine_boxes.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Fills/Crates/magazine_boxes.yml
@@ -262,7 +262,7 @@
       - id: RMCSpeedLoaderM44
       - id: RMCSpeedLoaderM44
       - id: RMCSpeedLoader44Marksman
-      # - id: RMCSpeedLoader44Heavy # TODO RMC14: Heavy m44 speedloader
+      - id: RMCSpeedLoader44Heavy
       - id: RMCBoxShotgunSlugs
       - id: RMCBoxShotgunSlugs
       - id: RMCBoxShotgunBuckshot
@@ -311,6 +311,15 @@
   - type: StorageFill
     contents:
     - id: RMCBoxMagazineRevolverM44Marksman
+
+- type: entity
+  parent: RMCCrateAmmo
+  id: RMCCrateBoxMagazineRevolverM44Heavy
+  name: Speedloader box (Heavy M44, 16x loaders)
+  components:
+  - type: StorageFill
+    contents:
+    - id: RMCBoxMagazineRevolverM44Heavy
 
 - type: entity
   parent: RMCCrateAmmo

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magazine_boxes.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magazine_boxes.yml
@@ -2753,6 +2753,53 @@
         tags:
         - RMCSpeedLoader44Marksman
 
+# M44 HEAVY
+- type: entity
+  parent: RMCBoxMagazinePistolBase
+  id: RMCBoxMagazineRevolverM44HeavyEmpty
+  name: speedloader box (Heavy M44 x 16)
+  description: A box of pistol speedloaders.
+  components:
+  - type: Construction
+    graph: RMCBoxMagazine
+    node: RMCBoxMagazineRevolverM44HeavyEmpty
+  - type: Sprite
+    layers:
+    - state: pistol_box
+      color: "#727e90"
+    - state: pistol_ammo_full
+      map: [ "enum.CMItemSlotsLayers.Fill" ]
+      color: "#7866FF"
+    - state: pistol_box_44
+      color: "#ffcb26"
+    - state: pistol_box_marking
+      color: "#7866FF"
+    - state: pistol_lid
+      map: [ "lid" ]
+      color: "#727e90"
+    - state: pistol_lid_marking
+      map: [ "lid_marking" ]
+      color: "#7866FF"
+  - type: CMItemSlots
+    count: 16
+    slot:
+      whitelist:
+        tags:
+        - RMCSpeedLoader44Heavy
+
+- type: entity
+  parent: RMCBoxMagazineRevolverM44HeavyEmpty
+  id: RMCBoxMagazineRevolverM44Heavy
+  suffix: Full
+  components:
+  - type: CMItemSlots
+    startingItem: RMCSpeedLoader44Heavy
+    count: 16
+    slot:
+      whitelist:
+        tags:
+        - RMCSpeedLoader44Heavy
+
 # Type 73
 - type: entity
   parent: RMCBoxMagazinePistolBase

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Revolvers/m44_revolver.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Revolvers/m44_revolver.yml
@@ -18,8 +18,10 @@
       tags:
       - RMCSpeedLoaderM44
       - RMCSpeedLoader44Marksman
+      - RMCSpeedLoader44Heavy
       - RMCCartridgeRevolver44
       - RMCCartridgeRevolver44Marksman
+      - RMCCartridgeRevolver44Heavy
     proto: RMCCartridgeRevolver44
     capacity: 7
     chambers: [ True, True, True, True, True, True, True ]
@@ -156,7 +158,37 @@
       color: "#FF744F"
       map: [ "enum.GunVisualLayers.MagUnshaded" ]
   - type: BallisticAmmoProvider
+    whitelist:
+      tags:
+      - RMCCartridgeRevolver44Marksman
     proto: RMCCartridgeRevolver44Marksman
+    capacity: 7
+
+- type: entity
+  parent: RMCSpeedLoaderM44
+  id: RMCSpeedLoader44Heavy
+  name: "M44 heavy speed loader (.44)"
+  description: A 7-round .44 revolver speed loader containing heavy bullets. While less damaging than traditional .44 rounds, they deliver a higher stopping power.
+  components:
+  - type: Tag
+    tags:
+    - RMCMagazineRevolver
+    - RMCSpeedLoader44Heavy
+  - type: Sprite
+    sprite: _RMC14/Objects/Weapons/Guns/Ammunition/SpeedLoaders/m44.rsi
+    layers:
+    - state: base
+      map: [ "enum.GunVisualLayers.Base" ]
+    - state: base-5
+      map: [ "enum.GunVisualLayers.Mag" ]
+    - state: base-unshaded-5
+      color: "#7866FF"
+      map: [ "enum.GunVisualLayers.MagUnshaded" ]
+  - type: BallisticAmmoProvider
+    whitelist:
+      tags:
+      - RMCCartridgeRevolver44Heavy
+    proto: RMCCartridgeRevolver44Heavy
     capacity: 7
 
 - type: entity
@@ -179,9 +211,21 @@
   - type: Tag
     tags:
     - Cartridge
-    - RMCCartridgeRevolver44
+    - RMCCartridgeRevolver44Marksman
   - type: CartridgeAmmo
     proto: RMCBulletRevolver44Marksman
+
+- type: entity
+  id: RMCCartridgeRevolver44Heavy
+  name: cartridge (.44 Heavy)
+  parent: CMCartridgePistolBase
+  components:
+  - type: Tag
+    tags:
+    - Cartridge
+    - RMCCartridgeRevolver44Heavy
+  - type: CartridgeAmmo
+    proto: RMCBulletRevolver44Heavy
 
 - type: entity
   parent: CMBulletBase
@@ -221,8 +265,31 @@
     - range: 12
       falloff: 10
 
+- type: entity
+  parent: CMBulletBase
+  id: RMCBulletRevolver44Heavy
+  name: bullet (.44 Heavy)
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Projectile
+    damage:
+      types:
+        Piercing: 35
+  - type: CMArmorPiercing
+    amount: 20
+  - type: RMCProjectileAccuracy
+    accuracy: 100
+  - type: RMCApplyBuildupOnHit
+    buildup: RMCHeavyRevolver
+  - type: RMCKnockdownOnBuildup
+    duration: 1
+    refresh: false
+
 - type: Tag
   id: RMCSpeedLoaderM44
 
 - type: Tag
   id: RMCSpeedLoader44Marksman
+
+- type: Tag
+  id: RMCSpeedLoader44Heavy

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/crewman.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/crewman.yml
@@ -213,7 +213,7 @@
         points: 10
       - id: CMMagazineRifleM54CExt
         points: 10
-      - id: RMCSpeedLoaderM44
+      - id: RMCSpeedLoader44Heavy
         points: 10
     - name: Utilities
       entries:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/intel.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/intel.yml
@@ -42,7 +42,9 @@
       - id: RMCMagazinePistolM13Ext
         points: 10
       - id: RMCSpeedLoader44Marksman
-        points: 10 # TODO RMC14 heavy speed revolver
+        points: 10
+      - id: RMCSpeedLoader44Heavy
+        points: 10
       - id: RMCMagazinePistolM1984AP
         points: 5
       - id: RMCMagazinePistolM1984HP

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/pilot.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/pilot.yml
@@ -199,7 +199,7 @@
         points: 10
       - id: CMMagazineRifleM54CExt
         points: 10
-      - id: RMCSpeedLoader44Marksman
+      - id: RMCSpeedLoader44Heavy
         points: 10
     - name: Utilities
       entries:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
@@ -446,10 +446,10 @@
         amount: 4
       - id: RMCMagazineSmartGun
         amount: 4
-      #- id: M44 Heavy Speed Loader (.44)
-      #  amount: 10
+      - id: RMCSpeedLoader44Heavy
+        amount: 10
       - id: RMCSpeedLoader44Marksman
-        amount: 16 # TODO RMC14 6 once heavy is in
+        amount: 6
       - id: RMCMagazinePistolM1984HP
         amount: 2
       - id: CMMagazineRifleM54CE2HT
@@ -599,8 +599,9 @@
         name: Magazine Box (Marksman M44 x 16)
         box: RMCSpeedLoader44Marksman
 
-#      - name: Magazine Box (Heavy M44 x 16)
-#        box: CMMagazineSMGM63
+      - id: RMCBoxMagazineRevolverM44Heavy
+        name: Magazine Box (Heavy M44 x 16)
+        box: RMCSpeedLoader44Heavy
 #      - name: Magazine Box (UT-Napthal Fuel x 8)
 #        box: CMMagazineSMGM63
 

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/engineer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/engineer.yml
@@ -105,8 +105,8 @@
       entries:
       - id: RMCMagazinePistolM13Ext
         points: 6
-      # - id: RMCSpeedLoader44Heavy
-      #   points: 6
+      - id: RMCSpeedLoader44Heavy
+        points: 6
       - id: RMCSpeedLoader44Marksman
         points: 6
       - id: RMCMagazinePistolM1984HP

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/leader.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/leader.yml
@@ -170,8 +170,8 @@
       entries:
       - id: RMCMagazinePistolM13Ext
         points: 6
-      # - id: RMCSpeedLoader44Heavy
-      #  points: 6
+      - id: RMCSpeedLoader44Heavy
+        points: 6
       - id: RMCSpeedLoader44Marksman
         points: 6
       - id: RMCMagazinePistolM1984HP

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/medic.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/medic.yml
@@ -135,8 +135,8 @@
       entries:
       - id: RMCMagazinePistolM13Ext
         points: 6
-      # - id: RMCSpeedLoader44Heavy
-      #  points: 6
+      - id: RMCSpeedLoader44Heavy
+        points: 6
       - id: RMCSpeedLoader44Marksman
         points: 6
       - id: RMCMagazinePistolM1984HP

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/prep.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/prep.yml
@@ -427,8 +427,8 @@
       entries:
       - id: RMCMagazineSmartGun
         amount: 1
-      #- id: CMSpeedLoaderM44Heavy
-      #  amount: 2
+      - id: RMCSpeedLoader44Heavy
+        amount: 2
       - id: RMCSpeedLoader44Marksman
         amount: 2
       - id: RMCMagazinePistolM1984AP

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/rifleman.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/rifleman.yml
@@ -145,8 +145,8 @@
       entries:
       - id: RMCMagazinePistolM13Ext
         points: 6
-      #- id: M44 Heavy Speedloader
-      #  points: 10
+      - id: RMCSpeedLoader44Heavy
+        points: 10
       - id: RMCSpeedLoader44Marksman
         points: 10
       - id: RMCMagazinePistolM1984HP

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/smart_gun_operator.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/smart_gun_operator.yml
@@ -50,8 +50,8 @@
       entries:
       - id: RMCMagazinePistolM13Ext
         points: 6
-      # - id: RMCSpeedLoader44Heavy
-      #  points: 10
+      - id: RMCSpeedLoader44Heavy
+        points: 10
       - id: RMCSpeedLoader44Marksman
         points: 10
       - id: RMCMagazinePistolM1984HP

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/specialist.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/specialist.yml
@@ -266,8 +266,8 @@
       entries:
       - id: RMCMagazinePistolM13Ext
         points: 6
-      # - id: RMCSpeedLoader44Heavy
-      #  points: 10
+      - id: RMCSpeedLoader44Heavy
+        points: 10
       - id: RMCSpeedLoader44Marksman
         points: 10
       - id: RMCMagazinePistolM1984HP

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/team_leader.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/team_leader.yml
@@ -57,8 +57,8 @@
       entries:
       - id: RMCMagazinePistolM13Ext
         points: 6
-      # - id: RMCSpeedLoader44Heavy
-      #  points: 10
+      - id: RMCSpeedLoader44Heavy
+        points: 10
       - id: RMCSpeedLoader44Marksman
         points: 10
       - id: RMCMagazinePistolM1984HP

--- a/Resources/Prototypes/_RMC14/Recipes/Construction/magazine_box_crafting.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Construction/magazine_box_crafting.yml
@@ -273,6 +273,18 @@
   iconColor: "#727e90"
   objectType: Item
 
+- type: construction
+  parent: RMC
+  name: Magazine Box (M44 Heavy)
+  id: RMCBoxMagazineRevolverM44HeavyEmpty
+  graph: RMCBoxMagazine
+  startNode: start
+  targetNode: RMCBoxMagazineRevolverM44HeavyEmpty
+  category: construction-category-cm-box-magazine
+  description: A box for holding many heavy speedloaders with a carrying handle.
+  iconColor: "#727e90"
+  objectType: Item
+
 # M13
 - type: construction
   parent: RMC
@@ -771,6 +783,11 @@
       - material: RMCSheetCardboard
         amount: 1
         doAfter: 0.25
+    - to: RMCBoxMagazineRevolverM44HeavyEmpty
+      steps:
+      - material: RMCSheetCardboard
+        amount: 1
+        doAfter: 0.25
 
     # M34 Incinerator
     - to: RMCBoxFlamerTankEmpty
@@ -956,6 +973,8 @@
     entity: RMCBoxMagazineRevolverM44Empty
   - node: RMCBoxMagazineRevolverM44MarksmanEmpty
     entity: RMCBoxMagazineRevolverM44MarksmanEmpty
+  - node: RMCBoxMagazineRevolverM44HeavyEmpty
+    entity: RMCBoxMagazineRevolverM44HeavyEmpty
 
   # Nailgun
   - node: RMCBoxMagazineSMGNailgunEmpty

--- a/Resources/Prototypes/_RMC14/Recipes/Materials/cardboard.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Materials/cardboard.yml
@@ -262,6 +262,7 @@
   - RMCDividerConstruction
   - RMCBoxMagazineRevolverM44EmptyBuild
   - RMCBoxMagazineRevolverM44MarksmanEmptyBuild
+  - RMCBoxMagazineRevolverM44HeavyEmptyBuild
   - RMCDividerConstruction
   - RMCBoxMagazinePistolM13EmptyBuild
   - RMCBoxMagazinePistolM13ExtEmptyBuild
@@ -318,6 +319,12 @@
   id: RMCBoxMagazineRevolverM44MarksmanEmptyBuild
   name: M44 speedloader box (Marksman)
   prototype: RMCBoxMagazineRevolverM44MarksmanEmpty
+
+- type: rmcConstruction
+  parent: RMCCardboardBuildBase
+  id: RMCBoxMagazineRevolverM44HeavyEmptyBuild
+  name: M44 speedloader box (Heavy)
+  prototype: RMCBoxMagazineRevolverM44HeavyEmpty
 
 - type: rmcConstruction
   parent: RMCCardboardBuildBase

--- a/Resources/Prototypes/_RMC14/Vehicles/APC/vendor.yml
+++ b/Resources/Prototypes/_RMC14/Vehicles/APC/vendor.yml
@@ -56,6 +56,10 @@
         amount: 0
       - id: RMCSpeedLoaderM44
         amount: 0
+      - id: RMCSpeedLoader44Heavy
+        amount: 0
+      - id: RMCSpeedLoader44Marksman
+        amount: 0
       - id: CMMagazinePistolM1984
         amount: 0
       - id: RMCMagazinePistolM13

--- a/Resources/Prototypes/_RMC14/buildups.yml
+++ b/Resources/Prototypes/_RMC14/buildups.yml
@@ -1,0 +1,13 @@
+- type: rmcBuildup
+  id: RMCHeavyRevolver
+  threshold: 3
+  decayAmount: 1
+  decayEvery: 2
+  refreshDecayOnApply: false
+  minimumSize: VerySmallXeno
+  maximumSize: Xeno
+  whitelist:
+    components:
+    - Xeno
+  appliedPopup: rmc-heavy-revolver-buildup
+  triggeredPopup: rmc-heavy-revolver-knockdown

--- a/Resources/Prototypes/_RMC14/rmc_tags.yml
+++ b/Resources/Prototypes/_RMC14/rmc_tags.yml
@@ -20,6 +20,9 @@
   id: RMCCartridgeRevolver44Marksman
 
 - type: Tag
+  id: RMCCartridgeRevolver44Heavy
+
+- type: Tag
   id: RCMCartridgePistol9mmSquashHead
 
 - type: Tag


### PR DESCRIPTION
## About the PR

Ports M44 heavy ammunition from [CMSS13](https://github.com/cmss13-devs/cmss13/pull/11674).

Heavy rounds deal 35 damage with 20 armor penetration and high accuracy. Each valid hit applies one shared buildup stack to a living, non-large xenomorph. One stack decays every two seconds without refreshing the timer. Reaching three stacks clears the buildup and briefly knocks the target down.

Adds the heavy cartridge, seven-round speed loader, magazine boxes, cardboard construction recipes, cargo crate, and CM-equivalent vendor distribution.

## Why / Balance

Heavy ammunition gives the M44 an alternative to its standard and marksman ammunition focused on stopping power rather than damage.

The round deals less damage than both existing M44 ammunition types and requires three hits before the buildup decays. The buildup is shared between shooters, but does not affect humans, dead xenomorphs, Crushers, Queens, or other large and immobile xenomorphs.

The knockdown has a base duration of one second and is reduced to approximately 0.67 seconds by the existing xenomorph stun modifier.

Requisitions receives 10 heavy speed loaders, while its marksman stock is reduced from 16 to the intended 6.

## Technical details

- Adds a reusable prototype-driven buildup system with configurable thresholds, decay, target filters, size limits, and popups.
- Stores independent buildup states by prototype ID, allowing multiple buildup effects to coexist on one entity.
- Adds an on-hit buildup applicator and a separate event-driven knockdown effect.
- Uses pause-resistant decay timing. Additional applications do not postpone decay unless configured to do so.
- Adds M44 heavy ammunition prototypes, tags, boxes, recipes, cargo entries, and vendor availability.
- Reuses the existing M44 RSI layers with a `#7866FF` ammunition marking. No new sprites are added.

## Media

<!-- Add an image of the heavy speed loader and a short video showing the third-hit knockdown. -->

## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- add: Added M44 heavy speed loaders. Landing three hits before their buildup decays briefly knocks down smaller xenomorphs.