### PR TITLE
Tunnelable tile overlay for Burrowers

### DIFF
--- a/Content.Client/_RMC14/Xenonids/Targeting/XenoAbilityPreviewOverlay.cs
+++ b/Content.Client/_RMC14/Xenonids/Targeting/XenoAbilityPreviewOverlay.cs
@@ -789,13 +789,17 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
         }
     }
 
-    // Overcommented to maybe help make the grid->world stuff less confusing, because it certainly confused me.
     private void DrawTileFilled(DrawingHandleWorld handle, EntityUid gridUid, MapGridComponent grid, HashSet<Vector2i> tiles, Color color)
     {
         if (tiles.Count == 0)
             return;
 
         var halfTileSize = grid.TileSizeHalfVector;
+
+        // Overcommented to maybe help make the grid->world stuff less confusing, because it certainly confused me.
+        // This is essentially the same as converting from grid-based `EntityCoordinates` to world-based `MapCoordinates`,
+        // just using raw `Vector2`s instead of the structs since they would fetch the grid's pos+rot for each tile rather than just once.
+        // (maybe a small optimisation, but this is potentially a lot of tiles updating every frame)
 
         // This grid's position and rotation relative to the base world.
         var (worldPos, worldRot) = _transform.GetWorldPositionRotation(gridUid);

--- a/Content.Client/_RMC14/Xenonids/Targeting/XenoAbilityPreviewOverlay.cs
+++ b/Content.Client/_RMC14/Xenonids/Targeting/XenoAbilityPreviewOverlay.cs
@@ -240,68 +240,6 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
         }
     }
 
-    private void DrawTunnelableTiles(in OverlayDrawArgs args, MapCoordinates originMap, XenoDigTunnelActionEvent tunnelEvent)
-    {
-        if (!_mapManager.TryFindGridAt(originMap, out var gridUid, out var grid))
-            return;
-
-        bool updateTileCache;
-        // If `_lastWorldBounds` hasn't been set yet or the screen's rotation has changed, update the tile cache.
-        if (_lastWorldBounds is not { } lastWorldBounds ||
-            lastWorldBounds.Rotation.GetCardinalDir() != args.WorldBounds.Rotation.GetCardinalDir())
-        {
-            updateTileCache = true;
-        }
-        // Otherwise, only update if the screen has moved more than a quarter tile in any direction.
-        else
-        {
-            var quarterTile = grid.TileSize / 4;
-            var diff = System.Numerics.Vector4.Abs(lastWorldBounds.Box.AsVector4 - args.WorldBounds.Box.AsVector4);
-
-            updateTileCache = diff.X > quarterTile || diff.Y > quarterTile || diff.Z > quarterTile || diff.W > quarterTile;
-        }
-
-        if (updateTileCache)
-        {
-            _tunnleableTileCache.Clear();
-            _lastWorldBounds = args.WorldBounds;
-
-            if (_almayerQ.HasComp(gridUid))
-                return;
-
-            foreach (var tile in _mapSystem.GetTilesIntersecting(gridUid, grid, args.WorldBounds))
-            {
-                if (!_turf.GetContentTileDefinition(tile).CanPlaceTunnel)
-                    continue;
-
-                if (!_area.TryGetArea((gridUid, grid), tile.GridIndices, out var area, out _))
-                    continue;
-                if (area.Value.Comp.NoTunnel)
-                    continue;
-
-                if (_turf.IsTileBlocked(tile, CollisionGroup.Impassable | CollisionGroup.MidImpassable | CollisionGroup.HighImpassable))
-                    continue;
-                if (_mapSystem.GetAnchoredEntities(gridUid, grid, tile.GridIndices).Any(_blockXenoConstructionQ.HasComp))
-                    continue;
-
-                _tunnleableTileCache.Add(tile.GridIndices);
-            }
-        }
-
-        // Filled and outlined overlay for all tunnelable tiles.
-        DrawTileFilled(args.WorldHandle, gridUid, grid, _tunnleableTileCache, TunnelAllowedFillColor);
-        DrawTileBorder(args.WorldHandle, gridUid, grid, _tunnleableTileCache, TunnelAllowedOutlineColor);
-
-        // Little "ghost" tunnel sprite on the tile that it will be placed.
-        if (TryGetTileIndices(originMap, out var playerTile) && _tunnleableTileCache.Contains(playerTile.Indices))
-        {
-            var spritePosition = _mapSystem.TileToVector((gridUid, grid), playerTile.Indices);
-            var tunnelSprite = _sprite.GetPrototypeIcon(tunnelEvent.Prototype).TextureFor(Direction.South);
-
-            args.WorldHandle.DrawTexture(tunnelSprite, spritePosition, new Color(0f, 0f, 0f, 0.5f));
-        }
-    }
-
     private void DrawResinSurge(
         in OverlayDrawArgs args,
         MapCoordinates originMap,
@@ -498,6 +436,68 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
         }
 
         DrawTileBorder(args.WorldHandle, gridUid, grid, aoeTiles, color);
