### PR TITLE
Allows Coffee Machines to Be Anchored On Tables

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Furniture/coffee_machine.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Furniture/coffee_machine.yml
@@ -36,13 +36,11 @@
     fixtures:
       fix1:
         shape:
-          !type:PhysShapeCircle
-          radius: 0.03
-        density: 155
+          !type:PhysShapeAabb
+          bounds: "-0.10,-0.10,0.10,0.10"
+        density: 500
         mask:
-        - MachineMask
-        layer:
-        - MobMask
+        - TabletopMachineMask
   - type: Damageable
     damageContainer: StructuralMarine
     damageModifierSet: StructuralMarine


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Allows the coffee machine to be anchored on tables.

## Why / Balance
Seems strange that it couldn't be secured on tables before, since it's a coffee machine.

## Technical details
YAML

## Media
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: Changed it so the coffee machine can be anchored onto tables
