### PR TITLE
Add a mute dead chat action to ghosts and apply a temporary mute/deafen to players that died

### DIFF
--- a/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml
+++ b/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml
@@ -26,6 +26,9 @@
                 <Label Text="{Loc 'ui-options-accessability-header-content'}"
                        StyleClasses="LabelKeyText"/>
                 <CheckBox Name="CensorNudityCheckBox" Text="{Loc 'ui-options-censor-nudity'}" />
+                <!-- RMC14 -->
+                <CheckBox Name="RMCPostDeathChatMuteCheckBox" Text="{Loc 'rmc-ui-options-post-death-chat-mute'}" />
+                <!-- RMC14 -->
             </BoxContainer>
         </ScrollContainer>
         <ui:OptionsTabControlRow Name="Control" Access="Public" />

--- a/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml.cs
@@ -10,6 +10,10 @@ namespace Content.Client.Options.UI.Tabs;
 [GenerateTypedNameReferences]
 public sealed partial class AccessibilityTab : Control
 {
+    // RMC14
+    private ConfirmationWindow? _postDeathChatMuteConfirmation;
+    // RMC14
+
     public AccessibilityTab()
     {
         RobustXamlLoader.Load(this);
@@ -31,7 +35,44 @@ public sealed partial class AccessibilityTab : Control
 
         Control.AddOptionCheckBox(CCVars.AccessibilityClientCensorNudity, CensorNudityCheckBox);
 
+        // RMC14
+        var postDeathChatMute = Control.AddOptionCheckBox(RMCCVars.RMCPostDeathChatMute, RMCPostDeathChatMuteCheckBox);
+        postDeathChatMute.ImmediateValueChanged += OnPostDeathChatMuteChanged;
+        // RMC14
+
         Control.Initialize();
     }
+
+    // RMC14
+    private void OnPostDeathChatMuteChanged(bool enabled)
+    {
+        if (enabled)
+            return;
+
+        RMCPostDeathChatMuteCheckBox.Pressed = true;
+        Control.ValueChanged();
+
+        if (_postDeathChatMuteConfirmation is { IsOpen: true })
+            return;
+
+        var window = new ConfirmationWindow();
+        _postDeathChatMuteConfirmation = window;
+        window.Setup(
+            Loc.GetString("rmc-ui-options-post-death-chat-mute-confirmation-title"),
+            Loc.GetString("rmc-ui-options-post-death-chat-mute-confirmation-text"),
+            Loc.GetString("rmc-ui-options-post-death-chat-mute-confirmation-accept"),
+            Loc.GetString("rmc-ui-options-post-death-chat-mute-confirmation-deny"));
+
+        window.AcceptButton.OnPressed += _ =>
+        {
+            RMCPostDeathChatMuteCheckBox.Pressed = false;
+            Control.ValueChanged();
+            window.Close();
+        };
+        window.DenyButton.OnPressed += _ => window.Close();
+        window.OnClose += () => _postDeathChatMuteConfirmation = null;
+        window.OpenCentered();
+    }
+    // RMC14
 }
 

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -75,7 +75,8 @@ public sealed partial class ChatUIController : UIController
     [UISystemDependency] private readonly RoleCodewordSystem? _roleCodewordSystem = default!;
 
     // RMC14
-    [UISystemDependency] private readonly SharedPopupSystem _popup = default!;
+    [UISystemDependency] private readonly CMGhostSystem? _cmGhost = default;
+    [UISystemDependency] private readonly SharedPopupSystem? _popup = default!;
     // RMC14
 
     private static readonly ProtoId<ColorPalettePrototype> ChatNamePalette = "ChatNames";
@@ -882,7 +883,7 @@ public sealed partial class ChatUIController : UIController
             _ent.HasComponent<RMCDeadChatMutedComponent>(localEntity))
         {
             var warning = Loc.GetString("rmc-ghost-dead-chat-send-blocked");
-            _popup.PopupClient(warning, localEntity, localEntity);
+            _popup?.PopupClient(warning, localEntity, localEntity);
             return;
         }
         // RMC14
