### PR TITLE
Fix for xenos dragging marines at max range being untacklable

### DIFF
--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
@@ -219,7 +219,9 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
             target = screen.GetClickedEntity(mousePos);
 
         var attackerPos = TransformSystem.GetMapCoordinates(attacker);
-        if (mousePos.MapId != attackerPos.MapId || (attackerPos.Position - mousePos.Position).Length() > meleeComponent.Range)
+        // RMC14
+        if (mousePos.MapId != attackerPos.MapId ||
+            (attackerPos.Position - mousePos.Position).Length() > _rmcMeleeWeapon.GetUserDisarmRange(attacker, target, meleeComponent))
             return;
 
         _rmcLagCompensation.SendLastRealTick(); // RMC14

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -986,7 +986,8 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
             }
         }
 
-        if (!InRange(user, target.Value, component.Range, session))
+        // RMC14
+        if (!InRange(user, target.Value, _rmcMelee.GetUserDisarmRange(user, target.Value, component), session))
         {
             return false;
         }

--- a/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
+++ b/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
@@ -72,6 +72,7 @@ public sealed class RMCPullingSystem : EntitySystem
         SubscribeLocalEvent<BuckleComponent, RMCGetPullTargetEvent>(OnGetPullTarget);
 
         SubscribeLocalEvent<XenoComponent, RMCPullToggleEvent>(OnXenoPullToggle);
+        SubscribeLocalEvent<XenoComponent, RMCMeleeUserGetDisarmRangeEvent>(OnXenoPullAlwaysAllowTackle);
 
         SubscribeLocalEvent<ParalyzeOnPullAttemptComponent, PullAttemptEvent>(OnParalyzeOnPullAttempt);
         SubscribeLocalEvent<InfectOnPullAttemptComponent, PullAttemptEvent>(OnInfectOnPullAttempt);
@@ -379,6 +380,18 @@ public sealed class RMCPullingSystem : EntitySystem
         EnsureComp<ActivePreventPulledWhileAliveComponent>(ent);
     }
 
+
+    private void OnXenoPullAlwaysAllowTackle(Entity<XenoComponent> ent, ref RMCMeleeUserGetDisarmRangeEvent args)
+    {
+        if (args.Target is not { } target)
+            return;
+
+        if (!TryComp(ent, out PullerComponent? puller) || puller.Pulling != target)
+            return;
+
+        args.Range = 100f;
+    }
+
     private void OnPreventPulledWhileAliveStop(Entity<PreventPulledWhileAliveComponent> ent, ref PullStoppedMessage args)
     {
         if (args.PulledUid != ent.Owner)
@@ -434,9 +447,9 @@ public sealed class RMCPullingSystem : EntitySystem
     {
         TryStopPullsOn(pullie);
 
-       if (TryComp(pullie, out PullerComponent? puller) &&
-            puller.Pulling != null &&
-            TryComp(puller.Pulling, out PullableComponent? pullable2))
+        if (TryComp(pullie, out PullerComponent? puller) &&
+             puller.Pulling != null &&
+             TryComp(puller.Pulling, out PullableComponent? pullable2))
         {
             _pulling.TryStopPull(puller.Pulling.Value, pullable2, pullie);
             return;

--- a/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
+++ b/Content.Shared/_RMC14/Pulling/RMCPullingSystem.cs
@@ -447,9 +447,9 @@ public sealed class RMCPullingSystem : EntitySystem
     {
         TryStopPullsOn(pullie);
 
-        if (TryComp(pullie, out PullerComponent? puller) &&
-             puller.Pulling != null &&
-             TryComp(puller.Pulling, out PullableComponent? pullable2))
+       if (TryComp(pullie, out PullerComponent? puller) &&
+            puller.Pulling != null &&
+            TryComp(puller.Pulling, out PullableComponent? pullable2))
         {
             _pulling.TryStopPull(puller.Pulling.Value, pullable2, pullie);
             return;

--- a/Content.Shared/_RMC14/Weapons/Melee/RMCMeleeUserGetDisarmRangeEvent.cs
+++ b/Content.Shared/_RMC14/Weapons/Melee/RMCMeleeUserGetDisarmRangeEvent.cs
@@ -1,0 +1,4 @@
+namespace Content.Shared._RMC14.Weapons.Melee;
+
+[ByRefEvent]
+public record struct RMCMeleeUserGetDisarmRangeEvent(EntityUid? Target, float Range);

--- a/Content.Shared/_RMC14/Weapons/Melee/SharedRMCMeleeWeaponSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Melee/SharedRMCMeleeWeaponSystem.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Numerics;
 using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Marines.Skills;
@@ -289,6 +289,20 @@ public abstract class SharedRMCMeleeWeaponSystem : EntitySystem
     public float GetUserLightAttackRange(EntityUid user, EntityUid? target, MeleeWeaponComponent melee)
     {
         var ev = new RMCMeleeUserGetRangeEvent(target, melee.Range);
+        RaiseLocalEvent(user, ref ev);
+        return ev.Range;
+    }
+
+    /// <summary>
+    ///     Melee range for a disarm/tackle. Defaults to <paramref name="melee"/>.Range;
+    ///     Allows for modification via <see cref="RMCMeleeUserGetDisarmRangeEvent"/>.
+    /// </summary>
+    /// <param name="user">The entity doing the disarm/tackle</param>
+    /// <param name="target">The initial target of the disarm/tackle</param>
+    /// <param name="melee">The melee weapon component of the weapon being used to disarm/tackle</param>
+    public float GetUserDisarmRange(EntityUid user, EntityUid? target, MeleeWeaponComponent melee)
+    {
+        var ev = new RMCMeleeUserGetDisarmRangeEvent(target, melee.Range);
         RaiseLocalEvent(user, ref ev);
         return ev.Range;
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
There's some innate range 'slack' built into the SS14 dragging system (joint.Length + **0.15f**) that can allow for a dragged marine to become out of range of a xeno's tackle while still being dragged. This PR allows xenos to be able to tackle marines that they're dragging regardless of range. Only applies to xeno's tackling and only the marine they're dragging. Still respects LoS, just removes the range component.

## Why / Balance
This is simply a quality of life fix, but can be argued to be a xeno buff. Seemed like an oversight that someone you are dragging can become out of range. An alternative fix would be to remove the 'slack' for xenos when dragging, or reduce the range that they can initiate a grab, but that could have some larger physics repercussions than simply removing the range component.

## Technical details
Added a new event, RMCMeleeUserGetDisarmRangeEvent, which can be used to adjust the range of the disarm event. Ensured that the base SS14 code that calculates disarm range uses the new GetUserDisarmRange() function which leverages this new event, but will use the pre-existing meleeComponent.Range value for non XenoComponents. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
<img width="1024" height="600" alt="Tackle" src="https://github.com/user-attachments/assets/05e8fc66-6fa7-4181-a64f-a84b22bff58c" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed xenos being unable to tackle marines grabbed and dragged when at max range.
