### PR TITLE
Replace gamma alert sound effect

### DIFF
--- a/Content.Shared/_RMC14/AlertLevel/RMCAlertLevelComponent.cs
+++ b/Content.Shared/_RMC14/AlertLevel/RMCAlertLevelComponent.cs
@@ -47,7 +47,7 @@ public sealed partial class RMCAlertLevelComponent : Component
 
     // TODO RMC14
     [DataField, AutoNetworkedField]
-    public SoundSpecifier? DeltaSound = new SoundPathSpecifier("/Audio/Misc/gamma.ogg");
+    public SoundSpecifier? DeltaSound = new SoundPathSpecifier("/Audio/_RMC14/Announcements/Marine/notice2.ogg");
 
     [DataField, AutoNetworkedField]
     public ProtoId<RadioChannelPrototype> RadioChannel = "MarineCommon";


### PR DESCRIPTION
## About the PR
Replace gamma alert sound effect with default announcement sound
Left it as a TODO still

## Why / Balance
Genuinely obnoxious and overly loud sound effect that plays every time hijack happens

It will need a better sound in the future but the upstream sound is NOT it

## Technical details
One line change in the delta sound field

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Replaced the gamma alert sound effect with the default announcement sound
