### PR TITLE
Ext Webbing and Operation Uniform to SEA Vendor

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/senior_enlisted_advisor.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/senior_enlisted_advisor.yml
@@ -20,6 +20,9 @@
       - id: CMBootsBlackFilled
       - id: CMMRE
       - id: RMCStampSEA
+      - id: RMCOuterClothingExternalWebbing      
+      - id: CMJumpsuitOperations
+        name: operations uniform
     - name: Gloves
       choices: { CMGloves: 1 }
       entries:


### PR DESCRIPTION
## About the PR
Added external webbing and Operations uniform to the SEA vendor as noted in parity.
From discord post: https://discord.com/channels/1168210010233376858/1544322918274834503

## Why / Balance
Drip or drown

## Technical details
Copied from elsewhere 3 lines of yaml

## Media
<img width="689" height="461" alt="Screenshot 2026-09-01 141726" src="https://github.com/user-attachments/assets/b1b0ae13-c337-4994-8d4f-f0f9f303bdb2" />
<img width="328" height="422" alt="Screenshot 2026-09-01 141822" src="https://github.com/user-attachments/assets/e7321870-369b-411c-ab5a-e6250ae8caa6" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Ext Webbing and Operation Uniform to SEA Vendor
