### PR TITLE
[fix] Spec/spotter sight locks

### DIFF
--- a/Content.Shared/_RMC14/NightVision/NightVisionItemComponent.cs
+++ b/Content.Shared/_RMC14/NightVision/NightVisionItemComponent.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Shared._RMC14.Marines.Skills;
 using Content.Shared.Inventory;
+using Content.Shared.Whitelist;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
@@ -28,6 +29,9 @@ public sealed partial class NightVisionItemComponent : Component
 
     [DataField, AutoNetworkedField]
     public Dictionary<EntProtoId<SkillDefinitionComponent>, int>? Skills;
+
+    [DataField, AutoNetworkedField]
+    public EntityWhitelist? Whitelist;
 
     [DataField, AutoNetworkedField]
     public bool Green;

--- a/Content.Shared/_RMC14/NightVision/SharedNightVisionSystem.cs
+++ b/Content.Shared/_RMC14/NightVision/SharedNightVisionSystem.cs
@@ -10,6 +10,7 @@ using Content.Shared.Popups;
 using Content.Shared.Rounding;
 using Content.Shared.Toggleable;
 using Content.Shared.Verbs;
+using Content.Shared.Whitelist;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Timing;
 
@@ -26,6 +27,7 @@ public abstract class SharedNightVisionSystem : EntitySystem
     [Dependency] private readonly SkillsSystem _skills = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly VisorSystem _visor = default!;
+    [Dependency] private readonly Whitelist _whitelist = default!;
 
     public override void Initialize()
     {
@@ -269,6 +271,12 @@ public abstract class SharedNightVisionSystem : EntitySystem
         DisableNightVisionItem(item, item.Comp.User);
 
         if (item.Comp.Skills != null && !_skills.HasAllSkills(user, item.Comp.Skills))
+        {
+            _popup.PopupClient(Loc.GetString("rmc-skills-hud-toggle"), user, user, PopupType.MediumCaution);
+            return;
+        }
+
+        if (item.Comp.Whitelist != null && !_whitelist.IsWhitelistPass(item.Comp.Whitelist, user))
         {
             _popup.PopupClient(Loc.GetString("rmc-skills-hud-toggle"), user, user, PopupType.MediumCaution);
             return;

--- a/Content.Shared/_RMC14/NightVision/SharedNightVisionSystem.cs
+++ b/Content.Shared/_RMC14/NightVision/SharedNightVisionSystem.cs
@@ -27,7 +27,7 @@ public abstract class SharedNightVisionSystem : EntitySystem
     [Dependency] private readonly SkillsSystem _skills = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly VisorSystem _visor = default!;
-    [Dependency] private readonly Whitelist _whitelist = default!;
+    [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
 
     public override void Initialize()
     {

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Eyes/glasses.yml
@@ -64,6 +64,9 @@
   - type: NightVisionItem
     mesons: true
     defaultState: half
+      whitelist:
+      components:
+        - SniperWhitelist
   - type: Appearance
   - type: GenericVisualizer
     visuals:
@@ -77,6 +80,11 @@
   id: CMGlassesM42SpotterSight
   name: M96 spotter sight
   description: A companion headset and night vision goggles system for UNMC spotters. Allows highlighted imaging of surroundings.
+  components:
+  - type: NightVisionItem
+    whitelist:
+      components:
+        - SpotterWhitelist
 
 - type: entity
   parent: CMGlassesM42ScoutSight
@@ -119,6 +127,9 @@
   - type: NightVisionItem
     mesons: true
     defaultState: half
+    whitelist:
+      components:
+        - ScoutWhitelist
   - type: Appearance
   - type: GenericVisualizer
     visuals:

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Eyes/glasses.yml
@@ -67,6 +67,7 @@
       whitelist:
       components:
         - SniperWhitelist
+  - type: RMCCryoUnavailableOnStore
   - type: Appearance
   - type: GenericVisualizer
     visuals:
@@ -130,6 +131,7 @@
     whitelist:
       components:
         - ScoutWhitelist
+  - type: RMCCryoUnavailableOnStore
   - type: Appearance
   - type: GenericVisualizer
     visuals:
@@ -167,6 +169,7 @@
     whitelist:
       components:
       - SmartGun
+  - type: RMCCryoUnavailableOnStore
   - type: Appearance
   - type: GenericVisualizer
     visuals:

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Eyes/glasses.yml
@@ -64,9 +64,9 @@
   - type: NightVisionItem
     mesons: true
     defaultState: half
-      whitelist:
+    whitelist:
       components:
-        - SniperWhitelist
+      - SniperWhitelist
   - type: RMCCryoUnavailableOnStore
   - type: Appearance
   - type: GenericVisualizer

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/specialist_loadouts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/specialist_loadouts.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   parent: RMCBaseEquipmentCase
   id: CMSniperEquipmentCase
   name: sniper equipment case
@@ -274,7 +274,7 @@
     contents:
     - id: CMArmorM45
     - id: CMArmorHelmetM45
-    - id: CMGlassesM42ScoutSight
+    - id: CMGlassesM42SpotterSight
     - id: CMBackpackSniper
     - id: RMCLaserDesignatorSpotter
     - id: CMPamphletSpotter


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Spotter's sight, sniper's scout sight, and scout's battle sight should all require their respective WS whitelists.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity.
These items are also biolocked in parity but I a. don't see the need for it and b. feel as if requiring the whitelist component will achieve the same effect. You may read this as me being lazy and not wanting to make a biolock system for sights or generic items :))))))))))
## Technical details
<!-- Summary of code changes for easier review. -->
Yaml + small C#
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
small fix
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Scout, spotter, and sniper/AMR night vision gear are now locked to their respective roles