### PR TITLE
Barricade blocking

### DIFF
--- a/Content.Shared/_RMC14/Barricade/ProjectileCoverComponent.cs
+++ b/Content.Shared/_RMC14/Barricade/ProjectileCoverComponent.cs
@@ -1,0 +1,11 @@
+using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Barricade;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class ProjectileCoverComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 Coverage = 85;
+}

--- a/Content.Shared/_RMC14/Barricade/SharedDirectionalAttackBlockSystem.cs
+++ b/Content.Shared/_RMC14/Barricade/SharedDirectionalAttackBlockSystem.cs
@@ -140,7 +140,6 @@ public abstract class SharedDirectionalAttackBlockSystem : EntitySystem
     {
         var passed = EnsureComp<ProjectileCoverPassedComponent>(projectile);
         passed.Barricades.Add(barricadeNet);
-        Dirty(projectile, passed);
     }
 
     /// <summary>

--- a/Content.Shared/_RMC14/Barricade/SharedDirectionalAttackBlockSystem.cs
+++ b/Content.Shared/_RMC14/Barricade/SharedDirectionalAttackBlockSystem.cs
@@ -1,15 +1,19 @@
 using System.Linq;
 using System.Numerics;
 using Content.Shared._RMC14.Marines;
+using Content.Shared._RMC14.Projectiles;
 using Content.Shared._RMC14.Random;
 using Content.Shared._RMC14.Weapons.Melee;
 using Content.Shared.Atmos;
 using Content.Shared.Damage;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Physics;
+using Content.Shared.Projectiles;
 using Content.Shared.Weapons.Melee.Events;
+using Content.Shared.Weapons.Ranged.Components;
 using Robust.Shared.Map;
 using Robust.Shared.Physics;
+using Robust.Shared.Physics.Events;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Timing;
 
@@ -24,6 +28,7 @@ public abstract class SharedDirectionalAttackBlockSystem : EntitySystem
     public override void Initialize()
     {
         SubscribeLocalEvent<MobStateComponent, MeleeAttackAttemptEvent>(OnMeleeAttackAttempt);
+        SubscribeLocalEvent<ProjectileCoverComponent, PreventCollideEvent>(OnBarricadePreventCollide);
     }
 
     private void OnMeleeAttackAttempt(Entity<MobStateComponent> ent, ref MeleeAttackAttemptEvent args)
@@ -53,6 +58,89 @@ public abstract class SharedDirectionalAttackBlockSystem : EntitySystem
             }
             break;
         }
+    }
+
+    private void OnBarricadePreventCollide(Entity<ProjectileCoverComponent> ent, ref PreventCollideEvent args)
+    {
+        if (args.Cancelled)
+            return;
+
+        if (!TryComp(args.OtherEntity, out ProjectileComponent? projectile))
+            return;
+
+        if (!Transform(ent).Anchored)
+            return;
+
+        var barricadeNet = GetNetEntity(ent.Owner);
+
+        if (TryComp(args.OtherEntity, out ProjectileCoverPassedComponent? passed) && passed.Barricades.Contains(barricadeNet))
+        {
+            args.Cancelled = true;
+            return;
+        }
+
+        // Shots aimed at barricade hit it
+        if (TryComp(args.OtherEntity, out TargetedProjectileComponent? targeted) && targeted.Target == ent.Owner)
+            return;
+
+        if (TryComp(args.OtherEntity, out ProjectileCoverInteractionComponent? interaction) && interaction.IgnoreCover)
+        {
+            args.Cancelled = true;
+            MarkPassed(args.OtherEntity, barricadeNet);
+            return;
+        }
+
+        if (!TryComp(args.OtherEntity, out RMCProjectileAccuracyComponent? accuracy) || accuracy.ShotFrom is not { } shotFrom)
+            return;
+
+        var facing = IsFacingTarget(ent.Owner, args.OtherEntity, shotFrom);
+        var behind = !facing && IsBehindTarget(ent.Owner, args.OtherEntity, shotFrom);
+        if (!facing && !behind)
+        {
+            args.Cancelled = true;
+            MarkPassed(args.OtherEntity, barricadeNet);
+            return;
+        }
+
+        var currentCoords = _transform.GetMoverCoordinates(args.OtherEntity);
+        var distance = (currentCoords.Position - shotFrom.Position).Length();
+
+        if (behind)
+        {
+            if (interaction is { StoppedByCover: true })
+                return;
+
+            distance -= 1;
+        }
+
+        if (distance < 1)
+        {
+            args.Cancelled = true;
+            MarkPassed(args.OtherEntity, barricadeNet);
+            return;
+        }
+
+        // accuracy can go over 100 (idk)
+        var accuracyValue = Math.Clamp((float) accuracy.Accuracy, 0f, 100f);
+        var coverage = (float) ent.Comp.Coverage;
+        var hitChance = Math.Min(coverage, coverage * distance / 6f + 50f * (1f - accuracyValue / 100f));
+
+        var tick = _timing.CurTick.Value;
+        var barricadeId = (long) barricadeNet.Id;
+        var roll = new Xoshiro128P(accuracy.GunSeed, ((long) tick << 32) | barricadeId).NextFloat(0, 100);
+
+        if (roll >= hitChance)
+        {
+            args.Cancelled = true;
+            MarkPassed(args.OtherEntity, barricadeNet);
+        }
+    }
+
+    private void MarkPassed(EntityUid projectile, NetEntity barricadeNet)
+    {
+        var passed = EnsureComp<ProjectileCoverPassedComponent>(projectile);
+        passed.Barricades.Add(barricadeNet);
+        Dirty(projectile, passed);
     }
 
     /// <summary>

