### PR TITLE
Many non-targeting xeno abilities now usable in tunnels/vents

### DIFF
--- a/Content.Shared/_RMC14/Actions/RMCInContainerActionComponent.cs
+++ b/Content.Shared/_RMC14/Actions/RMCInContainerActionComponent.cs
@@ -1,0 +1,12 @@
+using Content.Shared.FixedPoint;
+
+namespace Content.Shared._RMC14.Actions;
+
+/// <summary>
+///     Actions with this component should remain usable even when the entity is in a container that normally disables actions
+/// </summary>
+[RegisterComponent]
+[Access(typeof(SharedRMCActionsSystem))]
+public sealed partial class RMCInContainerActionComponent : Component
+{
+}

--- a/Content.Shared/_RMC14/Vents/SharedVentCrawlingSystem.cs
+++ b/Content.Shared/_RMC14/Vents/SharedVentCrawlingSystem.cs
@@ -26,6 +26,7 @@ using Content.Shared.Hands;
 using Content.Shared.Item;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Mobs.Systems;
+using Content.Shared._RMC14.Actions;
 
 namespace Content.Shared._RMC14.Vents;
 public abstract class SharedVentCrawlingSystem : EntitySystem
@@ -330,7 +331,8 @@ public abstract class SharedVentCrawlingSystem : EntitySystem
         var actions = _actions.GetActions(ent);
         foreach (var action in actions)
         {
-            _actions.SetEnabled(action.AsNullable(), false);
+            if (!HasComp<RMCInContainerActionComponent>(action))
+                _actions.SetEnabled(action.AsNullable(), false);
         }
     }
 
@@ -339,7 +341,8 @@ public abstract class SharedVentCrawlingSystem : EntitySystem
         var actions = _actions.GetActions(ent);
         foreach (var action in actions)
         {
-            _actions.SetEnabled(action.AsNullable(), true);
+            if (!HasComp<RMCInContainerActionComponent>(action))
+                _actions.SetEnabled(action.AsNullable(), true);
         }
     }
 

--- a/Content.Shared/_RMC14/Xenonids/Construction/Tunnel/XenoTunnelSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/Tunnel/XenoTunnelSystem.cs
@@ -839,7 +839,8 @@ public sealed class XenoTunnelSystem : EntitySystem
         var actions = _action.GetActions(ent);
         foreach (var action in actions)
         {
-            _action.SetEnabled(action.AsNullable(), newStatus);
+            if (!HasComp<RMCInContainerActionComponent>(action))
+                _action.SetEnabled(action.AsNullable(), newStatus);
         }
     }
 

--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -16,6 +16,7 @@
   - type: Action
     checkCanInteract: false
     checkConsciousness: false
+  - type: RMCInContainerAction
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
@@ -118,6 +118,7 @@
   - type: InstantAction
     event: !type:XenoRegurgitateActionEvent
   - type: RMCDazeableAction
+  - type: RMCInContainerAction
 
 - type: entity
   id: ActionXenoTailStab
@@ -574,6 +575,7 @@
     event: !type:XenoParalyzingSlashActionEvent
   - type: XenoActionPlasma
     cost: 50
+  - type: RMCInContainerAction
 
 - type: entity
   parent: ActionXenoBase
@@ -591,6 +593,7 @@
     event: !type:XenoCripplingStrikeActionEvent
   - type: XenoActionPlasma
     cost: 20
+  - type: RMCInContainerAction
 
 - type: entity
   parent: CMGuidebookActionXenoBase
@@ -825,6 +828,7 @@
     useDelay: 0.25
   - type: InstantAction
     event: !type:XenoToggleChargingActionEvent
+  - type: RMCInContainerAction
 
 - type: entity
   parent: ActionXenoFling
@@ -890,6 +894,7 @@
     useDelay: 1
   - type: InstantAction
     event: !type:XenoGasToggleActionEvent
