### PR TITLE
Add rocket launcher backblast effects

### DIFF
--- a/Content.Server/_RMC14/Weapons/Ranged/Backblast/RMCBackblastComponent.cs
+++ b/Content.Server/_RMC14/Weapons/Ranged/Backblast/RMCBackblastComponent.cs
@@ -1,0 +1,31 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._RMC14.Weapons.Ranged.Backblast;
+
+[RegisterComponent]
+public sealed partial class RMCBackblastComponent : Component
+{
+    [DataField(required: true)]
+    public EntProtoId NearEffect;
+
+    [DataField(required: true)]
+    public EntProtoId FarEffect;
+
+    [DataField]
+    public float KnockbackDistance = 2;
+
+    [DataField]
+    public float KnockbackSpeed = 25;
+
+    [DataField]
+    public TimeSpan KnockdownTime = TimeSpan.FromSeconds(1);
+
+    [DataField]
+    public TimeSpan DeafTime = TimeSpan.FromSeconds(15);
+
+    [DataField]
+    public TimeSpan StutterTime = TimeSpan.FromSeconds(15);
+
+    [DataField]
+    public TimeSpan DizzyTime = TimeSpan.FromSeconds(2);
+}

--- a/Content.Server/_RMC14/Weapons/Ranged/Backblast/RMCBackblastSystem.cs
+++ b/Content.Server/_RMC14/Weapons/Ranged/Backblast/RMCBackblastSystem.cs
@@ -1,0 +1,86 @@
+using System.Numerics;
+using Content.Shared._RMC14.Deafness;
+using Content.Shared._RMC14.Marines;
+using Content.Shared._RMC14.Stun;
+using Content.Shared.Directions;
+using Content.Shared.Drunk;
+using Content.Shared.Maps;
+using Content.Shared.Speech.EntitySystems;
+using Content.Shared.Stunnable;
+using Content.Shared.Weapons.Ranged.Systems;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Systems;
+
+namespace Content.Server._RMC14.Weapons.Ranged.Backblast;
+
+public sealed class RMCBackblastSystem : EntitySystem
+{
+    [Dependency] private readonly SharedDeafnessSystem _deafness = default!;
+    [Dependency] private readonly SharedDrunkSystem _drunk = default!;
+    [Dependency] private readonly RMCSizeStunSystem _sizeStun = default!;
+    [Dependency] private readonly SharedStunSystem _stun = default!;
+    [Dependency] private readonly SharedStutteringSystem _stutter = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly TurfSystem _turf = default!;
+
+    private readonly HashSet<EntityUid> _affected = new();
+    private readonly HashSet<EntityUid> _processed = new();
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<RMCBackblastComponent, GunShotEvent>(OnGunShot);
+    }
+
+    private void OnGunShot(Entity<RMCBackblastComponent> launcher, ref GunShotEvent args)
+    {
+        var shooter = _transform.GetMapCoordinates(args.User);
+        var target = _transform.ToMapCoordinates(args.ToCoordinates);
+
+        if (shooter.MapId != target.MapId)
+            return;
+
+        var shotVector = target.Position - shooter.Position;
+        if (shotVector == Vector2.Zero)
+            return;
+
+        var rearDirection = shotVector.ToWorldAngle().GetCardinalDir().GetOpposite();
+        var nearCoordinates = new MapCoordinates(shooter.Position + rearDirection.ToVec(), shooter.MapId);
+        var farCoordinates = new MapCoordinates(shooter.Position + rearDirection.ToVec() * 2, shooter.MapId);
+
+        Spawn(launcher.Comp.NearEffect, nearCoordinates);
+        Spawn(launcher.Comp.FarEffect, farCoordinates);
+
+        _processed.Clear();
+        ApplyBackblast(nearCoordinates, shooter, args.User, launcher.Comp);
+        ApplyBackblast(farCoordinates, shooter, args.User, launcher.Comp);
+    }
+
+    private void ApplyBackblast(
+        MapCoordinates coordinates,
+        MapCoordinates shooter,
+        EntityUid shooterEntity,
+        RMCBackblastComponent component)
+    {
+        _affected.Clear();
+        _turf.GetEntitiesInTile(_transform.ToCoordinates(coordinates), _affected, LookupFlags.Uncontained);
+
+        foreach (var marine in _affected)
+        {
+            if (marine == shooterEntity || !HasComp<MarineComponent>(marine) || !_processed.Add(marine))
+                continue;
+
+            _sizeStun.KnockBack(
+                marine,
+                shooter,
+                component.KnockbackDistance,
+                component.KnockbackDistance,
+                component.KnockbackSpeed);
+            _stun.TryKnockdown(marine, component.KnockdownTime, true);
+            _deafness.TryDeafen(marine, component.DeafTime, true);
+            _stutter.DoStutter(marine, component.StutterTime, true);
+            _drunk.TryApplyDrunkenness(marine, (float) component.DizzyTime.TotalSeconds, false);
+        }
+    }
+}

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/hjra_12_rocket_launcher.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/hjra_12_rocket_launcher.yml
@@ -68,6 +68,9 @@
   - type: IgnorePredictionHide
   - type: GunIgnorePrediction
   - type: AssistedReloadWeapon
