### PR TITLE
ASO Rework

### DIFF
--- a/Resources/Locale/en-US/_RMC14/job/auxiliarysupport.ftl
+++ b/Resources/Locale/en-US/_RMC14/job/auxiliarysupport.ftl
@@ -1,6 +1,6 @@
 # auxiliary support
 cm-job-name-aso = Auxiliary Support Officer
-cm-job-description-aso = Coordinate the intelligence department, and assist the Executive Officer.
+cm-job-description-aso = Coordinate marine intelligence and oversee the flight crew and vehicle crewmen. Ensure the operations of the Almayer run smoothly. 
 cm-job-prefix-aso = ASO
 CMJobAuxiliarySupportOfficer = Auxiliary Support Officer
 

--- a/Resources/Locale/en-US/_RMC14/new-to-job-popup.ftl
+++ b/Resources/Locale/en-US/_RMC14/new-to-job-popup.ftl
@@ -138,3 +138,13 @@ rmc-new-to-job-executive-bodyguard = Your job as an Executive Bodyguard is to en
                                              Whenever possible, attempt to verbally discourage the Liaison from taking antagonistic action against the ship, causing trouble for other players, or being excessively rude without IC reason. You are also encouraged to report any illegal action the CL commits to the MPs, and detain them and transfer them to the MPs if they are an active threat to other players.
 
                                              Do not deploy to fight the Xenonids, and remember that your greatest strength is in the roleplay you can provide the CL and the ship. You are permitted to carry a sidearm on Code Green and a longarm on Code Blue, although this right can be revoked by the Commander or CMP. Remember to strictly adhere to both escalation rules and MLaw.
+
+rmc-new-to-job-auxiliary-support-officer = As the Auxiliary Support Officer, you are responsible for managing and processing intel, as well as overseeing the flight crew and vehicle crewmen.
+                                                
+                                            You are primarily responsible for the overwatch and management of intelligence, as well as the processing and sorting of the documents they retrieve.
+
+                                            You oversee the flight crew and vehicle crewmen. Ensure they have what they need for the operation and advise them if necessary.
+
+                                            You are also responsible for maintaining shipside operations. If you notice a department struggling, you may offer yourself to help, but respect their decision if they refuse. If you insist, instead bring the issue to the current Commander for them to resolve.
+
+                                            Your quarters are located to the northeast of the Combat Information Center, just outside the main entrance. The computer lab, where you can overwatch intel and process documents, is located east of research.

--- a/Resources/Prototypes/_RMC14/Access/Groups/auxiliary_support_access_groups.yml
+++ b/Resources/Prototypes/_RMC14/Access/Groups/auxiliary_support_access_groups.yml
@@ -5,15 +5,12 @@
   tags:
   - CMAccessASO
   - RMCAccessCommand
-  - CMAccessBrig
-  - CMAccessArmory
   - CMAccessMedical
   - CMAccessResearch
   - CMAccessCE
   - CMAccessEngineering
   - CMAccessMaint
   - CMAccessOT
-  - CMAccessRequisitions
   - CMAccessMarinePrep
   - CMAccessAlpha
   - CMAccessBravo
@@ -26,7 +23,6 @@
   - CMAccessCrewman
   - RMCAccessDatabase
   - RMCAccessFieldDoctor
-  - RMCAccessSeniorCommand
   - RMCAccessLogs
 
 - type: accessGroup

--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/ship_headsets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Ears/ship_headsets.yml
@@ -132,6 +132,32 @@
 
 - type: entity
   parent: RMCHeadsetShip
+  id: CMHeadsetASO
+  name: auxiliary support officer's headset
+  description: Used by auxiliary command staff, features a non-standard brace.
+  components:
+  - type: Sprite
+    state: mcom_headset
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - CMEncryptionKeyCommon
+      - RMCEncryptionKeyAuxiliarySupportOfficer
+  - type: RMCRadioFilter
+    disabledChannels:
+    - MarineAlpha
+    - MarineBravo
+    - MarineCharlie
+    - MarineDelta
+    - MarineEcho
+    - MarineFoxtrot
+  - type: HeadsetMultiBroadcast
+    cooldown: 60
+  - type: RMCHeadset
+    radioTextIncrease: 3
+
+- type: entity
+  parent: RMCHeadsetShip
   id: CMHeadsetRequisition
   name: requisitions radio headset
   description: Used by the Requisitions Technicians, lightweight and portable.

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Devices/EncryptionKeys/ship.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Devices/EncryptionKeys/ship.yml
@@ -520,6 +520,30 @@
   - type: Sprite
     state: cap_key
 