+    }
+
+    private void DrawTunnelableTiles(in OverlayDrawArgs args, MapCoordinates originMap, XenoDigTunnelActionEvent tunnelEvent)
+    {
+        if (!_mapManager.TryFindGridAt(originMap, out var gridUid, out var grid))
+            return;
+
+        bool updateTileCache;
+        // If `_lastWorldBounds` hasn't been set yet or the screen's rotation has changed, update the tile cache.
+        if (_lastWorldBounds is not { } lastWorldBounds ||
+            lastWorldBounds.Rotation.GetCardinalDir() != args.WorldBounds.Rotation.GetCardinalDir())
+        {
+            updateTileCache = true;
+        }
+        // Otherwise, only update if the screen has moved more than a quarter tile in any direction.
+        else
+        {
+            var quarterTile = grid.TileSize / 4;
+            var diff = System.Numerics.Vector4.Abs(lastWorldBounds.Box.AsVector4 - args.WorldBounds.Box.AsVector4);
+
+            updateTileCache = diff.X > quarterTile || diff.Y > quarterTile || diff.Z > quarterTile || diff.W > quarterTile;
+        }
+
+        if (updateTileCache)
+        {
+            _tunnleableTileCache.Clear();
+            _lastWorldBounds = args.WorldBounds;
+
+            if (_almayerQ.HasComp(gridUid))
+                return;
+
+            foreach (var tile in _mapSystem.GetTilesIntersecting(gridUid, grid, args.WorldBounds))
+            {
+                if (!_turf.GetContentTileDefinition(tile).CanPlaceTunnel)
+                    continue;
+
+                if (!_area.TryGetArea((gridUid, grid), tile.GridIndices, out var area, out _))
+                    continue;
+                if (area.Value.Comp.NoTunnel)
+                    continue;
+
+                if (_turf.IsTileBlocked(tile, CollisionGroup.Impassable | CollisionGroup.MidImpassable | CollisionGroup.HighImpassable))
+                    continue;
+                if (_mapSystem.GetAnchoredEntities(gridUid, grid, tile.GridIndices).Any(_blockXenoConstructionQ.HasComp))
+                    continue;
+
+                _tunnleableTileCache.Add(tile.GridIndices);
+            }
+        }
+
+        // Filled and outlined overlay for all tunnelable tiles.
+        DrawTileFilled(args.WorldHandle, gridUid, grid, _tunnleableTileCache, TunnelAllowedFillColor);
+        DrawTileBorder(args.WorldHandle, gridUid, grid, _tunnleableTileCache, TunnelAllowedOutlineColor);
+
+        // Little "ghost" tunnel sprite on the tile that it will be placed.
+        if (TryGetTileIndices(originMap, out var playerTile) && _tunnleableTileCache.Contains(playerTile.Indices))
+        {
+            var spritePosition = _mapSystem.TileToVector((gridUid, grid), playerTile.Indices);
+            var tunnelSprite = _sprite.GetPrototypeIcon(tunnelEvent.Prototype).TextureFor(Direction.South);
+
+            args.WorldHandle.DrawTexture(tunnelSprite, spritePosition, new Color(0f, 0f, 0f, 0.5f));
+        }
     }
 
     private void DrawBurrowRange(

--- a/Content.Client/_RMC14/Xenonids/Targeting/XenoAbilityPreviewOverlay.cs
+++ b/Content.Client/_RMC14/Xenonids/Targeting/XenoAbilityPreviewOverlay.cs
@@ -51,8 +51,8 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
     private static readonly Color BlockerOutlineColor = new Color(0.65f, 0.65f, 0.65f);
     private static readonly Color AcidMineOutlineColor = new Color(0.6f, 0.9f, 0.2f);
     private static readonly Color DeployTrapsOutlineColor = new Color(0.8f, 0.6f, 0.2f);
-    private static readonly Color TunnelAllowedFillColor = Color.Green.WithAlpha(0.3f);
-    private static readonly Color TunnelAllowedOutlineColor = Color.Green.WithAlpha(0.6f);
+    private static readonly Color TunnelAllowedFillColor = Color.Green.WithAlpha(0.25f);
+    private static readonly Color TunnelAllowedOutlineColor = Color.Green.WithAlpha(0.5f);
 
     private const float OutlineAlpha = 0.8f;
     private const float OutlineThickness = 0.1f;
@@ -73,6 +73,7 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
     private readonly LineSystem _line;
     private readonly AreaSystem _area;
     private readonly TurfSystem _turf;
+    private readonly SpriteSystem _sprite;
     private readonly EntityQuery<ActionsComponent> _actionsQ;
     private readonly EntityQuery<TargetActionComponent> _targetActionQ;
     private readonly EntityQuery<WorldTargetActionComponent> _worldTargetQ;
@@ -110,6 +111,7 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
         _line = ents.System<LineSystem>();
         _area = ents.System<AreaSystem>();
         _turf = ents.System<TurfSystem>();
+        _sprite = ents.System<SpriteSystem>();
         _actionsQ = ents.GetEntityQuery<ActionsComponent>();
         _targetActionQ = ents.GetEntityQuery<TargetActionComponent>();
         _worldTargetQ = ents.GetEntityQuery<WorldTargetActionComponent>();
@@ -229,12 +231,12 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
                 break;
 
             case XenoDigTunnelActionEvent:
-                DrawTunnelableTiles(args, originMap);
+                DrawTunnelableTiles(args, originMap, (XenoDigTunnelActionEvent)worldTarget.Event);
                 break;
         }
     }
 
