### PR TITLE
Remove fish chatsan

### DIFF
--- a/Resources/Locale/en-US/_RMC14/cm-chatsan.ftl
+++ b/Resources/Locale/en-US/_RMC14/cm-chatsan.ftl
@@ -359,7 +359,6 @@ cm-chatsan-word-kitties = kitties
 cm-chatsan-word-kittens = kittens
 cm-chatsan-replacement-cats = felines
 
-cm-chatsan-word-fish = fish
 cm-chatsan-word-carp = carp
 cm-chatsan-replacement-fish = aquatic creature
 

--- a/Resources/Prototypes/_RMC14/Accents/cm_word_replacements.yml
+++ b/Resources/Prototypes/_RMC14/Accents/cm_word_replacements.yml
@@ -149,7 +149,6 @@
     cm-chatsan-word-cats: cm-chatsan-replacement-cats
     cm-chatsan-word-kitties: cm-chatsan-replacement-cats
     cm-chatsan-word-kittens: cm-chatsan-replacement-cats
-    cm-chatsan-word-fish: cm-chatsan-replacement-fish
     cm-chatsan-word-carp: cm-chatsan-replacement-fish
     cm-chatsan-word-rat: cm-chatsan-replacement-rat
     cm-chatsan-word-mouse: cm-chatsan-replacement-rat


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removes fish chatsan, keeps it for carp.

## Why / Balance
"Fish" is a verb. I often want to say "I will go fish some hosts" as an Oppressor, but I know it will get sanned and it's annoying. Also if xenonid fishing gets added, then this is even more relevant.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: CatAndHats
- remove: Removed "Fish" as a xenonid chatsan