@@ -938,7 +939,8 @@ public sealed partial class ChatUIController : UIController
             _ent.HasComponent<RMCDeadChatMutedComponent>(localEntity))
             return;
 
-        ProcessChatMessage(msg, !msg.HidePopup || msg.UseEmoteSpeechBubble);
+        if (_cmGhost?.ShouldMutePostDeathChat(msg.Channel) != true)
+            ProcessChatMessage(msg, !msg.HidePopup || msg.UseEmoteSpeechBubble);
         // RMC14
 
         if ((msg.Channel & ChatChannel.AdminRelated) == 0 ||

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -13,6 +13,7 @@ using Content.Client.Examine;
 using Content.Client.Gameplay;
 using Content.Client.Ghost;
 using Content.Client.Mind;
+using Content.Client.Popups;
 using Content.Client.Roles;
 using Content.Client.Stylesheets;
 using Content.Client.UserInterface.Screens;
@@ -25,7 +26,6 @@ using Content.Shared.Chat;
 using Content.Shared.Damage.ForceSay;
 using Content.Shared.Decals;
 using Content.Shared.Input;
-using Content.Shared.Popups;
 using Content.Shared.Radio;
 using Content.Shared.Roles.RoleCodeword;
 using Robust.Client.GameObjects;
@@ -76,7 +76,7 @@ public sealed partial class ChatUIController : UIController
 
     // RMC14
     [UISystemDependency] private readonly CMGhostSystem? _cmGhost = default;
-    [UISystemDependency] private readonly SharedPopupSystem? _popup = default!;
+    [UISystemDependency] private readonly PopupSystem? _popup = default!;
     // RMC14
 
     private static readonly ProtoId<ColorPalettePrototype> ChatNamePalette = "ChatNames";

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -886,6 +886,14 @@ public sealed partial class ChatUIController : UIController
             _popup?.PopupClient(warning, localEntity, localEntity);
             return;
         }
+
+        if (_cmGhost?.ShouldMutePostDeathChat((ChatChannel) channel) == true &&
+            _player.LocalEntity is { } postDeathMutedEntity)
+        {
+            var warning = Loc.GetString("rmc-ghost-post-death-chat-send-blocked");
+            _popup?.PopupClient(warning, postDeathMutedEntity, postDeathMutedEntity);
+            return;
+        }
         // RMC14
 
         _manager.SendMessage(text, prefixChannel == 0 ? channel : prefixChannel);

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Linq;
 using System.Numerics;
 using Content.Client._RMC14.Mentor;
+using Content.Client._RMC14.Mobs.Ghosts;
 using Content.Client.Administration.Managers;
 using Content.Client.Chat;
 using Content.Client.Chat.Managers;
@@ -24,6 +25,7 @@ using Content.Shared.Chat;
 using Content.Shared.Damage.ForceSay;
 using Content.Shared.Decals;
 using Content.Shared.Input;
+using Content.Shared.Popups;
 using Content.Shared.Radio;
 using Content.Shared.Roles.RoleCodeword;
 using Robust.Client.GameObjects;
@@ -71,6 +73,10 @@ public sealed partial class ChatUIController : UIController
     [UISystemDependency] private readonly TransformSystem? _transform = default;
     [UISystemDependency] private readonly MindSystem? _mindSystem = default!;
     [UISystemDependency] private readonly RoleCodewordSystem? _roleCodewordSystem = default!;
+
+    // RMC14
+    [UISystemDependency] private readonly SharedPopupSystem _popup = default!;
+    // RMC14
 
     private static readonly ProtoId<ColorPalettePrototype> ChatNamePalette = "ChatNames";
     private string[] _chatNameColors = default!;
@@ -870,6 +876,17 @@ public sealed partial class ChatUIController : UIController
             text = $";{text}";
         }
 
+        // RMC14
+        if (MapLocalIfGhost(channel) == ChatSelectChannel.Dead &&
+            _player.LocalEntity is { } localEntity &&
+            _ent.HasComponent<RMCDeadChatMutedComponent>(localEntity))
+        {
+            var warning = Loc.GetString("rmc-ghost-dead-chat-send-blocked");
+            _popup.PopupClient(warning, localEntity, localEntity);
+            return;
+        }
+        // RMC14
+
         _manager.SendMessage(text, prefixChannel == 0 ? channel : prefixChannel);
     }
 