-    private void DrawTunnelableTiles(in OverlayDrawArgs args, MapCoordinates originMap)
+    private void DrawTunnelableTiles(in OverlayDrawArgs args, MapCoordinates originMap, XenoDigTunnelActionEvent tunnelEvent)
     {
         if (!_mapManager.TryFindGridAt(originMap, out var gridUid, out var grid))
             return;
@@ -267,6 +269,14 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
         // Filled and outlined overlay for all tunnelable tiles.
         DrawTileFilled(args.WorldHandle, gridUid, grid, _tunnleableTileCache, TunnelAllowedFillColor);
         DrawTileBorder(args.WorldHandle, gridUid, grid, _tunnleableTileCache, TunnelAllowedOutlineColor);
+
+        if (TryGetTileIndices(originMap, out var playerTile) && _tunnleableTileCache.Contains(playerTile.Indices))
+        {
+            var spritePosition = _mapSystem.TileToVector((gridUid, grid), playerTile.Indices);
+            var tunnelSprite = _sprite.GetPrototypeIcon(tunnelEvent.Prototype).TextureFor(Direction.South);
+
+            args.WorldHandle.DrawTexture(tunnelSprite, spritePosition, new Color(0f, 0f, 0f, 0.5f));
+        }
     }
 
     private void DrawResinSurge(

--- a/Content.Client/_RMC14/Xenonids/Targeting/XenoAbilityPreviewOverlay.cs
+++ b/Content.Client/_RMC14/Xenonids/Targeting/XenoAbilityPreviewOverlay.cs
@@ -90,6 +90,9 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
     private readonly EntityQuery<TransformComponent> _xformQ;
     private readonly EntityQuery<AlmayerComponent> _almayerQ;
 
+    private Box2Rotated? _lastWorldBounds;
+    private readonly HashSet<Vector2i> _tunnleableTileCache = [];
+
     public XenoAbilityPreviewOverlay(IEntityManager ents)
     {
         _input = IoCManager.Resolve<IInputManager>();
@@ -235,28 +238,35 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
     {
         if (!_mapManager.TryFindGridAt(originMap, out var gridUid, out var grid))
             return;
-        if (_almayerQ.HasComp(gridUid)) // can't build tunnels on the ship
-            return;
 
-        var tunnelAllowedTiles = new HashSet<Vector2i>();
-        foreach (var tile in _mapSystem.GetTilesIntersecting(gridUid, grid, args.WorldBounds))
+        // Probably unnecessary optimisation to only update when the camera moves.
+        if (_lastWorldBounds != args.WorldBounds)
         {
-            if (!_turf.GetContentTileDefinition(tile).CanPlaceTunnel)
-                continue;
-            if (_turf.IsTileBlocked(tile, CollisionGroup.Impassable | CollisionGroup.MidImpassable | CollisionGroup.HighImpassable))
-                continue;
+            _tunnleableTileCache.Clear();
+            _lastWorldBounds = args.WorldBounds;
 
-            if (!_area.TryGetArea((gridUid, grid), tile.GridIndices, out var area, out _))
-                continue;
-            if (area.Value.Comp.NoTunnel)
-                continue;
+            if (_almayerQ.HasComp(gridUid))
+                return;
 
-            tunnelAllowedTiles.Add(tile.GridIndices);
+            foreach (var tile in _mapSystem.GetTilesIntersecting(gridUid, grid, args.WorldBounds))
+            {
+                if (!_turf.GetContentTileDefinition(tile).CanPlaceTunnel)
+                    continue;
+                if (_turf.IsTileBlocked(tile, CollisionGroup.Impassable | CollisionGroup.MidImpassable | CollisionGroup.HighImpassable))
+                    continue;
+
+                if (!_area.TryGetArea((gridUid, grid), tile.GridIndices, out var area, out _))
+                    continue;
+                if (area.Value.Comp.NoTunnel)
+                    continue;
+
+                _tunnleableTileCache.Add(tile.GridIndices);
+            }
         }
 
         // Filled and outlined overlay for all tunnelable tiles.
-        DrawTileFilled(args.WorldHandle, gridUid, grid, tunnelAllowedTiles, TunnelAllowedFillColor);
-        DrawTileBorder(args.WorldHandle, gridUid, grid, tunnelAllowedTiles, TunnelAllowedOutlineColor);
+        DrawTileFilled(args.WorldHandle, gridUid, grid, _tunnleableTileCache, TunnelAllowedFillColor);
+        DrawTileBorder(args.WorldHandle, gridUid, grid, _tunnleableTileCache, TunnelAllowedOutlineColor);
     }
 
     private void DrawResinSurge(

--- a/Content.Client/_RMC14/Xenonids/Targeting/XenoAbilityPreviewOverlay.cs
+++ b/Content.Client/_RMC14/Xenonids/Targeting/XenoAbilityPreviewOverlay.cs
@@ -73,14 +73,14 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
     private readonly IPrototypeManager _prototypes;
     private readonly IComponentFactory _componentFactory;
     private readonly IStateManager _stateManager;
+    private readonly AreaSystem _area;
+    private readonly LineSystem _line;
     private readonly SharedMapSystem _mapSystem;
     private readonly SharedPhysicsSystem _physics;
     private readonly SharedTransformSystem _transform;
-    private readonly LineSystem _line;
-    private readonly AreaSystem _area;
+    private readonly SpriteSystem _sprite;
     private readonly TagSystem _tags;
     private readonly TurfSystem _turf;
-    private readonly SpriteSystem _sprite;
     private readonly EntityQuery<ActionsComponent> _actionsQ;
     private readonly EntityQuery<AlmayerComponent> _almayerQ;
     private readonly EntityQuery<BlockXenoConstructionComponent> _blockXenoConstructionQ;
@@ -113,14 +113,14 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
         _prototypes = IoCManager.Resolve<IPrototypeManager>();
         _componentFactory = IoCManager.Resolve<IComponentFactory>();
         _stateManager = IoCManager.Resolve<IStateManager>();
+        _area = ents.System<AreaSystem>();
+        _line = ents.System<LineSystem>();
         _mapSystem = ents.System<SharedMapSystem>();
         _physics = ents.System<SharedPhysicsSystem>();
-        _transform = ents.System<SharedTransformSystem>();
-        _line = ents.System<LineSystem>();
-        _area = ents.System<AreaSystem>();
-        _tags = ents.System<TagSystem>();
-        _turf = ents.System<TurfSystem>();
         _sprite = ents.System<SpriteSystem>();
+        _tags = ents.System<TagSystem>();
+        _transform = ents.System<SharedTransformSystem>();
+        _turf = ents.System<TurfSystem>();
         _actionsQ = ents.GetEntityQuery<ActionsComponent>();
         _almayerQ = ents.GetEntityQuery<AlmayerComponent>();
         _blockXenoConstructionQ = ents.GetEntityQuery<BlockXenoConstructionComponent>();
@@ -240,8 +240,8 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
                 DrawPierce(args, player.Value, xform, originMap, mousePos, pierce);
                 break;
 
-            case XenoDigTunnelActionEvent:
-                DrawTunnelableTiles(args, originMap, (XenoDigTunnelActionEvent)worldTarget.Event);
+            case XenoDigTunnelActionEvent tunnelEvent:
+                DrawTunnelableTiles(args, originMap, tunnelEvent);
                 break;
         }
     }
@@ -805,7 +805,7 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
 
         var halfTileSize = grid.TileSizeHalfVector;
 
-        // Overcommented to maybe help make the grid->world stuff less confusing, because it certainly confused me.
+        // Overcommented to maybe help make the grid -> world stuff less confusing, because it certainly confused me.
         // This is essentially the same as converting from grid-based `EntityCoordinates` to world-based `MapCoordinates`,
         // just using raw `Vector2`s instead of the structs since they would fetch the grid's pos+rot for each tile rather than just once.
         // (maybe a small optimisation, but this is potentially a lot of tiles updating every frame)

--- a/Content.Client/_RMC14/Xenonids/Targeting/XenoAbilityPreviewOverlay.cs
+++ b/Content.Client/_RMC14/Xenonids/Targeting/XenoAbilityPreviewOverlay.cs
@@ -21,6 +21,7 @@ using Content.Shared._RMC14.Xenonids.Weeds;
 using Content.Shared.Actions.Components;
 using Content.Shared.Maps;
 using Content.Shared.Physics;
+using Content.Shared.Tag;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.Input;
@@ -56,6 +57,9 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
     private static readonly Color TunnelAllowedFillColor = Color.Green.WithAlpha(0.25f);
     private static readonly Color TunnelAllowedOutlineColor = Color.Green.WithAlpha(0.5f);
 
+    private static readonly ProtoId<TagPrototype> AirlockTag = "Airlock";
+    private static readonly ProtoId<TagPrototype> StructureTag = "Structure";
+
     private const float OutlineAlpha = 0.8f;
     private const float OutlineThickness = 0.1f;
     private const int BombardDefaultRadius = 3;
@@ -74,6 +78,7 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
     private readonly SharedTransformSystem _transform;
     private readonly LineSystem _line;
     private readonly AreaSystem _area;
+    private readonly TagSystem _tags;
     private readonly TurfSystem _turf;
     private readonly SpriteSystem _sprite;
     private readonly EntityQuery<ActionsComponent> _actionsQ;
@@ -113,6 +118,7 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
         _transform = ents.System<SharedTransformSystem>();
         _line = ents.System<LineSystem>();
         _area = ents.System<AreaSystem>();
+        _tags = ents.System<TagSystem>();
         _turf = ents.System<TurfSystem>();
         _sprite = ents.System<SpriteSystem>();
         _actionsQ = ents.GetEntityQuery<ActionsComponent>();
@@ -479,8 +485,11 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
 
                 if (_turf.IsTileBlocked(tile, CollisionGroup.Impassable | CollisionGroup.MidImpassable | CollisionGroup.HighImpassable))
                     continue;
-                if (_mapSystem.GetAnchoredEntities(gridUid, grid, tile.GridIndices).Any(_blockXenoConstructionQ.HasComp))
+                if (_mapSystem.GetAnchoredEntities(gridUid, grid, tile.GridIndices)
+                    .Any(e => _blockXenoConstructionQ.HasComp(e) || _tags.HasAnyTag(e, AirlockTag, StructureTag)))
+                {
                     continue;
+                }
 
                 _tunnleableTileCache.Add(tile.GridIndices);
             }

