### PR TITLE
Moves recorders from MP and MW vendors to the SecTech

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/police.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/police.yml
@@ -89,13 +89,7 @@
         amount: 10
       - id: RMCGuidebookSOP
         amount: 10
-    - name: Investigation
-      entries:
-      - id: RMCUniversalRecorder
-        amount: 3
-      - id: RMCBoxRegulationTapes
-        amount: 5
-
+        
 # WARDEN
 - type: entity
   parent: ColMarTechBase
@@ -188,9 +182,3 @@
         amount: 10
       - id: RMCGuidebookSOP
         amount: 10
-    - name: Investigation
-      entries:
-      - id: RMCUniversalRecorder
-        amount: 3
-      - id: RMCBoxRegulationTapes
-        amount: 5

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/vending_machines.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/vending_machines.yml
@@ -561,8 +561,8 @@
     CMHeadBeretRed: 6
     CMGlassesSecurity: 3
     CMHeadset: 6
-    #RegulationTape: 5
-    #TapeRecorder: 3
+    RMCUniversalRecorder: 3
+    RMCBoxRegulationTapes: 5
     #ClueScanner: 3
     #Camera: 8
     #CameraFilm: 8


### PR DESCRIPTION
## About the PR
Moved the recorder boxes and recorders into the sectech instead of the MW and MP vendor

## Why / Balance
CMP (vendor oversight seemingly) and PvI were missing access to recorders, this makes it more generally accessible, also the sectech had comments for it so it's probably parity

## Technical details
YAML

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: Moved spare recorders and tapes to the SecTech