@@ -914,7 +931,13 @@ public sealed partial class ChatUIController : UIController
     private void OnChatMessage(MsgChatMessage message)
     {
         var msg = message.Message;
+
         // RMC14
+        if (msg.Channel == ChatChannel.Dead &&
+            _player.LocalEntity is { } localEntity &&
+            _ent.HasComponent<RMCDeadChatMutedComponent>(localEntity))
+            return;
+
         ProcessChatMessage(msg, !msg.HidePopup || msg.UseEmoteSpeechBubble);
         // RMC14
 

--- a/Content.Client/_RMC14/Mobs/Ghosts/CMGhostSystem.cs
+++ b/Content.Client/_RMC14/Mobs/Ghosts/CMGhostSystem.cs
@@ -1,15 +1,17 @@
+using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Mobs;
-using Content.Shared.Actions;
+using Content.Shared.Chat;
 using Content.Shared.Popups;
 using Robust.Client.Player;
 
 namespace Content.Client._RMC14.Mobs.Ghosts
 {
-    public sealed class CMGhostSystem : EntitySystem
+    public sealed class CMGhostSystem : SharedCMGhostSystem
     {
-        [Dependency] private readonly SharedActionsSystem _actions = default!;
         [Dependency] private readonly IPlayerManager _player = default!;
         [Dependency] private readonly SharedPopupSystem _popup = default!;
+
+        private const ChatChannel PostDeathMutedChannels = ChatChannel.Local | ChatChannel.Whisper | ChatChannel.Radio | ChatChannel.Emotes | ChatChannel.Dead;
 
         public override void Initialize()
         {
@@ -39,10 +41,24 @@ namespace Content.Client._RMC14.Mobs.Ghosts
 
         private void OnCMGhostRemove(EntityUid uid, CMGhostComponent comp, ComponentRemove remove)
         {
-            _actions.RemoveAction(uid, comp.ToggleMarineHudEntity);
-            _actions.RemoveAction(uid, comp.ToggleXenoHudEntity);
-            _actions.RemoveAction(uid, comp.ToggleDeadChatEntity);
-            _actions.RemoveAction(uid, comp.FindParasiteEntity);
+            Actions.RemoveAction(uid, comp.ToggleMarineHudEntity);
+            Actions.RemoveAction(uid, comp.ToggleXenoHudEntity);
+            Actions.RemoveAction(uid, comp.ToggleDeadChatEntity);
+            Actions.RemoveAction(uid, comp.FindParasiteEntity);
+        }
+
+        public bool ShouldMutePostDeathChat(ChatChannel channel)
+        {
+            if ((channel & PostDeathMutedChannels) == 0 ||
+                !Config.GetCVar(RMCCVars.RMCPostDeathChatMute) ||
+                _player.LocalEntity is not { } localEntity ||
+                !TryComp(localEntity, out CMGhostComponent? ghost) ||
+                ghost.PostDeathChatMutedUntil is not { } mutedUntil)
+            {
+                return false;
+            }
+
+            return GameTiming.CurTime < mutedUntil;
         }
     }
 }

--- a/Content.Client/_RMC14/Mobs/Ghosts/CMGhostSystem.cs
+++ b/Content.Client/_RMC14/Mobs/Ghosts/CMGhostSystem.cs
@@ -1,23 +1,47 @@
-using Content.Shared.Ghost;
 using Content.Shared._RMC14.Mobs;
 using Content.Shared.Actions;
+using Content.Shared.Popups;
+using Robust.Client.Player;
 
 namespace Content.Client._RMC14.Mobs.Ghosts
 {
     public sealed class CMGhostSystem : EntitySystem
     {
         [Dependency] private readonly SharedActionsSystem _actions = default!;
+        [Dependency] private readonly IPlayerManager _player = default!;
+        [Dependency] private readonly SharedPopupSystem _popup = default!;
+
         public override void Initialize()
         {
             base.Initialize();
 
             SubscribeLocalEvent<CMGhostComponent, ComponentRemove>(OnCMGhostRemove);
+            SubscribeLocalEvent<CMGhostComponent, ToggleDeadChatActionEvent>(OnToggleDeadChat);
+        }
+
+        private void OnToggleDeadChat(Entity<CMGhostComponent> ent, ref ToggleDeadChatActionEvent args)
+        {
+            if (args.Handled || ent.Owner != _player.LocalEntity)
+                return;
+
+            args.Handled = true;
+            args.Toggle = true;
+
+            var msg = "rmc-ghost-dead-chat-unmuted";
+            if (!RemComp<RMCDeadChatMutedComponent>(ent))
+            {
+                EnsureComp<RMCDeadChatMutedComponent>(ent);
+                msg = "rmc-ghost-dead-chat-muted";
+            }
+
+            _popup.PopupClient(Loc.GetString(msg), ent, ent);
         }
 
         private void OnCMGhostRemove(EntityUid uid, CMGhostComponent comp, ComponentRemove remove)
         {
             _actions.RemoveAction(uid, comp.ToggleMarineHudEntity);
             _actions.RemoveAction(uid, comp.ToggleXenoHudEntity);
+            _actions.RemoveAction(uid, comp.ToggleDeadChatEntity);
             _actions.RemoveAction(uid, comp.FindParasiteEntity);
         }
     }

--- a/Content.Client/_RMC14/Mobs/Ghosts/RMCDeadChatMutedComponent.cs
+++ b/Content.Client/_RMC14/Mobs/Ghosts/RMCDeadChatMutedComponent.cs
@@ -1,0 +1,4 @@
+namespace Content.Client._RMC14.Mobs.Ghosts;
+
+[RegisterComponent, Access(typeof(CMGhostSystem))]
+public sealed partial class RMCDeadChatMutedComponent : Component;

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Numerics;
+using Content.Server._RMC14.Mobs;
 using Content.Server.Administration.Logs;
 using Content.Server.Chat.Managers;
 using Content.Server.GameTicking;
@@ -72,6 +73,10 @@ namespace Content.Server.Ghost
         [Dependency] private readonly IRobustRandom _random = default!;
         [Dependency] private readonly TagSystem _tag = default!;
         [Dependency] private readonly NameModifierSystem _nameMod = default!;
+
+        // RMC14
+        [Dependency] private readonly CMGhostSystem _cmGhost = default!;
+        // RMC14
 
         private EntityQuery<GhostComponent> _ghostQuery;
         private EntityQuery<PhysicsComponent> _physicsQuery;
@@ -510,6 +515,10 @@ namespace Content.Server.Ghost
             }
 
             SetCanReturnToBody((ghost, ghostComponent), canReturn);
+
+            // RMC14
+            _cmGhost.SetPostDeathChatMute(ghost, (mind.Owner, mind.Comp), mind.Comp.OwnedEntity);
+            // RMC14
 
             if (canReturn)
                 _minds.Visit(mind.Owner, ghost, mind.Comp);

--- a/Content.Server/_RMC14/Mobs/CMGhostSystem.cs
+++ b/Content.Server/_RMC14/Mobs/CMGhostSystem.cs
@@ -1,20 +1,23 @@
 using Content.Server.Ghost;
+using Content.Shared._RMC14.Admin;
 using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.Mobs;
 using Content.Shared._RMC14.PropCalling;
-using Content.Shared.Actions;
 using Content.Shared.Ghost;
+using Content.Shared.Mind;
+using Content.Shared.Mind.Components;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Components;
 using Content.Shared.Overlays;
 using Robust.Shared.Configuration;
 
 namespace Content.Server._RMC14.Mobs
 {
-    public sealed class CMGhostSystem : EntitySystem
+    public sealed class CMGhostSystem : SharedCMGhostSystem
     {
-        [Dependency] private readonly SharedActionsSystem _actions = default!;
-        [Dependency] private readonly IConfigurationManager _configuration = default!;
         [Dependency] private readonly SharedMarineSystem _marine = default!;
+        [Dependency] private readonly SharedMindSystem _mind = default!;
 
         private bool _ghostsCanBoo;
 
@@ -30,7 +33,10 @@ namespace Content.Server._RMC14.Mobs
             SubscribeLocalEvent<CMGhostComponent, ToggleMarineHudActionEvent>(OnMarineHudAction);
             SubscribeLocalEvent<CMGhostComponent, ToggleXenoHudActionEvent>(OnXenoHudAction);
 
-            Subs.CVar(_configuration, RMCCVars.RMCGhostCanBoo, OnGhostBooChange, true);
+            SubscribeLocalEvent<MindContainerComponent, MindAddedMessage>(OnMindAdded);
+            SubscribeLocalEvent<MindContainerComponent, MobStateChangedEvent>(OnMobStateChanged);
+
+            Subs.CVar(Config, RMCCVars.RMCGhostCanBoo, OnGhostBooChange, true);
         }
 
         private void OnGhostStartup(EntityUid uid, GhostHearingComponent comp, ComponentStartup args)
@@ -40,10 +46,10 @@ namespace Content.Server._RMC14.Mobs
 
         private void OnCMGhostStartup(EntityUid uid, CMGhostComponent comp, ComponentStartup args)
         {
-            _actions.AddAction(uid, ref comp.ToggleMarineHudEntity, comp.ToggleMarineHud);
-            _actions.AddAction(uid, ref comp.ToggleXenoHudEntity, comp.ToggleXenoHud);
-            _actions.AddAction(uid, ref comp.ToggleDeadChatEntity, comp.ToggleDeadChat);
-            _actions.AddAction(uid, ref comp.FindParasiteEntity, comp.FindParasite);
+            Actions.AddAction(uid, ref comp.ToggleMarineHudEntity, comp.ToggleMarineHud);
+            Actions.AddAction(uid, ref comp.ToggleXenoHudEntity, comp.ToggleXenoHud);
+            Actions.AddAction(uid, ref comp.ToggleDeadChatEntity, comp.ToggleDeadChat);
+            Actions.AddAction(uid, ref comp.FindParasiteEntity, comp.FindParasite);
 
             EnsureComp<ShowMarineIconsComponent>(uid);
             var bars = EnsureComp<ShowHealthBarsComponent>(uid);
@@ -62,7 +68,7 @@ namespace Content.Server._RMC14.Mobs
                 RemComp<ShowMarineIconsComponent>(uid);
                 RemCompDeferred<ShowHealthIconsComponent>(uid);
                 RemCompDeferred<ShowHealthBarsComponent>(uid);
-                _actions.SetToggled(comp.ToggleMarineHudEntity, true);
+                Actions.SetToggled(comp.ToggleMarineHudEntity, true);
             }
             else
             {
@@ -73,7 +79,7 @@ namespace Content.Server._RMC14.Mobs
                 var bars = EnsureComp<ShowHealthBarsComponent>(uid);
                 bars.DamageContainers.Add("Biological");
 
-                _actions.SetToggled(comp.ToggleMarineHudEntity, false);
+                Actions.SetToggled(comp.ToggleMarineHudEntity, false);
             }
         }
         private void OnXenoHudAction(EntityUid uid, CMGhostComponent comp, ToggleXenoHudActionEvent args)
@@ -83,12 +89,37 @@ namespace Content.Server._RMC14.Mobs
             if (HasComp<CMGhostXenoHudComponent>(uid))
             {
                 RemComp<CMGhostXenoHudComponent>(uid);
-                _actions.SetToggled(comp.ToggleXenoHudEntity, true);
+                Actions.SetToggled(comp.ToggleXenoHudEntity, true);
             }
             else
             {
                 AddComp<CMGhostXenoHudComponent>(uid);
-                _actions.SetToggled(comp.ToggleXenoHudEntity, false);
+                Actions.SetToggled(comp.ToggleXenoHudEntity, false);
+            }
+        }
+
+        private void OnMindAdded(Entity<MindContainerComponent> ent, ref MindAddedMessage args)
+        {
+            if (!HasComp<GhostComponent>(ent) &&
+                TryComp(ent, out MobStateComponent? mobState) &&
+                mobState.CurrentState != MobState.Dead)
+            {
+                args.Mind.Comp.TimeOfDeath = null;
+            }
+        }
+
+        private void OnMobStateChanged(Entity<MindContainerComponent> ent, ref MobStateChangedEvent args)
+        {
+            if (!_mind.TryGetMind(ent, out _, out var mind))
+                return;
+
+            if (args.NewMobState == MobState.Dead && args.OldMobState != MobState.Dead)
+            {
+                mind.TimeOfDeath = GameTiming.RealTime;
+            }
+            else if (args.OldMobState == MobState.Dead && args.NewMobState != MobState.Dead)
+            {
+                mind.TimeOfDeath = null;
             }
         }
 
@@ -108,15 +139,35 @@ namespace Content.Server._RMC14.Mobs
             }
         }
 
