### PR TITLE
Fix mapping autosave crash on Windows debug builds

### DIFF
--- a/Content.Server/Mapping/MappingSystem.cs
+++ b/Content.Server/Mapping/MappingSystem.cs
@@ -76,7 +76,7 @@ public sealed class MappingSystem : EntitySystem
             var saveDir = Path.Combine(_cfg.GetCVar(CCVars.AutosaveDirectory), name).Replace(Path.DirectorySeparatorChar, '/');
             _resMan.UserData.CreateDir(new ResPath(saveDir).ToRootedPath());
 
-            var path = new ResPath(Path.Combine(saveDir, $"{DateTime.Now:yyyy-M-dd_HH.mm.ss}-AUTO.yml"));
+            var path = new ResPath($"{saveDir}/{DateTime.Now:yyyy-M-dd_HH.mm.ss}-AUTO.yml");
             Log.Info($"Autosaving map {name} ({uid}) to {path}. Next save in {ReadableTimeLeft(uid)} seconds.");
 
             if (HasComp<MapComponent>(uid))


### PR DESCRIPTION
## About the PR
Fixes a server crash that happens on the first autosave tick of a mapping session on Windows debug builds.

## Why / Balance
No gameplay or balance impact. Currently any mapper running a local debug server on Windows gets the server killed as soon as autosave fires, which makes `toggleautosave` unusable there.

## Technical details
`MappingSystem.Update` built the autosave file path with `Path.Combine(saveDir, "...-AUTO.yml")`. On Windows `Path.Combine` joins with `\`, but `ResPath` expects a canonical path that only uses `/`, and its constructor runs `DebugTools.Assert(IsValidPath(canonPath))`. So on Windows the `new ResPath(...)` call throws an unhandled `DebugAssertException` and takes the server down.

The directory path just above already normalizes separators with `.Replace(Path.DirectorySeparatorChar, '/')`; only the file path was missed. It now uses an interpolated string with an explicit `/`, so no `Path.Combine` is involved:

```cs
var path = new ResPath($"{saveDir}/{DateTime.Now:yyyy-M-dd_HH.mm.ss}-AUTO.yml");
```

The assert is Debug-only and `Path.Combine` uses `/` on Linux, which is why release servers and Linux hosts never hit this.

## Media
Not required - one-line non-visual fix with no ingame changes.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- code: Fixed the server crashing on the first mapping autosave on Windows debug builds.