+# Auxiliary Support Officer
+- type: entity
+  parent: CMEncryptionKey
+  id: RMCEncryptionKeyAuxiliarySupportOfficer
+  name: auxiliary support officer encryption key
+  components:
+  - type: EncryptionKey
+    channels:
+    - MarineCommand
+    - MarineAlpha
+    - MarineBravo
+    - MarineCharlie
+    - MarineDelta
+    - MarineEcho
+    - MarineFoxtrot
+    - MarineEngineer
+    - MarineMedical
+    - MarineRequisition
+    - MarineJTAC
+    - MarineIntel
+    defaultChannel: MarineCommand
+  - type: Sprite
+    state: cmp_key
+
 # Vehicle Crewman
 - type: entity
   parent: CMEncryptionKey

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/auxiliary_support_officer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/auxiliary_support_officer.yml
@@ -3,6 +3,7 @@
   id: CMAuxiliarySupportOfficer
   name: cm-job-name-aso
   description: cm-job-description-aso
+  newToJobInfo: rmc-new-to-job-auxiliary-support-officer
   playTimeTracker: CMJobAuxiliarySupportOfficer
   requirements:
   - !type:DepartmentTimeRequirement
@@ -17,18 +18,21 @@
   - !type:DepartmentTimeRequirement
     department: CMAuxiliarySupport
     time: 18000 # 5 hours
-  - !type:DepartmentTimeRequirement
-    department: CMCommand
-    time: 3600 # 1 hour
   - !type:RoleTimeRequirement
     role: CMJobIntelOfficer
     time: 18000 # 5 hours
+  - !type:RoleTimeRequirement
+    role: CMJobsDropshipPilot
+    time: 18000 # 5 hours
+  - !type:DepartmentTimeRequirement
+    department: CMCommand
+    time: 3600 # 1 hour
   ranks:
-    RMCRankCaptain:
+    RMCRankFirstLT:
     - !type:RoleTimeRequirement
       role: CMJobAuxiliarySupportOfficer
       time: 252000 # 70 hours
-    RMCRankFirstLT: []
+    RMCRankSecondLT: []
   weight: 5
   startingGear: CMGearASO
   icon: "CMJobIconASO"
@@ -52,7 +56,7 @@
         RMCSkillIntel: 2
         RMCSkillJtac: 3
         RMCSkillLeadership: 3
-        RMCSkillMedical: 2
+        RMCSkillMedical: 3
         RMCSkillNavigations: 1
         RMCSkillOverwatch: 1
         RMCSkillPilot: 2
@@ -86,7 +90,7 @@
     outerClothing: CMCoatASO
     shoes: CMBootsBlack
     id: CMIDCardASO
-    ears: CMHeadsetSeniorCommand
+    ears: CMHeadsetASO
     pocket1: RMCPouchGeneralLarge
     pocket2: RMCPouchGeneralLarge
   storage:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/auxiliary_support_officer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/auxiliary_support_officer.yml
@@ -9,6 +9,9 @@
   - !type:DepartmentTimeRequirement
     department: CMSquad
     time: 18000 # 5 hours
+  - !type:DepartmentTimeRequirement
+    department: CMRequisitions
+    time: 3600 # 1 hour
   - !type:TotalJobsTimeRequirement
     group: CMJobsEngineering
     time: 18000 # 5 hours
@@ -18,12 +21,15 @@
   - !type:DepartmentTimeRequirement
     department: CMAuxiliarySupport
     time: 18000 # 5 hours
-  - !type:RoleTimeRequirement
-    role: CMJobIntelOfficer
+  - !type:TotalJobsTimeRequirement
+    group: CMJobsDropshipPilot
     time: 18000 # 5 hours
   - !type:DepartmentTimeRequirement
     department: CMCommand
     time: 3600 # 1 hour
+  - !type:RoleTimeRequirement
+    role: CMJobIntelOfficer
+    time: 18000 # 5 hours
   ranks:
     RMCRankFirstLT:
     - !type:RoleTimeRequirement

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/auxiliary_support_officer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/auxiliary_support_officer.yml
@@ -58,7 +58,7 @@
         RMCSkillFireman: 1
         RMCSkillIntel: 2
         RMCSkillJtac: 3
-        RMCSkillLeadership: 3
+        RMCSkillLeadership: 2
         RMCSkillMedical: 3
         RMCSkillNavigations: 1
         RMCSkillOverwatch: 1

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/auxiliary_support_officer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/auxiliary_support_officer.yml
@@ -21,9 +21,6 @@
   - !type:RoleTimeRequirement
     role: CMJobIntelOfficer
     time: 18000 # 5 hours
-  - !type:RoleTimeRequirement
-    role: CMJobsDropshipPilot
-    time: 18000 # 5 hours
   - !type:DepartmentTimeRequirement
     department: CMCommand
     time: 3600 # 1 hour

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/auxiliary_support_officer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/auxiliary_support_officer.yml
@@ -9,11 +9,11 @@
   - !type:DepartmentTimeRequirement
     department: CMSquad
     time: 18000 # 5 hours
