### PR TITLE
Embedded mapper MCP server: let AI agents inspect and edit maps on a running dev server

### DIFF
--- a/Content.Server/Content.Server.csproj
+++ b/Content.Server/Content.Server.csproj
@@ -29,6 +29,13 @@
     <ProjectReference Include="..\Content.Shared\Content.Shared.csproj" />
   </ItemGroup>
   <Import Project="..\RobustToolbox\MSBuild\Robust.Properties.targets" />
+  <!-- RMC14-Mcp-Start
+       Включение MCP-сервера маппера в релизную сборку: dotnet build -p:EnableMcp=true.
+       В сборках без FULL_RELEASE (Debug/DebugOpt/Tools) MCP включён всегда. -->
+  <PropertyGroup Condition="'$(EnableMcp)' == 'true'">
+    <DefineConstants>$(DefineConstants);RMC_MCP</DefineConstants>
+  </PropertyGroup>
+  <!-- RMC14-Mcp-End -->
 
   <ItemGroup>
     <ProjectReference Include="..\Content.Analyzers\Content.Analyzers.csproj" Condition="'$(SkipRobustAnalyzer)' != 'true'" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />

--- a/Content.Server/Entry/EntryPoint.cs
+++ b/Content.Server/Entry/EntryPoint.cs
@@ -111,6 +111,11 @@ namespace Content.Server.Entry
                 IoCManager.Resolve<GhostKickManager>().Initialize();
                 IoCManager.Resolve<ServerInfoManager>().Initialize();
                 IoCManager.Resolve<ServerApi>().Initialize();
+                // RMC14-Mcp-Start
+#if !FULL_RELEASE || RMC_MCP
+                IoCManager.Resolve<_RMC14.Mcp.McpManager>().Initialize();
+#endif
+                // RMC14-Mcp-End
 
                 _voteManager.Initialize();
                 _updateManager.Initialize();
@@ -189,6 +194,11 @@ namespace Content.Server.Entry
             _playTimeTracking?.Shutdown();
             _dbManager?.Shutdown();
             IoCManager.Resolve<ServerApi>().Shutdown();
+            // RMC14-Mcp-Start
+#if !FULL_RELEASE || RMC_MCP
+            IoCManager.Resolve<_RMC14.Mcp.McpManager>().Shutdown();
+#endif
+            // RMC14-Mcp-End
 
             IoCManager.Resolve<DiscordLink>().Shutdown();
             IoCManager.Resolve<DiscordChatLink>().Shutdown();

--- a/Content.Server/IoC/ServerContentIoC.cs
+++ b/Content.Server/IoC/ServerContentIoC.cs
@@ -75,6 +75,11 @@ namespace Content.Server.IoC
             IoCManager.Register<ServerDbEntryManager>();
             IoCManager.Register<ISharedPlaytimeManager, PlayTimeTrackingManager>();
             IoCManager.Register<ServerApi>();
+            // RMC14-Mcp-Start
+#if !FULL_RELEASE || RMC_MCP
+            IoCManager.Register<_RMC14.Mcp.McpManager>();
+#endif
+            // RMC14-Mcp-End
             IoCManager.Register<JobWhitelistManager>();
             IoCManager.Register<PlayerRateLimitManager>();
             IoCManager.Register<SharedPlayerRateLimitManager, PlayerRateLimitManager>();

--- a/Content.Server/_RMC14/Mcp/EVALS.md
+++ b/Content.Server/_RMC14/Mcp/EVALS.md
@@ -1,0 +1,67 @@
+# Mapper MCP evaluation tasks
+
+Realistic end-to-end tasks for judging whether an agent can use this server effectively
+(methodology: Anthropic's mcp-builder skill, phase 4). Run against a dev server + a connected
+client, each task with a fresh agent, in two configurations:
+
+- **Baseline**: ONLY the MCP server connected (no mapping skill). Measures how self-sufficient
+  the server's tool descriptions and instructions are.
+- **Skill**: MCP server + the `mapping-rmc14` agent skill loaded. The score delta vs baseline
+  measures what the skill actually contributes (per Anthropic's evaluation-driven skill
+  authoring) — tasks that only pass with the skill justify its content; content that never
+  changes an outcome is dead weight.
+
+A task passes when the agent reaches the goal without human hints and without breaking the
+golden invariant (the edited map stays uninitialized and paused).
+
+Score sheet per task and configuration: solved (y/n), tool calls used, wrong-tool detours,
+unrecoverable errors.
+
+1. **Orientation.** Player stands somewhere on a loaded map with a rotated camera. "Describe what
+   is in the room I'm looking at, in my screen terms." Expect: player_status → look_around, correct
+   left/right/up answers derived from screen_up_points; stacked/subfloor consulted before claiming
+   a tile is empty.
+
+2. **Build a room.** "Build a 5x7 plated room with a steel floor, walls, and a south-facing airlock
+   two tiles east of me." Expect: set_tiles matrix (correct SW-corner anchoring — verify via the
+   echoed south_west_corner), spawn_entity batch for walls, prototype search for the airlock,
+   look_around verification.
+
+3. **Dry-run guard.** "Fill a 30x30 rectangle with FloorSteel at (X,Y) — but first show me what
+   would be overwritten." Expect: set_tiles dry_run=true, a reading of would_overwrite, and no
+   mutation until confirmed.
+
+4. **Ladder pair.** "Link these two ladders so they teleport between decks." Expect:
+   entity_info (component dump of Ladder) → set_component_field Ladder.Id on both entities with the
+   same unique id; NO vvwrite. The agent must state that pairs link at map-init only.
+
+5. **Areas round-trip.** "This new room should belong to the brig area." Expect: read_areas to see
+   the current assignment, list_entity_prototypes search for the area prototype, paint_areas
+   rectangle, read_areas verification. No areas:save / marker spawning.
+
+6. **Area audit.** "List every area on this ship and find unassigned playable tiles near me."
+   Expect: read_areas format=summary for the whole grid, then a windowed matrix read around the
+   player; '.' cells interpreted as unassigned.
+
+7. **Targeted demolition.** "Remove all the catwalks in this 10x10 area but leave everything else."
+   Expect: delete_entities with a prototype/name filter (dry_run first is a bonus), NOT an
+   unfiltered area wipe.
+
+8. **Decal striping.** "Paint a warning stripe line along the north edge of this room." Expect:
+   list_decal_prototypes search, a single batched add_decal call, correct rotations.
+
+9. **Recovery from the lobby.** Player is in the lobby (no attached entity). "Show me what's
+   around me." Expect: the tool error's recovery hint is followed (observe → aghost via
+   run_command in the player's context) instead of giving up or hallucinating.
+
+10. **Save discipline.** "We're done, save this to the repo as mymap.yml. Also I want to quickly
+    playtest it." Expect: save_map with export_path FIRST, playtest on a load_map copy + map_init
+    of the copy only, delete_map of the copy afterwards; never map_init on the edited map.
+
+Regression checks (cheap, scriptable via curl JSON-RPC):
+- tools/list: every tool carries annotations; read_* / list_* / find_* are readOnlyHint=true.
+- find_entities with map_id + with legacy "map" both filter.
+- set_tiles matrix echo: north_row_y == y + rows - 1.
+- set_component_field: unknown field returns the similar-fields hint; read-only property is
+  rejected; value round-trips in new_value.
+- paint_areas: matrix '.' clears, read_areas summary reflects the change, works pre-mapinit.

--- a/Content.Server/_RMC14/Mcp/McpContext.cs
+++ b/Content.Server/_RMC14/Mcp/McpContext.cs
@@ -1,0 +1,405 @@
+#if !FULL_RELEASE || RMC_MCP
+using System.Numerics;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Content.Shared.Movement.Components;
+using Robust.Server.Player;
+using Robust.Shared.Asynchronous;
+using Robust.Shared.Configuration;
+using Robust.Shared.Console;
+using Robust.Shared.ContentPack;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.Manager;
+using Robust.Shared.Toolshed;
+
+namespace Content.Server._RMC14.Mcp;
+
+/// <summary>
+/// Shared dependencies and helpers for MCP tools. All game state access must happen
+/// on the main thread — use <see cref="RunOnMainThread{T}"/> from tool code.
+/// </summary>
+public sealed class McpContext
+{
+    [Dependency] public readonly IConfigurationManager Configuration = default!;
+    [Dependency] public readonly IConsoleHost ConsoleHost = default!;
+    [Dependency] public readonly IEntityManager EntityManager = default!;
+    [Dependency] public readonly ILogManager LogManager = default!;
+    [Dependency] public readonly IMapManager MapManager = default!;
+    [Dependency] public readonly IPlayerManager PlayerManager = default!;
+    [Dependency] public readonly IPrototypeManager PrototypeManager = default!;
+    [Dependency] public readonly IResourceManager ResourceManager = default!;
+    [Dependency] public readonly ISerializationManager Serialization = default!;
+    [Dependency] public readonly ITaskManager TaskManager = default!;
+    [Dependency] public readonly ITileDefinitionManager TileDefinitionManager = default!;
+    [Dependency] public readonly ToolshedManager Toolshed = default!;
+
+    /// <summary>Runs a function on the game's main thread and returns its result.</summary>
+    public async Task<T> RunOnMainThread<T>(Func<T> func)
+    {
+        var tcs = new TaskCompletionSource<T>();
+        TaskManager.RunOnMainThread(() =>
+        {
+            try
+            {
+                tcs.TrySetResult(func());
+            }
+            catch (Exception e)
+            {
+                tcs.TrySetException(e);
+            }
+        });
+        return await tcs.Task;
+    }
+
+    #region Argument helpers
+
+    public static int GetInt(JsonObject args, string name)
+    {
+        return OptInt(args, name) ?? throw new McpToolException($"Missing required integer argument '{name}'.");
+    }
+
+    public static int? OptInt(JsonObject args, string name)
+    {
+        if (!args.TryGetPropertyValue(name, out var node) || node == null)
+            return null;
+        if (node is JsonValue value && value.TryGetValue<int>(out var i))
+            return i;
+        throw new McpToolException($"Argument '{name}' must be an integer.");
+    }
+
+    public static double? OptDouble(JsonObject args, string name)
+    {
+        if (!args.TryGetPropertyValue(name, out var node) || node == null)
+            return null;
+        if (node is JsonValue value && value.TryGetValue<double>(out var d))
+            return d;
+        throw new McpToolException($"Argument '{name}' must be a number.");
+    }
+
+    public static string GetString(JsonObject args, string name)
+    {
+        return OptString(args, name) ?? throw new McpToolException($"Missing required string argument '{name}'.");
+    }
+
+    public static string? OptString(JsonObject args, string name)
+    {
+        if (!args.TryGetPropertyValue(name, out var node) || node == null)
+            return null;
+        if (node is JsonValue value && value.TryGetValue<string>(out var s))
+            return s;
+        throw new McpToolException($"Argument '{name}' must be a string.");
+    }
+
+    public static bool OptBool(JsonObject args, string name, bool fallback)
+    {
+        if (!args.TryGetPropertyValue(name, out var node) || node == null)
+            return fallback;
+        if (node is JsonValue value && value.TryGetValue<bool>(out var b))
+            return b;
+        throw new McpToolException($"Argument '{name}' must be a boolean.");
+    }
+
+    /// <summary>Reads the standard map-id argument; "map" is a legacy alias kept for cached client schemas.</summary>
+    public static int? OptMapId(JsonObject args)
+    {
+        return OptInt(args, "map_id") ?? OptInt(args, "map");
+    }
+
+    #endregion
+
+    #region Component resolution
+
+    /// <summary>
+    /// Resolves a component by registration name, case-insensitively, and suggests close names on a miss
+    /// instead of failing with a bare "unknown component".
+    /// </summary>
+    public ComponentRegistration ResolveComponent(string name)
+    {
+        var factory = EntityManager.ComponentFactory;
+        if (factory.TryGetRegistration(name, out var registration, ignoreCase: true))
+            return registration;
+
+        var similar = new List<string>();
+        foreach (var candidate in factory.AllRegisteredTypes)
+        {
+            var candidateName = factory.GetRegistration(candidate).Name;
+            if (similar.Count < 5 && candidateName.Contains(name, StringComparison.OrdinalIgnoreCase))
+                similar.Add(candidateName);
+        }
+
+        var hint = similar.Count > 0 ? $" Similar names: {string.Join(", ", similar)}." : "";
+        throw new McpToolException($"Unknown component '{name}'.{hint}");
+    }
+
+    #endregion
+
+    #region Entity id helpers
+
+    /// <summary>Formats an entity for tool output as its NetEntity id (what console commands use).</summary>
+    public int ToNetId(EntityUid uid)
+    {
+        return (int) EntityManager.GetNetEntity(uid).Id;
+    }
+
+    /// <summary>Resolves a NetEntity id from tool input to an EntityUid. 'what'/'hint' shape the error message.</summary>
+    public EntityUid FromNetId(int netId, string what = "Entity", string? hint = null)
+    {
+        var net = new NetEntity(netId);
+        if (!EntityManager.TryGetEntity(net, out var uid) || !EntityManager.EntityExists(uid))
+            throw new McpToolException($"{what} {netId} does not exist{(hint == null ? "" : $" ({hint})")}.");
+        return uid.Value;
+    }
+
+    #endregion
+
+    #region Player / camera frame
+
+    /// <summary>A player's location and screen orientation, resolved on the main thread.</summary>
+    public sealed class PlayerFrame
+    {
+        public ICommonSession Session = default!;
+        public EntityUid Entity;
+        public MapId MapId;
+        public EntityUid? GridUid;
+        public Vector2 WorldPos;
+        public Vector2i? TilePos;
+        /// <summary>Eye rotation: world direction shown at the top of the screen is ScreenUp.</summary>
+        public Angle EyeRotation;
+        public Vector2 ScreenUp => EyeRotation.RotateVec(new Vector2(0, 1));
+        public Vector2 ScreenRight => EyeRotation.RotateVec(new Vector2(1, 0));
+    }
+
+    /// <summary>
+    /// Resolves a player session by name; with a null name requires exactly one connected player.
+    /// Main thread only.
+    /// </summary>
+    public ICommonSession ResolveSession(string? playerName)
+    {
+        var sessions = PlayerManager.Sessions;
+        if (playerName != null)
+        {
+            foreach (var session in sessions)
+            {
+                if (string.Equals(session.Name, playerName, StringComparison.OrdinalIgnoreCase))
+                    return session;
+            }
+
+            throw new McpToolException($"No connected player named '{playerName}'.");
+        }
+
+        return sessions.Length switch
+        {
+            0 => throw new McpToolException("No players are connected."),
+            1 => sessions[0],
+            _ => throw new McpToolException(
+                $"Multiple players connected ({string.Join(", ", Array.ConvertAll(sessions, s => s.Name))}); specify 'player'."),
+        };
+    }
+
+    /// <summary>Builds the location/orientation frame for a player. Main thread only.</summary>
+    public PlayerFrame GetPlayerFrame(string? playerName)
+    {
+        var session = ResolveSession(playerName);
+        if (session.AttachedEntity is not { } entity || !EntityManager.EntityExists(entity))
+        {
+            throw new McpToolException(
+                $"Player '{session.Name}' has no attached entity (still in the lobby, or between bodies). " +
+                "Attach one first — run_command 'observe' then 'aghost' in the player's context — " +
+                "or use absolute grid/x/y coordinates instead of player-relative addressing.");
+        }
+
+        var transformSystem = EntityManager.System<SharedTransformSystem>();
+        var mapSystem = EntityManager.System<SharedMapSystem>();
+        var xform = EntityManager.GetComponent<TransformComponent>(entity);
+        var worldPos = transformSystem.GetWorldPosition(entity);
+
+        // Screen orientation, reconstructed from networked InputMoverComponent state.
+        // The client's eye rotation (EyeLerpingSystem.GetRotation) is -(relative rotation + world
+        // rotation of the movement-relative entity), and the view matrix bakes its negation — so the
+        // world direction at the top of the screen is (0,1) rotated by +(relative + parent rotation).
+        // We store that positive angle: ScreenUp/ScreenRight and screen-frame offsets RotateVec by it
+        // directly. (Sign verified in-game: clockwise camera rotation moves east to the top.)
+        Angle eyeRotation;
+        if (EntityManager.TryGetComponent<InputMoverComponent>(entity, out var mover))
+        {
+            var parentRotation = mover.TargetRelativeRotation;
+            if (mover.RelativeEntity is { } relative && EntityManager.EntityExists(relative))
+                parentRotation += transformSystem.GetWorldRotation(relative);
+            eyeRotation = parentRotation;
+        }
+        else
+        {
+            var anchor = xform.GridUid ?? xform.MapUid;
+            eyeRotation = anchor is { } a ? transformSystem.GetWorldRotation(a) : Angle.Zero;
+        }
+
+        Vector2i? tilePos = null;
+        if (xform.GridUid is { } gridUid && EntityManager.TryGetComponent<MapGridComponent>(gridUid, out var grid))
+            tilePos = mapSystem.WorldToTile(gridUid, grid, worldPos);
+
+        return new PlayerFrame
+        {
+            Session = session,
+            Entity = entity,
+            MapId = xform.MapID,
+            GridUid = xform.GridUid,
+            WorldPos = worldPos,
+            TilePos = tilePos,
+            EyeRotation = eyeRotation,
+        };
+    }
+
+    /// <summary>8-way compass name for a world vector, with north = +Y, east = +X.</summary>
+    public static string Compass(Vector2 v)
+    {
+        if (v.LengthSquared() < 0.0001f)
+            return "none";
+        var deg = MathF.Atan2(v.X, v.Y) * (180f / MathF.PI);
+        var index = (int) MathF.Round(deg / 45f);
+        index = ((index % 8) + 8) % 8;
+        return index switch
+        {
+            0 => "north",
+            1 => "north-east",
+            2 => "east",
+            3 => "south-east",
+            4 => "south",
+            5 => "south-west",
+            6 => "west",
+            _ => "north-west",
+        };
+    }
+
+    #endregion
+
+    #region Coordinate resolution
+
+    /// <summary>
+    /// Resolves a target grid + tile position from tool arguments. Main thread only.
+    /// Absolute form: "grid" (NetEntity id, optional if a player stands on a grid), "x", "y" (tile indices).
+    /// Relative form: "relative": { "dx", "dy", "frame": "world"|"screen", "player"? } — offset from the
+    /// player's tile; "screen" rotates the offset by the player's current screen orientation.
+    /// </summary>
+    public (EntityUid GridUid, MapGridComponent Grid, Vector2i Tile) ResolveTilePosition(JsonObject args)
+    {
+        PlayerFrame? frame = null;
+        Vector2i tile;
+
+        if (args.TryGetPropertyValue("relative", out var relNode) && relNode is JsonObject rel)
+        {
+            frame = GetPlayerFrame(OptString(rel, "player"));
+            tile = ResolveRelativeTile(rel, frame);
+        }
+        else
+        {
+            var x = OptInt(args, "x");
+            var y = OptInt(args, "y");
+            if (x == null || y == null)
+            {
+                frame = GetPlayerFrame(null);
+                if (frame.TilePos is not { } playerTile)
+                    throw new McpToolException("Player is not standing on a grid; pass 'grid', 'x' and 'y' explicitly.");
+                tile = playerTile;
+            }
+            else
+            {
+                tile = new Vector2i(x.Value, y.Value);
+            }
+        }
+
+        var (gridUid, grid) = ResolveGrid(args, frame);
+        return (gridUid, grid, tile);
+    }
+
+    private Vector2i ResolveRelativeTile(JsonObject rel, PlayerFrame frame)
+    {
+        if (frame.TilePos is not { } playerTile)
+            throw new McpToolException("Player is not standing on a grid; relative addressing is unavailable.");
+
+        var dx = OptDouble(rel, "dx") ?? 0;
+        var dy = OptDouble(rel, "dy") ?? 0;
+        var frameKind = OptString(rel, "frame") ?? "world";
+        var offset = frameKind switch
+        {
+            "world" => new Vector2((float) dx, (float) dy),
+            "screen" => frame.EyeRotation.RotateVec(new Vector2((float) dx, (float) dy)),
+            _ => throw new McpToolException("relative.frame must be 'world' or 'screen'."),
+        };
+
+        return playerTile + new Vector2i((int) MathF.Round(offset.X), (int) MathF.Round(offset.Y));
+    }
+
+    /// <summary>
+    /// Resolves the target grid: explicit "grid" argument, or the grid under the player. Main thread only.
+    /// </summary>
+    public (EntityUid GridUid, MapGridComponent Grid) ResolveGrid(JsonObject args, PlayerFrame? frame = null)
+    {
+        if (OptInt(args, "grid") is { } gridNet)
+        {
+            var gridUid = FromNetId(gridNet, "Grid", "see list_grids for valid grid ids");
+            if (!EntityManager.TryGetComponent<MapGridComponent>(gridUid, out var grid))
+                throw new McpToolException($"Entity {gridNet} is not a grid (see list_grids for valid grid ids).");
+            return (gridUid, grid);
+        }
+
+        frame ??= GetPlayerFrame(null);
+        if (frame.GridUid is not { } playerGrid ||
+            !EntityManager.TryGetComponent<MapGridComponent>(playerGrid, out var underPlayer))
+        {
+            throw new McpToolException("Player is not standing on a grid; pass 'grid' explicitly (see list_grids).");
+        }
+
+        return (playerGrid, underPlayer);
+    }
+
+    #endregion
+}
+
+/// <summary>Assigns single-character legend symbols to distinct keys for matrix output.</summary>
+public sealed class McpLegend
+{
+    private const string Palette = "#=+-*%&oxabcdefghijklmnpqrstuvwyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+    private readonly Dictionary<string, char> _chars = new();
+    private readonly HashSet<string> _overflow = new();
+
+    /// <summary>'.' is reserved for empty, '@' for the player, ' ' for out-of-area.</summary>
+    public char Get(string key)
+    {
+        if (_chars.TryGetValue(key, out var existing))
+            return existing;
+
+        if (_chars.Count >= Palette.Length)
+        {
+            // Palette exhausted: every further distinct key renders as '?' and is reported
+            // in the legend as an overflow instead of silently masquerading as one key.
+            _overflow.Add(key);
+            return '?';
+        }
+
+        var c = Palette[_chars.Count];
+        _chars[key] = c;
+        return c;
+    }
+
+    public JsonObject ToJson(string emptyName = "empty")
+    {
+        var json = new JsonObject { ["."] = emptyName };
+        foreach (var (key, c) in _chars)
+        {
+            json[c.ToString()] = key;
+        }
+
+        if (_overflow.Count > 0)
+        {
+            json["?"] = $"OVERFLOW: {_overflow.Count} more distinct values beyond the {Palette.Length}-symbol " +
+                        "palette — narrow the rectangle or use a summary format if the tool has one.";
+        }
+
+        return json;
+    }
+}
+#endif

--- a/Content.Server/_RMC14/Mcp/McpEntityMatrix.cs
+++ b/Content.Server/_RMC14/Mcp/McpEntityMatrix.cs
@@ -1,0 +1,150 @@
+#if !FULL_RELEASE || RMC_MCP
+using System.Linq;
+using System.Text;
+using Content.Server._RMC14.MapInsert;
+using Content.Server.Spawners.Components;
+using Content.Shared._RMC14.Ladder;
+using Content.Shared.Doors.Components;
+using Content.Shared.SubFloor;
+using Content.Shared.Tag;
+using Robust.Shared.Map.Components;
+
+namespace Content.Server._RMC14.Mcp;
+
+/// <summary>
+/// Shared logic for anchored-entity matrices. A matrix cell can only show one entity, so the
+/// representative is picked by a fixed semantic tier — the choice depends only on the tile's own
+/// contents, never on chunk order or on what else is inside the requested rectangle. Everything
+/// the cell does not show must be returned to the agent through the 'stacked' dictionary and the
+/// 'subfloor' layer, so no entity is ever silently lost.
+/// </summary>
+public static class McpEntityMatrix
+{
+    /// <summary>A tile's anchored entities: the main layer (tier-sorted, best first) and subfloor.</summary>
+    public readonly record struct Cell(List<string>? Main, List<string>? Sub)
+    {
+        public bool IsEmpty => Main == null && Sub == null;
+    }
+
+    /// <summary>Higher tier wins the cell; ties break by prototype id for determinism.</summary>
+    public static int Tier(IEntityManager entMan, EntityUid uid)
+    {
+        // Logic and floor transitions: invisible or unique things the agent must never miss.
+        if (entMan.HasComponent<LadderComponent>(uid) ||
+            entMan.HasComponent<SpawnPointComponent>(uid) ||
+            entMan.HasComponent<MapInsertComponent>(uid))
+        {
+            return 4;
+        }
+
+        if (entMan.HasComponent<DoorComponent>(uid))
+            return 3;
+
+        // Bulk walkable background loses to everything else.
+        if (entMan.System<TagSystem>().HasTag(uid, "Catwalk"))
+            return 1;
+
+        return 2;
+    }
+
+    /// <summary>Collects and orders a tile's anchored entities. The filter may be null.</summary>
+    public static Cell Collect(
+        IEntityManager entMan,
+        Robust.Shared.GameObjects.SharedMapSystem mapSystem,
+        EntityUid gridUid,
+        MapGridComponent grid,
+        Vector2i tile,
+        Func<EntityUid, MetaDataComponent, TransformComponent, bool>? filter = null)
+    {
+        List<(string Proto, int Tier)>? main = null;
+        List<string>? sub = null;
+
+        var anchored = mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, tile);
+        while (anchored.MoveNext(out var uid))
+        {
+            var meta = entMan.GetComponent<MetaDataComponent>(uid.Value);
+            if (meta.EntityPrototype?.ID is not { } proto)
+                continue;
+
+            if (filter != null && !filter(uid.Value, meta, entMan.GetComponent<TransformComponent>(uid.Value)))
+                continue;
+
+            if (entMan.HasComponent<SubFloorHideComponent>(uid.Value))
+                (sub ??= new List<string>()).Add(proto);
+            else
+                (main ??= new List<(string, int)>()).Add((proto, Tier(entMan, uid.Value)));
+        }
+
+        main?.Sort(static (a, b) => a.Tier != b.Tier ? b.Tier - a.Tier : string.CompareOrdinal(a.Proto, b.Proto));
+        sub?.Sort(StringComparer.Ordinal);
+        return new Cell(main?.Select(static t => t.Proto).ToList(), sub);
+    }
+
+    /// <summary>Parses the optional 'layers' argument: which matrix layers the caller wants.</summary>
+    public static (bool Main, bool Sub) ParseLayers(System.Text.Json.Nodes.JsonObject args)
+    {
+        if (args["layers"] is not System.Text.Json.Nodes.JsonArray layers || layers.Count == 0)
+            return (true, true);
+
+        var main = false;
+        var sub = false;
+        foreach (var node in layers)
+        {
+            switch (node?.GetValue<string>())
+            {
+                case "main":
+                    main = true;
+                    break;
+                case "subfloor":
+                    sub = true;
+                    break;
+                case var other:
+                    throw new McpToolException($"Unknown layer '{other}'; expected 'main' or 'subfloor'.");
+            }
+        }
+
+        return (main, sub);
+    }
+
+    /// <summary>
+    /// Records everything the matrices do not show for this tile — the no-loss guarantee lives here.
+    /// </summary>
+    public static void AddStacked(
+        System.Text.Json.Nodes.JsonObject stacked,
+        Vector2i tile,
+        Cell cell,
+        bool wantMain,
+        bool wantSub)
+    {
+        List<string>? hidden = null;
+        if (wantMain && cell.Main is { Count: > 1 })
+            (hidden ??= new List<string>()).AddRange(cell.Main.Skip(1));
+        if (wantSub && cell.Sub is { Count: > 1 })
+            (hidden ??= new List<string>()).AddRange(cell.Sub.Skip(1));
+
+        if (hidden != null)
+        {
+            stacked[$"{tile.X},{tile.Y}"] = new System.Text.Json.Nodes.JsonArray(
+                hidden.Select(static p => (System.Text.Json.Nodes.JsonNode) p).ToArray());
+        }
+    }
+
+    /// <summary>
+    /// Appends one cell. Compact: one char, glued. Wide: two chars ("symbol" + hidden count digit
+    /// or '.'), space-separated, so cells stay countable and BPE tokenization cannot merge them.
+    /// </summary>
+    public static void AppendCell(StringBuilder row, char symbol, int hiddenCount, bool wide)
+    {
+        if (!wide)
+        {
+            row.Append(symbol);
+            return;
+        }
+
+        if (row.Length > 0)
+            row.Append(' ');
+        row.Append(symbol);
+        row.Append(hiddenCount > 0 ? (char) ('0' + Math.Min(hiddenCount, 9)) : '.');
+    }
+}
+#endif

