### PR TITLE
Xeno actions name obfuscation

### DIFF
--- a/Content.Server/_RMC14/Xenonids/AcidBloodSplash/AcidBloodSplashSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/AcidBloodSplash/AcidBloodSplashSystem.cs
@@ -8,6 +8,7 @@ using Robust.Shared.Random;
 using Content.Shared.Coordinates;
 using Content.Shared.Chat.Prototypes;
 using Content.Shared._RMC14.Emote;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Popups;
 using Robust.Shared.Player;
 using Content.Shared._RMC14.Xenonids;
@@ -94,8 +95,18 @@ public sealed class AcidBloodSplashSystem : EntitySystem
 
             _audio.PlayPvs(ent.Comp.AcidSplashSound, target);
 
-            _popup.PopupEntity(Loc.GetString("rmc-xeno-acid-blood-target-others", ("target", target)), target, Filter.PvsExcept(target), true, PopupType.SmallCaution);
             _popup.PopupEntity(Loc.GetString("rmc-xeno-acid-blood-target-self"), target, target, PopupType.MediumCaution);
+
+            var others = Filter.PvsExcept(target).Recipients;
+            foreach (var other in others)
+            {
+                if (other.AttachedEntity is not { } otherEnt)
+                    continue;
+
+                var otherTarget = ("target", Identity.Name(target, EntityManager, otherEnt));
+                var otherMessage = Loc.GetString("rmc-xeno-acid-blood-target-others", otherTarget);
+                _popup.PopupEntity(otherMessage, target, otherEnt, PopupType.SmallCaution);
+            }
 
             // TODO: don't activate when target don't feel pain
             if (_random.NextFloat() < ent.Comp.TargetScreamProbability && !HasComp<RMCUnconsciousComponent>(target))

--- a/Content.Shared/_RMC14/Xenonids/Devour/XenoDevourSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Devour/XenoDevourSystem.cs
@@ -394,7 +394,7 @@ public sealed class XenoDevourSystem : EntitySystem
         if (attemptEv.Cancelled)
             return;
 
-        var targetName = Identity.Entity(target, EntityManager, xeno);
+        var targetName = Identity.Name(target, EntityManager, xeno);
         var container = _container.EnsureContainer<ContainerSlot>(xeno, xeno.Comp.DevourContainerId);
         if (!_container.Insert(target, container))
         {
@@ -407,16 +407,27 @@ public sealed class XenoDevourSystem : EntitySystem
         devoured.RegurgitateAt = _timing.CurTime + xeno.Comp.RegurgitateAfter;
         devoured.NextDevouredAttackTimeAllowed = TimeSpan.Zero;
 
-        _popup.PopupClient(Loc.GetString("cm-xeno-devour-self", ("target", targetName)), xeno, xeno, PopupType.Medium);
-        _popup.PopupEntity(Loc.GetString("cm-xeno-devour-target", ("user", xeno.Owner)), xeno, target, PopupType.MediumCaution);
+        var selfMessage = Loc.GetString("cm-xeno-devour-self", ("target", targetName));
+        _popup.PopupClient(selfMessage, xeno, xeno, PopupType.Medium);
 
-        var others = Filter.PvsExcept(xeno).RemovePlayerByAttachedEntity(target);
-        foreach (var session in others.Recipients)
+        var others = Filter.PvsExcept(xeno).Recipients;
+        foreach (var other in others)
         {
-            if (session.AttachedEntity is not { } recipient)
+            if (other.AttachedEntity is not { } otherEnt)
                 continue;
 
-            _popup.PopupEntity(Loc.GetString("cm-xeno-devour-observer", ("user", Identity.Entity(xeno, EntityManager)), ("target", targetName)), xeno, recipient, PopupType.MediumCaution);
+            if (otherEnt == target)
+            {
+                var targetMessage = Loc.GetString("cm-xeno-devour-target", ("user", Identity.Name(xeno, EntityManager, target)));
+                _popup.PopupEntity(targetMessage, xeno, otherEnt);
+            }
+            else
+            {
+                var otherXeno = ("user", Identity.Name(xeno, EntityManager, otherEnt));
+                var otherTarget = ("target", Identity.Name(target, EntityManager, otherEnt));
+                var otherMessage = Loc.GetString("cm-xeno-devour-observer", otherXeno, otherTarget);
+                _popup.PopupEntity(otherMessage, xeno, otherEnt, PopupType.MediumCaution);
+            }
         }
 
         var ev = new XenoDevouredEvent(target, xeno.Owner);
@@ -598,18 +609,27 @@ public sealed class XenoDevourSystem : EntitySystem
             ForceVisible = true,
         };
 
