### PR TITLE
Fixes miniscule barbed wire typo

### DIFF
--- a/Resources/Locale/en-US/_RMC14/barbedwire/barbedwire.ftl
+++ b/Resources/Locale/en-US/_RMC14/barbedwire/barbedwire.ftl
@@ -1,6 +1,6 @@
 barbed-wire-slot-insert-full = The barricade already has barbed wire on it!
 barbed-wire-slot-insert-success = You wired the barricade with barbed wire.
-barbed-wire-damage = The barbed wire slice into your skin!
+barbed-wire-damage = The barbed wire slices into your skin!
 barbed-wire-slot-wiring = You begin wiring the barricade with barbed wire...
 
 barbed-wire-cutting-action-begin = You begin cutting the barbed wire...


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Fixes what i believe is a minor typo in the message text for hitting barbed cades

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

I couldnt take it anymore and added a single letter

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed a microscopic typo in the text that is displayed when hitting barbed barricades
