### PR TITLE
Xeno Ability Name Obfuscation

### DIFF
--- a/Content.Shared/_RMC14/Shields/CrusherShieldSystem.cs
+++ b/Content.Shared/_RMC14/Shields/CrusherShieldSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared.Actions;
 using Content.Shared.Coordinates;
 using Content.Shared.Explosion;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Popups;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
@@ -49,8 +50,18 @@ public sealed partial class CrusherShieldSystem : EntitySystem
         if (_net.IsClient)
             return;
 
-        _popup.PopupEntity(Loc.GetString("rmc-xeno-defensive-shield-activate", ("user", xeno)), xeno, Filter.PvsExcept(xeno), true, PopupType.MediumCaution);
-        _popup.PopupEntity(Loc.GetString("rmc-xeno-defensive-shield-activate-self", ("user", xeno)), xeno, xeno, PopupType.Medium);
+        var selfMessage = Loc.GetString("rmc-xeno-defensive-shield-activate-self");
+        _popup.PopupClient(selfMessage, xeno, xeno, PopupType.Medium);
+
+        var others = Filter.PvsExcept(xeno).Recipients;
+        foreach (var other in others)
+        {
+            if (other.AttachedEntity is not { } otherEnt)
+                continue;
+
+            var otherMessage = Loc.GetString("rmc-xeno-defensive-shield-activate", ("user", Identity.Name(xeno, EntityManager, otherEnt)));
+            _popup.PopupEntity(otherMessage, xeno, otherEnt, PopupType.MediumCaution);
+        }
         SpawnAttachedTo(xeno.Comp.Effect, xeno.Owner.ToCoordinates());
         foreach (var action in _rmcActions.GetActionsWithEvent<XenoDefensiveShieldActionEvent>(xeno))
         {

--- a/Content.Shared/_RMC14/Shields/CrusherShieldSystem.cs
+++ b/Content.Shared/_RMC14/Shields/CrusherShieldSystem.cs
@@ -51,7 +51,7 @@ public sealed partial class CrusherShieldSystem : EntitySystem
             return;
 
         var selfMessage = Loc.GetString("rmc-xeno-defensive-shield-activate-self");
-        _popup.PopupClient(selfMessage, xeno, xeno, PopupType.Medium);
+        _popup.PopupEntity(selfMessage, xeno, xeno, PopupType.Medium);
 
         var others = Filter.PvsExcept(xeno).Recipients;
         foreach (var other in others)

--- a/Content.Shared/_RMC14/Xenonids/Empower/XenoEmpowerSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Empower/XenoEmpowerSystem.cs
@@ -14,6 +14,7 @@ using Content.Shared.Damage;
 using Content.Shared.Effects;
 using Content.Shared.Examine;
 using Content.Shared.FixedPoint;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Maps;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Popups;
@@ -101,8 +102,18 @@ public sealed class XenoEmpowerSystem : EntitySystem
                 _actions.SetToggled(action.AsNullable(), true);
             }
 
-            _popup.PopupPredicted(Loc.GetString("rmc-xeno-empower-start-self"), Loc.GetString("rmc-xeno-empower-start-others", ("user", xeno)),
-                xeno, xeno, PopupType.MediumCaution);
+            var selfMessage = Loc.GetString("rmc-xeno-empower-start-self");
+            _popup.PopupClient(selfMessage, xeno, xeno, PopupType.MediumCaution);
+
+            var others = Filter.PvsExcept(xeno).Recipients;
+            foreach (var other in others)
+            {
+                if (other.AttachedEntity is not { } otherEnt)
+                continue;
+
+                var otherMessage = Loc.GetString("rmc-xeno-empower-start-others", ("user", Identity.Name(xeno, EntityManager, otherEnt)));
+                _popup.PopupEntity(otherMessage, xeno, otherEnt, PopupType.MediumCaution);
+            }
         }
         else
             FullEmpower(xeno);

