### PR TITLE
Fix CAS missiles offsetting up to 6 tiles away

### DIFF
--- a/Content.Shared/_RMC14/Dropship/Weapon/SharedDropshipWeaponSystem.cs
+++ b/Content.Shared/_RMC14/Dropship/Weapon/SharedDropshipWeaponSystem.cs
@@ -744,12 +744,13 @@ public abstract class SharedDropshipWeaponSystem : EntitySystem
         Dirty(weapon.Value, weaponComp);
 
         var spread = ev.Spread;
+        var originalCoords = coordinates;
         var targetCoords = coordinates;
         if (spread != 0)
             targetCoords = targetCoords.Offset(_random.NextVector2(-spread, spread + 1));
 
         if (ev.Explosion != null && HasNonDeletableWallOnTile(targetCoords))
-            targetCoords = FindAlternateLandingTile(targetCoords, 3);
+            targetCoords = FindAlternateLandingTile(targetCoords, originalCoords, (int)spread);
         var inFlight = Spawn(null, MapCoordinates.Nullspace);
         var inFlightComp = new AmmoInFlightComponent
         {
@@ -791,7 +792,7 @@ public abstract class SharedDropshipWeaponSystem : EntitySystem
 
         var spawnTarget = _transform.GetMoverCoordinates(active).SnapToGrid(EntityManager, _mapManager);
         if (ammo.Explosion != null && HasNonDeletableWallOnTile(spawnTarget))
-            spawnTarget = FindAlternateLandingTile(spawnTarget, 3);
+            spawnTarget = FindAlternateLandingTile(spawnTarget, spawnTarget, 3);
 
         var inFlight = Spawn(null, MapCoordinates.Nullspace);
         var inFlightComp = new AmmoInFlightComponent
@@ -1665,9 +1666,13 @@ public abstract class SharedDropshipWeaponSystem : EntitySystem
         return foundWall;
     }
 
-    private EntityCoordinates FindAlternateLandingTile(EntityCoordinates desired, int maxRadius = 3)
+    private EntityCoordinates FindAlternateLandingTile(EntityCoordinates desired, EntityCoordinates original, int maxRadius = 3)
     {
         var origin = desired.SnapToGrid(EntityManager, _mapManager);
+        var maximumX = original.Position.X + maxRadius;
+        var maximumY = original.Position.Y + maxRadius;
+        var minimumX = original.Position.X - maxRadius;
+        var minimumY = original.Position.Y - maxRadius;
 
         for (var r = 1; r <= maxRadius; r++)
         {
@@ -1678,6 +1683,23 @@ public abstract class SharedDropshipWeaponSystem : EntitySystem
                     continue;
 
                 var candidate = origin.Offset(new Vector2i(x, y));
+                if (!(!(candidate.Position.X <= minimumX) && (candidate.Position.X <= maximumX) && !(candidate.Position.Y <= minimumY) && (candidate.Position.Y <= maximumY)))
+                    continue;
+
+                if (!HasNonDeletableWallOnTile(candidate))
+                    return candidate;
+            }
+        }
+
+        for (var r = 1; r <= maxRadius; r++)
+        {
+            for (var x = -r; x <= r; x++)
+            for (var y = -r; y <= r; y++)
+            {
+                if (Math.Abs(x) != r && Math.Abs(y) != r)
+                    continue;
+
+                var candidate = original.Offset(new Vector2i(x, y));
                 if (!HasNonDeletableWallOnTile(candidate))
                     return candidate;
             }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixes an issue with PR #8860 that allowed 'double-offsetting', resulting in missiles being offset up to 6 tiles away from the original CAS mark.

## Why / Balance
Bugfix. Missile offset now behaves as intended.

## Technical details
If the initial tile selected by the missile offset is an indestructible wall, tiles within 3 tiles of *that* tile become valid search targets for FindAlternateLandingTile.  
- Added a range limit to FindAlternateLandingTile to only select tiles within both 3 tiles of the initial tile *and* the offset tile.  
- If no valid tiles exist within this bound (i.e. the initial offset is sent three tiles into cave wall), searches all tiles around the original flare until a valid tile is found.
- If no valid tiles are found (physically impossible outside of a dev environment, as cas marks can't be placed deep into indestructible walls), missile fires on the original offset.

## Media
Not sure how to display this in a way that reliably demonstrates that missiles *can't* offset anymore, but I have thoroughly tested it.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixes an issue with PR #8860 that allowed 'double-offsetting', resulting in missiles being offset up to 6 tiles away from the original CAS mark.