-        var targetName = Identity.Name(target, EntityManager, xeno);
-        _popup.PopupClient(Loc.GetString("cm-xeno-devour-start-self", ("target", targetName)), target, xeno);
+        var selfMessage = Loc.GetString("cm-xeno-devour-start-self", ("target", Identity.Name(target, EntityManager, xeno)));
+        _popup.PopupClient(selfMessage, target, xeno);
 
-        _popup.PopupEntity(Loc.GetString("cm-xeno-devour-start-target", ("user", xeno)), xeno, target, PopupType.MediumCaution);
-
-        var others = Filter.PvsExcept(xeno).RemovePlayerByAttachedEntity(target);
-        foreach (var session in others.Recipients)
+        var others = Filter.PvsExcept(xeno).Recipients;
+        foreach (var other in others)
         {
-            if (session.AttachedEntity is not { } recipient)
+            if (other.AttachedEntity is not { } otherEnt)
                 continue;
 
-            _popup.PopupEntity(Loc.GetString("cm-xeno-devour-start-observer", ("user", xeno), ("target", targetName)), target, recipient, PopupType.SmallCaution);
+            if (otherEnt == target)
+            {
+                var targetMessage = Loc.GetString("cm-xeno-devour-start-target", ("user", Identity.Name(xeno, EntityManager, target)));
+                _popup.PopupEntity(targetMessage, xeno, otherEnt, PopupType.MediumCaution);
+            }
+            else
+            {
+                var otherXeno = ("user", Identity.Name(xeno, EntityManager, otherEnt));
+                var otherTarget = ("target", Identity.Name(target, EntityManager, otherEnt));
+                var otherMessage = Loc.GetString("cm-xeno-devour-start-observer", otherXeno, otherTarget);
+                _popup.PopupEntity(otherMessage, target, otherEnt, PopupType.SmallCaution);
+            }
         }
 
         _doAfter.TryStartDoAfter(doAfter);
@@ -699,7 +719,7 @@ public sealed class XenoDevourSystem : EntitySystem
             if (!comp.Warned && time >= comp.WarnAt)
             {
                 comp.Warned = true;
-                _popup.PopupEntity(Loc.GetString("cm-xeno-devour-regurgitate", ("target", uid)), xeno, xeno, PopupType.MediumCaution);
+                _popup.PopupEntity(Loc.GetString("cm-xeno-devour-regurgitate", ("target", Identity.Name(uid, EntityManager, xeno))), xeno, xeno, PopupType.MediumCaution);
             }
 
             if (time >= comp.RegurgitateAt)

--- a/Content.Shared/_RMC14/Xenonids/Fruit/SharedXenoFruitSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Fruit/SharedXenoFruitSystem.cs
@@ -25,6 +25,7 @@ using Content.Shared.Examine;
 using Content.Shared.FixedPoint;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Maps;
 using Content.Shared.Mobs;
@@ -40,6 +41,7 @@ using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Network;
+using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Spawners;
 using Robust.Shared.Timing;
@@ -492,8 +494,18 @@ public sealed class SharedXenoFruitSystem : EntitySystem
 
         var popupSelf = fruitOverflow ? Loc.GetString("rmc-xeno-fruit-plant-limit-exceeded")
             : Loc.GetString("rmc-xeno-fruit-plant-success-self");
-        var popupOthers = Loc.GetString("rmc-xeno-fruit-plant-success-others", ("xeno", xeno));
-        _popup.PopupPredicted(popupSelf, popupOthers, xeno.Owner, xeno.Owner);
+        _popup.PopupClient(popupSelf, xeno.Owner, xeno.Owner);
+
+        var others = Filter.PvsExcept(xeno.Owner).Recipients;
+        foreach (var other in others)
+        {
+            if (other.AttachedEntity is not { } otherEnt)
+                continue;
+
+            var otherXeno = ("xeno", Identity.Name(xeno, EntityManager, otherEnt));
+            var otherMessage = Loc.GetString("rmc-xeno-fruit-plant-success-others", otherXeno);
+            _popup.PopupEntity(otherMessage, xeno, otherEnt);
+        }
 
         UpdateFruitCount(xeno);
     }
