### PR TITLE
Changed the provost clipboard's name

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Misc/clipboard.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Misc/clipboard.yml
@@ -88,7 +88,7 @@
 - type: entity
   parent: CMClipboard
   id: RMCProvostClipboard
-  name: clipboard
+  name: Provost clipboard
   components:
   - type: ItemSlots
     slots:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The provost clipboard is now named "Provost clipboard" instead of just "clipboard."

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Consistency with the Weston-Yamada clipboard.

## Technical details
<!-- Summary of code changes for easier review. -->
One line change to ./clipboard.yaml.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
<img width="348" height="396" alt="A screenshot of the ingame entity spawn menu. Provost clipboard is available." src="https://github.com/user-attachments/assets/b94dbf36-2bcd-4fa7-a959-d624ddd2be6c" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.