--- a/Content.Shared/_RMC14/Xenonids/Fruit/SharedXenoFruitSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Fruit/SharedXenoFruitSystem.cs
@@ -26,6 +26,7 @@ using Content.Shared.FixedPoint;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Maps;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
@@ -40,6 +41,7 @@ using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Network;
+using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Spawners;
 using Robust.Shared.Timing;
@@ -490,10 +492,19 @@ public sealed class SharedXenoFruitSystem : EntitySystem
             _adminLogs.Add(LogType.RMCXenoFruitPlant, $"Xeno {ToPrettyString(xeno.Owner):xeno} planted {ToPrettyString(entity):entity} at {coordinates}");
         }
 
-        var popupSelf = fruitOverflow ? Loc.GetString("rmc-xeno-fruit-plant-limit-exceeded")
+        var selfMessage = fruitOverflow ? Loc.GetString("rmc-xeno-fruit-plant-limit-exceeded")
             : Loc.GetString("rmc-xeno-fruit-plant-success-self");
-        var popupOthers = Loc.GetString("rmc-xeno-fruit-plant-success-others", ("xeno", xeno));
-        _popup.PopupPredicted(popupSelf, popupOthers, xeno.Owner, xeno.Owner);
+        _popup.PopupClient(selfMessage, xeno.Owner, xeno.Owner);
+
+        var others = Filter.PvsExcept(xeno.Owner).Recipients;
+        foreach (var other in others)
+        {
+            if (other.AttachedEntity is not { } otherEnt)
+            continue;
+
+            var otherMessage = Loc.GetString("rmc-xeno-fruit-plant-success-others", ("xeno", Identity.Name(xeno, EntityManager, otherEnt)));
+            _popup.PopupEntity(otherMessage, xeno.Owner, otherEnt);
+        }
 
         UpdateFruitCount(xeno);
     }

--- a/Content.Shared/_RMC14/Xenonids/Headbite/XenoHeadbiteSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Headbite/XenoHeadbiteSystem.cs
@@ -8,6 +8,7 @@ using Content.Shared.Damage;
 using Content.Shared.DoAfter;
 using Content.Shared.Effects;
 using Content.Shared.FixedPoint;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Jittering;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Popups;
@@ -101,11 +102,18 @@ public sealed class XenoHeadbiteSystem : EntitySystem
 
         _rmcDamageable.DoLethalDamage(target, false, xeno);
 
-        var selfMsg = Loc.GetString("rmc-xeno-headbite-hit-self", ("xeno", xeno.Owner), ("target", target));
-        _popup.PopupClient(selfMsg, xeno, xeno, PopupType.Medium);
+        var selfMessage = Loc.GetString("rmc-xeno-headbite-hit-self", ("target", Identity.Name(target, EntityManager, xeno)));;
+        _popup.PopupClient(selfMessage, xeno, xeno, PopupType.Medium);
 
-        var othersMsg = Loc.GetString("rmc-xeno-headbite-hit-others", ("xeno", xeno.Owner), ("target", target));
-        _popup.PopupEntity(othersMsg, xeno, Filter.PvsExcept(xeno), true, PopupType.MediumCaution);
+        var others = Filter.PvsExcept(xeno).Recipients;
+        foreach (var other in others)
+        {
+            if (other.AttachedEntity is not { } otherEnt)
+            continue;
+
+            var otherMessage = Loc.GetString("rmc-xeno-headbite-hit-others", ("xeno", Identity.Name(xeno, EntityManager, otherEnt)), ("target", Identity.Name(target, EntityManager, otherEnt)));
+            _popup.PopupEntity(otherMessage, xeno, otherEnt, PopupType.MediumCaution);
+        }
     }
 
     private bool CanHeadbite(EntityUid xeno, EntityUid target)

--- a/Content.Shared/_RMC14/Xenonids/Heal/SharedXenoHealSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Heal/SharedXenoHealSystem.cs
@@ -14,6 +14,7 @@ using Content.Shared.Coordinates;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.FixedPoint;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Jittering;
 using Content.Shared.Mobs;