+  - type: RMCInContainerAction
 
 - type: entity
   parent: CMGuidebookActionXenoBase
@@ -965,6 +970,7 @@
       state: screech
   - type: InstantAction
     event: !type:XenoForTheHiveActionEvent
+  - type: RMCInContainerAction
 
 - type: entity
   parent: ActionXenoBase
@@ -1161,6 +1167,7 @@
       state: shift_spit_xeno_acid
   - type: InstantAction
     event: !type:XenoSpitToggleActionEvent
+  - type: RMCInContainerAction
 
 - type: entity
   parent: ActionXenoBase
@@ -1428,6 +1435,7 @@
   - type: InstantAction
     event: !type:XenoCripplingStrikeActionEvent
   - type: ActionBlockIfResting
+  - type: RMCInContainerAction
 
 - type: entity
   parent: ActionXenoBase

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_self_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_self_actions.yml
@@ -12,6 +12,7 @@
     useDelay: 1
   - type: InstantAction
     event: !type:XenoRestActionEvent
+  - type: RMCInContainerAction
 
 - type: entity
   parent: CMGuidebookActionXenoBase
@@ -35,6 +36,7 @@
       state: watch_xeno
   - type: InstantAction
     event: !type:XenoWatchActionEvent
+  - type: RMCInContainerAction
 
 - type: entity
   parent: CMGuidebookActionXenoBase
@@ -59,6 +61,7 @@
     useDelay: 0.33
   - type: InstantAction
     event: !type:XenoPheromonesActionEvent
+  - type: RMCInContainerAction
 
 - type: entity
   parent: CMGuidebookActionXenoBase
@@ -84,6 +87,7 @@
     useDelay: 0.5
   - type: InstantAction
     event: !type:XenoHideActionEvent
+  - type: RMCInContainerAction
 
 - type: entity
   parent: CMGuidebookActionXenoBase
@@ -159,6 +163,7 @@
     useDelay: 0.25
   - type: InstantAction
     event: !type:XenoResinWalkerActionEvent
+  - type: RMCInContainerAction
 
 - type: entity
   parent: CMGuidebookActionXenoBase
@@ -181,6 +186,7 @@
     useDelay: 0.2
   - type: InstantAction
     event: !type:XenoZoomActionEvent
+  - type: RMCInContainerAction
 
 - type: entity
   parent: CMGuidebookActionXenoBase
@@ -206,6 +212,7 @@
     event: !type:XenoWordQueenActionEvent
   - type: XenoWordQueenAction
   - type: RMCDazeableAction
+  - type: RMCInContainerAction
 
 - type: entity
   id: ActionXenoPsychicWhisper
@@ -229,6 +236,7 @@
       components:
       - MobState
   - type: RMCDazeableAction
+  - type: RMCInContainerAction
 
 - type: entity
   id: ActionXenoPsychicRadiance
@@ -245,6 +253,7 @@
   - type: InstantAction
     event: !type:XenoPsychicRadianceActionEvent
   - type: RMCDazeableAction
+  - type: RMCInContainerAction
 
 - type: entity
   id: ActionXenoGiveOrder
@@ -261,6 +270,7 @@
   - type: InstantAction
     event: !type:XenoGiveOrderActionEvent
   - type: RMCDazeableAction
+  - type: RMCInContainerAction
 
 - type: entity
   id: ActionXenoGrowOvipositor
@@ -300,6 +310,7 @@
       state: lurker_invisibility
   - type: InstantAction
     event: !type:XenoTurnInvisibleActionEvent
+  - type: RMCInContainerAction
 
 - type: entity
   parent: CMGuidebookActionXenoBase
@@ -323,6 +334,7 @@
     useDelay: 26
   - type: InstantAction
     event: !type:XenoDefensiveShieldActionEvent
+  - type: RMCInContainerAction
 
 - type: entity
   parent: CMGuidebookActionXenoBase
