### PR TITLE
add the missing hive boons

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Evolution/EvolutionIgnoreGranterComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/EvolutionIgnoreGranterComponent.cs
@@ -1,0 +1,7 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.Evolution;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(XenoEvolutionSystem))]
+public sealed partial class EvolutionIgnoreGranterComponent : Component;

--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared._RMC14.Xenonids.Announce;
 using Content.Shared._RMC14.Xenonids.Egg;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.JoinXeno;
+using Content.Shared._RMC14.Xenonids.ManageHive.Boons;
 using Content.Shared._RMC14.Xenonids.Weeds;
 using Content.Shared.Actions;
 using Content.Shared.Administration.Logs;
@@ -96,6 +97,8 @@ public sealed class XenoEvolutionSystem : EntitySystem
         SubscribeLocalEvent<XenoEvolutionGranterComponent, NewXenoEvolvedEvent>(OnGranterEvolved);
 
         SubscribeLocalEvent<XenoOvipositorChangedEvent>(OnOvipositorChanged);
+
+        SubscribeLocalEvent<HiveBoonActivateAdaptabilityEvent>(OnBoonAdaptability);
 
         Subs.BuiEvents<XenoEvolutionComponent>(XenoEvolutionUIKey.Key,
             subs =>
@@ -304,6 +307,49 @@ public sealed class XenoEvolutionSystem : EntitySystem
     private void OnGranterEvolved(Entity<XenoEvolutionGranterComponent> ent, ref NewXenoEvolvedEvent args)
     {
         _xenoAnnounce.AnnounceSameHive(ent.Owner, Loc.GetString("rmc-new-queen"));
+    }
+
+    private void OnBoonAdaptability(HiveBoonActivateAdaptabilityEvent ev)
+    {
+        var castes = new List<(EntProtoId Id, int Tier)>();
+        foreach (var prototype in _prototypes.EnumeratePrototypes<EntityPrototype>())
+        {
+            if (!prototype.TryGetComponent(out XenoEvolutionComponent? evolution, _compFactory))
+                continue;
+
+            foreach (var id in evolution.EvolvesTo)
+            {
+                if (_prototypes.TryIndex(id, out var caste) &&
+                    caste.TryGetComponent(out XenoComponent? xeno, _compFactory))
+                {
+                    castes.Add((id, xeno.Tier));
+                }
+            }
+        }
+
+        var xenos = EntityQueryEnumerator<XenoComponent, XenoEvolutionComponent>();
+        while (xenos.MoveNext(out var uid, out var xenoComp, out var comp))
+        {
+            if (_mobState.IsDead(uid) || !_xenoHive.FromSameHive(uid, ev.Boon))
+                continue;
+
+            var self = Prototype(uid)?.ID;
+            foreach (var (id, tier) in castes)
+            {
+                if (tier != xenoComp.Tier ||
+                    id.Id == self ||
+                    comp.EvolvesToWithoutPoints.Contains(id))
+                {
+                    continue;
+                }
+
+                comp.EvolvesToWithoutPoints.Add(id);
+            }
+
+            Dirty(uid, comp);
+        }
+
+        _xenoAnnounce.AnnounceSameHiveDefaultSound(ev.Boon, "The Queen has loosened our forms. We may take the shape of another of our rank!");
     }
 
     private void OnOvipositorChanged(ref XenoOvipositorChangedEvent ev)
@@ -807,6 +853,10 @@ public sealed class XenoEvolutionSystem : EntitySystem
                 _xenoHive.AnnounceNeedsOvipositorToSameHive(uid);
             }
         }
+
+        var ignoreGranter = EntityQueryEnumerator<EvolutionIgnoreGranterComponent>();
+        if (ignoreGranter.MoveNext(out _))
+            hasGranter = true;
 
         var evoBonus = FixedPoint2.Zero;
         var bonuses = EntityQueryEnumerator<EvolutionBonusComponent>();

--- a/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonActivateAdaptabilityEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonActivateAdaptabilityEvent.cs
@@ -1,0 +1,6 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Xenonids.ManageHive.Boons;
+
+[Serializable, NetSerializable]
+public sealed partial class HiveBoonActivateAdaptabilityEvent : HiveBoonEvent;

--- a/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonActivateAggressionEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonActivateAggressionEvent.cs
@@ -1,0 +1,6 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Xenonids.ManageHive.Boons;
+
+[Serializable, NetSerializable]
+public sealed partial class HiveBoonActivateAggressionEvent : HiveBoonEvent;

--- a/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonActivateEvolutionEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonActivateEvolutionEvent.cs
@@ -1,0 +1,6 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Xenonids.ManageHive.Boons;
+
+[Serializable, NetSerializable]
+public sealed partial class HiveBoonActivateEvolutionEvent : HiveBoonEvent;

