### PR TITLE
Kutjevo toxic water fix and small additions

### DIFF
--- a/Resources/Maps/_RMC14/Inserts/Kutjevo/surv_spawn_bar.yml
+++ b/Resources/Maps/_RMC14/Inserts/Kutjevo/surv_spawn_bar.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 264.0.2
   forkId: ""
   forkVersion: ""
-  time: 04/16/2026 20:53:51
+  time: 08/21/2026 10:37:29
   entityCount: 67
 maps: []
 grids:
@@ -135,7 +135,7 @@ entities:
       parent: 1
     - type: SpriteSetRenderOrder
       offset: -0.5,-1.5
-- proto: CMBarricadeMetal
+- proto: CMBarricadeFolding
   entities:
   - uid: 34
     components:

--- a/Resources/Maps/_RMC14/kutjevo.yml
+++ b/Resources/Maps/_RMC14/kutjevo.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 264.0.2
   forkId: ""
   forkVersion: ""
-  time: 06/20/2026 00:05:29
-  entityCount: 26682
+  time: 08/21/2026 10:35:10
+  entityCount: 26683
 maps:
 - 1
 grids:
@@ -41688,6 +41688,61 @@ entities:
     - type: Transform
       pos: 163.5,-91.5
       parent: 1
+- proto: CMBarricadeFolding
+  entities:
+  - uid: 145
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 120.5,-48.5
+      parent: 1
+  - uid: 146
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 55.5,-160.5
+      parent: 1
+  - uid: 147
+    components:
+    - type: Transform
+      pos: 131.5,-53.5
+      parent: 1
+  - uid: 148
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 127.5,-53.5
+      parent: 1
+  - uid: 149
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 127.5,-52.5
+      parent: 1
+  - uid: 152
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 35.5,-55.5
+      parent: 1
+  - uid: 153
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 43.5,-56.5
+      parent: 1
+  - uid: 154
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 42.5,-56.5
+      parent: 1
+  - uid: 155
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 34.5,-55.5
+      parent: 1
 - proto: CMBarricadeMetal
   entities:
   - uid: 139
@@ -41734,35 +41789,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 35.5,-27.5
       parent: 1
-  - uid: 145
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 120.5,-48.5
-      parent: 1
-  - uid: 146
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 55.5,-160.5
-      parent: 1
-  - uid: 147
-    components:
-    - type: Transform
-      pos: 131.5,-53.5
-      parent: 1
-  - uid: 148
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 127.5,-52.5
-      parent: 1
-  - uid: 149
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 127.5,-53.5
-      parent: 1
   - uid: 150
     components:
     - type: Transform
@@ -41774,30 +41800,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 53.5,-51.5
-      parent: 1
-  - uid: 152
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 42.5,-56.5
-      parent: 1
-  - uid: 153
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 34.5,-55.5
-      parent: 1
-  - uid: 154
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 35.5,-55.5
-      parent: 1
-  - uid: 155
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 43.5,-56.5
       parent: 1
 - proto: CMBed
   entities:
@@ -43621,6 +43623,206 @@ entities:
     - type: Transform
       pos: 120.5,-84.5
       parent: 1
