### PR TITLE
[Fix] larva and parasites can now move underneath single-entity double doors

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Doors/DoubleDoors/base-double-doors.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Doors/DoubleDoors/base-double-doors.yml
@@ -20,7 +20,7 @@
         mask:
         - FullTileMask
         layer:
-        - FullTileLayer
+        - AirlockLayer
 
 - type: entity
   parent: RMCDoubleDoorBase


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
God's finest yaml warrior
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfix #10704 
## Technical details
<!-- Summary of code changes for easier review. -->
RMCBaseDoubleDoor had fulltilelayer instead of airlocklayer, but otherwise had an identical fixtures component to its parent. 
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Larva and parasites can fit under single-entity double doors again