--- a/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonMeleeDamageComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonMeleeDamageComponent.cs
@@ -1,0 +1,17 @@
+using Content.Shared.Damage.Prototypes;
+using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._RMC14.Xenonids.ManageHive.Boons;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(HiveBoonSystem))]
+public sealed partial class HiveBoonMeleeDamageComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 Amount = 5;
+
+    [DataField, AutoNetworkedField]
+    public ProtoId<DamageGroupPrototype> DamageGroup = "Brute";
+}

--- a/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonSystem.cs
@@ -17,6 +17,7 @@ using Content.Shared._RMC14.Xenonids.Construction;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Weeds;
 using Content.Shared.Coordinates;
+using Content.Shared.Damage;
 using Content.Shared.Examine;
 using Content.Shared.GameTicking;
 using Content.Shared.Mind;
@@ -24,6 +25,7 @@ using Content.Shared.Mobs.Systems;
 using Content.Shared.Players.PlayTimeTracking;
 using Content.Shared.Popups;
 using Content.Shared.Roles;
+using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.Configuration;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
@@ -90,6 +92,10 @@ public sealed class HiveBoonSystem : EntitySystem
         SubscribeLocalEvent<HiveBoonActivateFireResistanceEvent>(OnActivateFireResistance);
         SubscribeLocalEvent<HiveBoonActivateLarvaSurgeEvent>(OnActivateLarvaSurge);
         SubscribeLocalEvent<HiveBoonActivateKingEvent>(OnActivateKing);
+        SubscribeLocalEvent<HiveBoonActivateEvolutionEvent>(OnActivateEvolution);
+        SubscribeLocalEvent<HiveBoonActivateAggressionEvent>(OnActivateAggression);
+
+        SubscribeLocalEvent<GetMeleeDamageEvent>(OnGetMeleeDamage);
 
         SubscribeLocalEvent<XenoComponent, RMCGetFireImmunityEvent>(OnGetTileFireImmunity);
         SubscribeLocalEvent<XenoComponent, GetIgnitionImmunityEvent>(OnGetTileFireIgnitionImmunity);
@@ -167,6 +173,16 @@ public sealed class HiveBoonSystem : EntitySystem
         _xenoAnnounce.AnnounceSameHiveDefaultSound(ev.Boon, "The Queen has awakened 5 extra burrowed larva to join the hive!");
     }
 
+    private void OnActivateEvolution(HiveBoonActivateEvolutionEvent ev)
+    {
+        _xenoAnnounce.AnnounceSameHiveDefaultSound(ev.Boon, "The Queen has hastened our growth. We will mature far quicker!");
+    }
+
+    private void OnActivateAggression(HiveBoonActivateAggressionEvent ev)
+    {
+        _xenoAnnounce.AnnounceSameHiveDefaultSound(ev.Boon, "The Queen has sharpened our claws. Our strikes will land far harder!");
+    }
+
     private void OnActivateKing(HiveBoonActivateKingEvent ev)
     {
         var pylonQuery = EntityQueryEnumerator<HivePylonComponent>();
@@ -207,6 +223,21 @@ public sealed class HiveBoonSystem : EntitySystem
         {
             if (_hive.FromSameHive(uid, xeno.Owner))
                 args.Ignite = false;
+        }
+    }
+
+    private void OnGetMeleeDamage(ref GetMeleeDamageEvent args)
+    {
+        if (!HasComp<XenoComponent>(args.User))
+            return;
+
+        var query = EntityQueryEnumerator<HiveBoonMeleeDamageComponent>();
+        while (query.MoveNext(out var uid, out var boon))
+        {
+            if (!_hive.FromSameHive(uid, args.User))
+                continue;
+
+            args.Damage += new DamageSpecifier(_prototype.Index(boon.DamageGroup), boon.Amount);
         }
     }
 

--- a/Resources/Prototypes/_RMC14/Entities/rmc_hive_boons.yml
+++ b/Resources/Prototypes/_RMC14/Entities/rmc_hive_boons.yml
@@ -19,6 +19,78 @@
 
 - type: entity
   parent: RMCHiveBoonBase
