### PR TITLE
[Fix] Missing emerald medal icon in stats window

### DIFF
--- a/Content.Client/_RMC14/RMCPlaytimeStats/RMCPlaytimeStatsWindow.cs
+++ b/Content.Client/_RMC14/RMCPlaytimeStats/RMCPlaytimeStatsWindow.cs
@@ -69,12 +69,12 @@ public sealed partial class RMCPlaytimeStatsWindow : FancyWindow
     {
         if (playtime >= _prismaticTime)
             return RMCPlaytimeMedalType.Prismatic;
+        else if (playtime >= _emeraldTime)
+            return RMCPlaytimeMedalType.Emerald;
         else if (playtime >= _amethystTime)
             return RMCPlaytimeMedalType.Amethyst;
         else if (playtime >= _rubyTime)
             return RMCPlaytimeMedalType.Ruby;
-        else if (playtime >= _emeraldTime)
-            return RMCPlaytimeMedalType.Emerald;
         else if (playtime >= _platinumTime)
             return RMCPlaytimeMedalType.Platinum;
         else if (playtime >= _goldTime)


### PR DESCRIPTION
## About the PR
The emerald medal icon in the stats window fails to load, and just shows the amethyst medal instead.
Its entirely due to the wrong order of icon checking.

## Why / Balance
Bug

## Technical details
Re-order the medal check to correctly show the emerald. 

## Media
<img width="357" height="158" alt="image" src="https://github.com/user-attachments/assets/8eed7af8-068d-4300-9080-ca88331899b1" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Emerald Medals now appear properly in Stats Window.