+  - uid: 6978
+    components:
+    - type: Transform
+      pos: 143.5,-64.5
+      parent: 1
+  - uid: 6979
+    components:
+    - type: Transform
+      pos: 142.5,-67.5
+      parent: 1
+  - uid: 6980
+    components:
+    - type: Transform
+      pos: 105.5,-81.5
+      parent: 1
+  - uid: 6981
+    components:
+    - type: Transform
+      pos: 105.5,-82.5
+      parent: 1
+  - uid: 6982
+    components:
+    - type: Transform
+      pos: 104.5,-82.5
+      parent: 1
+  - uid: 6983
+    components:
+    - type: Transform
+      pos: 103.5,-79.5
+      parent: 1
+  - uid: 6984
+    components:
+    - type: Transform
+      pos: 105.5,-80.5
+      parent: 1
+  - uid: 6985
+    components:
+    - type: Transform
+      pos: 102.5,-79.5
+      parent: 1
+  - uid: 6986
+    components:
+    - type: Transform
+      pos: 103.5,-82.5
+      parent: 1
+  - uid: 6987
+    components:
+    - type: Transform
+      pos: 102.5,-80.5
+      parent: 1
+  - uid: 6988
+    components:
+    - type: Transform
+      pos: 105.5,-79.5
+      parent: 1
+  - uid: 6989
+    components:
+    - type: Transform
+      pos: 104.5,-79.5
+      parent: 1
+  - uid: 6990
+    components:
+    - type: Transform
+      pos: 102.5,-82.5
+      parent: 1
+  - uid: 6991
+    components:
+    - type: Transform
+      pos: 102.5,-81.5
+      parent: 1
+  - uid: 6992
+    components:
+    - type: Transform
+      pos: 142.5,-65.5
+      parent: 1
+  - uid: 6993
+    components:
+    - type: Transform
+      pos: 145.5,-66.5
+      parent: 1
+  - uid: 7002
+    components:
+    - type: Transform
+      pos: 141.5,-65.5
+      parent: 1
+  - uid: 7003
+    components:
+    - type: Transform
+      pos: 144.5,-67.5
+      parent: 1
+  - uid: 7004
+    components:
+    - type: Transform
+      pos: 144.5,-65.5
+      parent: 1
+  - uid: 7005
+    components:
+    - type: Transform
+      pos: 143.5,-68.5
+      parent: 1
+  - uid: 7047
+    components:
+    - type: Transform
+      pos: 141.5,-67.5
+      parent: 1
+  - uid: 7048
+    components:
+    - type: Transform
+      pos: 142.5,-64.5
+      parent: 1
+  - uid: 7049
+    components:
+    - type: Transform
+      pos: 141.5,-66.5
+      parent: 1
+  - uid: 7050
+    components:
+    - type: Transform
+      pos: 144.5,-64.5
+      parent: 1
+  - uid: 7051
+    components:
+    - type: Transform
+      pos: 142.5,-68.5
+      parent: 1
+  - uid: 7052
+    components:
+    - type: Transform
+      pos: 145.5,-65.5
+      parent: 1
+  - uid: 7053
+    components:
+    - type: Transform
+      pos: 144.5,-68.5
+      parent: 1
+  - uid: 7054
+    components:
+    - type: Transform
+      pos: 145.5,-67.5
+      parent: 1
+  - uid: 7061
+    components:
+    - type: Transform
+      pos: 102.5,-69.5
+      parent: 1
+  - uid: 7062
+    components:
+    - type: Transform
+      pos: 102.5,-70.5
+      parent: 1
+  - uid: 7063
+    components:
+    - type: Transform
+      pos: 102.5,-71.5
+      parent: 1
+  - uid: 7064
+    components:
+    - type: Transform
+      pos: 105.5,-70.5
+      parent: 1
+  - uid: 7065
+    components:
+    - type: Transform
+      pos: 103.5,-69.5
+      parent: 1
+  - uid: 7066
+    components:
+    - type: Transform
+      pos: 105.5,-71.5
+      parent: 1
+  - uid: 7067
+    components:
+    - type: Transform
+      pos: 102.5,-72.5
+      parent: 1
+  - uid: 7068
+    components:
+    - type: Transform
+      pos: 105.5,-72.5
+      parent: 1
+  - uid: 7069
+    components:
+    - type: Transform
+      pos: 103.5,-72.5
+      parent: 1
+  - uid: 7070
+    components:
+    - type: Transform
+      pos: 104.5,-69.5
+      parent: 1
+  - uid: 7071
+    components:
+    - type: Transform
+      pos: 105.5,-69.5
+      parent: 1
+  - uid: 7072
+    components:
+    - type: Transform
+      pos: 104.5,-72.5
+      parent: 1
 - proto: CMFolderBlue
   entities:
   - uid: 498
@@ -44209,13 +44411,6 @@ entities:
     components:
     - type: Transform
       pos: 141.22011,-135.36378
-      parent: 1
-- proto: CMPillCanisterDexalin
-  entities:
-  - uid: 609
-    components:
-    - type: Transform
-      pos: 118.5,-64.5
       parent: 1
 - proto: CMPosterSafetyGuidance
   entities:
@@ -67882,6 +68077,13 @@ entities:
     - type: Transform
       pos: 103.5,-63.5
       parent: 1
+- proto: RMCPillCanisterDexalinNoSkill
+  entities:
+  - uid: 609
+    components:
+    - type: Transform
+      pos: 118.5,-64.5
+      parent: 1
 - proto: RMCPillCanisterKelotaneNoSkill
   entities:
   - uid: 584
@@ -75145,6 +75347,13 @@ entities:
       rot: 3.141592653589793 rad
       pos: 142.5,-120.5
       parent: 1
+- proto: RMCPlayingCardDeck
+  entities:
+  - uid: 26683
+    components:
+    - type: Transform
+      pos: 145.5,-109.5
+      parent: 1
 - proto: RMCPodDoorButtonBigRed
   entities:
   - uid: 6047
@@ -80969,86 +81178,6 @@ entities:
     - type: Transform
       pos: 47.5,-162.5
       parent: 1