--- a/Content.Client/_RMC14/Xenonids/Targeting/XenoAbilityPreviewOverlay.cs
+++ b/Content.Client/_RMC14/Xenonids/Targeting/XenoAbilityPreviewOverlay.cs
@@ -37,6 +37,8 @@ using Robust.Shared.Maths;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Prototypes;
+using Content.Shared._RMC14.Xenonids.Construction.Tunnel;
+using Content.Shared._RMC14.Areas;
 
 namespace Content.Client._RMC14.Xenonids.Targeting;
 
@@ -72,6 +74,8 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
     private readonly SharedPhysicsSystem _physics;
     private readonly SharedTransformSystem _transform;
     private readonly LineSystem _line;
+    private readonly AreaSystem _area;
+    private readonly TurfSystem _turf;
     private readonly EntityQuery<ActionsComponent> _actionsQ;
     private readonly EntityQuery<TargetActionComponent> _targetActionQ;
     private readonly EntityQuery<WorldTargetActionComponent> _worldTargetQ;
@@ -103,6 +107,8 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
         _physics = ents.System<SharedPhysicsSystem>();
         _transform = ents.System<SharedTransformSystem>();
         _line = ents.System<LineSystem>();
+        _area = ents.System<AreaSystem>();
+        _turf = ents.System<TurfSystem>();
         _actionsQ = ents.GetEntityQuery<ActionsComponent>();
         _targetActionQ = ents.GetEntityQuery<TargetActionComponent>();
         _worldTargetQ = ents.GetEntityQuery<WorldTargetActionComponent>();
@@ -219,6 +225,57 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
                     return;
                 DrawPierce(args, player.Value, xform, originMap, mousePos, pierce);
                 break;
+
+            case XenoDigTunnelActionEvent:
+                DrawTunnelDigAllowed(args, player.Value, originMap, mousePos);
+                break;
+        }
+    }
+
+    /*
+    todos:
+    better method name
+    border around mousepos with highlighted colour
+    */
+    private void DrawTunnelDigAllowed(in OverlayDrawArgs args, EntityUid player, MapCoordinates originMap, MapCoordinates mousePos)
+    {
+        var gridsInView = new List<Entity<MapGridComponent>>();
+        _mapManager.FindGridsIntersecting(args.MapId, args.WorldBounds, ref gridsInView);
+
+        foreach (var grid in gridsInView)
+        {
+            var tunnelAllowedTiles = new HashSet<Vector2i>();
+
+            foreach (var tile in _mapSystem.GetTilesIntersecting(grid, grid.Comp, args.WorldBounds))
+            {
+                if (!_turf.GetContentTileDefinition(tile).CanPlaceTunnel)
+                    continue;
+                if (_turf.IsTileBlocked(tile, CollisionGroup.Impassable | CollisionGroup.MidImpassable | CollisionGroup.HighImpassable))
+                    continue;
+
+                if (!_area.TryGetArea(grid, tile.GridIndices, out var area, out _))
+                    continue;
+                if (area.Value.Comp.NoTunnel)
+                    continue;
+
+                tunnelAllowedTiles.Add(tile.GridIndices);
+            }
+
+            foreach (var tileCoords in tunnelAllowedTiles)
+            {
+                // Filled-in overlay
+                args.WorldHandle.DrawRect(
+                    new Box2(
+                        tileCoords.X,
+                        tileCoords.Y,
+                        tileCoords.X + grid.Comp.TileSize,
+                        tileCoords.Y + grid.Comp.TileSize
+                    ),
+                    Color.Green.WithAlpha(0.5f)
+                );
+            }
+            // Outline overlay
+            DrawTileBorder(args.WorldHandle, grid.Owner, grid.Comp, tunnelAllowedTiles, Color.Green);
         }
     }
 
@@ -274,7 +331,7 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
             return;
 
         var center = _mapSystem.CoordinatesToTile(gridUid, grid, mousePos);
-        var tileRadius = (int) MathF.Ceiling(radius);
+        var tileRadius = (int)MathF.Ceiling(radius);
         var tiles = new HashSet<Vector2i>();
         for (var x = -tileRadius; x <= tileRadius; x++)
         {
@@ -310,14 +367,14 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
         // Convert the orthogonal world vector to a tile-space step
         // by seeing which tile neighbour it points most toward
         var orthoTile = new Vector2i(
-            (int) MathF.Round(ortho.X),
-            (int) MathF.Round(ortho.Y)
+            (int)MathF.Round(ortho.X),
+            (int)MathF.Round(ortho.Y)
         );
 
         if (orthoTile == Vector2i.Zero)
             orthoTile = new Vector2i(1, 0);
 
-        var radius = (int) deployTraps.DeployTrapsRadius;
+        var radius = (int)deployTraps.DeployTrapsRadius;
         var rangeSquared = deployTraps.Range * deployTraps.Range;
         var validTiles = new HashSet<Vector2i>();
         var invalidTiles = new HashSet<Vector2i>();
@@ -443,7 +500,7 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
 
         var center = _mapSystem.CoordinatesToTile(gridUid, grid, originMap);
         var tileSize = grid.TileSize;
-        var maxTiles = (int) MathF.Ceiling(range / tileSize);
+        var maxTiles = (int)MathF.Ceiling(range / tileSize);
         var tiles = new HashSet<Vector2i>();
         for (var x = -maxTiles; x <= maxTiles; x++)
         {
@@ -754,7 +811,7 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
                 return mask;
         }
 
-        return (int) (CollisionGroup.Impassable | CollisionGroup.BulletImpassable | CollisionGroup.XenoProjectileImpassable);
+        return (int)(CollisionGroup.Impassable | CollisionGroup.BulletImpassable | CollisionGroup.XenoProjectileImpassable);
     }
 
     private MapCoordinates AdjustProjectileImpact(EntProtoId projectile, MapCoordinates origin, MapCoordinates impact)

