### PR TITLE
Tweak item usability while devoured

### DIFF
--- a/Content.Shared/Interaction/SmartEquipSystem.cs
+++ b/Content.Shared/Interaction/SmartEquipSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared._RMC14.Intel.Detector;
 using Content.Shared._RMC14.MotionDetector;
+using Content.Shared._RMC14.Xenonids.Devour;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Hands.Components;
@@ -128,6 +129,11 @@ public sealed class SmartEquipSystem : EntitySystem
         var session = playerSession;
         var equipmentSlot = msg.EquipmentSlot;
         if (playerSession.AttachedEntity is not { Valid: true } uid || !Exists(uid))
+            return;
+
+        // RMC14
+        // Disable smartequip if player is devoured
+        if (HasComp<DevouredComponent>(uid))
             return;
 
         // early out if we don't have any hands or a valid inventory slot

--- a/Content.Shared/_RMC14/Xenonids/Devour/XenoDevourSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Devour/XenoDevourSystem.cs
@@ -4,8 +4,10 @@ using Content.Shared._RMC14.Armor;
 using Content.Shared._RMC14.Attachable.Components;
 using Content.Shared._RMC14.CombatMode;
 using Content.Shared._RMC14.Fireman;
+using Content.Shared._RMC14.Hands;
 using Content.Shared._RMC14.Inventory;
 using Content.Shared._RMC14.Pulling;
+using Content.Shared._RMC14.Storage;
 using Content.Shared._RMC14.Synth;
 using Content.Shared._RMC14.TrainingDummy;
 using Content.Shared._RMC14.Vents;
@@ -33,6 +35,8 @@ using Content.Shared.Mobs.Systems;
 using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Popups;
+using Content.Shared.Storage;
+using Content.Shared.Storage.Components;
 using Content.Shared.Stunnable;
 using Content.Shared.Throwing;
 using Content.Shared.Weapons.Melee;
@@ -86,7 +90,7 @@ public sealed class XenoDevourSystem : EntitySystem
         SubscribeLocalEvent<DevouredComponent, InteractionAttemptEvent>(OnDevouredInteractionAttempt);
         SubscribeLocalEvent<DevouredComponent, UpdateCanMoveEvent>(OnDevouredAttempt);
         SubscribeLocalEvent<DevouredComponent, ThrowAttemptEvent>(OnDevouredAttempt);
-        SubscribeLocalEvent<DevouredComponent, DropAttemptEvent>(OnDevouredAttempt);
+        SubscribeLocalEvent<DevouredComponent, DropAttemptEvent>(OnDevouredDropAttempt);
         SubscribeLocalEvent<DevouredComponent, UseAttemptEvent>(OnUseAttempt);
         SubscribeLocalEvent<DevouredComponent, PickupAttemptEvent>(OnDevouredPickupAttempt);
         SubscribeLocalEvent<DevouredComponent, IsEquippingAttemptEvent>(OnDevouredIsEquippingAttempt);
@@ -191,7 +195,8 @@ public sealed class XenoDevourSystem : EntitySystem
         if (args.Target == null)
             return;
 
-        if (!HasComp<UsableWhileDevouredComponent>(args.Target) && (!_container.TryGetContainingContainer(ent.Owner, out var container) ||
+        if ((!HasComp<UsableWhileDevouredComponent>(args.Target) && (!HasComp<StorageComponent>(args.Target) || HasComp<StorageOpenDoAfterComponent>(args.Target)))
+            && (!_container.TryGetContainingContainer(ent.Owner, out var container) ||
             !HasComp<XenoDevourComponent>(container.Owner) || args.Target != container.Owner))
         {
             args.Cancelled = true;
@@ -210,6 +215,12 @@ public sealed class XenoDevourSystem : EntitySystem
 
         args.Handled = true;
         DevouredHandleBreakout((args.User, devoured));
+    }
+
+    private void OnDevouredDropAttempt(Entity<DevouredComponent> devoured, ref DropAttemptEvent args)
+    {
+        if (_hands.TryGetActiveItem(devoured.Owner, out var heldItem) && !HasComp<UsableWhileDevouredComponent>(heldItem))
+            args.Cancel();
     }
 
     private void OnDevouredAttempt<T>(Entity<DevouredComponent> devoured, ref T args) where T : CancellableEntityEventArgs

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Melee/ice_axe.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Melee/ice_axe.yml
@@ -26,6 +26,7 @@
   - type: DisarmMalus
     malus: 0.225
   - type: UsableWhileDevoured
+    canUnequip: true
   - type: DeleteOnExplosion
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Melee/katana.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Melee/katana.yml
@@ -19,6 +19,7 @@
       types:
         Slash: 45
   - type: UsableWhileDevoured
+    canUnequip: true
 
 - type: entity
   parent: RMCKatana

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Melee/kitchen.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Melee/kitchen.yml
@@ -27,6 +27,7 @@
   - type: DisarmMalus
     malus: 0.225
   - type: UsableWhileDevoured
+    canUnequip: true
   - type: Tag
     tags:
     - Knife

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Melee/knife.yml
@@ -51,6 +51,7 @@
   - type: DisarmMalus
     malus: 0.225
   - type: UsableWhileDevoured
+    canUnequip: true
   - type: AttachableVisuals
     rsi: _RMC14/Objects/Weapons/Guns/Attachments/barrel.rsi
     prefix: bayonet
@@ -229,6 +230,7 @@
       types:
         Slash: 50
   - type: UsableWhileDevoured
+    canUnequip: true
   - type: Item
     size: Small
     sprite: _RMC14/Objects/Weapons/Melee/m11_knife.rsi
@@ -265,6 +267,7 @@
       types:
         Slash: 50
   - type: UsableWhileDevoured
+    canUnequip: true
   - type: Item
     size: Small
     sprite: _RMC14/Objects/Weapons/Melee/fs_knife.rsi
@@ -300,6 +303,7 @@
       types:
         Slash: 10
   - type: UsableWhileDevoured
+    canUnequip: true
   - type: Item
     size: Large
     sprite: _RMC14/Objects/Weapons/Melee/machete.rsi
@@ -352,6 +356,7 @@
       types:
         Slash: 55
   - type: UsableWhileDevoured
+    canUnequip: true
 
 - type: entity
   parent: CMM2132Machete
@@ -403,6 +408,7 @@
       types:
         Slash: 3
   - type: UsableWhileDevoured
+    canUnequip: true
   - type: ItemToggleMeleeWeapon
     activatedSoundOnHit:
       path: /Audio/Weapons/genhit3.ogg


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Now while devoured you can:
- Freely equip, unequip and use certain items ( such as knifes, machetes, ice axes, katanas, guns and etc )
- Drop items listed above
- Open storage items in your inventory ( satchel, pouches and etc. except backpacks )

Also you can put bayonet in your boots and smart equip is blocked while devoured

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity.

Resolves #10584
Resolves #8193


## Technical details
<!-- Summary of code changes for easier review. -->
Added check on 'UsableWhileDevoured' items for drop attempt event so that you can store bayonet in boots/ machetes in pouches.
Added check on storage items for interaction attempt event so that you can open the storage

Disabled smart equip keybinds while devoured due to smartEquipSystem not really checking if character can equip item, which results in item being dropped to the floor.

And some yml tweaks to make some items fully usable while devoured

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

https://github.com/user-attachments/assets/63d3e1da-2089-4dea-90db-145ee891ce3b


https://github.com/user-attachments/assets/e069b913-e605-48c2-899a-bd22c5093777


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Some items can now be freely equipped/unequipped while devoured.
- fix: Bayonets are now able to be stored in boots while devoured.