@@ -25,6 +26,7 @@ using Content.Shared.StatusEffectNew;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
+using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
@@ -305,7 +307,18 @@ public abstract class SharedXenoHealSystem : EntitySystem
 
         SacrificialHealShout(ent);
         _xenoAnnounce.AnnounceSameHive(ent.Owner, Loc.GetString("rmc-xeno-sacrifice-heal-target-announcement", ("healer_xeno", ent), ("target_xeno", target)), popup:PopupType.Large);
-        _popup.PopupPredicted(Loc.GetString("rmc-xeno-sacrifice-heal-target-enviorment", ("healer_xeno", ent), ("target_xeno", target)), target, ent, PopupType.Medium);
+
+        var others = Filter.Pvs(ent).Recipients;
+        foreach (var other in others)
+        {
+            if (other.AttachedEntity is not { } otherEnt)
+            continue;
+
+            var healerXeno = ("healer_xeno", Identity.Name(ent, EntityManager, otherEnt));
+            var targetXeno = ("target_xeno", Identity.Name(target, EntityManager, otherEnt));
+            var healMessage = Loc.GetString("rmc-xeno-sacrifice-heal-target-enviorment", healerXeno, targetXeno);
+            _popup.PopupEntity(healMessage, target, otherEnt, PopupType.Medium);
+        }
 
         // Heal from crit
         var targetTotalDamage = targetDamageComp.TotalDamage;

--- a/Content.Shared/_RMC14/Xenonids/Hedgehog/XenoShardSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hedgehog/XenoShardSystem.cs
@@ -16,6 +16,8 @@ using Content.Shared._RMC14.Explosion;
 using Content.Shared.Coordinates;
 using Content.Shared.Projectiles;
 using Content.Shared._RMC14.Xenonids.Sweep;
+using Content.Shared.IdentityManagement;
+using Robust.Shared.Player;
 
 namespace Content.Shared._RMC14.Xenonids.Hedgehog;
 
@@ -174,9 +176,18 @@ public sealed class XenoShardSystem : EntitySystem
         _shield.ApplyShield(ent, XenoShieldSystem.ShieldType.Hedgehog, ent.Comp.ShieldAmount, visualState: ent.Comp.VisualState);
 
         // Show CM13-style messages
-        var selfMsg = Loc.GetString("rmc-spike-shield-self");
-        var othersMsg = Loc.GetString("rmc-spike-shield-others", ("user", ent));
-        _popup.PopupPredicted(selfMsg, othersMsg, ent, ent);
+        var selfMessage = Loc.GetString("rmc-spike-shield-self");
+        _popup.PopupClient(selfMessage, ent, ent);
+
+        var others = Filter.PvsExcept(ent).Recipients;
+        foreach (var other in others)
+        {
+            if (other.AttachedEntity is not { } otherEnt)
+            continue;
+
+            var otherMessage = Loc.GetString("rmc-spike-shield-others", ("user", Identity.Name(ent, EntityManager, otherEnt)));
+            _popup.PopupEntity(otherMessage, ent, otherEnt);
+        }
         _aura.GiveAura(ent, Color.Blue, ent.Comp.ShieldDuration, 2);
 
         args.Handled = true;

--- a/Content.Shared/_RMC14/Xenonids/ResinSurge/SharedXenoResinSurgeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/ResinSurge/SharedXenoResinSurgeSystem.cs
@@ -12,12 +12,14 @@ using Content.Shared.Coordinates.Helpers;
 using Content.Shared.DoAfter;
 using Content.Shared.Doors.Components;
 using Content.Shared.Examine;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Maps;
 using Content.Shared.Popups;
 using Content.Shared.Spawning;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Network;
+using Robust.Shared.Player;
 
 namespace Content.Shared._RMC14.Xenonids.ResinSurge;
 
@@ -135,9 +137,19 @@ public sealed class SharedXenoResinSurgeSystem : EntitySystem
                 }
 
                 // If no, buff structure
