### PR TITLE
Small weapon fixes

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/under_attachments.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/under_attachments.yml
@@ -341,6 +341,41 @@
   - type: NoMixingReagents
 
 - type: entity
+  parent: RMCAttachmentMiniFlamethrower
+  id: RMCAttachmentMiniFlamethrowerAdvanced
+  name: advanced underbarrel flamethrower # TODO RMC14: No intensity switch on this one, remove the regular UBF as a parent once we get it
+  components:
+  - type: Tag
+    tags:
+    - RMCAttachmentUnderbarrel
+    - RMCAttachmentMiniFlamethrowerAdvanced
+  - type: SolutionContainerManager
+    solutions:
+      rmc_flamer_tank:
+        maxVol: 50
+        reagents:
+        - ReagentId: RMCNapalmUT
+          Quantity: 50
+  - type: RMCFlamerAmmoProvider
+  - type: RMCFlamerTank
+    maxIntensity: 30
+    maxDuration: 20
+    maxRange: 6
+    reagentWhitelist:
+    - RMCNapalmUT
+    - WeldingFuel
+
+- type: entity
+  parent: RMCAttachmentMiniFlamethrowerAdvanced
+  id: RMCAttachmentMiniFlamethrowerAdvancedIntegrated
+  name: integrated flamethrower
+  components:
+  - type: Tag
+    tags:
+    - RMCAttachmentUnderbarrel
+    - RMCAttachmentMiniFlamethrowerAdvancedIntegrated
+
+- type: entity
   parent: RMCUnderAttachmentBase
   id: CMAttachmentXMVESG1FlamerNozzle
   name: XM-VESG-1 flamer nozzle
@@ -1075,6 +1110,12 @@
 
 - type: Tag
   id: RMCAttachmentMiniFlamethrower
+
+- type: Tag
+  id: RMCAttachmentMiniFlamethrowerAdvanced
+
+- type: Tag
+  id: RMCAttachmentMiniFlamethrowerAdvancedIntegrated
 
 - type: Tag
   id: RMCAttachmentUnderbarrelExtinguisher

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/kt42_pistol.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/kt42_pistol.yml
@@ -7,7 +7,7 @@
   - type: RMCSelectiveFire
     scatterWielded: 5
     scatterUnwielded: 6
-    baseFireRate: 10
+    baseFireRate: 4
   - type: Sprite
     sprite: _RMC14/Objects/Weapons/Guns/Pistols/kt42.rsi
   - type: Clothing

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/np92_pistol.yml.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/np92_pistol.yml.yml
@@ -107,7 +107,7 @@
     - Burst
     scatterWielded: 5
     scatterUnwielded: 5
-    baseFireRate: 3.5
+    baseFireRate: 10
     burstScatterMult: 5
     modifiers:
       Burst:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/np92_pistol.yml.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/np92_pistol.yml.yml
@@ -80,6 +80,7 @@
   name: NPZ92 pistol
   description: The NPZ92 is a version of the NP92 that includes an integrated suppressor, issued sparingly to Kommando units.
   components:
+  - type: GunClickToFire
   - type: Tag
     tags:
     - Sidearm

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/np92_pistol.yml.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/np92_pistol.yml.yml
@@ -4,6 +4,7 @@
   name: NP92 pistol
   description: The standard issue sidearm of the SPP. The NP92 is a small but powerful sidearm, well-liked by most it is issued to, although some prefer the weapon it was meant to replace, the Type 73. Takes 12 round magazines.
   components:
+  - type: GunClickToFire
   - type: Tag
     tags:
     - Sidearm
@@ -31,7 +32,7 @@
     - Burst
     scatterWielded: 5
     scatterUnwielded: 5
-    baseFireRate: 3.5
+    baseFireRate: 10
     burstScatterMult: 5
     modifiers:
       Burst:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/t73_pistol.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Pistols/t73_pistol.yml
@@ -31,7 +31,7 @@
     - Burst
     scatterWielded: 5
     scatterUnwielded: 5
-    baseFireRate: 2.5
+    baseFireRate: 4
     burstScatterMult: 5
     modifiers:
       Burst:
@@ -80,7 +80,7 @@
   parent: CMWeaponPistolBase
   id: RMCWeaponPistolT74
   name: Type 74 pistol
