### PR TITLE
Fix hull wall descriptions and stuff

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Walls/walls.yml
@@ -411,6 +411,7 @@
   id: CMWallReinforcedHeavy
   name: heavy reinforced hull
   description: A huge chunk of ultra-reinforced metal used to separate rooms. Looks virtually indestructible.
+  suffix: Indestructible
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Walls/rwall.rsi
@@ -426,11 +427,12 @@
     - doors
     base: rwall
 
+# Outer Hull Walls
 - type: entity
   parent: CMWallReinforcedHeavy
   id: CMWallReinforcedHeavyAlmayer
-  name: heavy reinforced hull
-  description: A highly reinforced metal wall used to separate rooms and make up the ship.
+  name: outer hull
+  description: A metal wall used to separate space from the ship. Looks virtually indestructible.
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Walls/almayer_black.rsi
@@ -444,10 +446,16 @@
     - doors
     base: wall
 
+# Inner Hull Walls
 - type: entity
   parent: CMWallReinforcedHeavyAlmayer
+  id: CMWallReinforcedHeavyAlmayerInner
+  name: structural hull
+  description: The core structure of the hull, it holds the ship together. Looks virtually indestructible.
+
+- type: entity
+  parent: CMWallReinforcedHeavyAlmayerInner
   id: RMCWallAlmayerReinforcedHeavyDeco1
-  name: heavy reinforced hull
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Walls/almayer_black.rsi
@@ -495,9 +503,11 @@
     key: walls
     mode: NoSprite
 
+# Hull wall until hijack
 - type: entity
   parent: CMWallReinforcedHeavyAlmayer
-  id: RMCWallReinforcedHeavyAlmayerHijackBustable # RMC14 TODO: Add functionality
+  id: RMCWallReinforcedHeavyAlmayerHijackBustable # TODO RMC14: Add functionality - This hull wall should turn into a reinforced wall upon hijack landing.
+  name: heavy reinforced hull
   description: A highly reinforced metal wall used to separate rooms and make up the ship. It would take a great impact to weaken this wall.
   suffix: Hijack Bustable
 
@@ -528,8 +538,8 @@
 - type: entity
   parent: CMWallReinforcedHeavy
   id: CMWallReinforcedHeavyAlmayerWhite
-  name: heavy reinforced hull
-  description: A highly reinforced metal wall used to separate rooms and make up the ship.
+  name: ultra reinforced hull
+  description: An extremely reinforced metal wall used to isolate potentially dangerous areas. Looks virtually indestructible.
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Walls/almayer_white.rsi
@@ -546,7 +556,7 @@
 - type: entity
   parent: CMWallReinforcedHeavy
   id: CMWallReinforcedHeavyAlmayerAI
-  name: heavy reinforced hull
+  name: ultra reinforced hull
   description: An extremely reinforced metal wall used to isolate potentially dangerous areas. Looks virtually indestructible.
   components:
   - type: Sprite
@@ -578,8 +588,6 @@
     - windows
     - doors
     base: aiwall
-
-# TODO RMC14 temp hull, breakable only after hijack
 
 # Shuttle
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Cleaned up the almayer wall descriptions. Indestructible walls will now all say they are indestructible.

Outer hull - outside hull wall, indestructible
structural hull - inner hull wall, indestructible [new - used for staircase indestructible walls]
ultra reinforced hull - inner hull wall, indestructible (research and AI core walls)
heavy reinforced hull - inner hull wall, indestructible until hijack (doesn't work yet)
reinforced hull - reinforced wall
hull - normal wall

## Why / Balance
Parity. Correcting. Etc.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: CatAndHats
- fix: Fixed almayer hull wall descriptions and names
