### PR TITLE
Xenos wake up if trying to move while resting

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Rest/XenoRestSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Rest/XenoRestSystem.cs
@@ -16,6 +16,7 @@ using Content.Shared._RMC14.Xenonids.Sweep;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Actions;
 using Content.Shared.Interaction.Events;
+using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Popups;
@@ -238,5 +239,18 @@ public sealed class XenoRestSystem : EntitySystem
 
         // Xeno had no rest action for some reason.
         return false;
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        // If a resting xeno tries to move while resting, unrest them if possible.
+        var query = EntityQueryEnumerator<XenoRestingComponent, InputMoverComponent>();
+        while (query.MoveNext(out var xeno, out var rest, out var mover))
+        {
+            if (rest.Running && mover.HasDirectionalMovement)
+                TryRestAction(xeno);
+        }
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Trying to move while resting will now unrest you if possible.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This is a QOL change that will fix new queens accidentally resting in ovi, which prevents queen eye movement which leads to them getting confused. It also prevents accidental combat rests from being too disruptive and hard to correct in the heat of combat.

## Technical details
<!-- Summary of code changes for easier review. -->
Rest system loops through all resting xenos checking for movement key inputs in order to unrest them.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Xenos who try to move while resting will now wake up.