-                var popupSelf = Loc.GetString("rmc-xeno-resin-surge-shield-self", ("target", entity));
-                var popupOthers = Loc.GetString("rmc-xeno-resin-surge-shield-others", ("xeno", xeno), ("target", entity));
-                _popup.PopupPredicted(popupSelf, popupOthers, xeno, xeno);
+                var selfMessage = Loc.GetString("rmc-xeno-resin-surge-shield-self", ("target", entity));
+                _popup.PopupClient(selfMessage, xeno, xeno);
+
+                var others = Filter.PvsExcept(xeno).Recipients;
+                foreach (var other in others)
+                {
+                    if (other.AttachedEntity is not { } otherEnt)
+                    continue;
+
+                    var xenoName = ("xeno", Identity.Name(xeno, EntityManager, otherEnt));
+                    var otherMessage = Loc.GetString("rmc-xeno-resin-surge-shield-others", xenoName, ("target", entity));
+                    _popup.PopupEntity(otherMessage, xeno, otherEnt);
+                }
 
                 _xenoReinforce.Reinforce(entity, xeno.Comp.ReinforceAmount, xeno.Comp.ReinforceDuration);
 
@@ -185,9 +197,19 @@ public sealed class SharedXenoResinSurgeSystem : EntitySystem
 
                 if (weeds != null && _hive.FromSameHive(xeno.Owner, weedEnt))
                 {
-                    var popupSelf = Loc.GetString("rmc-xeno-resin-surge-wall-self");
-                    var popupOthers = Loc.GetString("rmc-xeno-resin-surge-wall-others", ("xeno", xeno));
-                    _popup.PopupPredicted(popupSelf, popupOthers, xeno, xeno);
+                    var selfMessage = Loc.GetString("rmc-xeno-resin-surge-wall-self");
+                    _popup.PopupClient(selfMessage, xeno, xeno);
+
+                    var others = Filter.PvsExcept(xeno).Recipients;
+                    foreach (var other in others)
+                    {
+                        if (other.AttachedEntity is not { } otherEnt)
+                        continue;
+
+                        var xenoName = ("xeno", Identity.Name(xeno, EntityManager, otherEnt));
+                        var otherMessage = Loc.GetString("rmc-xeno-resin-surge-wall-others", xenoName);
+                        _popup.PopupEntity(otherMessage, xeno, otherEnt);
+                    }
 
                     SurgeUnstableWall(xeno, target);
                     return;
@@ -216,9 +238,19 @@ public sealed class SharedXenoResinSurgeSystem : EntitySystem
             !TryComp(gridId, out MapGridComponent? grid))
             return;
 
