### PR TITLE
Add command access to tech tree console

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/rmc_intel.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/rmc_intel.yml
@@ -198,6 +198,9 @@
     blacklist:
       components:
       - Xeno
+  - type: AccessReader
+    access: [ [ "RMCAccessCommand" ] ]
+  - type: ActivatableUIRequiresAccess
 
 - type: entity
   parent: RMCCommunicationsConsoleBase


### PR DESCRIPTION
## About the PR
Only ID's with command access can open the tech tree console

## Why / Balance
Parity

## Technical details
yml

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed the tech tree console being accessible to everyone instead of being locked behind command access