### PR TITLE
Fixed crippling strike not resetting attack cooldown

### DIFF
--- a/Content.Shared/_RMC14/Weapons/Melee/SharedRMCMeleeWeaponSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Melee/SharedRMCMeleeWeaponSystem.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Numerics;
 using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Marines.Skills;
@@ -68,6 +68,9 @@ public abstract class SharedRMCMeleeWeaponSystem : EntitySystem
             RemComp<MeleeResetComponent>(ent);
             return;
         }
+
+        if (TryComp<RMCMeleeUserCooldownComponent>(ent, out var userCooldown))
+            userCooldown.NextAttack = _timing.CurTime;
 
         ent.Comp.OriginalTime = weapon.NextAttack;
         weapon.NextAttack = _timing.CurTime;
@@ -210,7 +213,12 @@ public abstract class SharedRMCMeleeWeaponSystem : EntitySystem
             return;
 
         if (disarm)
-            weapon.NextAttack = reset.OriginalTime;
+        {
+            var ev = new BlockDisarmResetEvent();
+            RaiseLocalEvent(weaponUid, ref ev);
+            if (!ev.Cancelled)
+                weapon.NextAttack = reset.OriginalTime;
+        }
 
         RemComp<MeleeResetComponent>(weaponUid);
         Dirty(weaponUid, weapon);
@@ -293,3 +301,6 @@ public abstract class SharedRMCMeleeWeaponSystem : EntitySystem
         return ev.Range;
     }
 }
+
+[ByRefEvent]
+public record struct BlockDisarmResetEvent(bool Cancelled = false);

--- a/Content.Shared/_RMC14/Xenonids/Crippling/XenoCripplingStrikeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Crippling/XenoCripplingStrikeSystem.cs
@@ -32,6 +32,7 @@ public sealed class XenoCripplingStrikeSystem : EntitySystem
 
         SubscribeLocalEvent<XenoActiveCripplingStrikeComponent, MeleeHitEvent>(OnXenoCripplingStrikeHit);
         SubscribeLocalEvent<XenoActiveCripplingStrikeComponent, MeleeAttackAttemptEvent>(OnActiveCripplingStrikeMeleeAttempt);
+        SubscribeLocalEvent<XenoActiveCripplingStrikeComponent, BlockDisarmResetEvent>(OnBlockDisarmResetEvent);
         SubscribeLocalEvent<XenoActiveCripplingStrikeComponent, RefreshMovementSpeedModifiersEvent>(OnActiveCripplingRefreshSpeed);
         SubscribeLocalEvent<XenoActiveCripplingStrikeComponent, ComponentRemove>(OnActiveCripplingRemove);
 
@@ -144,6 +145,12 @@ public sealed class XenoCripplingStrikeSystem : EntitySystem
                 args.Attack = new LightAttackEvent(disarm.Target, netAttacker, disarm.Coordinates);
                 break;
         }
+    }
+
+    private void OnBlockDisarmResetEvent(Entity<XenoActiveCripplingStrikeComponent> xeno, ref BlockDisarmResetEvent ev)
+    {
+        if (xeno.Comp.Running)
+            ev.Cancelled = true;
     }
 
     public override void Update(float frameTime)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed crippling strike no longer resetting the lurker's attack cooldown.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfix.

## Technical details
<!-- Summary of code changes for easier review. -->
Resetting melee also resets the attack delay in the new RMCMeleeUserCooldownComponent.
Added `BlockDisarmResetEvent` so systems can allow disarm cooldown to also be reset. (Without this, the tackle -> light attack replacement functionality of crippling strike doesn't use light attack cooldown.)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed lurkers' crippling strike not resetting their attack cooldown.
