### PR TITLE
[Parity] Flamer firerate nerfs + M34-T2

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/under_attachments.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/under_attachments.yml
@@ -290,7 +290,7 @@
     size: Normal
   - type: Gun
     cameraRecoilScalar: 0
-    fireRate: 0.333
+    fireRate: 0.25
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Flamethrowers/m34_flamer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Flamethrowers/m34_flamer.yml
@@ -27,7 +27,7 @@
     - Back
   - type: Gun
     cameraRecoilScalar: 0
-    fireRate: 0.333
+    fireRate: 0.286
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Flamethrowers/m34t_flamer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Flamethrowers/m34t_flamer.yml
@@ -54,6 +54,7 @@
   id: RMCWeaponFlamerSpecAuto
   name: M34-T2 incinerator unit
   description: A prototyped model of the M34-T incinerator unit, it was discontinued after its automatic mode was deemed too expensive to deploy in the field.
+  suffix: DO NOT MAP
   components:
     - type: Gun
       fireRate: 2

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Flamethrowers/m34t_flamer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Flamethrowers/m34t_flamer.yml
@@ -50,6 +50,19 @@
     locked: true
 
 - type: entity
+  parent: RMCWeaponFlamerSpec
+  id: RMCWeaponFlamerSpecAuto
+  name: M34-T2 incinerator unit
+  description: A prototyped model of the M34-T incinerator unit, it was discontinued after its automatic mode was deemed too expensive to deploy in the field.
+  components:
+    - type: Gun
+    fireRate: 2
+    selectedMode: FullAuto
+    availableModes:
+    - SemiAuto
+    - FullAuto
+
+- type: entity
   parent: RMCTankFlamer
   id: RMCTankFlamerLarge
   name: M34 large incinerator tank

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Flamethrowers/m34t_flamer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Flamethrowers/m34t_flamer.yml
@@ -56,11 +56,11 @@
   description: A prototyped model of the M34-T incinerator unit, it was discontinued after its automatic mode was deemed too expensive to deploy in the field.
   components:
     - type: Gun
-    fireRate: 2
-    selectedMode: FullAuto
-    availableModes:
-    - SemiAuto
-    - FullAuto
+      fireRate: 2
+      selectedMode: FullAuto
+      availableModes:
+      - SemiAuto
+      - FullAuto
 
 - type: entity
   parent: RMCTankFlamer


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added the M34-T2, an automatic version of the M34-T, for admin spawn. Yes it exists in parity. Yes it has a firerate of 2. Yes it is automatic. I don't know.
Reduced the firerate of the UBF and any flamer parenting off of the M34.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Reduced firerate of flamers might affect marines negatively but probably not by much. Go My Parity.
## Technical details
<!-- Summary of code changes for easier review. -->
Yamlmaxxing.
The M34-T2 in parity uses a firedelay of 5 deciseconds between shots. 1/0.5 gives us a firerate of 2. Also, I left its fire mode selection in GunComponent since it has no scatter or recoil, and RMCSelectiveFireComponent simply overrides the settings in GunComponent.
The base flamer proto in parity uses a firedelay of 35 (7 * 5) deciseconds between shots. 1/3.5 gives us a firerate of 0.2857, rounded up to 0.286.
The UBF in parity uses a firedelay of 40 (8 * 5) deciseconds between shots. 1/4 gives us a firerate of 0.25.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added the M34-T2, an automatic version of the M34-T, for admin spawn
- tweak: Reduced the firerate of most flamers from 0.333 to 0.286
- tweak: Reduced the firerate of the underbarrel flamer from 0.333 to 0.25