### PR TITLE
Add riot M44 ammo, update riot ammo to have blue tips.

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Magazines/riotammo.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Magazines/riotammo.yml
@@ -106,6 +106,13 @@
     - RMCCartridgeRifle10x24mmRubber
   - type: CartridgeAmmo
     proto: BulletRifle10x24mmRubber
+  - type: Sprite
+    layers:
+      - state: base
+        map: [ "enum.AmmoVisualLayers.Base" ]
+      - state: tip
+        map: [ "enum.AmmoVisualLayers.Tip" ]
+        color: "#0A00C8"
 
 - type: entity
   parent: RMCBaseBullet
@@ -165,6 +172,13 @@
     - RMCCartridge10x20mmRubber
   - type: CartridgeAmmo
     proto: Bullet10x20mmRubber
+  - type: Sprite
+    layers:
+      - state: base
+        map: [ "enum.AmmoVisualLayers.Base" ]
+      - state: tip
+        map: [ "enum.AmmoVisualLayers.Tip" ]
+        color: "#0A00C8"
 
 - type: entity
   parent: RMCBaseBullet
@@ -252,6 +266,13 @@
     - RMCCartridgePistol9mmRubber
   - type: CartridgeAmmo
     proto: RMCBulletPistol9mmRubber
+  - type: Sprite
+    layers:
+      - state: base
+        map: [ "enum.AmmoVisualLayers.Base" ]
+      - state: tip
+        map: [ "enum.AmmoVisualLayers.Tip" ]
+        color: "#0A00C8"
 
 - type: entity
   parent: CMBulletBase
@@ -265,6 +286,65 @@
         Blunt: 3
   - type: RMCStaminaDamageOnCollide
     damage: 10
+
+- type: entity
+  parent: RMCSpeedLoaderM44
+  id: RMCSpeedLoader44Rubber
+  name: "M44 speed loader rubber (.44)"
+  description: A revolver speed loader filled with less-lethal rubber ammo.
+  components:
+  - type: Tag
+    tags:
+    - RMCMagazineRevolver
+    - RMCSpeedLoader44Rubber
+  - type: Sprite
+    sprite: _RMC14/Objects/Weapons/Guns/Ammunition/SpeedLoaders/m44.rsi
+    layers:
+    - state: base
+      map: [ "enum.GunVisualLayers.Base" ]
+    - state: base-5
+      map: [ "enum.GunVisualLayers.Mag" ]
+    - state: base-unshaded-5
+      color: "#0A00C8"
+      map: [ "enum.GunVisualLayers.MagUnshaded" ]
+  - type: BallisticAmmoProvider
+    proto: RMCCartridgeRevolver44Rubber
+    capacity: 7
+
+- type: entity
+  id: RMCCartridgeRevolver44Rubber
+  name: rubber cartridge (.44)
+  description: A less-lethal .44 rubber round.
+  parent: CMCartridgePistolBase
+  components:
+  - type: Tag
+    tags:
+    - Cartridge
+    - RMCCartridgeRevolver44Rubber
+    - RMCCartridgeRevolver44
+  - type: CartridgeAmmo
+    proto: RMCBulletRevolver44Rubber
+  - type: Sprite
+    layers:
+      - state: base
+        map: [ "enum.AmmoVisualLayers.Base" ]
+      - state: tip
+        map: [ "enum.AmmoVisualLayers.Tip" ]
+        color: "#0A00C8"
+- type: entity
+  parent: CMBulletBase
+  id: RMCBulletRevolver44Rubber
+  name: rubber bullet (.44)
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Projectile
+    damage:
+      types:
+        Blunt: 5
+  - type: RMCStaminaDamageOnCollide
+    damage: 15
+  - type: RMCProjectileAccuracy
+    accuracy: 90
 
 ## Tags
 
@@ -297,3 +377,9 @@
 
 - type: Tag
   id: RMCCartridgePistol9mmRubber
+
+- type: Tag
+  id: RMCCartridgeRevolver44Rubber
+
+- type: Tag
+  id: RMCSpeedLoader44Rubber

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Revolvers/m44_revolver.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Revolvers/m44_revolver.yml
@@ -18,8 +18,10 @@
       tags:
       - RMCSpeedLoaderM44
       - RMCSpeedLoader44Marksman
+      - RMCSpeedLoader44Rubber
       - RMCCartridgeRevolver44
       - RMCCartridgeRevolver44Marksman
+      - RMCCartridgeRevolver44Rubber
     proto: RMCCartridgeRevolver44
     capacity: 7
     chambers: [ True, True, True, True, True, True, True ]

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/vending_machines.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/vending_machines.yml
@@ -595,6 +595,7 @@
     ##RMCGrenadeTearGas: 40
     RMCMagazinePistolM1984Rubber: 40
     RMCMagazinePistolM77Rubber: 40
+    RMCSpeedLoader44Rubber: 40
     RMCMagazineRifleM54CRubber: 40
     RMCMagazineRifleM54CMK1Rubber: 10
     RMCMagazineRifleM4SPRRubber: 40


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added rubber bullets for M44 revolver. Changed sprites on all riot ammunition to have blue tips.

## Why / Balance
Blue tips help differentiate riot ammo from live ammo.
M44 rubber ammo is mostly for MPs to do drills with.

## Technical details
yaml code

## Media
<img width="1010" height="811" alt="Screenshot_20260816_190740" src="https://github.com/user-attachments/assets/9dcc7c45-a73c-4579-8eb4-df6b71999cb8" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added M44 Riot ammo.
- tweak: Changed riot bullets to have a blue tip.