+  - type: RMCBackblast
+    nearEffect: RMCBackblastSmokeNear
+    farEffect: RMCBackblastSmokeFar
   - type: WieldedCrosshair
     rsi:
       sprite: _RMC14/Interface/MousePointer/explosive_mouse.rsi
@@ -165,6 +168,8 @@
     layers:
     - state: hjra_tank
       map: ["enum.AmmoVisualLayers.Base"]
+  - type: Projectile
+    angle: 90
   - type: IgnorePredictionHide
 
 - type: entity
@@ -182,6 +187,8 @@
     layers:
     - state: hjra_explosive
       map: ["enum.AmmoVisualLayers.Base"]
+  - type: Projectile
+    angle: 90
   - type: IgnorePredictionHide
 
 - type: entity
@@ -215,6 +222,7 @@
         restitution: 0.0
         density: 20
   - type: Projectile
+    angle: 90
     impactEffect: BulletImpactEffect
     damage:
       types:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/l33_daamsl.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/l33_daamsl.yml
@@ -21,3 +21,6 @@
       tags: []
   - type: Corrodible
     isCorrodible: false
+  - type: RMCBackblast
+    nearEffect: RMCBackblastSmokeNear
+    farEffect: RMCBackblastSmokeFar

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m5_atl_rocket_launcher.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m5_atl_rocket_launcher.yml
@@ -70,7 +70,7 @@
   parent: [RMCBaseWeaponLauncher, RMCBaseAttachableHolder]
   name: M5-ATL
   id: RMCWeaponLauncherM5ATL
-  description: "The M5 Anti-Tank Launcher is a powerful anti-armor infantry weapon, commonly fielded by the UNMC. Used to take out light-tanks and enemy structures, the M5-ATL is a dangerous weapon with a variety of combat uses, depending on the loaded ammunition, and is capable of firing both shells and rocket-propelled grenades.\n\nThis one is missing its smart optics completely, and seems to be damaged, greatly limiting its range..."
+  description: The M5 Anti-Tank Launcher is a powerful anti-armor infantry weapon, commonly fielded by the UNMC. Used to take out light-tanks and enemy structures, the M5-ATL is a dangerous weapon with a variety of combat uses, depending on the loaded ammunition, and is capable of firing both shells and rocket-propelled grenades.
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Weapons/Guns/RocketLaunchers/m5atl/m5atl_inhands.rsi
@@ -91,6 +91,34 @@
   - type: Corrodible
     isCorrodible: false
   - type: RMCMagneticItem
