### PR TITLE
Changed Some Lamp Behaviours

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Tools/flashlights.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Tools/flashlights.yml
@@ -164,8 +164,18 @@
       - state: lamp-on
         visible: false
         map: [ "light" ]
+  - type: RemoveComponents
+    components:
+    - type: Clothing
+      quickEquip: false
+      slots:
+      - belt
+      - suitstorage
+    - type: Tag
+      tags:
+      - Flashlight
   - type: Item
-    size: Large
+    size: Normal
 
 - type: entity
   parent: RMCLamp
@@ -223,6 +233,8 @@
         map: [ "light" ]
   - type: PointLight
     radius: 6
+  - type: Item
+    size: Large
 
 - type: entity
   parent: RMCLampTripod


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
No longer allows desk-lamps to be stored on the belt, suitstorage, or inside of helmets. Allows them to be stored inside of bags.

## Why / Balance
Makes logical sense; lamps are often small enough to fit into bags and backpacks, and aren't exactly known for being stored on individuals belts or inside of hats.

## Technical details
YAML

## Media
<img width="520" height="143" alt="image" src="https://github.com/user-attachments/assets/5c889514-f371-4086-ad2b-b04f4762aa29" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- remove: Removed the ability for desk-lamps to be stored in hats, belts, or on suitstorage
- tweak: Changed it so desk-lamps can be stored inside of bags.