-  description: The Type 74 is the designation for a specially modified Type 73 with an integrated laser sight system, multiple lightning cuts to reduce weight in order to allow a higher pressure round to be used with the same recoil sping, and a more comfortable grip. Due to the adoption of the NP92, the Type 74 was produced in limited numbers, because of this it is typically only issued on request to high-ranking officers
+  description: The Type 74 is the designation for a specially modified Type 73 with an integrated laser sight system, multiple lightning cuts to reduce weight in order to allow a higher pressure round to be used with the same recoil sping, and a more comfortable grip. Due to the adoption of the NP92, the Type 74 was produced in limited numbers, because of this it is typically only issued on request to high-ranking officers.
   components:
   - type: Tag
     tags:
@@ -106,7 +106,7 @@
     - SemiAuto
     scatterWielded: 4
     scatterUnwielded: 4
-    baseFireRate: 2.5
+    baseFireRate: 4
     burstScatterMult: 5
   - type: ItemSlots
     slots:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/type71.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/type71.yml
@@ -150,10 +150,10 @@
           - RMCAttachmentType71Stock
       rmc-aslot-underbarrel:
         locked: true
-        startingAttachable: RMCAttachmentMiniFlamethrower
+        startingAttachable: RMCAttachmentMiniFlamethrowerAdvancedIntegrated
         whitelist:
           tags:
-          - RMCAttachmentMiniFlamethrower
+          - RMCAttachmentMiniFlamethrowerAdvancedIntegrated
 
 - type: entity
   parent: CMMagazineRifleBase

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/fp9000.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/fp9000.yml
@@ -73,6 +73,9 @@
           - RMCAttachmentExtendedBarrel
           - RMCAttachmentExtendedCompensator
           - RMCAttachmentRecoilCompensator
+        random:
+        - RMCAttachmentExtendedBarrel
+        - RMCAttachmentRecoilCompensator
       rmc-aslot-rail:
         locked: true
         startingAttachable: RMCAttachmentFP9000Scope
@@ -83,6 +86,8 @@
         whitelist:
           tags:
           - RMCAttachmentLaserSight
+        random:
+        - RMCAttachmentLaserSight
   - type: AttachableHolderVisuals
     offsets:
       rmc-aslot-rail: 0.06, .15

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/type64.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SMGs/type64.yml
@@ -4,6 +4,8 @@
   id: RMCWeaponSMGType64
   description: The standard submachinegun of the SPP, sporting an unusual 64 round helical magazine, it has a high fire-rate, but is unusually accurate. This one is bulky and unergonomic, denoting it as civilian use or as an export model.
   components:
+  - type: GunDamageModifier
+    multiplier: 1.15
   - type: Sprite
     sprite: _RMC14/Objects/Weapons/Guns/SMGs/type64.rsi
     layers:
@@ -97,7 +99,7 @@
 - type: entity
   parent: CMMagazineRifleBase
   id: RMCMagazineSMGType64
-  name: "Type 64 magazine (10x20mm)"
+  name: "Type 64 magazine (7.62x19mm)"
   components:
   - type: Tag
     tags:
@@ -129,7 +131,7 @@
 - type: entity
   parent: RMCMagazineSMGType64
   id: RMCMagazineSMGType64Rubber
-  name: "Type 64 rubber magazine (10x20mm)"
+  name: "Type 64 rubber magazine (7.62x19mm)"
   components:
   - type: Tag
     tags:
@@ -154,7 +156,7 @@
 - type: entity
   parent: CMCartridgeSMGBase
   id: RMCCartridgeType64
-  name: cartridge (10x20mm)
+  name: cartridge (7.62x19mm)
   components:
   - type: Tag
     tags:
@@ -166,7 +168,7 @@
 - type: entity
   parent: CMCartridgeSMGBase
   id: RMCCartridgeType64Rubber
-  name: cartridge (10x20mm)
+  name: cartridge (7.62x19mm)
   components:
   - type: Tag
     tags:


### PR DESCRIPTION
## About the PR
Adds the advanced UBF for the Type 71-F 

Renamed Type 64 magazines to display their actual caliber

Added the missing 1.15x damage multiplier to the Type 64

Added randomized attachments to FP9000

Firerate changes:

KT-42: 10 -> 4
NP92: 3.5 -> 10 (Removed hold to fire)
Type73/74: 2.5 -> 4

## Why / Balance
fixes

## Technical details
all yaml

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added the advanced underbarrel flamethrower to the Type 71-F
- tweak: The FP9000 now spawns with randomized attachments
- tweak: Fixed KT-42, Type 73, Type 74 and NP92 firerates being incorrect
- fix: Fixed Type 64 magazines displaying the wrong caliber