+  - type: RMCBackblast
+    nearEffect: RMCBackblastSmokeNear
+    farEffect: RMCBackblastSmokeFar
+
+- type: entity
+  id: RMCBackblastSmokeNear
+  name: backblast smoke
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Transform
+    anchored: true
+  - type: Sprite
+    drawdepth: Effects
+    sprite: _RMC14/Effects/smoke.rsi
+    state: smoke2
+  - type: TimedDespawn
+    lifetime: 1.5
+  - type: Tag
+    tags:
+    - HideContextMenu
+
+- type: entity
+  parent: RMCBackblastSmokeNear
+  id: RMCBackblastSmokeFar
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: TimedDespawn
+    lifetime: 1
 
 # 84mm HE
 - type: entity

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m5a1_slaw.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Launchers/m5a1_slaw.yml
@@ -19,6 +19,9 @@
     cycleable: false
     whitelist:
       tags: []
+  - type: RMCBackblast
+    nearEffect: RMCBackblastSmokeNear
+    farEffect: RMCBackblastSmokeFar
   - type: RMCFoldableGun
     foldDelay: 2
     foldText: rmc-gun-foldable-launcher-fold-self


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->


Ports CM13' two-tile backblast smoke and gameplay effects for the M5-ATL, M5A1 SLAW, M5A2 SHEL, HJRA-12, and L33 DAAMSL when they successfully fire. Some values have been altered slightly, like how long the smoke lingers, and extra cosmetic details are present, such as the smoke effect being staggered, though these are minor.

The nearest smoke appears one tile behind the shooter for 1.5 seconds. The farther smoke appears two tiles behind the shooter for 1 second, making the outer exhaust dissipate first. Both effects spawn immediately and do not spread.

Marines caught on either backblast tile are knocked two tiles away from the shooter, knocked down for 1 second, deafened for 15 seconds, made to stutter for 15 seconds, and given 2 seconds of blood-loss-style spinning/dizziness without drunken slurring. The shooter is explicitly excluded so you can walk backward while shooting and not hit yourself or overlap. It should be noted that, although the backblast deals no damage, hitting a wall still can.

Also corrects the flight orientation of all HJRA-12 rocket variants, as before they shot sideways, and removes the obsolete sentence in the M5-ATL description claiming its smart optics and range are damaged.

## Why / Balance

Parity

## Technical details
<!-- Summary of code changes for easier review. -->


- Adds an `RMCBackblast` server component and system that listen for `GunShotEvent`, so backblast only occurs after a successful shot.
- Determines the real shot vector from the shooter to `GunShotEvent.ToCoordinates`, converts it to a cardinal direction, and places the effects in the opposite direction.
- Spawns independent, non-spreading smoke effect entities one and two tiles behind the shooter with `TimedDespawn` lifetimes of 1.5 and 1 second.
- Processes the two rear tiles independently and only affects uncontained entities with `MarineComponent`.
- Explicitly excludes the shooter and prevents the same marine from being processed twice if the first knockback carries them into the second tile, both bugs found in testing
- Uses the existing RMC size-stun knockback with a distance of 2 and speed of 25.
- Applies 1 second of knockdown, 15 seconds of deafness, 15 seconds of stuttering, and 2 seconds of non-slurring dizziness.
- Adds the component to `RMCWeaponLauncherM5ATL`, `RMCWeaponLauncherDisposable`, `RMCWeaponLauncherHJRA12`, and `RMCWeaponLauncherL33`. The M5A2 SHEL inherits it from `RMCWeaponLauncherDisposable`.
- Applies a 90-degree projectile angle correction to all three HJRA-12 rocket variants.


## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

https://github.com/user-attachments/assets/215096c3-8ddb-4246-8375-03bbe2169b2e

Having issues screen recording for a video of the backblast knockback. It will be added when I can, though it works as stated.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added backblast smoke and effects to the M5-ATL, M5A1 SLAW, M5A2 SHEL, HJRA-12, and L33 DAAMSL.
- tweak: Marines directly behind a firing rocket launcher are knocked away and temporarily debilitated by its backblast.
- tweak: Updated the M5-ATL description.
- fix: Fixed HJRA-12 rocket sprites appearing sideways in flight.