### PR TITLE
Minor Poster Fixes

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Wallmounts/Signs/posters.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Wallmounts/Signs/posters.yml
@@ -775,8 +775,8 @@
 - type: entity
   parent: CMPosterBase
   id: CMPosterMarineCorp1
-  name: "marine corp poster"
-  description: "Join the Marine Corp. Enlist today, protect tomorrow!"
+  name: "marine corps poster"
+  description: "Join the Marine Corps. Enlist today, protect tomorrow!"
   components:
   - type: Sprite
     state: marine_corp_1
@@ -784,8 +784,8 @@
 - type: entity
   parent: CMPosterMarineCorp1
   id: CMPosterMarineCorp2
-  name: "marine corp poster"
-  description: "Join the Marine Corp. Enlist today, protect tomorrow!"
+  name: "marine corps poster"
+  description: "Join the Marine Corps. Enlist today, protect tomorrow!"
   components:
   - type: Sprite
     state: marine_corp_2
@@ -793,8 +793,8 @@
 - type: entity
   parent: CMPosterMarineCorp1
   id: CMPosterMarineCorp3
-  name: "marine corp poster"
-  description: "Every Paycheck a Fortune! Every Formation a Parade! - Join the Colonial Marines!"
+  name: "marine corps poster"
+  description: "Every Paycheck a Fortune! Every Formation a Parade! - Join the UN Marine Corps!"
   components:
   - type: Sprite
     state: marine_corp_3
@@ -802,7 +802,7 @@
 - type: entity
   parent: CMPosterMarineCorp1
   id: CMPosterMarineCorp4
-  name: "marine corp poster"
+  name: "marine corps poster"
   description: "This poster depicts the logo of the UN Marine Corps, Oorah!"
   components:
   - type: Sprite
@@ -811,8 +811,8 @@
 - type: entity
   parent: CMPosterMarineCorp1
   id: CMPosterMarineCorp5
-  name: "UN marine corp poster"
-  description: "YOU GIVE US WINGS, WINGS OF LIBERTY - United Nations Marine Corp."
+  name: "UN marine corps poster"
+  description: "YOU GIVE US WINGS, WINGS OF LIBERTY - United Nations Marine Corps."
   components:
   - type: Sprite
     state: marine_corp_5
@@ -820,7 +820,7 @@
 - type: entity
   parent: CMPosterMarineCorp1
   id: CMPosterMarineCorp6
-  name: "UN marine corp poster"
+  name: "UN marine corps poster"
   description: "UNMC MARINES - FIRST TO FIGHT."
   components:
   - type: Sprite
@@ -829,8 +829,8 @@
 - type: entity
   parent: CMPosterMarineCorp1
   id: CMPosterMarineCorp7
-  name: "UN marine corp poster"
-  description: "No one stands alone with the United Nations Marine Corp - JOIN US!"
+  name: "UN marine corps poster"
+  description: "No one stands alone with the United Nations Marine Corps - JOIN US!"
   components:
   - type: Sprite
     state: marine_corp_7


### PR DESCRIPTION
## About the PR
Makes some minor spelling tweaks to some posters.

Main one is CMPosterMarineCorp3 which still mentioned the Colonial Marines. This has been updated to instead say the UN Marine Corps.

Also, updates any player-facing mentions of "marine corp" to "marine corps". Asset names and comments in the file have been left untouched.

Ashes mentioned there might be a PR that fixes these already up but after some searching I couldn't find this. If this ends up being a duplicate, sorry!

## Why / Balance
Grammatical fixes.

## Technical details
Several updated entries in: Resources/Prototypes/_RMC14/Entities/Structures/Wallmounts/Signs/posters.yml

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: Some posters have been adjusted so that mentions of a "marine corp" now read "marine corps".
- tweak: Removed a mention of the Colonial Marines from a poster.
