### PR TITLE
[Fix] Fixes gun magazines negative values after refilling.

### DIFF
--- a/Content.Shared/_RMC14/Weapons/Ranged/Ammo/BulletBox/BulletBoxSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/Ammo/BulletBox/BulletBoxSystem.cs
@@ -5,7 +5,9 @@ using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
 using Content.Shared.Verbs;
+using Content.Shared.Weapons.Ranged;
 using Content.Shared.Weapons.Ranged.Components;
+using Content.Shared.Weapons.Ranged.Events;
 using Content.Shared.Weapons.Ranged.Systems;
 
 namespace Content.Shared._RMC14.Weapons.Ranged.Ammo.BulletBox;
@@ -141,7 +143,21 @@ public sealed class BulletBoxSystem : EntitySystem
                 return;
 
             transfer = Math.Min(transfer, used.Comp2.Count);
-            _gun.SetBallisticUnspawned((used, used.Comp2), used.Comp2.UnspawnedCount - transfer);
+
+            var taken = new List<(EntityUid? Entity, IShootable Shootable)>();
+            var takeEv = new TakeAmmoEvent(transfer, taken, Transform(usedId).Coordinates, user);
+            RaiseLocalEvent(usedId, takeEv);
+
+            transfer = taken.Count;
+            foreach (var (round, _) in taken)
+            {
+                if (round is { } roundId)
+                    PredictedDel(roundId);
+            }
+
+            if (transfer <= 0)
+                return;
+
             ent.Comp.Amount += transfer;
         }
         _popup.PopupClient(Loc.GetString("rmc-bullet-box-transfer-done", ("amount", transfer), ("used", ent)), ent, user);

--- a/Content.Shared/_RMC14/Weapons/Ranged/Ammo/BulletBox/BulletBoxSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/Ammo/BulletBox/BulletBoxSystem.cs
@@ -144,19 +144,23 @@ public sealed class BulletBoxSystem : EntitySystem
 
             transfer = Math.Min(transfer, used.Comp2.Count);
 
-            var taken = new List<(EntityUid? Entity, IShootable Shootable)>();
-            var takeEv = new TakeAmmoEvent(transfer, taken, Transform(usedId).Coordinates, user);
-            RaiseLocalEvent(usedId, takeEv);
+            var fromUnspawned = Math.Min(transfer, used.Comp2.UnspawnedCount);
+            if (fromUnspawned > 0)
+                _gun.SetBallisticUnspawned((used, used.Comp2), used.Comp2.UnspawnedCount - fromUnspawned);
 
-            transfer = taken.Count;
-            foreach (var (round, _) in taken)
+            var remaining = transfer - fromUnspawned;
+            if (remaining > 0)
             {
-                if (round is { } roundId)
-                    PredictedDel(roundId);
-            }
+                var taken = new List<(EntityUid? Entity, IShootable Shootable)>();
+                var takeEv = new TakeAmmoEvent(remaining, taken, Transform(usedId).Coordinates, user);
+                RaiseLocalEvent(usedId, takeEv);
 
-            if (transfer <= 0)
-                return;
+                foreach (var (round, _) in taken)
+                {
+                    if (round is { } roundId)
+                        PredictedDel(roundId);
+                }
+            }
 
             ent.Comp.Amount += transfer;
         }


### PR DESCRIPTION
## About the PR
Fixes #10685 

Fixes magazines sometimes going into negative values after refilling from magazines and "spam cans".

## Why / Balance
Fix

## Technical details
fixes the system as it didn't take from both stores of bullets. 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- fix: Fixed magazines sometimes getting negative values.