@@ -658,17 +670,37 @@ public sealed class SharedXenoFruitSystem : EntitySystem
         };
 
         var popupSelf = Loc.GetString("rmc-xeno-fruit-eat-fail-self", ("fruit", fruit));
-        var popupOthers = Loc.GetString("rmc-xeno-fruit-eat-fail-others", ("fruit", fruit), ("xeno", user));
 
         if (!_doAfter.TryStartDoAfter(doAfter))
         {
-            _popup.PopupPredicted(popupSelf, popupOthers, user, user);
+            _popup.PopupClient(popupSelf, user, user);
+
+            var viewers = Filter.PvsExcept(user).Recipients;
+            foreach (var other in viewers)
+            {
+                if (other.AttachedEntity is not { } otherEnt)
+                    continue;
+
+                var otherXeno = ("xeno", Identity.Name(user, EntityManager, otherEnt));
+                var otherMessage = Loc.GetString("rmc-xeno-fruit-eat-fail-others", ("fruit", fruit), otherXeno);
+                _popup.PopupEntity(otherMessage, user, otherEnt);
+            }
             return false;
         }
 
         popupSelf = Loc.GetString("rmc-xeno-fruit-eat-start-self", ("fruit", fruit));
-        popupOthers = Loc.GetString("rmc-xeno-fruit-eat-start-others", ("fruit", fruit), ("xeno", user));
-        _popup.PopupPredicted(popupSelf, popupOthers, user, user);
+        _popup.PopupClient(popupSelf, user, user);
+
+        var others = Filter.PvsExcept(user).Recipients;
+        foreach (var other in others)
+        {
+            if (other.AttachedEntity is not { } otherEnt)
+                continue;
+
+            var otherXeno = ("xeno", Identity.Name(user, EntityManager, otherEnt));
+            var otherMessage = Loc.GetString("rmc-xeno-fruit-eat-start-others", ("fruit", fruit), otherXeno);
+            _popup.PopupEntity(otherMessage, user, otherEnt);
+        }
         return true;
     }
 
@@ -678,17 +710,19 @@ public sealed class SharedXenoFruitSystem : EntitySystem
         if (!HasComp<XenoComponent>(user) || fruit.Comp.State == XenoFruitState.Eaten)
             return false;
 
+        var targetName = ("target", Identity.Name(target, EntityManager, user));
+
         // Can't feed non-xenos
         if (!HasComp<XenoComponent>(target))
         {
-            _popup.PopupClient(Loc.GetString("rmc-xeno-fruit-feed-refuse", ("target",target), ("fruit", fruit)), user, user, PopupType.SmallCaution);
+            _popup.PopupClient(Loc.GetString("rmc-xeno-fruit-feed-refuse", targetName, ("fruit", fruit)), user, user, PopupType.SmallCaution);
             return false;
         }
 
         // Check if target is alive
         if (_mobState.IsDead(target))
         {
-            _popup.PopupClient(Loc.GetString("rmc-xeno-fruit-feed-dead", ("target", target), ("fruit", fruit)), user, user);
+            _popup.PopupClient(Loc.GetString("rmc-xeno-fruit-feed-dead", targetName, ("fruit", fruit)), user, user);
             return false;
         }
 
@@ -700,7 +734,7 @@ public sealed class SharedXenoFruitSystem : EntitySystem
         }
         else if (!_hive.FromSameHive(user, target))
         {
-            _popup.PopupClient(Loc.GetString("rmc-xeno-fruit-feed-wrong-hive", ("target", target)), user, user, PopupType.SmallCaution);
+            _popup.PopupClient(Loc.GetString("rmc-xeno-fruit-feed-wrong-hive", targetName), user, user, PopupType.SmallCaution);
             return false;
         }
 
@@ -733,22 +767,60 @@ public sealed class SharedXenoFruitSystem : EntitySystem
             TargetEffect = "RMCEffectHealBusy"
         };
 
