### PR TITLE
Makes Hijack Bustable window/wall work

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Walls/walls.yml
@@ -620,6 +620,9 @@
   name: heavy reinforced hull
   description: A highly reinforced metal wall used to separate rooms and make up the ship. It would take a great impact to weaken this wall.
   suffix: Hijack Bustable
+  components:
+  - type: RMCReplaceOnHijackLand
+    id: CMWallReinforcedAlmayer
 
 - type: entity
   parent: RMCWallAlmayerReinforcedHeavyDeco1

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Windows/windows.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Windows/windows.yml
@@ -132,6 +132,9 @@
   id: RMCWindowReinforcedAlmayerHullHijackBustable
   description: A glass window with a special rod matrix inside a wall frame. This one was made out of exotic materials to prevent hull breaches. It would take a great impact to weaken this window.
   suffix: Hijack Bustable
+  components:
+  - type: RMCReplaceOnHijackLand
+    id: RMCWindowFrameAlmayer # TODO RMC14 : also spawn glass shards
 
 - type: entity
   parent: CMBaseWindow


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixes Hijack Bustable windows not working after their component was removed by accident
Adds Hijack Bustable wall functioning

## Why / Balance
Fixes, stuff we want

## Media
video showing it works if needed
https://github.com/user-attachments/assets/49e62179-6c7b-4fc8-873e-7bdf0b89d681

that wall breaking is just the hijack random wall damage, not to do with this PR, but it's nice to show it still works on the hijack bustable walls

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: CatAndHats
- add: Added function to Hijack Bustable Walls, they now turn into Reinforced wall on Hijack
- fix: Fixed Hijack Bustable windows not breaking into window frames
