### PR TITLE
Infection, Larva Burst, and Egg interaction Name Obfuscation

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
@@ -21,6 +21,7 @@ using Content.Shared.FixedPoint;
 using Content.Shared.Ghost;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Item;
@@ -285,7 +286,18 @@ public sealed class XenoEggSystem : EntitySystem
             RootEntity = true
         };
 
-        _popup.PopupPredicted(Loc.GetString("rmc-xeno-egg-plant-self"), Loc.GetString("rmc-xeno-egg-plant", ("user", args.User)), egg, args.User);
+        var selfMessage = Loc.GetString("rmc-xeno-egg-plant-self");
+        _popup.PopupClient(selfMessage, args.User, args.User);
+
+        var others = Filter.PvsExcept(args.User).Recipients;
+        foreach (var other in others)
+        {
+            if (other.AttachedEntity is not { } otherEnt)
+                continue;
+
+            var otherMessage = Loc.GetString("rmc-xeno-egg-plant", ("user", Identity.Name(args.User, EntityManager, otherEnt)));
+            _popup.PopupEntity(otherMessage, args.User, otherEnt, PopupType.MediumCaution);
+        }
 
         _doAfter.TryStartDoAfter(doAfter);
     }
@@ -413,8 +425,18 @@ public sealed class XenoEggSystem : EntitySystem
         if (!CanReturnParasitePopup(args.User, used, egg))
             return;
 
-        _popup.PopupEntity(Loc.GetString("rmc-xeno-egg-return-user"), args.User, args.User);
-        _popup.PopupEntity(Loc.GetString("rmc-xeno-egg-return", ("user", args.User), ("parasite", args.Used)), egg, Filter.PvsExcept(args.User), true);
+        var selfMessage = Loc.GetString("rmc-xeno-egg-return-user");
+        _popup.PopupEntity(selfMessage, args.User, args.User);
+
+        var others = Filter.PvsExcept(args.User).Recipients;
+        foreach (var other in others)
+        {
+            if (other.AttachedEntity is not { } otherEnt)
+                continue;
+
+            var otherMessage = Loc.GetString("rmc-xeno-egg-return", ("user", Identity.Name(args.User, EntityManager, otherEnt)), ("parasite", Identity.Name(args.Used.Value, EntityManager, otherEnt)));
+            _popup.PopupEntity(otherMessage, egg, otherEnt, PopupType.MediumCaution);
+        }
 
         SetEggState(egg, XenoEggState.Grown);
         QueueDel(args.Used);

--- a/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
@@ -253,7 +253,8 @@ public abstract partial class SharedXenoParasiteSystem : EntitySystem
             !HasComp<InfectableComponent>(args.PullerUid) &&
             !HasComp<SynthComponent>(args.PullerUid))
         {
-            _popup.PopupClient(Loc.GetString("rmc-xeno-parasite-nonplayer-pull", ("parasite", ent)), ent, args.PullerUid, PopupType.SmallCaution);
+            var selfMessage = Loc.GetString("rmc-xeno-parasite-nonplayer-pull", ("parasite", Identity.Name(ent, EntityManager, args.PullerUid)));
+            _popup.PopupClient(selfMessage, ent, args.PullerUid, PopupType.SmallCaution);
             args.Cancelled = true;
         }
     }
@@ -262,7 +263,8 @@ public abstract partial class SharedXenoParasiteSystem : EntitySystem
     {
         if (!HasComp<ParasiteAIComponent>(ent))
         {
-            _popup.PopupClient(Loc.GetString("rmc-xeno-parasite-player-pickup", ("parasite", ent)), ent, args.User, PopupType.SmallCaution);
+            var selfMessage = Loc.GetString("rmc-xeno-parasite-player-pickup", ("parasite", Identity.Name(ent, EntityManager, args.User)));
+            _popup.PopupClient(selfMessage, ent, args.User, PopupType.SmallCaution);
             args.Cancel();
             return;
         }
@@ -530,8 +532,9 @@ public abstract partial class SharedXenoParasiteSystem : EntitySystem
     {
         if (!IsInfectable(parasite, victim))
         {
+            var selfMessage = Loc.GetString("rmc-xeno-failed-cant-infect", ("target", Identity.Name(victim, EntityManager, user)));
             if (popup)
-                _popup.PopupClient(Loc.GetString("rmc-xeno-failed-cant-infect", ("target", victim)), victim, user, PopupType.MediumCaution);
+                _popup.PopupClient(selfMessage, victim, user, PopupType.MediumCaution);
 
             return false;
         }
@@ -541,8 +544,9 @@ public abstract partial class SharedXenoParasiteSystem : EntitySystem
             && TryComp(victim, out StandingStateComponent? standing)
             && !_standing.IsDown(victim, standing))
         {
+            var selfMessage = Loc.GetString("rmc-xeno-failed-cant-reach", ("target", Identity.Name(victim, EntityManager, user)));
             if (popup)
-                _popup.PopupClient(Loc.GetString("rmc-xeno-failed-cant-reach", ("target", victim)), victim, user, PopupType.MediumCaution);
+                _popup.PopupClient(selfMessage, victim, user, PopupType.MediumCaution);
 
             return false;
         }
@@ -880,7 +884,15 @@ public abstract partial class SharedXenoParasiteSystem : EntitySystem
         if (_container.TryGetContainingContainer(victim, out var container) && HasComp<RMCHideParasiteInfectionContainerPopupComponent>(container.Owner))
             return;
 
-        _popup.PopupEntity(Loc.GetString("rmc-xeno-infection-shakes", ("victim", victim)), victim, Filter.PvsExcept(victim), true, PopupType.MediumCaution);
+        var others = Filter.PvsExcept(victim).Recipients;
+        foreach (var other in others)
+        {
+            if (other.AttachedEntity is not { } otherEnt)
+                continue;
+
+            var otherMessage = Loc.GetString("rmc-xeno-infection-shakes", ("victim", Identity.Name(victim, EntityManager, otherEnt)));
+            _popup.PopupEntity(otherMessage, victim, otherEnt, PopupType.MediumCaution);
+        }
     }
 
     private void OnTryMove(Entity<BursterComponent> burster, ref MoveInputEvent args)