-        var popupSelf = Loc.GetString("rmc-xeno-fruit-feed-fail-self", ("target", target), ("fruit", fruit));
-        var popupTarget = Loc.GetString("rmc-xeno-fruit-feed-fail-target", ("user", user), ("fruit", fruit));
-        var popupOthers = Loc.GetString("rmc-xeno-fruit-feed-fail-others", ("user", user), ("target", target), ("fruit", fruit));
-
         if (!_doAfter.TryStartDoAfter(doAfter))
         {
-            _popup.PopupClient(popupTarget, target, target, PopupType.MediumCaution);
-            _popup.PopupPredicted(popupSelf, popupOthers, user, user);
+            var selfTgt = ("target", Identity.Name(target, EntityManager, user));
+            var selfMsg = Loc.GetString("rmc-xeno-fruit-feed-fail-self", selfTgt, ("fruit", fruit));
+            _popup.PopupClient(selfMsg, user, user);
+
+            var viewers = Filter.PvsExcept(user).Recipients;
+            foreach (var other in viewers)
+            {
+                if (other.AttachedEntity is not { } otherEnt)
+                    continue;
+
+                if (otherEnt == target)
+                {
+                    var targetUser = ("user", Identity.Name(user, EntityManager, target));
+                    var targetMessage = Loc.GetString("rmc-xeno-fruit-feed-fail-target", ("user", user), ("fruit", fruit));
+                    _popup.PopupEntity(targetMessage, target, otherEnt, PopupType.MediumCaution);
+                }
+                else
+                {
+                    var otherUser = ("user", Identity.Name(user, EntityManager, otherEnt));
+                    var otherTarget = ("target", Identity.Name(target, EntityManager, otherEnt));
+                    var otherMessage = Loc.GetString("rmc-xeno-fruit-feed-fail-others", otherUser, otherTarget, ("fruit", fruit));
+                    _popup.PopupEntity(otherMessage, user, otherEnt);
+                }
+            }
             return false;
         }
 
-        popupSelf = Loc.GetString("rmc-xeno-fruit-feed-start-self", ("target", target), ("fruit", fruit));
-        popupTarget = Loc.GetString("rmc-xeno-fruit-feed-start-target", ("user", user), ("fruit", fruit));
-        popupOthers = Loc.GetString("rmc-xeno-fruit-feed-start-others", ("user", user), ("target", target), ("fruit", fruit));
-        _popup.PopupClient(popupTarget, target, target, PopupType.MediumCaution);
-        _popup.PopupPredicted(popupSelf, popupOthers, user, user);
+
+        var selfTarget = ("target", Identity.Name(target, EntityManager, user));
+        var selfMessage = Loc.GetString("rmc-xeno-fruit-feed-start-self", selfTarget, ("fruit", fruit));
+        _popup.PopupClient(selfMessage, user, user);
+
+        var others = Filter.PvsExcept(user).Recipients;
+        foreach (var other in others)
+        {
+            if (other.AttachedEntity is not { } otherEnt)
+                continue;
+
+            if (otherEnt == target)
+            {
+                var targetUser = ("user", Identity.Name(user, EntityManager, target));
+                var targetMessage = Loc.GetString("rmc-xeno-fruit-feed-start-target", ("user", user), ("fruit", fruit));
+                _popup.PopupEntity(targetMessage, target, otherEnt, PopupType.MediumCaution);
+            }
+            else
+            {
+                var otherUser = ("user", Identity.Name(user, EntityManager, otherEnt));
+                var otherTarget = ("target", Identity.Name(target, EntityManager, otherEnt));
+                var otherMessage = Loc.GetString("rmc-xeno-fruit-feed-start-others", otherUser, otherTarget, ("fruit", fruit));
+                _popup.PopupEntity(otherMessage, user, otherEnt);
+            }
+        }
         return true;
     }
 


### PR DESCRIPTION
## About the PR
Hid other faction's names for Fruit planting and feeding, Acid blood hitting someone else, Devouring, and Regurgitating.

## Why / Balance
Obfuscation, preventing metagaming, bugfixing.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl: CatAndHats
- fix: Obfuscated Fruit planting/feeding, Acid blood hitting someone, devouring, and regurgitating popups so they no longer reveal names between factions