### PR TITLE
Made various small objects not collide with players

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Furniture/coatrack.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Furniture/coatrack.yml
@@ -8,6 +8,7 @@
     noRot: true
   - type: Physics
     bodyType: Static
+    canCollide: false
   - type: Sprite
     sprite: _RMC14/Structures/Furniture/coatrack.rsi
     state: coatrack0
@@ -23,7 +24,7 @@
         mask:
         - MachineMask
         layer:
-        - Opaque
+        - MobMask
   - type: Damageable
     damageContainer: StructuralMarine
     damageModifierSet: StructuralMarine

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Furniture/coatrack.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Furniture/coatrack.yml
@@ -23,7 +23,7 @@
         mask:
         - MachineMask
         layer:
-        - MobMask
+        - Opaque
   - type: Damageable
     damageContainer: StructuralMarine
     damageModifierSet: StructuralMarine

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Furniture/hospital_divider.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Furniture/hospital_divider.yml
@@ -9,6 +9,7 @@
   - type: VehicleSmashable
   - type: Physics
     bodyType: Static
+    canCollide: false
   - type: Sprite
     sprite: _RMC14/Structures/Furniture/hospital_divider.rsi
     state: hospitalcurtain

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/rmc_communications_console.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/rmc_communications_console.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   abstract: true
   parent: CMBaseStructure
   id: RMCCommunicationsConsoleBase
@@ -7,6 +7,7 @@
     anchored: false
   - type: Physics
     bodyType: Static
+    canCollide: false
   - type: Sprite
     drawdepth: SmallObjects
     sprite: _RMC14/Structures/Machines/rmc_groundside_communications_console.rsi

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/television.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/television.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   parent: [ BaseMachinePowered, RMCConstructibleMachine ]
   id: RMCTelevision
   name: television set
@@ -20,6 +20,8 @@
         enum.PowerDeviceVisualLayers.Powered:
           True: { visible: true }
           False: { visible: false }
+  - type: Physics
+    canCollide: false
   - type: Fixtures
     fixtures:
       fix1:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Platforms/platform.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Platforms/platform.yml
@@ -145,6 +145,7 @@
     - Wall
   components:
   - type: Physics
+    canCollide: false
   - type: Damageable
     damageContainer: Inorganic
   - type: Destructible

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Storage/securecrates.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Storage/securecrates.yml
@@ -761,7 +761,7 @@
         mask:
         - SmallMobMask
         layer:
-        - MachineLayer
+        - Opaque
   - type: PlaceableSurface
     isPlaceable: false
   - type: Damageable
@@ -898,7 +898,7 @@
         mask:
         - SmallMobMask
         layer:
-        - MachineLayer
+        - Opaque
   - type: PlaceableSurface
     isPlaceable: false
   - type: Damageable

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Storage/securecrates.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Storage/securecrates.yml
@@ -751,6 +751,7 @@
     noRot: true
   - type: InteractionOutline
   - type: Physics
+    canCollide: false
   - type: Fixtures
     fixtures:
       fix1:
@@ -761,7 +762,7 @@
         mask:
         - SmallMobMask
         layer:
-        - Opaque
+        - MachineLayer
   - type: PlaceableSurface
     isPlaceable: false
   - type: Damageable
@@ -888,6 +889,7 @@
     noRot: true
   - type: InteractionOutline
   - type: Physics
+    canCollide: false
   - type: Fixtures
     fixtures:
       fix1:
@@ -898,7 +900,7 @@
         mask:
         - SmallMobMask
         layer:
-        - Opaque
+        - MachineLayer
   - type: PlaceableSurface
     isPlaceable: false
   - type: Damageable

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Wallmounts/surveillance_camera.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Wallmounts/surveillance_camera.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   id: RMCSurveillanceCameraAlmayer
   name: ship-grade camera
   description: It's used to monitor rooms.
@@ -77,6 +77,7 @@
     anchored: false
   - type: Physics
     bodyType: Static
+    canCollide: false
   - type: Sprite
     sprite: _RMC14/Structures/Machines/computer.rsi
     layers:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Small crates, coat racks, desktop computers, televisions, hospital dividers, and small platform corners no longer collide with players.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity. It is not possible to collide with any of the above objects in CM13.

## Technical details
<!-- Summary of code changes for easier review. -->
Set `canCollide: false` on all relevant objects.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Small crates, coat racks, desktop computers, televisions, hospital dividers, and small platform corners no longer collide with players.
