### PR TITLE
Temp Hull Wall entity and description fixes

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Walls/walls.yml
@@ -430,7 +430,7 @@
   parent: CMWallReinforcedHeavy
   id: CMWallReinforcedHeavyAlmayer
   name: heavy reinforced hull
-  description: A highly reinforced metal wall used to separate rooms and make up the ship. It would take a great impact to weaken this wall.
+  description: A highly reinforced metal wall used to separate rooms and make up the ship.
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Walls/almayer_black.rsi
@@ -495,6 +495,13 @@
     key: walls
     mode: NoSprite
 
+# Temp Hull
+- type: entity
+  parent: CMWallReinforcedHeavyAlmayer
+  id: RMCWallReinforcedHeavyAlmayerHijackBustable
+  description: A highly reinforced metal wall used to separate rooms and make up the ship. It would take a great impact to weaken this wall.
+  suffix: Hijack Bustable
+
 - type: entity
   parent: RMCWallAlmayerReinforcedHeavyDeco1
   id: RMCWallAlmayerReinforcedHeavyDecoElevator
@@ -523,7 +530,7 @@
   parent: CMWallReinforcedHeavy
   id: CMWallReinforcedHeavyAlmayerWhite
   name: heavy reinforced hull
-  description: A highly reinforced metal wall used to separate rooms and make up the ship. It would take a great impact to weaken this wall.
+  description: A highly reinforced metal wall used to separate rooms and make up the ship.
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Walls/almayer_white.rsi

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Walls/walls.yml
@@ -495,10 +495,9 @@
     key: walls
     mode: NoSprite
 
-# Temp Hull
 - type: entity
   parent: CMWallReinforcedHeavyAlmayer
-  id: RMCWallReinforcedHeavyAlmayerHijackBustable
+  id: RMCWallReinforcedHeavyAlmayerHijackBustable # RMC14 TODO: Add functionality
   description: A highly reinforced metal wall used to separate rooms and make up the ship. It would take a great impact to weaken this wall.
   suffix: Hijack Bustable
 

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Windows/windows.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Windows/windows.yml
@@ -130,6 +130,7 @@
 - type: entity
   parent: CMWindowReinforcedAlmayerHull
   id: RMCWindowReinforcedAlmayerHullHijackBustable
+  description: A glass window with a special rod matrix inside a wall frame. This one was made out of exotic materials to prevent hull breaches. It would take a great impact to weaken this window.
   suffix: Hijack Bustable
 
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added hijack bustable hull wall entity for mapping, currently won't work like the window version.

Regular almayer hull walls had the hijack bustable wall description, fixed.

## Why / Balance
Fixes, for future purposes, for athena

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