--- a/Content.Client/_RMC14/Xenonids/Targeting/XenoAbilityPreviewOverlay.cs
+++ b/Content.Client/_RMC14/Xenonids/Targeting/XenoAbilityPreviewOverlay.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Numerics;
 using Content.Client.Gameplay;
 using Content.Client.UserInterface.Systems.Actions;
@@ -29,16 +26,14 @@ using Robust.Client.State;
 using Robust.Client.UserInterface;
 using Robust.Shared.Configuration;
 using Robust.Shared.Enums;
-using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
-using Robust.Shared.Maths;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Prototypes;
 using Content.Shared._RMC14.Xenonids.Construction.Tunnel;
 using Content.Shared._RMC14.Areas;
+using Content.Shared._RMC14.Marines;
 
 namespace Content.Client._RMC14.Xenonids.Targeting;
 
@@ -56,6 +51,8 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
     private static readonly Color BlockerOutlineColor = new Color(0.65f, 0.65f, 0.65f);
     private static readonly Color AcidMineOutlineColor = new Color(0.6f, 0.9f, 0.2f);
     private static readonly Color DeployTrapsOutlineColor = new Color(0.8f, 0.6f, 0.2f);
+    private static readonly Color TunnelAllowedFillColor = Color.Green.WithAlpha(0.3f);
+    private static readonly Color TunnelAllowedOutlineColor = Color.Green.WithAlpha(0.6f);
 
     private const float OutlineAlpha = 0.8f;
     private const float OutlineThickness = 0.1f;
@@ -91,6 +88,7 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
     private readonly EntityQuery<XenoAbductComponent> _abductQ;
     private readonly EntityQuery<XenoPierceComponent> _pierceQ;
     private readonly EntityQuery<TransformComponent> _xformQ;
+    private readonly EntityQuery<AlmayerComponent> _almayerQ;
 
     public XenoAbilityPreviewOverlay(IEntityManager ents)
     {
@@ -124,6 +122,7 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
         _abductQ = ents.GetEntityQuery<XenoAbductComponent>();
         _pierceQ = ents.GetEntityQuery<XenoPierceComponent>();
         _xformQ = ents.GetEntityQuery<TransformComponent>();
+        _almayerQ = ents.GetEntityQuery<AlmayerComponent>();
     }
 
     protected override void Draw(in OverlayDrawArgs args)
@@ -227,56 +226,37 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
                 break;
 
             case XenoDigTunnelActionEvent:
-                DrawTunnelDigAllowed(args, player.Value, originMap, mousePos);
+                DrawTunnelableTiles(args, originMap);
                 break;
         }
     }
 