+        public void SetPostDeathChatMute(EntityUid ghostUid, Entity<MindComponent> mind, EntityUid? sourceBody)
+        {
+            if (sourceBody is { } body && HasComp<RMCAdminSpawnedComponent>(body))
+                return;
+
+            if (mind.Comp.TimeOfDeath is not { } timeOfDeath)
+                return;
+
+            if (!TryComp(ghostUid, out CMGhostComponent? ghost))
+                return;
+
+            var duration = TimeSpan.FromSeconds(Math.Max(0, Config.GetCVar(RMCCVars.RMCPostDeathChatMuteTimeSeconds)));
+            var elapsed = GameTiming.RealTime - timeOfDeath;
+            var remaining = duration - (elapsed > TimeSpan.Zero ? elapsed : TimeSpan.Zero);
+            if (remaining <= TimeSpan.Zero)
+                return;
+
+            SetPostDeathChatMutedUntil((ghostUid, ghost), GameTiming.CurTime + remaining);
+        }
+
         private void ChangeGhostBoo(Entity<GhostComponent> ghost)
         {
             if (_ghostsCanBoo)
             {
-                _actions.AddAction(ghost.Owner, ref ghost.Comp.BooActionEntity, ghost.Comp.BooAction);
+                Actions.AddAction(ghost.Owner, ref ghost.Comp.BooActionEntity, ghost.Comp.BooAction);
             }
             else
             {
-                _actions.RemoveAction(ghost.Owner, ghost.Comp.BooActionEntity);
+                Actions.RemoveAction(ghost.Owner, ghost.Comp.BooActionEntity);
             }
         }
     }