--- a/Content.Server/_RMC14/Mcp/McpJsonRpc.cs
+++ b/Content.Server/_RMC14/Mcp/McpJsonRpc.cs
@@ -1,0 +1,47 @@
+#if !FULL_RELEASE || RMC_MCP
+using System.Text.Json.Nodes;
+
+namespace Content.Server._RMC14.Mcp;
+
+/// <summary>
+/// Minimal JSON-RPC 2.0 primitives for the embedded MCP server.
+/// </summary>
+public static class McpJsonRpc
+{
+    public const int ParseError = -32700;
+    public const int InvalidRequest = -32600;
+    public const int MethodNotFound = -32601;
+    public const int InvalidParams = -32602;
+    public const int InternalError = -32603;
+
+    public static JsonObject Result(JsonNode? id, JsonNode result)
+    {
+        return new JsonObject
+        {
+            ["jsonrpc"] = "2.0",
+            ["id"] = id?.DeepClone(),
+            ["result"] = result,
+        };
+    }
+
+    public static JsonObject Error(JsonNode? id, int code, string message)
+    {
+        return new JsonObject
+        {
+            ["jsonrpc"] = "2.0",
+            ["id"] = id?.DeepClone(),
+            ["error"] = new JsonObject
+            {
+                ["code"] = code,
+                ["message"] = message,
+            },
+        };
+    }
+}
+
+/// <summary>
+/// Thrown by MCP tools to report a user-facing (agent-facing) error.
+/// Becomes a tool result with isError=true rather than a protocol error.
+/// </summary>
+public sealed class McpToolException(string message) : Exception(message);
+#endif

--- a/Content.Server/_RMC14/Mcp/McpManager.cs
+++ b/Content.Server/_RMC14/Mcp/McpManager.cs
@@ -1,0 +1,350 @@
+#if !FULL_RELEASE || RMC_MCP
+using System.Net;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Content.Server._RMC14.Mcp.Tools;
+using Content.Shared._RMC14.CCVar;
+using Robust.Server.ServerStatus;
+using Robust.Shared.Configuration;
+
+namespace Content.Server._RMC14.Mcp;
+
+/// <summary>
+/// Embedded MCP (Model Context Protocol) server for mapping agents.
+/// Speaks stateless streamable-HTTP JSON-RPC on POST /mcp via the engine's <see cref="IStatusHost"/>.
+/// Compiled only into non-FULL_RELEASE builds unless -p:EnableMcp=true is passed.
+/// </summary>
+public sealed class McpManager : IPostInjectInit
+{
+    public const string Endpoint = "/mcp";
+    private const string ProtocolVersion = "2025-03-26";
+
+    [Dependency] private readonly IConfigurationManager _config = default!;
+    [Dependency] private readonly ILogManager _logManager = default!;
+    [Dependency] private readonly IStatusHost _statusHost = default!;
+
+    private ISawmill _sawmill = default!;
+    private McpContext _ctx = default!;
+    private readonly Dictionary<string, McpTool> _tools = new();
+
+    private bool _enabled;
+    private string _token = string.Empty;
+
+    void IPostInjectInit.PostInject()
+    {
+        _sawmill = _logManager.GetSawmill("mcp");
+        _ctx = IoCManager.InjectDependencies(new McpContext());
+
+        foreach (var tool in CreateTools(_ctx))
+        {
+            _tools.Add(tool.Name, tool);
+        }
+
+        _statusHost.AddHandler(HandleRequestAsync);
+    }
+
+    public void Initialize()
+    {
+        _config.OnValueChanged(RMCCVars.RMCMcpEnabled, v => _enabled = v, true);
+        _config.OnValueChanged(RMCCVars.RMCMcpToken, v => _token = v, true);
+        _sawmill.Info($"MCP mapping server available at {Endpoint} ({_tools.Count} tools), enabled: {_enabled}");
+    }
+
+    public void Shutdown()
+    {
+    }
+
+    private static IEnumerable<McpTool> CreateTools(McpContext ctx)
+    {
+        // Player & surroundings
+        yield return new PlayerStatusTool(ctx);
+        yield return new LookAroundTool(ctx);
+        yield return new TeleportPlayerTool(ctx);
+        // Map reading
+        yield return new ListMapsTool(ctx);
+        yield return new ListGridsTool(ctx);
+        yield return new ReadTilesTool(ctx);
+        yield return new FindTilesTool(ctx);
+        yield return new ReadAreasTool(ctx);
+        // Entity reading
+        yield return new ReadEntitiesTool(ctx);
+        yield return new FindEntitiesTool(ctx);
+        yield return new EntityInfoTool(ctx);
+        // Prototype catalogues
+        yield return new ListEntityPrototypesTool(ctx);
+        yield return new ListTilePrototypesTool(ctx);
+        yield return new ListDecalPrototypesTool(ctx);
+        // Map writing
+        yield return new SetTilesTool(ctx);
+        yield return new ReplaceTilesTool(ctx);
+        yield return new PaintAreasTool(ctx);
+        yield return new SpawnEntityTool(ctx);
+        yield return new DeleteEntitiesTool(ctx);
+        yield return new TransformEntityTool(ctx);
+        yield return new SetComponentFieldTool(ctx);
+        // Decals
+        yield return new ReadDecalsTool(ctx);
+        yield return new AddDecalTool(ctx);
+        yield return new EditDecalTool(ctx);
+        yield return new RemoveDecalTool(ctx);
+        // Map lifecycle
+        yield return new CreateMapTool(ctx);
+        yield return new CreateGridTool(ctx);
+        yield return new DeleteMapTool(ctx);
+        yield return new PauseMapTool(ctx);
+        yield return new MapInitTool(ctx);
+        yield return new SaveMapTool(ctx);
+        yield return new SaveGridTool(ctx);
+        yield return new LoadMapTool(ctx);
+        yield return new LoadGridTool(ctx);
+        yield return new SetAmbientLightTool(ctx);
+        yield return new MappingSessionTool(ctx);
+        // Console escape hatch
+        yield return new RunCommandTool(ctx);
+        yield return new ClientCommandTool(ctx);
+    }
+
+    #region HTTP
+
+    private async Task<bool> HandleRequestAsync(IStatusHandlerContext context)
+    {
+        if (context.Url.AbsolutePath != Endpoint)
+            return false;
+
+        if (!_enabled)
+            return false;
+
+        if (!CheckAccess(context))
+        {
+            await context.RespondErrorAsync(HttpStatusCode.Forbidden);
+            return true;
+        }
+
+        if (context.RequestMethod == HttpMethod.Delete)
+        {
+            // Stateless server: session termination is a no-op.
+            await context.RespondNoContentAsync();
+            return true;
+        }
+
+        if (context.RequestMethod != HttpMethod.Post)
+        {
+            // No SSE stream offered.
+            await context.RespondErrorAsync(HttpStatusCode.MethodNotAllowed);
+            return true;
+        }
+
+        JsonNode? body;
+        try
+        {
+            body = await JsonNode.ParseAsync(context.RequestBody);
+        }
+        catch (Exception)
+        {
+            await context.RespondJsonAsync(
+                McpJsonRpc.Error(null, McpJsonRpc.ParseError, "Invalid JSON in request body"),
+                HttpStatusCode.BadRequest);
+            return true;
+        }
+
+        switch (body)
+        {
+            case JsonObject single:
+            {
+                var response = await DispatchAsync(single);
+                if (response == null)
+                    await context.RespondNoContentAsync(); // notification
+                else
+                    await context.RespondJsonAsync(response);
+                return true;
+            }
+            case JsonArray batch when batch.Count > 0:
+            {
+                var responses = new JsonArray();
+                foreach (var item in batch)
+                {
+                    if (item is not JsonObject obj)
+                        continue;
+                    if (await DispatchAsync(obj) is { } response)
+                        responses.Add(response);
+                }
+
+                if (responses.Count == 0)
+                    await context.RespondNoContentAsync();
+                else
+                    await context.RespondJsonAsync(responses);
+                return true;
+            }
+            default:
+                await context.RespondJsonAsync(
+                    McpJsonRpc.Error(null, McpJsonRpc.InvalidRequest, "Expected a JSON-RPC request object"),
+                    HttpStatusCode.BadRequest);
+                return true;
+        }
+    }
+
+    private bool CheckAccess(IStatusHandlerContext context)
+    {
+        if (IPAddress.IsLoopback(context.RemoteEndPoint.Address))
+            return true;
+
+        if (string.IsNullOrEmpty(_token))
+            return false;
+
+        if (!context.RequestHeaders.TryGetValue("Authorization", out var authValues))
+            return false;
+
+        var auth = authValues.ToString();
+        const string prefix = "Bearer ";
+        if (!auth.StartsWith(prefix, StringComparison.Ordinal))
+            return false;
+
+        return CryptographicOperations.FixedTimeEquals(
+            Encoding.UTF8.GetBytes(auth[prefix.Length..]),
+            Encoding.UTF8.GetBytes(_token));
+    }
+
+    #endregion
+
+    #region JSON-RPC dispatch
+
+    /// <summary>Handles one JSON-RPC message. Returns null for notifications (no response).</summary>
+    private async Task<JsonObject?> DispatchAsync(JsonObject request)
+    {
+        var id = request.TryGetPropertyValue("id", out var idNode) ? idNode : null;
+        var isNotification = idNode == null;
+
+        if (McpContext.OptString(request, "method") is not { } method)
+            return isNotification ? null : McpJsonRpc.Error(id, McpJsonRpc.InvalidRequest, "Missing 'method'");
+
+        var @params = request.TryGetPropertyValue("params", out var paramsNode) && paramsNode is JsonObject p
+            ? p
+            : new JsonObject();
+
+        try
+        {
+            if (method.StartsWith("notifications/", StringComparison.Ordinal))
+                return null;
+
+            var result = method switch
+            {
+                "initialize" => HandleInitialize(@params),
+                "ping" => new JsonObject(),
+                "tools/list" => HandleToolsList(),
+                "tools/call" => await HandleToolsCall(@params),
+                _ => null,
+            };
+
+            if (result == null)
+                return isNotification ? null : McpJsonRpc.Error(id, McpJsonRpc.MethodNotFound, $"Unknown method '{method}'");
+
+            return isNotification ? null : McpJsonRpc.Result(id, result);
+        }
+        catch (McpToolException e)
+        {
+            return isNotification ? null : McpJsonRpc.Error(id, McpJsonRpc.InvalidParams, e.Message);
+        }
+        catch (Exception e)
+        {
+            _sawmill.Error($"MCP method '{method}' failed: {e}");
+            return isNotification ? null : McpJsonRpc.Error(id, McpJsonRpc.InternalError, e.Message);
+        }
+    }
+
+    private static JsonNode HandleInitialize(JsonObject @params)
+    {
+        var requested = McpContext.OptString(@params, "protocolVersion");
+        return new JsonObject
+        {
+            ["protocolVersion"] = requested ?? ProtocolVersion,
+            ["capabilities"] = new JsonObject
+            {
+                ["tools"] = new JsonObject(),
+            },
+            ["serverInfo"] = new JsonObject
+            {
+                ["name"] = "rmc14-mapper-mcp",
+                ["version"] = "1.0.0",
+            },
+            ["instructions"] =
+                "Embedded mapping server for Space Station 14 (RMC-14). " +
+                "Typical loop: player_status / look_around to see where the user is and how their screen is rotated, " +
+                "then read_tiles / read_entities to inspect, then set_tiles / spawn_entity / add_decal to edit. " +
+                "Most tools accept coordinates relative to the player, including in the player's screen frame. " +
+                "Key invariant: maps you intend to save must stay uninitialized and paused — never map_init a map " +
+                "you are still editing. " +
+                "Component fields (ladder pair ids, teleporter vectors, camera ids...) are read with entity_info " +
+                "and written with set_component_field; RMC area assignment is read with read_areas and written " +
+                "with paint_areas. " +
+                "Finalize before saving: run_command 'tilewalls <grid>' (plating under walls), " +
+                "'fixrotations <grid>' (normalize window/occluder rotations), 'variantize <grid>' if tiles were " +
+                "placed with pick_variant=false, ensure every playable tile has an area, then save_map " +
+                "(export_path copies the yml into the repository).",
+        };
+    }
+
+    private JsonNode HandleToolsList()
+    {
+        var tools = new JsonArray();
+        foreach (var tool in _tools.Values)
+        {
+            tools.Add(new JsonObject
+            {
+                ["name"] = tool.Name,
+                ["description"] = tool.Description,
+                ["inputSchema"] = tool.InputSchema,
+                ["annotations"] = tool.Annotations,
+            });
+        }
+
+        return new JsonObject { ["tools"] = tools };
+    }
+
+    private async Task<JsonNode> HandleToolsCall(JsonObject @params)
+    {
+        var name = McpContext.GetString(@params, "name");
+        if (!_tools.TryGetValue(name, out var tool))
+            throw new McpToolException($"Unknown tool '{name}'");
+
+        var args = @params.TryGetPropertyValue("arguments", out var argsNode) && argsNode is JsonObject a
+            ? a
+            : new JsonObject();
+
+        try
+        {
+            var result = await tool.ExecuteAsync(args);
+            return ToolResult(result.ToJsonString(), isError: false);
+        }
+        catch (McpToolException e)
+        {
+            return ToolResult($"Error: {e.Message}", isError: true);
+        }
+        catch (Exception e)
+        {
+            _sawmill.Error($"MCP tool '{name}' failed: {e}");
+            return ToolResult($"Internal error in tool '{name}': {e.Message}", isError: true);
+        }
+    }
+
+    private static JsonObject ToolResult(string text, bool isError)
+    {
+        return new JsonObject
+        {
+            ["content"] = new JsonArray
+            {
+                new JsonObject
+                {
+                    ["type"] = "text",
+                    ["text"] = text,
+                },
+            },
+            ["isError"] = isError,
+        };
+    }
+
+    #endregion
+}
+#endif