@@ -937,13 +949,22 @@ public abstract partial class SharedXenoParasiteSystem : EntitySystem
             EnsureComp<VictimBurstComponent>(burstFrom);
             _appearance.SetData(burstFrom.Owner, BurstVisuals.Visuals, VictimBurstState.Bursting);
 
-            var shakeFilter = Filter.PvsExcept(victim);
-            shakeFilter.RemoveWhereAttachedEntity(HasComp<BursterComponent>); // not visible the larva
-
             if (_net.IsServer)
             {
                 _popup.PopupEntity(Loc.GetString("rmc-xeno-infection-burst-now-victim"), victim, victim, PopupType.MediumCaution);
-                _popup.PopupEntity(Loc.GetString("rmc-xeno-infection-burst-soon", ("victim", victim)), victim, shakeFilter, true, PopupType.LargeCaution);
+
+                var others = Filter.PvsExcept(victim).Recipients;
+                foreach (var other in others)
+                {
+                    if (other.AttachedEntity is not { } otherEnt)
+                    continue;
+
+                    if (otherEnt != spawnedLarva) // not visible to the larva
+                    {
+                        var otherMessage = Loc.GetString("rmc-xeno-infection-burst-soon", ("victim", Identity.Name(victim, EntityManager, otherEnt)));
+                        _popup.PopupEntity(otherMessage, victim, otherEnt, PopupType.LargeCaution);
+                    }
+                }
                 _jitter.DoJitter(victim, comp.JitterTime / 1.2, true, 14f, 5f, true); // violent jitter
             }
 
@@ -1012,8 +1033,15 @@ public abstract partial class SharedXenoParasiteSystem : EntitySystem
 
                     if (_net.IsServer && doPopup)
                     {
-                        var popupMessage = Loc.GetString("rmc-xeno-infect-fail", ("target", victim), ("clothing", containedEntity));
-                        _popup.PopupEntity(popupMessage, victim, PopupType.SmallCaution);
+                        var others = Filter.Pvs(victim).Recipients;
+                        foreach (var other in others)
+                        {
+                            if (other.AttachedEntity is not { } otherEnt)
+                                continue;
+
+                            var popupMessage = Loc.GetString("rmc-xeno-infect-fail", ("target", Identity.Name(victim, EntityManager, otherEnt)), ("clothing", containedEntity));
+                            _popup.PopupEntity(popupMessage, victim, otherEnt, PopupType.SmallCaution);
+                        }
                     }
 
                     return false;
@@ -1028,8 +1056,15 @@ public abstract partial class SharedXenoParasiteSystem : EntitySystem
 
         if (_net.IsServer && doPopup && rippedOffItem != null)
         {
-            var popupMessage = Loc.GetString("rmc-xeno-infect-success", ("target", victim), ("clothing", rippedOffItem));
-            _popup.PopupEntity(popupMessage, victim, PopupType.MediumCaution);
+            var others = Filter.Pvs(victim).Recipients;
+            foreach (var other in others)
+            {
+                if (other.AttachedEntity is not { } otherEnt)
+                    continue;
+
+                var popupMessage = Loc.GetString("rmc-xeno-infect-success", ("target", Identity.Name(victim, EntityManager, otherEnt)), ("clothing", rippedOffItem));
+                _popup.PopupEntity(popupMessage, victim, otherEnt, PopupType.MediumCaution);
+            }
         }
 
         return true;

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-eggs.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-eggs.ftl
@@ -14,7 +14,7 @@ rmc-xeno-egg-fail-return = This egg can't hold this child.
 rmc-xeno-egg-return-start = We start putting the child into the egg.
 rmc-xeno-egg-return-user = We place the child back into the egg.
 rmc-xeno-egg-return-self = {CAPITALIZE($parasite)} crawls back into the egg.
-rmc-xeno-egg-return = {CAPITALIZE($user)} slides {$parasite} back into the egg.
+rmc-xeno-egg-return = {CAPITALIZE($user)} slides {THE($parasite)} back into the egg.
 
 rmc-xeno-egg-ghost-verb = Become parasite
 rmc-xeno-egg-ghost-need-time = You ghosted too recently. You cannot become a parasite until 3 minutes have passed ({$seconds} seconds remaining).


### PR DESCRIPTION
## About the PR
Obfuscated names for planting eggs, putting children in eggs, failing to pick up parasites, failing to pull parasites, successful infection, failed infection, can't infect, can't reach to infect, larva burst shaking mid-stage and final burst.

## Why / Balance
Obfuscation, preventing metagaming, bugfixing.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: CatAndHats
- fix: Obfuscated Egg, Parasite, and Larva Burst popups so they no longer reveal names between factions