-        var popupSelf = Loc.GetString("rmc-xeno-resin-surge-sticky-self");
-        var popupOthers = Loc.GetString("rmc-xeno-resin-surge-sticky-others", ("xeno", xeno));
-        _popup.PopupPredicted(popupSelf, popupOthers, xeno, xeno);
+        var selfMessage = Loc.GetString("rmc-xeno-resin-surge-sticky-self");
+        _popup.PopupClient(selfMessage, xeno, xeno);
+
+        var others = Filter.PvsExcept(xeno).Recipients;
+        foreach (var other in others)
+        {
+            if (other.AttachedEntity is not { } otherEnt)
+            continue;
+
+            var xenoName = ("xeno", Identity.Name(xeno, EntityManager, otherEnt));
+            var otherMessage = Loc.GetString("rmc-xeno-resin-surge-sticky-others", xenoName);
+            _popup.PopupEntity(otherMessage, xeno, otherEnt);
+        }
 
         if (_net.IsServer)
         {

--- a/Content.Shared/_RMC14/Xenonids/Retrieve/XenoRetrieveSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Retrieve/XenoRetrieveSystem.cs
@@ -8,6 +8,7 @@ using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Rest;
 using Content.Shared.Coordinates;
 using Content.Shared.DoAfter;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Physics;
@@ -16,6 +17,7 @@ using Content.Shared.Standing;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
+using Robust.Shared.Player;
 using Robust.Shared.Timing;
 
 namespace Content.Shared._RMC14.Xenonids.Retrieve;
@@ -104,10 +106,6 @@ public sealed class XenoRetrieveSystem : EntitySystem
 
         if (_doAfter.TryStartDoAfter(doAfter))
         {
-            var selfMsg = Loc.GetString("rmc-xeno-retrieve-start-self", ("target", target));
-            var othersMsg = Loc.GetString("rmc-xeno-retrieve-start-others", ("user", xeno), ("target", target));
-            _popup.PopupPredicted(selfMsg, othersMsg, xeno, xeno);
-
             foreach (var visual in xeno.Comp.Visuals)
             {
                 QueueDel(visual);
@@ -178,9 +176,26 @@ public sealed class XenoRetrieveSystem : EntitySystem
         _physics.ApplyLinearImpulse(target, impulse, body: physics);
         _physics.SetBodyStatus(target, physics, BodyStatus.InAir);
 
-        var selfMsg = Loc.GetString("rmc-xeno-retrieve-finish-user", ("target", target));
-        var othersMsg = Loc.GetString("rmc-xeno-retrieve-finish-others", ("user", xeno), ("target", target));
-        _popup.PopupPredicted(selfMsg, othersMsg, xeno, xeno);
+        var selfMessage = Loc.GetString("rmc-xeno-retrieve-finish-self", ("target", target));
+        _popup.PopupClient(selfMessage, xeno, xeno);
+
+        var others = Filter.PvsExcept(xeno).Recipients;
+        foreach (var other in others)
+        {
+            if (other.AttachedEntity is not { } otherEnt)
+                continue;
+
+            if (otherEnt == target)
+            {
+                var targetMessage = Loc.GetString("rmc-xeno-retrieve-finish-target", ("user", xeno));
+                _popup.PopupEntity(targetMessage, xeno, otherEnt);
+            }
+            else
+            {
+                var otherMessage = Loc.GetString("rmc-xeno-retrieve-finish-others", ("user", Identity.Name(xeno, EntityManager, otherEnt)), ("target", Identity.Name(target, EntityManager, otherEnt)));
+                _popup.PopupEntity(otherMessage, xeno, otherEnt);
+            }
+        }
         _audio.PlayPredicted(xeno.Comp.Sound, xeno, xeno);
     }
 

--- a/Content.Shared/_RMC14/Xenonids/Soak/XenoSoakSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Soak/XenoSoakSystem.cs
@@ -87,7 +87,7 @@ public sealed class XenoSoakSystem : EntitySystem
         if (_net.IsServer)
         {
             var selfMessage = Loc.GetString("rmc-xeno-soak-end-self");
-            _popup.PopupClient(selfMessage, xeno, xeno, PopupType.MediumCaution);
+            _popup.PopupEntity(selfMessage, xeno, xeno, PopupType.MediumCaution);
 
             var others = Filter.PvsExcept(xeno).Recipients;
             foreach (var other in others)

--- a/Content.Shared/_RMC14/Xenonids/Soak/XenoSoakSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Soak/XenoSoakSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared._RMC14.Xenonids.Stab;
 using Content.Shared.Actions;
 using Content.Shared.Damage;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Popups;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
@@ -46,7 +47,19 @@ public sealed class XenoSoakSystem : EntitySystem
         soak.DamageAccumulated = 0;
         Dirty(xeno.Owner, soak);
 
-        _popup.PopupPredicted(Loc.GetString("rmc-xeno-soak-self"), Loc.GetString("rmc-xeno-soak-others", ("xeno", xeno)), xeno, xeno, PopupType.MediumCaution);
+        var selfMessage = Loc.GetString("rmc-xeno-soak-self");
+        _popup.PopupClient(selfMessage, xeno, xeno, PopupType.MediumCaution);
+
+        var others = Filter.PvsExcept(xeno).Recipients;
+        foreach (var other in others)
+        {
+            if (other.AttachedEntity is not { } otherEnt)
+            continue;
+
+            var otherMessage = Loc.GetString("rmc-xeno-soak-others", ("xeno", Identity.Name(xeno, EntityManager, otherEnt)));
+            _popup.PopupEntity(otherMessage, xeno, otherEnt, PopupType.MediumCaution);
+        }
+
         _aura.GiveAura(xeno, soak.SoakColor, xeno.Comp.Duration);
     }
 
@@ -73,8 +86,19 @@ public sealed class XenoSoakSystem : EntitySystem
 
         if (_net.IsServer)
         {
-            _popup.PopupEntity(Loc.GetString("rmc-xeno-soak-end-self"), xeno, xeno, PopupType.MediumCaution);
-            _popup.PopupEntity(Loc.GetString("rmc-xeno-soak-end-others", ("xeno", xeno)), xeno, Filter.PvsExcept(xeno), true, PopupType.MediumCaution);
+            var selfMessage = Loc.GetString("rmc-xeno-soak-end-self");
+            _popup.PopupClient(selfMessage, xeno, xeno, PopupType.MediumCaution);
+
+            var others = Filter.PvsExcept(xeno).Recipients;
+            foreach (var other in others)
+            {
+                if (other.AttachedEntity is not { } otherEnt)
+                continue;
+
+                var otherMessage = Loc.GetString("rmc-xeno-soak-end-others", ("xeno", Identity.Name(xeno, EntityManager, otherEnt)));
+                _popup.PopupEntity(otherMessage, xeno, otherEnt, PopupType.MediumCaution);
+            }
+
         }
     }
 

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
@@ -242,10 +242,9 @@ rmc-xeno-retrieve-anchored = That sister cannot move!
 rmc-xeno-retrieve-too-big = {$target} is too big to retrieve while standing up!
 rmc-xeno-retrieve-dead = {$target} is already dead!
 rmc-xeno-retrieve-blocked = We can't reach {$target} with our resin retrieval hook!
-rmc-xeno-retrieve-start-self = We prepare to fire our resin retrieval hook at {$target}!
-rmc-xeno-retrieve-start-others = {$user} prepares to fire its resin retrieval hook at {$target}!
-rmc-xeno-retrieve-finish-user = We fling {$target} over our head with our resin hook!
-rmc-xeno-retrieve-finish-target = We are pulled toward {$user}!
+rmc-xeno-retrieve-finish-self = We fling {$target} over our head with our resin hook!
+rmc-xeno-retrieve-finish-target = We are pulled over {$user}'s head!
+rmc-xeno-retrieve-finish-others = {$target} is pulled over {$user}'s head!
 
 # Aid
 rmc-xeno-aid-self = We cannot heal ourself!


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added name obfuscation to hide xeno names from marines, to: Crusher Hunker-Down, Valkyrie Hook, Ravager Empower, Hedgehog Shield, Vampire Headbite, Steelcrest Soak, Gardener Fruit Planting and multiple Resin Surge actions, Healer Sacrifice.

Changed pop-up text for Valkyrie Hook. Before it would show a starting and ending popup which would play within milliseconds of each other and makes them both unreadable, Now it shows only at the end and also fixes the end popup not appearing from other people.

## Why / Balance
bugfixing, reducing metagaming.

## Media

Before Valk Hook
https://github.com/user-attachments/assets/4fdb6b24-f5bb-46ba-afb8-f63ff2f9b056


After Valk Hook
https://github.com/user-attachments/assets/37e6df34-a7f0-4b6b-906d-03697122ee78


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: CatAndHats
- fix: Fixed xeno names being revealed to marines for many abilities - Crusher Hunker-Down, Valkyrie Hook, Ravager Empower, Hedgehog Shield, Vampire Headbite, Steelcrest Soak, Gardener Fruit Planting and multiple Resin Surge actions, and Healer Sacrifice.
- tweak: Changed the Valkyrie Hook text popup to only show at the end, not the start and end, so it should now be more readable