--- a/Content.Server/_RMC14/Mobs/CMGhostSystem.cs
+++ b/Content.Server/_RMC14/Mobs/CMGhostSystem.cs
@@ -42,6 +42,7 @@ namespace Content.Server._RMC14.Mobs
         {
             _actions.AddAction(uid, ref comp.ToggleMarineHudEntity, comp.ToggleMarineHud);
             _actions.AddAction(uid, ref comp.ToggleXenoHudEntity, comp.ToggleXenoHud);
+            _actions.AddAction(uid, ref comp.ToggleDeadChatEntity, comp.ToggleDeadChat);
             _actions.AddAction(uid, ref comp.FindParasiteEntity, comp.FindParasite);
 
             EnsureComp<ShowMarineIconsComponent>(uid);

--- a/Content.Shared/_RMC14/CCVar/RMCCVars.cs
+++ b/Content.Shared/_RMC14/CCVar/RMCCVars.cs
@@ -548,6 +548,12 @@ public sealed partial class RMCCVars : CVars
     public static readonly CVarDef<bool> RMCGhostCanBoo =
         CVarDef.Create("rmc.ghosts_can_boo", false, CVar.SERVER | CVar.SERVERONLY);
 
+    public static readonly CVarDef<bool> RMCPostDeathChatMute =
+        CVarDef.Create("rmc.post_death_chat_mute", true, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    public static readonly CVarDef<int> RMCPostDeathChatMuteTimeSeconds =
+        CVarDef.Create("rmc.post_death_chat_mute_time_seconds", 10, CVar.SERVER | CVar.SERVERONLY);
+
     public static readonly CVarDef<int> RMCRoyalResinEveryMinutes =
         CVarDef.Create("rmc.royal_resin_every_minutes", 5, CVar.REPLICATED | CVar.SERVER);
 

--- a/Content.Shared/_RMC14/Mobs/CMGhostComponent.cs
+++ b/Content.Shared/_RMC14/Mobs/CMGhostComponent.cs
@@ -23,6 +23,12 @@ public sealed partial class CMGhostComponent : Component
     public EntityUid? ToggleXenoHudEntity;
 
     [DataField]
+    public EntProtoId ToggleDeadChat = "RMCActionToggleDeadChat";
+
+    [DataField, AutoNetworkedField]
+    public EntityUid? ToggleDeadChatEntity;
+
+    [DataField]
     public EntProtoId FindParasite = "ActionFindParasite";
 
     [DataField, AutoNetworkedField]
@@ -33,3 +39,5 @@ public sealed partial class CMGhostComponent : Component
 public sealed partial class ToggleMarineHudActionEvent : InstantActionEvent { }
 
 public sealed partial class ToggleXenoHudActionEvent : InstantActionEvent { }
+
+public sealed partial class ToggleDeadChatActionEvent : InstantActionEvent;

--- a/Content.Shared/_RMC14/Mobs/CMGhostComponent.cs
+++ b/Content.Shared/_RMC14/Mobs/CMGhostComponent.cs
@@ -6,7 +6,7 @@ using Content.Shared._RMC14.Roles.FindParasite;
 
 namespace Content.Shared._RMC14.Mobs;
 
-[RegisterComponent, NetworkedComponent, Access([typeof(SharedGhostSystem)])]
+[RegisterComponent, NetworkedComponent, Access([typeof(SharedCMGhostSystem), typeof(SharedGhostSystem)])]
 [AutoGenerateComponentState(true)]
 public sealed partial class CMGhostComponent : Component
 {
@@ -27,6 +27,9 @@ public sealed partial class CMGhostComponent : Component
 
     [DataField, AutoNetworkedField]
     public EntityUid? ToggleDeadChatEntity;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan? PostDeathChatMutedUntil;
 
     [DataField]
     public EntProtoId FindParasite = "ActionFindParasite";

--- a/Content.Shared/_RMC14/Mobs/SharedCMGhostSystem.cs
+++ b/Content.Shared/_RMC14/Mobs/SharedCMGhostSystem.cs
@@ -1,0 +1,21 @@
+using Content.Shared.Actions;
+using Robust.Shared.Configuration;
+using Robust.Shared.Timing;
+
+namespace Content.Shared._RMC14.Mobs;
+
+public abstract class SharedCMGhostSystem : EntitySystem
+{
+    [Dependency] protected readonly SharedActionsSystem Actions = default!;
+    [Dependency] protected readonly IConfigurationManager Config = default!;
+    [Dependency] protected readonly IGameTiming GameTiming = default!;
+
+    protected void SetPostDeathChatMutedUntil(Entity<CMGhostComponent?> ent, TimeSpan? value)
+    {
+        if (!Resolve(ent, ref ent.Comp) || ent.Comp.PostDeathChatMutedUntil == value)
+            return;
+
+        ent.Comp.PostDeathChatMutedUntil = value;
+        Dirty(ent);
+    }
+}

--- a/Resources/Locale/en-US/_RMC14/mobs/cm-ghost.ftl
+++ b/Resources/Locale/en-US/_RMC14/mobs/cm-ghost.ftl
@@ -1,7 +1,10 @@
-﻿cm-ghost-window-title = Are you sure you want to ghost?
+cm-ghost-window-title = Are you sure you want to ghost?
 cm-ghost-window-text = Are you -sure- you want to ghost? You are alive.
   If you ghost, [bold][color=red]you won't be able to return to your body.[/color][/bold]
   You can't change your mind so choose wisely!
 cm-ghost-window-stay = Stay in body
 cm-ghost-ghost = Ghost
 rmc-ghost-gui-toggle-lighting-manager-popup-halfbright = Half-bright mode.
+rmc-ghost-dead-chat-muted = Dead chat messages and speech bubbles are now muted.
+rmc-ghost-dead-chat-unmuted = Dead chat messages and speech bubbles are no longer muted.
+rmc-ghost-dead-chat-send-blocked = Dead chat is muted. Unmute it before sending a message.

--- a/Resources/Locale/en-US/_RMC14/mobs/cm-ghost.ftl
+++ b/Resources/Locale/en-US/_RMC14/mobs/cm-ghost.ftl
@@ -8,3 +8,4 @@ rmc-ghost-gui-toggle-lighting-manager-popup-halfbright = Half-bright mode.
 rmc-ghost-dead-chat-muted = Dead chat messages and speech bubbles are now muted.
 rmc-ghost-dead-chat-unmuted = Dead chat messages and speech bubbles are no longer muted.
 rmc-ghost-dead-chat-send-blocked = Dead chat is muted. Unmute it before sending a message.
+rmc-ghost-post-death-chat-send-blocked = Chat is temporarily muted after death.

--- a/Resources/Locale/en-US/_RMC14/ui.ftl
+++ b/Resources/Locale/en-US/_RMC14/ui.ftl
@@ -4,6 +4,17 @@ rmc-ui-options-cassettes-volume = Cassette volume:
 rmc-ui-options-hijack-song-volume = Hijack song volume:
 rmc-ui-options-xeno-ability-previews = Show xeno ability previews
 rmc-ui-options-marine-equipment-previews = Show marine equipment previews
+rmc-ui-options-post-death-chat-mute = Mute chat briefly after death
+rmc-ui-options-post-death-chat-mute-confirmation-title = Disable post-death chat mute?
+rmc-ui-options-post-death-chat-mute-confirmation-text = Disabling this mute means you may immediately see the reaction of other characters after your character dies.
+  Remember to separate character interactions from player interactions, comments about your character are not necessarily directed at you.
+
+  If something upsets you, step away before responding, and use admin help for rule-breaking behavior.
+  Read the "Roleplay Setting Disclaimer" in the "Don't Antagonize/Harass Others" section of the rules.
+
+  By continuing, you acknowledge that you may see potentially upsetting post-death reactions and agree not to get upset at other players over in-character interactions.
+rmc-ui-options-post-death-chat-mute-confirmation-accept = I understand, disable
+rmc-ui-options-post-death-chat-mute-confirmation-deny = Keep chat mute enabled
 
 rmc-ui-voicelines = Voicelines
 rmc-ui-options-tab-voicelines = Voicelines

--- a/Resources/Prototypes/_RMC14/Actions/Ghosts/cm_observer.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Ghosts/cm_observer.yml
@@ -31,6 +31,22 @@
     event: !type:ToggleXenoHudActionEvent
 
 - type: entity
+  parent: BaseMentalAction
+  id: RMCActionToggleDeadChat
+  name: Mute Dead Chat
+  description: Suppress dead chat messages and speech bubbles.
+  components:
+  - type: Action
+    checkCanInteract: false
+    clientExclusive: true
+    icon:
+      sprite: Clothing/Ears/Headsets/base.rsi
+      state: icon
+    iconOn: Interface/Actions/ghostHearingToggled.png
+  - type: InstantAction
+    event: !type:ToggleDeadChatActionEvent
+
+- type: entity
   id: ActionFindParasite
   name: Find Parasite
   description: Find Ghostrolable Parasites


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

- Ghosts now have a new action that can be toggled to completely disable ghost chat.
- Dying now mutes and deafens you for 10 seconds. This is enabled by default and can be disabled in the options menu.
- A mind’s time of death now resets when entering a living body instead of carrying over from a previous death.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
QOL

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Dygon
- tweak: Ghosts now have an action that lets them completely mute dead chat.
- tweak: Ghosts can’t see or send gameplay chat for 10 seconds after dying. This can be disabled in the Accessibility settings
- fix: A mind’s time of death now resets when entering a living body instead of carrying over from a previous death.