-    /*
-    todos:
-    better method name
-    border around mousepos with highlighted colour
-    */
-    private void DrawTunnelDigAllowed(in OverlayDrawArgs args, EntityUid player, MapCoordinates originMap, MapCoordinates mousePos)
+    private void DrawTunnelableTiles(in OverlayDrawArgs args, MapCoordinates originMap)
     {
-        var gridsInView = new List<Entity<MapGridComponent>>();
-        _mapManager.FindGridsIntersecting(args.MapId, args.WorldBounds, ref gridsInView);
+        if (!_mapManager.TryFindGridAt(originMap, out var gridUid, out var grid))
+            return;
+        if (_almayerQ.HasComp(gridUid)) // can't build tunnels on the ship
+            return;
 
-        foreach (var grid in gridsInView)
+        var tunnelAllowedTiles = new HashSet<Vector2i>();
+        foreach (var tile in _mapSystem.GetTilesIntersecting(gridUid, grid, args.WorldBounds))
         {
-            var tunnelAllowedTiles = new HashSet<Vector2i>();
+            if (!_turf.GetContentTileDefinition(tile).CanPlaceTunnel)
+                continue;
+            if (_turf.IsTileBlocked(tile, CollisionGroup.Impassable | CollisionGroup.MidImpassable | CollisionGroup.HighImpassable))
+                continue;
 
-            foreach (var tile in _mapSystem.GetTilesIntersecting(grid, grid.Comp, args.WorldBounds))
-            {
-                if (!_turf.GetContentTileDefinition(tile).CanPlaceTunnel)
-                    continue;
-                if (_turf.IsTileBlocked(tile, CollisionGroup.Impassable | CollisionGroup.MidImpassable | CollisionGroup.HighImpassable))
-                    continue;
+            if (!_area.TryGetArea((gridUid, grid), tile.GridIndices, out var area, out _))
+                continue;
+            if (area.Value.Comp.NoTunnel)
+                continue;
 
-                if (!_area.TryGetArea(grid, tile.GridIndices, out var area, out _))
-                    continue;
-                if (area.Value.Comp.NoTunnel)
-                    continue;
-
-                tunnelAllowedTiles.Add(tile.GridIndices);
-            }
-
-            foreach (var tileCoords in tunnelAllowedTiles)
-            {
-                // Filled-in overlay
-                args.WorldHandle.DrawRect(
-                    new Box2(
-                        tileCoords.X,
-                        tileCoords.Y,
-                        tileCoords.X + grid.Comp.TileSize,
-                        tileCoords.Y + grid.Comp.TileSize
-                    ),
-                    Color.Green.WithAlpha(0.5f)
-                );
-            }
-            // Outline overlay
-            DrawTileBorder(args.WorldHandle, grid.Owner, grid.Comp, tunnelAllowedTiles, Color.Green);
+            tunnelAllowedTiles.Add(tile.GridIndices);
         }
+
+        // Filled and outlined overlay for all tunnelable tiles.
+        DrawTileFilled(args.WorldHandle, gridUid, grid, tunnelAllowedTiles, TunnelAllowedFillColor);
+        DrawTileBorder(args.WorldHandle, gridUid, grid, tunnelAllowedTiles, TunnelAllowedOutlineColor);
     }
 
     private void DrawResinSurge(
@@ -745,24 +725,53 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
             return;
 
         var tileSize = grid.TileSize;
-        var tileSizeVec = new Vector2(tileSize, tileSize);
+        var gridMatrix = _transform.GetWorldMatrix(gridUid);
 
         foreach (var indices in tiles)
         {
-            var baseLocal = new Vector2(indices.X * tileSize, indices.Y * tileSize);
-            var p00 = _transform.ToMapCoordinates(new EntityCoordinates(gridUid, baseLocal)).Position;
-            var p10 = _transform.ToMapCoordinates(new EntityCoordinates(gridUid, baseLocal + new Vector2(tileSize, 0f))).Position;
-            var p11 = _transform.ToMapCoordinates(new EntityCoordinates(gridUid, baseLocal + tileSizeVec)).Position;
-            var p01 = _transform.ToMapCoordinates(new EntityCoordinates(gridUid, baseLocal + new Vector2(0f, tileSize))).Position;
+            var baseLocal = _mapSystem.TileToVector((gridUid, grid), indices);
+            var bottomLeft = Vector2.Transform(baseLocal, gridMatrix);
+            var bottomRight = Vector2.Transform(baseLocal + new Vector2(tileSize, 0f), gridMatrix);
+            var topLeft = Vector2.Transform(baseLocal + new Vector2(0f, tileSize), gridMatrix);
+            var topRight = Vector2.Transform(baseLocal + grid.TileSizeVector, gridMatrix);
 
             if (!tiles.Contains(new Vector2i(indices.X, indices.Y + 1)))
-                DrawEdge(handle, p01, p11, color);
+                DrawEdge(handle, topLeft, topRight, color);
             if (!tiles.Contains(new Vector2i(indices.X, indices.Y - 1)))
-                DrawEdge(handle, p00, p10, color);
+                DrawEdge(handle, bottomLeft, bottomRight, color);
             if (!tiles.Contains(new Vector2i(indices.X + 1, indices.Y)))
-                DrawEdge(handle, p10, p11, color);
+                DrawEdge(handle, bottomRight, topRight, color);
             if (!tiles.Contains(new Vector2i(indices.X - 1, indices.Y)))
-                DrawEdge(handle, p00, p01, color);
+                DrawEdge(handle, bottomLeft, topLeft, color);
+        }
+    }
+
+    // Overcommented to maybe help make the grid->world stuff less confusing, because it certainly confused me.
+    private void DrawTileFilled(DrawingHandleWorld handle, EntityUid gridUid, MapGridComponent grid, HashSet<Vector2i> tiles, Color color)
+    {
+        if (tiles.Count == 0)
+            return;
+
+        var halfTileSize = grid.TileSizeHalfVector;
+
+        // This grid's position and rotation relative to the base world.
+        var (worldPos, worldRot) = _transform.GetWorldPositionRotation(gridUid);
+        // Transform matrix to quickly convert from grid-based coords to world coords.
+        var gridMatrix = Matrix3Helpers.CreateTransform(worldPos, worldRot);
+
+        foreach (var indices in tiles)
+        {
+            // Grid-based coords of the center point of this tile.
+            var localCenter = _mapSystem.TileCenterToVector(gridUid, grid, indices);
+            // "Real" world coords of the center point.
+            var worldCenter = Vector2.Transform(localCenter, gridMatrix);
+
+            // A tile-sized `Box2` centered around `worldCenter`.
+            var centeredBox = new Box2(worldCenter - halfTileSize, worldCenter + halfTileSize);
+            // `centeredBox` rotated to match the rotation of the grid, and thus the rotation of the tile.
+            var rotatedBox = new Box2Rotated(centeredBox, worldRot, worldCenter);
+
+            handle.DrawRect(rotatedBox, color);
         }
     }
 

--- a/Content.Client/_RMC14/Xenonids/Targeting/XenoAbilityPreviewOverlay.cs
+++ b/Content.Client/_RMC14/Xenonids/Targeting/XenoAbilityPreviewOverlay.cs
@@ -1,20 +1,23 @@
-using System.Numerics;
 using Content.Client.Gameplay;
 using Content.Client.UserInterface.Systems.Actions;
+using Content.Shared._RMC14.Areas;
 using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Line;
+using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.Projectiles;
 using Content.Shared._RMC14.Smoke;
+using Content.Shared._RMC14.Xenonids.Abduct;
 using Content.Shared._RMC14.Xenonids.AcidMine;
 using Content.Shared._RMC14.Xenonids.Bombard;
 using Content.Shared._RMC14.Xenonids.Burrow;
+using Content.Shared._RMC14.Xenonids.Construction;
+using Content.Shared._RMC14.Xenonids.Construction.Tunnel;
 using Content.Shared._RMC14.Xenonids.DeployTraps;
 using Content.Shared._RMC14.Xenonids.Fruit.Components;
+using Content.Shared._RMC14.Xenonids.Pierce;
 using Content.Shared._RMC14.Xenonids.ResinSurge;
 using Content.Shared._RMC14.Xenonids.Spray;
 using Content.Shared._RMC14.Xenonids.Weeds;
-using Content.Shared._RMC14.Xenonids.Abduct;
-using Content.Shared._RMC14.Xenonids.Pierce;
 using Content.Shared.Actions.Components;
 using Content.Shared.Maps;
 using Content.Shared.Physics;
@@ -31,9 +34,8 @@ using Robust.Shared.Map.Components;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Prototypes;
-using Content.Shared._RMC14.Xenonids.Construction.Tunnel;
-using Content.Shared._RMC14.Areas;
-using Content.Shared._RMC14.Marines;
+using System.Linq;
+using System.Numerics;
 
 namespace Content.Client._RMC14.Xenonids.Targeting;
 
@@ -75,6 +77,8 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
     private readonly TurfSystem _turf;
     private readonly SpriteSystem _sprite;
     private readonly EntityQuery<ActionsComponent> _actionsQ;
+    private readonly EntityQuery<AlmayerComponent> _almayerQ;
+    private readonly EntityQuery<BlockXenoConstructionComponent> _blockXenoConstructionQ;
     private readonly EntityQuery<TargetActionComponent> _targetActionQ;
     private readonly EntityQuery<WorldTargetActionComponent> _worldTargetQ;
     private readonly EntityQuery<XenoSprayAcidComponent> _sprayQ;
@@ -89,7 +93,6 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
     private readonly EntityQuery<XenoAbductComponent> _abductQ;
     private readonly EntityQuery<XenoPierceComponent> _pierceQ;
     private readonly EntityQuery<TransformComponent> _xformQ;
-    private readonly EntityQuery<AlmayerComponent> _almayerQ;
 
     private Box2Rotated? _lastWorldBounds;
     private readonly HashSet<Vector2i> _tunnleableTileCache = [];