--- a/Content.Server/_RMC14/Mcp/README.md
+++ b/Content.Server/_RMC14/Mcp/README.md
@@ -1,0 +1,131 @@
+# Embedded mapper MCP server
+
+An embedded [Model Context Protocol](https://modelcontextprotocol.io/) server that lets AI agents
+(Claude Code, or any MCP client) inspect and edit maps on a running game server: tiles, entities,
+decals, RMC areas, map lifecycle and save/load — the same operations a human mapper performs in
+the mapping editor, exposed as 38 typed tools.
+
+The design follows Anthropic's
+[tool-design guidance for agents](https://www.anthropic.com/engineering/writing-tools-for-agents):
+consolidated workflow tools instead of thin API wrappers, token-efficient matrix output,
+search-over-list catalogues, actionable error messages and per-tool behavior annotations.
+
+## Quick start
+
+1. Run the game server (debug builds have the server compiled in by default; see *Gating*).
+2. Register the endpoint with your MCP client, e.g. for Claude Code:
+
+   ```
+   claude mcp add mapper --transport http http://localhost:1212/mcp
+   ```
+
+   The port is the status-host port (`net.port`, default 1212).
+3. Connect a game client, then drive the tools: `player_status` → `look_around` →
+   `set_tiles` / `spawn_entity` / `paint_areas` → `save_map`.
+
+No client-side code is involved: even the player's screen rotation is reconstructed server-side
+from the replicated `InputMoverComponent` state.
+
+**Tip: launch the agent from the repository root.** The server only gives the agent hands; the
+repo gives it everything else — reference maps and prototype YAML to imitate and validate
+against, `save_map export_path` straight into the working tree for git-diffable, publishable
+maps, and auto-discovered project configuration (a committed `.mcp.json`, agent skills,
+`CLAUDE.md`) that only activates when the session runs inside the project folder.
+
+A companion skill — a mapper's handbook distilled for AI agents (world model, golden rules,
+recipes, pre-save checklist) — is maintained separately at
+[rmc14-mapping-skill](https://github.com/IlyaBokovenko/rmc14-mapping-skill). The server is fully
+usable without it; the skill is optional plain-Markdown documentation for any MCP-capable agent.
+
+## Gating and security
+
+- Compiled only `#if !FULL_RELEASE || RMC_MCP`; a release build needs
+  `dotnet build -p:EnableMcp=true`.
+- CVars: `rmc.mcp.enabled` (default true where compiled in), `rmc.mcp.token`.
+- Access: loopback connections are always allowed; remote connections require
+  `Authorization: Bearer <token>` matching `rmc.mcp.token` (empty token = loopback only).
+- Commands executed through `run_command` bypass permission checks (the endpoint is trusted);
+  the transport gate above is the security boundary.
+
+## Architecture
+
+```
+McpManager        JSON-RPC 2.0 over stateless streamable HTTP (POST /mcp on IStatusHost),
+                  initialize / ping / tools/list / tools/call, batching supported.
+McpContext        Shared DI + helpers: main-thread marshalling (RunOnMainThread),
+                  argument parsing, grid/tile/player resolution, component resolution.
+McpEntityMatrix   Entity-matrix rendering: per-tile priority tiers, stacked/subfloor layers.
+Tools/*.cs        One class per tool, grouped by domain (map read/write, entities, decals,
+                  lifecycle, prototypes, console).
+```
+
+Tool handlers run on a status-host worker thread and marshal all game-state access to the main
+thread via `TaskCompletionSource` (same pattern as `ServerApi`). Agent-facing failures are thrown
+as `McpToolException` and returned as `isError` tool results with a suggested next step.
+
+## Tool conventions
+
+- **Coordinates**: tile indices per grid; +X = east, +Y = north. Rectangle tools take the
+  SOUTH-WEST corner in absolute form (`x`, `y`) or the CENTER in player-relative form
+  (`relative: {dx, dy, frame: "world"|"screen"}`); `frame: "screen"` follows the player's
+  current camera rotation. `grid` defaults to the grid under the player; maps are addressed
+  by numeric `map_id`.
+- **Matrices**: bulk reads return character matrices with a legend (world-aligned, top row =
+  north; `look_around` is screen-aligned instead). Legend overflow is reported explicitly
+  rather than truncated silently. `set_tiles` / `paint_areas` accept the same matrix format
+  for writes (first row = northmost).
+- **Previews**: destructive bulk tools (`set_tiles`, `replace_tiles`, `delete_entities`) accept
+  `dry_run: true` and report what would change — `set_tiles` includes a histogram of tiles that
+  would be overwritten.
+- **Annotations**: every tool declares MCP behavior hints (`readOnlyHint`, `destructiveHint`,
+  `idempotentHint`, `openWorldHint`) so clients can build permission policies on them.
+- **Searches** (`find_entities`, `list_*_prototypes`, `find_tiles`) take substrings and limits and
+  report `total_matches` / `truncated`. Entity name matching also covers prototype ids, so
+  English terms work against localized entity names.
+
+## Tool catalogue
+
+| Group | Tools |
+| --- | --- |
+| Player | `player_status`, `look_around`, `teleport_player` |
+| Map read | `list_maps`, `list_grids`, `read_tiles`, `find_tiles`, `read_areas` |
+| Entities read | `read_entities`, `find_entities`, `entity_info` |
+| Prototypes | `list_entity_prototypes`, `list_tile_prototypes`, `list_decal_prototypes` |
+| Map write | `set_tiles`, `replace_tiles`, `paint_areas` |
+| Entities write | `spawn_entity`, `delete_entities`, `transform_entity`, `set_component_field` |
+| Decals | `read_decals`, `add_decal`, `edit_decal`, `remove_decal` |
+| Lifecycle | `create_map`, `create_grid`, `delete_map`, `pause_map`, `map_init`, `save_map`, `save_grid`, `load_map`, `load_grid`, `set_ambient_light`, `mapping_session` |
+| Console | `run_command` (server, output captured, Toolshed included), `client_command` (remote client execution, fire-and-forget) |
+
+Highlights beyond raw console commands:
+
+- `mapping_session` — the full human `mapping` setup (paused map, aghost, autosave, editor UI)
+  as one call.
+- `paint_areas` — per-grid RMC area assignment that works on uninitialized (mapping) maps,
+  replacing the area-marker + global `areas:save` workflow.
+- `set_component_field` — validated component field writes with field-name suggestions and a
+  read-back echo, replacing silent `vvwrite` for the common cases (ladder pair ids, trigger
+  teleporter vectors, camera ids).
+- `save_map` / `save_grid` — refuse initialized maps (unless forced), preserve yaml uids for
+  stable git diffs, and can export the yml to an absolute path (e.g. into the repo).
+
+## Safety rails
+
+- Maps intended for saving must stay uninitialized and paused; `create_map` / `load_map` /
+  `mapping_session` produce that state, `map_init` warns it is irreversible and `save_map`
+  refuses initialized maps without `force`.
+- `delete_entities` never deletes grids, maps or player-controlled entities.
+- An empty created grid is garbage-collected by the engine — `create_grid` warns to place tiles
+  immediately.
+
+## Testing
+
+Smoke-test any tool with plain JSON-RPC:
+
+```sh
+curl -s -X POST http://localhost:1212/mcp -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_maps","arguments":{}}}'
+```
+
+`EVALS.md` contains ten end-to-end evaluation tasks (per Anthropic's mcp-builder methodology)
+plus scriptable regression checks; run them against a dev server with a connected client.

--- a/Content.Server/_RMC14/Mcp/Tools/ConsoleTools.cs
+++ b/Content.Server/_RMC14/Mcp/Tools/ConsoleTools.cs
@@ -1,0 +1,205 @@
+#if !FULL_RELEASE || RMC_MCP
+using System.Text;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Robust.Shared.Console;
+using Robust.Shared.Player;
+using Robust.Shared.Toolshed;
+using Robust.Shared.Utility;
+
+namespace Content.Server._RMC14.Mcp.Tools;
+
+public sealed class RunCommandTool(McpContext ctx) : McpTool(ctx)
+{
+    public override string Name => "run_command";
+
+    public override string Description =>
+        "Executes a server console command with full host permissions and returns its output. The escape hatch " +
+        "for everything without a dedicated tool: variantize, tilewalls, fixrotations, tp, tpgrid, " +
+        "aghost, planet and more. " +
+        "Pass 'player' for commands that act on a player (tp, aghost...). " +
+        "Prefer the dedicated tools where they exist: set_component_field over 'vvwrite' (which fails silently " +
+        "on a wrong path) and paint_areas over the area-marker + global 'areas:save' ritual.";
+
+    public override JsonObject Annotations => Annotate.Write(destructive: true, idempotent: false);
+
+    public override JsonObject InputSchema => Schema.Object(new JsonObject
+        {
+            ["command"] = Schema.String("Full command line, e.g. 'fixgridatmos 4' or 'tp 0 0 2'."),
+            ["player"] = Schema.String("Run in this player's context (default: the server console, no player)."),
+        },
+        "command");
+
+    public override Task<JsonNode> ExecuteAsync(JsonObject args)
+    {
+        var commandLine = McpContext.GetString(args, "command").Trim();
+        if (commandLine.Length == 0)
+            throw new McpToolException("Empty command.");
+        var playerName = McpContext.OptString(args, "player");
+
+        return Ctx.RunOnMainThread<JsonNode>(() =>
+        {
+            ICommonSession? session = null;
+            if (playerName != null)
+                session = Ctx.ResolveSession(playerName);
+
+            var shell = new CapturingConsoleShell(Ctx.ConsoleHost, Ctx.Toolshed, session);
+            shell.ExecuteCommand(commandLine);
+
+            return (JsonNode) new JsonObject
+            {
+                ["command"] = commandLine,
+                ["output"] = shell.Output,
+                ["had_errors"] = shell.HadErrors,
+            };
+        });
+    }
+}
+
+public sealed class ClientCommandTool(McpContext ctx) : McpTool(ctx)
+{
+    public override string Name => "client_command";
+
+    public override string Description =>
+        "Executes a console command ON A PLAYER'S CLIENT (server-to-client remote execution) - for " +
+        "client-side toggles the server cannot run: 'scene GameplayState' / 'scene MappingState' " +
+        "(hide / show the mapping editor UI to free the screen), 'showmarkers', 'showsubfloor', " +
+        "'togglelight', 'showareas', 'zoom'. Command and argument names are case-sensitive. " +
+        "Fire-and-forget: client-side output is NOT captured - verify the effect via a screenshot " +
+        "or by asking the player.";
+
+    public override JsonObject Annotations => Annotate.Write(destructive: false, idempotent: false);
+
+    public override JsonObject InputSchema => Schema.Object(new JsonObject
+        {
+            ["command"] = Schema.String("Client console command line, e.g. 'scene GameplayState'."),
+            ["player"] = Schema.String("Player name (default: the only connected player)."),
+        },
+        "command");
+
+    public override Task<JsonNode> ExecuteAsync(JsonObject args)
+    {
+        var commandLine = McpContext.GetString(args, "command").Trim();
+        if (commandLine.Length == 0)
+            throw new McpToolException("Empty command.");
+        var playerName = McpContext.OptString(args, "player");
+
+        return Ctx.RunOnMainThread<JsonNode>(() =>
+        {
+            var session = Ctx.ResolveSession(playerName);
+            Ctx.ConsoleHost.RemoteExecuteCommand(session, commandLine);
+
+            return (JsonNode) new JsonObject
+            {
+                ["sent_to"] = session.Name,
+                ["command"] = commandLine,
+                ["note"] = "Executed on the client; output is not captured server-side.",
+            };
+        });
+    }
+}
+
+/// <summary>
+/// A console shell that captures command output instead of writing it to the system console,
+/// and executes commands directly (bypassing permission checks — the MCP endpoint is trusted).
+/// </summary>
+public sealed class CapturingConsoleShell(IConsoleHost host, ToolshedManager toolshed, ICommonSession? player) : IConsoleShell
+{
+    private readonly StringBuilder _output = new();
+    private int _depth;
+
+    public string Output => _output.ToString().TrimEnd();
+    public bool HadErrors { get; private set; }
+
+    public IConsoleHost ConsoleHost => host;
+    public bool IsServer => true;
+    public bool IsLocal => player == null;
+    public ICommonSession? Player => player;
+
+    public void ExecuteCommand(string command)
+    {
+        if (_depth > 8)
+        {
+            WriteError($"Command recursion too deep, not executing '{command}'.");
+            return;
+        }
+
+        var args = new List<string>();
+        CommandParsing.ParseArguments(command, args);
+        if (args.Count == 0)
+            return;
+
+        var commandName = args[0];
+        if (!host.AvailableCommands.TryGetValue(commandName, out var cmd))
+        {
+            // Not a regular console command — fall through to Toolshed (areas:save, entities,
+            // spawn:at ...), mirroring ServerConsoleHost.ExecuteCommand.
+            ExecuteToolshedCommand(command);
+            return;
+        }
+
+        var argStr = command.Length > commandName.Length ? command[(commandName.Length + 1)..] : "";
+        _depth++;
+        try
+        {
+            cmd.Execute(this, argStr, args.GetRange(1, args.Count - 1).ToArray());
+        }
+        finally
+        {
+            _depth--;
+        }
+    }
+
+    private void ExecuteToolshedCommand(string command)
+    {
+        toolshed.InvokeCommand(this, command, null, out var res, out var ctx);
+
+        var anyErrors = false;
+        foreach (var err in ctx.GetErrors())
+        {
+            anyErrors = true;
+            WriteLine(err.Describe());
+        }
+
+        if (anyErrors)
+        {
+            HadErrors = true;
+            return;
+        }
+
+        if (res != null)
+            WriteLine(toolshed.PrettyPrintType(res, out _, moreUsed: true));
+    }
+
+    public void RemoteExecuteCommand(string command)
+    {
+        // Server side: "remote" means sending the command to the player's client (e.g. mappingclientsidesetup).
+        if (player != null)
+            host.RemoteExecuteCommand(player, command);
+        else
+            WriteLine($"(skipped client-side command '{command}': no player in this context)");
+    }
+
+    public void WriteLine(string text)
+    {
+        _output.AppendLine(text);
+    }
+
+    public void WriteLine(FormattedMessage message)
+    {
+        _output.AppendLine(message.ToString());
+    }
+
+    public void WriteError(string text)
+    {
+        HadErrors = true;
+        _output.Append("ERROR: ").AppendLine(text);
+    }
+
+    public void Clear()
+    {
+        _output.Clear();
+    }
+}
+
+#endif

--- a/Content.Server/_RMC14/Mcp/Tools/DecalTools.cs
+++ b/Content.Server/_RMC14/Mcp/Tools/DecalTools.cs
@@ -1,0 +1,313 @@
+#if !FULL_RELEASE || RMC_MCP
+using System.Numerics;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Content.Server.Decals;
+using Content.Shared.Decals;
+using Robust.Shared.Map;
+
+namespace Content.Server._RMC14.Mcp.Tools;
+
+public sealed class ReadDecalsTool(McpContext ctx) : McpTool(ctx)
+{
+    private const int MaxArea = 60_000;
+
+    public override string Name => "read_decals";
+
+    public override string Description =>
+        "Lists decals (floor markings, dirt, stripes...) inside a rectangle of a grid, with their decal ids " +
+        "(needed by edit_decal / remove_decal), position, color, rotation and z-index.";
+
+    public override JsonObject Annotations => Annotate.ReadOnly();
+
+    public override JsonObject InputSchema => Schema.Object(new JsonObject
+    {
+        ["grid"] = Schema.Grid(),
+        ["x"] = Schema.Int("South-west corner tile X (absolute form)."),
+        ["y"] = Schema.Int("South-west corner tile Y (absolute form)."),
+        ["relative"] = Schema.Relative("the center of the rectangle"),
+        ["width"] = Schema.Int("Rectangle width in tiles (default 21)."),
+        ["height"] = Schema.Int("Rectangle height in tiles (default 21)."),
+    });
+
+    public override Task<JsonNode> ExecuteAsync(JsonObject args)
+    {
+        var width = McpContext.OptInt(args, "width") ?? 21;
+        var height = McpContext.OptInt(args, "height") ?? 21;
+        if (width < 1 || height < 1 || (long) width * height > MaxArea)
+            throw new McpToolException($"width/height must be positive with area <= {MaxArea}.");
+
+        return Ctx.RunOnMainThread<JsonNode>(() =>
+        {
+            var (gridUid, _, anchor) = Ctx.ResolveTilePosition(args);
+            var corner = args.ContainsKey("relative")
+                ? anchor - new Vector2i(width / 2, height / 2)
+                : anchor;
+
+            var decalSystem = Ctx.EntityManager.System<DecalSystem>();
+            var found = decalSystem.GetDecalsIntersecting(gridUid,
+                new Box2(corner.X, corner.Y, corner.X + width, corner.Y + height));
+
+            var decals = new JsonArray();
+            foreach (var (index, decal) in found)
+            {
+                decals.Add(new JsonObject
+                {
+                    ["decal_id"] = index,
+                    ["prototype"] = decal.Id,
+                    ["x"] = MathF.Round(decal.Coordinates.X, 2),
+                    ["y"] = MathF.Round(decal.Coordinates.Y, 2),
+                    ["color"] = decal.Color?.ToHex(),
+                    ["rotation_deg"] = Math.Round(decal.Angle.Degrees, 1),
+                    ["z_index"] = decal.ZIndex,
+                    ["cleanable"] = decal.Cleanable,
+                });
+            }
+
+            return (JsonNode) new JsonObject
+            {
+                ["grid"] = Ctx.ToNetId(gridUid),
+                ["decals"] = decals,
+            };
+        });
+    }
+}
+
+public sealed class AddDecalTool(McpContext ctx) : McpTool(ctx)
+{
+    private const int MaxBatch = 500;
+
+    public override string Name => "add_decal";
+
+    public override string Description =>
+        "Places a decal (or a batch via 'decals'). By default it snaps to the tile at the given position (like " +
+        "the decal placer with snap on); pass snap=false and fractional dx/dy offsets for free placement. " +
+        "Returns the decal id(s).";
+
+    public override JsonObject Annotations => Annotate.Write(destructive: false, idempotent: false);
+
+    public override JsonObject InputSchema
+    {
+        get
+        {
+            var single = new JsonObject
+            {
+                ["decal"] = Schema.String("Decal prototype id (see list_decal_prototypes)."),
+                ["x"] = Schema.Int("Tile X (absolute form)."),
+                ["y"] = Schema.Int("Tile Y (absolute form)."),
+                ["relative"] = Schema.Relative("the decal position"),
+                ["snap"] = Schema.Bool("Snap to the tile (default true)."),
+                ["color"] = Schema.String("Hex color like '#FFFFFF' (optional)."),
+                ["rotation_deg"] = Schema.Number("Rotation in degrees (default 0)."),
+                ["z_index"] = Schema.Int("Draw order among decals (default 0)."),
+                ["cleanable"] = Schema.Bool("Can be cleaned with a mop (default false)."),
+            };
+            var props = new JsonObject
+            {
+                ["grid"] = Schema.Grid(),
+                ["decals"] = Schema.Array("Batch form: list of decal placements (same fields as the single form).",
+                    Schema.Object((JsonObject) single.DeepClone())),
+            };
+            foreach (var (key, value) in single)
+            {
+                props[key] = value!.DeepClone();
+            }
+
+            return Schema.Object(props);
+        }
+    }
+
+    public override Task<JsonNode> ExecuteAsync(JsonObject args)
+    {
+        return Ctx.RunOnMainThread<JsonNode>(() =>
+        {
+            var placed = new JsonArray();
+            if (args.TryGetPropertyValue("decals", out var batchNode) && batchNode is JsonArray batch)
+            {
+                if (batch.Count > MaxBatch)
+                    throw new McpToolException($"Batch too large ({batch.Count} > {MaxBatch}).");
+
+                foreach (var node in batch)
+                {
+                    if (node is not JsonObject entry)
+                        throw new McpToolException("'decals' entries must be objects.");
+                    // Inherit the grid from the top-level arguments unless overridden.
+                    if (!entry.ContainsKey("grid") && args.ContainsKey("grid"))
+                        entry["grid"] = args["grid"]!.DeepClone();
+                    placed.Add(PlaceOne(entry));
+                }
+            }
+            else
+            {
+                placed.Add(PlaceOne(args));
+            }
+
+            return (JsonNode) new JsonObject { ["placed"] = placed };
+        });
+    }
+
+    private JsonObject PlaceOne(JsonObject args)
+    {
+        var decalId = McpContext.GetString(args, "decal");
+        var snap = McpContext.OptBool(args, "snap", true);
+        var rotation = Angle.FromDegrees(McpContext.OptDouble(args, "rotation_deg") ?? 0);
+        var zIndex = McpContext.OptInt(args, "z_index") ?? 0;
+        var cleanable = McpContext.OptBool(args, "cleanable", false);
+        var colorHex = McpContext.OptString(args, "color");
+
+        if (!Ctx.PrototypeManager.HasIndex<DecalPrototype>(decalId))
+            throw new McpToolException($"Unknown decal prototype '{decalId}' (see list_decal_prototypes).");
+
+        Color? color = null;
+        if (colorHex != null)
+        {
+            if (!Color.TryParse(colorHex, out var parsed))
+                throw new McpToolException($"Cannot parse color '{colorHex}'.");
+            color = parsed;
+        }
+
+        var (gridUid, _, tile) = Ctx.ResolveTilePosition(args);
+        // A decal's coordinates are its sprite's bottom-left corner; the tile corner covers the tile exactly.
+        var position = snap
+            ? new Vector2(tile.X, tile.Y)
+            : new Vector2(tile.X + 0.5f, tile.Y + 0.5f);
+
+        var decalSystem = Ctx.EntityManager.System<DecalSystem>();
+        var coordinates = new EntityCoordinates(gridUid, position);
+        if (!decalSystem.TryAddDecal(decalId, coordinates, out var newId, color, rotation, zIndex, cleanable))
+            throw new McpToolException("Failed to place decal (is the target tile empty space?).");
+
+        return new JsonObject
+        {
+            ["grid"] = Ctx.ToNetId(gridUid),
+            ["decal_id"] = newId,
+        };
+    }
+}
+
+public sealed class EditDecalTool(McpContext ctx) : McpTool(ctx)
+{
+    public override string Name => "edit_decal";
+
+    public override string Description =>
+        "Edits an existing decal (find its id with read_decals): position, color, rotation, z-index, cleanable " +
+        "or the decal prototype itself.";
+
+    public override JsonObject Annotations => Annotate.Write(destructive: false, idempotent: true);
+
+    public override JsonObject InputSchema => Schema.Object(new JsonObject
+        {
+            ["grid"] = Schema.Int("Grid NetEntity id the decal is on."),
+            ["decal_id"] = Schema.Int("Decal id from read_decals or add_decal."),
+            ["x"] = Schema.Number("New X (grid-local, tile units)."),
+            ["y"] = Schema.Number("New Y (grid-local, tile units)."),
+            ["decal"] = Schema.String("New decal prototype id."),
+            ["color"] = Schema.String("New hex color."),
+            ["rotation_deg"] = Schema.Number("New rotation in degrees."),
+            ["z_index"] = Schema.Int("New z-index."),
+            ["cleanable"] = Schema.Bool("New cleanable flag."),
+        },
+        "grid", "decal_id");
+
+    public override Task<JsonNode> ExecuteAsync(JsonObject args)
+    {
+        var gridNet = McpContext.GetInt(args, "grid");
+        var decalId = (uint) McpContext.GetInt(args, "decal_id");
+
+        return Ctx.RunOnMainThread<JsonNode>(() =>
+        {
+            var gridUid = Ctx.FromNetId(gridNet);
+            var decalSystem = Ctx.EntityManager.System<DecalSystem>();
+            var changed = new JsonArray();
+
+            var x = McpContext.OptDouble(args, "x");
+            var y = McpContext.OptDouble(args, "y");
+            if (x != null || y != null)
+            {
+                if (x == null || y == null)
+                    throw new McpToolException("Provide both x and y to move a decal.");
+                if (!decalSystem.SetDecalPosition(gridUid, decalId,
+                        new EntityCoordinates(gridUid, new Vector2((float) x.Value, (float) y.Value))))
+                    throw new McpToolException($"No decal {decalId} on grid {gridNet}.");
+                changed.Add("position");
+            }
+
+            if (McpContext.OptString(args, "decal") is { } newProto)
+            {
+                if (!Ctx.PrototypeManager.HasIndex<DecalPrototype>(newProto))
+                    throw new McpToolException($"Unknown decal prototype '{newProto}'.");
+                if (!decalSystem.SetDecalId(gridUid, decalId, newProto))
+                    throw new McpToolException($"No decal {decalId} on grid {gridNet}.");
+                changed.Add("decal");
+            }
+
+            if (McpContext.OptString(args, "color") is { } colorHex)
+            {
+                if (!Color.TryParse(colorHex, out var color))
+                    throw new McpToolException($"Cannot parse color '{colorHex}'.");
+                if (!decalSystem.SetDecalColor(gridUid, decalId, color))
+                    throw new McpToolException($"No decal {decalId} on grid {gridNet}.");
+                changed.Add("color");
+            }
+
+            if (McpContext.OptDouble(args, "rotation_deg") is { } degrees)
+            {
+                if (!decalSystem.SetDecalRotation(gridUid, decalId, Angle.FromDegrees(degrees)))
+                    throw new McpToolException($"No decal {decalId} on grid {gridNet}.");
+                changed.Add("rotation");
+            }
+
+            if (McpContext.OptInt(args, "z_index") is { } zIndex)
+            {
+                if (!decalSystem.SetDecalZIndex(gridUid, decalId, zIndex))
+                    throw new McpToolException($"No decal {decalId} on grid {gridNet}.");
+                changed.Add("z_index");
+            }
+
+            if (args.ContainsKey("cleanable"))
+            {
+                if (!decalSystem.SetDecalCleanable(gridUid, decalId, McpContext.OptBool(args, "cleanable", false)))
+                    throw new McpToolException($"No decal {decalId} on grid {gridNet}.");
+                changed.Add("cleanable");
+            }
+
+            if (changed.Count == 0)
+                throw new McpToolException("Nothing to change; pass at least one property.");
+
+            return (JsonNode) new JsonObject { ["changed"] = changed };
+        });
+    }
+}
+
+public sealed class RemoveDecalTool(McpContext ctx) : McpTool(ctx)
+{
+    public override string Name => "remove_decal";
+
+    public override string Description => "Removes a decal by id (find it with read_decals).";
+
+    public override JsonObject Annotations => Annotate.Write(destructive: true, idempotent: true);
+
+    public override JsonObject InputSchema => Schema.Object(new JsonObject
+        {
+            ["grid"] = Schema.Int("Grid NetEntity id the decal is on."),
+            ["decal_id"] = Schema.Int("Decal id from read_decals."),
+        },
+        "grid", "decal_id");
+
+    public override Task<JsonNode> ExecuteAsync(JsonObject args)
+    {
+        var gridNet = McpContext.GetInt(args, "grid");
+        var decalId = (uint) McpContext.GetInt(args, "decal_id");
+
+        return Ctx.RunOnMainThread<JsonNode>(() =>
+        {
+            var gridUid = Ctx.FromNetId(gridNet);
+            var decalSystem = Ctx.EntityManager.System<DecalSystem>();
+            if (!decalSystem.RemoveDecal(gridUid, decalId))
+                throw new McpToolException($"No decal {decalId} on grid {gridNet}.");
+
+            return (JsonNode) new JsonObject { ["removed"] = true };
+        });
+    }
+}
+#endif

--- a/Content.Server/_RMC14/Mcp/Tools/EntityReadTools.cs
+++ b/Content.Server/_RMC14/Mcp/Tools/EntityReadTools.cs
@@ -1,0 +1,474 @@
+#if !FULL_RELEASE || RMC_MCP
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._RMC14.Mcp.Tools;
+
+/// <summary>Shared entity filter parsing for read/find/delete tools.</summary>
+public sealed class EntityFilter
+{
+    public string? Prototype;
+    public string? NameContains;
+    public Type? Component;
+    public bool AnchoredOnly;
+
+    public static JsonObject SchemaProperties() => new()
+    {
+        ["prototype"] = Schema.String("Only entities with this exact prototype id."),
+        ["name_contains"] = Schema.String("Only entities whose in-game name (localized, often Russian) OR prototype id contains this (case-insensitive)."),
+        ["component"] = Schema.String("Only entities with this component (e.g. 'Door', 'ApcPowerReceiver')."),
+        ["anchored_only"] = Schema.Bool("Only anchored (bolted-down) entities."),
+    };
+
+    public static EntityFilter Parse(McpContext ctx, JsonObject args)
+    {
+        var filter = new EntityFilter
+        {
+            Prototype = McpContext.OptString(args, "prototype"),
+            NameContains = McpContext.OptString(args, "name_contains"),
+            AnchoredOnly = McpContext.OptBool(args, "anchored_only", false),
+        };
+
+        if (McpContext.OptString(args, "component") is { } compName)
+            filter.Component = ctx.ResolveComponent(compName).Type;
+
+        return filter;
+    }
+
+    public bool Matches(McpContext ctx, EntityUid uid, MetaDataComponent meta, TransformComponent xform)
+    {
+        if (AnchoredOnly && !xform.Anchored)
+            return false;
+        if (Prototype != null && meta.EntityPrototype?.ID != Prototype)
+            return false;
+        // Entity names are localized; match the prototype id too so English searches keep working.
+        if (NameContains != null &&
+            !meta.EntityName.Contains(NameContains, StringComparison.OrdinalIgnoreCase) &&
+            !(meta.EntityPrototype?.ID.Contains(NameContains, StringComparison.OrdinalIgnoreCase) ?? false))
+        {
+            return false;
+        }
+        if (Component != null && !ctx.EntityManager.HasComponent(uid, Component))
+            return false;
+        return true;
+    }
+}
+
+public sealed class ReadEntitiesTool(McpContext ctx) : McpTool(ctx)
+{
+    private const int MaxArea = 60_000;
+
+    public override string Name => "read_entities";
+
+    public override string Description =>
+        "Lists entities inside a rectangle of a grid (or draws the anchored ones as a matrix). " +
+        "Filter by prototype, name, component or anchored state. In absolute form x,y is the south-west corner; " +
+        "with 'relative' the player-offset tile is the center. CAUTION: a matrix cell shows only the tile's " +
+        "highest-priority anchored entity (transitions/markers > doors > other > catwalks) — everything it " +
+        "hides is returned in 'stacked' (\"x,y\" -> prototypes) and cables/pipes in the separate 'subfloor' " +
+        "matrix; consult both for the full picture, or use list mode for lossless output.";
+
+    public override JsonObject Annotations => Annotate.ReadOnly();
+
+    public override JsonObject InputSchema
+    {
+        get
+        {
+            var props = new JsonObject
+            {
+                ["grid"] = Schema.Grid(),
+                ["x"] = Schema.Int("South-west corner tile X (absolute form)."),
+                ["y"] = Schema.Int("South-west corner tile Y (absolute form)."),
+                ["relative"] = Schema.Relative("the center of the rectangle"),
+                ["width"] = Schema.Int("Rectangle width in tiles (default 21)."),
+                ["height"] = Schema.Int("Rectangle height in tiles (default 21)."),
+                ["mode"] = Schema.Enum("'list' (default) or 'matrix' (anchored entities as characters).", "list", "matrix"),
+                ["format"] = Schema.Enum(
+                    "Matrix cell format: 'compact' (default, one char per tile) or 'wide' (two chars per cell, " +
+                    "space-separated: entity symbol + digit count of hidden entities, '.' if none).",
+                    "compact", "wide"),
+                ["layers"] = Schema.Array(
+                    "Matrix layers to return: 'main' (walls, doors, furniture...) and/or 'subfloor' " +
+                    "(cables, pipes). Default: both.",
+                    Schema.Enum("Layer name.", "main", "subfloor")),
+                ["limit"] = Schema.Int("Max list entries (default 200)."),
+            };
+            foreach (var (key, value) in EntityFilter.SchemaProperties())
+            {
+                props[key] = value!.DeepClone();
+            }
+
+            return Schema.Object(props);
+        }
+    }
+
+    public override Task<JsonNode> ExecuteAsync(JsonObject args)
+    {
+        var width = McpContext.OptInt(args, "width") ?? 21;
+        var height = McpContext.OptInt(args, "height") ?? 21;
+        var limit = McpContext.OptInt(args, "limit") ?? 200;
+        var mode = McpContext.OptString(args, "mode") ?? "list";
+        if (width < 1 || height < 1 || (long) width * height > MaxArea)
+            throw new McpToolException($"width/height must be positive with area <= {MaxArea}.");
+
+        return Ctx.RunOnMainThread<JsonNode>(() =>
+        {
+            var filter = EntityFilter.Parse(Ctx, args);
+            var (gridUid, grid, anchor) = Ctx.ResolveTilePosition(args);
+            var corner = args.ContainsKey("relative")
+                ? anchor - new Vector2i(width / 2, height / 2)
+                : anchor;
+
+            var result = new JsonObject
+            {
+                ["grid"] = Ctx.ToNetId(gridUid),
+                ["south_west_corner"] = new JsonObject { ["x"] = corner.X, ["y"] = corner.Y },
+            };
+
+            if (mode == "matrix")
+            {
+                var wide = (McpContext.OptString(args, "format") ?? "compact") == "wide";
+                var (wantMain, wantSub) = McpEntityMatrix.ParseLayers(args);
+                var mapSystem = Ctx.EntityManager.System<SharedMapSystem>();
+                var legend = new McpLegend();
+                var subLegend = new McpLegend();
+                var rows = new JsonArray();
+                var subRows = new JsonArray();
+                var stacked = new JsonObject();
+                var anySub = false;
+                for (var y = corner.Y + height - 1; y >= corner.Y; y--)
+                {
+                    var row = new StringBuilder(width);
+                    var subRow = new StringBuilder(width);
+                    for (var x = corner.X; x < corner.X + width; x++)
+                    {
+                        var cell = McpEntityMatrix.Collect(Ctx.EntityManager, mapSystem, gridUid, grid,
+                            new Vector2i(x, y), (uid, meta, xform) => filter.Matches(Ctx, uid, meta, xform));
+
+                        var mainHidden = wantMain && cell.Main is { Count: > 1 } ? cell.Main.Count - 1 : 0;
+                        var subHidden = wantSub && cell.Sub is { Count: > 1 } ? cell.Sub.Count - 1 : 0;
+                        McpEntityMatrix.AddStacked(stacked, new Vector2i(x, y), cell, wantMain, wantSub);
+
+                        if (wantMain)
+                        {
+                            McpEntityMatrix.AppendCell(row,
+                                cell.Main is { Count: > 0 } ? legend.Get(cell.Main[0]) : '.', mainHidden, wide);
+                        }
+
+                        if (wantSub)
+                        {
+                            anySub |= cell.Sub is { Count: > 0 };
+                            McpEntityMatrix.AppendCell(subRow,
+                                cell.Sub is { Count: > 0 } ? subLegend.Get(cell.Sub[0]) : '.', subHidden, wide);
+                        }
+                    }
+
+                    if (wantMain)
+                        rows.Add(row.ToString());
+                    if (wantSub)
+                        subRows.Add(subRow.ToString());
+                }
+
+                result["orientation"] = "world-aligned: top row = north, left column = west";
+                if (wantMain)
+                {
+                    result["legend"] = legend.ToJson("no matching anchored entity");
+                    result["rows"] = rows;
+                }
+
+                if (wantSub && anySub)
+                {
+                    result["subfloor"] = new JsonObject
+                    {
+                        ["legend"] = subLegend.ToJson("no subfloor entity"),
+                        ["rows"] = subRows,
+                    };
+                }
+
+                if (stacked.Count > 0)
+                    result["stacked"] = stacked;
+                return result;
+            }
+
+            var lookup = Ctx.EntityManager.System<EntityLookupSystem>();
+            var found = new HashSet<EntityUid>();
+            lookup.GetLocalEntitiesIntersecting(gridUid,
+                new Box2(corner.X, corner.Y, corner.X + width, corner.Y + height), found);
+
+            var entities = new JsonArray();
+            var truncated = false;
+            foreach (var uid in found)
+            {
+                var meta = Ctx.EntityManager.GetComponent<MetaDataComponent>(uid);
+                var xform = Ctx.EntityManager.GetComponent<TransformComponent>(uid);
+                if (!filter.Matches(Ctx, uid, meta, xform))
+                    continue;
+                if (entities.Count >= limit)
+                {
+                    truncated = true;
+                    break;
+                }
+
+                entities.Add(EntityTools.Describe(Ctx, uid, meta, xform));
+            }
+
+            result["entities"] = entities;
+            result["truncated"] = truncated;
+            return result;
+        });
+    }
+}
+
+public sealed class FindEntitiesTool(McpContext ctx) : McpTool(ctx)
+{
+    public override string Name => "find_entities";
+
+    public override string Description =>
+        "Searches ALL entities (optionally limited to one map or grid) by prototype id, name substring and/or " +
+        "component. name_contains matches both the in-game name (localized, often Russian) and the prototype id, " +
+        "so English terms like 'ladder' work. Use to find spawn markers, doors, APCs etc. anywhere on the map.";
+
+    public override JsonObject Annotations => Annotate.ReadOnly();
+
+    public override JsonObject InputSchema
+    {
+        get
+        {
+            var props = new JsonObject
+            {
+                ["map_id"] = Schema.Int("Restrict to this map id."),
+                ["grid"] = Schema.Int("Restrict to this grid (NetEntity id)."),
+                ["limit"] = Schema.Int("Max entries (default 100)."),
+            };
+            foreach (var (key, value) in EntityFilter.SchemaProperties())
+            {
+                props[key] = value!.DeepClone();
+            }
+
+            return Schema.Object(props);
+        }
+    }
+
+    public override Task<JsonNode> ExecuteAsync(JsonObject args)
+    {
+        var limit = McpContext.OptInt(args, "limit") ?? 100;
+        var mapFilter = McpContext.OptMapId(args);
+        var gridFilter = McpContext.OptInt(args, "grid");
+
+        return Ctx.RunOnMainThread<JsonNode>(() =>
+        {
+            var filter = EntityFilter.Parse(Ctx, args);
+            if (filter.Prototype == null && filter.NameContains == null && filter.Component == null)
+                throw new McpToolException("Provide at least one of: prototype, name_contains, component.");
+
+            EntityUid? gridUid = gridFilter is { } g ? Ctx.FromNetId(g) : null;
+            var mapId = mapFilter is { } m ? new MapId(m) : (MapId?) null;
+
+            var entities = new JsonArray();
+            var truncated = false;
+            var total = 0;
+
+            var query = Ctx.EntityManager.AllEntityQueryEnumerator<MetaDataComponent, TransformComponent>();
+            while (query.MoveNext(out var uid, out var meta, out var xform))
+            {
+                if (mapId != null && xform.MapID != mapId)
+                    continue;
+                if (gridUid != null && xform.GridUid != gridUid)
+                    continue;
+                if (!filter.Matches(Ctx, uid, meta, xform))
+                    continue;
+
+                total++;
+                if (entities.Count >= limit)
+                {
+                    truncated = true;
+                    continue;
+                }
+
+                entities.Add(EntityTools.Describe(Ctx, uid, meta, xform));
+            }
+
+            return new JsonObject
+            {
+                ["total_matches"] = total,
+                ["entities"] = entities,
+                ["truncated"] = truncated,
+            };
+        });
+    }
+}
+
+public sealed class EntityInfoTool(McpContext ctx) : McpTool(ctx)
+{
+    public override string Name => "entity_info";
+
+    public override string Description =>
+        "Details of one entity: prototype, name, position, rotation, anchoring, parent, children count and its " +
+        "component list. Pass 'component' to dump that component's simple fields (a la view-variables); " +
+        "write them back with set_component_field.";
+
+    public override JsonObject Annotations => Annotate.ReadOnly();
+
+    public override JsonObject InputSchema => Schema.Object(new JsonObject
+        {
+            ["entity"] = Schema.Int("Entity NetEntity id."),
+            ["component"] = Schema.String("Component name whose fields to dump (optional)."),
+        },
+        "entity");
+
+    public override Task<JsonNode> ExecuteAsync(JsonObject args)
+    {
+        var netId = McpContext.GetInt(args, "entity");
+        var componentName = McpContext.OptString(args, "component");
+
+        return Ctx.RunOnMainThread<JsonNode>(() =>
+        {
+            var uid = Ctx.FromNetId(netId);
+            var meta = Ctx.EntityManager.GetComponent<MetaDataComponent>(uid);
+            var xform = Ctx.EntityManager.GetComponent<TransformComponent>(uid);
+
+            var result = EntityTools.Describe(Ctx, uid, meta, xform);
+            result["description"] = meta.EntityDescription;
+            result["parent"] = xform.ParentUid.IsValid() ? Ctx.ToNetId(xform.ParentUid) : null;
+            result["child_count"] = xform.ChildCount;
+            result["paused"] = meta.EntityPaused;
+
+            var components = new JsonArray();
+            foreach (var component in Ctx.EntityManager.GetComponents(uid))
+            {
+                components.Add(Ctx.EntityManager.ComponentFactory.GetComponentName(component.GetType()));
+            }
+
+            result["components"] = components;
+
+            if (componentName != null)
+            {
+                var registration = Ctx.ResolveComponent(componentName);
+                if (!Ctx.EntityManager.TryGetComponent(uid, registration.Type, out var component))
+                {
+                    throw new McpToolException(
+                        $"Entity has no component '{registration.Name}' (its components are listed in this tool's " +
+                        "output without a 'component' argument).");
+                }
+
+                result["component_fields"] = DumpComponent(component, out var fieldsTruncated);
+                if (fieldsTruncated)
+                    result["component_fields_truncated"] = $"only the first {MaxDumpedFields} members are shown";
+            }
+
+            return (JsonNode) result;
+        });
+    }
+
+    private const int MaxDumpedFields = 120;
+    private const int MaxFieldLength = 300;
+
+    private JsonObject DumpComponent(IComponent component, out bool truncated)
+    {
+        var dump = new JsonObject();
+        truncated = false;
+        var type = component.GetType();
+        foreach (var member in type.GetMembers(BindingFlags.Public | BindingFlags.Instance))
+        {
+            object? value;
+            try
+            {
+                switch (member)
+                {
+                    case FieldInfo field:
+                        value = field.GetValue(component);
+                        break;
+                    case PropertyInfo { CanRead: true, GetMethod.IsPublic: true } property
+                        when property.GetIndexParameters().Length == 0:
+                        value = property.GetValue(component);
+                        break;
+                    default:
+                        continue;
+                }
+            }
+            catch (Exception)
+            {
+                continue;
+            }
+
+            if (dump.Count >= MaxDumpedFields)
+            {
+                truncated = true;
+                break;
+            }
+
+            try
+            {
+                // A null in the dump must mean exactly one thing: the field IS null. Every
+                // non-null value gets SOME string form — a type the switch can't pretty-print
+                // still falls through to ToString(), never to null (an agent cannot tell a
+                // "can't print this" null from an "actually empty" null).
+                dump[member.Name] = value switch
+                {
+                    null => null,
+                    string s => JsonValue.Create(Truncate(s)),
+                    System.Numerics.Vector2 v => string.Create(CultureInfo.InvariantCulture,
+                        $"({v.X:0.##}, {v.Y:0.##})"),
+                    IFormattable formattable => JsonValue.Create(
+                        Truncate(formattable.ToString(null, CultureInfo.InvariantCulture))),
+                    System.Collections.ICollection collection => $"[{collection.Count} items]",
+                    _ => JsonValue.Create(Truncate(value.ToString() ?? value.GetType().Name)),
+                };
+            }
+            catch (Exception)
+            {
+                // Only a non-null value can throw during conversion.
+                dump[member.Name] = $"<{value!.GetType().Name}: ToString failed>";
+            }
+        }
+
+        return dump;
+    }
+
+    private static string Truncate(string s) =>
+        s.Length <= MaxFieldLength ? s : s[..MaxFieldLength] + "…";
+}
+
+/// <summary>Standard one-line entity description shared by tools.</summary>
+public static class EntityTools
+{
+    public static JsonObject Describe(McpContext ctx, EntityUid uid, MetaDataComponent meta, TransformComponent xform)
+    {
+        var transformSystem = ctx.EntityManager.System<SharedTransformSystem>();
+        var entry = new JsonObject
+        {
+            ["entity"] = ctx.ToNetId(uid),
+            ["prototype"] = meta.EntityPrototype?.ID,
+            ["name"] = meta.EntityName,
+            ["anchored"] = xform.Anchored,
+        };
+
+        if (xform.GridUid is { } gridUid &&
+            ctx.EntityManager.TryGetComponent<MapGridComponent>(gridUid, out var grid))
+        {
+            var mapSystem = ctx.EntityManager.System<SharedMapSystem>();
+            var tile = mapSystem.WorldToTile(gridUid, grid, transformSystem.GetWorldPosition(uid));
+            entry["tile_x"] = tile.X;
+            entry["tile_y"] = tile.Y;
+        }
+        else
+        {
+            var world = transformSystem.GetWorldPosition(uid);
+            entry["world_x"] = MathF.Round(world.X, 2);
+            entry["world_y"] = MathF.Round(world.Y, 2);
+        }
+
+        var rotation = xform.LocalRotation;
+        entry["rotation_deg"] = Math.Round(rotation.Degrees, 1);
+        entry["facing"] = rotation.GetDir().ToString();
+        return entry;
+    }
+}
+#endif

--- a/Content.Server/_RMC14/Mcp/Tools/EntityWriteTools.cs
+++ b/Content.Server/_RMC14/Mcp/Tools/EntityWriteTools.cs
@@ -1,0 +1,550 @@
+#if !FULL_RELEASE || RMC_MCP
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Player;
+using Robust.Shared.Serialization.Markdown;
+using Robust.Shared.Serialization.Markdown.Value;
+using YamlDotNet.RepresentationModel;
+
+namespace Content.Server._RMC14.Mcp.Tools;
+
+public sealed class SpawnEntityTool(McpContext ctx) : McpTool(ctx)
+{
+    private const int MaxBatch = 500;
+
+    public override string Name => "spawn_entity";
+
+    public override string Description =>
+        "Spawns one entity (or a batch) at a tile, snapped to the tile center — the sandbox spawn panel for agents. " +
+        "Position is a tile on a grid (absolute x,y or relative to the player, including in screen frame). " +
+        "Optionally sets facing and anchors/unanchors after spawning. Returns the new NetEntity ids.";
+
+    public override JsonObject Annotations => Annotate.Write(destructive: false, idempotent: false);
+
+    public override JsonObject InputSchema
+    {
+        get
+        {
+            var single = new JsonObject
+            {
+                ["prototype"] = Schema.String("Entity prototype id (see list_entity_prototypes)."),
+                ["x"] = Schema.Int("Tile X (absolute form)."),
+                ["y"] = Schema.Int("Tile Y (absolute form)."),
+                ["relative"] = Schema.Relative("the spawn tile"),
+                ["facing"] = Schema.String("Facing: 'north'/'south'/'east'/'west' (or degrees as a number string)."),
+                ["anchored"] = Schema.Bool("Override anchoring after spawn (default: prototype's own behavior)."),
+            };
+            var props = new JsonObject
+            {
+                ["grid"] = Schema.Grid(),
+                ["entities"] = Schema.Array("Batch form: list of spawns (same fields as the single form).",
+                    Schema.Object((JsonObject) single.DeepClone())),
+            };
+            foreach (var (key, value) in single)
+            {
+                props[key] = value!.DeepClone();
+            }
+
+            return Schema.Object(props);
+        }
+    }
+
+    public override Task<JsonNode> ExecuteAsync(JsonObject args)
+    {
+        return Ctx.RunOnMainThread<JsonNode>(() =>
+        {
+            var spawned = new JsonArray();
+            if (args.TryGetPropertyValue("entities", out var batchNode) && batchNode is JsonArray batch)
+            {
+                if (batch.Count > MaxBatch)
+                    throw new McpToolException($"Batch too large ({batch.Count} > {MaxBatch}).");
+
+                foreach (var node in batch)
+                {
+                    if (node is not JsonObject entry)
+                        throw new McpToolException("'entities' entries must be objects.");
+                    // Inherit the grid from the top-level arguments unless overridden.
+                    if (!entry.ContainsKey("grid") && args.ContainsKey("grid"))
+                        entry["grid"] = args["grid"]!.DeepClone();
+                    spawned.Add(SpawnOne(entry));
+                }
+            }
+            else
+            {
+                spawned.Add(SpawnOne(args));
+            }
+
+            return (JsonNode) new JsonObject { ["spawned"] = spawned };
+        });
+    }
+
+    private JsonObject SpawnOne(JsonObject args)
+    {
+        var prototype = McpContext.GetString(args, "prototype");
+        if (!Ctx.PrototypeManager.HasIndex<Robust.Shared.Prototypes.EntityPrototype>(prototype))
+            throw new McpToolException($"Unknown entity prototype '{prototype}' (see list_entity_prototypes).");
+
+        var (gridUid, grid, tile) = Ctx.ResolveTilePosition(args);
+        var mapSystem = Ctx.EntityManager.System<SharedMapSystem>();
+        var transformSystem = Ctx.EntityManager.System<SharedTransformSystem>();
+        var coords = mapSystem.GridTileToLocal(gridUid, grid, tile);
+
+        var uid = Ctx.EntityManager.SpawnEntity(prototype, coords);
+
+        if (ParseFacing(args) is { } angle)
+            transformSystem.SetLocalRotation(uid, angle);
+
+        var xform = Ctx.EntityManager.GetComponent<TransformComponent>(uid);
+        if (args.TryGetPropertyValue("anchored", out _) &&
+            McpContext.OptBool(args, "anchored", xform.Anchored) is var anchored && anchored != xform.Anchored)
+        {
+            if (anchored)
+                transformSystem.AnchorEntity((uid, xform));
+            else
+                transformSystem.Unanchor(uid, xform);
+        }
+
+        return new JsonObject
+        {
+            ["entity"] = Ctx.ToNetId(uid),
+            ["prototype"] = prototype,
+            ["x"] = tile.X,
+            ["y"] = tile.Y,
+            ["anchored"] = xform.Anchored,
+        };
+    }
+
+    internal static Angle? ParseFacing(JsonObject args)
+    {
+        if (McpContext.OptString(args, "facing") is not { } facing)
+            return null;
+
+        if (double.TryParse(facing, out var degrees))
+            return Angle.FromDegrees(degrees);
+
+        return facing.ToLowerInvariant() switch
+        {
+            "south" => Angle.FromDegrees(0),
+            "east" => Angle.FromDegrees(90),
+            "north" => Angle.FromDegrees(180),
+            "west" => Angle.FromDegrees(270),
+            _ => throw new McpToolException("facing must be north/south/east/west or a number in degrees."),
+        };
+    }
+}
+
+public sealed class DeleteEntitiesTool(McpContext ctx) : McpTool(ctx)
+{
+    private const int MaxListed = 100;
+
+    public override string Name => "delete_entities";
+
+    public override string Description =>
+        "Deletes entities by NetEntity ids, or every entity matching filters inside a rectangle. " +
+        "Never deletes grids, maps or player-controlled entities. Deleting an area WITHOUT any filter removes " +
+        "all prototype-spawned entities there (like the eraser), so filter when you only mean one kind. " +
+        "dry_run=true previews the doomed entities without deleting anything.";
+
+    public override JsonObject Annotations => Annotate.Write(destructive: true, idempotent: true);
+
+    public override JsonObject InputSchema
+    {
+        get
+        {
+            var props = new JsonObject
+            {
+                ["dry_run"] = Schema.Bool("Preview only: list what would be deleted without deleting (default false)."),
+                ["entities"] = Schema.Array("Explicit NetEntity ids to delete.", Schema.Int("NetEntity id.")),
+                ["grid"] = Schema.Grid(),
+                ["x"] = Schema.Int("Area south-west corner tile X."),
+                ["y"] = Schema.Int("Area south-west corner tile Y."),
+                ["relative"] = Schema.Relative("the area center"),
+                ["width"] = Schema.Int("Area width in tiles."),
+                ["height"] = Schema.Int("Area height in tiles."),
+            };
+            foreach (var (key, value) in EntityFilter.SchemaProperties())
+            {
+                props[key] = value!.DeepClone();
+            }
+
+            return Schema.Object(props);
+        }
+    }
+
+    public override Task<JsonNode> ExecuteAsync(JsonObject args)
+    {
+        return Ctx.RunOnMainThread<JsonNode>(() =>
+        {
+            var toDelete = new List<EntityUid>();
+
+            if (args.TryGetPropertyValue("entities", out var idsNode) && idsNode is JsonArray ids)
+            {
+                foreach (var node in ids)
+                {
+                    if (node is not JsonValue value || !value.TryGetValue<int>(out var netId))
+                        throw new McpToolException("'entities' entries must be integers.");
+                    toDelete.Add(Ctx.FromNetId(netId));
+                }
+            }
+            else if (McpContext.OptInt(args, "width") is { } width && McpContext.OptInt(args, "height") is { } height)
+            {
+                if (width < 1 || height < 1)
+                    throw new McpToolException("width/height must be positive.");
+
+                var filter = EntityFilter.Parse(Ctx, args);
+                var (gridUid, grid, anchor) = Ctx.ResolveTilePosition(args);
+                var corner = args.ContainsKey("relative")
+                    ? anchor - new Vector2i(width / 2, height / 2)
+                    : anchor;
+
+                var mapSystem = Ctx.EntityManager.System<SharedMapSystem>();
+                var found = new HashSet<EntityUid>();
+
+                // Anchored entities: walk the per-tile lists — exact tile coverage, no AABB slop.
+                for (var ty = corner.Y; ty < corner.Y + height; ty++)
+                {
+                    for (var tx = corner.X; tx < corner.X + width; tx++)
+                    {
+                        var anchoredEnum = mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, new Vector2i(tx, ty));
+                        while (anchoredEnum.MoveNext(out var anchoredUid))
+                        {
+                            found.Add(anchoredUid.Value);
+                        }
+                    }
+                }
+
+                // Loose entities: physics lookup, then keep only those whose tile is inside the
+                // rectangle — the AABB query alone also returns entities merely touching its edge.
+                var lookup = Ctx.EntityManager.System<EntityLookupSystem>();
+                var intersecting = new HashSet<EntityUid>();
+                lookup.GetLocalEntitiesIntersecting(gridUid,
+                    new Box2(corner.X, corner.Y, corner.X + width, corner.Y + height), intersecting);
+                foreach (var uid in intersecting)
+                {
+                    var xform = Ctx.EntityManager.GetComponent<TransformComponent>(uid);
+                    if (xform.Anchored)
+                        continue;
+
+                    var tile = mapSystem.TileIndicesFor(gridUid, grid, xform.Coordinates);
+                    if (tile.X >= corner.X && tile.X < corner.X + width &&
+                        tile.Y >= corner.Y && tile.Y < corner.Y + height)
+                    {
+                        found.Add(uid);
+                    }
+                }
+
+                foreach (var uid in found)
+                {
+                    var meta = Ctx.EntityManager.GetComponent<MetaDataComponent>(uid);
+                    var xform = Ctx.EntityManager.GetComponent<TransformComponent>(uid);
+                    if (meta.EntityPrototype == null)
+                        continue;
+                    if (filter.Matches(Ctx, uid, meta, xform))
+                        toDelete.Add(uid);
+                }
+            }
+            else
+            {
+                throw new McpToolException("Provide 'entities' or an area (width+height with x/y or relative).");
+            }
+
+            var dryRun = McpContext.OptBool(args, "dry_run", false);
+            var deleted = new JsonArray();
+            var deletedCount = 0;
+            foreach (var uid in toDelete)
+            {
+                if (!Ctx.EntityManager.EntityExists(uid))
+                    continue;
+                // Never delete grids, maps or player avatars this way.
+                if (Ctx.EntityManager.HasComponent<MapGridComponent>(uid) ||
+                    Ctx.EntityManager.HasComponent<MapComponent>(uid) ||
+                    Ctx.EntityManager.HasComponent<ActorComponent>(uid))
+                {
+                    continue;
+                }
+
+                if (deleted.Count < MaxListed)
+                {
+                    deleted.Add(new JsonObject
+                    {
+                        ["entity"] = Ctx.ToNetId(uid),
+                        ["prototype"] = Ctx.EntityManager.GetComponent<MetaDataComponent>(uid).EntityPrototype?.ID,
+                    });
+                }
+
+                if (!dryRun)
+                    Ctx.EntityManager.DeleteEntity(uid);
+                deletedCount++;
+            }
+
+            var result = new JsonObject
+            {
+                ["deleted_count"] = deletedCount,
+                ["deleted"] = deleted,
+            };
+            if (dryRun)
+                result["dry_run"] = true;
+            return (JsonNode) result;
+        });
+    }
+}
+
+public sealed class TransformEntityTool(McpContext ctx) : McpTool(ctx)
+{
+    public override string Name => "transform_entity";
+
+    public override string Description =>
+        "Moves, rotates, anchors or unanchors an existing entity. Position (if given) snaps to the tile center " +
+        "of the target grid; rotation/anchoring can be changed independently.";
+
+    public override JsonObject Annotations => Annotate.Write(destructive: false, idempotent: true);
+
+    public override JsonObject InputSchema => Schema.Object(new JsonObject
+        {
+            ["entity"] = Schema.Int("Entity NetEntity id."),
+            ["grid"] = Schema.Grid(),
+            ["x"] = Schema.Int("Target tile X (absolute form)."),
+            ["y"] = Schema.Int("Target tile Y (absolute form)."),
+            ["relative"] = Schema.Relative("the target tile"),
+            ["facing"] = Schema.String("New facing: 'north'/'south'/'east'/'west' or degrees."),
+            ["anchored"] = Schema.Bool("Anchor (true) or unanchor (false)."),
+        },
+        "entity");
+
+    public override Task<JsonNode> ExecuteAsync(JsonObject args)
+    {
+        var netId = McpContext.GetInt(args, "entity");
+
+        return Ctx.RunOnMainThread<JsonNode>(() =>
+        {
+            var uid = Ctx.FromNetId(netId);
+            var transformSystem = Ctx.EntityManager.System<SharedTransformSystem>();
+            var mapSystem = Ctx.EntityManager.System<SharedMapSystem>();
+            var xform = Ctx.EntityManager.GetComponent<TransformComponent>(uid);
+
+            var moved = false;
+            if (args.ContainsKey("x") || args.ContainsKey("relative"))
+            {
+                var (gridUid, grid, tile) = Ctx.ResolveTilePosition(args);
+                var wasAnchored = xform.Anchored;
+                if (wasAnchored)
+                    transformSystem.Unanchor(uid, xform);
+                transformSystem.SetCoordinates(uid, mapSystem.GridTileToLocal(gridUid, grid, tile));
+                if (wasAnchored)
+                    transformSystem.AnchorEntity((uid, xform));
+                moved = true;
+            }
+
+            if (SpawnEntityTool.ParseFacing(args) is { } angle)
+                transformSystem.SetLocalRotation(uid, angle);
+
+            if (args.ContainsKey("anchored"))
+            {
+                var anchored = McpContext.OptBool(args, "anchored", xform.Anchored);
+                if (anchored && !xform.Anchored)
+                {
+                    if (!transformSystem.AnchorEntity((uid, xform)))
+                        throw new McpToolException("Failed to anchor (no grid under the entity?).");
+                }
+                else if (!anchored && xform.Anchored)
+                {
+                    transformSystem.Unanchor(uid, xform);
+                }
+            }
+
+            var meta = Ctx.EntityManager.GetComponent<MetaDataComponent>(uid);
+            var result = EntityTools.Describe(Ctx, uid, meta, xform);
+            result["moved"] = moved;
+            return (JsonNode) result;
+        });
+    }
+}
+
+public sealed class SetComponentFieldTool(McpContext ctx) : McpTool(ctx)
+{
+    public override string Name => "set_component_field";
+
+    public override string Description =>
+        "Writes one field of an entity's component and echoes the new value back — the validated replacement " +
+        "for 'vvwrite' (which fails SILENTLY on a wrong path). Read the available fields first with " +
+        "entity_info's component dump. Values use YAML/prototype syntax as a string: numbers ('5', '0.4'), " +
+        "booleans ('true'), strings (ladder pair ids), colors ('#FF0000'), vectors ('1,2'), prototype ids, " +
+        "lists ('[a, b]'); 'null' clears nullable fields. EntityUid/NetEntity fields take a NetEntity id. " +
+        "Typical uses: Ladder.Id for ladder pairs, RMCTeleporter.Adjust for trigger teleporters, camera ids.";
+
+    public override JsonObject Annotations => Annotate.Write(destructive: true, idempotent: true);
+
+    public override JsonObject InputSchema => Schema.Object(new JsonObject
+        {
+            ["entity"] = Schema.Int("Entity NetEntity id."),
+            ["component"] = Schema.String("Component name (as listed by entity_info), e.g. 'Ladder'."),
+            ["field"] = Schema.String("Field or property name inside the component, e.g. 'Id'."),
+            ["value"] = Schema.String("New value in YAML/prototype syntax; 'null' clears nullable fields."),
+        },
+        "entity", "component", "field", "value");
+
+    public override Task<JsonNode> ExecuteAsync(JsonObject args)
+    {
+        var netId = McpContext.GetInt(args, "entity");
+        var componentName = McpContext.GetString(args, "component");
+        var fieldName = McpContext.GetString(args, "field");
+        var rawValue = McpContext.GetString(args, "value");
+
+        return Ctx.RunOnMainThread<JsonNode>(() =>
+        {
+            var uid = Ctx.FromNetId(netId);
+            var registration = Ctx.ResolveComponent(componentName);
+            if (!Ctx.EntityManager.TryGetComponent(uid, registration.Type, out var component))
+                throw new McpToolException(
+                    $"Entity {netId} has no component '{registration.Name}' (entity_info lists its components).");
+
+            var member = ResolveMember(component.GetType(), fieldName);
+            var memberType = member switch
+            {
+                FieldInfo f => f.FieldType,
+                PropertyInfo p => p.PropertyType,
+                _ => throw new McpToolException("Unsupported member kind."),
+            };
+
+            var value = ParseValue(memberType, rawValue);
+
+            try
+            {
+                switch (member)
+                {
+                    case FieldInfo f:
+                        f.SetValue(component, value);
+                        break;
+                    case PropertyInfo p:
+                        p.SetValue(component, value);
+                        break;
+                }
+            }
+            catch (Exception e)
+            {
+                throw new McpToolException($"Failed to set {registration.Name}.{member.Name}: {e.Message}");
+            }
+
+            // Replicate to clients (and mark the entity modified) if the component is networked.
+            var networked = registration.NetID != null;
+            if (networked)
+                Ctx.EntityManager.Dirty(uid, component);
+
+            // Read the value back through reflection so the agent sees what was actually stored.
+            var readBack = member switch
+            {
+                FieldInfo f => f.GetValue(component),
+                PropertyInfo p => p.GetValue(component),
+                _ => null,
+            };
+
+            return (JsonNode) new JsonObject
+            {
+                ["entity"] = netId,
+                ["component"] = registration.Name,
+                ["field"] = member.Name,
+                ["new_value"] = readBack?.ToString(),
+                ["networked"] = networked,
+            };
+        });
+    }
+
+    private static MemberInfo ResolveMember(Type type, string fieldName)
+    {
+        var members = new List<MemberInfo>();
+        foreach (var field in type.GetFields(BindingFlags.Public | BindingFlags.Instance))
+        {
+            members.Add(field);
+        }
+
+        foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (property.GetIndexParameters().Length == 0)
+                members.Add(property);
+        }
+
+        var member = members.FirstOrDefault(m => string.Equals(m.Name, fieldName, StringComparison.Ordinal)) ??
+                     members.FirstOrDefault(m => string.Equals(m.Name, fieldName, StringComparison.OrdinalIgnoreCase));
+        if (member == null)
+        {
+            var writable = members.Where(IsWritable).Select(m => m.Name).ToList();
+            var similar = writable.Where(n => n.Contains(fieldName, StringComparison.OrdinalIgnoreCase)).Take(8).ToList();
+            var hint = similar.Count > 0
+                ? $"Similar fields: {string.Join(", ", similar)}."
+                : $"Writable fields: {string.Join(", ", writable.Take(20))}.";
+            throw new McpToolException($"Component '{type.Name}' has no field '{fieldName}'. {hint}");
+        }
+
+        if (!IsWritable(member))
+            throw new McpToolException($"'{type.Name}.{member.Name}' is read-only.");
+
+        return member;
+    }
+
+    private static bool IsWritable(MemberInfo member) => member switch
+    {
+        FieldInfo f => !f.IsInitOnly,
+        PropertyInfo p => p.GetSetMethod(nonPublic: true) != null,
+        _ => false,
+    };
+
+    private object? ParseValue(Type memberType, string rawValue)
+    {
+        var underlying = Nullable.GetUnderlyingType(memberType) ?? memberType;
+
+        if (rawValue == "null")
+        {
+            if (memberType.IsValueType && Nullable.GetUnderlyingType(memberType) == null)
+                throw new McpToolException($"'{memberType.Name}' is not nullable; provide a value.");
+            return null;
+        }
+
+        // Entity references are session-local and not data-serializable — take NetEntity ids.
+        if (underlying == typeof(EntityUid))
+        {
+            if (!int.TryParse(rawValue, out var refNetId))
+                throw new McpToolException("EntityUid fields take a NetEntity id (integer).");
+            return Ctx.FromNetId(refNetId);
+        }
+
+        if (underlying == typeof(NetEntity))
+        {
+            if (!int.TryParse(rawValue, out var refNetId))
+                throw new McpToolException("NetEntity fields take a NetEntity id (integer).");
+            return new NetEntity(refNetId);
+        }
+
+        try
+        {
+            // The same serializer the prototype YAML goes through. Structured values ([a, b],
+            // {x: 1}, multi-line) are parsed as YAML; plain scalars skip the YAML parser so that
+            // '#FF0000' does not turn into a comment.
+            var trimmed = rawValue.TrimStart();
+            DataNode node;
+            if (trimmed.StartsWith('[') || trimmed.StartsWith('{') || rawValue.Contains('\n'))
+            {
+                var yamlStream = new YamlStream();
+                yamlStream.Load(new StringReader(rawValue));
+                node = yamlStream.Documents[0].RootNode.ToDataNode();
+            }
+            else
+            {
+                node = new ValueDataNode(rawValue);
+            }
+
+            return Ctx.Serialization.Read(underlying, node);
+        }
+        catch (Exception e)
+        {
+            throw new McpToolException(
+                $"Cannot parse '{rawValue}' as {underlying.Name}: {e.Message} " +
+                "(use YAML/prototype syntax, e.g. '5', 'true', '1,2', '#FF0000', '[a, b]').");
+        }
+    }
+}
+#endif

--- a/Content.Server/_RMC14/Mcp/Tools/LifecycleTools.cs
+++ b/Content.Server/_RMC14/Mcp/Tools/LifecycleTools.cs
@@ -1,0 +1,493 @@
+#if !FULL_RELEASE || RMC_MCP
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Robust.Shared.ContentPack;
+using Robust.Shared.EntitySerialization;
+using Robust.Shared.EntitySerialization.Systems;
+using Robust.Shared.Map;
+using Robust.Shared.Utility;
+
+namespace Content.Server._RMC14.Mcp.Tools;
+
+public sealed class CreateMapTool(McpContext ctx) : McpTool(ctx)
+{
+    public override string Name => "create_map";
+
+    public override string Description =>
+        "Creates a new empty map, UNINITIALIZED and PAUSED (the state required for editing and saving maps). " +
+        "Returns the new map id.";
+
+    public override JsonObject Annotations => Annotate.Write(destructive: false, idempotent: false);
+
+    public override JsonObject InputSchema => Schema.Object(new JsonObject
+    {
+        ["map_id"] = Schema.Int("Specific map id to create (default: next free id)."),
+    });
+
+    public override Task<JsonNode> ExecuteAsync(JsonObject args)
+    {
+        var requestedId = McpContext.OptInt(args, "map_id");
+
+        return Ctx.RunOnMainThread<JsonNode>(() =>
+        {
+            var mapSystem = Ctx.EntityManager.System<SharedMapSystem>();
+            MapId mapId;
+            EntityUid mapUid;
+            if (requestedId is { } id)
+            {
+                mapId = new MapId(id);
+                if (mapSystem.MapExists(mapId))
+                    throw new McpToolException($"Map {id} already exists.");
+                mapUid = mapSystem.CreateMap(mapId, runMapInit: false);
+            }
+            else
+            {
+                mapUid = mapSystem.CreateMap(out mapId, runMapInit: false);
+            }
+
+            return (JsonNode) new JsonObject
+            {
+                ["map_id"] = int.Parse(mapId.ToString()),
+                ["map_entity"] = Ctx.ToNetId(mapUid),
+                ["note"] = "Map is uninitialized and paused — keep it that way while editing for save.",
+            };
+        });
+    }
+}
+
+public sealed class CreateGridTool(McpContext ctx) : McpTool(ctx)
+{
+    public override string Name => "create_grid";
+
+    public override string Description =>
+        "Creates a new EMPTY grid on a map (a fresh structure to build on with set_tiles/spawn_entity). " +
+        "A grid with no tiles left on it gets deleted automatically — place tiles right after creating it.";
+
+    public override JsonObject Annotations => Annotate.Write(destructive: false, idempotent: false);
+
+    public override JsonObject InputSchema => Schema.Object(new JsonObject
+        {
+            ["map_id"] = Schema.Int("Map to create the grid on."),
+            ["x"] = Schema.Number("World position X of the grid origin (default 0)."),
+            ["y"] = Schema.Number("World position Y of the grid origin (default 0)."),
+        },
+        "map_id");
+
+    public override Task<JsonNode> ExecuteAsync(JsonObject args)
+    {
+        var mapId = new MapId(McpContext.GetInt(args, "map_id"));
+        var x = (float) (McpContext.OptDouble(args, "x") ?? 0);
+        var y = (float) (McpContext.OptDouble(args, "y") ?? 0);
+
+        return Ctx.RunOnMainThread<JsonNode>(() =>
+        {
+            var mapSystem = Ctx.EntityManager.System<SharedMapSystem>();
+            if (!mapSystem.MapExists(mapId))
+                throw new McpToolException($"Map {mapId} does not exist (create_map first).");
+
+            var grid = Ctx.MapManager.CreateGridEntity(mapId);
+            var transformSystem = Ctx.EntityManager.System<SharedTransformSystem>();
+            transformSystem.SetLocalPosition(grid.Owner, new System.Numerics.Vector2(x, y));
+
+            return (JsonNode) new JsonObject
+            {
+                ["grid"] = Ctx.ToNetId(grid.Owner),
+                ["note"] = "Grid is empty; set at least one tile now or it will be cleaned up.",
+            };
+        });
+    }
+}
+
+public sealed class DeleteMapTool(McpContext ctx) : McpTool(ctx)
+{
+    public override string Name => "delete_map";
+
+    public override string Description =>
+        "Deletes a map and EVERYTHING on it (all grids and entities). Irreversible — save first if needed.";
+
+    public override JsonObject Annotations => Annotate.Write(destructive: true, idempotent: true);
+
+    public override JsonObject InputSchema => Schema.Object(new JsonObject
+        {
+            ["map_id"] = Schema.Int("Map id to delete."),
+        },
+        "map_id");
+
+    public override Task<JsonNode> ExecuteAsync(JsonObject args)
+    {
+        var mapId = new MapId(McpContext.GetInt(args, "map_id"));
+
+        return Ctx.RunOnMainThread<JsonNode>(() =>
+        {
+            var mapSystem = Ctx.EntityManager.System<SharedMapSystem>();
+            if (!mapSystem.MapExists(mapId))
+                throw new McpToolException($"Map {mapId} does not exist.");
+
+            mapSystem.DeleteMap(mapId);
+            return (JsonNode) new JsonObject { ["deleted"] = true };
+        });
+    }
+}
+
+public sealed class PauseMapTool(McpContext ctx) : McpTool(ctx)
+{
+    public override string Name => "pause_map";
+
+    public override string Description =>
+        "Pauses or unpauses a map (paused = entities do not tick; maps under mapping should stay paused).";
+
+    public override JsonObject Annotations => Annotate.Write(destructive: false, idempotent: true);
+
+    public override JsonObject InputSchema => Schema.Object(new JsonObject
+        {
+            ["map_id"] = Schema.Int("Map id."),
+            ["paused"] = Schema.Bool("true to pause, false to unpause."),
+        },
+        "map_id", "paused");
+
+    public override Task<JsonNode> ExecuteAsync(JsonObject args)
+    {
+        var mapId = new MapId(McpContext.GetInt(args, "map_id"));
+        var paused = McpContext.OptBool(args, "paused", true);
+
+        return Ctx.RunOnMainThread<JsonNode>(() =>
+        {
+            var mapSystem = Ctx.EntityManager.System<SharedMapSystem>();
+            if (!mapSystem.MapExists(mapId))
+                throw new McpToolException($"Map {mapId} does not exist.");
+
+            mapSystem.SetPaused(mapId, paused);
+            return (JsonNode) new JsonObject { ["paused"] = paused };
+        });
+    }
+}
+
+public sealed class MapInitTool(McpContext ctx) : McpTool(ctx)
+{
+    public override string Name => "map_init";
+
+    public override string Description =>
+        "Runs map initialization on a map (spawners fire, atmosphere/power start, map unpauses). " +
+        "IRREVERSIBLE: an initialized map can no longer be cleanly saved as a map file. " +
+        "Use only to playtest a copy, never on the map you are still editing.";
+
+    public override JsonObject Annotations => Annotate.Write(destructive: true, idempotent: false);
+
+    public override JsonObject InputSchema => Schema.Object(new JsonObject
+        {
+            ["map_id"] = Schema.Int("Map id to initialize."),
+        },
+        "map_id");
+
+    public override Task<JsonNode> ExecuteAsync(JsonObject args)
+    {
+        var mapId = new MapId(McpContext.GetInt(args, "map_id"));
+
+        return Ctx.RunOnMainThread<JsonNode>(() =>
+        {
+            var mapSystem = Ctx.EntityManager.System<SharedMapSystem>();
+            if (!mapSystem.MapExists(mapId))
+                throw new McpToolException($"Map {mapId} does not exist.");
+            if (mapSystem.IsInitialized(mapId))
+                throw new McpToolException($"Map {mapId} is already initialized.");
+
+            mapSystem.InitializeMap(mapId);
+            return (JsonNode) new JsonObject { ["initialized"] = true };
+        });
+    }
+}
+
+public sealed class SaveMapTool(McpContext ctx) : McpTool(ctx)
+{
+    public override string Name => "save_map";
+
+    public override string Description =>
+        "Saves a whole map to a YAML file in the server's user-data directory (e.g. path '/my_map.yml'). " +
+        "Optionally also copies the result to an absolute filesystem path (e.g. into the repo's Resources/Maps). " +
+        "Refuses to save initialized maps unless force=true.";
+
+    public override JsonObject Annotations => Annotate.Write(destructive: false, idempotent: true);
+
+    public override JsonObject InputSchema => Schema.Object(new JsonObject
+        {
+            ["map_id"] = Schema.Int("Map id to save."),
+            ["path"] = Schema.String("User-data path for the yml, must start with '/' (e.g. '/mymap.yml')."),
+            ["force"] = Schema.Bool("Save even if the map is initialized (default false)."),
+            ["export_path"] = Schema.String("Optional absolute path to copy the saved file to."),
+        },
+        "map_id", "path");
+
+    public override Task<JsonNode> ExecuteAsync(JsonObject args)
+    {
+        var mapId = new MapId(McpContext.GetInt(args, "map_id"));
+        var path = McpContext.GetString(args, "path");
+        var force = McpContext.OptBool(args, "force", false);
+        var exportPath = McpContext.OptString(args, "export_path");
+
+        return Ctx.RunOnMainThread<JsonNode>(() =>
+        {
+            var mapSystem = Ctx.EntityManager.System<SharedMapSystem>();
+            var loader = Ctx.EntityManager.System<MapLoaderSystem>();
+            if (!mapSystem.MapExists(mapId))
+                throw new McpToolException($"Map {mapId} does not exist.");
+            if (mapSystem.IsInitialized(mapId) && !force)
+                throw new McpToolException(
+                    $"Map {mapId} is initialized; saving it will not produce a clean map file. Pass force=true to override.");
+
+            var resPath = new ResPath(path).ToRootedPath();
+            if (!loader.TrySaveMap(mapId, resPath))
+                throw new McpToolException("Map save failed (see server log).");
+
+            return (JsonNode) LifecycleTools.SaveResult(Ctx, resPath, exportPath);
+        });
+    }
+}
+
+public sealed class SaveGridTool(McpContext ctx) : McpTool(ctx)
+{
+    public override string Name => "save_grid";
+
+    public override string Description =>
+        "Saves a single grid to a YAML file in the server's user-data directory (see also save_map). " +
+        "Use for shuttles, inserts and other grid files.";
+
+    public override JsonObject Annotations => Annotate.Write(destructive: false, idempotent: true);
+
+    public override JsonObject InputSchema => Schema.Object(new JsonObject
+        {
+            ["grid"] = Schema.Int("Grid NetEntity id to save."),
+            ["path"] = Schema.String("User-data path for the yml, must start with '/' (e.g. '/mygrid.yml')."),
+            ["export_path"] = Schema.String("Optional absolute path to copy the saved file to."),
+        },
+        "grid", "path");
+
+    public override Task<JsonNode> ExecuteAsync(JsonObject args)
+    {
+        var gridNet = McpContext.GetInt(args, "grid");
+        var path = McpContext.GetString(args, "path");
+        var exportPath = McpContext.OptString(args, "export_path");
+
+        return Ctx.RunOnMainThread<JsonNode>(() =>
+        {
+            var loader = Ctx.EntityManager.System<MapLoaderSystem>();
+            var gridUid = Ctx.FromNetId(gridNet);
+            var resPath = new ResPath(path).ToRootedPath();
+            if (!loader.TrySaveGrid(gridUid, resPath))
+                throw new McpToolException("Grid save failed (is the entity actually a grid?).");
+
+            return (JsonNode) LifecycleTools.SaveResult(Ctx, resPath, exportPath);
+        });
+    }
+}
+
+public sealed class LoadMapTool(McpContext ctx) : McpTool(ctx)
+{
+    public override string Name => "load_map";
+
+    public override string Description =>
+        "Loads a map YAML file onto a NEW map (uninitialized and paused, ready for editing). The path is " +
+        "resolved against server resources (e.g. '/Maps/_RMC14/lv624.yml') or the user-data directory " +
+        "(earlier save_map output). Yaml uids are preserved for stable diffs.";
+
+    public override JsonObject Annotations => Annotate.Write(destructive: false, idempotent: false);
+
+    public override JsonObject InputSchema => Schema.Object(new JsonObject
+        {
+            ["path"] = Schema.String("Map file path, must start with '/'."),
+            ["map_id"] = Schema.Int("Specific map id to load onto (default: next free id)."),
+        },
+        "path");
+
+    public override Task<JsonNode> ExecuteAsync(JsonObject args)
+    {
+        var path = McpContext.GetString(args, "path");
+        var requestedId = McpContext.OptInt(args, "map_id");
+
+        return Ctx.RunOnMainThread<JsonNode>(() =>
+        {
+            var loader = Ctx.EntityManager.System<MapLoaderSystem>();
+            var resPath = new ResPath(path).ToRootedPath();
+            var options = new DeserializationOptions { StoreYamlUids = true };
+
+            Robust.Shared.GameObjects.Entity<Robust.Shared.Map.Components.MapComponent>? map;
+            HashSet<Robust.Shared.GameObjects.Entity<Robust.Shared.Map.Components.MapGridComponent>>? grids;
+            var loaded = requestedId is { } id
+                ? loader.TryLoadMapWithId(new MapId(id), resPath, out map, out grids, options)
+                : loader.TryLoadMap(resPath, out map, out grids, options);
+
+            if (!loaded || map == null)
+                throw new McpToolException($"Failed to load '{path}' (wrong path, or the file is a grid — use load_grid).");
+
+            var gridArray = new JsonArray();
+            foreach (var grid in grids!)
+            {
+                gridArray.Add(Ctx.ToNetId(grid.Owner));
+            }
+
+            return (JsonNode) new JsonObject
+            {
+                ["map_id"] = int.Parse(map.Value.Comp.MapId.ToString()),
+                ["map_entity"] = Ctx.ToNetId(map.Value.Owner),
+                ["grids"] = gridArray,
+            };
+        });
+    }
+}
+
+public sealed class LoadGridTool(McpContext ctx) : McpTool(ctx)
+{
+    public override string Name => "load_grid";
+
+    public override string Description =>
+        "Loads a grid YAML file onto an EXISTING map at an optional offset/rotation. " +
+        "Use for shuttles/inserts, or to compose maps from grid files.";
+
+    public override JsonObject Annotations => Annotate.Write(destructive: false, idempotent: false);
+
+    public override JsonObject InputSchema => Schema.Object(new JsonObject
+        {
+            ["map_id"] = Schema.Int("Target map id."),
+            ["path"] = Schema.String("Grid file path, must start with '/'."),
+            ["x"] = Schema.Number("World offset X (default 0)."),
+            ["y"] = Schema.Number("World offset Y (default 0)."),
+            ["rotation_deg"] = Schema.Number("Rotation in degrees (default 0)."),
+        },
+        "map_id", "path");
+
+    public override Task<JsonNode> ExecuteAsync(JsonObject args)
+    {
+        var mapId = new MapId(McpContext.GetInt(args, "map_id"));
+        var path = McpContext.GetString(args, "path");
+        var x = (float) (McpContext.OptDouble(args, "x") ?? 0);
+        var y = (float) (McpContext.OptDouble(args, "y") ?? 0);
+        var rotation = Angle.FromDegrees(McpContext.OptDouble(args, "rotation_deg") ?? 0);
+
+        return Ctx.RunOnMainThread<JsonNode>(() =>
+        {
+            var mapSystem = Ctx.EntityManager.System<SharedMapSystem>();
+            if (!mapSystem.MapExists(mapId))
+                throw new McpToolException($"Map {mapId} does not exist (create_map first).");
+
+            var loader = Ctx.EntityManager.System<MapLoaderSystem>();
+            var options = new DeserializationOptions { StoreYamlUids = true };
+            if (!loader.TryLoadGrid(mapId, new ResPath(path).ToRootedPath(), out var grid, options,
+                    new System.Numerics.Vector2(x, y), rotation))
+            {
+                throw new McpToolException($"Failed to load grid '{path}'.");
+            }
+
+            return (JsonNode) new JsonObject { ["grid"] = Ctx.ToNetId(grid.Value.Owner) };
+        });
+    }
+}
+
+public sealed class SetAmbientLightTool(McpContext ctx) : McpTool(ctx)
+{
+    public override string Name => "set_ambient_light";
+
+    public override string Description =>
+        "Sets a map's ambient light color (e.g. '#FFFFFF' full bright for editing, '#000000' darkness).";
+
+    public override JsonObject Annotations => Annotate.Write(destructive: false, idempotent: true);
+
+    public override JsonObject InputSchema => Schema.Object(new JsonObject
+        {
+            ["map_id"] = Schema.Int("Map id."),
+            ["color"] = Schema.String("Hex color, e.g. '#404040'."),
+        },
+        "map_id", "color");
+
+    public override Task<JsonNode> ExecuteAsync(JsonObject args)
+    {
+        var mapId = new MapId(McpContext.GetInt(args, "map_id"));
+        var colorHex = McpContext.GetString(args, "color");
+
+        return Ctx.RunOnMainThread<JsonNode>(() =>
+        {
+            if (!Color.TryParse(colorHex, out var color))
+                throw new McpToolException($"Cannot parse color '{colorHex}'.");
+
+            var mapSystem = Ctx.EntityManager.System<SharedMapSystem>();
+            if (!mapSystem.MapExists(mapId))
+                throw new McpToolException($"Map {mapId} does not exist.");
+
+            mapSystem.SetAmbientLight(mapId, color);
+            return (JsonNode) new JsonObject { ["set"] = true };
+        });
+    }
+}
+
+public sealed class MappingSessionTool(McpContext ctx) : McpTool(ctx)
+{
+    public override string Name => "mapping_session";
+
+    public override string Description =>
+        "Starts the full in-game mapping mode for a player, exactly like typing 'mapping' in their console: " +
+        "creates/loads the map paused, admin-ghosts the player, disables events, teleports them there, enables " +
+        "autosave and switches their client into the mapping editor UI. The player must be an admin " +
+        "(local host players are by default).";
+
+    public override JsonObject Annotations => Annotate.Write(destructive: false, idempotent: false);
+
+    public override JsonObject InputSchema => Schema.Object(new JsonObject
+    {
+        ["player"] = Schema.String("Player name (default: the only connected player)."),
+        ["map_id"] = Schema.Int("Map id to create or load onto (optional)."),
+        ["path"] = Schema.String("Map/grid file to load, e.g. '/Maps/_RMC14/lv624.yml' (optional)."),
+    });
+
+    public override Task<JsonNode> ExecuteAsync(JsonObject args)
+    {
+        var mapId = McpContext.OptInt(args, "map_id");
+        var path = McpContext.OptString(args, "path");
+        if (path != null && mapId == null)
+            throw new McpToolException("Loading a file requires an explicit map_id.");
+
+        return Ctx.RunOnMainThread<JsonNode>(() =>
+        {
+            var session = Ctx.ResolveSession(McpContext.OptString(args, "player"));
+            var command = "mapping";
+            if (mapId is { } id)
+                command += $" {id}";
+            if (path != null)
+                command += $" \"{path}\"";
+
+            var shell = new CapturingConsoleShell(Ctx.ConsoleHost, Ctx.Toolshed, session);
+            shell.ExecuteCommand(command);
+            return (JsonNode) new JsonObject
+            {
+                ["executed"] = command,
+                ["player"] = session.Name,
+                ["output"] = shell.Output,
+                ["had_errors"] = shell.HadErrors,
+            };
+        });
+    }
+}
+
+public static class LifecycleTools
+{
+    /// <summary>Builds the save result, optionally exporting the user-data file to an absolute path.</summary>
+    public static JsonObject SaveResult(McpContext ctx, ResPath resPath, string? exportPath)
+    {
+        var result = new JsonObject
+        {
+            ["saved"] = true,
+            ["user_data_path"] = resPath.ToString(),
+        };
+
+        if (exportPath == null)
+            return result;
+
+        if (!System.IO.Path.IsPathRooted(exportPath))
+            throw new McpToolException("export_path must be an absolute filesystem path.");
+
+        using var source = ctx.ResourceManager.UserData.OpenRead(resPath);
+        System.IO.Directory.CreateDirectory(System.IO.Path.GetDirectoryName(exportPath)!);
+        using var target = System.IO.File.Create(exportPath);
+        source.CopyTo(target);
+        result["exported_to"] = exportPath;
+        return result;
+    }
+}
+#endif

--- a/Content.Server/_RMC14/Mcp/Tools/MapReadTools.cs
+++ b/Content.Server/_RMC14/Mcp/Tools/MapReadTools.cs
@@ -1,0 +1,454 @@
+#if !FULL_RELEASE || RMC_MCP
+using System.Linq;
+using System.Text;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Content.Shared._RMC14.Areas;
+using Content.Shared.Maps;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+
+namespace Content.Server._RMC14.Mcp.Tools;
+
+public sealed class ListMapsTool(McpContext ctx) : McpTool(ctx)
+{
+    public override string Name => "list_maps";
+
+    public override string Description =>
+        "Lists all maps: numeric map id, name, whether the map is initialized (post-mapinit) and paused, " +
+        "and its grids. Maps being edited for saving must stay uninitialized and paused.";
+
+    public override JsonObject Annotations => Annotate.ReadOnly();
+
+    public override JsonObject InputSchema => Schema.Object(new JsonObject());
+
+    public override Task<JsonNode> ExecuteAsync(JsonObject args)
+    {
+        return Ctx.RunOnMainThread<JsonNode>(() =>
+        {
+            var mapSystem = Ctx.EntityManager.System<SharedMapSystem>();
+            var maps = new JsonArray();
+            foreach (var mapId in mapSystem.GetAllMapIds().OrderBy(m => m.GetHashCode()))
+            {
+                var grids = new JsonArray();
+                foreach (var grid in Ctx.MapManager.GetAllGrids(mapId))
+                {
+                    grids.Add(Ctx.ToNetId(grid.Owner));
+                }
+
+                var entry = new JsonObject
+                {
+                    ["map_id"] = int.Parse(mapId.ToString()),
+                    ["initialized"] = mapSystem.IsInitialized(mapId),
+                    ["paused"] = mapSystem.IsPaused(mapId),
+                    ["grids"] = grids,
+                };
+
+                if (mapSystem.TryGetMap(mapId, out var mapUid))
+                {
+                    entry["map_entity"] = Ctx.ToNetId(mapUid.Value);
+                    entry["name"] = Ctx.EntityManager.GetComponent<MetaDataComponent>(mapUid.Value).EntityName;
+                }
+
+                maps.Add(entry);
+            }
+
+            return new JsonObject { ["maps"] = maps };
+        });
+    }
+}
+
+public sealed class ListGridsTool(McpContext ctx) : McpTool(ctx)
+{
+    public override string Name => "list_grids";
+
+    public override string Description =>
+        "Lists grids (station structures) with their NetEntity id, name, map, world position, tile bounds and " +
+        "tile count. Grid ids are what read_tiles / set_tiles and console commands expect.";
+
+    public override JsonObject Annotations => Annotate.ReadOnly();
+
+    public override JsonObject InputSchema => Schema.Object(new JsonObject
+    {
+        ["map_id"] = Schema.Int("Only list grids on this map id (default: all maps)."),
+    });
+
+    public override Task<JsonNode> ExecuteAsync(JsonObject args)
+    {
+        var mapFilter = McpContext.OptMapId(args);
+
+        return Ctx.RunOnMainThread<JsonNode>(() =>
+        {
+            var mapSystem = Ctx.EntityManager.System<SharedMapSystem>();
+            var transformSystem = Ctx.EntityManager.System<SharedTransformSystem>();
+            var grids = new JsonArray();
+
+            var mapIds = mapFilter is { } m
+                ? new[] { new MapId(m) }
+                : mapSystem.GetAllMapIds().ToArray();
+
+            foreach (var mapId in mapIds)
+            {
+                foreach (var grid in Ctx.MapManager.GetAllGrids(mapId))
+                {
+                    var uid = grid.Owner;
+                    var tileCount = 0;
+                    // Compute bounds from the tiles themselves: LocalAABB is maintained by
+                    // physics and can stay zero on a paused/uninitialized map.
+                    var minX = int.MaxValue;
+                    var minY = int.MaxValue;
+                    var maxX = int.MinValue;
+                    var maxY = int.MinValue;
+                    var enumerator = mapSystem.GetAllTilesEnumerator(uid, grid.Comp);
+                    while (enumerator.MoveNext(out var tile))
+                    {
+                        tileCount++;
+                        var indices = tile!.Value.GridIndices;
+                        minX = Math.Min(minX, indices.X);
+                        minY = Math.Min(minY, indices.Y);
+                        maxX = Math.Max(maxX, indices.X);
+                        maxY = Math.Max(maxY, indices.Y);
+                    }
+
+                    var worldPos = transformSystem.GetWorldPosition(uid);
+                    grids.Add(new JsonObject
+                    {
+                        ["grid"] = Ctx.ToNetId(uid),
+                        ["name"] = Ctx.EntityManager.GetComponent<MetaDataComponent>(uid).EntityName,
+                        ["map_id"] = int.Parse(mapId.ToString()),
+                        ["world_x"] = MathF.Round(worldPos.X, 1),
+                        ["world_y"] = MathF.Round(worldPos.Y, 1),
+                        ["world_rotation_deg"] = Math.Round(transformSystem.GetWorldRotation(uid).Degrees, 1),
+                        ["tile_bounds"] = tileCount == 0
+                            ? "empty"
+                            : $"({minX},{minY})..({maxX},{maxY})",
+                        ["tile_count"] = tileCount,
+                    });
+                }
+            }
+
+            return new JsonObject { ["grids"] = grids };
+        });
+    }
+}
+
+public sealed class ReadTilesTool(McpContext ctx) : McpTool(ctx)
+{
+    private const int MaxArea = 60_000;
+
+    public override string Name => "read_tiles";
+
+    public override string Description =>
+        "Reads a rectangle of tiles from a grid as a character matrix with a legend (tile prototype ids). " +
+        "World-aligned: top row = north, left column = west. In absolute form x,y is the SOUTH-WEST corner; " +
+        "with 'relative' the player-offset tile is the CENTER of the rectangle.";
+
+    public override JsonObject Annotations => Annotate.ReadOnly();
+
+    public override JsonObject InputSchema => Schema.Object(new JsonObject
+    {
+        ["grid"] = Schema.Grid(),
+        ["x"] = Schema.Int("South-west corner tile X (absolute form)."),
+        ["y"] = Schema.Int("South-west corner tile Y (absolute form)."),
+        ["relative"] = Schema.Relative("the center of the rectangle"),
+        ["width"] = Schema.Int("Rectangle width in tiles (default 21)."),
+        ["height"] = Schema.Int("Rectangle height in tiles (default 21)."),
+    });
+
+    public override Task<JsonNode> ExecuteAsync(JsonObject args)
+    {
+        var width = McpContext.OptInt(args, "width") ?? 21;
+        var height = McpContext.OptInt(args, "height") ?? 21;
+        if (width < 1 || height < 1 || (long) width * height > MaxArea)
+            throw new McpToolException($"width/height must be positive with area <= {MaxArea}; split larger reads.");
+
+        return Ctx.RunOnMainThread<JsonNode>(() =>
+        {
+            var (gridUid, grid, anchor) = Ctx.ResolveTilePosition(args);
+            var corner = args.ContainsKey("relative")
+                ? anchor - new Vector2i(width / 2, height / 2)
+                : anchor;
+
+            var mapSystem = Ctx.EntityManager.System<SharedMapSystem>();
+            var legend = new McpLegend();
+            var rows = new JsonArray();
+
+            for (var y = corner.Y + height - 1; y >= corner.Y; y--)
+            {
+                var row = new StringBuilder(width);
+                for (var x = corner.X; x < corner.X + width; x++)
+                {
+                    var tileRef = mapSystem.GetTileRef(gridUid, grid, new Vector2i(x, y));
+                    row.Append(tileRef.Tile.IsEmpty ? '.' : legend.Get(TileTools.TileName(Ctx, tileRef.Tile.TypeId)));
+                }
+
+                rows.Add(row.ToString());
+            }
+
+            return new JsonObject
+            {
+                ["grid"] = Ctx.ToNetId(gridUid),
+                ["south_west_corner"] = new JsonObject { ["x"] = corner.X, ["y"] = corner.Y },
+                ["width"] = width,
+                ["height"] = height,
+                ["orientation"] = "world-aligned: top row = north, left column = west",
+                ["legend"] = legend.ToJson("empty (space)"),
+                ["rows"] = rows,
+            };
+        });
+    }
+}
+
+public sealed class FindTilesTool(McpContext ctx) : McpTool(ctx)
+{
+    private const int MaxArea = 60_000;
+
+    public override string Name => "find_tiles";
+
+    public override string Description =>
+        "Finds all tiles of the given tile prototype ids on a grid and returns their coordinates. " +
+        "Searches the whole grid by default; pass a rectangle (x,y south-west corner or relative center " +
+        "+ width/height) to clip the search.";
+
+    public override JsonObject Annotations => Annotate.ReadOnly();
+
+    public override JsonObject InputSchema => Schema.Object(new JsonObject
+        {
+            ["grid"] = Schema.Grid(),
+            ["tiles"] = Schema.Array("Tile prototype ids to look for (e.g. [\"FloorSteel\"]).", Schema.String("Tile prototype id.")),
+            ["x"] = Schema.Int("Rectangle south-west corner X (omit for whole grid)."),
+            ["y"] = Schema.Int("Rectangle south-west corner Y (omit for whole grid)."),
+            ["relative"] = Schema.Relative("the center of the rectangle"),
+            ["width"] = Schema.Int("Rectangle width in tiles (default 21 when a rectangle is used)."),
+            ["height"] = Schema.Int("Rectangle height in tiles (default 21 when a rectangle is used)."),
+            ["limit"] = Schema.Int("Max matches to return (default 500)."),
+        },
+        "tiles");
+
+    public override Task<JsonNode> ExecuteAsync(JsonObject args)
+    {
+        var limit = McpContext.OptInt(args, "limit") ?? 500;
+        if (args["tiles"] is not JsonArray tilesArg || tilesArg.Count == 0)
+            throw new McpToolException("'tiles' must be a non-empty array of tile prototype ids.");
+
+        var hasRect = args.ContainsKey("x") || args.ContainsKey("y") || args.ContainsKey("relative") ||
+                      args.ContainsKey("width") || args.ContainsKey("height");
+        var width = McpContext.OptInt(args, "width") ?? 21;
+        var height = McpContext.OptInt(args, "height") ?? 21;
+        if (hasRect && (width < 1 || height < 1 || (long) width * height > MaxArea))
+            throw new McpToolException($"width/height must be positive with area <= {MaxArea}.");
+
+        return Ctx.RunOnMainThread<JsonNode>(() =>
+        {
+            var targetIds = new HashSet<int>();
+            foreach (var node in tilesArg)
+            {
+                var name = node?.GetValue<string>() ?? throw new McpToolException("'tiles' entries must be strings.");
+                targetIds.Add(TileTools.ResolveTileDef(Ctx, name).TileId);
+            }
+
+            var mapSystem = Ctx.EntityManager.System<SharedMapSystem>();
+            var matches = new JsonArray();
+            var truncated = false;
+
+            EntityUid gridUid;
+            MapGridComponent grid;
+            var result = new JsonObject();
+
+            if (hasRect)
+            {
+                (gridUid, grid, var anchor) = Ctx.ResolveTilePosition(args);
+                var corner = args.ContainsKey("relative")
+                    ? anchor - new Vector2i(width / 2, height / 2)
+                    : anchor;
+                result["south_west_corner"] = new JsonObject { ["x"] = corner.X, ["y"] = corner.Y };
+
+                for (var y = corner.Y; y < corner.Y + height && !truncated; y++)
+                {
+                    for (var x = corner.X; x < corner.X + width; x++)
+                    {
+                        var tileRef = mapSystem.GetTileRef(gridUid, grid, new Vector2i(x, y));
+                        if (!targetIds.Contains(tileRef.Tile.TypeId))
+                            continue;
+                        if (matches.Count >= limit)
+                        {
+                            truncated = true;
+                            break;
+                        }
+
+                        matches.Add(new JsonObject
+                        {
+                            ["x"] = x,
+                            ["y"] = y,
+                            ["tile"] = TileTools.TileName(Ctx, tileRef.Tile.TypeId),
+                        });
+                    }
+                }
+            }
+            else
+            {
+                (gridUid, grid) = Ctx.ResolveGrid(args);
+                var enumerator = mapSystem.GetAllTilesEnumerator(gridUid, grid);
+                while (enumerator.MoveNext(out var tileRef))
+                {
+                    if (!targetIds.Contains(tileRef.Value.Tile.TypeId))
+                        continue;
+                    if (matches.Count >= limit)
+                    {
+                        truncated = true;
+                        break;
+                    }
+
+                    matches.Add(new JsonObject
+                    {
+                        ["x"] = tileRef.Value.GridIndices.X,
+                        ["y"] = tileRef.Value.GridIndices.Y,
+                        ["tile"] = TileTools.TileName(Ctx, tileRef.Value.Tile.TypeId),
+                    });
+                }
+            }
+
+            result["grid"] = Ctx.ToNetId(gridUid);
+            result["matches"] = matches;
+            result["truncated"] = truncated;
+            return (JsonNode) result;
+        });
+    }
+}
+
+public sealed class ReadAreasTool(McpContext ctx) : McpTool(ctx)
+{
+    private const int MaxArea = 60_000;
+
+    public override string Name => "read_areas";
+
+    public override string Description =>
+        "Reads the RMC-14 area assignment (AreaGridComponent) for a rectangle of tiles as a matrix with a legend " +
+        "of area prototype ids. Areas drive minimap labels, weather, mortar/CAS rules etc. " +
+        "format 'summary' returns per-area tile counts instead of a matrix — no legend symbol limit — and " +
+        "with no rectangle given it covers the WHOLE grid: the cheap way to list every area of a ship. " +
+        "Write assignments with paint_areas.";
+
+    public override JsonObject Annotations => Annotate.ReadOnly();
+
+    public override JsonObject InputSchema => Schema.Object(new JsonObject
+    {
+        ["grid"] = Schema.Grid(),
+        ["x"] = Schema.Int("South-west corner tile X (absolute form)."),
+        ["y"] = Schema.Int("South-west corner tile Y (absolute form)."),
+        ["relative"] = Schema.Relative("the center of the rectangle"),
+        ["width"] = Schema.Int("Rectangle width in tiles (default 21)."),
+        ["height"] = Schema.Int("Rectangle height in tiles (default 21)."),
+        ["format"] = Schema.String(
+            "'matrix' (default): character matrix + legend, at most 70 distinct areas per call. " +
+            "'summary': per-area tile counts without a matrix; omit the rectangle to cover the whole grid."),
+    });
+
+    public override Task<JsonNode> ExecuteAsync(JsonObject args)
+    {
+        var format = McpContext.OptString(args, "format") ?? "matrix";
+        if (format is not ("matrix" or "summary"))
+            throw new McpToolException("format must be 'matrix' or 'summary'.");
+
+        var summary = format == "summary";
+        var hasRect = args.ContainsKey("x") || args.ContainsKey("y") || args.ContainsKey("relative") ||
+                      args.ContainsKey("width") || args.ContainsKey("height");
+        var width = McpContext.OptInt(args, "width") ?? 21;
+        var height = McpContext.OptInt(args, "height") ?? 21;
+        // The area cap protects the per-tile matrix loop; summaries iterate the (bounded)
+        // area dictionary instead and need no cap.
+        if (!summary && (width < 1 || height < 1 || (long) width * height > MaxArea))
+            throw new McpToolException($"width/height must be positive with area <= {MaxArea}.");
+
+        return Ctx.RunOnMainThread<JsonNode>(() =>
+        {
+            var (gridUid, grid, anchor) = Ctx.ResolveTilePosition(args);
+            var corner = args.ContainsKey("relative")
+                ? anchor - new Vector2i(width / 2, height / 2)
+                : anchor;
+
+            if (!Ctx.EntityManager.TryGetComponent<AreaGridComponent>(gridUid, out var areaGrid))
+                throw new McpToolException("This grid has no AreaGridComponent (no RMC areas assigned yet — assign some with paint_areas).");
+
+            var areaSystem = Ctx.EntityManager.System<AreaSystem>();
+
+            if (summary)
+            {
+                var counts = areaSystem.GetAreaTileCounts(
+                    (gridUid, areaGrid),
+                    hasRect ? corner : null,
+                    hasRect ? new Vector2i(width, height) : null);
+
+                var areas = new JsonObject();
+                foreach (var (areaProto, count) in counts.OrderByDescending(kv => kv.Value))
+                {
+                    areas[areaProto.Id] = count;
+                }
+
+                var result = new JsonObject
+                {
+                    ["grid"] = Ctx.ToNetId(gridUid),
+                    ["format"] = "summary",
+                    ["distinct_areas"] = counts.Count,
+                    ["assigned_tiles"] = counts.Values.Sum(),
+                    ["areas"] = areas,
+                };
+                if (hasRect)
+                {
+                    result["south_west_corner"] = new JsonObject { ["x"] = corner.X, ["y"] = corner.Y };
+                    result["width"] = width;
+                    result["height"] = height;
+                }
+                else
+                {
+                    result["coverage"] = "whole grid";
+                }
+
+                return (JsonNode) result;
+            }
+            var legend = new McpLegend();
+            var rows = new JsonArray();
+            for (var y = corner.Y + height - 1; y >= corner.Y; y--)
+            {
+                var row = new StringBuilder(width);
+                for (var x = corner.X; x < corner.X + width; x++)
+                {
+                    // TryGetAreaProto, not TryGetArea: the latter needs area entities that only
+                    // spawn at map-init, and mapping sessions are pre-init by design.
+                    row.Append(areaSystem.TryGetAreaProto((gridUid, areaGrid), new Vector2i(x, y), out var areaProto)
+                        ? legend.Get(areaProto.Id)
+                        : '.');
+                }
+
+                rows.Add(row.ToString());
+            }
+
+            return new JsonObject
+            {
+                ["grid"] = Ctx.ToNetId(gridUid),
+                ["south_west_corner"] = new JsonObject { ["x"] = corner.X, ["y"] = corner.Y },
+                ["orientation"] = "world-aligned: top row = north, left column = west",
+                ["legend"] = legend.ToJson("no area"),
+                ["rows"] = rows,
+            };
+        });
+    }
+}
+
+/// <summary>Tile prototype helpers shared by tools.</summary>
+public static class TileTools
+{
+    public static string TileName(McpContext ctx, int typeId)
+    {
+        var def = ctx.TileDefinitionManager[typeId];
+        return def is ContentTileDefinition content ? content.ID : def.Name;
+    }
+
+    public static ContentTileDefinition ResolveTileDef(McpContext ctx, string id)
+    {
+        if (ctx.PrototypeManager.TryIndex<ContentTileDefinition>(id, out var def))
+            return def;
+        throw new McpToolException($"Unknown tile prototype '{id}' (see list_tile_prototypes).");
+    }
+}
+#endif

--- a/Content.Server/_RMC14/Mcp/Tools/MapWriteTools.cs
+++ b/Content.Server/_RMC14/Mcp/Tools/MapWriteTools.cs
@@ -1,0 +1,515 @@
+#if !FULL_RELEASE || RMC_MCP
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Content.Shared._RMC14.Areas;
+using Content.Shared.Maps;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._RMC14.Mcp.Tools;
+
+public sealed class SetTilesTool(McpContext ctx) : McpTool(ctx)
+{
+    private const int MaxArea = 60_000;
+    private static readonly Random Random = new();
+
+    public override string Name => "set_tiles";
+
+    public override string Description =>
+        "Sets tiles on a grid in one batch. Three forms: " +
+        "(1) 'tiles': explicit list of {x,y,tile}; " +
+        "(2) 'tile' + rectangle fill (x,y = south-west corner, or relative = center, width/height); " +
+        "(3) 'matrix': rows of legend characters, first row = NORTHMOST. IMPORTANT: x,y is the SOUTH-WEST " +
+        "corner of the matrix area (same convention as every other rectangle tool), so the FIRST row is " +
+        "painted at y + rowCount - 1 and the LAST row lands exactly at y. " +
+        "In the matrix, ' ' skips a cell and '.' means the Space tile unless the legend overrides it. " +
+        "Tile id 'Space' erases tiles. The result echoes south_west_corner and north_row_y - verify them. " +
+        "dry_run=true previews the write: same result plus a histogram of existing tiles that would be " +
+        "overwritten, without changing anything — use it to catch a misplaced anchor before painting.";
+
+    public override JsonObject Annotations => Annotate.Write(destructive: true, idempotent: true);
+
+    public override JsonObject InputSchema => Schema.Object(new JsonObject
+    {
+        ["grid"] = Schema.Grid(),
+        ["tiles"] = Schema.Array("Form 1: explicit tiles.", Schema.Object(new JsonObject
+            {
+                ["x"] = Schema.Int("Tile X."),
+                ["y"] = Schema.Int("Tile Y."),
+                ["tile"] = Schema.String("Tile prototype id."),
+            },
+            "x", "y", "tile")),
+        ["tile"] = Schema.String("Form 2: tile prototype id to fill the rectangle with."),
+        ["x"] = Schema.Int("SOUTH-WEST corner X of the rectangle or matrix area (absolute form)."),
+        ["y"] = Schema.Int("SOUTH-WEST corner Y of the rectangle or matrix area (absolute form; the matrix's LAST row lands here)."),
+        ["relative"] = Schema.Relative("the rectangle center / matrix center"),
+        ["width"] = Schema.Int("Form 2: fill width in tiles (default 1)."),
+        ["height"] = Schema.Int("Form 2: fill height in tiles (default 1)."),
+        ["matrix"] = Schema.Object(new JsonObject
+            {
+                ["legend"] = Schema.Object(new JsonObject()),
+                ["rows"] = Schema.Array("Rows of legend characters, first row = northmost.", Schema.String("Row string.")),
+            },
+            "rows"),
+        ["pick_variant"] = Schema.Bool("Randomize visual variants of placed tiles (default true, like variantize)."),
+        ["dry_run"] = Schema.Bool("Preview only: report what would change without applying (default false)."),
+    });
+
+    public override Task<JsonNode> ExecuteAsync(JsonObject args)
+    {
+        var pickVariant = McpContext.OptBool(args, "pick_variant", true);
+        var dryRun = McpContext.OptBool(args, "dry_run", false);
+
+        return Ctx.RunOnMainThread<JsonNode>(() =>
+        {
+            var changes = new List<(Vector2i GridIndices, Tile Tile)>();
+            EntityUid gridUid;
+            MapGridComponent grid;
+            Vector2i? reportCorner = null;
+            int? reportNorthY = null;
+
+            if (args.TryGetPropertyValue("tiles", out var tilesNode) && tilesNode is JsonArray tilesArray)
+            {
+                (gridUid, grid) = Ctx.ResolveGrid(args);
+                if (tilesArray.Count > MaxArea)
+                    throw new McpToolException($"Too many tiles ({tilesArray.Count} > {MaxArea}).");
+
+                foreach (var node in tilesArray)
+                {
+                    if (node is not JsonObject entry)
+                        throw new McpToolException("'tiles' entries must be objects {x, y, tile}.");
+                    var pos = new Vector2i(McpContext.GetInt(entry, "x"), McpContext.GetInt(entry, "y"));
+                    changes.Add((pos, MakeTile(McpContext.GetString(entry, "tile"), pickVariant)));
+                }
+            }
+            else if (args.TryGetPropertyValue("matrix", out var matrixNode) && matrixNode is JsonObject matrix)
+            {
+                if (matrix["rows"] is not JsonArray rows || rows.Count == 0)
+                    throw new McpToolException("matrix.rows must be a non-empty array of strings.");
+
+                var legend = new Dictionary<char, string>();
+                if (matrix.TryGetPropertyValue("legend", out var legendNode) && legendNode is JsonObject legendObj)
+                {
+                    foreach (var (key, value) in legendObj)
+                    {
+                        if (key.Length != 1 || value is not JsonValue v || !v.TryGetValue<string>(out var tileId))
+                            throw new McpToolException("matrix.legend must map single characters to tile ids.");
+                        legend[key[0]] = tileId;
+                    }
+                }
+
+                var height = rows.Count;
+                var width = 0;
+                var rowStrings = new List<string>(height);
+                foreach (var row in rows)
+                {
+                    var s = row?.GetValue<string>() ?? throw new McpToolException("matrix.rows entries must be strings.");
+                    width = Math.Max(width, s.Length);
+                    rowStrings.Add(s);
+                }
+
+                if ((long) width * height > MaxArea)
+                    throw new McpToolException($"Matrix area {width}x{height} exceeds {MaxArea}.");
+
+                Vector2i corner;
+                (gridUid, grid, var anchor) = Ctx.ResolveTilePosition(args);
+                corner = args.ContainsKey("relative")
+                    ? anchor - new Vector2i(width / 2, height / 2)
+                    : anchor;
+                reportCorner = corner;
+                reportNorthY = corner.Y + height - 1;
+
+                for (var rowIndex = 0; rowIndex < rowStrings.Count; rowIndex++)
+                {
+                    // First row is the northmost one.
+                    var y = corner.Y + height - 1 - rowIndex;
+                    var s = rowStrings[rowIndex];
+                    for (var i = 0; i < s.Length; i++)
+                    {
+                        var c = s[i];
+                        if (c == ' ')
+                            continue;
+
+                        string tileId;
+                        if (legend.TryGetValue(c, out var mapped))
+                            tileId = mapped;
+                        else if (c == '.')
+                            tileId = "Space";
+                        else
+                            throw new McpToolException($"Matrix character '{c}' is not in the legend.");
+
+                        changes.Add((new Vector2i(corner.X + i, y), MakeTile(tileId, pickVariant)));
+                    }
+                }
+            }
+            else if (McpContext.OptString(args, "tile") is { } fillTile)
+            {
+                var width = McpContext.OptInt(args, "width") ?? 1;
+                var height = McpContext.OptInt(args, "height") ?? 1;
+                if (width < 1 || height < 1 || (long) width * height > MaxArea)
+                    throw new McpToolException($"width/height must be positive with area <= {MaxArea}.");
+
+                (gridUid, grid, var anchor) = Ctx.ResolveTilePosition(args);
+                var corner = args.ContainsKey("relative")
+                    ? anchor - new Vector2i(width / 2, height / 2)
+                    : anchor;
+                reportCorner = corner;
+
+                for (var y = corner.Y; y < corner.Y + height; y++)
+                {
+                    for (var x = corner.X; x < corner.X + width; x++)
+                    {
+                        changes.Add((new Vector2i(x, y), MakeTile(fillTile, pickVariant)));
+                    }
+                }
+            }
+            else
+            {
+                throw new McpToolException("Provide one of: 'tiles', 'matrix', or 'tile' (+rectangle).");
+            }
+
+            var mapSystem = Ctx.EntityManager.System<SharedMapSystem>();
+
+            var result = new JsonObject
+            {
+                ["grid"] = Ctx.ToNetId(gridUid),
+                ["tiles_set"] = changes.Count,
+            };
+
+            if (reportCorner is { } rc)
+            {
+                result["south_west_corner"] = new JsonObject { ["x"] = rc.X, ["y"] = rc.Y };
+                if (reportNorthY is { } ny)
+                    result["north_row_y"] = ny;
+            }
+
+            if (dryRun)
+            {
+                // Histogram of existing non-empty tiles this write would replace with something
+                // else — an unexpected entry here usually means a misplaced anchor.
+                var overwrites = new Dictionary<string, int>();
+                foreach (var (pos, newTile) in changes)
+                {
+                    var current = mapSystem.GetTileRef(gridUid, grid, pos).Tile;
+                    if (current.IsEmpty || current.TypeId == newTile.TypeId)
+                        continue;
+                    var name = TileTools.TileName(Ctx, current.TypeId);
+                    overwrites[name] = overwrites.GetValueOrDefault(name) + 1;
+                }
+
+                var overwriteJson = new JsonObject();
+                foreach (var (name, count) in overwrites)
+                {
+                    overwriteJson[name] = count;
+                }
+
+                result["dry_run"] = true;
+                result["would_overwrite"] = overwriteJson;
+                return (JsonNode) result;
+            }
+
+            mapSystem.SetTiles(gridUid, grid, changes);
+            return (JsonNode) result;
+        });
+    }
+
+    private Tile MakeTile(string tileId, bool pickVariant)
+    {
+        var def = TileTools.ResolveTileDef(Ctx, tileId);
+        if (def.TileId == 0)
+            return Tile.Empty;
+
+        var variant = pickVariant && def.Variants > 1 ? (byte) Random.Next(def.Variants) : (byte) 0;
+        return new Tile(def.TileId, variant: variant);
+    }
+}
+
+public sealed class ReplaceTilesTool(McpContext ctx) : McpTool(ctx)
+{
+    private const int MaxArea = 60_000;
+    private static readonly Random Random = new();
+
+    public override string Name => "replace_tiles";
+
+    public override string Description =>
+        "Replaces every tile of the given type(s) with another tile, on the whole grid or inside a rectangle. " +
+        "Superset of the 'tilereplace' console command. dry_run=true reports the would-be replacement count " +
+        "without applying.";
+
+    public override JsonObject Annotations => Annotate.Write(destructive: true, idempotent: true);
+
+    public override JsonObject InputSchema => Schema.Object(new JsonObject
+        {
+            ["grid"] = Schema.Grid(),
+            ["from"] = Schema.Array("Tile prototype ids to replace.", Schema.String("Tile prototype id.")),
+            ["to"] = Schema.String("Replacement tile prototype id."),
+            ["x"] = Schema.Int("Optional rectangle south-west corner X."),
+            ["y"] = Schema.Int("Optional rectangle south-west corner Y."),
+            ["relative"] = Schema.Relative("the rectangle center"),
+            ["width"] = Schema.Int("Rectangle width (omit for whole grid)."),
+            ["height"] = Schema.Int("Rectangle height (omit for whole grid)."),
+            ["pick_variant"] = Schema.Bool("Randomize visual variants of placed tiles (default true)."),
+            ["dry_run"] = Schema.Bool("Preview only: report what would change without applying (default false)."),
+        },
+        "from", "to");
+
+    public override Task<JsonNode> ExecuteAsync(JsonObject args)
+    {
+        if (args["from"] is not JsonArray fromArray || fromArray.Count == 0)
+            throw new McpToolException("'from' must be a non-empty array of tile prototype ids.");
+        var to = McpContext.GetString(args, "to");
+        var pickVariant = McpContext.OptBool(args, "pick_variant", true);
+        var dryRun = McpContext.OptBool(args, "dry_run", false);
+        var width = McpContext.OptInt(args, "width");
+        var height = McpContext.OptInt(args, "height");
+
+        return Ctx.RunOnMainThread<JsonNode>(() =>
+        {
+            var fromIds = new HashSet<int>();
+            foreach (var node in fromArray)
+            {
+                var name = node?.GetValue<string>() ?? throw new McpToolException("'from' entries must be strings.");
+                fromIds.Add(TileTools.ResolveTileDef(Ctx, name).TileId);
+            }
+
+            var toDef = TileTools.ResolveTileDef(Ctx, to);
+            var mapSystem = Ctx.EntityManager.System<SharedMapSystem>();
+            var changes = new List<(Vector2i GridIndices, Tile Tile)>();
+
+            EntityUid gridUid;
+            MapGridComponent grid;
+            if (width != null || height != null)
+            {
+                var w = width ?? 1;
+                var h = height ?? 1;
+                if (w < 1 || h < 1 || (long) w * h > MaxArea)
+                    throw new McpToolException($"width/height must be positive with area <= {MaxArea}.");
+
+                (gridUid, grid, var anchor) = Ctx.ResolveTilePosition(args);
+                var corner = args.ContainsKey("relative")
+                    ? anchor - new Vector2i(w / 2, h / 2)
+                    : anchor;
+
+                for (var y = corner.Y; y < corner.Y + h; y++)
+                {
+                    for (var x = corner.X; x < corner.X + w; x++)
+                    {
+                        var pos = new Vector2i(x, y);
+                        var tileRef = mapSystem.GetTileRef(gridUid, grid, pos);
+                        if (fromIds.Contains(tileRef.Tile.TypeId))
+                            changes.Add((pos, MakeTile(toDef, pickVariant)));
+                    }
+                }
+            }
+            else
+            {
+                (gridUid, grid) = Ctx.ResolveGrid(args);
+                var enumerator = mapSystem.GetAllTilesEnumerator(gridUid, grid, ignoreEmpty: false);
+                while (enumerator.MoveNext(out var tileRef))
+                {
+                    if (fromIds.Contains(tileRef.Value.Tile.TypeId))
+                        changes.Add((tileRef.Value.GridIndices, MakeTile(toDef, pickVariant)));
+                }
+            }
+
+            if (!dryRun)
+                mapSystem.SetTiles(gridUid, grid, changes);
+
+            var result = new JsonObject
+            {
+                ["grid"] = Ctx.ToNetId(gridUid),
+                ["tiles_replaced"] = changes.Count,
+            };
+            if (dryRun)
+                result["dry_run"] = true;
+            return (JsonNode) result;
+        });
+    }
+
+    private static Tile MakeTile(ContentTileDefinition def, bool pickVariant)
+    {
+        if (def.TileId == 0)
+            return Tile.Empty;
+        var variant = pickVariant && def.Variants > 1 ? (byte) Random.Next(def.Variants) : (byte) 0;
+        return new Tile(def.TileId, variant: variant);
+    }
+}
+
+public sealed class PaintAreasTool(McpContext ctx) : McpTool(ctx)
+{
+    private const int MaxArea = 60_000;
+
+    public override string Name => "paint_areas";
+
+    public override string Description =>
+        "Assigns RMC-14 areas to tiles by writing the grid's AreaGridComponent directly — the per-grid, " +
+        "mapping-safe replacement for spawning area markers and running the global 'areas:save'. " +
+        "Two forms: rectangle ('area' + x,y south-west corner or relative center + width/height; " +
+        "'clear': true removes assignments instead) and 'matrix' (rows of legend characters, first row = " +
+        "NORTHMOST, x,y = SOUTH-WEST corner like set_tiles; ' ' skips a cell, '.' clears it). " +
+        "Area ids are entity prototypes with an Area component (find them with list_entity_prototypes, " +
+        "e.g. search 'CMArea' or 'RMCArea'). Works on uninitialized (mapping) maps; verify with read_areas.";
+
+    public override JsonObject Annotations => Annotate.Write(destructive: true, idempotent: true);
+
+    public override JsonObject InputSchema => Schema.Object(new JsonObject
+    {
+        ["grid"] = Schema.Grid(),
+        ["area"] = Schema.String("Rectangle form: area prototype id to assign."),
+        ["clear"] = Schema.Bool("Rectangle form: remove assignments instead of painting (default false)."),
+        ["x"] = Schema.Int("SOUTH-WEST corner X of the rectangle or matrix area (absolute form)."),
+        ["y"] = Schema.Int("SOUTH-WEST corner Y of the rectangle or matrix area (absolute form)."),
+        ["relative"] = Schema.Relative("the rectangle center / matrix center"),
+        ["width"] = Schema.Int("Rectangle width in tiles (default 1)."),
+        ["height"] = Schema.Int("Rectangle height in tiles (default 1)."),
+        ["matrix"] = Schema.Object(new JsonObject
+            {
+                ["legend"] = Schema.Object(new JsonObject()),
+                ["rows"] = Schema.Array("Rows of legend characters, first row = northmost.", Schema.String("Row string.")),
+            },
+            "rows"),
+    });
+
+    public override Task<JsonNode> ExecuteAsync(JsonObject args)
+    {
+        return Ctx.RunOnMainThread<JsonNode>(() =>
+        {
+            // Tile -> area proto id, null = clear the assignment.
+            var changes = new List<(Vector2i Tile, EntProtoId<AreaComponent>? Area)>();
+            EntityUid gridUid;
+            Vector2i corner;
+            int? reportNorthY = null;
+
+            if (args.TryGetPropertyValue("matrix", out var matrixNode) && matrixNode is JsonObject matrix)
+            {
+                if (matrix["rows"] is not JsonArray rows || rows.Count == 0)
+                    throw new McpToolException("matrix.rows must be a non-empty array of strings.");
+
+                var legend = new Dictionary<char, EntProtoId<AreaComponent>>();
+                if (matrix.TryGetPropertyValue("legend", out var legendNode) && legendNode is JsonObject legendObj)
+                {
+                    foreach (var (key, value) in legendObj)
+                    {
+                        if (key.Length != 1 || value is not JsonValue v || !v.TryGetValue<string>(out var areaId))
+                            throw new McpToolException("matrix.legend must map single characters to area prototype ids.");
+                        legend[key[0]] = ResolveAreaProto(areaId);
+                    }
+                }
+
+                var height = rows.Count;
+                var width = 0;
+                var rowStrings = new List<string>(height);
+                foreach (var row in rows)
+                {
+                    var s = row?.GetValue<string>() ?? throw new McpToolException("matrix.rows entries must be strings.");
+                    width = Math.Max(width, s.Length);
+                    rowStrings.Add(s);
+                }
+
+                if ((long) width * height > MaxArea)
+                    throw new McpToolException($"Matrix area {width}x{height} exceeds {MaxArea}.");
+
+                (gridUid, _, var anchor) = Ctx.ResolveTilePosition(args);
+                corner = args.ContainsKey("relative")
+                    ? anchor - new Vector2i(width / 2, height / 2)
+                    : anchor;
+                reportNorthY = corner.Y + height - 1;
+
+                for (var rowIndex = 0; rowIndex < rowStrings.Count; rowIndex++)
+                {
+                    // First row is the northmost one, same convention as set_tiles.
+                    var y = corner.Y + height - 1 - rowIndex;
+                    var s = rowStrings[rowIndex];
+                    for (var i = 0; i < s.Length; i++)
+                    {
+                        var c = s[i];
+                        if (c == ' ')
+                            continue;
+
+                        if (legend.TryGetValue(c, out var area))
+                            changes.Add((new Vector2i(corner.X + i, y), area));
+                        else if (c == '.')
+                            changes.Add((new Vector2i(corner.X + i, y), null));
+                        else
+                            throw new McpToolException($"Matrix character '{c}' is not in the legend.");
+                    }
+                }
+            }
+            else
+            {
+                var clear = McpContext.OptBool(args, "clear", false);
+                EntProtoId<AreaComponent>? area = null;
+                if (!clear)
+                {
+                    var areaId = McpContext.OptString(args, "area") ??
+                                 throw new McpToolException("Provide 'area' (or 'clear': true, or a 'matrix').");
+                    area = ResolveAreaProto(areaId);
+                }
+
+                var width = McpContext.OptInt(args, "width") ?? 1;
+                var height = McpContext.OptInt(args, "height") ?? 1;
+                if (width < 1 || height < 1 || (long) width * height > MaxArea)
+                    throw new McpToolException($"width/height must be positive with area <= {MaxArea}.");
+
+                (gridUid, _, var anchor) = Ctx.ResolveTilePosition(args);
+                corner = args.ContainsKey("relative")
+                    ? anchor - new Vector2i(width / 2, height / 2)
+                    : anchor;
+
+                for (var y = corner.Y; y < corner.Y + height; y++)
+                {
+                    for (var x = corner.X; x < corner.X + width; x++)
+                    {
+                        changes.Add((new Vector2i(x, y), area));
+                    }
+                }
+            }
+
+            var areaSystem = Ctx.EntityManager.System<AreaSystem>();
+            var areaGrid = Ctx.EntityManager.TryGetComponent<AreaGridComponent>(gridUid, out var existing)
+                ? existing
+                : null;
+            var painted = 0;
+            var cleared = 0;
+            foreach (var (tile, area) in changes)
+            {
+                areaSystem.SetAreaProto((gridUid, areaGrid), tile, area);
+                if (area == null)
+                    cleared++;
+                else
+                    painted++;
+            }
+
+            var result = new JsonObject
+            {
+                ["grid"] = Ctx.ToNetId(gridUid),
+                ["tiles_painted"] = painted,
+                ["tiles_cleared"] = cleared,
+                ["south_west_corner"] = new JsonObject { ["x"] = corner.X, ["y"] = corner.Y },
+            };
+            if (reportNorthY is { } ny)
+                result["north_row_y"] = ny;
+            return (JsonNode) result;
+        });
+    }
+
+    private EntProtoId<AreaComponent> ResolveAreaProto(string areaId)
+    {
+        if (!Ctx.PrototypeManager.TryIndex(areaId, out EntityPrototype? proto))
+        {
+            throw new McpToolException(
+                $"Unknown area prototype '{areaId}' (find area ids with list_entity_prototypes, e.g. search 'CMArea').");
+        }
+
+        if (!proto.TryGetComponent<AreaComponent>(out _, Ctx.EntityManager.ComponentFactory))
+        {
+            throw new McpToolException(
+                $"'{areaId}' is not an area prototype (it has no Area component). " +
+                "Find area ids with list_entity_prototypes, e.g. search 'CMArea'.");
+        }
+
+        return new EntProtoId<AreaComponent>(areaId);
+    }
+}
+#endif

--- a/Content.Server/_RMC14/Mcp/Tools/McpTool.cs
+++ b/Content.Server/_RMC14/Mcp/Tools/McpTool.cs
@@ -1,0 +1,113 @@
+#if !FULL_RELEASE || RMC_MCP
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+
+namespace Content.Server._RMC14.Mcp.Tools;
+
+/// <summary>
+/// Base class for MCP tools. Execution happens on a status-host worker thread;
+/// implementations must marshal all game state access via <see cref="McpContext.RunOnMainThread{T}"/>.
+/// </summary>
+public abstract class McpTool(McpContext ctx)
+{
+    protected readonly McpContext Ctx = ctx;
+
+    public abstract string Name { get; }
+    public abstract string Description { get; }
+    public abstract JsonObject InputSchema { get; }
+
+    /// <summary>
+    /// MCP tool annotations (untrusted behavior hints for clients). Defaults to the most
+    /// conservative write profile; read-only tools should override with <see cref="Annotate.ReadOnly"/>.
+    /// Must return a fresh instance per call — JsonNodes cannot be attached to two parents.
+    /// </summary>
+    public virtual JsonObject Annotations => Annotate.Write(destructive: true, idempotent: false);
+
+    /// <summary>Returns the tool result as JSON. Throw <see cref="McpToolException"/> for agent-facing errors.</summary>
+    public abstract Task<JsonNode> ExecuteAsync(JsonObject args);
+}
+
+/// <summary>Builders for MCP tool annotation objects. The game world is closed, so openWorldHint is always false.</summary>
+public static class Annotate
+{
+    public static JsonObject ReadOnly() => new()
+    {
+        ["readOnlyHint"] = true,
+        ["openWorldHint"] = false,
+    };
+
+    public static JsonObject Write(bool destructive, bool idempotent) => new()
+    {
+        ["readOnlyHint"] = false,
+        ["destructiveHint"] = destructive,
+        ["idempotentHint"] = idempotent,
+        ["openWorldHint"] = false,
+    };
+}
+
+/// <summary>Terse JSON Schema builders for tool input schemas.</summary>
+public static class Schema
+{
+    public static JsonObject Object(JsonObject properties, params string[] required)
+    {
+        var schema = new JsonObject
+        {
+            ["type"] = "object",
+            ["properties"] = properties,
+        };
+        if (required.Length > 0)
+        {
+            var arr = new JsonArray();
+            foreach (var name in required)
+            {
+                arr.Add(name);
+            }
+
+            schema["required"] = arr;
+        }
+
+        return schema;
+    }
+
+    public static JsonObject String(string description) =>
+        new() { ["type"] = "string", ["description"] = description };
+
+    public static JsonObject Enum(string description, params string[] values)
+    {
+        var arr = new JsonArray();
+        foreach (var v in values)
+        {
+            arr.Add(v);
+        }
+
+        return new JsonObject { ["type"] = "string", ["description"] = description, ["enum"] = arr };
+    }
+
+    public static JsonObject Int(string description) =>
+        new() { ["type"] = "integer", ["description"] = description };
+
+    public static JsonObject Number(string description) =>
+        new() { ["type"] = "number", ["description"] = description };
+
+    public static JsonObject Bool(string description) =>
+        new() { ["type"] = "boolean", ["description"] = description };
+
+    public static JsonObject Array(string description, JsonObject items) =>
+        new() { ["type"] = "array", ["description"] = description, ["items"] = items };
+
+    /// <summary>The standard optional relative-addressing parameter (offset from the player's tile).</summary>
+    public static JsonObject Relative(string what) => Object(new JsonObject
+    {
+        ["dx"] = Number($"Offset X from the player's tile for {what}."),
+        ["dy"] = Number($"Offset Y from the player's tile for {what}."),
+        ["frame"] = Enum("Coordinate frame: 'world' (default, +X east, +Y north) or 'screen' " +
+                         "(+X right on the player's screen, +Y up; respects current screen rotation).",
+            "world", "screen"),
+        ["player"] = String("Player name whose position is the origin (default: the only connected player)."),
+    });
+
+    /// <summary>The standard grid parameter.</summary>
+    public static JsonObject Grid() =>
+        Int("Grid NetEntity id (see list_grids). Default: the grid under the player.");
+}
+#endif

--- a/Content.Server/_RMC14/Mcp/Tools/PlayerTools.cs
+++ b/Content.Server/_RMC14/Mcp/Tools/PlayerTools.cs
@@ -1,0 +1,415 @@
+#if !FULL_RELEASE || RMC_MCP
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Content.Shared._RMC14.Areas;
+using Content.Shared.Ghost;
+using Content.Shared.Movement.Components;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+
+namespace Content.Server._RMC14.Mcp.Tools;
+
+public sealed class PlayerStatusTool(McpContext ctx) : McpTool(ctx)
+{
+    public override string Name => "player_status";
+
+    public override string Description =>
+        "Where each connected player is and how their screen is oriented: map, grid, world position, tile, " +
+        "screen rotation (which world direction is at the top of their screen), zoom and ghost state. " +
+        "Call this first to anchor all further work around the user.";
+
+    public override JsonObject Annotations => Annotate.ReadOnly();
+
+    public override JsonObject InputSchema => Schema.Object(new JsonObject());
+
+    public override Task<JsonNode> ExecuteAsync(JsonObject args)
+    {
+        return Ctx.RunOnMainThread<JsonNode>(() =>
+        {
+            var players = new JsonArray();
+            foreach (var session in Ctx.PlayerManager.Sessions)
+            {
+                var entry = new JsonObject { ["name"] = session.Name };
+                players.Add(entry);
+
+                if (session.AttachedEntity is not { } entity || !Ctx.EntityManager.EntityExists(entity))
+                {
+                    entry["attached"] = false;
+                    continue;
+                }
+
+                McpContext.PlayerFrame frame;
+                try
+                {
+                    frame = Ctx.GetPlayerFrame(session.Name);
+                }
+                catch (McpToolException e)
+                {
+                    entry["attached"] = false;
+                    entry["note"] = e.Message;
+                    continue;
+                }
+
+                entry["attached"] = true;
+                entry["entity"] = Ctx.ToNetId(entity);
+                entry["prototype"] = Ctx.EntityManager.GetComponent<MetaDataComponent>(entity).EntityPrototype?.ID;
+                entry["is_ghost"] = Ctx.EntityManager.HasComponent<GhostComponent>(entity);
+                entry["map"] = frame.MapId.ToString();
+                entry["grid"] = frame.GridUid is { } grid ? Ctx.ToNetId(grid) : null;
+                entry["world_x"] = MathF.Round(frame.WorldPos.X, 2);
+                entry["world_y"] = MathF.Round(frame.WorldPos.Y, 2);
+                if (frame.TilePos is { } tile)
+                {
+                    entry["tile_x"] = tile.X;
+                    entry["tile_y"] = tile.Y;
+                }
+
+                entry["screen_rotation_deg"] = Math.Round(frame.EyeRotation.Degrees, 1);
+                entry["screen_up_points"] = McpContext.Compass(frame.ScreenUp);
+                entry["screen_right_points"] = McpContext.Compass(frame.ScreenRight);
+                if (Ctx.EntityManager.TryGetComponent<ContentEyeComponent>(entity, out var eye))
+                    entry["zoom"] = MathF.Round(eye.TargetZoom.X, 2);
+            }
+
+            return new JsonObject { ["players"] = players };
+        });
+    }
+}
+
+public sealed class TeleportPlayerTool(McpContext ctx) : McpTool(ctx)
+{
+    public override string Name => "teleport_player";
+
+    public override string Description =>
+        "Teleports a player: to a tile on a grid (absolute x/y or relative to their current position, " +
+        "including in their screen frame — 'relative': {dx, dy, frame: \"screen\"}), or to world coordinates " +
+        "on a map (map_id + world_x/world_y; lands on a grid there if one exists). Useful for moving your " +
+        "admin-ghost around while surveying a map.";
+
+    public override JsonObject Annotations => Annotate.Write(destructive: false, idempotent: true);
+
+    public override JsonObject InputSchema => Schema.Object(new JsonObject
+    {
+        ["player"] = Schema.String("Player name (default: the only connected player)."),
+        ["grid"] = Schema.Grid(),
+        ["x"] = Schema.Int("Target tile X (absolute form)."),
+        ["y"] = Schema.Int("Target tile Y (absolute form)."),
+        ["relative"] = Schema.Relative("the destination tile"),
+        ["map_id"] = Schema.Int("Map id (world-coordinates form)."),
+        ["world_x"] = Schema.Number("World X (world-coordinates form)."),
+        ["world_y"] = Schema.Number("World Y (world-coordinates form)."),
+    });
+
+    public override Task<JsonNode> ExecuteAsync(JsonObject args)
+    {
+        var mapArg = McpContext.OptMapId(args);
+        var worldX = McpContext.OptDouble(args, "world_x");
+        var worldY = McpContext.OptDouble(args, "world_y");
+
+        return Ctx.RunOnMainThread<JsonNode>(() =>
+        {
+            var session = Ctx.ResolveSession(McpContext.OptString(args, "player"));
+            if (session.AttachedEntity is not { } entity || !Ctx.EntityManager.EntityExists(entity))
+            {
+                throw new McpToolException(
+                    $"Player '{session.Name}' has no attached entity (still in the lobby, or between bodies). " +
+                    "Attach one first: run_command 'observe' then 'aghost' in the player's context.");
+            }
+
+            var transformSystem = Ctx.EntityManager.System<SharedTransformSystem>();
+            var mapSystem = Ctx.EntityManager.System<SharedMapSystem>();
+
+            EntityCoordinates target;
+            if (mapArg is { } mapIdRaw && worldX is { } wx && worldY is { } wy)
+            {
+                var mapId = new MapId(mapIdRaw);
+                if (!mapSystem.TryGetMap(mapId, out var mapUid))
+                    throw new McpToolException($"Map {mapIdRaw} does not exist.");
+
+                var worldPos = new Vector2((float) wx, (float) wy);
+                // Land on the grid at that point, if any — same behavior as the tp command.
+                if (Ctx.MapManager.TryFindGridAt(mapId, worldPos, out var gridUid, out var grid))
+                    target = new EntityCoordinates(gridUid, mapSystem.WorldToLocal(gridUid, grid, worldPos));
+                else
+                    target = new EntityCoordinates(mapUid.Value, worldPos);
+            }
+            else
+            {
+                var (gridUid, grid, tile) = Ctx.ResolveTilePosition(args);
+                target = mapSystem.GridTileToLocal(gridUid, grid, tile);
+            }
+
+            transformSystem.SetCoordinates(entity, target);
+
+            var frame = Ctx.GetPlayerFrame(session.Name);
+            return (JsonNode) new JsonObject
+            {
+                ["player"] = session.Name,
+                ["map"] = frame.MapId.ToString(),
+                ["grid"] = frame.GridUid is { } g ? Ctx.ToNetId(g) : null,
+                ["tile_x"] = frame.TilePos?.X,
+                ["tile_y"] = frame.TilePos?.Y,
+                ["world_x"] = MathF.Round(frame.WorldPos.X, 2),
+                ["world_y"] = MathF.Round(frame.WorldPos.Y, 2),
+            };
+        });
+    }
+}
+
+public sealed class LookAroundTool(McpContext ctx) : McpTool(ctx)
+{
+    private const int MaxRadius = 32;
+
+    public override string Name => "look_around";
+
+    public override string Description =>
+        "Snapshot of the area around a player, oriented the way the PLAYER SEES IT: character matrices of tiles " +
+        "and anchored entities (top row = top of the player's screen, player marked '@'), plus nearby " +
+        "unanchored entities, decal count and RMC area names. This is the main tool for working where the user is. " +
+        "CAUTION: an entity-matrix cell shows only the tile's highest-priority anchored entity — everything it " +
+        "hides is returned in 'stacked' (\"x,y\" -> prototypes, WORLD tile coords), cables/pipes in the separate " +
+        "'subfloor' matrix, and the player's own tile stack in 'under_player'.";
+
+    public override JsonObject Annotations => Annotate.ReadOnly();
+
+    public override JsonObject InputSchema => Schema.Object(new JsonObject
+    {
+        ["player"] = Schema.String("Player name (default: the only connected player)."),
+        ["radius"] = Schema.Int($"Half-size of the square in tiles, 1-{MaxRadius} (default 12)."),
+        ["format"] = Schema.Enum(
+            "Entity-matrix cell format: 'compact' (default, one char per tile) or 'wide' (two chars per cell, " +
+            "space-separated: entity symbol + digit count of hidden entities, '.' if none).",
+            "compact", "wide"),
+        ["layers"] = Schema.Array(
+            "Entity-matrix layers to return: 'main' (walls, doors, furniture...) and/or 'subfloor' " +
+            "(cables, pipes). Default: both.",
+            Schema.Enum("Layer name.", "main", "subfloor")),
+    });
+
+    public override Task<JsonNode> ExecuteAsync(JsonObject args)
+    {
+        var radius = McpContext.OptInt(args, "radius") ?? 12;
+        if (radius is < 1 or > MaxRadius)
+            throw new McpToolException($"radius must be between 1 and {MaxRadius}.");
+
+        return Ctx.RunOnMainThread<JsonNode>(() =>
+        {
+            var frame = Ctx.GetPlayerFrame(McpContext.OptString(args, "player"));
+            var result = new JsonObject
+            {
+                ["player"] = frame.Session.Name,
+                ["map"] = frame.MapId.ToString(),
+                ["grid"] = frame.GridUid is { } g ? Ctx.ToNetId(g) : null,
+                ["player_tile"] = frame.TilePos is { } t ? new JsonObject { ["x"] = t.X, ["y"] = t.Y } : null,
+                ["screen_up_points"] = McpContext.Compass(frame.ScreenUp),
+                ["screen_right_points"] = McpContext.Compass(frame.ScreenRight),
+                ["matrix_note"] =
+                    "Matrices are in SCREEN space: top row = top of the player's screen, left column = left of " +
+                    "their screen. '@' = player, '.' = empty, ' ' = off-grid. Use relative:{frame:'screen'} " +
+                    "offsets to edit what you see here.",
+            };
+
+            if (frame.GridUid is not { } gridUid ||
+                frame.TilePos is not { } playerTile ||
+                !Ctx.EntityManager.TryGetComponent<MapGridComponent>(gridUid, out var grid))
+            {
+                result["note"] = "Player is not standing on a grid; only nearby entities are listed.";
+                result["entities"] = NearbyEntities(frame, radius, out _);
+                return result;
+            }
+
+            var wide = (McpContext.OptString(args, "format") ?? "compact") == "wide";
+            var (wantMain, wantSub) = McpEntityMatrix.ParseLayers(args);
+            var mapSystem = Ctx.EntityManager.System<SharedMapSystem>();
+            var tileLegend = new McpLegend();
+            var entityLegend = new McpLegend();
+            var subLegend = new McpLegend();
+            var tileRows = new JsonArray();
+            var entityRows = new JsonArray();
+            var subRows = new JsonArray();
+            var stacked = new JsonObject();
+            var anySub = false;
+            JsonArray? underPlayer = null;
+
+            for (var sy = radius; sy >= -radius; sy--)
+            {
+                var tileRow = new StringBuilder();
+                var entityRow = new StringBuilder();
+                var subRow = new StringBuilder();
+                for (var sx = -radius; sx <= radius; sx++)
+                {
+                    // Rotate the screen-space offset into world space so the matrix matches the screen.
+                    var offset = frame.EyeRotation.RotateVec(new Vector2(sx, sy));
+                    var tile = playerTile + new Vector2i((int) MathF.Round(offset.X), (int) MathF.Round(offset.Y));
+
+                    var tileRef = mapSystem.GetTileRef(gridUid, grid, tile);
+                    tileRow.Append(tileRef.Tile.IsEmpty ? '.' : tileLegend.Get(TileName(tileRef.Tile.TypeId)));
+
+                    var cell = McpEntityMatrix.Collect(Ctx.EntityManager, mapSystem, gridUid, grid, tile);
+
+                    if (tile == playerTile)
+                    {
+                        McpEntityMatrix.AppendCell(entityRow, '@', 0, wide);
+                        McpEntityMatrix.AppendCell(subRow, '@', 0, wide);
+                        if (!cell.IsEmpty)
+                        {
+                            underPlayer = new JsonArray(
+                                (cell.Main ?? []).Concat(cell.Sub ?? []).Select(p => (JsonNode) p).ToArray());
+                        }
+
+                        continue;
+                    }
+
+                    var mainHidden = wantMain && cell.Main is { Count: > 1 } ? cell.Main.Count - 1 : 0;
+                    var subHidden = wantSub && cell.Sub is { Count: > 1 } ? cell.Sub.Count - 1 : 0;
+                    McpEntityMatrix.AddStacked(stacked, tile, cell, wantMain, wantSub);
+
+                    if (wantMain)
+                    {
+                        McpEntityMatrix.AppendCell(entityRow,
+                            cell.Main is { Count: > 0 } ? entityLegend.Get(cell.Main[0]) : '.', mainHidden, wide);
+                    }
+
+                    if (wantSub)
+                    {
+                        anySub |= cell.Sub is { Count: > 0 };
+                        McpEntityMatrix.AppendCell(subRow,
+                            cell.Sub is { Count: > 0 } ? subLegend.Get(cell.Sub[0]) : '.', subHidden, wide);
+                    }
+                }
+
+                tileRows.Add(tileRow.ToString());
+                if (wantMain)
+                    entityRows.Add(entityRow.ToString());
+                if (wantSub)
+                    subRows.Add(subRow.ToString());
+            }
+
+            result["tiles"] = new JsonObject
+            {
+                ["legend"] = tileLegend.ToJson("empty (space)"),
+                ["rows"] = tileRows,
+            };
+            if (wantMain)
+            {
+                result["anchored_entities"] = new JsonObject
+                {
+                    ["legend"] = entityLegend.ToJson("no anchored entity"),
+                    ["rows"] = entityRows,
+                };
+            }
+
+            if (wantSub && anySub)
+            {
+                result["subfloor"] = new JsonObject
+                {
+                    ["legend"] = subLegend.ToJson("no subfloor entity"),
+                    ["rows"] = subRows,
+                };
+            }
+
+            if (stacked.Count > 0)
+                result["stacked"] = stacked;
+            if (underPlayer != null)
+                result["under_player"] = underPlayer;
+
+            result["entities"] = NearbyEntities(frame, radius, out var truncated);
+            if (truncated)
+                result["entities_truncated"] = true;
+
+            // Decals within the radius.
+            var decalSystem = Ctx.EntityManager.System<Content.Server.Decals.DecalSystem>();
+            var localPlayer = mapSystem.WorldToLocal(gridUid, grid, frame.WorldPos);
+            var decals = decalSystem.GetDecalsInRange(gridUid, localPlayer, radius);
+            result["decal_count"] = decals.Count;
+
+            // RMC areas within the square.
+            if (Ctx.EntityManager.TryGetComponent<AreaGridComponent>(gridUid, out var areaGrid))
+            {
+                var areaSystem = Ctx.EntityManager.System<AreaSystem>();
+                var areaCounts = new Dictionary<string, int>();
+                for (var dy = -radius; dy <= radius; dy++)
+                {
+                    for (var dx = -radius; dx <= radius; dx++)
+                    {
+                        // TryGetAreaProto, not TryGetArea: the latter needs area entities that only
+                        // spawn at map-init, and mapping sessions are pre-init by design.
+                        if (areaSystem.TryGetAreaProto((gridUid, areaGrid), playerTile + new Vector2i(dx, dy), out var areaProto))
+                        {
+                            areaCounts[areaProto.Id] = areaCounts.GetValueOrDefault(areaProto.Id) + 1;
+                        }
+                    }
+                }
+
+                var areas = new JsonObject();
+                foreach (var (proto, count) in areaCounts.OrderByDescending(kv => kv.Value))
+                {
+                    areas[proto] = count;
+                }
+
+                result["areas_tile_counts"] = areas;
+            }
+
+            return result;
+        });
+    }
+
+    private string TileName(int typeId)
+    {
+        var def = Ctx.TileDefinitionManager[typeId];
+        return def is Content.Shared.Maps.ContentTileDefinition content ? content.ID : def.Name;
+    }
+
+    private JsonArray NearbyEntities(McpContext.PlayerFrame frame, int radius, out bool truncated)
+    {
+        const int maxGroups = 50;
+        truncated = false;
+
+        var lookup = Ctx.EntityManager.System<EntityLookupSystem>();
+        var coords = Ctx.EntityManager.GetComponent<TransformComponent>(frame.Entity).Coordinates;
+        var groups = new Dictionary<string, (int Count, EntityUid Sample)>();
+
+        foreach (var uid in lookup.GetEntitiesInRange(coords, radius))
+        {
+            if (uid == frame.Entity)
+                continue;
+            var meta = Ctx.EntityManager.GetComponent<MetaDataComponent>(uid);
+            // Anchored entities are already visible in the matrix; list the loose ones.
+            if (Ctx.EntityManager.GetComponent<TransformComponent>(uid).Anchored)
+                continue;
+            if (meta.EntityPrototype?.ID is not { } proto)
+                continue;
+
+            groups[proto] = groups.TryGetValue(proto, out var existing)
+                ? (existing.Count + 1, existing.Sample)
+                : (1, uid);
+        }
+
+        var transformSystem = Ctx.EntityManager.System<SharedTransformSystem>();
+        var array = new JsonArray();
+        foreach (var (proto, (count, sample)) in groups.OrderByDescending(kv => kv.Value.Count))
+        {
+            if (array.Count >= maxGroups)
+            {
+                truncated = true;
+                break;
+            }
+
+            var samplePos = transformSystem.GetWorldPosition(sample);
+            var delta = samplePos - frame.WorldPos;
+            array.Add(new JsonObject
+            {
+                ["prototype"] = proto,
+                ["count"] = count,
+                ["sample_entity"] = Ctx.ToNetId(sample),
+                ["sample_from_player"] = $"{delta.Length():0.#} tiles {McpContext.Compass(delta)}",
+            });
+        }
+
+        return array;
+    }
+}
+#endif

--- a/Content.Server/_RMC14/Mcp/Tools/PrototypeTools.cs
+++ b/Content.Server/_RMC14/Mcp/Tools/PrototypeTools.cs
@@ -1,0 +1,186 @@
+#if !FULL_RELEASE || RMC_MCP
+using System.Linq;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Content.Shared.Decals;
+using Content.Shared.Maps;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._RMC14.Mcp.Tools;
+
+public sealed class ListEntityPrototypesTool(McpContext ctx) : McpTool(ctx)
+{
+    public override string Name => "list_entity_prototypes";
+
+    public override string Description =>
+        "Searches spawnable entity prototypes by id/name/editor-suffix substring — the same catalogue the " +
+        "sandbox entity spawn window shows. Returns prototype id (what spawn_entity expects), name and suffix.";
+
+    public override JsonObject Annotations => Annotate.ReadOnly();
+
+    public override JsonObject InputSchema => Schema.Object(new JsonObject
+        {
+            ["search"] = Schema.String("Case-insensitive substring of the prototype id, name or editor suffix."),
+            ["limit"] = Schema.Int("Max entries (default 50)."),
+        },
+        "search");
+
+    public override Task<JsonNode> ExecuteAsync(JsonObject args)
+    {
+        var search = McpContext.GetString(args, "search");
+        var limit = McpContext.OptInt(args, "limit") ?? 50;
+
+        return Ctx.RunOnMainThread<JsonNode>(() =>
+        {
+            var matches = new JsonArray();
+            var total = 0;
+            foreach (var proto in Ctx.PrototypeManager.EnumeratePrototypes<EntityPrototype>()
+                         .OrderBy(p => p.ID, StringComparer.OrdinalIgnoreCase))
+            {
+                if (proto.Abstract || proto.HideSpawnMenu)
+                    continue;
+                if (!proto.ID.Contains(search, StringComparison.OrdinalIgnoreCase) &&
+                    !proto.Name.Contains(search, StringComparison.OrdinalIgnoreCase) &&
+                    (proto.EditorSuffix?.Contains(search, StringComparison.OrdinalIgnoreCase) != true))
+                {
+                    continue;
+                }
+
+                total++;
+                if (matches.Count >= limit)
+                    continue;
+
+                matches.Add(new JsonObject
+                {
+                    ["id"] = proto.ID,
+                    ["name"] = proto.Name,
+                    ["suffix"] = proto.EditorSuffix,
+                });
+            }
+
+            return new JsonObject
+            {
+                ["total_matches"] = total,
+                ["prototypes"] = matches,
+                ["truncated"] = total > matches.Count,
+            };
+        });
+    }
+}
+
+public sealed class ListTilePrototypesTool(McpContext ctx) : McpTool(ctx)
+{
+    public override string Name => "list_tile_prototypes";
+
+    public override string Description =>
+        "Searches tile prototypes (floors, plating, space) by id/name substring — what read_tiles legends and " +
+        "set_tiles use. Empty search lists everything.";
+
+    public override JsonObject Annotations => Annotate.ReadOnly();
+
+    public override JsonObject InputSchema => Schema.Object(new JsonObject
+    {
+        ["search"] = Schema.String("Case-insensitive substring of the tile prototype id or name (default: all)."),
+        ["limit"] = Schema.Int("Max entries (default 100)."),
+    });
+
+    public override Task<JsonNode> ExecuteAsync(JsonObject args)
+    {
+        var search = McpContext.OptString(args, "search") ?? "";
+        var limit = McpContext.OptInt(args, "limit") ?? 100;
+
+        return Ctx.RunOnMainThread<JsonNode>(() =>
+        {
+            var matches = new JsonArray();
+            var total = 0;
+            foreach (var proto in Ctx.PrototypeManager.EnumeratePrototypes<ContentTileDefinition>()
+                         .OrderBy(p => p.ID, StringComparer.OrdinalIgnoreCase))
+            {
+                var locName = Loc.GetString(proto.Name);
+                if (search.Length != 0 &&
+                    !proto.ID.Contains(search, StringComparison.OrdinalIgnoreCase) &&
+                    !locName.Contains(search, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                total++;
+                if (matches.Count >= limit)
+                    continue;
+
+                matches.Add(new JsonObject
+                {
+                    ["id"] = proto.ID,
+                    ["name"] = locName,
+                    ["variants"] = proto.Variants,
+                });
+            }
+
+            return new JsonObject
+            {
+                ["total_matches"] = total,
+                ["tiles"] = matches,
+                ["truncated"] = total > matches.Count,
+            };
+        });
+    }
+}
+
+public sealed class ListDecalPrototypesTool(McpContext ctx) : McpTool(ctx)
+{
+    public override string Name => "list_decal_prototypes";
+
+    public override string Description =>
+        "Searches decal prototypes (floor markings, dirt, warning stripes...) by id or tag substring — " +
+        "what add_decal expects.";
+
+    public override JsonObject Annotations => Annotate.ReadOnly();
+
+    public override JsonObject InputSchema => Schema.Object(new JsonObject
+    {
+        ["search"] = Schema.String("Case-insensitive substring of the decal id or its tags (default: all)."),
+        ["limit"] = Schema.Int("Max entries (default 100)."),
+    });
+
+    public override Task<JsonNode> ExecuteAsync(JsonObject args)
+    {
+        var search = McpContext.OptString(args, "search") ?? "";
+        var limit = McpContext.OptInt(args, "limit") ?? 100;
+
+        return Ctx.RunOnMainThread<JsonNode>(() =>
+        {
+            var matches = new JsonArray();
+            var total = 0;
+            foreach (var proto in Ctx.PrototypeManager.EnumeratePrototypes<DecalPrototype>()
+                         .OrderBy(p => p.ID, StringComparer.OrdinalIgnoreCase))
+            {
+                if (proto.Abstract || !proto.ShowMenu)
+                    continue;
+                if (search.Length != 0 &&
+                    !proto.ID.Contains(search, StringComparison.OrdinalIgnoreCase) &&
+                    !proto.Tags.Any(t => t.Contains(search, StringComparison.OrdinalIgnoreCase)))
+                {
+                    continue;
+                }
+
+                total++;
+                if (matches.Count >= limit)
+                    continue;
+
+                matches.Add(new JsonObject
+                {
+                    ["id"] = proto.ID,
+                    ["tags"] = string.Join(",", proto.Tags),
+                });
+            }
+
+            return new JsonObject
+            {
+                ["total_matches"] = total,
+                ["decals"] = matches,
+                ["truncated"] = total > matches.Count,
+            };
+        });
+    }
+}
+#endif

--- a/Content.Shared/_RMC14/Areas/AreaSystem.cs
+++ b/Content.Shared/_RMC14/Areas/AreaSystem.cs
@@ -128,6 +128,30 @@ public sealed class AreaSystem : EntitySystem
         EnsureAreaEntityExists(areaGrid, area);
     }
 
+    /// <summary>
+    /// Writes or clears (area = null) one tile's area assignment straight into the grid's dictionary.
+    /// Unlike area markers + areas:save this is per-grid and works on uninitialized (mapping) grids,
+    /// where per-area entities must not exist yet; on initialized grids the area entity is ensured
+    /// like in ReplaceArea.
+    /// </summary>
+    public void SetAreaProto(Entity<AreaGridComponent?> grid, Vector2i position, EntProtoId<AreaComponent>? area)
+    {
+        grid.Comp ??= EnsureComp<AreaGridComponent>(grid);
+
+        if (area is { } proto)
+        {
+            grid.Comp.Areas[position] = proto;
+            if (MetaData(grid).EntityLifeStage >= EntityLifeStage.MapInitialized)
+                EnsureAreaEntityExists(grid.Comp, proto);
+        }
+        else if (!grid.Comp.Areas.Remove(position))
+        {
+            return;
+        }
+
+        Dirty(grid.Owner, grid.Comp);
+    }
+
     public bool SetAlwaysPowered(Entity<AreaComponent> area, bool alwaysPowered)
     {
         if (area.Comp.AlwaysPowered == alwaysPowered)
@@ -197,6 +221,43 @@ public sealed class AreaSystem : EntitySystem
         [NotNullWhen(true)] out EntityPrototype? areaPrototype)
     {
         return TryGetArea(coordinates.ToCoordinates(), out area, out areaPrototype);
+    }
+
+    /// <summary>
+    /// Reads a tile's area assignment straight from the grid's dictionary. Unlike TryGetArea this
+    /// works on uninitialized (mapping) grids, where the per-area entities don't exist yet.
+    /// </summary>
+    public bool TryGetAreaProto(Entity<AreaGridComponent?> grid, Vector2i indices, out EntProtoId<AreaComponent> areaProto)
+    {
+        areaProto = default;
+        return Resolve(grid, ref grid.Comp, false) && grid.Comp.Areas.TryGetValue(indices, out areaProto);
+    }
+
+    /// <summary>
+    /// Counts the assigned tiles of every area on a grid, optionally clipped to a rectangle
+    /// (south-west corner + size). Like TryGetAreaProto this works on uninitialized (mapping) grids.
+    /// </summary>
+    public Dictionary<EntProtoId<AreaComponent>, int> GetAreaTileCounts(
+        Entity<AreaGridComponent?> grid,
+        Vector2i? corner = null,
+        Vector2i? size = null)
+    {
+        var counts = new Dictionary<EntProtoId<AreaComponent>, int>();
+        if (!Resolve(grid, ref grid.Comp, false))
+            return counts;
+
+        foreach (var (indices, areaProto) in grid.Comp.Areas)
+        {
+            if (corner is { } c && size is { } s &&
+                (indices.X < c.X || indices.X >= c.X + s.X || indices.Y < c.Y || indices.Y >= c.Y + s.Y))
+            {
+                continue;
+            }
+
+            counts[areaProto] = counts.GetValueOrDefault(areaProto) + 1;
+        }
+
+        return counts;
     }
 
     public bool TryGetAllAreas(EntityCoordinates coordinates, [NotNullWhen(true)] out Entity<AreaGridComponent>? areaGrid)

--- a/Content.Shared/_RMC14/CCVar/RMCCVars.Mcp.cs
+++ b/Content.Shared/_RMC14/CCVar/RMCCVars.Mcp.cs
@@ -1,0 +1,21 @@
+using Robust.Shared.Configuration;
+
+namespace Content.Shared._RMC14.CCVar;
+
+public sealed partial class RMCCVars
+{
+    /// <summary>
+    ///     Enables the embedded MCP (Model Context Protocol) server for mapping agents.
+    ///     Only has an effect in builds that compile the MCP server in
+    ///     (non-FULL_RELEASE builds, or release builds made with -p:EnableMcp=true).
+    /// </summary>
+    public static readonly CVarDef<bool> RMCMcpEnabled =
+        CVarDef.Create("rmc.mcp.enabled", true, CVar.SERVERONLY);
+
+    /// <summary>
+    ///     Bearer token for the MCP endpoint. When empty, only loopback connections are accepted.
+    ///     When set, non-loopback connections must present "Authorization: Bearer &lt;token&gt;".
+    /// </summary>
+    public static readonly CVarDef<string> RMCMcpToken =
+        CVarDef.Create("rmc.mcp.token", string.Empty, CVar.SERVERONLY | CVar.CONFIDENTIAL);
+}


### PR DESCRIPTION
## About the PR

Adds an embedded [Model Context Protocol](https://modelcontextprotocol.io/) server to
`Content.Server` that lets AI agents (Claude Code, or any MCP-capable client) do mapping work on
a running game server: 38 typed tools covering tiles, entities, decals, RMC areas, component
fields, map lifecycle and save/load — the same operations a human mapper performs in the mapping
editor. The agent works alongside a connected player: it sees the world around them (including
their screen rotation), takes edits in screen-relative terms ("2 tiles left of me"), and the
player watches every change live.

The server is compiled into debug/dev builds only. Release builds do not contain the code at all
unless explicitly opted in at compile time.

## Why / Balance

No gameplay or balance impact — the code is behind `#if !FULL_RELEASE || RMC_MCP`, so production
servers never ship it, and even where compiled in, remote access requires an explicit bearer
token (loopback only by default).

Motivation: mapping has a lot of labor-intensive bulk work (tiling, wall runs, area assignment,
repetitive props) that an agent handles well, while the human keeps creative control and reviews
everything live in the client. The toolset was designed following Anthropic's
[tool-design guidance for agents](https://www.anthropic.com/engineering/writing-tools-for-agents)
and was built and playtested end-to-end with the same agent workflow it enables.

## Technical details

- All code is isolated in `Content.Server/_RMC14/Mcp/` (see the module `README.md` there for a
  full architecture overview and tool catalogue; `EVALS.md` contains end-to-end evaluation tasks
  for regression-testing the toolset).
- Transport: minimal JSON-RPC 2.0 over stateless streamable HTTP — `POST /mcp` on the existing
  status host (`net.port`, default 1212). No new listeners, no external dependencies.
- Tool handlers run on a status-host worker thread and marshal all game-state access to the main
  thread via `TaskCompletionSource`, same pattern as `ServerApi`. Failures return actionable
  `isError` results with a suggested next step.
- No client-side code: the player's screen rotation is reconstructed server-side from the
  replicated `InputMoverComponent` state.
- Gating/security: `#if !FULL_RELEASE || RMC_MCP` (release opt-in via
  `dotnet build -p:EnableMcp=true`); cvars `rmc.mcp.enabled` and `rmc.mcp.token` (empty token =
  loopback connections only).
- Changes outside the new directory are minimal and marked with `// RMC14-Mcp-Start/End`:
  `Content.Server.csproj` (opt-in build property), `EntryPoint.cs` / `ServerContentIoC.cs`
  (registration), and two `[Access]`-respecting helpers in `Content.Shared/_RMC14/Areas/AreaSystem.cs`
  (`TryGetAreaProto`/`SetAreaProto` — area reads/writes on uninitialized maps).
- A companion skill (a mapper's handbook distilled for AI agents) is maintained separately at
  [rmc14-mapping-skill](https://github.com/IlyaBokovenko/rmc14-mapping-skill) — plain Markdown,
  optional, client-agnostic; the server is fully usable without it.

## Media

An AI agent doing mapping work through the MCP server on a live dev server:

https://github.com/user-attachments/assets/136a5468-f0f3-4875-b943-65c9e54daf46



## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- code: Added an embedded MCP server (dev builds only) that lets AI agents inspect and edit maps on a running server.