+  id: RMCHiveBoonEvolution
+  name: Minor Boon of Evolution
+  description: Doubles evolution speed for 5 minutes.
+  components:
+  - type: HiveBoonDefinition
+    duration: 5m
+    duplicateId: RMCHiveBoonEvolution
+    event: !type:HiveBoonActivateEvolutionEvent
+  - type: EvolutionBonus
+    amount: 0.5
+
+- type: entity
+  parent: RMCHiveBoonBase
+  id: RMCHiveBoonAggression
+  name: Minor Boon of Aggression
+  description: Increases all xenonid damage by 5 for 5 minutes.
+  components:
+  - type: HiveBoonDefinition
+    duration: 5m
+    duplicateId: RMCHiveBoonAggression
+    event: !type:HiveBoonActivateAggressionEvent
+  - type: HiveBoonMeleeDamage
+    amount: 5
+
+- type: entity
+  parent: RMCHiveBoonBase
+  id: RMCHiveBoonEvolutionMajor
+  name: Major Boon of Evolution
+  description: Doubles evolution speed for 10 minutes, and allows evolution progress without an ovipositor.
+  components:
+  - type: HiveBoonDefinition
+    cost: 2
+    pylons: 2
+    duration: 10m
+    unlockAt: 60m
+    duplicateId: RMCHiveBoonEvolutionMajor
+    event: !type:HiveBoonActivateEvolutionEvent
+  - type: EvolutionBonus
+    amount: 0.5
+  - type: EvolutionIgnoreGranter
+
+- type: entity
+  parent: RMCHiveBoonBase
+  id: RMCHiveBoonAggressionMajor
+  name: Major Boon of Aggression
+  description: Increases all xenonid damage by 10 for 10 minutes.
+  components:
+  - type: HiveBoonDefinition
+    cost: 2
+    pylons: 2
+    duration: 10m
+    unlockAt: 60m
+    duplicateId: RMCHiveBoonAggressionMajor
+    event: !type:HiveBoonActivateAggressionEvent
+  - type: HiveBoonMeleeDamage
+    amount: 10
+
+- type: entity
+  parent: RMCHiveBoonBase
+  id: RMCHiveBoonAdaptability
+  name: Boon of Adaptability
+  description: Allows each xenonid to change to a different caste of the same tier.
+  components:
+  - type: HiveBoonDefinition
+    cost: 2
+    pylons: 2
+    unlockAt: 60m
+    duplicateId: RMCHiveBoonAdaptability
+    event: !type:HiveBoonActivateAdaptabilityEvent
+
+- type: entity
+  parent: RMCHiveBoonBase
   id: RMCHiveBoonLarvaSurge
   name: Surge of Larva
   description: Provides 5 larva instantly to the hive.


### PR DESCRIPTION
## About the PR
Adds the five hive boons that were still missing from the royal resin menu, so the list matches CM13:

- Minor Boon of Evolution: 1 resin, doubles evolution speed for 5 minutes
- Minor Boon of Aggression: 1 resin, +5 xenonid melee damage for 5 minutes
- Major Boon of Evolution: 2 resin and 2 pylons, doubles evolution speed for 10 minutes and lets evolution progress without an ovipositor
- Major Boon of Aggression: 2 resin and 2 pylons, +10 xenonid melee damage for 10 minutes
- Boon of Adaptability: 2 resin and 2 pylons, lets every xenonid swap to another caste of its own tier for free

Major boons unlock an hour into the round, like in CM13.

## Why / Balance
Royal resin, pylons, His Grace and the fire and larva boons are already in, so right now the Queen has three things to spend resin on out of the eight CM13 has. These are the other five, with the same costs, durations and unlock times.

## Technical details
Almost all of it is data. The effects reuse things that were already there:

- The evolution boons just carry `EvolutionBonus` on the boon entity. `XenoEvolutionSystem` already sums that component globally, and `TryActivateBoon` already puts a `TimedDespawn` on the boon, so the buff expires on its own.
- `EvolutionIgnoreGranter` is a new marker for the ovipositor bypass, checked right next to the existing bonus and override queries.
- The aggression boons carry `HiveBoonMeleeDamage`, and `HiveBoonSystem` adds the flat damage on `GetMeleeDamageEvent`, filtered by hive the same way the fire immunity boon is. The subscription is broadcast because `XenoSystem` already holds the directed one on `XenoComponent`.
- Adaptability fills in `evolvesToWithoutPoints`, which was already wired up in the evolution UI and in `CanEvolvePopup`. The same tier caste list is built from every prototype that appears in some `evolvesTo`, so strains, queens and admin xenonids stay out of it and any new caste gets picked up on its own.

No upstream files touched, it all lives under `_RMC14`.

## Media
Not recorded yet, this needs a round with both relay pylons held and an hour on the clock. What I did check locally: it builds clean, the YAML linter reports no errors, the server boots and restarts rounds fine, and `EntityTest.SpawnAndDirtyAllEntities` passes.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: The Queen can now buy the Minor and Major Boons of Evolution, the Minor and Major Boons of Aggression, and the Boon of Adaptability with royal resin.