-  - uid: 6978
-    components:
-    - type: Transform
-      pos: 145.5,-66.5
-      parent: 1
-  - uid: 6979
-    components:
-    - type: Transform
-      pos: 142.5,-67.5
-      parent: 1
-  - uid: 6980
-    components:
-    - type: Transform
-      pos: 105.5,-82.5
-      parent: 1
-  - uid: 6981
-    components:
-    - type: Transform
-      pos: 104.5,-82.5
-      parent: 1
-  - uid: 6982
-    components:
-    - type: Transform
-      pos: 103.5,-82.5
-      parent: 1
-  - uid: 6983
-    components:
-    - type: Transform
-      pos: 104.5,-79.5
-      parent: 1
-  - uid: 6984
-    components:
-    - type: Transform
-      pos: 105.5,-81.5
-      parent: 1
-  - uid: 6985
-    components:
-    - type: Transform
-      pos: 103.5,-79.5
-      parent: 1
-  - uid: 6986
-    components:
-    - type: Transform
-      pos: 102.5,-82.5
-      parent: 1
-  - uid: 6987
-    components:
-    - type: Transform
-      pos: 102.5,-79.5
-      parent: 1
-  - uid: 6988
-    components:
-    - type: Transform
-      pos: 105.5,-80.5
-      parent: 1
-  - uid: 6989
-    components:
-    - type: Transform
-      pos: 105.5,-79.5
-      parent: 1
-  - uid: 6990
-    components:
-    - type: Transform
-      pos: 102.5,-81.5
-      parent: 1
-  - uid: 6991
-    components:
-    - type: Transform
-      pos: 102.5,-80.5
-      parent: 1
-  - uid: 6992
-    components:
-    - type: Transform
-      pos: 144.5,-67.5
-      parent: 1
-  - uid: 6993
-    components:
-    - type: Transform
-      pos: 143.5,-64.5
-      parent: 1
   - uid: 6994
     components:
     - type: Transform
@@ -81088,26 +81217,6 @@ entities:
     components:
     - type: Transform
       pos: 46.5,-162.5
-      parent: 1
-  - uid: 7002
-    components:
-    - type: Transform
-      pos: 142.5,-68.5
-      parent: 1
-  - uid: 7003
-    components:
-    - type: Transform
-      pos: 142.5,-65.5
-      parent: 1
-  - uid: 7004
-    components:
-    - type: Transform
-      pos: 144.5,-65.5
-      parent: 1
-  - uid: 7005
-    components:
-    - type: Transform
-      pos: 141.5,-66.5
       parent: 1
   - uid: 7006
     components:
@@ -81314,46 +81423,6 @@ entities:
     - type: Transform
       pos: 46.5,-153.5
       parent: 1
-  - uid: 7047
-    components:
-    - type: Transform
-      pos: 144.5,-68.5
-      parent: 1
-  - uid: 7048
-    components:
-    - type: Transform
-      pos: 145.5,-67.5
-      parent: 1
-  - uid: 7049
-    components:
-    - type: Transform
-      pos: 143.5,-68.5
-      parent: 1
-  - uid: 7050
-    components:
-    - type: Transform
-      pos: 145.5,-65.5
-      parent: 1
-  - uid: 7051
-    components:
-    - type: Transform
-      pos: 141.5,-67.5
-      parent: 1
-  - uid: 7052
-    components:
-    - type: Transform
-      pos: 144.5,-64.5
-      parent: 1
-  - uid: 7053
-    components:
-    - type: Transform
-      pos: 141.5,-65.5
-      parent: 1
-  - uid: 7054
-    components:
-    - type: Transform
-      pos: 142.5,-64.5
-      parent: 1
   - uid: 7055
     components:
     - type: Transform
@@ -81383,66 +81452,6 @@ entities:
     components:
     - type: Transform
       pos: 138.5,-103.5
-      parent: 1
-  - uid: 7061
-    components:
-    - type: Transform
-      pos: 104.5,-72.5
-      parent: 1
-  - uid: 7062
-    components:
-    - type: Transform
-      pos: 103.5,-72.5
-      parent: 1
-  - uid: 7063
-    components:
-    - type: Transform
-      pos: 102.5,-72.5
-      parent: 1
-  - uid: 7064
-    components:
-    - type: Transform
-      pos: 105.5,-69.5
-      parent: 1
-  - uid: 7065
-    components:
-    - type: Transform
-      pos: 105.5,-72.5
-      parent: 1
-  - uid: 7066
-    components:
-    - type: Transform
-      pos: 104.5,-69.5
-      parent: 1
-  - uid: 7067
-    components:
-    - type: Transform
-      pos: 102.5,-71.5
-      parent: 1
-  - uid: 7068
-    components:
-    - type: Transform
-      pos: 103.5,-69.5
-      parent: 1
-  - uid: 7069
-    components:
-    - type: Transform
-      pos: 102.5,-70.5
-      parent: 1
-  - uid: 7070
-    components:
-    - type: Transform
-      pos: 105.5,-71.5
-      parent: 1
-  - uid: 7071
-    components:
-    - type: Transform
-      pos: 105.5,-70.5
-      parent: 1
-  - uid: 7072
-    components:
-    - type: Transform
-      pos: 102.5,-69.5
       parent: 1
   - uid: 7073
     components:
@@ -175140,7 +175149,7 @@ entities:
     - type: Transform
       pos: 42.5,-109.5
       parent: 1
-- proto: RMCWeaponShotgunHG3712
+- proto: RMCWeaponShotgunM12
   entities:
   - uid: 25801
     components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removed toxic water from Kutjevo where players could touch it, in CM13 the water is not toxic despite it looking so on the mapper due to strange water purification mechanics and wouldn't damage anyway because the damaging effect is on the effectblocker not the water tile, I have left the ones behind indestructible walls for now because it looks good.

Mapped composite barricades, fixed a pill bottle not being skillless, mapped a deck of cards.

## Why / Balance
Parity.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: CatAndHats
- fix: Fixed some water on Kutjevo being toxic when it shouldn't have been