@@ -113,6 +116,8 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
         _turf = ents.System<TurfSystem>();
         _sprite = ents.System<SpriteSystem>();
         _actionsQ = ents.GetEntityQuery<ActionsComponent>();
+        _almayerQ = ents.GetEntityQuery<AlmayerComponent>();
+        _blockXenoConstructionQ = ents.GetEntityQuery<BlockXenoConstructionComponent>();
         _targetActionQ = ents.GetEntityQuery<TargetActionComponent>();
         _worldTargetQ = ents.GetEntityQuery<WorldTargetActionComponent>();
         _sprayQ = ents.GetEntityQuery<XenoSprayAcidComponent>();
@@ -127,7 +132,6 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
         _abductQ = ents.GetEntityQuery<XenoAbductComponent>();
         _pierceQ = ents.GetEntityQuery<XenoPierceComponent>();
         _xformQ = ents.GetEntityQuery<TransformComponent>();
-        _almayerQ = ents.GetEntityQuery<AlmayerComponent>();
     }
 
     protected override void Draw(in OverlayDrawArgs args)
@@ -241,8 +245,23 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
         if (!_mapManager.TryFindGridAt(originMap, out var gridUid, out var grid))
             return;
 
-        // Probably unnecessary optimisation to only update when the camera moves.
-        if (_lastWorldBounds != args.WorldBounds)
+        bool updateTileCache;
+        // If `_lastWorldBounds` hasn't been set yet or the screen's rotation has changed, update the tile cache.
+        if (_lastWorldBounds is not { } lastWorldBounds ||
+            lastWorldBounds.Rotation.GetCardinalDir() != args.WorldBounds.Rotation.GetCardinalDir())
+        {
+            updateTileCache = true;
+        }
+        // Otherwise, only update if the screen has moved more than a quarter tile in any direction.
+        else
+        {
+            var quarterTile = grid.TileSize / 4;
+            var diff = System.Numerics.Vector4.Abs(lastWorldBounds.Box.AsVector4 - args.WorldBounds.Box.AsVector4);
+
+            updateTileCache = diff.X > quarterTile || diff.Y > quarterTile || diff.Z > quarterTile || diff.W > quarterTile;
+        }
+
+        if (updateTileCache)
         {
             _tunnleableTileCache.Clear();
             _lastWorldBounds = args.WorldBounds;
@@ -254,12 +273,15 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
             {
                 if (!_turf.GetContentTileDefinition(tile).CanPlaceTunnel)
                     continue;
-                if (_turf.IsTileBlocked(tile, CollisionGroup.Impassable | CollisionGroup.MidImpassable | CollisionGroup.HighImpassable))
-                    continue;
 
                 if (!_area.TryGetArea((gridUid, grid), tile.GridIndices, out var area, out _))
                     continue;
                 if (area.Value.Comp.NoTunnel)
+                    continue;
+
+                if (_turf.IsTileBlocked(tile, CollisionGroup.Impassable | CollisionGroup.MidImpassable | CollisionGroup.HighImpassable))
+                    continue;
+                if (_mapSystem.GetAnchoredEntities(gridUid, grid, tile.GridIndices).Any(_blockXenoConstructionQ.HasComp))
                     continue;
 
                 _tunnleableTileCache.Add(tile.GridIndices);
@@ -270,6 +292,7 @@ public sealed class XenoAbilityPreviewOverlay : Overlay
         DrawTileFilled(args.WorldHandle, gridUid, grid, _tunnleableTileCache, TunnelAllowedFillColor);
         DrawTileBorder(args.WorldHandle, gridUid, grid, _tunnleableTileCache, TunnelAllowedOutlineColor);
 
+        // Little "ghost" tunnel sprite on the tile that it will be placed.
         if (TryGetTileIndices(originMap, out var playerTile) && _tunnleableTileCache.Contains(playerTile.Indices))
         {
             var spritePosition = _mapSystem.TileToVector((gridUid, grid), playerTile.Indices);

--- a/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/SharedXenoConstructionSystem.cs
@@ -11,8 +11,6 @@ using Content.Shared._RMC14.Sentry;
 using Content.Shared._RMC14.Xenonids.Announce;
 using Content.Shared._RMC14.Xenonids.Construction.Events;
 using Content.Shared._RMC14.Xenonids.Construction.Nest;
-using Content.Shared._RMC14.Xenonids.Construction.Tunnel;
-using Content.Shared._RMC14.Xenonids.Egg;
 using Content.Shared._RMC14.Xenonids.Evolution;
 using Content.Shared._RMC14.Xenonids.Eye;
 using Content.Shared._RMC14.Vehicle;
@@ -104,8 +102,6 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
     private EntityQuery<SentryComponent> _sentryQuery;
     private EntityQuery<TransformComponent> _transformQuery;
     private EntityQuery<XenoConstructComponent> _xenoConstructQuery;
-    private EntityQuery<XenoEggComponent> _xenoEggQuery;
-    private EntityQuery<XenoTunnelComponent> _xenoTunnelQuery;
     private EntityQuery<QueenBuildingBoostComponent> _queenBoostQuery;
 
     private const string XenoStructuresAnimation = "RMCEffect";
@@ -128,8 +124,6 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
         _sentryQuery = GetEntityQuery<SentryComponent>();
         _transformQuery = GetEntityQuery<TransformComponent>();
         _xenoConstructQuery = GetEntityQuery<XenoConstructComponent>();
-        _xenoEggQuery = GetEntityQuery<XenoEggComponent>();
-        _xenoTunnelQuery = GetEntityQuery<XenoTunnelComponent>();
         _queenBoostQuery = GetEntityQuery<QueenBuildingBoostComponent>();
 
         SubscribeLocalEvent<NewXenoEvolvedEvent>(OnNewXenoEvolved);
@@ -1435,8 +1429,6 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
             }
 
             if (_xenoConstructQuery.HasComp(uid) ||
-                _xenoEggQuery.HasComp(uid) ||
-                _xenoTunnelQuery.HasComp(uid) ||
                 _sentryQuery.HasComp(uid) ||
                 _blockXenoConstructionQuery.HasComp(uid))
             {
@@ -1775,12 +1767,6 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
         var hasWeeds = false;
         while (anchored.MoveNext(out var uid))
         {
-            if (HasComp<XenoEggComponent>(uid))
-            {
-                popupType = "rmc-xeno-construction-blocked";
-                return false;
-            }
-
             if (_hiveConstructionNodeQuery.TryGetComponent(uid, out var node) &&
                 node.BlockOtherNodes)
             {
@@ -1791,7 +1777,6 @@ public sealed class SharedXenoConstructionSystem : EntitySystem
             if (HasComp<XenoConstructComponent>(uid) ||
                 _tags.HasAnyTag(uid.Value, StructureTag, AirlockTag) ||
                 HasComp<StrapComponent>(uid) ||
-                _xenoTunnelQuery.HasComp(uid) ||
                 _sentryQuery.HasComp(uid) ||
                 _blockXenoConstructionQuery.HasComp(uid))
             {

--- a/Content.Shared/_RMC14/Xenonids/Construction/Tunnel/XenoTunnelSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/Tunnel/XenoTunnelSystem.cs
@@ -932,7 +932,7 @@ public sealed class SelectDestinationTunnelInterfaceState(Dictionary<string, Net
     public Dictionary<string, NetEntity> HiveTunnels = hiveTunnels;
 }
 
-public sealed partial class XenoDigTunnelActionEvent : InstantActionEvent
+public sealed partial class XenoDigTunnelActionEvent : WorldTargetActionEvent
 {
     [DataField]
     public EntProtoId Prototype = "XenoTunnel";

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_construction_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_construction_actions.yml
@@ -223,7 +223,10 @@
       sprite: _RMC14/Actions/xeno_actions.rsi
       state: build_tunnel
     useDelay: 300
-  - type: InstantAction
+  - type: TargetAction
+    deselectOnMiss: true
+    checkCanAccess: false
+  - type: WorldTargetAction
     event: !type:XenoDigTunnelActionEvent
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_construction_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_construction_actions.yml
@@ -224,10 +224,12 @@
       state: build_tunnel
     useDelay: 300
   - type: TargetAction
+    range: 16
     deselectOnMiss: true
     checkCanAccess: false
   - type: WorldTargetAction
     event: !type:XenoDigTunnelActionEvent
+  - type: ActionBlockIfResting
 
 - type: entity
   parent: CMGuidebookActionXenoBase

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_egg.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_egg.yml
@@ -83,6 +83,7 @@
     - Electrocution
   - type: DeletedByWeedKiller
   - type: XenoChargeDontHit
+  - type: BlockXenoConstruction
 
 - type: entity
   parent: BaseItem

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_tunnel.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_tunnel.yml
@@ -40,6 +40,7 @@
   - type: DeletedByWeedKiller
   - type: XenoFriendly
   - type: RMCTrackable
+  - type: BlockXenoConstruction
 
 - type: entity
   parent: XenoTunnel


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added an overlay to the Burrower 'Dig Tunnel' ability to highlight every tile in view that a tunnel can be created on.

## Why / Balance
Helps make burrower gameplay less confusing.
Currently there's no way to tell where you can actually make a tunnel without just walking over to a tile and trying it out. A lot of maps are pretty inconsistent with where they'll allow a tunnel, so this is a massive help in that regard.

## Technical details
In order to allow this to work with the existing `XenoAbilityPreviewOverlay` system, the tunnel ability has been changed from an "instant" action to a "targeted" action with a range of 16, similar to the Carrier '[Carrier's Bond](https://github.com/RMC-14/RMC-14/blob/d2aea0eb692f686ee0ffa4c5af1bc2d58c252bc7/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_self_actions.yml#L374-L378)' ability.
Clicking on the ability once will show the overlay, then clicking again will dig a tunnel under the player's current tile, which is now shown with a little ghost tunnel sprite.

The overlay is created by looping through every tile within the viewport's `WorldBounds` and checking for elements which are required by the `OnCreateTunnel()`, `CanPlaceTunnelPopup()`, and `CanPlaceXenoStructure()` methods. Notably this doesn't include checks for a few things like whether there's a vehicle nearby or if a chair is on the tile since those didn't seem too necessary.

As a bit of a streamlining thing I also added `BlockXenoConstruction` to placed tunnels and eggs, to allow for them to be included in the existing `BlockXenoConstructionComponent` check rather than needing separate checks for each of their components. This doesn't affect their logic at all it just cleans up some queries.

Honestly I didn't notice any performance difference with the overlay open (on my pc at least), but given the potential impact I've made the list of tunnelable tiles be cached in a `HashSet`, which will only update if the player's camera moves more than 1/4 of a tile or rotates by 90°, revealing new tiles. The only real downside to this approach is that any tiles changing states while the player is stationary (i.e. a wall being destroyed) won't be shown until they move.

Finally, the overlay is drawn by sending the tile cache to the existing `DrawTileBorder()` method and a new `DrawTileFilled()` method (plus the tunnel ghost too).
I spent nearly a full day trying and failing to get it to draw properly and, full disclosure, I eventually caved in and asked an AI (Claude) how it recommended it be structured. Its contributions to this project were [L802 - L828](https://github.com/SabreML/RMC-14/blob/97c49824174298652542ea799f287b2855cc44cc/Content.Client/_RMC14/Xenonids/Targeting/XenoAbilityPreviewOverlay.cs#L820-L828) and the suggestion to optimise `DrawTileBorder()` using a `Matrix3`. Everything else is my own.
(`Vector2i` -> `EntityCoordinates` -> `MapCoordinates` -> `Vector2` is a lot of steps when you can just do a `Transform()` with the grid's matrix. This wouldn't work if the tiles were on different grids, but currently that isn't possible)

Since it took me so long to figure that out I put (way too many) step-by-step comments in the `DrawTileFilled()` method to potentially help anyone else having the same problem.

## Media
### Video demonstration:

https://github.com/user-attachments/assets/28b6e3a2-d095-4ccf-90d0-600723308a60

(very compressed for some reason)

<details>
<summary><b>Random examples:</b></summary>

#### Hybrisa:
<img width="2560" height="1392" alt="Hybrisa" src="https://github.com/user-attachments/assets/ac66de88-cd84-4b19-8203-636b35bfe915" />

#### Shiva's:
<img width="2560" height="1392" alt="Shiva" src="https://github.com/user-attachments/assets/713a97cb-6a6b-423d-a02e-452c9dd4ca49" />

#### Chance's:
<img width="2560" height="1392" alt="Chance&#39;s" src="https://github.com/user-attachments/assets/88f2323e-64fc-4923-a1c0-c641fe4a6b87" />

#### Trijent:
<img width="2560" height="1392" alt="Trijent" src="https://github.com/user-attachments/assets/eea68e5e-08d7-40bb-a20b-8be4fcbc45fd" />

</details>

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added an overlay for the 'Dig Tunnel' ability to highlight all valid tiles.