-  - !type:DepartmentTimeRequirement
-    department: CMRequisitions
-    time: 18000 # 5 hours
   - !type:TotalJobsTimeRequirement
     group: CMJobsEngineering
+    time: 18000 # 5 hours
+  - !type:TotalJobsTimeRequirement
+    group: CMJobsMedical
     time: 18000 # 5 hours
   - !type:DepartmentTimeRequirement
     department: CMAuxiliarySupport

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/crewman.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/crewman.yml
@@ -16,7 +16,7 @@
   startingGear: CMGearVehicleCrewman
   icon: "CMJobIconVehicleCrewman"
   joinNotifyCrew: false
-  supervisors: cm-job-supervisors-co
+  supervisors: cm-job-supervisors-aso
   accessGroups:
   - VehicleCrewman
   roleWeight: 0.25

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Engineering/chief_engineer.yml
@@ -20,7 +20,7 @@
   requireAdminNotify: true
   joinNotifyCrew: false
   marineAuthorityLevel: 9
-  supervisors: cm-job-supervisors-aso
+  supervisors: rmc-job-supervisors-commander
   accessGroups:
   - CMCE
   roleWeight: 0.25

--- a/Resources/ServerInfo/Guidebook/_RMC14/SOP/RMCMarineSOPDepartment.xml
+++ b/Resources/ServerInfo/Guidebook/_RMC14/SOP/RMCMarineSOPDepartment.xml
@@ -48,6 +48,7 @@
   - The [bold]Auxiliary Support Officer[/bold] is in charge of the auxiliary department and responsible for the procedure of intelligence operations.
   - The [bold]Auxiliary Support Officer[/bold] is responsible for maintaining operations between departments and may assist departments where convenient.
   - The [bold]Auxiliary Support Officer[/bold] may only assist extensively, that is performing the duties of a member of that department, when granted permission by the present [bold]Department Head[/bold] or [color=#008000][bold]Commander[/bold][/color].
+  - The [bold]Auxiliary Support Officer[/bold] may not assist [color=#ff000d][bold]MP[/bold][/color] unless they have been deputized.
 
   ### Intelligence
   - The [bold]Auxiliary Support Officer[/bold] is in charge of [bold]Intelligence Officers[/bold] and the intelligence squad.

--- a/Resources/ServerInfo/Guidebook/_RMC14/SOP/RMCMarineSOPDepartment.xml
+++ b/Resources/ServerInfo/Guidebook/_RMC14/SOP/RMCMarineSOPDepartment.xml
@@ -43,8 +43,15 @@
   - The ordnance technicians are part of the engineering department.
   - During code [bold][color=black]Delta[/color][/bold], the engineering department is to follow orders from command. All engineering personnel are to join the marines in either holding the warship, or assisting with evacuation of civilians, depending on the orders of command.
 
-  ## Dropships and Gunships
+  ## Auxiliary
 
+  - The [bold]Auxiliary Support Officer[/bold] is in charge of the auxiliary department and responsible for the procedure of intelligence operations.
+  - The [bold]Auxiliary Support Officer[/bold] is responsible for maintaining operations between departments and may assist departments where convenient.
+  - The [bold]Auxiliary Support Officer[/bold] may only assist extensively, that is performing the duties of a member of that department, when granted permission by the present [bold]Department Head[/bold] or [color=#008000][bold]Commander[/bold][/color].
+
+  ### Intelligence
+  - The [bold]Auxiliary Support Officer[/bold] is in charge of [bold]Intelligence Officers[/bold] and the intelligence squad.
+  - The [bold]Auxiliary Support Officer[/bold] requires permission from a given marine's [bold]Squad Leader[/bold] to transfer them into intelligence.
 
   ### General
 

--- a/Resources/ServerInfo/Guidebook/_RMC14/SOP/RMCMarineSOPNONModDeployment.xml
+++ b/Resources/ServerInfo/Guidebook/_RMC14/SOP/RMCMarineSOPNONModDeployment.xml
@@ -44,7 +44,8 @@
 
   ### Engineering
 
-  - The [bold]Chief Engineer[/bold] may deploy to the [bold]FOB[/bold] if there is an [bold]Auxiliary Support Officer[/bold] on board, but still requires permission from them or the [color=#008000][bold]Commander[/bold][/color].
+  - The [bold]Chief Engineer[/bold] may deploy to the [bold]FOB[/bold] with the permission of the [color=#008000][bold]Commander[/bold][/color].
+  - At least one member of the engineering department must remain aboard the warship at all times. If the [bold]Chief Engineer[/bold] is present, it must be them.
   - Both the [bold]Chief Engineer[/bold] and maintenance techs may only deploy with the purpose of building the [bold]FOB[/bold], and telecommunications, but must leave if these areas are no longer considered secure.
 
   ### Medical

--- a/Resources/ServerInfo/Guidebook/_RMC14/SOP/RMCMarineSOPNONModDeployment.xml
+++ b/Resources/ServerInfo/Guidebook/_RMC14/SOP/RMCMarineSOPNONModDeployment.xml
@@ -45,7 +45,6 @@
   ### Engineering
 
   - The [bold]Chief Engineer[/bold] may deploy to the [bold]FOB[/bold] with the permission of the [color=#008000][bold]Commander[/bold][/color].
-  - At least one member of the engineering department must remain aboard the warship at all times. If the [bold]Chief Engineer[/bold] is present, it must be them.
   - Both the [bold]Chief Engineer[/bold] and maintenance techs may only deploy with the purpose of building the [bold]FOB[/bold], and telecommunications, but must leave if these areas are no longer considered secure.
 
   ### Medical


### PR DESCRIPTION
## About the PR
Changes several components of the ASO and implements guardrails to render the role a proper support officer. Reduces redundancy in the role's provisions and overall makes it more difficult to interrupt shipside operations. **These changes were made with the design goal of making the ASO an intelligence overwatch first, and a shipside assistant second.**

An essential list of the changes made are,
- Reduced ASO rank-ups from O2-O3 to O1-O2.
- Removed brig and armory access from the ASO. 
- Removed ASO requisitions (i.e. ASRS/vendor) access.
- Added a new-to-job popup for the ASO.
- Added a unique headset to the ASO that does not have MP comms.
- Deployment SOP; CE now answers directly to the Commander.
- Deployment SOP; the CE now requires the permission of the Commander to deploy.
- Department SOP; the ASO is officially stated as the department head of auxiliary. This includes stipulations that the ASO may help shipside departments, but must get permission from the corresponding department head or Commander to perform the duties of a member of that department. Additionally, they must receive SL permission to transfer marines.
- Changed VC's supervisor to the ASO.
- Changed CE's supervisor to the Commander.
- Changed ASO's description to match these changes.
- Changed ASO's requisitions requirement to a medical requirement.
- Upgraded ASO's medical skill.

## Why / Balance
It's no secret that the ASO is in a bit of a development hell, between what CM13 wants to do with the role and how RMC14 wants to implement it. Prior to this PR, I had identified three core issues with the role,

1. There is a lack of creative direction and proper implementation with the ASO, with the resulting freeform leading to some ASOs improvising at the expense of others.
2. The ASO's duty is not well-spoken both mechanically and legally.
3. The O3 rank-up and MP comms is a likely contributor to ASO power-tripping.

Therefore, to address these issues,

1. The ASO must be clearly creatively defined and implemented. In the case of this PR, the ASO was reimplemented with the design goal of making them a proper support officer capable of liaising between departments and ensuring their functionality, all of which comes second to their currently-acquainted expectation of overwatching and processing intelligence. Additionally, the ASO has had their medical skill increased to 3 so they can substantially assist with medical work.
2. The ASO must be properly introduced and explained. This is done with a new-to-job popup explaining the gist of the role to newer players, as well as clearly outlining the expectations and responsibilities of the role within SOP. Their description has also been modified to accommodate the aforementioned design goal and new purpose.
3. The ASO must have these removed and toned down to be in-line with other department heads and becoming of someone of their position in the chain of command. The O2-O3 rank-up suggests more authority than the ASO really has, especially as the third in command, hence why it has been reduced to the standard O1-O2 rank-ups of most command roles. Additionally, the ASO has nothing to do with MP, hence the removal of these comms and accesses.

I have discussed and workshopped this rework extensively within the community and I believe it addresses the root causes of most ASO issues, whilst implementing them in an enjoyable and realistic fashion. **That is, ASOs will no longer have arbitrary access or authority, and instead act as the department head of auxiliary/intelligence and an assistant to departments.**

## Technical details
- Adds a new ASO headset prototype in `ship_headsets.yml`
- Tweaked the access preset of the ASO in `auxiliary_support_access_groups.yml`
- Various changes in `auxiliary_support_officer.yml`
- Adds a new ASO job popup in `new-to-job-popup.ftl`
- Tweaks Department SOP regarding auxiliary in `RMCMarineSOPDepartment.xml`
- Tweaks Deployment SOP regarding engineering in `RMCMarineSOPNONModDeployment.xml`
- Changed the superior of VC in `crewman.yml`
- Changed the superior of CE in `chief_engineer.yml`
- Changed the ASO's description in `auxiliarysupport.ftl`

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: Completely reworked the ASO's implementation.