--- a/Content.Shared/_RMC14/Barricade/SharedDirectionalAttackBlockSystem.cs
+++ b/Content.Shared/_RMC14/Barricade/SharedDirectionalAttackBlockSystem.cs
@@ -105,12 +105,18 @@ public abstract class SharedDirectionalAttackBlockSystem : EntitySystem
         var currentCoords = _transform.GetMoverCoordinates(args.OtherEntity);
         var distance = (currentCoords.Position - shotFrom.Position).Length();
 
-        if (behind)
+        if (facing)
         {
             if (interaction is { StoppedByCover: true })
                 return;
 
             distance -= 1;
+        }
+        else if (distance > 3)
+        {
+            args.Cancelled = true;
+            MarkPassed(args.OtherEntity, barricadeNet);
+            return;
         }
 
         if (distance < 1)

--- a/Content.Shared/_RMC14/Projectiles/ProjectileCoverInteractionComponent.cs
+++ b/Content.Shared/_RMC14/Projectiles/ProjectileCoverInteractionComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Projectiles;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class ProjectileCoverInteractionComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public bool IgnoreCover;
+
+    [DataField, AutoNetworkedField]
+    public bool StoppedByCover;
+}

--- a/Content.Shared/_RMC14/Projectiles/ProjectileCoverPassedComponent.cs
+++ b/Content.Shared/_RMC14/Projectiles/ProjectileCoverPassedComponent.cs
@@ -1,12 +1,10 @@
 using Content.Shared._RMC14.Barricade;
-using Robust.Shared.GameStates;
 
 namespace Content.Shared._RMC14.Projectiles;
 
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent]
 [Access(typeof(SharedDirectionalAttackBlockSystem))]
 public sealed partial class ProjectileCoverPassedComponent : Component
 {
-    [DataField, AutoNetworkedField]
     public HashSet<NetEntity> Barricades = new();
 }

--- a/Content.Shared/_RMC14/Projectiles/ProjectileCoverPassedComponent.cs
+++ b/Content.Shared/_RMC14/Projectiles/ProjectileCoverPassedComponent.cs
@@ -1,0 +1,12 @@
+using Content.Shared._RMC14.Barricade;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Projectiles;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(SharedDirectionalAttackBlockSystem))]
+public sealed partial class ProjectileCoverPassedComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public HashSet<NetEntity> Barricades = new();
+}

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/sentry.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/sentry.yml
@@ -22,6 +22,8 @@
     thresholds:
     - range: 22
       falloff: 10
+  - type: ProjectileCoverInteraction
+    ignoreCover: true
 
 - type: entity
   parent: RMCBaseBullet
@@ -45,6 +47,8 @@
     thresholds:
     - range: 22
       falloff: 10
+  - type: ProjectileCoverInteraction
+    ignoreCover: true
 
 - type: entity
   parent: RMCBaseBullet

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shrapnel.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shrapnel.yml
@@ -40,3 +40,5 @@
     thresholds:
     - range: 32
       falloff: 10
