### PR TITLE
[Fix] Open doors no longer block some mechanics

### DIFF
--- a/Content.Shared/_RMC14/Line/LineSystem.cs
+++ b/Content.Shared/_RMC14/Line/LineSystem.cs
@@ -160,6 +160,11 @@ public sealed class LineSystem : EntitySystem
                 if (!_tag.HasAnyTag(entity, StructureTag, WallTag))
                     continue;
 
+                // open or opening doors don't count as blockers
+                // if the entity is a door, and the door isn't closed, denying, or welded, ignore it as a blocker
+                if (_doorQuery.TryComp(entity, out var door) && door.State != DoorState.Closed && door.State != DoorState.Denying && door.State != DoorState.Welded)
+                    continue;
+
                 blockCount++;
 
                 if (blockCount < 2)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Minor C# change, added an if statement. Linesystem counted two opening doors as blockers on the diagonal.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfix.
## Technical details
<!-- Summary of code changes for easier review. -->
Check to see if a potential blocker is a door, and if said door is not closed, denying, or welded, skip further blocker checks on that door.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Open doors no longer block some mechanics, including Oppressor's Abduct and the M34 incinerator