@@ -401,6 +413,7 @@
     useDelay: 1
   - type: InstantAction
     event: !type:XenoReserveParasiteActionEvent
+  - type: RMCInContainerAction
 
 - type: entity
   parent: CMGuidebookActionXenoBase
@@ -423,6 +436,7 @@
     useDelay: 0.5
   - type: InstantAction
     event: !type:ManageHiveActionEvent
+  - type: RMCInContainerAction
 
 - type: entity
   id: ActionXenoDodge
@@ -438,6 +452,7 @@
     useDelay: 13
   - type: InstantAction
     event: !type:XenoDodgeActionEvent
+  - type: RMCInContainerAction
 
 - type: entity
   parent: ActionXenoBase
@@ -483,6 +498,7 @@
   - type: InstantAction
     event: !type:XenoSoakActionEvent
   - type: ActionBlockIfResting
+  - type: RMCInContainerAction
 
 - type: entity
   parent: ActionXenoBase
@@ -520,6 +536,7 @@
       state: lay_egg
   - type: InstantAction
     event: !type:XenoGenerateEggsActionEvent
+  - type: RMCInContainerAction
 
 - type: entity
   parent: CMGuidebookActionXenoBase

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_self_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_self_actions.yml
@@ -236,7 +236,7 @@
       components:
       - MobState
   - type: RMCDazeableAction
-  - type: RMCInContainerAction
+  # - type: RMCInContainerAction # TODO can't target mobs from inside tunnels but this would be nice to have in the future
 
 - type: entity
   id: ActionXenoPsychicRadiance

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_utility_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_utility_actions.yml
@@ -197,6 +197,7 @@
     useDelay: 1
   - type: InstantAction
     event: !type:HiveLeaderSquadActionEvent
+  - type: RMCInContainerAction
 
 - type: entity
   parent: ActionXenoBase
@@ -213,6 +214,7 @@
     useDelay: 3
   - type: InstantAction
     event: !type:HiveLeaderActionEvent
+  - type: RMCInContainerAction
 
 - type: entity
   parent: CMGuidebookActionXenoBase
@@ -411,6 +413,7 @@
     event: !type:ActionXenoSpikeShieldEvent
   - type: ActionBlockIfResting
   - type: RMCDazeableAction
+  - type: RMCInContainerAction
 
 - type: entity
   parent: ActionXenoBase

--- a/Resources/Prototypes/_RMC14/Actions/tactical_map_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/tactical_map_actions.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   abstract: true
   id: RMCActionOpenTacticalMap
   name: Open Tactical Map
@@ -7,6 +7,7 @@
     itemIconStyle: NoItem
   - type: InstantAction
     event: !type:OpenTacticalMapActionEvent
+  - type: RMCInContainerAction
 
 - type: entity
   parent: RMCActionOpenTacticalMap


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The majority of xeno non-targeting, non-AOE abilities are now usable inside vents or tunnels. For example, toggling hiding, watching xenos, hive management, making a hive announcement, toggling combat mode, turning invisible, regurgitating, and resting are now all usable inside vents or tunnels.

Fixes #10765.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
QOL changes. Tunnels were disabling many abilities that don't interact with other players, which was annoying for basically no gameplay impact.

Also a bug fix for xenos that disconnected in tunnels or vents, which caused them to rest and become unable to un-rest.

## Technical details
<!-- Summary of code changes for easier review. -->
Added RMCInContainerActionComponent to mark actions that should be usable inside containers that normally disable them.
Tunnel and vent crawl systems key off RMCInContainerActionComponent to not disable those actions.
Added RMCInContainerActionComponent to a large amount of actions that should be usable inside tunnels/vents.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

https://github.com/user-attachments/assets/8c0d3c13-2bdb-4aed-ba8a-022563d7149c


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Xenos can now use most no-target, self-target, or toggle-able actions while inside a tunnel or vent.
- fix: Fixed xenos disconnecting inside tunnels or vents becoming stuck due to resting and being unable to unrest.
