### PR TITLE
Scout ammo economy change

### DIFF
--- a/Resources/Prototypes/_RMC14/Catalog/Fills/Crates/weapon_specialist_ammo.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Fills/Crates/weapon_specialist_ammo.yml
@@ -123,22 +123,22 @@
 - type: entity
   parent: RMCCrateAmmo
   id: RMCCrateMagazineM4SPRCustomImpact
-  name: M4SPR Scout Impact Magazine Crate (x3)
+  name: M4SPR Scout Impact Magazine Crate (x4)
   components:
   - type: StorageFill
     contents:
     - id: RMCMagazineRifleM4SPRA19Impact
-      amount: 3
+      amount: 4
 
 - type: entity
   parent: RMCCrateAmmo
   id: RMCCrateMagazineM4SPRCustomIncendiary
-  name: M4SPR Scout Incendiary Magazine Crate (x3)
+  name: M4SPR Scout Incendiary Magazine Crate (x4)
   components:
   - type: StorageFill
     contents:
     - id: RMCMagazineRifleM4SPRA19Incendiary
-      amount: 3
+      amount: 4
 
 - type: entity
   parent: RMCCrateAmmo

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/specialist_loadouts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/specialist_loadouts.yml
@@ -150,9 +150,9 @@
     - id: RMCMagazineRifleM4SPRA19
       amount: 4
     - id: RMCMagazineRifleM4SPRA19Incendiary
-      amount: 2
+      amount: 3
     - id: RMCMagazineRifleM4SPRA19Impact
-      amount: 2
+      amount: 3
     - id: RMCBackpackScout
     - id: RMCMK80
     - id: CMMagazinePistolMK80


### PR DESCRIPTION
## About the PR
Increases the amount of incendiary and high impact magazines in their kit and requisition crates by one magazine each

## Why / Balance
Parity, added after burst fire was removed from scout on CM

## Technical details
Like four lines of YML

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The scout now recieves one more incendiary and high impact magazine each in both their kit and requisition crate purchases