### PR TITLE
[Fix] Fixes Knockdown sprites staying stale after mispredict rollback.

### DIFF
--- a/Content.Shared/Standing/StandingStateComponent.cs
+++ b/Content.Shared/Standing/StandingStateComponent.cs
@@ -3,7 +3,8 @@ using Robust.Shared.GameStates;
 
 namespace Content.Shared.Standing
 {
-    [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+    // AutoGenComponentState set to true for RMCStandingSystem 176 to fix sprite states after knockdown mispredict.
+    [RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true)]
     [Access(typeof(StandingStateSystem))]
     public sealed partial class StandingStateComponent : Component
     {

--- a/Content.Shared/Standing/StandingStateComponent.cs
+++ b/Content.Shared/Standing/StandingStateComponent.cs
@@ -3,7 +3,7 @@ using Robust.Shared.GameStates;
 
 namespace Content.Shared.Standing
 {
-    // AutoGenComponentState set to true for RMCStandingSystem 176 to fix sprite states after knockdown mispredict.
+    // AutoGenComponentState set to true for RMCStandingSystem OnStandingState to resync after knockdown mispredict.
     [RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true)]
     [Access(typeof(StandingStateSystem))]
     public sealed partial class StandingStateComponent : Component

--- a/Content.Shared/Standing/StandingStateComponent.cs
+++ b/Content.Shared/Standing/StandingStateComponent.cs
@@ -3,8 +3,10 @@ using Robust.Shared.GameStates;
 
 namespace Content.Shared.Standing
 {
-    // AutoGenComponentState set to true for RMCStandingSystem OnStandingState to resync after knockdown mispredict.
+    // RMC14
+    // AutoGenComponentState set to true for RMCStandingSystem OnStandingState
     [RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true)]
+    // RMC14
     [Access(typeof(StandingStateSystem))]
     public sealed partial class StandingStateComponent : Component
     {

--- a/Content.Shared/_RMC14/Standing/RMCStandingSystem.cs
+++ b/Content.Shared/_RMC14/Standing/RMCStandingSystem.cs
@@ -172,7 +172,7 @@ public sealed class RMCStandingSystem : EntitySystem
         if (entity.Owner != args.Entity.Owner || !_standing.IsDown(entity.Owner, entity.Comp))
             return;
 
-        args.Evasion += (int) EvasionModifiers.Rest;
+        args.Evasion += (int)EvasionModifiers.Rest;
     }
 
     // SetData no-ops during state application, so queue the rotation resync for the next update after a knockdown mispredict.

--- a/Content.Shared/_RMC14/Standing/RMCStandingSystem.cs
+++ b/Content.Shared/_RMC14/Standing/RMCStandingSystem.cs
@@ -30,6 +30,8 @@ public sealed class RMCStandingSystem : EntitySystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
 
+    private readonly HashSet<EntityUid> _rotationResync = new();
+
     public override void Initialize()
     {
         SubscribeLocalEvent<DropItemsOnRestComponent, BuckledEvent>(OnDropBuckled);
@@ -173,14 +175,10 @@ public sealed class RMCStandingSystem : EntitySystem
         args.Evasion += (int) EvasionModifiers.Rest;
     }
 
-    // Resync the rotation visuals after knockdown mispredict
+    // SetData no-ops during state application, so queue the rotation resync for the next update after a knockdown mispredict.
     private void OnStandingState(Entity<StandingStateComponent> ent, ref AfterAutoHandleStateEvent args)
     {
-        var target = _standing.IsDown(ent) ? RotationState.Horizontal : RotationState.Vertical;
-        if (_appearance.TryGetData<RotationState>(ent, RotationVisuals.RotationState, out var current) && current == target)
-            return;
-
-        _appearance.SetData(ent.Owner, RotationVisuals.RotationState, target);
+        _rotationResync.Add(ent);
     }
 
     private void OnRestStood(Entity<RMCRestComponent> ent, ref StoodEvent args)
@@ -220,5 +218,27 @@ public sealed class RMCStandingSystem : EntitySystem
 
         if (!resting)
             _standing.Stand(rest);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        if (_rotationResync.Count == 0)
+            return;
+
+        foreach (var uid in _rotationResync)
+        {
+            if (!TryComp(uid, out StandingStateComponent? standing))
+                continue;
+
+            var target = _standing.IsDown(uid, standing) ? RotationState.Horizontal : RotationState.Vertical;
+            if (_appearance.TryGetData<RotationState>(uid, RotationVisuals.RotationState, out var current) && current == target)
+                continue;
+
+            _appearance.SetData(uid, RotationVisuals.RotationState, target);
+        }
+
+        _rotationResync.Clear();
     }
 }

--- a/Content.Shared/_RMC14/Standing/RMCStandingSystem.cs
+++ b/Content.Shared/_RMC14/Standing/RMCStandingSystem.cs
@@ -10,6 +10,7 @@ using Content.Shared.Mobs.Systems;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Popups;
 using Content.Shared.Pulling.Events;
+using Content.Shared.Rotation;
 using Content.Shared.Standing;
 using Content.Shared.Stunnable;
 using Robust.Shared.Containers;
@@ -27,6 +28,7 @@ public sealed class RMCStandingSystem : EntitySystem
     [Dependency] private readonly MovementSpeedModifierSystem _movementSpeed = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
 
     public override void Initialize()
     {
@@ -41,6 +43,7 @@ public sealed class RMCStandingSystem : EntitySystem
         SubscribeLocalEvent<DownOnEnterComponent, EntRemovedFromContainerMessage>(OnLeaveDown);
 
         SubscribeLocalEvent<StandingStateComponent, EvasionRefreshModifiersEvent>(OnStandingStateEvasionRefresh);
+        SubscribeLocalEvent<StandingStateComponent, AfterAutoHandleStateEvent>(OnStandingState);
 
         SubscribeLocalEvent<RMCRestComponent, StoodEvent>(OnRestStood);
         SubscribeLocalEvent<RMCRestComponent, StandAttemptEvent>(OnRestStandAttempt);
@@ -168,6 +171,16 @@ public sealed class RMCStandingSystem : EntitySystem
             return;
 
         args.Evasion += (int) EvasionModifiers.Rest;
+    }
+
+    // Resync the rotation visuals after knockdown mispredict
+    private void OnStandingState(Entity<StandingStateComponent> ent, ref AfterAutoHandleStateEvent args)
+    {
+        var target = _standing.IsDown(ent) ? RotationState.Horizontal : RotationState.Vertical;
+        if (_appearance.TryGetData<RotationState>(ent, RotationVisuals.RotationState, out var current) && current == target)
+            return;
+
+        _appearance.SetData(ent.Owner, RotationVisuals.RotationState, target);
     }
 
     private void OnRestStood(Entity<RMCRestComponent> ent, ref StoodEvent args)


### PR DESCRIPTION
## About the PR
Fixes Knockdown sprites staying stale after mispredict rollback.
Sprite rotation was stuck stale after a rollback from a mispredicted infection knockdown.
At least I hope it does, the timings suck to work around.
## Why / Balance
Fixes

## Technical details
Subscribed to the servers standingstate and resyncs at the next update because setdata nops during applying


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:

- fix: Fixed character sprites staying prone after a knockdown/infection mispredict rollback.

