### PR TITLE
Fix prefab wall parenting

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Walls/shiva_walls.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Walls/shiva_walls.yml
@@ -80,11 +80,9 @@
     - doors
     base: shiva_fab_r
 
-- type: entity
-  parent: RMCBaseWallReinforced
+- type: entity # TODO RMC14: Clean up the ID's for the colored walls, they are supposed to regular fab walls
+  parent: RCMWallShivaFab
   id: RCMWallShivaReinforcedFabOrange
-  name: reinforced prefabricated structure wall
-  description: This structure is made of metal support rods. The poly-kevlon has been replaced with sheet metal, reinforcing it.
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Walls/shiva_fab_oj.rsi
@@ -100,10 +98,8 @@
     base: shiva_fab_oj
 
 - type: entity
-  parent: RMCBaseWallReinforced
+  parent: RCMWallShivaFab
   id: RCMWallShivaReinforcedFabBlue
-  name: reinforced prefabricated structure wall
-  description: This structure is made of metal support rods. The poly-kevlon has been replaced with sheet metal, reinforcing it.
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Walls/shiva_fab_blu.rsi
@@ -119,10 +115,8 @@
     base: shiva_fab_blu
 
 - type: entity
-  parent: RMCBaseWallReinforced
+  parent: RCMWallShivaFab
   id: RCMWallShivaReinforcedFabPink
-  name: reinforced prefabricated structure wall
-  description: This structure is made of metal support rods. The poly-kevlon has been replaced with sheet metal, reinforcing it.
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Walls/shiva_fab_pnk.rsi
@@ -138,10 +132,8 @@
     base: shiva_fab_pnk
 
 - type: entity
-  parent: RMCBaseWallReinforced
+  parent: RCMWallShivaFab
   id: RCMWallShivaReinforcedFabWhite
-  name: reinforced prefabricated structure wall
-  description: This structure is made of metal support rods. The poly-kevlon has been replaced with sheet metal, reinforcing it.
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Walls/shiva_fab_wht.rsi
@@ -157,10 +149,8 @@
     base: shiva_fab_wht
 
 - type: entity
-  parent: RMCBaseWallReinforced
+  parent: RCMWallShivaFab
   id: RCMWallShivaReinforcedFabRed
-  name: reinforced prefabricated structure wall
-  description: This structure is made of metal support rods. The poly-kevlon has been replaced with sheet metal, reinforcing it.
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Walls/shiva_fab_red.rsi


### PR DESCRIPTION
## About the PR
Fix shiva colored prefab wall variants being incorrectly parented to reinforced fab walls instead of soft fab walls

## Why / Balance
Parity

## Technical details
Yaml

## Media

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed shivas colored prefab wall variants being reinforced instead of soft walls