+  - type: ProjectileCoverInteraction
+    stoppedByCover: true

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Snipers/l112_sniper.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Snipers/l112_sniper.yml
@@ -293,6 +293,8 @@
   - type: AimedShotEffect
     extraHits: 1
   - type: IgnoreSwiftSteps
+  - type: ProjectileCoverInteraction
+    ignoreCover: true
 
 - type: entity
   parent: RMCBaseBullet
@@ -319,6 +321,8 @@
   - type: AimedShotEffect
     extraHits: 1
   - type: IgnoreSwiftSteps
+  - type: ProjectileCoverInteraction
+    ignoreCover: true
 
 - type: Tag
   id: RMCL112SniperRifle

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Snipers/m96c_sniper.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Snipers/m96c_sniper.yml
@@ -172,6 +172,8 @@
       buildup: true
   - type: AimedShotEffect
     extraHits: 2
+  - type: ProjectileCoverInteraction
+    ignoreCover: true
 
 - type: Tag
   id: CMM96CSniperRifle

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Snipers/m96s_sniper.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Snipers/m96s_sniper.yml
@@ -214,6 +214,8 @@
   - type: AimedShotEffect
     extraHits: 2
   - type: IgnoreSwiftSteps
+  - type: ProjectileCoverInteraction
+    ignoreCover: true
 
 - type: entity
   parent: CMBulletSniper10x28mm

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Snipers/type88_sniper.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Snipers/type88_sniper.yml
@@ -168,6 +168,8 @@
       falloff: 10
       buildup: true
   - type: IgnoreSwiftSteps
+  - type: ProjectileCoverInteraction
+    ignoreCover: true
 
 - type: Tag
   id: RMCType88SniperRifle

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_projectiles.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_projectiles.yml
@@ -177,6 +177,8 @@
     deleteOnFriendlyXeno: false
   - type: ProjectileMaxRange
     max: 5
+  - type: ProjectileCoverInteraction
+    stoppedByCover: true
 
 - type: entity
   id: XenoBoneChipsProjectile

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_projectiles.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_projectiles.yml
@@ -204,6 +204,8 @@
     max: 4
   - type: RMCProjectileAccuracy
     accuracy: 135
+  - type: ProjectileCoverInteraction
+    stoppedByCover: true
 
 - type: entity
   parent: XenoBoneChipsProjectile # TODO one projectile out of the 8 spawned for fire spikes is this one
@@ -373,6 +375,8 @@
     accuracy: 110
   - type: ProjectileMaxRange
     max: 3
+  - type: ProjectileCoverInteraction
+    stoppedByCover: true
 
 - type: entity
   parent: XenoAcidBallSpitProjectile
@@ -475,6 +479,8 @@
     drawDepth: Effects # Draws above mobs
   - type: ProjectileMaxRange
     max: 3.5
+  - type: ProjectileCoverInteraction
+    stoppedByCover: true
   - type: PreventCollideWithDead
   - type: Projectile
     impactEffect: null

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Walls/Barricades/barricade_base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Walls/Barricades/barricade_base.yml
@@ -30,7 +30,7 @@
         layer:
         - TableLayer
         - BarricadeImpassable
-        # - BulletImpassable TODO
+        - BulletImpassable
   - type: RotationDrawDepth
     southDrawDepth: OverMobs
   - type: Barricade
@@ -38,6 +38,7 @@
     damageContainer: Inorganic
     damageModifierSet: CMBarricade
   - type: DirectionalAttackBlocker
+  - type: ProjectileCover
   - type: RMCLeapProtection
     inherentStunDuration: 3
     fullProtection: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Cades now block projectiles based on distance 
You can target cades with projectiles 
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
parity
- closes #8739


## Technical details
<!-- Summary of code changes for easier review. -->
some reason rarely a mispredict can occur, but I think this is an issue with the way the recoil angle is done. I think the curtick can differ slightly at higher ping causing very minor variations. 

like here the angle is different between the server & client, client bullet hits the wall, server bullet hits the cade

client shooting
<img width="475" height="391" alt="image" src="https://github.com/user-attachments/assets/fbb89d85-e6b3-4651-9fac-b946ddc078ff" />

server
<img width="411" height="327" alt="image" src="https://github.com/user-attachments/assets/2d92fb30-7fc0-4d30-a6e4-82edb5f712e6" />

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

https://github.com/user-attachments/assets/956a6b8f-51fc-452a-8be4-cfc2d91372ae


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Cades now block projectiles based on distance 
- add: You can now target cades with projectiles 
